### PR TITLE
Add Difficulty Class Icons to Rulebook

### DIFF
--- a/index.html
+++ b/index.html
@@ -682,17 +682,17 @@
 
             <div class="card-body" style="background-color: var(--bg-card); border: 1px solid #444; border-radius: 6px; padding: 20px; margin-bottom: 20px;">
                 <h2 style="color: var(--border-accent); display: flex; align-items: center; gap: 10px;">
-                    <img src="https://i.imgur.com/p70Fei4.png" alt="Dificultad" style="width: 24px; height: 24px;">
+                    <img src="https://i.imgur.com/mrm9j1b.png" alt="Dificultad" style="width: 24px; height: 24px;">
                     2. Clases de Dificultad (DC)
                 </h2>
                 <div class="concept-text" style="font-size: 15px;">
                     <p>Toda acción tiene un obstáculo a superar. El DJ establecerá una Clase de Dificultad (DC) que tu Resultado Final debe igualar o superar. La escala de dificultad en este sistema sube de 3 en 3, con un tope máximo de 30.</p>
                     <ul style="list-style-type: none; padding-left: 0;">
-                        <li><strong style="color: var(--green-success);">DC 3 a 6: Trivial / Muy Fácil</strong> (Casi automático para alguien con buena habilidad).</li>
-                        <li><strong style="color: var(--cyan-tech);">DC 9 a 12: Fácil / Medio</strong> (El estándar para acciones bajo presión).</li>
-                        <li><strong style="color: var(--border-accent);">DC 15 a 18: Difícil / Muy Difícil</strong> (Requiere verdadera habilidad y suerte con las monedas).</li>
-                        <li><strong style="color: var(--red-neon);">DC 21 a 27: Extremo / Heroico</strong> (Solo los verdaderos expertos en su campo lo logran).</li>
-                        <li><strong style="color: var(--red-bright);">DC 30: Imposible</strong> (El límite absoluto del sistema; un milagro estadístico que requiere 5 caras y pura maestría).</li>
+                        <li style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;"><img src="https://i.imgur.com/LPVzoUw.png" alt="Trivial" style="width: 20px; height: 20px;"><strong style="color: var(--green-success);">DC 3 a 6: Trivial / Muy Fácil</strong> <span>(Casi automático para alguien con buena habilidad).</span></li>
+                        <li style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;"><img src="https://i.imgur.com/cVHvEKb.png" alt="Fácil" style="width: 20px; height: 20px;"><strong style="color: var(--cyan-tech);">DC 9 a 12: Fácil / Medio</strong> <span>(El estándar para acciones bajo presión).</span></li>
+                        <li style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;"><img src="https://i.imgur.com/0kog02u.png" alt="Difícil" style="width: 20px; height: 20px;"><strong style="color: var(--border-accent);">DC 15 a 18: Difícil / Muy Difícil</strong> <span>(Requiere verdadera habilidad y suerte con las monedas).</span></li>
+                        <li style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;"><img src="https://i.imgur.com/DDIlSeT.png" alt="Extremo" style="width: 20px; height: 20px;"><strong style="color: var(--red-neon);">DC 21 a 27: Extremo / Heroico</strong> <span>(Solo los verdaderos expertos en su campo lo logran).</span></li>
+                        <li style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;"><img src="https://i.imgur.com/mrm9j1b.png" alt="Imposible" style="width: 20px; height: 20px;"><strong style="color: var(--red-bright);">DC 30: Imposible</strong> <span>(El límite absoluto del sistema; un milagro estadístico que requiere 5 caras y pura maestría).</span></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Replaced static list items in the Difficulty Classes section with flex containers that align new difficulty icons with their corresponding text. Also updated the header icon for the section. Verified styling and alignment with Playwright tests.

---
*PR created automatically by Jules for task [16220339334556364425](https://jules.google.com/task/16220339334556364425) started by @sokcrow*