### PR TITLE
Add Damage Modifier Formula

### DIFF
--- a/index.html
+++ b/index.html
@@ -806,6 +806,14 @@
                             </li>
                             <li><strong style="color: var(--green-success);">2. Modificador de Daño:</strong> Al hacer daño con Habilidades de Ataque, la diferencia entre el Offense Level del atacante y el Defense Level del defensor modifica porcentualmente el daño infligido. Este cálculo se aplica por encima de las Resistencias.
                                 <br>La fórmula exacta del modificador de daño es:
+                                <div style="display: flex; align-items: center; justify-content: center; gap: 10px; margin: 20px 0; font-family: 'Share Tech Mono', monospace; font-size: 20px; color: var(--cyan-tech);">
+                                    <span>M = </span>
+                                    <div style="display: flex; flex-direction: column; align-items: center;">
+                                        <span style="border-bottom: 2px solid var(--cyan-tech); padding: 0 10px 2px 10px;">Off - Def</span>
+                                        <span style="padding: 2px 10px 0 10px;">|Off - Def| + 25</span>
+                                    </div>
+                                    <span>&times; 100</span>
+                                </div>
                                 <ul>
                                     <li><strong style="color: var(--cyan-tech);">M</strong> es el modificador de daño (en %).</li>
                                     <li><strong style="color: var(--cyan-tech);">Off</strong> es el Offense Level de la Habilidad de Ataque.</li>


### PR DESCRIPTION
Fixes the missing formula issue in the "Defensive y Offensive Level" section as requested by the user. The formula calculation `M = (Off - Def) / (|Off - Def| + 25) * 100` was added to `index.html` using a stylized HTML/CSS block. Verified visually via Playwright.

---
*PR created automatically by Jules for task [12741843714870424593](https://jules.google.com/task/12741843714870424593) started by @sokcrow*