### PR TITLE
Update intro dialogues and migrate origin grid

### DIFF
--- a/creacion_personaje.html
+++ b/creacion_personaje.html
@@ -6,6 +6,20 @@
     <title>Creación de Personaje</title>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Special+Elite&display=swap');
+
+        :root {
+            --bg-main: #121212;
+            --bg-card: #1e1e1e;
+            --border-accent: #ffae00;
+            --text-main: #ffffff;
+            --text-muted: #aaaaaa;
+            --red-dark: #500000;
+            --red-bright: #ff0000;
+            --red-neon: #ff4444;
+            --green-success: #44ff44;
+            --cyan-tech: #00ffff;
+        }
 
         body, html {
             margin: 0;
@@ -107,6 +121,239 @@
             text-shadow: 0 0 10px rgba(255, 255, 255, 0.8);
         }
 
+        /* Origin Selection Grid Styles (Copied from index.html) */
+        .origin-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+            gap: 20px;
+            margin-bottom: 30px;
+            width: 100%;
+            max-width: 1200px;
+            padding: 0 20px;
+            box-sizing: border-box;
+        }
+
+        .origin-card {
+            background-color: var(--bg-card);
+            border: 1px solid #333;
+            border-radius: 6px;
+            overflow: hidden;
+            transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+            display: flex;
+            flex-direction: column;
+            cursor: pointer;
+        }
+
+        .origin-grid.has-selection .origin-card:not(.selected) {
+            opacity: 0.5;
+            transform: scale(0.98);
+        }
+
+        .origin-card:hover {
+            transform: translateY(-5px);
+            border-color: var(--border-accent);
+            box-shadow: 0 5px 15px rgba(255, 174, 0, 0.1);
+            opacity: 1 !important;
+        }
+
+        .origin-card.selected {
+            border-color: var(--border-accent);
+            transform: translateY(-5px) scale(1.02);
+            opacity: 1;
+            animation: flicker 2s infinite alternate;
+        }
+
+        @keyframes flicker {
+            0% { box-shadow: 0 0 10px var(--border-accent); border-color: var(--border-accent); }
+            50% { box-shadow: 0 0 25px var(--border-accent), 0 0 5px inset var(--border-accent); border-color: #ffcc55; }
+            100% { box-shadow: 0 0 10px var(--border-accent); border-color: var(--border-accent); }
+        }
+
+        .card-header {
+            background: linear-gradient(to right, var(--red-dark), #2a0000);
+            padding: 15px;
+            border-bottom: 1px solid var(--red-bright);
+        }
+
+        .card-header h2 {
+            margin: 0;
+            font-size: 18px;
+            color: var(--text-main);
+            text-transform: uppercase;
+        }
+
+        .card-body {
+            padding: 15px;
+            flex-grow: 1;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .concept-text {
+            font-size: 13px;
+            color: var(--text-muted);
+            line-height: 1.5;
+            margin-bottom: 15px;
+        }
+
+        .stats-box {
+            background-color: #111;
+            border: 1px solid #444;
+            border-radius: 4px;
+            padding: 10px;
+            margin-bottom: 15px;
+            display: grid;
+            gap: 8px;
+        }
+
+        .stat-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-size: 13px;
+        }
+
+        .stat-col {
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+        }
+
+        .stat-name-label {
+            font-size: 10px;
+            color: var(--text-muted);
+            text-transform: uppercase;
+        }
+
+        .stat-label {
+            font-weight: bold;
+            color: var(--text-main);
+        }
+
+        .stat-val-pos {
+            color: var(--green-success);
+            font-weight: bold;
+        }
+
+        .stat-val-neg {
+            color: var(--red-neon);
+            font-weight: bold;
+        }
+
+        .stat-val-skill {
+            color: var(--cyan-tech);
+            font-weight: bold;
+        }
+
+        .trait-box {
+            margin-top: auto;
+            border-top: 1px dashed #444;
+            padding-top: 10px;
+        }
+
+        .trait-title {
+            font-size: 12px;
+            color: var(--border-accent);
+            text-transform: uppercase;
+            font-weight: bold;
+            margin-bottom: 5px;
+        }
+
+        .trait-desc {
+            font-size: 12px;
+            color: var(--text-main);
+            line-height: 1.4;
+        }
+
+        .human-selects, .subrace-container {
+            display: none;
+            flex-direction: column;
+            gap: 10px;
+            margin-top: 10px;
+        }
+
+        .origin-card.selected .human-selects,
+        .origin-card.selected .subrace-container {
+            display: flex;
+        }
+
+        .human-select-row {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .human-select-row label {
+            font-size: 12px;
+            color: var(--text-main);
+            display: flex;
+            justify-content: space-between;
+        }
+
+        .choice-select {
+            width: 100%;
+            background-color: #111;
+            color: var(--text-main);
+            border: 1px solid #444;
+            padding: 6px;
+            border-radius: 4px;
+            outline: none;
+            cursor: pointer;
+            font-size: 13px;
+        }
+
+        .choice-select.error {
+            border-color: var(--red-neon);
+            box-shadow: 0 0 5px var(--red-neon);
+        }
+
+        .choice-select:focus {
+            border-color: var(--border-accent);
+        }
+
+        .nav-buttons {
+            margin-top: 30px;
+            display: flex;
+            justify-content: center;
+            width: 100%;
+        }
+
+        .btn {
+            background-color: var(--red-dark);
+            color: var(--text-main);
+            border: 1px solid var(--red-bright);
+            padding: 15px 30px;
+            font-size: 16px;
+            font-weight: bold;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            cursor: pointer;
+            border-radius: 4px;
+            transition: all 0.2s ease;
+        }
+
+        .btn:hover:not(:disabled) {
+            background-color: var(--red-bright);
+            box-shadow: 0 0 15px rgba(255, 0, 0, 0.6);
+            transform: scale(1.02);
+        }
+
+        .btn:disabled {
+            background-color: #333;
+            border-color: #555;
+            color: #777;
+            cursor: not-allowed;
+            transform: none;
+            box-shadow: none;
+        }
+
+        .human-error-msg {
+            color: var(--red-neon);
+            font-size: 12px;
+            margin-top: 5px;
+            display: none;
+        }
+
         /* Dialogue Phase */
         #phase-dialogue {
             cursor: pointer;
@@ -162,31 +409,13 @@
             </div>
         </div>
 
-        <div id="phase1" class="phase hidden">
+        <div id="phase1" class="phase hidden" style="justify-content: flex-start; padding-top: 50px; overflow-y: auto;">
             <h1 class="question">¿Que eres?</h1>
-            <div class="roulette-container">
-                <ul class="roulette" id="roulette-list">
-                    <li>Humano</li>
-                    <li>Lizalin</li>
-                    <li>Kobold</li>
-                    <li>Kenku</li>
-                    <li>Centauro</li>
-                    <li>Goliat</li>
-                    <li>Goblin</li>
-                    <li>Hada</li>
-                    <li>Aasimar</li>
-                    <li>Tiefling</li>
-                    <li>Warforged</li>
-                    <li>Felinae</li>
-                    <li>Semi Dragón</li>
-                    <li>Lupae</li>
-                    <li>Moonfae</li>
-                    <li>Undae</li>
-                    <li>Elnae</li>
-                    <li>Yuan-ti Pura Sangre</li>
-                    <li>Lanae</li>
-                    <li>Tsune</li>
-                </ul>
+            <div id="origin-grid" class="origin-grid">
+                <!-- Las tarjetas se generarán dinámicamente aquí con JavaScript -->
+            </div>
+            <div class="nav-buttons" style="margin-bottom: 50px;">
+                <button id="btn-confirmar-origen" class="btn" disabled>Confirmar Origen</button>
             </div>
         </div>
 
@@ -198,6 +427,1131 @@
 
     <script>
         document.addEventListener('DOMContentLoaded', () => {
+
+        // 1. Base de Datos de Razas
+        const atributosLista = [
+            "Vigor", "Instinto", "Fortaleza", "Carisma", "Perspicacia", "Seducción",
+            "Agilidad", "Análisis", "Sigilo", "Presencia", "Engaño", "Percepción",
+            "Voluntad", "Cardio", "Manejo", "Reflejos", "Templanza", "Prudencia",
+            "Empatía", "Fe", "Represión", "Memoria", "Ciencia", "Negociación", "Atletismo"
+        ].sort();
+
+        const racesData = [
+            {
+                id: 'humano',
+                nombre: 'Humano',
+                isHuman: true,
+                perksSelection: 2,
+                perks: [
+                    { id: 'adaptable', nombre: 'Adaptable', desc: 'Obtienes +1 en 2 Habilidades de tu elección.' },
+                    { id: 'dulces_suenos', nombre: 'Dulces Sueños', desc: 'En un descanso Largo despiertas con +5 de SP.' },
+                    { id: 'determinado', nombre: 'Determinado', desc: 'Cuando tu HP llega a 40% o menos, ganas 2 de SP por turno.' },
+                    { id: 'rencoroso', nombre: 'Rencoroso', desc: 'Cuando recibes daño, obtienes +1 de Damage Up (Max 3) la siguiente ronda.' },
+                    { id: 'terco', nombre: 'Terco', desc: 'Una vez por descanso largo, puedes repetir una tirada de Habilidad fallida.' },
+                    { id: 'mente_fria', nombre: 'Mente Fría', desc: 'Comienzas cada combate con +5 de SP.' },
+                    { id: 'endurecido', nombre: 'Endurecido', desc: 'Cuando tu SP está en números negativos (menor a 0), obtienes +1 de Protection.' },
+                    { id: 'superviviente', nombre: 'Superviviente', desc: 'Al llegar a 20% o menos HP, la siguiente ronda obtienes +20 SP.' },
+                    { id: 'alerta', nombre: 'Alerta', desc: 'No puedes ser sorprendido, +1 Min Speed, +2 Max Speed.' },
+                    { id: 'oportunista', nombre: 'Oportunista', desc: 'Al asestar el golpe letal a un enemigo, recuperas 5 de SP.' },
+                    { id: 'firme', nombre: 'Firme', desc: 'Reduces tu primer umbral de Aturdimiento (Stagger) en un 10%.' },
+                    { id: 'euforico', nombre: 'Eufórico', desc: 'Al ganar un Choque, recuperas 2 de SP adicional.' },
+                    { id: 'evasivo', nombre: 'Evasivo', desc: 'Poder Base de Evade +1, poder de moneda de Evade +3.' },
+                    { id: 'desesperado', nombre: 'Desesperado', desc: 'Cuando tu SP llega a -20 o menos, obtienes +1 al Poder Base de tus habilidades.' },
+                    { id: 'preparado', nombre: 'Preparado', desc: 'Comienzas cada combate con un Escudo equivalente al 10% de tu HP máximo.' }
+                ]
+            },
+            {
+                id: 'lizalin',
+                nombre: 'Lizalin',
+                isHuman: false,
+                perksSelection: 0,
+                mods: { cuspide: 'Vigor', excelente: 'Instinto', bueno: 'Fortaleza', deficiente: 'Carisma', punto_ciego: 'Perspicacia', critica: 'Seducción' },
+                perks: [
+                    { id: 'fauces_hambrientas', nombre: 'Fauces Hambrientas', desc: 'Al acertar un ataque de Mordida, recuperas 5 HP.' },
+                    { id: 'piel_escamosa', nombre: 'Piel Escamosa', desc: 'El Poder de Moneda de tus habilidades de tipo "Guard" aumenta en +3.' },
+                    { id: 'pulmones_pantano', nombre: 'Pulmones de Pantano', desc: 'Puedes aguantar la respiración hasta por 30 minutos sin sufrir penalizadores.' },
+                    { id: 'artesano_astuto', nombre: 'Artesano Astuto', desc: 'Puedes fabricar armas usando cadáveres. Las armas creadas son siempre Tier 3.' }
+                ]
+            },
+            {
+                id: 'kobold',
+                nombre: 'Kobold',
+                isHuman: false,
+                perksSelection: 0,
+                mods: { cuspide: 'Agilidad', excelente: 'Análisis', bueno: 'Sigilo', deficiente: 'Vigor', punto_ciego: 'Presencia', critica: 'Fortaleza' },
+                perks: [
+                    { id: 'tactica_manada', nombre: 'Táctica de Manada', desc: 'Obtienes +1 Attack Power UP por cada aliado a 5ft del mismo objetivo (Máx. 3).' },
+                    { id: 'suplicio_distractor', nombre: 'Suplicio Distractor', desc: 'Al usarlo, el objetivo obtiene +2 Attack Power Down.' },
+                    { id: 'ingenieria_tunel', nombre: 'Ingeniería de Túnel', desc: 'Obtienes +3 de poder de check para desarmar trampas o piratear accesos mecánicos.' }
+                ]
+            },
+            {
+                id: 'kenku',
+                nombre: 'Kenku',
+                isHuman: false,
+                perksSelection: 0,
+                mods: { cuspide: 'Engaño', excelente: 'Sigilo', bueno: 'Percepción', deficiente: 'Voluntad', punto_ciego: 'Carisma', critica: 'Presencia' },
+                perks: [
+                    { id: 'imitacion', nombre: 'Imitación', desc: 'Puedes copiar voces y sonidos a la perfección (requiere haberlos escuchado antes).' },
+                    { id: 'comunicacion_limitada', nombre: 'Comunicación Limitada', desc: 'No posees voz propia; solo puedes hablar usando sonidos y frases memorizadas.' },
+                    { id: 'falsificador_experto', nombre: 'Falsificador Experto', desc: 'Obtienes +3 en Engaño para falsificar documentos u objetos.' }
+                ]
+            },
+            {
+                id: 'centauro',
+                nombre: 'Centauro',
+                isHuman: false,
+                perksSelection: 0,
+                mods: { cuspide: 'Fortaleza', excelente: 'Cardio', bueno: 'Instinto', deficiente: 'Manejo', punto_ciego: 'Agilidad', critica: 'Sigilo' },
+                perks: [
+                    { id: 'embestida', nombre: 'Embestida', desc: 'Si tu Speed es 10+, obtienes +2 Clash Power Up.' },
+                    { id: 'complexion_equina', nombre: 'Complexión Equina', desc: 'Tus Slots de Inventario Activo aumentan +5. Tienes -3 en Checks de Agilidad para escalar o moverte por espacios estrechos.' }
+                ]
+            },
+            {
+                id: 'goliat',
+                nombre: 'Goliat',
+                isHuman: false,
+                perksSelection: 0,
+                mods: { cuspide: 'Fortaleza', excelente: 'Vigor', bueno: 'Voluntad', deficiente: 'Reflejos', punto_ciego: 'Sigilo', critica: 'Agilidad' },
+                perks: [
+                    { id: 'resistencia_petrea', nombre: 'Resistencia Pétrea', desc: 'Al inicio del combate, obtienes un Escudo igual al 15% de tu HP Máximo.' },
+                    { id: 'nacido_cumbre', nombre: 'Nacido en la Cumbre', desc: 'Eres resistente al daño de Hielo y estás aclimatado a las grandes alturas.' }
+                ]
+            },
+            {
+                id: 'goblin',
+                nombre: 'Goblin',
+                isHuman: false,
+                perksSelection: 0,
+                mods: { cuspide: 'Agilidad', excelente: 'Engaño', bueno: 'Sigilo', deficiente: 'Templanza', punto_ciego: 'Prudencia', critica: 'Presencia' },
+                perks: [
+                    { id: 'escabullirse', nombre: 'Escabullirse', desc: 'Al poder de tus monedas de Evade se les suma tu Agilidad.' },
+                    { id: 'furia_pequenos', nombre: 'Furia de los Pequeños', desc: 'Antes de golpear, si el enemigo es de un tamaño mayor al tuyo, obtienes +2 de Damage Up.' }
+                ]
+            },
+            {
+                id: 'hada',
+                nombre: 'Hada',
+                isHuman: false,
+                perksSelection: 0,
+                subrazas: [
+                    {
+                        id: 'hada_fuego',
+                        nombre: 'Hada de Fuego',
+                        mods: { cuspide: 'Reflejos', excelente: 'Presencia', bueno: 'Agilidad', deficiente: 'Empatía', punto_ciego: 'Prudencia', critica: 'Fortaleza' },
+                        perks: [
+                            { id: 'resistencia_fuego', nombre: 'Resistencia al Fuego', desc: 'Absorbe el daño de Fuego y tiene vulnerabilidad al Frío.' },
+                            { id: 'llama_ignea', nombre: 'Llama Ígnea', desc: 'Al iniciar tu turno: Enemigos a 5 ft obtienen +3 Burn Potency. Aliados a 5 ft pierden 1 Burn Count.' }
+                        ]
+                    },
+                    {
+                        id: 'hada_flores',
+                        nombre: 'Hada de las Flores',
+                        mods: { cuspide: 'Empatía', excelente: 'Carisma', bueno: 'Agilidad', deficiente: 'Vigor', punto_ciego: 'Represión', critica: 'Fortaleza' },
+                        perks: [
+                            { id: 'empatia_floral', nombre: 'Empatía Floral', desc: 'Puedes comunicarte telepáticamente con plantas a 30 ft.' },
+                            { id: 'aromas_calmantes', nombre: 'Aromas Calmantes', desc: 'En tu turno, aliados a 5 ft recuperan +3 SP. Si están por debajo de -15 SP, recuperan +6 SP.' }
+                        ]
+                    },
+                    {
+                        id: 'hada_hielo',
+                        nombre: 'Hada de Hielo',
+                        mods: { cuspide: 'Templanza', excelente: 'Reflejos', bueno: 'Agilidad', deficiente: 'Empatía', punto_ciego: 'Carisma', critica: 'Fortaleza' },
+                        perks: [
+                            { id: 'resistencia_frio', nombre: 'Resistencia al Frío', desc: 'Absorbe el daño de Frío y tiene vulnerabilidad al Fuego.' },
+                            { id: 'toque_helado', nombre: 'Toque Helado', desc: 'Al iniciar tu turno: Enemigos a 5 ft obtienen +3 Cold Potency. Aliados a 5 ft pierden 1 Cold Count.' }
+                        ]
+                    },
+                    {
+                        id: 'hada_luz',
+                        nombre: 'Hada de Luz',
+                        mods: { cuspide: 'Presencia', excelente: 'Carisma', bueno: 'Agilidad', deficiente: 'Sigilo', punto_ciego: 'Vigor', critica: 'Fortaleza' },
+                        perks: [
+                            { id: 'luz_brillante', nombre: 'Luz Brillante', desc: 'Tu brillo aumenta a 40 ft de luz brillante y tenue.' },
+                            { id: 'bendicion_hadas', nombre: 'Bendición de las Hadas', desc: 'En tu turno, aliados a 5 ft recuperan +5 HP.' },
+                            { id: 'destello_cegador', nombre: 'Destello Cegador', desc: 'Una vez por descanso largo, gastas 1 Slot de Acción para emitir luz cegadora. Criaturas a 10 ft hacen salvación de Percepción o quedan Cegadas hasta el final de su próximo turno.' }
+                        ]
+                    }
+                ],
+                perks: [
+                    { id: 'vuelo', nombre: 'Vuelo', desc: 'Obtienes velocidad de vuelo de 30 ft. Para usarla, debes transformarte a tamaño Pequeño y no llevar armadura media o pesada.' },
+                    { id: 'brillo_natural', nombre: 'Brillo Natural', desc: 'Emites luz brillante a voluntad en tu forma de hada en 10 ft y luz tenue en otros 10 ft.' },
+                    { id: 'forma_hada', nombre: 'Forma de Hada', desc: 'Gastas 1 Slot de Acción para hacerte de tamaño Diminuto (toma 30 seg). Te vuelves muy débil y frágil al daño. Tu efecto de hada cambia dependiendo de tu elemento.' }
+                ]
+            },
+            {
+                id: 'aasimar',
+                nombre: 'Aasimar',
+                isHuman: false,
+                perksSelection: 0,
+                subrazas: [
+                    {
+                        id: 'aasimar_protector',
+                        nombre: 'Aasimar Protector',
+                        mods: { cuspide: 'Fe', excelente: 'Presencia', bueno: 'Voluntad', deficiente: 'Engaño', punto_ciego: 'Sigilo', critica: 'Seducción' },
+                        perks: [
+                            { id: 'revelacion_radiante', nombre: 'Revelación Radiante', desc: 'Requiere un Descanso Largo. Gastas 1 Slot de Acción. Durante 10 rondas ganas velocidad de vuelo (30 ft). Además, aliados a 10 ft obtienen un escudo igual al 10% de tu HP Max, y en tu turno obtienes +2 de Protection.' }
+                        ]
+                    },
+                    {
+                        id: 'aasimar_azotador',
+                        nombre: 'Aasimar Azotador (Scourge)',
+                        mods: { cuspide: 'Presencia', excelente: 'Fortaleza', bueno: 'Voluntad', deficiente: 'Empatía', punto_ciego: 'Sigilo', critica: 'Engaño' },
+                        perks: [
+                            { id: 'consumo_divino', nombre: 'Consumo Divino', desc: 'Requiere un Descanso Largo. Gastas 1 Slot de Acción. Durante 10 rondas, al final de tu turno, todas las criaturas a 10 ft reciben daño radiante fijo igual al 10% de tu HP Max y obtienes +2 Damage Up.' }
+                        ]
+                    },
+                    {
+                        id: 'aasimar_caido',
+                        nombre: 'Aasimar Caído (Fallen)',
+                        mods: { cuspide: 'Vigor', excelente: 'Presencia', bueno: 'Fortaleza', deficiente: 'Fe', punto_ciego: 'Empatía', critica: 'Prudencia' },
+                        perks: [
+                            { id: 'presencia_aterradora', nombre: 'Presencia Aterradora', desc: 'Requiere un Descanso Largo. Gastas 1 Slot de Acción. En tu turno, todos a 10 ft deben hacer una salvación de Alma o reciben 5 de Offensive Level Down, y en tu turno obtienes +2 Damage Up.' }
+                        ]
+                    }
+                ],
+                perks: [
+                    { id: 'resistencia_celestial', nombre: 'Resistencia Celestial', desc: 'Tienes Resistencia al daño Radiante y al daño Necrótico.' },
+                    { id: 'portador_luz', nombre: 'Portador de la Luz', desc: 'Emites luz pasiva a tu alrededor a voluntad (10 ft brillante y 10 ft tenue).' },
+                    { id: 'manos_sanadoras', nombre: 'Manos Sanadoras', desc: 'Curas a un aliado tocado por 10 HP + tu Alma.' }
+                ]
+            },
+            {
+                id: 'tiefling',
+                nombre: 'Tiefling',
+                isHuman: false,
+                perksSelection: 0,
+                subrazas: [
+                    {
+                        id: 'tiefling_asmodeo',
+                        nombre: 'Herencia de Asmodeo',
+                        mods: { cuspide: 'Represión', excelente: 'Presencia', bueno: 'Análisis', deficiente: 'Empatía', punto_ciego: 'Seducción', critica: 'Fe' },
+                        perks: [
+                            { id: 'llama_tirano', nombre: 'Llama del Tirano', desc: 'Gastas 1 Slot de Acción. Enemigos a 10 ft obtienen +3 Burn Potency y +2 Burn Count.' },
+                            { id: 'hechizos_asmodeo', nombre: 'Magia de Asmodeo', desc: 'Tu Alma es tu estadística de lanzamiento. Truco: Taumaturgia. Nivel 15: Represión Infernal. Nivel 25: Oscuridad.' }
+                        ]
+                    },
+                    {
+                        id: 'tiefling_baalzebul',
+                        nombre: 'Herencia de Baalzebul',
+                        mods: { cuspide: 'Engaño', excelente: 'Presencia', bueno: 'Análisis', deficiente: 'Empatía', punto_ciego: 'Fe', critica: 'Templanza' },
+                        perks: [
+                            { id: 'toque_putrido', nombre: 'Toque Pútrido', desc: 'Tus ataques cuerpo a cuerpo aplican +1 Potency y +1 Count al Golpear.' },
+                            { id: 'hechizos_baalzebul', nombre: 'Magia de Baalzebul', desc: 'Tu Alma es tu estadística de lanzamiento. Truco: Taumaturgia. Nivel 15: Rayo de Dolor. Nivel 25: Corona de la Locura.' }
+                        ]
+                    },
+                    {
+                        id: 'tiefling_dispater',
+                        nombre: 'Herencia de Dispater',
+                        mods: { cuspide: 'Análisis', excelente: 'Presencia', bueno: 'Engaño', deficiente: 'Empatía', punto_ciego: 'Fe', critica: 'Fortaleza' },
+                        perks: [
+                            { id: 'piel_dis', nombre: 'Piel de Dis', desc: 'Aumenta tu Defensive Lvl +2.' },
+                            { id: 'hechizos_dispater', nombre: 'Magia de Dispater', desc: 'Tu Alma es tu estadística de lanzamiento. Truco: Taumaturgia. Nivel 15: Disfrazarse. Nivel 25: Detectar Pensamiento.' }
+                        ]
+                    },
+                    {
+                        id: 'tiefling_glasya',
+                        nombre: 'Herencia de Glasya',
+                        mods: { cuspide: 'Sigilo', excelente: 'Engaño', bueno: 'Presencia', deficiente: 'Empatía', punto_ciego: 'Fe', critica: 'Represión' },
+                        perks: [
+                            { id: 'paso_enganoso', nombre: 'Paso Engañoso', desc: 'Tu poder de moneda para las habilidades de Evade aumenta en +3.' },
+                            { id: 'hechizos_glasya', nombre: 'Magia de Glasya', desc: 'Tu Alma es tu estadística de lanzamiento. Truco: Ilusión Menor. Nivel 15: Disfrazarse. Nivel 25: Invisibilidad.' }
+                        ]
+                    },
+                    {
+                        id: 'tiefling_fierna',
+                        nombre: 'Herencia de Fierna',
+                        mods: { cuspide: 'Carisma', excelente: 'Empatía', bueno: 'Seducción', deficiente: 'Represión', punto_ciego: 'Fe', critica: 'Prudencia' },
+                        perks: [
+                            { id: 'palabras_flegethos', nombre: 'Palabras de Flegethos', desc: 'Al ganar un Choque (Clash) de una habilidad ofensiva, el objetivo pierde 3 de SP.' },
+                            { id: 'hechizos_fierna', nombre: 'Magia de Fierna', desc: 'Tu Alma es tu estadística de lanzamiento. Truco: Amistad. Nivel 15: Encantar Persona. Nivel 25: Sugestión.' }
+                        ]
+                    },
+                    {
+                        id: 'tiefling_levistus',
+                        nombre: 'Herencia de Levistus',
+                        mods: { cuspide: 'Templanza', excelente: 'Presencia', bueno: 'Fortaleza', deficiente: 'Empatía', punto_ciego: 'Fe', critica: 'Agilidad' },
+                        perks: [
+                            { id: 'corazon_congelado', nombre: 'Corazón Congelado', desc: 'Cambias tu Resistencia Infernal de Fuego a Hielo. Si un enemigo te golpea, recibe +1 Cold Potency.' },
+                            { id: 'hechizos_levistus', nombre: 'Magia de Levistus', desc: 'Tu Alma es tu estadística de lanzamiento. Truco: Rayo de Hielo. Nivel 15: Armadura de Agathys. Nivel 25: Oscuridad.' }
+                        ]
+                    },
+                    {
+                        id: 'tiefling_mammon',
+                        nombre: 'Herencia de Mammon',
+                        mods: { cuspide: 'Negociación', excelente: 'Análisis', bueno: 'Prudencia', deficiente: 'Empatía', punto_ciego: 'Fe', critica: 'Seducción' },
+                        perks: [
+                            { id: 'manos_codiciosas', nombre: 'Manos Codiciosas', desc: 'Obtienes +2 Slots de Inventario Activo y +3 en tiradas de Manejo, robo o manipulación de cerraduras.' },
+                            { id: 'hechizos_mammon', nombre: 'Magia de Mammon', desc: 'Tu Alma es tu estadística de lanzamiento. Truco: Mano de Mago. Nivel 15: Disco Flotante. Nivel 25: Cerradura Arcana.' }
+                        ]
+                    },
+                    {
+                        id: 'tiefling_mefistofeles',
+                        nombre: 'Herencia de Mefistófeles',
+                        mods: { cuspide: 'Ciencia', excelente: 'Análisis', bueno: 'Presencia', deficiente: 'Empatía', punto_ciego: 'Fe', critica: 'Sigilo' },
+                        perks: [
+                            { id: 'hoja_llameante', nombre: 'Hoja Llameante', desc: 'Tus habilidades que cuesten SP para activarse ganan +1 Damage Up.' },
+                            { id: 'hechizos_mefistofeles', nombre: 'Magia de Mefistófeles', desc: 'Tu Alma es tu estadística de lanzamiento. Truco: Mano de Mago. Nivel 15: Manos Ardientes. Nivel 25: Filo Llameante.' }
+                        ]
+                    },
+                    {
+                        id: 'tiefling_zariel',
+                        nombre: 'Herencia de Zariel',
+                        mods: { cuspide: 'Vigor', excelente: 'Presencia', bueno: 'Fortaleza', deficiente: 'Empatía', punto_ciego: 'Fe', critica: 'Prudencia' },
+                        perks: [
+                            { id: 'golpe_marcador', nombre: 'Golpe Marcador', desc: 'Al inicio de tu turno, puedes aplicar 1 de Fragile a un enemigo a 5 ft.' },
+                            { id: 'hechizos_zariel', nombre: 'Magia de Zariel', desc: 'Tu Alma es tu estadística de lanzamiento. Truco: Taumaturgia. Nivel 15: Golpe Abrasador. Nivel 25: Golpe Marcador.' }
+                        ]
+                    }
+                ],
+                perks: [
+                    { id: 'vision_oscuridad', nombre: 'Visión en la Oscuridad', desc: 'Puedes ver en la oscuridad hasta 60 ft.' },
+                    { id: 'resistencia_infernal', nombre: 'Resistencia Infernal', desc: 'Tienes Resistencia al daño de Fuego.' }
+                ]
+            },
+            {
+                id: 'warforged',
+                nombre: 'Warforged',
+                isHuman: false,
+                perksSelection: 0,
+                subrazas: [
+                    {
+                        id: 'warforged_envoy',
+                        nombre: 'Modelo: Envoy',
+                        mods: { cuspide: 'Análisis', excelente: 'Manejo', bueno: 'Negociación', deficiente: 'Instinto', punto_ciego: 'Fe', critica: 'Empatía' },
+                        perks: [
+                            { id: 'diseno_especializado', nombre: 'Diseño Especializado', desc: 'Obtienes +3 de poder de check en una Habilidad a tu elección y en Manejo, y aprendes un idioma adicional.' },
+                            { id: 'herramienta_integrada', nombre: 'Herramienta Integrada', desc: 'Tu herramienta elegida está integrada en tu cuerpo. No ocupa Slots de Inventario Activo, siempre puedes usarla si tienes las manos libres y te da +3 en la tarea que fue diseñada.' }
+                        ]
+                    },
+                    {
+                        id: 'warforged_juggernaut',
+                        nombre: 'Modelo: Juggernaut',
+                        mods: { cuspide: 'Fortaleza', excelente: 'Vigor', bueno: 'Voluntad', deficiente: 'Agilidad', punto_ciego: 'Seducción', critica: 'Empatía' },
+                        perks: [
+                            { id: 'punos_hierro', nombre: 'Puños de Hierro', desc: 'Tu ataque Desarmado es de Poder Base 5 + Fortaleza y Poder de Moneda 6 + Fortaleza.' },
+                            { id: 'refuerzo_corporal', nombre: 'Refuerzo Corporal', desc: 'Tu armadura está integrada directamente. Obtienes +2 de Defense Level de forma pasiva y permanente.' }
+                        ]
+                    },
+                    {
+                        id: 'warforged_skirmisher',
+                        nombre: 'Modelo: Skirmisher',
+                        mods: { cuspide: 'Agilidad', excelente: 'Sigilo', bueno: 'Reflejos', deficiente: 'Carisma', punto_ciego: 'Presencia', critica: 'Empatía' },
+                        perks: [
+                            { id: 'veloz', nombre: 'Veloz', desc: 'Tu velocidad base aumenta a 35 ft., +2 Min Speed y +2 Max Speed.' },
+                            { id: 'reconocimiento_solitario', nombre: 'Reconocimiento Solitario', desc: 'Si no tienes aliados a 10 ft de ti, obtienes +2 de Haste en tu turno y +3 a tus checks de Sigilo.' }
+                        ]
+                    }
+                ],
+                perks: [
+                    { id: 'resistencia_warforged', nombre: 'Resistencia Warforged', desc: 'Eres inmune a los estados de Poison y Toxin, y a las enfermedades. No necesitas comer, beber ni dormir, y eres inmune a efectos de Sueño.' },
+                    { id: 'inactividad_centinela', nombre: 'Inactividad Centinela', desc: 'Durante un descanso largo, pareces apagado pero permaneces consciente, pudiendo ver y oír normalmente.' }
+                ]
+            },
+            {
+                id: 'felinae',
+                nombre: 'Felinae',
+                isHuman: false,
+                perksSelection: 0,
+                subrazas: [
+                    {
+                        id: 'felinae_ordinario',
+                        nombre: 'Felinae Ordinario',
+                        mods: { cuspide: 'Agilidad', excelente: 'Sigilo', bueno: 'Reflejos', deficiente: 'Fortaleza', punto_ciego: 'Represión', critica: 'Ciencia' },
+                        perks: [
+                            { id: 'ligero_pies', nombre: 'Ligero de Pies', desc: 'Tu velocidad base aumenta a 40 ft.' },
+                            { id: 'pisada_felina', nombre: 'Pisada Felina', desc: 'Obtienes +3 de poder de check en Sigilo.' },
+                            { id: 'nueve_vidas', nombre: 'Nueve Vidas', desc: 'Reduces un 70% el daño por caída.' }
+                        ]
+                    },
+                    {
+                        id: 'felinae_grande',
+                        nombre: 'Felinae Grande',
+                        mods: { cuspide: 'Vigor', excelente: 'Agilidad', bueno: 'Fortaleza', deficiente: 'Sigilo', punto_ciego: 'Memoria', critica: 'Ciencia' },
+                        perks: [
+                            { id: 'garras_grandes', nombre: 'Garras Grandes', desc: 'El daño de tus garras aumenta. Ahora tu ataque desarmado tiene Poder Base 6 + Fortaleza y Poder de Moneda 6 + Fortaleza.' },
+                            { id: 'cuerpo_poderoso', nombre: 'Cuerpo Poderoso', desc: 'Cuentas como una criatura Grande para cargar peso. Obtienes +5 Slots de Inventario Activo.' },
+                            { id: 'depredador_silencioso', nombre: 'Depredador Silencioso', desc: 'Obtienes +3 de poder de check en Sigilo.' }
+                        ]
+                    },
+                    {
+                        id: 'felinae_mistico',
+                        nombre: 'Felinae Místico',
+                        mods: { cuspide: 'Ciencia', excelente: 'Agilidad', bueno: 'Memoria', deficiente: 'Vigor', punto_ciego: 'Fortaleza', critica: 'Atletismo' },
+                        perks: [
+                            { id: 'misticismo_felino', nombre: 'Misticismo Felino', desc: 'Aprendes un Truco de tu elección. Tu Alma es tu estadística de lanzamiento.' },
+                            { id: 'estudiante_magia', nombre: 'Estudiante de la Magia', desc: 'Obtienes +3 de poder de check en Arcanos.' },
+                            { id: 'lenguaje_extra', nombre: 'Lenguaje Extra', desc: 'Aprendes un idioma adicional de tu elección.' }
+                        ]
+                    }
+                ],
+                perks: [
+                    { id: 'vision_oscuridad', nombre: 'Visión en la Oscuridad', desc: 'Puedes ver en la oscuridad hasta 60 ft.' },
+                    { id: 'garras_naturales', nombre: 'Garras Naturales', desc: 'Tu ataque desarmado es de daño Cortante. Tiene Poder Base 4 + Agilidad y Poder de Moneda 4 + Agilidad.' },
+                    { id: 'reflejos_felinos', nombre: 'Reflejos Felinos', desc: 'Obtienes +1 Min Speed y +1 Max Speed.' }
+                ]
+            },
+            {
+                id: 'semi_dragon',
+                nombre: 'Semi Dragón',
+                isHuman: false,
+                perksSelection: 0,
+                subrazas: [
+                    {
+                        id: 'semi_dragon_rojo',
+                        nombre: 'Ascendencia Roja (Fuego / Cono)',
+                        mods: { cuspide: 'Presencia', excelente: 'Vigor', bueno: 'Fortaleza', deficiente: 'Sigilo', punto_ciego: 'Agilidad', critica: 'Empatía' },
+                        perks: [
+                            { id: 'aliento_rojo', nombre: 'Aliento de Fuego (Cono)', desc: 'Área: Cono 15 ft. Poder Base: 12 + Alma. Poder de Moneda: 10. Estado: Burn.' },
+                            { id: 'sangre_roja', nombre: 'Sangre Roja', desc: 'Resistencia al daño de Fuego.' },
+                            { id: 'indomable', nombre: 'Indomable', desc: 'Eres inmune a estados que induzcan Miedo o Encantamiento.' }
+                        ]
+                    },
+                    {
+                        id: 'semi_dragon_negro',
+                        nombre: 'Ascendencia Negra (Ácido / Línea)',
+                        mods: { cuspide: 'Vigor', excelente: 'Fortaleza', bueno: 'Instinto', deficiente: 'Carisma', punto_ciego: 'Seducción', critica: 'Empatía' },
+                        perks: [
+                            { id: 'aliento_negro', nombre: 'Aliento de Ácido (Línea)', desc: 'Área: Línea. Poder Base: 14 + Alma. Poder de Moneda: 10. Estado: Acid.' },
+                            { id: 'sangre_negra', nombre: 'Sangre Negra', desc: 'Resistencia al daño de Ácido.' },
+                            { id: 'fuerza_implacable', nombre: 'Fuerza Implacable', desc: 'Añades tu Fortaleza al Poder de Moneda de tu Aliento de Dragón.' }
+                        ]
+                    },
+                    {
+                        id: 'semi_dragon_verde',
+                        nombre: 'Ascendencia Verde (Veneno / Cono)',
+                        mods: { cuspide: 'Engaño', excelente: 'Presencia', bueno: 'Perspicacia', deficiente: 'Vigor', punto_ciego: 'Fortaleza', critica: 'Fe' },
+                        perks: [
+                            { id: 'aliento_verde', nombre: 'Aliento de Veneno (Cono)', desc: 'Área: Cono 15 ft. Poder Base: 12 + Alma. Poder de Moneda: 10. Estado: Poison.' },
+                            { id: 'sangre_verde', nombre: 'Sangre Verde', desc: 'Resistencia al daño de Veneno.' },
+                            { id: 'embaucador_dotado', nombre: 'Embaucador Dotado', desc: 'Obtienes +3 en poder de check de Engaño. Aprendes el hechizo Disfrazarse.' }
+                        ]
+                    },
+                    {
+                        id: 'semi_dragon_blanco',
+                        nombre: 'Ascendencia Blanca (Hielo / Cono)',
+                        mods: { cuspide: 'Instinto', excelente: 'Vigor', bueno: 'Percepción', deficiente: 'Carisma', punto_ciego: 'Negociación', critica: 'Empatía' },
+                        perks: [
+                            { id: 'aliento_blanco', nombre: 'Aliento de Hielo (Cono)', desc: 'Área: Cono 15 ft. Poder Base: 12 + Alma. Poder de Moneda: 10. Estado: Cold.' },
+                            { id: 'sangre_blanca', nombre: 'Sangre Blanca', desc: 'Resistencia al daño de Hielo/Frío.' },
+                            { id: 'cazador_habil', nombre: 'Cazador Hábil', desc: 'Obtienes +3 en poder de check de Supervivencia. En tu turno, en Choques con objetivos con menor Speed obtienes +1 Damage Up.' }
+                        ]
+                    },
+                    {
+                        id: 'semi_dragon_azul',
+                        nombre: 'Ascendencia Azul (Eléctrico / Línea)',
+                        mods: { cuspide: 'Sigilo', excelente: 'Vigor', bueno: 'Agilidad', deficiente: 'Empatía', punto_ciego: 'Fe', critica: 'Ciencia' },
+                        perks: [
+                            { id: 'aliento_azul', nombre: 'Aliento Eléctrico (Línea)', desc: 'Área: Línea. Poder Base: 14 + Alma. Poder de Moneda: 10. Estado: Shock.' },
+                            { id: 'sangre_azul', nombre: 'Sangre Azul', desc: 'Resistencia al daño Eléctrico.' },
+                            { id: 'depredador_desierto', nombre: 'Depredador del Desierto', desc: 'Obtienes velocidad de excavar (15 ft) en tierra suelta. Enemigos tienen -8 a Percepción para detectarte si estás enterrado.' }
+                        ]
+                    },
+                    {
+                        id: 'semi_dragon_oro',
+                        nombre: 'Ascendencia Oro (Fuego / Cono)',
+                        mods: { cuspide: 'Perspicacia', excelente: 'Presencia', bueno: 'Fe', deficiente: 'Sigilo', punto_ciego: 'Engaño', critica: 'Agilidad' },
+                        perks: [
+                            { id: 'aliento_oro', nombre: 'Aliento de Fuego (Cono)', desc: 'Área: Cono 15 ft. Poder Base: 12 + Alma. Poder de Moneda: 10. Estado: Burn. (Inflige daño Radiante contra Demonios y No-Muertos).' },
+                            { id: 'sangre_dorada', nombre: 'Sangre Dorada', desc: 'Resistencia al daño de Fuego.' },
+                            { id: 'companero_reservado', nombre: 'Compañero Reservado', desc: 'Obtienes +3 en poder de check de Instinto.' }
+                        ]
+                    },
+                    {
+                        id: 'semi_dragon_laton',
+                        nombre: 'Ascendencia Latón (Fuego / Línea)',
+                        mods: { cuspide: 'Negociación', excelente: 'Carisma', bueno: 'Presencia', deficiente: 'Fortaleza', punto_ciego: 'Vigor', critica: 'Sigilo' },
+                        perks: [
+                            { id: 'aliento_laton', nombre: 'Aliento de Fuego (Línea)', desc: 'Área: Línea. Poder Base: 14 + Alma. Poder de Moneda: 10. Estado: Burn.' },
+                            { id: 'sangre_laton', nombre: 'Sangre de Latón', desc: 'Resistencia al daño de Fuego.' },
+                            { id: 'audazmente_hablador', nombre: 'Audazmente Hablador', desc: 'Obtienes +3 en poder de check de Negociación. Eres inmune a ser puesto a dormir mágicamente.' }
+                        ]
+                    },
+                    {
+                        id: 'semi_dragon_cobre',
+                        nombre: 'Ascendencia Cobre (Ácido / Línea)',
+                        mods: { cuspide: 'Carisma', excelente: 'Engaño', bueno: 'Agilidad', deficiente: 'Fortaleza', punto_ciego: 'Vigor', critica: 'Represión' },
+                        perks: [
+                            { id: 'aliento_cobre', nombre: 'Aliento de Ácido (Línea)', desc: 'Área: Línea. Poder Base: 14 + Alma. Poder de Moneda: 10. Estado: Acid.' },
+                            { id: 'sangre_cobre', nombre: 'Sangre de Cobre', desc: 'Resistencia al daño de Ácido.' },
+                            { id: 'anfitrion_jugueton', nombre: 'Anfitrión Juguetón', desc: 'Obtienes +3 en poder de check de Carisma. Aprendes el truco Burla Viciosa.' }
+                        ]
+                    },
+                    {
+                        id: 'semi_dragon_bronce',
+                        nombre: 'Ascendencia Bronce (Eléctrico / Línea)',
+                        mods: { cuspide: 'Fortaleza', excelente: 'Vigor', bueno: 'Atletismo', deficiente: 'Sigilo', punto_ciego: 'Engaño', critica: 'Agilidad' },
+                        perks: [
+                            { id: 'aliento_bronce', nombre: 'Aliento Eléctrico (Línea)', desc: 'Área: Línea. Poder Base: 14 + Alma. Poder de Moneda: 10. Estado: Shock.' },
+                            { id: 'sangre_bronce', nombre: 'Sangre de Bronce', desc: 'Resistencia al daño Eléctrico.' },
+                            { id: 'dragon_costa', nombre: 'Dragón de la Costa', desc: 'Puedes respirar bajo el agua y tienes velocidad de nado de 30 ft.' }
+                        ]
+                    },
+                    {
+                        id: 'semi_dragon_plata',
+                        nombre: 'Ascendencia Plata (Hielo / Cono)',
+                        mods: { cuspide: 'Templanza', excelente: 'Presencia', bueno: 'Análisis', deficiente: 'Sigilo', punto_ciego: 'Engaño', critica: 'Agilidad' },
+                        perks: [
+                            { id: 'aliento_plata', nombre: 'Aliento Paralizante (Cono)', desc: 'Área: Cono 15 ft. Poder Base: 12 + Alma. Poder de Moneda: 10. Estado: Cold. (En lugar de daño y estado normal, puedes soltar gas que aplica +8 Paralysis Count a los afectados).' },
+                            { id: 'sangre_plateada', nombre: 'Sangre Plateada', desc: 'Resistencia al daño de Hielo/Frío.' }
+                        ]
+                    }
+                ],
+                perks: [
+                    { id: 'vision_oscuridad', nombre: 'Visión en la Oscuridad', desc: 'Puedes ver en la oscuridad hasta 60 ft.' },
+                    { id: 'aliento_dragon_base', nombre: 'Aliento de Dragón', desc: 'Una vez por descanso largo, gastas 1 Slot de Acción para exhalar tu elemento. Reciben 10 de daño fijo de tu elemento y aplicas +3 Potency y +2 Count del estado asociado. Usa 1 Red Coin (Las estadísticas exactas y la forma dependen de tu ascendencia).' }
+                ]
+            },
+            {
+                id: 'lupae',
+                nombre: 'Lupae',
+                isHuman: false,
+                perksSelection: 0,
+                mods: { cuspide: 'Fortaleza', excelente: 'Percepción', bueno: 'Instinto', deficiente: 'Seducción', punto_ciego: 'Engaño', critica: 'Ciencia' },
+                perks: [
+                    { id: 'vision_oscuridad', nombre: 'Visión en la Oscuridad', desc: 'Puedes ver en la oscuridad hasta 60 ft.' },
+                    { id: 'sentidos_agudos', nombre: 'Sentidos Agudos', desc: 'Obtienes +3 de poder de check en Percepción que involucren el olfato o el oído.' },
+                    { id: 'dureza_canis', nombre: 'Dureza Canis', desc: 'Eres resistente al daño de Veneno y a las enfermedades.' },
+                    { id: 'colmillos', nombre: 'Colmillos', desc: 'Tu ataque desarmado hace daño Perforante. Tiene Poder Base 4 + Fortaleza y Poder de Moneda 4 + Fortaleza. Si el objetivo es de tamaño menor que tú y le asestas un golpe, le aplicas 10 de Bind.' },
+                    { id: 'tactica_manada', nombre: 'Táctica de Manada', desc: 'Si tienes aliados a 5 ft del objetivo, obtienes +1 Clash Power Up por aliado cercano (Max 3).' }
+                ]
+            },
+            {
+                id: 'moonfae',
+                nombre: 'Moonfae',
+                isHuman: false,
+                perksSelection: 0,
+                subrazas: [
+                    {
+                        id: 'moonfae_llena',
+                        nombre: 'Ciclo: Luna Llena',
+                        mods: { cuspide: 'Presencia', excelente: 'Fortaleza', bueno: 'Vigor', deficiente: 'Agilidad', punto_ciego: 'Sigilo', critica: 'Ciencia' },
+                        perks: [
+                            { id: 'cuerpo_poderoso', nombre: 'Cuerpo Poderoso', desc: 'Cuentas como una criatura Grande. Eres inmune a estados que induzcan Miedo.' },
+                            { id: 'estocada', nombre: 'Estocada', desc: 'Si no te moviste en el turno anterior, tus ataques cuerpo a cuerpo obtienen +5 ft. de alcance y +3 Offensive Level Up.' }
+                        ]
+                    },
+                    {
+                        id: 'moonfae_creciente',
+                        nombre: 'Ciclo: Luna Creciente',
+                        mods: { cuspide: 'Agilidad', excelente: 'Reflejos', bueno: 'Cardio', deficiente: 'Fortaleza', punto_ciego: 'Vigor', critica: 'Ciencia' },
+                        perks: [
+                            { id: 'rapido', nombre: 'Rápido', desc: 'Tu velocidad base aumenta a 35 ft y +1 Min/Max Speed.' },
+                            { id: 'escape_agil', nombre: 'Escape Ágil', desc: 'Como reacción cuando un enemigo te hace un unopposed attack, usas Evade y obtienes +1 Defense Power Up (Max 3).' }
+                        ]
+                    },
+                    {
+                        id: 'moonfae_nueva',
+                        nombre: 'Ciclo: Luna Nueva',
+                        mods: { cuspide: 'Perspicacia', excelente: 'Empatía', bueno: 'Sigilo', deficiente: 'Presencia', punto_ciego: 'Vigor', critica: 'Fortaleza' },
+                        perks: [
+                            { id: 'magia_lunar', nombre: 'Magia Lunar', desc: 'Tu Alma es tu estadística de lanzamiento. Nivel 15: Detectar Magia. Nivel 25: Rayo Lunar.' },
+                            { id: 'empatia', nombre: 'Empatía', desc: 'Con un Slot de Acción, tocas a una criatura. Puedes restaurarle 7 SP o hacerle perder 7 SP basándote en su estado emocional.' }
+                        ]
+                    },
+                    {
+                        id: 'moonfae_carmesi',
+                        nombre: 'Ciclo: Luna Carmesí',
+                        mods: { cuspide: 'Engaño', excelente: 'Fe', bueno: 'Instinto', deficiente: 'Empatía', punto_ciego: 'Prudencia', critica: 'Fortaleza' },
+                        perks: [
+                            { id: 'magia_mas_alla', nombre: 'Magia del Más Allá', desc: 'Tu Alma es tu estadística de lanzamiento. Nivel 15: Brazos de Hadar. Nivel 25: Hoja de Sombras.' },
+                            { id: 'conocimiento_inquietante', nombre: 'Conocimiento Inquietante', desc: 'Al inicio de tu turno, puedes aplicar 4 de Defense Level Down a un enemigo a 15 ft.' }
+                        ]
+                    },
+                    {
+                        id: 'moonfae_azul',
+                        nombre: 'Ciclo: Luna Azul',
+                        mods: { cuspide: 'Carisma', excelente: 'Perspicacia', bueno: 'Voluntad', deficiente: 'Vigor', punto_ciego: 'Atletismo', critica: 'Fortaleza' },
+                        perks: [
+                            { id: 'suerte_conejo', nombre: 'Suerte del Conejo', desc: 'Después de un descanso largo, obtienes 3 usos de Suerte Adicionales (el Máximo de Suerte pasa a 9). Puedes gastar 1 uso para sumar +3 al poder final de un check tuyo o de un aliado a 10 ft.' },
+                            { id: 'accion_favorable', nombre: 'Acción Favorable', desc: 'Puedes aplicar +2 Attack Power Up o +2 Defense Power Up a un aliado en tu turno usando 1 punto de tu suerte.' }
+                        ]
+                    }
+                ],
+                perks: [
+                    { id: 'vision_oscuridad', nombre: 'Visión en la Oscuridad', desc: 'Puedes ver en la oscuridad hasta 60 ft.' },
+                    { id: 'audicion_aguda', nombre: 'Audición Aguda', desc: 'Obtienes +3 de poder de check en Percepción que involucren el oído.' },
+                    { id: 'magia_moonfae', nombre: 'Magia Moonfae', desc: 'Aprendes el truco Taumaturgia. Tu Alma es tu estadística de lanzamiento.' },
+                    { id: 'transformacion_lunar', nombre: 'Transformación Lunar', desc: 'Gastas 1 Slot de Acción para tomar la forma de un conejo pequeño (tu equipo desaparece temporalmente). Tu velocidad aumenta a 40 ft y obtienes +2 Min Speed y +2 Max Speed, obtienes +6 en Percepción, pero sufres -6 en checks de Fortaleza.' }
+                ]
+            },
+            {
+                id: 'undae',
+                nombre: 'Undae',
+                isHuman: false,
+                perksSelection: 0,
+                subrazas: [
+                    {
+                        id: 'undae_guerra',
+                        nombre: 'Undae de Guerra',
+                        mods: { cuspide: 'Vigor', excelente: 'Atletismo', bueno: 'Presencia', deficiente: 'Engaño', punto_ciego: 'Ciencia', critica: 'Seducción' },
+                        perks: [
+                            { id: 'entrenamiento_marcial', nombre: 'Entrenamiento Marcial', desc: 'Obtienes +1 al poder base de espadas largas, cortas, lanzas o arcos largos.' },
+                            { id: 'tenacidad_acuatica', nombre: 'Tenacidad Acuática', desc: 'Tu velocidad de nado es de 60 ft.' },
+                            { id: 'intimidacion_natural', nombre: 'Intimidación Natural', desc: 'Obtienes +3 de poder de check en Presencia.' }
+                        ]
+                    },
+                    {
+                        id: 'undae_roca',
+                        nombre: 'Undae de Roca',
+                        mods: { cuspide: 'Fortaleza', excelente: 'Voluntad', bueno: 'Templanza', deficiente: 'Agilidad', punto_ciego: 'Reflejos', critica: 'Carisma' },
+                        perks: [
+                            { id: 'piel_gruesa', nombre: 'Piel Gruesa', desc: 'Tienes Resistencia al daño Cortante pero eres débil al Perforante.' },
+                            { id: 'paso_estable', nombre: 'Paso Estable', desc: 'Obtienes +2 Defense Level Up pasivo, y tu Poder de Moneda de Guard aumenta en +5.' },
+                            { id: 'tenazas', nombre: 'Tenaza/s', desc: 'Tu ataque Desarmado hace daño Perforante. Tiene un Poder Base y Poder de Moneda de 4 + Fortaleza. Al golpear a un objetivo aplicas +3 de Bind.' }
+                        ]
+                    },
+                    {
+                        id: 'undae_mistico',
+                        nombre: 'Undae Místico',
+                        mods: { cuspide: 'Empatía', excelente: 'Carisma', bueno: 'Fe', deficiente: 'Vigor', punto_ciego: 'Atletismo', critica: 'Presencia' },
+                        perks: [
+                            { id: 'magia_anfibia', nombre: 'Magia Anfibia', desc: 'Aprendes los trucos Magia Druídica y Controlar Agua. Tu Alma es tu estadística de lanzamiento.' },
+                            { id: 'aura_reconfortante', nombre: 'Aura Reconfortante', desc: 'Gasta un Slot de Acción para curar 15 HP a un aliado.' },
+                            { id: 'presencia_calmante', nombre: 'Presencia Calmante', desc: 'Obtienes +3 en poder de check de Negociación cuando hablas con criaturas heridas o con el SP negativo.' }
+                        ]
+                    },
+                    {
+                        id: 'undae_silvestre',
+                        nombre: 'Undae Silvestre',
+                        mods: { cuspide: 'Instinto', excelente: 'Sigilo', bueno: 'Empatía', deficiente: 'Manejo', punto_ciego: 'Análisis', critica: 'Represión' },
+                        perks: [
+                            { id: 'lengua_selva', nombre: 'Lengua de la Selva', desc: 'Puedes comunicarte con bestias y plantas.' },
+                            { id: 'paso_silencioso', nombre: 'Paso Silencioso', desc: 'Obtienes +3 en poder de check de Sigilo en terreno natural.' },
+                            { id: 'amigo_vida', nombre: 'Amigo de la Vida', desc: 'Cuando curas a un aliado o lo estabilizas, ese aliado obtiene +3 HP Healing Up para el resto de la ronda.' }
+                        ]
+                    }
+                ],
+                perks: [
+                    { id: 'vision_oscuridad', nombre: 'Visión en la Oscuridad', desc: 'Puedes ver en la oscuridad hasta 60 ft.' },
+                    { id: 'anfibio', nombre: 'Anfibio', desc: 'Puedes respirar tanto aire como agua.' },
+                    { id: 'inmunidad_veneno', nombre: 'Inmunidad al Veneno', desc: 'Eres inmune al daño de Veneno.' },
+                    { id: 'regeneracion_undae', nombre: 'Regeneración Undae', desc: 'Al comienzo de la Ronda, recuperas un 5% de tu HP Máximo si no recibiste daño de Fuego o Ácido en la Ronda anterior. (No funciona si tu HP llega a 0).' }
+                ]
+            },
+            {
+                id: 'elnae',
+                nombre: 'Elnae',
+                isHuman: false,
+                perksSelection: 0,
+                mods: { cuspide: 'Agilidad', excelente: 'Percepción', bueno: 'Cardio', deficiente: 'Represión', punto_ciego: 'Vigor', critica: 'Fortaleza' },
+                perks: [
+                    { id: 'vision_oscuridad', nombre: 'Visión en la Oscuridad', desc: 'Puedes ver en la oscuridad hasta 60 ft.' },
+                    { id: 'vuelo_elnae', nombre: 'Vuelo', desc: 'Tu velocidad de vuelo es de 50 ft. No puedes llevar armaduras medianas para usar esta habilidad.' },
+                    { id: 'huesos_fragiles', nombre: 'Huesos Ligeros y Frágiles', desc: 'No puedes usar ni obtener competencia en armaduras pesadas y tus Threshold aumentan un 10%, Evade +3 en suelo y +6 al volar.' },
+                    { id: 'parte_naturaleza', nombre: 'Parte de la Naturaleza', desc: 'Aprendes el truco Magia Druídica. Tu Alma es tu estadística de lanzamiento. A Nivel 15 aprendes Enredar. A Nivel 25 aprendes Crecimiento de Espinas.' }
+                ]
+            },
+            {
+                id: 'yuanti_pura_sangre',
+                nombre: 'Yuan-ti Pura Sangre',
+                isHuman: false,
+                perksSelection: 0,
+                subrazas: [
+                    {
+                        id: 'yuanti_rojo',
+                        nombre: 'Ojos Rojos (Ira)',
+                        mods: { cuspide: 'Vigor', excelente: 'Atletismo', bueno: 'Reflejos', deficiente: 'Templanza', punto_ciego: 'Empatía', critica: 'Fe' },
+                        perks: [
+                            { id: 'furia_fria', nombre: 'Furia Fría', desc: 'Permite contraatacar con una reacción.' },
+                            { id: 'bono_ira', nombre: 'Instinto Agresivo', desc: 'Obtienes +3 en Fortaleza y Agilidad.' }
+                        ]
+                    },
+                    {
+                        id: 'yuanti_morado',
+                        nombre: 'Ojos Morados (Envidia)',
+                        mods: { cuspide: 'Engaño', excelente: 'Análisis', bueno: 'Percepción', deficiente: 'Voluntad', punto_ciego: 'Fe', critica: 'Empatía' },
+                        perks: [
+                            { id: 'magia_envidia', nombre: 'Mente Codiciosa', desc: 'Tienes acceso a Detectar Magia.' },
+                            { id: 'bono_envidia', nombre: 'Aprendiz Veloz', desc: 'Obtienes +3 en Engaño o Arcana.' }
+                        ]
+                    },
+                    {
+                        id: 'yuanti_cyan',
+                        nombre: 'Ojos Cyan (Melancolía)',
+                        mods: { cuspide: 'Voluntad', excelente: 'Templanza', bueno: 'Perspicacia', deficiente: 'Vigor', punto_ciego: 'Fe', critica: 'Empatía' },
+                        perks: [
+                            { id: 'magia_melancolia', nombre: 'Ecos de la Antigüedad', desc: 'Puedes lanzar Santuario.' },
+                            { id: 'bono_melancolia', nombre: 'Influencia Sutil', desc: 'Obtienes +3 a Negociación.' }
+                        ]
+                    },
+                    {
+                        id: 'yuanti_azul',
+                        nombre: 'Ojos Azules (Orgullo)',
+                        mods: { cuspide: 'Memoria', excelente: 'Presencia', bueno: 'Represión', deficiente: 'Agilidad', punto_ciego: 'Fe', critica: 'Empatía' },
+                        perks: [
+                            { id: 'magia_orgullo', nombre: 'Escudo del Linaje', desc: 'Tienes acceso al conjuro Escudo.' },
+                            { id: 'bono_orgullo', nombre: 'Memoria Heráldica', desc: 'Ganan +3 en Historia y dos idiomas.' }
+                        ]
+                    },
+                    {
+                        id: 'yuanti_verde',
+                        nombre: 'Ojos Verdes (Gula)',
+                        mods: { cuspide: 'Percepción', excelente: 'Análisis', bueno: 'Instinto', deficiente: 'Templanza', punto_ciego: 'Fe', critica: 'Empatía' },
+                        perks: [
+                            { id: 'impulso_voraz', nombre: 'Impulso Voraz', desc: 'Recuperas 5 de HP y SP al derrotar a una criatura.' },
+                            { id: 'bono_gula', nombre: 'Rapiñar Conocimientos', desc: 'Suman +3 a Investigación o Percepción.' }
+                        ]
+                    },
+                    {
+                        id: 'yuanti_naranja',
+                        nombre: 'Ojos Naranjas (Lujuria)',
+                        mods: { cuspide: 'Ciencia', excelente: 'Memoria', bueno: 'Análisis', deficiente: 'Prudencia', punto_ciego: 'Fe', critica: 'Empatía' },
+                        perks: [
+                            { id: 'magia_lujuria', nombre: 'Revelación Prohibida', desc: 'Puedes lanzar Identificar.' },
+                            { id: 'bono_lujuria', nombre: 'Obsesión Brillante', desc: 'Suman +3 a Arcana o Lore.' }
+                        ]
+                    },
+                    {
+                        id: 'yuanti_amarillo',
+                        nombre: 'Ojos Amarillos (Pereza)',
+                        mods: { cuspide: 'Análisis', excelente: 'Presencia', bueno: 'Negociación', deficiente: 'Cardio', punto_ciego: 'Fe', critica: 'Empatía' },
+                        perks: [
+                            { id: 'magia_pereza', nombre: 'Dominio Táctico', desc: 'Puedes lanzar Orden Imperiosa.' },
+                            { id: 'bono_pereza', nombre: 'Optimización Letal', desc: 'Obtienen +3 en Negociación o Presencia.' }
+                        ]
+                    },
+                    {
+                        id: 'yuanti_palido',
+                        nombre: 'Los Pálidos (Mutaciones Empáticas)',
+                        mods: { cuspide: 'Empatía', excelente: 'Perspicacia', bueno: 'Manejo', deficiente: 'Represión', punto_ciego: 'Voluntad', critica: 'Presencia' },
+                        perks: [
+                            { id: 'magia_palido', nombre: 'Empatía Latente', desc: 'Puedes lanzar Calmar Emociones.' },
+                            { id: 'bono_palido', nombre: 'Chispa de Sentir', desc: 'Suman +3 a Perspicacia y obtienen +2 a una habilidad a elección.' }
+                        ]
+                    }
+                ],
+                perks: [
+                    { id: 'vision_oscuridad', nombre: 'Visión en la Oscuridad', desc: 'Tienes visión en la oscuridad hasta 60 pies.' },
+                    { id: 'inmunidad_veneno', nombre: 'Inmunidad al Veneno', desc: 'Posees inmunidad total al daño por veneno.' },
+                    { id: 'magia_innata', nombre: 'Magia Innata', desc: 'Conoces el truco Espray Venenoso y Amistad Animal (las serpientes tienen -9 al salvar). Al nivel 15 obtienes Sugestión. Alma es tu atributo de lanzamiento.' },
+                    { id: 'resistencia_magica', nombre: 'Resistencia Mágica', desc: 'Tienes ventaja en las tiradas de salvación contra magia.' }
+                ]
+            },
+            {
+                id: 'lanae',
+                nombre: 'Lanae',
+                isHuman: false,
+                perksSelection: 0,
+                mods: { cuspide: 'Empatía', excelente: 'Vigor', bueno: 'Templanza', deficiente: 'Engaño', punto_ciego: 'Manejo', critica: 'Presencia' },
+                perks: [
+                    {
+                        id: 'velocidad_lanae',
+                        nombre: 'Montañés',
+                        desc: 'Tu velocidad de desplazamiento es de 30 ft. Además, tienes una velocidad de escalada de 30 ft.'
+                    },
+                    {
+                        id: 'magia_lanae',
+                        nombre: 'Magia Lanae',
+                        desc: 'Puedes lanzar el conjuro Calmar Emociones una vez por descanso largo sin gastar espacio de conjuro. Tu Alma es tu estadística de lanzamiento. Además, la magia no puede hacer que te duermas.'
+                    },
+                    {
+                        id: 'resiliencia_comunitaria',
+                        nombre: 'Resiliencia Comunitaria',
+                        desc: 'Si fallas un check o tirada de salvación, puedes apoyarte en tus lazos para obtener una bonificación a la tirada igual al número de aliados que puedas ver en un radio de 30 ft (máximo bonificación de +5). Puedes usar este rasgo 5 Veces por descanso largo.'
+                    },
+                    {
+                        id: 'nacido_montana',
+                        nombre: 'Nacido en la Montaña',
+                        desc: 'Tienes Resistencia al daño de Hielo/Frío y estás aclimatado a altitudes elevadas.'
+                    },
+                    {
+                        id: 'cuernos_lanae',
+                        nombre: 'Cuernos',
+                        desc: 'Tus cuernos son armas naturales de combate cuerpo a cuerpo. Tu ataque desarmado hace daño Contundente, tiene Poder Base 4 + Fortaleza y Poder de Moneda 4 + Fortaleza.'
+                    }
+                ]
+            },
+            {
+                id: 'tsune',
+                nombre: 'Tsune',
+                isHuman: false,
+                perksSelection: 0,
+                mods: { cuspide: 'Engaño', excelente: 'Agilidad', bueno: 'Seducción', deficiente: 'Vigor', punto_ciego: 'Prudencia', critica: 'Fortaleza' },
+                perks: [
+                    {
+                        id: 'vision_oscuridad',
+                        nombre: 'Visión en la Oscuridad',
+                        desc: 'Puedes ver en la oscuridad hasta 60 ft.'
+                    },
+                    {
+                        id: 'naturaleza_enganosa',
+                        nombre: 'Naturaleza Engañosa',
+                        desc: 'Eres un maestro de las medias verdades. Obtienes +3 de poder de check en Engaño.'
+                    },
+                    {
+                        id: 'magia_tsune',
+                        nombre: 'Magia de Tsune',
+                        desc: 'Aprendes el truco Ilusión Menor. A nivel 15 aprendes Disfrazarse. A nivel 25 aprendes Invisibilidad. Tu Alma es tu estadística de lanzamiento.'
+                    },
+                    {
+                        id: 'forma_vulpina',
+                        nombre: 'Forma Vulpina',
+                        desc: 'Gastas 1 Slot de Acción para transformarte en un zorro pequeño. Velocidad 40 ft y +2 Min/Max Speed. Obtienes +6 en checks de Sigilo, pero sufres -6 en checks de Fortaleza.'
+                    },
+                    {
+                        id: 'fuego_fatuo',
+                        nombre: 'Fuego Fatuo',
+                        desc: 'Ataque mágico a 30 ft. Poder Base 4 + Alma y Poder de Moneda 5 + Alma. Al golpear, infliges daño de Fuego y aplicas +2 Burn Count.'
+                    }
+                ]
+            }
+        ];
+
+        const modValues = {
+            cuspide: { label: 'Cúspide', val: 3, class: 'stat-val-pos' },
+            excelente: { label: 'Excelente', val: 2, class: 'stat-val-pos' },
+            bueno: { label: 'Bueno', val: 1, class: 'stat-val-pos' },
+            deficiente: { label: 'Deficiente', val: -1, class: 'stat-val-neg' },
+            punto_ciego: { label: 'Punto Ciego', val: -2, class: 'stat-val-neg' },
+            critica: { label: 'Crítica', val: -3, class: 'stat-val-neg' }
+        };
+
+        // 4. Estado Global
+        const luminousState = {
+            originId: null,
+            subraceId: null,
+            modifiers: {}, // Mods de atributos (Vigor, etc.)
+            humanPerks: [],
+            baseStats: { cuerpo: 0, mente: 0, alma: 0 } // Stats principales
+        };
+
+        function renderOrigins() {
+            if (!gridContainer) return;
+            gridContainer.innerHTML = '';
+
+            let optionsHtml = '<option value="" disabled selected>Selecciona Atributo</option>';
+            atributosLista.forEach(attr => {
+                optionsHtml += `<option value="${attr}">${attr}</option>`;
+            });
+
+            racesData.forEach(raza => {
+                const card = document.createElement('div');
+                card.className = 'origin-card';
+                card.dataset.id = raza.id;
+
+                let bodyHtml = '';
+
+                if (raza.isHuman) {
+                    let selectsHtml = '';
+                    for (const [key, data] of Object.entries(modValues)) {
+                        const sign = data.val > 0 ? '+' : '';
+                        selectsHtml += `
+                            <div class="human-select-row">
+                                <label>
+                                    <span>${data.label}</span>
+                                    <span class="${data.class}">${sign}${data.val}</span>
+                                </label>
+                                <select class="choice-select human-mod-select" data-mod="${key}">
+                                    ${optionsHtml}
+                                </select>
+                            </div>
+                        `;
+                    }
+
+                    let perksOptionsHtml = '<option value="" disabled selected>Selecciona Perk</option>';
+                    if (raza.perks) {
+                        raza.perks.forEach(p => {
+                            perksOptionsHtml += `<option value="${p.id}">${p.nombre}</option>`;
+                        });
+                    }
+
+                    let perksSelectsHtml = '';
+                    if (raza.perksSelection) {
+                        for (let i = 0; i < raza.perksSelection; i++) {
+                            perksSelectsHtml += `
+                                <div class="human-select-row" style="margin-top: 10px; display: block;">
+                                    <select class="choice-select human-perk-select" data-index="${i}" style="width: 100%;">
+                                        ${perksOptionsHtml}
+                                    </select>
+                                    <div class="perk-desc" id="human-perk-desc-${i}" style="font-size: 11px; color: var(--text-muted); margin-top: 4px; display: none;"></div>
+                                </div>
+                            `;
+                        }
+                    }
+
+                    bodyHtml = `
+                        <div class="stats-box">
+                            <div style="font-size: 13px; color: var(--text-muted); text-align: center; margin-bottom: 5px;">Personaliza tus atributos</div>
+                            <div class="human-selects">
+                                ${selectsHtml}
+                            </div>
+                            <div style="font-size: 13px; color: var(--text-muted); text-align: center; margin-top: 15px; margin-bottom: 5px; border-top: 1px dashed #444; padding-top: 10px;">Elige ${raza.perksSelection || 0} Perks</div>
+                            <div class="human-perk-selects">
+                                ${perksSelectsHtml}
+                            </div>
+                            <div class="human-error-msg" id="human-error" style="margin-top: 10px;">Hay opciones repetidas o sin seleccionar.</div>
+                        </div>
+                    `;
+                } else if (raza.subrazas) {
+                    let subraceOptions = '<option value="" disabled selected>Selecciona Subraza</option>';
+                    raza.subrazas.forEach(sr => {
+                        subraceOptions += `<option value="${sr.id}">${sr.nombre}</option>`;
+                    });
+
+                    let perksHtml = '';
+                    if (raza.perks) {
+                        perksHtml = `<div class="trait-box" style="margin-top: 15px; border-top: 1px dashed #444; padding-top: 10px;">`;
+                        raza.perks.forEach(p => {
+                            perksHtml += `
+                                <div style="margin-bottom: 8px;">
+                                    <div class="trait-title">${p.nombre}</div>
+                                    <div class="trait-desc">${p.desc}</div>
+                                </div>
+                            `;
+                        });
+                        perksHtml += `</div>`;
+                    }
+
+                    bodyHtml = `
+                        <div class="stats-box">
+                            <div class="subrace-container">
+                                <select class="choice-select subrace-select" data-race="${raza.id}">
+                                    ${subraceOptions}
+                                </select>
+                                <div class="subrace-stats-display" style="margin-top: 10px; display: grid; gap: 8px;"></div>
+                            </div>
+                        </div>
+                        ${perksHtml}
+                    `;
+                } else {
+                    let statsHtml = '';
+                    for (const [key, attrName] of Object.entries(raza.mods)) {
+                        const data = modValues[key];
+                        const sign = data.val > 0 ? '+' : '';
+                        statsHtml += `
+                            <div class="stat-row">
+                                <div class="stat-col">
+                                    <span class="stat-name-label">${data.label}</span>
+                                    <span class="stat-label">${attrName}</span>
+                                </div>
+                                <span class="${data.class}">${sign}${data.val}</span>
+                            </div>
+                        `;
+                    }
+
+                    let perksHtml = '';
+                    if (raza.perks) {
+                        perksHtml = `<div class="trait-box" style="margin-top: 15px; border-top: 1px dashed #444; padding-top: 10px;">`;
+                        raza.perks.forEach(p => {
+                            perksHtml += `
+                                <div style="margin-bottom: 8px;">
+                                    <div class="trait-title">${p.nombre}</div>
+                                    <div class="trait-desc">${p.desc}</div>
+                                </div>
+                            `;
+                        });
+                        perksHtml += `</div>`;
+                    }
+
+                    bodyHtml = `
+                        <div class="stats-box">
+                            ${statsHtml}
+                        </div>
+                        ${perksHtml}
+                    `;
+                }
+
+                card.innerHTML = `
+                    <div class="card-header">
+                        <h2>${raza.nombre}</h2>
+                    </div>
+                    <div class="card-body">
+                        ${bodyHtml}
+                    </div>
+                `;
+
+                card.addEventListener('click', (e) => {
+                    if (e.target.tagName === 'SELECT' || e.target.tagName === 'OPTION') return;
+                    seleccionarOrigen(raza.id);
+                });
+
+                gridContainer.appendChild(card);
+            });
+
+            gridContainer.addEventListener('change', (e) => {
+                if (e.target.classList.contains('human-mod-select') || e.target.classList.contains('human-perk-select')) {
+                    if (e.target.classList.contains('human-perk-select')) {
+                        const index = e.target.dataset.index;
+                        const descDiv = document.getElementById(`human-perk-desc-${index}`);
+                        const humanRace = racesData.find(r => r.id === 'humano');
+                        const perkData = humanRace.perks.find(p => p.id === e.target.value);
+                        if (perkData && descDiv) {
+                            descDiv.textContent = perkData.desc;
+                            descDiv.style.display = 'block';
+                        }
+                    }
+                    validarHumano();
+                } else if (e.target.classList.contains('subrace-select')) {
+                    const raceId = e.target.dataset.race;
+                    const subraceId = e.target.value;
+                    mostrarStatsSubraza(raceId, subraceId, e.target.nextElementSibling);
+                    validarOrigenConSubraza();
+                }
+            });
+        }
+
+        function mostrarStatsSubraza(raceId, subraceId, displayDiv) {
+            const raza = racesData.find(r => r.id === raceId);
+            const subraza = raza.subrazas.find(sr => sr.id === subraceId);
+            let statsHtml = '';
+            for (const [key, attrName] of Object.entries(subraza.mods)) {
+                const data = modValues[key];
+                const sign = data.val > 0 ? '+' : '';
+                statsHtml += `
+                    <div class="stat-row">
+                        <div class="stat-col">
+                            <span class="stat-name-label">${data.label}</span>
+                            <span class="stat-label">${attrName}</span>
+                        </div>
+                        <span class="${data.class}">${sign}${data.val}</span>
+                    </div>
+                `;
+            }
+
+            if (subraza.perks) {
+                statsHtml += `<div class="trait-box" style="margin-top: 15px; border-top: 1px dashed #444; padding-top: 10px;">`;
+                subraza.perks.forEach(p => {
+                    statsHtml += `
+                        <div style="margin-bottom: 8px;">
+                            <div class="trait-title" style="color: var(--green-success);">${p.nombre}</div>
+                            <div class="trait-desc">${p.desc}</div>
+                        </div>
+                    `;
+                });
+                statsHtml += `</div>`;
+            }
+
+            displayDiv.innerHTML = statsHtml;
+        }
+
+        // 6. Lógica de Selección y Validación
+        function seleccionarOrigen(id) {
+            luminousState.originId = id;
+
+            const cards = document.querySelectorAll('.origin-card');
+            cards.forEach(card => {
+                if (card.dataset.id === id) {
+                    card.classList.add('selected');
+                } else {
+                    card.classList.remove('selected');
+                }
+            });
+
+            if (id) {
+                gridContainer.classList.add('has-selection');
+            } else {
+                gridContainer.classList.remove('has-selection');
+            }
+
+            if (id === 'humano') {
+                validarHumano();
+            } else {
+                const raza = racesData.find(r => r.id === id);
+                if (raza.subrazas) {
+                    validarOrigenConSubraza();
+                } else {
+                    luminousState.modifiers = {};
+                    for (const [key, attrName] of Object.entries(raza.mods)) {
+                        luminousState.modifiers[attrName] = modValues[key].val;
+                    }
+                    btnConfirmarOrigen.disabled = false;
+                }
+            }
+        }
+
+        function validarOrigenConSubraza() {
+            const raza = racesData.find(r => r.id === luminousState.originId);
+            if (!raza || !raza.subrazas) return;
+
+            const selectedCard = document.querySelector(`.origin-card[data-id="${luminousState.originId}"]`);
+            const select = selectedCard.querySelector('.subrace-select');
+
+            if (!select.value) {
+                btnConfirmarOrigen.disabled = true;
+            } else {
+                luminousState.subraceId = select.value;
+                const subraza = raza.subrazas.find(sr => sr.id === select.value);
+                luminousState.modifiers = {};
+                for (const [key, attrName] of Object.entries(subraza.mods)) {
+                    luminousState.modifiers[attrName] = modValues[key].val;
+                }
+                btnConfirmarOrigen.disabled = false;
+            }
+        }
+
+        function validarHumano() {
+            if (luminousState.originId !== 'humano') return;
+
+            const modSelects = document.querySelectorAll('.human-mod-select');
+            const perkSelects = document.querySelectorAll('.human-perk-select');
+            const errorMsg = document.getElementById('human-error');
+            const modValuesSelected = [];
+            const perkValuesSelected = [];
+            let isValid = true;
+
+            modSelects.forEach(s => s.classList.remove('error'));
+            perkSelects.forEach(s => s.classList.remove('error'));
+
+            // Validar modificadores
+            modSelects.forEach(select => {
+                const val = select.value;
+                if (!val) {
+                    isValid = false;
+                } else if (modValuesSelected.includes(val)) {
+                    isValid = false;
+                    select.classList.add('error');
+                    const firstDuplicate = Array.from(modSelects).find(s => s.value === val);
+                    if (firstDuplicate) firstDuplicate.classList.add('error');
+                } else {
+                    modValuesSelected.push(val);
+                }
+            });
+
+            // Validar perks
+            perkSelects.forEach(select => {
+                const val = select.value;
+                if (!val) {
+                    isValid = false;
+                } else if (perkValuesSelected.includes(val)) {
+                    isValid = false;
+                    select.classList.add('error');
+                    const firstDuplicate = Array.from(perkSelects).find(s => s.value === val);
+                    if (firstDuplicate) firstDuplicate.classList.add('error');
+                } else {
+                    perkValuesSelected.push(val);
+                }
+            });
+
+            if (!isValid) {
+                errorMsg.style.display = 'block';
+                btnConfirmarOrigen.disabled = true;
+            } else {
+                errorMsg.style.display = 'none';
+                btnConfirmarOrigen.disabled = false;
+
+                // Actualizar estado de modificadores
+                luminousState.modifiers = {};
+                modSelects.forEach(select => {
+                    const modKey = select.dataset.mod;
+                    const attrName = select.value;
+                    luminousState.modifiers[attrName] = modValues[modKey].val;
+                });
+
+                // Actualizar estado de perks de humano
+                luminousState.humanPerks = [];
+                const humanRace = racesData.find(r => r.id === 'humano');
+                perkSelects.forEach(select => {
+                    const perkId = select.value;
+                    const perkData = humanRace.perks.find(p => p.id === perkId);
+                    if (perkData) {
+                        luminousState.humanPerks.push(perkData);
+                    }
+                });
+            }
+        }
+
             const phaseIntro = document.getElementById('phase-intro');
             const introDialogueText = document.getElementById('intro-dialogue-text');
             const nameInputContainer = document.getElementById('name-input-container');
@@ -211,11 +1565,12 @@
 
             const introDialogues = [
                 "Vaya...",
-                "No esperaba a nadie...<br>Aún...<br>Debes estar algo inquieto...",
+                "No esperaba a nadie...",
+                "Aún...",
+                "Debes estar algo inquieto...",
                 "¿Cómo te llamas?",
                 "Lastima...",
-                "No lo recordarás si sigues avanzando...",
-                "¿Que eres?"
+                "No lo recordarás si sigues avanzando..."
             ];
 
             function typeIntroText(htmlText) {
@@ -234,11 +1589,11 @@
                 function typeNext() {
                     if (nodeIndex >= nodes.length) {
                         isIntroTyping = false;
-                        if (introStep === 2) { // ¿Cómo te llamas?
+                        if (introStep === 4) { // ¿Cómo te llamas?
                             nameInputContainer.classList.remove('hidden');
                             characterNameInput.focus();
                         }
-                        if (introStep === 5) { // ¿Que eres?
+                        if (introStep === 6) { // Last one before transition
                             finishIntroPhase();
                         }
                         return;
@@ -290,20 +1645,20 @@
                 if (e.type === 'touchstart') e.preventDefault();
 
                 // If we are waiting for name input, don't advance on click
-                if (introStep === 2 && !isIntroTyping) return;
+                if (introStep === 4 && !isIntroTyping) return;
                 // If we are at the last step, the transition handles itself
-                if (introStep === 5) return;
+                if (introStep === 6) return;
 
                 if (isIntroTyping) {
                     clearTimeout(typingTimeout);
                     introDialogueText.innerHTML = introDialogues[introStep];
                     isIntroTyping = false;
 
-                    if (introStep === 2) {
+                    if (introStep === 4) {
                         nameInputContainer.classList.remove('hidden');
                         characterNameInput.focus();
                     }
-                    if (introStep === 5) {
+                    if (introStep === 6) {
                         finishIntroPhase();
                     }
                 } else {
@@ -344,7 +1699,6 @@
             const phase1 = document.getElementById('phase1');
             const phaseDialogue = document.getElementById('phase-dialogue');
             const dialogueText = document.getElementById('dialogue-text');
-            const rouletteItems = document.querySelectorAll('.roulette li');
 
             let currentDialogueStep = 0;
             const dialogues = [
@@ -353,21 +1707,25 @@
                 "Tal vez sea interesante..."
             ];
 
-            // Handle option selection
-            rouletteItems.forEach(item => {
-                item.addEventListener('click', () => {
-                    // Transition to Phase 2 (Black screen + first dialogue)
-                    phase1.classList.add('fade-out');
+            let gridContainer = document.getElementById('origin-grid');
+            let btnConfirmarOrigen = document.getElementById('btn-confirmar-origen');
 
-                    setTimeout(() => {
-                        phase1.classList.add('hidden');
-                        phase1.classList.remove('fade-out');
+            renderOrigins();
 
-                        // Show dialogue phase
-                        phaseDialogue.classList.remove('hidden');
-                        showDialogue(currentDialogueStep);
-                    }, 1500); // Wait for fade out
-                });
+            btnConfirmarOrigen.addEventListener('click', () => {
+                if (btnConfirmarOrigen.disabled) return;
+
+                // Transition to Phase 2 (Black screen + first dialogue)
+                phase1.classList.add('fade-out');
+
+                setTimeout(() => {
+                    phase1.classList.add('hidden');
+                    phase1.classList.remove('fade-out');
+
+                    // Show dialogue phase
+                    phaseDialogue.classList.remove('hidden');
+                    showDialogue(currentDialogueStep);
+                }, 1500); // Wait for fade out
             });
 
             // Handle dialogue progression


### PR DESCRIPTION
Update the intro dialogues in `creacion_personaje.html` to display line by line, requiring individual clicks to advance. Replace the outdated roulette race selector in Phase 1 with the modern, card-based origin grid ported from `index.html`, including its associated CSS styles and JavaScript logic. Clean up unused and dead code from the migration process.

---
*PR created automatically by Jules for task [2263643374005942003](https://jules.google.com/task/2263643374005942003) started by @sokcrow*