### PR TITLE
Multiply Ahn starting funds by 10 for backgrounds

### DIFF
--- a/creacion_personaje.html
+++ b/creacion_personaje.html
@@ -548,7 +548,7 @@
                 category: 'Privilegio y Poder',
                 desc: 'Naciste en una cuna de oro, rodeado de blasones y linajes antiguos. Tu infancia estuvo dictada por el protocolo, las alianzas y las expectativas de tu apellido.',
                 benefit: '+3 en Negociación.',
-                funds: '150,000 Ahn. Comienzas con un Anillo de Sello de tu casa.',
+                funds: '1,500,000 Ahn. Comienzas con un Anillo de Sello de tu casa.',
                 entityResponse: "Se alzaron sobre pedestales, creyendo que el cielo les pertenecía... Qué frágil es la corona que forja el mortal."
             },
             {
@@ -557,7 +557,7 @@
                 category: 'Privilegio y Poder',
                 desc: 'Tu familia no tenía títulos, pero tenía flotas, caravanas y monopolios. Creciste aprendiendo que todo en este mundo tiene un precio.',
                 benefit: '+3 en Manejo.',
-                funds: '200,000 Ahn. Comienzas con un libro de contabilidad familiar.',
+                funds: '2,000,000 Ahn. Comienzas con un libro de contabilidad familiar.',
                 entityResponse: "Pusieron precio a la tierra, al mar y al espíritu. Ilusos que intentan comprar la eternidad con metales muertos."
             },
             {
@@ -566,7 +566,7 @@
                 category: 'Privilegio y Poder',
                 desc: 'Tu apellido alguna vez inspiró respeto, pero la guerra, la traición o las deudas lo redujeron a cenizas. Creciste escuchando historias de una grandeza que nunca viviste.',
                 benefit: '+3 en Presencia.',
-                funds: '50,000 Ahn. Comienzas con un blasón desgastado o una reliquia rota.',
+                funds: '500,000 Ahn. Comienzas con un blasón desgastado o una reliquia rota.',
                 entityResponse: "Aferrados a nombres que el viento ya borró. El orgullo es un alimento amargo cuando no hay pan."
             },
             {
@@ -575,7 +575,7 @@
                 category: 'Privilegio y Poder',
                 desc: 'Creciste en los pasillos de una academia o biblioteca. Tus padres valoraban el conocimiento por encima de cualquier otra cosa.',
                 benefit: '+3 en Memoria.',
-                funds: '100,000 Ahn. Comienzas con un tomo de historia antiguo.',
+                funds: '1,000,000 Ahn. Comienzas con un tomo de historia antiguo.',
                 entityResponse: "Acumularon palabras en torres de marfil, ciegos a las verdades que no pueden ser escritas con tinta."
             },
             {
@@ -584,7 +584,7 @@
                 category: 'La Espada y la Fe',
                 desc: 'Generaciones de tu familia han marchado a la guerra. Creciste en campamentos o fortalezas, donde la disciplina era la única forma de afecto.',
                 benefit: '+3 en Fortaleza.',
-                funds: '40,000 Ahn. Comienzas con un arma heredada (Tier 1).',
+                funds: '400,000 Ahn. Comienzas con un arma heredada (Tier 1).',
                 entityResponse: "Forjados para sangrar por causas ajenas. Tu herencia es el filo y la cicatriz, un ciclo que nunca termina."
             },
             {
@@ -593,7 +593,7 @@
                 category: 'La Espada y la Fe',
                 desc: 'Tus padres eran los encargados de mantener el orden en las calles o las fronteras de tu hogar. Aprendiste rápido a identificar quién es una amenaza.',
                 benefit: '+3 en Percepción.',
-                funds: '30,000 Ahn. Comienzas con una insignia de la guardia.',
+                funds: '300,000 Ahn. Comienzas con una insignia de la guardia.',
                 entityResponse: "Ojos que vigilan en la noche, creyendo que pueden contener la oscuridad... ignorando que la oscuridad ya está dentro."
             },
             {
@@ -602,7 +602,7 @@
                 category: 'La Espada y la Fe',
                 desc: 'Entregado a los clérigos desde joven. Creciste bajo la estricta mirada de los dogmas, rodeado de incienso y coros solemnes.',
                 benefit: '+3 en Fe.',
-                funds: '20,000 Ahn. Comienzas con un símbolo sagrado.',
+                funds: '200,000 Ahn. Comienzas con un símbolo sagrado.',
                 entityResponse: "Rodillas gastadas sobre piedra fría, elevando plegarias a un silencio absoluto. La devoción es el refugio de los temerosos."
             },
             {
@@ -611,7 +611,7 @@
                 category: 'La Espada y la Fe',
                 desc: 'Vidas nómadas vendiendo la espada al mejor postor. Aprendiste que la lealtad es un lujo que solo los ricos pueden pagar.',
                 benefit: '+3 en Reflejos.',
-                funds: '50,000 Ahn. Comienzas con un contrato antiguo.',
+                funds: '500,000 Ahn. Comienzas con un contrato antiguo.',
                 entityResponse: "Vidas entregadas a quienes ofrecen más oro. Tu lealtad tiene el peso exacto de la moneda que cae en tu palma."
             },
             {
@@ -620,7 +620,7 @@
                 category: 'Gremios y Tierras',
                 desc: 'Naciste con las manos en la tierra. Tu infancia fue marcada por las estaciones, las cosechas, las sequías y el trabajo extenuante bajo el sol.',
                 benefit: '+3 en Vigor.',
-                funds: '10,000 Ahn. Comienzas con semillas de tu región.',
+                funds: '100,000 Ahn. Comienzas con semillas de tu región.',
                 entityResponse: "Atados a la tierra y al capricho del clima. Una vida simple, esperando una cosecha que siempre se marchita."
             },
             {
@@ -629,7 +629,7 @@
                 category: 'Gremios y Tierras',
                 desc: 'Herreros, carpinteros o tejedores. Creciste rodeado de herramientas y aprendiste el valor de crear cosas duraderas con tus propias manos.',
                 benefit: '+3 en Análisis.',
-                funds: '35,000 Ahn. Comienzas con herramientas de artesano de buena calidad.',
+                funds: '350,000 Ahn. Comienzas con herramientas de artesano de buena calidad.',
                 entityResponse: "Manos marcadas por el esfuerzo de dar forma a lo inerte. Crean afanosamente, olvidando que el tiempo, inevitablemente, lo destruirá todo."
             },
             {
@@ -638,7 +638,7 @@
                 category: 'Gremios y Tierras',
                 desc: 'Tu hogar fue una caravana en constante movimiento. Aprendiste a tratar con extraños, a regatear y a leer las intenciones de la gente en el camino.',
                 benefit: '+3 en Carisma.',
-                funds: '25,000 Ahn. Comienzas con un mapa gastado de rutas comerciales.',
+                funds: '250,000 Ahn. Comienzas con un mapa gastado de rutas comerciales.',
                 entityResponse: "Condenados a caminar sin descanso, trazando senderos en un mundo que siempre vuelve a borrar sus huellas."
             },
             {
@@ -647,7 +647,7 @@
                 category: 'Gremios y Tierras',
                 desc: 'Naciste en medio de un espectáculo ambulante. Tu vida estuvo llena de música, historias, máscaras y aplausos efímeros.',
                 benefit: '+3 en Seducción.',
-                funds: '15,000 Ahn. Comienzas con un instrumento musical o una máscara teatral.',
+                funds: '150,000 Ahn. Comienzas con un instrumento musical o una máscara teatral.',
                 entityResponse: "Danzantes en el teatro de la ilusión. Tejen mentiras hermosas para aquellos que no soportan mirar la realidad."
             },
             {
@@ -656,7 +656,7 @@
                 category: 'Las Sombras y el Margen',
                 desc: 'No conociste a tus padres o los perdiste muy pronto. La calle te enseñó a correr, a esconderte y a pelear por las sobras.',
                 benefit: '+3 en Agilidad.',
-                funds: '500 Ahn.',
+                funds: '5,000 Ahn.',
                 entityResponse: "Nacido de la ruina, aferrándote a la decadencia. Eres el remanente que perdura cuando los grandes cimientos colapsan."
             },
             {
@@ -665,7 +665,7 @@
                 category: 'Las Sombras y el Margen',
                 desc: 'Creciste en una familia o gremio donde tomar lo ajeno era la norma. Te enseñaron a caminar sin hacer ruido y a abrir aquello que estaba cerrado.',
                 benefit: '+3 en Sigilo.',
-                funds: '10,000 Ahn. Comienzas con ganzúas.',
+                funds: '100,000 Ahn. Comienzas con ganzúas.',
                 entityResponse: "Lo que el mundo niega, la sombra lo arrebata. Vives en los resquicios de las leyes que otros fingen respetar."
             },
             {
@@ -674,7 +674,7 @@
                 category: 'Las Sombras y el Margen',
                 desc: 'Tus mentores te enseñaron que la gente quiere ser engañada. Aprendiste a fabricar historias y a vivir de la credulidad de los demás.',
                 benefit: '+3 en Engaño.',
-                funds: '15,000 Ahn. Comienzas con dados trucados o cartas marcadas.',
+                funds: '150,000 Ahn. Comienzas con dados trucados o cartas marcadas.',
                 entityResponse: "La verdad es solo arcilla en tus manos. Has descubierto que la mentira es la moneda más valiosa entre los vivos."
             },
             {
@@ -683,7 +683,7 @@
                 category: 'Las Sombras y el Margen',
                 desc: 'Tu familia fue expulsada de su tierra natal. Creciste como un forastero en todas partes, aprendiendo a confiar únicamente en tus propios instintos.',
                 benefit: '+3 en Instinto.',
-                funds: '2,000 Ahn. Comienzas con tierra o un recuerdo de tu antiguo hogar.',
+                funds: '20,000 Ahn. Comienzas con tierra o un recuerdo de tu antiguo hogar.',
                 entityResponse: "Marcados por el repudio. El mundo les arrebató un hogar, entregándoles a cambio la más cruel y vasta de las libertades."
             },
             {
@@ -692,7 +692,7 @@
                 category: 'Trabajo Duro y Servidumbre',
                 desc: 'Tus padres limpiaban los pasillos de los nobles. Aprendiste desde niño a ser invisible, a anticipar necesidades y a nunca mirar a los ojos.',
                 benefit: '+3 en Empatía.',
-                funds: '4,000 Ahn.',
+                funds: '40,000 Ahn.',
                 entityResponse: "Existir únicamente para sostener las copas de quienes se creen dueños de todo. Has dominado el triste arte de ser una sombra."
             },
             {
@@ -701,7 +701,7 @@
                 category: 'Trabajo Duro y Servidumbre',
                 desc: 'Creciste en las profundidades, picando piedra o extrayendo minerales bajo condiciones brutales. Tus pulmones y músculos conocen bien el castigo.',
                 benefit: '+3 en Atletismo.',
-                funds: '5,000 Ahn. Comienzas con un pico o una linterna minera.',
+                funds: '50,000 Ahn. Comienzas con un pico o una linterna minera.',
                 entityResponse: "Enterrados en vida para arrancar fragmentos del corazón del mundo. Tu herencia es únicamente el polvo y la oscuridad."
             },
             {
@@ -719,7 +719,7 @@
                 category: 'Trabajo Duro y Servidumbre',
                 desc: 'Alguien tiene que lidiar con los muertos. Creciste entre tumbas, aprendiendo a lidiar con el olor a tierra removida y el peso de la mortalidad.',
                 benefit: '+3 en Represión.',
-                funds: '8,000 Ahn. Comienzas con una pala pequeña o incienso funerario.',
+                funds: '80,000 Ahn. Comienzas con una pala pequeña o incienso funerario.',
                 entityResponse: "Creciste a la sombra del final, ordenando los restos de lo que alguna vez respiró. Al menos los que ya no están no te mienten."
             },
         ];


### PR DESCRIPTION
Multiplied the `Ahn` funds in `creacion_personaje.html` by 10 to balance character starting funds for the '¿De dónde vienes?' backgrounds against the higher-tier professions shown later in character creation.

---
*PR created automatically by Jules for task [9576920513767113117](https://jules.google.com/task/9576920513767113117) started by @sokcrow*