### PR TITLE
Add batch 2 psychological backgrounds

### DIFF
--- a/creacion_personaje.html
+++ b/creacion_personaje.html
@@ -1146,927 +1146,1847 @@
         ];
 
                 const psychologicalBackgroundsData = [
-    {
-        "id": "el_atormentado",
-        "name": "El Atormentado",
-        "desc": "Eres el único testigo de un suceso que la lógica de la Ciudad no puede procesar. No fue un accidente común; fue una fractura en tu realidad que te eligió como espectador. Mientras los demás caminan ignorantes, tú llevas el peso de algo que no puede ser nombrado. Tu sistema nervioso se encarga de recordártelo cada vez que el silencio se vuelve demasiado denso.",
-        "quote": "Vamos a abrir tu expediente. Miremos cada paso ciego que diste hacia el abismo. Veamos cómo construiste tu propia jaula antes de perderlo todo.",
-        "ideales": [
             {
-                "nombre": "Verdad",
-                "desc": "Las mentiras de la Ciudad son una jaula; solo la realidad cruda importa."
+                "id": "el_atormentado",
+                "name": "El Atormentado",
+                "desc": "Eres el único testigo de un suceso que la lógica de la Ciudad no puede procesar. No fue un accidente común; fue una fractura en tu realidad que te eligió como espectador. Mientras los demás caminan ignorantes, tú llevas el peso de algo que no puede ser nombrado. Tu sistema nervioso se encarga de recordártelo cada vez que el silencio se vuelve demasiado denso.",
+                "quote": "Vamos a abrir tu expediente. Miremos cada paso ciego que diste hacia el abismo. Veamos cómo construiste tu propia jaula antes de perderlo todo.",
+                "ideales": [
+                    {
+                        "nombre": "Verdad",
+                        "desc": "Las mentiras de la Ciudad son una jaula; solo la realidad cruda importa."
+                    },
+                    {
+                        "nombre": "Compasión",
+                        "desc": "Nadie más debería experimentar el colapso que yo viví."
+                    },
+                    {
+                        "nombre": "Supervivencia",
+                        "desc": "Soy el único registro vivo de lo que pasó; debo persistir."
+                    },
+                    {
+                        "nombre": "Propósito",
+                        "desc": "Este dolor debe tener un significado mayor que el simple azar."
+                    },
+                    {
+                        "nombre": "Venganza",
+                        "desc": "Si el mundo me rompió, yo encontraré la forma de romperlo de vuelta."
+                    },
+                    {
+                        "nombre": "Conocimiento",
+                        "desc": "Nombrar el trauma es la única forma de no ser devorado por él."
+                    },
+                    {
+                        "nombre": "Aislamiento",
+                        "desc": "Mi sola presencia es un recordatorio de la fragilidad de los demás."
+                    },
+                    {
+                        "nombre": "Poder",
+                        "desc": "Si sobreviví a aquello, nada en esta Ciudad puede volver a hacerme daño."
+                    }
+                ],
+                "vinculos": [
+                    {
+                        "nombre": "Respuesta Somática",
+                        "desc": "Sensación física de una mano en tu hombro en habitaciones oscuras."
+                    },
+                    {
+                        "nombre": "Disonancia Sensorial",
+                        "desc": "Un estímulo específico (olor, luz) provoca parálisis inmediata."
+                    },
+                    {
+                        "nombre": "Amnesia Selectiva",
+                        "desc": "Un \"bloque muerto\" en tu memoria para evitar el colapso."
+                    },
+                    {
+                        "nombre": "Anclaje Táctil",
+                        "desc": "Un objeto de alguien que perdiste; te da pánico soltarlo."
+                    },
+                    {
+                        "nombre": "Compulsión de Seguridad",
+                        "desc": "Ritual repetitivo necesario para \"mantener el mundo en su sitio\"."
+                    },
+                    {
+                        "nombre": "Despersonalización",
+                        "desc": "Convicción de que no sobreviviste y eres solo un eco observando."
+                    }
+                ],
+                "grietas": [
+                    {
+                        "nombre": "Paranoia",
+                        "desc": "Las sombras se mueven con intenciones que solo tú notas."
+                    },
+                    {
+                        "nombre": "Obsesión",
+                        "desc": "Todo es una pista y cada silencio es una amenaza encubierta."
+                    },
+                    {
+                        "nombre": "Vacío",
+                        "desc": "Tus emociones se quedaron en aquel lugar; ahora solo queda análisis frío."
+                    },
+                    {
+                        "nombre": "Temeridad",
+                        "desc": "Estás convencido de que lo peor ya pasó; el riesgo ya no genera miedo."
+                    },
+                    {
+                        "nombre": "Culpabilidad",
+                        "desc": "Buscas constantemente una razón lógica de por qué tú sigues aquí."
+                    },
+                    {
+                        "nombre": "Secretismo",
+                        "desc": "Si supieran tu nivel de distorsión, te tratarían como a un error del sistema."
+                    }
+                ]
             },
             {
-                "nombre": "Compasión",
-                "desc": "Nadie más debería experimentar el colapso que yo viví."
+                "id": "el_trasgresor",
+                "name": "El Trasgresor",
+                "desc": "Cruzaste una línea que juraste nunca tocar por miedo o ambición. El peso de ese acto es una mancha en tu conciencia. Eres un profesional del bajo mundo que descubrió que su propia moralidad tenía un precio, y ahora vives con el eco de la traición que lo cambió todo.",
+                "quote": "La lealtad es el chiste más viejo de la Ciudad. Afilaste el cuchillo, se lo pusiste en la mano y luego les diste la espalda. ¿De verdad te sorprendió sentir el acero?",
+                "ideales": [
+                    {
+                        "nombre": "Pragmatismo",
+                        "desc": "Los principios son un lujo que los vivos no pueden permitirse."
+                    },
+                    {
+                        "nombre": "Redención",
+                        "desc": "Mis acciones actuales deben pesar más que mi crimen pasado."
+                    },
+                    {
+                        "nombre": "Nihilismo",
+                        "desc": "Si nada tiene valor moral, no hay por qué pedir perdón."
+                    },
+                    {
+                        "nombre": "Orden",
+                        "desc": "Crucé la línea para evitar un caos mayor."
+                    },
+                    {
+                        "nombre": "Ambición",
+                        "desc": "Solo los que se ensucian las manos llegan a la cima."
+                    },
+                    {
+                        "nombre": "Castigo",
+                        "desc": "Merezco cada gramo de dolor que el destino me arroje."
+                    },
+                    {
+                        "nombre": "Autonomía",
+                        "desc": "No sigo leyes, solo mis instintos de supervivencia."
+                    },
+                    {
+                        "nombre": "Cinismo",
+                        "desc": "Todos son trasgresores; yo solo fui el descubierto."
+                    }
+                ],
+                "vinculos": [
+                    {
+                        "nombre": "Memoria Táctil",
+                        "desc": "Peso imaginario de sangre en las manos; lavado compulsivo."
+                    },
+                    {
+                        "nombre": "Anclaje de Culpa",
+                        "desc": "El objeto obtenido por traición; náuseas al verlo pero incapaz de tirarlo."
+                    },
+                    {
+                        "nombre": "Fijación Nominal",
+                        "desc": "Repetir el nombre de tu víctima como mantra bajo presión."
+                    },
+                    {
+                        "nombre": "Evitación de Reflejos",
+                        "desc": "Incapacidad de mirar tu propio rostro en un espejo."
+                    },
+                    {
+                        "nombre": "Flashback Auditivo",
+                        "desc": "El sonido de la última súplica ignorada suena en el silencio."
+                    },
+                    {
+                        "nombre": "Compulsión Reparadora",
+                        "desc": "Necesidad irracional de ayudar a desconocidos que te recuerdan a tu víctima."
+                    }
+                ],
+                "grietas": [
+                    {
+                        "nombre": "Autosabotaje",
+                        "desc": "Arruinas tus planes porque sientes que no mereces el éxito."
+                    },
+                    {
+                        "nombre": "Desconfianza Proyectada",
+                        "desc": "Asumes que todos van a traicionarte."
+                    },
+                    {
+                        "nombre": "Mudez Selectiva",
+                        "desc": "Bloqueo mental ante palabras que disparan el recuerdo del acto."
+                    },
+                    {
+                        "nombre": "Frigidez Emocional",
+                        "desc": "Capacidad de sentir afecto anulada para evitar el peso moral."
+                    },
+                    {
+                        "nombre": "Necesidad de Confesión",
+                        "desc": "Impulso peligroso de contar la verdad en momentos vulnerables."
+                    },
+                    {
+                        "nombre": "Justificación Agresiva",
+                        "desc": "Violencia inmediata si alguien cuestiona tu moralidad."
+                    }
+                ]
             },
             {
-                "nombre": "Supervivencia",
-                "desc": "Soy el único registro vivo de lo que pasó; debo persistir."
+                "id": "el_caido",
+                "name": "El Caído",
+                "desc": "Tuviste poder, nombre y respeto. La caída no fue solo financiera, fue una demolición de tu identidad. Caminas por las calles que antes mirabas desde las alturas, y la herida de tu fracaso se infecta con cada mirada de desprecio.",
+                "quote": "Estabas en la cima mirando a las ratas, hasta que el piso resultó ser de cristal. La caída siempre rompe más a los que vuelan alto.",
+                "ideales": [
+                    {
+                        "nombre": "Estatus",
+                        "desc": "Sin poder no somos nada; debo recuperarlo."
+                    },
+                    {
+                        "nombre": "Justicia",
+                        "desc": "Manipularon el sistema para tirarme; la verdad debe salir."
+                    },
+                    {
+                        "nombre": "Resentimiento",
+                        "desc": "La Ciudad me dio la espalda; yo le mostraré mi peor cara."
+                    },
+                    {
+                        "nombre": "Humildad",
+                        "desc": "He visto el fondo y aprendido lo que realmente importa."
+                    },
+                    {
+                        "nombre": "Superioridad",
+                        "desc": "Mi intelecto no desapareció con mi dinero; sigo estando por encima."
+                    },
+                    {
+                        "nombre": "Venganza",
+                        "desc": "Solo quiero ver arder a quienes me quitaron mi vida."
+                    },
+                    {
+                        "nombre": "Seguridad",
+                        "desc": "Nunca volveré a ser vulnerable ante el capricho ajeno."
+                    },
+                    {
+                        "nombre": "Legado",
+                        "desc": "Mis acciones aún deben significar algo para el futuro."
+                    }
+                ],
+                "vinculos": [
+                    {
+                        "nombre": "Disonancia Cognitiva",
+                        "desc": "Sigues dando órdenes a gente que ya no te conoce."
+                    },
+                    {
+                        "nombre": "Fetiche de Estatus",
+                        "desc": "Un accesorio de lujo roto que es lo único que no te embargaron."
+                    },
+                    {
+                        "nombre": "Lista de Agravios",
+                        "desc": "Registro mental de cada persona que celebró tu ruina."
+                    },
+                    {
+                        "nombre": "Agorafobia Selectiva",
+                        "desc": "Pánico a ser reconocido en zonas donde antes eras importante."
+                    },
+                    {
+                        "nombre": "Somatización del Fracaso",
+                        "desc": "Asfixia al ver el logo de tu antigua corporación o grupo."
+                    },
+                    {
+                        "nombre": "Idealización del Pasado",
+                        "desc": "Distorsión donde tus errores desaparecen y solo queda el \"paraíso\"."
+                    }
+                ],
+                "grietas": [
+                    {
+                        "nombre": "Arrogancia Defensiva",
+                        "desc": "Tratar a otros como inferiores para ocultar tu inseguridad."
+                    },
+                    {
+                        "nombre": "Incapacidad de Adaptación",
+                        "desc": "Negativa a realizar tareas \"bajas\" aunque tu vida dependa de ello."
+                    },
+                    {
+                        "nombre": "Despilfarro",
+                        "desc": "Gastar recursos en lujos para mantener la ilusión de éxito."
+                    },
+                    {
+                        "nombre": "Vulnerabilidad a la Adulación",
+                        "desc": "Manipulable por cualquiera que te trate con \"respeto\"."
+                    },
+                    {
+                        "nombre": "Vergüenza Paralizante",
+                        "desc": "Incapacidad de pedir ayuda; prefieres morir antes que mendigar."
+                    },
+                    {
+                        "nombre": "Mendacidad",
+                        "desc": "Mentiras constantes sobre tu situación actual para no colapsar."
+                    }
+                ]
             },
             {
-                "nombre": "Propósito",
-                "desc": "Este dolor debe tener un significado mayor que el simple azar."
+                "id": "la_herramienta_rota",
+                "name": "La Herramienta Rota",
+                "desc": "Fuiste diseñado o entrenado para una función. Pero algo falló: un error técnico o un colapso mental. Te desecharon como un engranaje desgastado. Ahora tienes una libertad que no sabes usar y un propósito que ya no existe.",
+                "quote": "La Ciudad no desperdicia nada. Si estás aquí afuera es porque ya no sirves ni para reciclaje. Eres el sobrante de una ecuación cerrada.",
+                "ideales": [
+                    {
+                        "nombre": "Eficiencia",
+                        "desc": "El mundo funciona mejor cuando cada pieza hace lo que debe."
+                    },
+                    {
+                        "nombre": "Libertad",
+                        "desc": "Ser inútil es la única forma de ser libre del sistema."
+                    },
+                    {
+                        "nombre": "Relevancia",
+                        "desc": "Debo encontrar un nuevo propósito para no desaparecer."
+                    },
+                    {
+                        "nombre": "Autodestrucción",
+                        "desc": "Una herramienta rota solo sirve para ser destruida."
+                    },
+                    {
+                        "nombre": "Curiosidad",
+                        "desc": "Quiero saber qué hay fuera de mi protocolo original."
+                    },
+                    {
+                        "nombre": "Resentimiento",
+                        "desc": "Seré la arena en los engranajes de quienes me usaron."
+                    },
+                    {
+                        "nombre": "Perfección",
+                        "desc": "Me repararé para demostrar que se equivocaron conmigo."
+                    },
+                    {
+                        "nombre": "Pertenencia",
+                        "desc": "Busco desesperadamente a alguien que me diga qué hacer."
+                    }
+                ],
+                "vinculos": [
+                    {
+                        "nombre": "Eco de Protocolo",
+                        "desc": "Despertar y realizar rutinas de mantenimiento para equipo inexistente."
+                    },
+                    {
+                        "nombre": "Fobia a la Inspección",
+                        "desc": "Miedo irracional a que alguien encuentre el \"error\" en tu mente."
+                    },
+                    {
+                        "nombre": "Despersonalización Funcional",
+                        "desc": "Referirse a uno mismo en tercera persona o como objeto."
+                    },
+                    {
+                        "nombre": "Dependencia de Órdenes",
+                        "desc": "Ansiedad y desorientación si no hay instrucciones claras."
+                    },
+                    {
+                        "nombre": "Somatización del Error",
+                        "desc": "Tic nervioso que coincide con el momento en que \"fallaste\"."
+                    },
+                    {
+                        "nombre": "Fijación con el Creador",
+                        "desc": "Obsesión por encontrar a quien te fabricó o entrenó."
+                    }
+                ],
+                "grietas": [
+                    {
+                        "nombre": "Apatía Programada",
+                        "desc": "Incapacidad de sentir interés por nada que no sea una tarea."
+                    },
+                    {
+                        "nombre": "Rigidez Mental",
+                        "desc": "Dificultad extrema para improvisar si el plan se desvía."
+                    },
+                    {
+                        "nombre": "Obsesión por la Limpieza",
+                        "desc": "Limpieza compulsiva para evitar el \"desgaste\" final."
+                    },
+                    {
+                        "nombre": "Sumisión Involuntaria",
+                        "desc": "Obedecer a cualquier figura de autoridad sin cuestionar."
+                    },
+                    {
+                        "nombre": "Falta de Instinto",
+                        "desc": "Incapacidad de reconocer el peligro personal; no fuiste diseñado para ello."
+                    },
+                    {
+                        "nombre": "Vacío de Identidad",
+                        "desc": "No tener gustos propios; ser un reflejo de quienes te rodean."
+                    }
+                ]
             },
             {
-                "nombre": "Venganza",
-                "desc": "Si el mundo me rompió, yo encontraré la forma de romperlo de vuelta."
+                "id": "el_aspirante",
+                "name": "El Aspirante",
+                "desc": "Tu motor es la presión de un futuro que aún no alcanzas. Has memorizado protocolos y entrenado hasta el cansancio. Tu conflicto es la ansiedad de ser el \"novato perfecto\" en un mundo que devora a los inexpertos.",
+                "quote": "Mírate, tan limpio. Eres como un libro nuevo esperando que la Ciudad escriba su primera tragedia. ¿Crees que tu disciplina te salvará?",
+                "ideales": [
+                    {
+                        "nombre": "Ambición",
+                        "desc": "La cima es el único lugar para respirar."
+                    },
+                    {
+                        "nombre": "Disciplina",
+                        "desc": "Si sigo el manual a la perfección, nada saldrá mal."
+                    },
+                    {
+                        "nombre": "Reconocimiento",
+                        "desc": "Mi nombre debe significar algo en los registros."
+                    },
+                    {
+                        "nombre": "Superación",
+                        "desc": "Cada fallo es un dato para mejorar mi siguiente versión."
+                    },
+                    {
+                        "nombre": "Lealtad",
+                        "desc": "Serviré a quien me dé la oportunidad de demostrar mi valor."
+                    },
+                    {
+                        "nombre": "Perfección",
+                        "desc": "El error no es una opción, es una mancha."
+                    },
+                    {
+                        "nombre": "Curiosidad",
+                        "desc": "Ver hasta dónde llega el agujero de este oficio."
+                    },
+                    {
+                        "nombre": "Pragmatismo",
+                        "desc": "Busco un contrato que me saque de la calle."
+                    }
+                ],
+                "vinculos": [
+                    {
+                        "nombre": "Memoria Muscular Rígida",
+                        "desc": "Posturas de combate automáticas ante ruidos fuertes."
+                    },
+                    {
+                        "nombre": "Hiper-vigilancia de Estatus",
+                        "desc": "Analizar equipo ajeno para medir peligrosidad instintivamente."
+                    },
+                    {
+                        "nombre": "Anclaje de Rutina",
+                        "desc": "Necesidad de ejercicios técnicos diarios para sentir control."
+                    },
+                    {
+                        "nombre": "Fijación con el Mentor",
+                        "desc": "Proyectar la voz de un superior criticando tus fallos."
+                    },
+                    {
+                        "nombre": "Somatización del Rendimiento",
+                        "desc": "Temblor en manos cuando no cumples expectativas."
+                    },
+                    {
+                        "nombre": "Dependencia de Validación",
+                        "desc": "Buscar la aprobación visual de aliados tras cada acción."
+                    }
+                ],
+                "grietas": [
+                    {
+                        "nombre": "Exceso de Confianza",
+                        "desc": "Creer que el manual es igual a la realidad del peligro."
+                    },
+                    {
+                        "nombre": "Inflexibilidad",
+                        "desc": "Bloqueo cuando la situación sale de los protocolos memorizados."
+                    },
+                    {
+                        "nombre": "Ansiedad por el Éxito",
+                        "desc": "Miedo paralizante a ser considerado \"promedio\"."
+                    },
+                    {
+                        "nombre": "Temeridad Ingenua",
+                        "desc": "Exposición innecesaria para impresionar a autoridades."
+                    },
+                    {
+                        "nombre": "Ceguera Jerárquica",
+                        "desc": "Ignorar consejos de quienes consideras de rango inferior."
+                    },
+                    {
+                        "nombre": "Frustración Explosiva",
+                        "desc": "Ira desmedida ante tus propios errores técnicos."
+                    }
+                ]
             },
             {
-                "nombre": "Conocimiento",
-                "desc": "Nombrar el trauma es la única forma de no ser devorado por él."
+                "id": "el_archivista",
+                "name": "El Archivista",
+                "desc": "Eres un almacén de secretos ajenos. Tu mente es un catálogo de hechos y te cuesta distinguir entre tus recuerdos y los expedientes que has procesado.",
+                "quote": "Has pasado tanto tiempo leyendo vidas ajenas que olvidaste la tuya. ¿Qué harás cuando la realidad no tenga índice ni glosario?",
+                "ideales": [
+                    {
+                        "nombre": "Orden",
+                        "desc": "El caos es solo información no clasificada."
+                    },
+                    {
+                        "nombre": "Objetividad",
+                        "desc": "Los sentimientos son ruido que ensucia los hechos."
+                    },
+                    {
+                        "nombre": "Verdad",
+                        "desc": "La historia es lo que quedó registrado."
+                    },
+                    {
+                        "nombre": "Preservación",
+                        "desc": "Nada debe perderse; el olvido es el enemigo."
+                    },
+                    {
+                        "nombre": "Curiosidad",
+                        "desc": "Cada secreto es un rompecabezas por resolver."
+                    },
+                    {
+                        "nombre": "Neutralidad",
+                        "desc": "Solo registro; no es mi función juzgar."
+                    },
+                    {
+                        "nombre": "Utilidad",
+                        "desc": "El conocimiento es la herramienta más afilada."
+                    },
+                    {
+                        "nombre": "Discreción",
+                        "desc": "El archivista es invisible; la información es lo que brilla."
+                    }
+                ],
+                "vinculos": [
+                    {
+                        "nombre": "Filtrado Sensorial",
+                        "desc": "Bloqueo de estímulos \"irrelevantes\" para la tarea actual."
+                    },
+                    {
+                        "nombre": "Catalogación Compulsiva",
+                        "desc": "Clasificar mentalmente a personas por utilidad o riesgo."
+                    },
+                    {
+                        "nombre": "Disonancia de Memoria",
+                        "desc": "Recordar traumas de expedientes leídos como propios."
+                    },
+                    {
+                        "nombre": "Fijación con el Dato",
+                        "desc": "Necesidad de tocar registros físicos para calmar la ansiedad."
+                    },
+                    {
+                        "nombre": "Sinestesia Informativa",
+                        "desc": "Datos complejos provocan sensaciones físicas (frío/calor)."
+                    },
+                    {
+                        "nombre": "Desapego del Observador",
+                        "desc": "Sentirse frente a una pantalla incluso en la acción real."
+                    }
+                ],
+                "grietas": [
+                    {
+                        "nombre": "Indiferencia Social",
+                        "desc": "Ver el dolor ajeno como una estadística más."
+                    },
+                    {
+                        "nombre": "Parálisis por Análisis",
+                        "desc": "Bloqueo intentando procesar todas las variables antes de actuar."
+                    },
+                    {
+                        "nombre": "Obsesión por el Detalle",
+                        "desc": "Perder de vista el problema general por un dato mínimo."
+                    },
+                    {
+                        "nombre": "Arrogancia Intelectual",
+                        "desc": "Desprecio a quienes no manejan la información con precisión."
+                    },
+                    {
+                        "nombre": "Dificultad de Acción",
+                        "desc": "Incomodidad física al decidir por intuición y no por datos."
+                    },
+                    {
+                        "nombre": "Amnesia de lo Cotidiano",
+                        "desc": "Recordar códigos antiguos pero olvidar dónde dejaste tu equipo."
+                    }
+                ]
             },
             {
-                "nombre": "Aislamiento",
-                "desc": "Mi sola presencia es un recordatorio de la fragilidad de los demás."
+                "id": "el_artesano",
+                "name": "El Artesano",
+                "desc": "Tu conexión con la materia es más fuerte que con las personas. En un mundo de desechables, tú entiendes cómo funcionan las tripas de la Ciudad.",
+                "quote": "Crees que arreglas cosas, pero solo retrasas lo inevitable. ¿Quién te arreglará a ti cuando el desgaste te alcance?",
+                "ideales": [
+                    {
+                        "nombre": "Calidad",
+                        "desc": "Un trabajo bien hecho es la única inmortalidad."
+                    },
+                    {
+                        "nombre": "Funcionalidad",
+                        "desc": "Si no sirve para nada, no debería existir."
+                    },
+                    {
+                        "nombre": "Innovación",
+                        "desc": "Siempre hay una forma más eficiente."
+                    },
+                    {
+                        "nombre": "Resiliencia",
+                        "desc": "Todo puede repararse con las piezas correctas."
+                    },
+                    {
+                        "nombre": "Autonomía",
+                        "desc": "Mi valor reside en mi habilidad, no en quien me contrata."
+                    },
+                    {
+                        "nombre": "Estética",
+                        "desc": "La forma sigue a la función, con belleza cruel."
+                    },
+                    {
+                        "nombre": "Honestidad",
+                        "desc": "Los materiales te dicen la verdad si sabes escuchar."
+                    },
+                    {
+                        "nombre": "Curiosidad Técnica",
+                        "desc": "Necesidad de saber cómo está construido todo."
+                    }
+                ],
+                "vinculos": [
+                    {
+                        "nombre": "Sensibilidad Háptica",
+                        "desc": "Identificar fallos solo por la vibración en los dedos."
+                    },
+                    {
+                        "nombre": "Fetiche de Herramienta",
+                        "desc": "Ansiedad física extrema si te separan de tu equipo."
+                    },
+                    {
+                        "nombre": "Visión de Despiece",
+                        "desc": "Descomponer mentalmente todo (y a todos) en componentes."
+                    },
+                    {
+                        "nombre": "Somatización del Desgaste",
+                        "desc": "Dolor en articulaciones al ver máquinas mal mantenidas."
+                    },
+                    {
+                        "nombre": "Compulsión de Ajuste",
+                        "desc": "Intentar \"arreglar\" objetos ajenos sin permiso."
+                    },
+                    {
+                        "nombre": "Silencio Operativo",
+                        "desc": "Incapacidad de hablar mientras realizas una tarea técnica."
+                    }
+                ],
+                "grietas": [
+                    {
+                        "nombre": "Materialismo Estricto",
+                        "desc": "Si no se puede medir o tocar, no existe."
+                    },
+                    {
+                        "nombre": "Perfeccionismo Paralizante",
+                        "desc": "Negativa a terminar algo si no es perfecto."
+                    },
+                    {
+                        "nombre": "Deshumanización",
+                        "desc": "Tratar a aliados como piezas de equipo que se mantienen o reemplazan."
+                    },
+                    {
+                        "nombre": "Rigidez Metódica",
+                        "desc": "Ira si alguien altera el orden de tus herramientas."
+                    },
+                    {
+                        "nombre": "Obsesión por el Reciclaje",
+                        "desc": "Acumular chatarra con la convicción de que \"servirá\"."
+                    },
+                    {
+                        "nombre": "Falta de Tacto Social",
+                        "desc": "Decir verdades crudas como si fueras un informe técnico."
+                    }
+                ]
             },
             {
-                "nombre": "Poder",
-                "desc": "Si sobreviví a aquello, nada en esta Ciudad puede volver a hacerme daño."
-            }
-        ],
-        "vinculos": [
-            {
-                "nombre": "Respuesta Somática",
-                "desc": "Sensación física de una mano en tu hombro en habitaciones oscuras."
+                "id": "el_residente",
+                "name": "El Residente",
+                "desc": "Eres el producto estándar de los Distritos. Sobrevives a base de rutinas y ruido. Eres la estadística que sigue caminando, pero la monotonía ha marcado tu mente.",
+                "quote": "Eres el ruido de fondo. El engranaje que nadie nota hasta que deja de girar. ¿Qué queda de ti sin tu rutina?",
+                "ideales": [
+                    {
+                        "nombre": "Estabilidad",
+                        "desc": "El orden es lo único que nos salva del hambre."
+                    },
+                    {
+                        "nombre": "Invisibilidad",
+                        "desc": "Si nadie te nota, nadie te cobra deudas."
+                    },
+                    {
+                        "nombre": "Solidaridad",
+                        "desc": "Los de abajo somos los únicos que nos cuidamos."
+                    },
+                    {
+                        "nombre": "Resiliencia",
+                        "desc": "No necesito ser fuerte, solo durar un día más."
+                    },
+                    {
+                        "nombre": "Curiosidad",
+                        "desc": "Observar es la única forma de viajar que conozco."
+                    },
+                    {
+                        "nombre": "Pragmatismo",
+                        "desc": "No busco justicia, solo que no me corten la luz."
+                    },
+                    {
+                        "nombre": "Paciencia",
+                        "desc": "La Ciudad devora a los que corren demasiado."
+                    },
+                    {
+                        "nombre": "Deseo",
+                        "desc": "Algún día estaré del otro lado del cristal."
+                    }
+                ],
+                "vinculos": [
+                    {
+                        "nombre": "Agorafobia Urbana",
+                        "desc": "Necesidad del ruido de la multitud para no entrar en pánico."
+                    },
+                    {
+                        "nombre": "Fijación con el Horario",
+                        "desc": "La pérdida de tiempo provoca taquicardia real."
+                    },
+                    {
+                        "nombre": "Somatización del Hambre",
+                        "desc": "Vacío doloroso en el estómago al sentirse inseguro."
+                    },
+                    {
+                        "nombre": "Dependencia de la Multitud",
+                        "desc": "Sentir que dejas de existir si estás solo."
+                    },
+                    {
+                        "nombre": "Memoria Táctil de Llaves",
+                        "desc": "Tocar pertenencias constantemente por miedo al robo."
+                    },
+                    {
+                        "nombre": "Respuesta a la Sirena",
+                        "desc": "Alerta máxima automática ante alarmas corporativas."
+                    }
+                ],
+                "grietas": [
+                    {
+                        "nombre": "Pasividad",
+                        "desc": "Esperar que otros tomen las decisiones difíciles."
+                    },
+                    {
+                        "nombre": "Miedo al Cambio",
+                        "desc": "Bloqueo ante cualquier plan que requiera improvisar."
+                    },
+                    {
+                        "nombre": "Falta de Aspiración",
+                        "desc": "Desconfianza de cualquier oportunidad \"buena\"."
+                    },
+                    {
+                        "nombre": "Cinismo Popular",
+                        "desc": "Desprecio a ideales elevados; considerarlos mentiras."
+                    },
+                    {
+                        "nombre": "Acumulación",
+                        "desc": "Guardar basura por miedo irracional a necesitarla."
+                    },
+                    {
+                        "nombre": "Sumisión al Uniforme",
+                        "desc": "Dificultad para desobedecer a cualquier autoridad."
+                    }
+                ]
             },
             {
-                "nombre": "Disonancia Sensorial",
-                "desc": "Un estímulo específico (olor, luz) provoca parálisis inmediata."
+                "id": "el_mensajero",
+                "name": "El Mensajero",
+                "desc": "Tu vida es movimiento y velocidad. Conoces atajos y grietas, pero tu mente nunca se detiene. El miedo a llegar tarde es tu motor.",
+                "quote": "Corre, pequeño ratón. ¿Qué pasará cuando dejes de correr y el silencio te alcance?",
+                "ideales": [
+                    {
+                        "nombre": "Velocidad",
+                        "desc": "El movimiento es la única libertad."
+                    },
+                    {
+                        "nombre": "Neutralidad",
+                        "desc": "No leo el mensaje; la información no es mi problema."
+                    },
+                    {
+                        "nombre": "Confiabilidad",
+                        "desc": "Mi palabra es lo único que poseo."
+                    },
+                    {
+                        "nombre": "Autonomía",
+                        "desc": "Nadie encadena a quien siempre va un paso por delante."
+                    },
+                    {
+                        "nombre": "Conocimiento",
+                        "desc": "Conocer los caminos es poseer la Ciudad."
+                    },
+                    {
+                        "nombre": "Eficiencia",
+                        "desc": "El camino más corto es el más valioso."
+                    },
+                    {
+                        "nombre": "Sigilo",
+                        "desc": "El éxito es ser un fantasma en el sistema."
+                    },
+                    {
+                        "nombre": "Desapego",
+                        "desc": "No me quedo lo suficiente para echar raíces."
+                    }
+                ],
+                "vinculos": [
+                    {
+                        "nombre": "Inquietud Motora",
+                        "desc": "Incapacidad de estar quieto; piernas en movimiento constante."
+                    },
+                    {
+                        "nombre": "Hiper-fijación de Rutas",
+                        "desc": "Calcular salidas de emergencia en cada habitación."
+                    },
+                    {
+                        "nombre": "Sinestesia de Presión",
+                        "desc": "Sentir el peso del tiempo como presión física."
+                    },
+                    {
+                        "nombre": "Fobia al Encierro",
+                        "desc": "Espacios sin múltiples salidas provocan asfixia."
+                    },
+                    {
+                        "nombre": "Dependencia de Adrenalina",
+                        "desc": "Vacío profundo si no hay riesgo o urgencia."
+                    },
+                    {
+                        "nombre": "Anclaje Espacial",
+                        "desc": "Memorizar puntos de referencia para mantener la identidad."
+                    }
+                ],
+                "grietas": [
+                    {
+                        "nombre": "Impulsividad",
+                        "desc": "Actuar antes de pensar; movimiento sobre estrategia."
+                    },
+                    {
+                        "nombre": "Falta de Atención",
+                        "desc": "Aburrimiento rápido de planes detallados."
+                    },
+                    {
+                        "nombre": "Dificultad de Vínculo",
+                        "desc": "No confías porque siempre planeas tu salida."
+                    },
+                    {
+                        "nombre": "Ansiedad Anticipatoria",
+                        "desc": "Preocupación obsesiva por problemas que no han pasado."
+                    },
+                    {
+                        "nombre": "Irresponsabilidad",
+                        "desc": "Ignorar el daño que causan tus entregas."
+                    },
+                    {
+                        "nombre": "Fatiga Crónica Ignorada",
+                        "desc": "Llevar el cuerpo al límite sin admitir cansancio."
+                    }
+                ]
             },
             {
-                "nombre": "Amnesia Selectiva",
-                "desc": "Un \"bloque muerto\" en tu memoria para evitar el colapso."
+                "id": "el_mediador",
+                "name": "El Mediador",
+                "desc": "Eres el lubricante social. Sabes qué decir y a quién, pero tu personalidad es un reflejo de lo que otros quieren ver. No sabes quién eres solo.",
+                "quote": "Qué máscara tan bonita. Si te la quitas descubrirás que debajo no queda nada.",
+                "ideales": [
+                    {
+                        "nombre": "Equilibrio",
+                        "desc": "Todo conflicto es un fallo de comunicación."
+                    },
+                    {
+                        "nombre": "Influencia",
+                        "desc": "No necesito armas si controlo a quien las empuña."
+                    },
+                    {
+                        "nombre": "Discreción",
+                        "desc": "Los secretos son la moneda más valiosa."
+                    },
+                    {
+                        "nombre": "Empatía",
+                        "desc": "Entender el deseo ajeno es la clave para dominarlo."
+                    },
+                    {
+                        "nombre": "Paz",
+                        "desc": "La violencia es ineficiente; prefiero el comercio."
+                    },
+                    {
+                        "nombre": "Pragmatismo",
+                        "desc": "No hay amigos, solo intereses temporales."
+                    },
+                    {
+                        "nombre": "Prestigio",
+                        "desc": "Mi reputación es mi único escudo."
+                    },
+                    {
+                        "nombre": "Adaptabilidad",
+                        "desc": "Soy el agua que toma la forma del recipiente."
+                    }
+                ],
+                "vinculos": [
+                    {
+                        "nombre": "Reflejo Especular",
+                        "desc": "Copiar gestos y tono de voz ajenos inconscientemente."
+                    },
+                    {
+                        "nombre": "Detección Somática",
+                        "desc": "Náusea real ante mentiras o incongruencias."
+                    },
+                    {
+                        "nombre": "Vacío de Identidad",
+                        "desc": "Ansiedad al estar solo por no tener a quién proyectar."
+                    },
+                    {
+                        "nombre": "Hiper-análisis",
+                        "desc": "Incapacidad de aceptar amabilidad sin buscar el beneficio oculto."
+                    },
+                    {
+                        "nombre": "Necesidad de Aprobación",
+                        "desc": "Impulso de suavizar tensiones innecesariamente."
+                    },
+                    {
+                        "nombre": "Somatización del Compromiso",
+                        "desc": "Opresión en garganta al romper un acuerdo."
+                    }
+                ],
+                "grietas": [
+                    {
+                        "nombre": "Manipulación Compulsiva",
+                        "desc": "Intentar controlar situaciones sociales siempre."
+                    },
+                    {
+                        "nombre": "Indecisión",
+                        "desc": "Tratar de quedar bien con ambos bandos hasta que es tarde."
+                    },
+                    {
+                        "nombre": "Falsedad Habitual",
+                        "desc": "Mentiras pequeñas por pura costumbre."
+                    },
+                    {
+                        "nombre": "Miedo a la Confrontación",
+                        "desc": "Evitar problemas directos hasta que explotan."
+                    },
+                    {
+                        "nombre": "Superficialidad",
+                        "desc": "Centrarse en etiquetas e ignorar problemas reales."
+                    },
+                    {
+                        "nombre": "Vulnerabilidad al Chantaje",
+                        "desc": "Pánico a que tu verdadera opinión sea pública."
+                    }
+                ]
             },
             {
-                "nombre": "Anclaje Táctil",
-                "desc": "Un objeto de alguien que perdiste; te da pánico soltarlo."
+                "id": "el_idealista",
+                "name": "El Idealista",
+                "desc": "Fuiste un genio en un campo que ya no existe o que te fue arrebatado. Tu mente vive en el pasado, en una época donde los conceptos tenían alas y la realidad no era tan opaca. Llevas contigo una melancolía poética que te hace sentir como si estuvieras atrapado detrás de un cristal, observando un mundo que ha perdido su color. Tu lucha no es física, es el esfuerzo constante por no dejar que tu \"yo\" interno se disuelva en el vacío de la Ciudad.",
+                "quote": "Vuelas en una jaula de espejos, creyendo que el reflejo de tus alas es libertad. ¿Qué harás cuando el cristal se rompa y descubras que olvidaste cómo tocar el suelo?",
+                "ideales": [
+                    {
+                        "nombre": "Belleza",
+                        "desc": "Incluso en el fango, debe existir un rastro de perfección."
+                    },
+                    {
+                        "nombre": "Originalidad",
+                        "desc": "Ser un reflejo de otros es la verdadera muerte."
+                    },
+                    {
+                        "nombre": "Trascendencia",
+                        "desc": "Mi existencia debe significar más que un simple contrato."
+                    },
+                    {
+                        "nombre": "Memoria",
+                        "desc": "El pasado es el único lugar donde todavía soy libre."
+                    },
+                    {
+                        "nombre": "Silencio",
+                        "desc": "La paz interna es más valiosa que cualquier éxito externo."
+                    },
+                    {
+                        "nombre": "Poesía",
+                        "desc": "La realidad es insoportable sin una metáfora que la sostenga."
+                    },
+                    {
+                        "nombre": "Verdad",
+                        "desc": "Prefiero una tragedia honesta a una mentira reconfortante."
+                    },
+                    {
+                        "nombre": "Esencia",
+                        "desc": "Busco aquello que nos hace humanos antes de que el sistema nos procese."
+                    }
+                ],
+                "vinculos": [
+                    {
+                        "nombre": "Disonancia de Reflejo",
+                        "desc": "Evitas los espejos porque a veces no reconoces a la persona que te devuelve la mirada."
+                    },
+                    {
+                        "nombre": "Fijación Lirica",
+                        "desc": "Necesitas recitar o escribir fragmentos de pensamientos abstractos para no perder el hilo de tu identidad."
+                    },
+                    {
+                        "nombre": "Melancolía Somática",
+                        "desc": "Una sensación de pesadez en el pecho que solo desaparece cuando estás solo y en silencio."
+                    },
+                    {
+                        "nombre": "Anclaje de Nostalgia",
+                        "desc": "Un objeto sin valor práctico que representa una época en la que fuiste \"tuyo\"."
+                    },
+                    {
+                        "nombre": "Fobia a la Multitud",
+                        "desc": "El ruido de la gente te hace sentir que tus propios pensamientos se desvanecen."
+                    },
+                    {
+                        "nombre": "Sinestesia del Recuerdo",
+                        "desc": "Ciertos olores o luces te transportan a memorias tan vívidas que pierdes la noción del presente."
+                    }
+                ],
+                "grietas": [
+                    {
+                        "nombre": "Aislamiento Voluntario",
+                        "desc": "Te retiras emocionalmente de las situaciones, volviéndote inalcanzable para tus aliados."
+                    },
+                    {
+                        "nombre": "Letargo",
+                        "desc": "En momentos de crisis, tu mente se ralentiza y te cuesta horrores tomar decisiones prácticas."
+                    },
+                    {
+                        "nombre": "Desapego Vital",
+                        "desc": "Tratas tu propia seguridad con una indiferencia que asusta a los demás."
+                    },
+                    {
+                        "nombre": "Obsesión por el Pasado",
+                        "desc": "Ignoras problemas actuales por centrarte en errores o glorias que ya no importan."
+                    },
+                    {
+                        "nombre": "Vulnerabilidad Emocional",
+                        "desc": "Una sola palabra o gesto puede derribar toda tu defensa psicológica."
+                    },
+                    {
+                        "nombre": "Incomunicación",
+                        "desc": "Te expresas de forma tan críptica que nadie entiende realmente lo que necesitas."
+                    }
+                ]
             },
             {
-                "nombre": "Compulsión de Seguridad",
-                "desc": "Ritual repetitivo necesario para \"mantener el mundo en su sitio\"."
+                "id": "el_sabelotodo",
+                "name": "El Sabelotodo",
+                "desc": "La incertidumbre no existe en tu vocabulario. Posees una confianza absoluta en tu intelecto y en tu capacidad para procesar la realidad. Para ti, el mundo es un libro abierto cuyos capítulos ya has leído. Tu problema no es la falta de información, sino el aislamiento que provoca saber que estás varios pasos por delante de todos los demás. Eres el ancla técnica del grupo, pero tu arrogancia es una muralla que nadie puede saltar.",
+                "quote": "Tú preguntas por qué, yo pregunto cuándo. No es arrogancia si los hechos siempre me dan la razón. El problema de ser el único con ojos es tener que guiar a tantos ciegos.",
+                "ideales": [
+                    {
+                        "nombre": "Certeza",
+                        "desc": "La duda es un error de procesamiento que no me permito."
+                    },
+                    {
+                        "nombre": "Eficacia",
+                        "desc": "El camino más lógico es el único que debe ser recorrido."
+                    },
+                    {
+                        "nombre": "Superioridad",
+                        "desc": "Mi intelecto es mi única y verdadera jerarquía."
+                    },
+                    {
+                        "nombre": "Predicción",
+                        "desc": "Si conoces las variables, el futuro es solo una formalidad."
+                    },
+                    {
+                        "nombre": "Control",
+                        "desc": "La información es el único poder real en la Ciudad."
+                    },
+                    {
+                        "nombre": "Autonomía",
+                        "desc": "No necesito consejos, solo herramientas y tiempo."
+                    },
+                    {
+                        "nombre": "Claridad",
+                        "desc": "El caos es solo orden que los demás no saben leer."
+                    },
+                    {
+                        "nombre": "Objetividad",
+                        "desc": "Los sentimientos son variables irrelevantes en la ecuación del éxito."
+                    }
+                ],
+                "vinculos": [
+                    {
+                        "nombre": "Hiper-análisis Compulsivo",
+                        "desc": "Eres incapaz de disfrutar de un momento sin descomponerlo en probabilidades de fallo."
+                    },
+                    {
+                        "nombre": "Disonancia Empática",
+                        "desc": "Sientes una irritación física real cuando alguien toma una decisión basada en emociones."
+                    },
+                    {
+                        "nombre": "Fetiche Informativo",
+                        "desc": "Necesitas tener acceso constante a datos o registros para no sentirte vulnerable."
+                    },
+                    {
+                        "nombre": "Somatización del Error",
+                        "desc": "Un tic nervioso en el ojo o un dolor de cabeza fulminante cuando algo sale mal por \"estupidez\" ajena."
+                    },
+                    {
+                        "nombre": "Desconexión Social",
+                        "desc": "Te refieres a las personas por sus funciones o habilidades, olvidando sus nombres."
+                    },
+                    {
+                        "nombre": "Anclaje de Certeza",
+                        "desc": "Repites hechos científicos o lógicos complejos como mantra para mantener la calma."
+                    }
+                ],
+                "grietas": [
+                    {
+                        "nombre": "Arrogancia Paralizante",
+                        "desc": "Te niegas a escuchar planes ajenos si no coinciden con tu lógica inicial."
+                    },
+                    {
+                        "nombre": "Incapacidad de Improvisación",
+                        "desc": "Te bloqueas si ocurre algo que considerabas \"estadísticamente imposible\"."
+                    },
+                    {
+                        "nombre": "Condescendencia Agresiva",
+                        "desc": "Tratas a tus aliados con un desprecio que destruye la moral del equipo."
+                    },
+                    {
+                        "nombre": "Aislamiento Intelectual",
+                        "desc": "Te guardas información crucial porque crees que los demás no sabrán usarla correctamente."
+                    },
+                    {
+                        "nombre": "Falta de Autocrítica",
+                        "desc": "Si un plan falla, siempre buscas el error en los demás antes que en tu propia lógica."
+                    },
+                    {
+                        "nombre": "Obsesión por la Verdad",
+                        "desc": "Dices realidades crudas en momentos inoportunos, sin medir las consecuencias sociales."
+                    }
+                ]
             },
             {
-                "nombre": "Despersonalización",
-                "desc": "Convicción de que no sobreviviste y eres solo un eco observando."
-            }
-        ],
-        "grietas": [
-            {
-                "nombre": "Paranoia",
-                "desc": "Las sombras se mueven con intenciones que solo tú notas."
+                "id": "el_inocente",
+                "name": "El Inocente",
+                "desc": "Has decidido que el horror de la Ciudad es solo un telón de fondo para una historia de heroísmo que solo tú ves. Vives en una fantasía de justicia, caballerosidad y misiones nobles. Tu mente filtra la suciedad y la sangre, convirtiéndolas en pruebas de valor. Eres el corazón del grupo, pero tu incapacidad para ver la realidad como es te convierte en un peligro andante tanto para ti como para los que intentan protegerte.",
+                "quote": "¡Mirad ese molino, es un gigante del sistema! No temáis, mi espada es recta y mi corazón puro. ¿Por qué lloráis? Hoy es un día glorioso para la justicia.",
+                "ideales": [
+                    {
+                        "nombre": "Justicia",
+                        "desc": "El bien siempre debe triunfar, cueste lo que cueste."
+                    },
+                    {
+                        "nombre": "Heroísmo",
+                        "desc": "Un verdadero guerrero nunca da la espalda al peligro."
+                    },
+                    {
+                        "nombre": "Lealtad",
+                        "desc": "Mis amigos son mis hermanos de armas y mi vida es suya."
+                    },
+                    {
+                        "nombre": "Honor",
+                        "desc": "Mi palabra es un contrato inquebrantable ante Dios y la Ciudad."
+                    },
+                    {
+                        "nombre": "Esperanza",
+                        "desc": "Siempre hay una luz al final del túnel, aunque yo tenga que encenderla."
+                    },
+                    {
+                        "nombre": "Sacrificio",
+                        "desc": "Mi dolor es un precio justo por la sonrisa de otros."
+                    },
+                    {
+                        "nombre": "Pureza",
+                        "desc": "Me niego a dejar que la mugre de la Ciudad manche mi alma."
+                    },
+                    {
+                        "nombre": "Entusiasmo",
+                        "desc": "Cada día es una nueva aventura hacia la gloria."
+                    }
+                ],
+                "vinculos": [
+                    {
+                        "nombre": "Disonancia Cognitiva",
+                        "desc": "Tu mente \"edita\" visualmente las escenas de gore excesivo para que parezcan algo más heroico."
+                    },
+                    {
+                        "nombre": "Fijación de Idolatría",
+                        "desc": "Llevas un póster, medalla o foto de un \"héroe\" que es tu única brújula moral."
+                    },
+                    {
+                        "nombre": "Somatización del Valor",
+                        "desc": "Una descarga de adrenalina incontrolable que te obliga a cargar hacia el peligro sin pensar."
+                    },
+                    {
+                        "nombre": "Compulsión de Discurso",
+                        "desc": "Sientes la necesidad de gritar proclamas heroicas para acallar el miedo interno."
+                    },
+                    {
+                        "nombre": "Anclaje de Fantasía",
+                        "desc": "Un juguete o baratija que para ti es un objeto de poder legendario."
+                    },
+                    {
+                        "nombre": "Respuesta Infantil",
+                        "desc": "Ante un trauma extremo, tu mente retrocede a un estado de negación absoluta y alegría forzada."
+                    }
+                ],
+                "grietas": [
+                    {
+                        "nombre": "Imprudencia Suicida",
+                        "desc": "Te lanzas a situaciones imposibles creyendo que el \"destino\" te protegerá."
+                    },
+                    {
+                        "nombre": "Ceguera de Realidad",
+                        "desc": "Ignoras las señales obvias de traición o peligro porque no encajan en tu historia."
+                    },
+                    {
+                        "nombre": "Terquedad Idealista",
+                        "desc": "Te niegas a realizar acciones pragmáticas (como huir) porque las consideras \"cobardes\"."
+                    },
+                    {
+                        "nombre": "Vulnerabilidad al Desengaño",
+                        "desc": "Si la realidad rompe tu fantasía, entras en un estado catatónico de colapso mental."
+                    },
+                    {
+                        "nombre": "Irresponsabilidad Consecuencial",
+                        "desc": "No mides el daño que tus \"actos heroicos\" causan a terceros."
+                    },
+                    {
+                        "nombre": "Dependencia Emocional",
+                        "desc": "Necesitas que alguien valide constantemente tu rol de héroe para no desmoronarte."
+                    }
+                ]
             },
             {
-                "nombre": "Obsesión",
-                "desc": "Todo es una pista y cada silencio es una amenaza encubierta."
+                "id": "el_arma",
+                "name": "El Arma",
+                "desc": "Para ti, el conflicto no es un problema, es una forma de arte. Eres lacónico, directo y letal. Ves la violencia como una expresión estética donde la brevedad y la precisión son lo único que importa. Tu mente es una galería de momentos violentos perfectamente ejecutados. No te interesan las explicaciones largas ni los motivos; solo el momento en que el acero toca la carne y la composición se completa.",
+                "quote": "S.Y.N.C. (Sangre. Y. Nueva. Composición). No hables. Solo mira cómo el rojo fluye sobre el gris. El arte debe ser breve. Como tu vida.",
+                "ideales": [
+                    {
+                        "nombre": "Estética",
+                        "desc": "La violencia debe ser hermosa o no ser nada."
+                    },
+                    {
+                        "nombre": "Brevedad",
+                        "desc": "Si puedes decirlo en una palabra, no uses dos. Si puedes matar en un segundo, no uses tres."
+                    },
+                    {
+                        "nombre": "Precisión",
+                        "desc": "El caos es para los amateurs; yo busco la perfección del trazo."
+                    },
+                    {
+                        "nombre": "Disciplina",
+                        "desc": "Mi cuerpo es el pincel y el mundo es el lienzo."
+                    },
+                    {
+                        "nombre": "Franqueza",
+                        "desc": "Las palabras mienten, el filo de un arma siempre dice la verdad."
+                    },
+                    {
+                        "nombre": "Independencia",
+                        "desc": "Mi arte es mío; no sigo órdenes, sigo instintos."
+                    },
+                    {
+                        "nombre": "Perfección",
+                        "desc": "Cada ejecución debe superar a la anterior en técnica y forma."
+                    },
+                    {
+                        "nombre": "Silencio",
+                        "desc": "La verdadera obra de arte ocurre en el instante después del último grito."
+                    }
+                ],
+                "vinculos": [
+                    {
+                        "nombre": "Fijación con el Filo",
+                        "desc": "Pasas horas afilando o limpiando tu equipo de forma rítmica para entrar en trance."
+                    },
+                    {
+                        "nombre": "Sinestesia de Combate",
+                        "desc": "Ves colores o escuchas música específica cuando estás en medio de un enfrentamiento."
+                    },
+                    {
+                        "nombre": "Abstracción del Dolor",
+                        "desc": "Eres capaz de observar tus propias heridas con una curiosidad puramente artística."
+                    },
+                    {
+                        "nombre": "Somatización de la Inactividad",
+                        "desc": "Te pica la piel y te tiemblan las manos cuando pasas demasiado tiempo sin \"crear\"."
+                    },
+                    {
+                        "nombre": "Anclaje Táctil Corto",
+                        "desc": "Necesitas sentir el frío del metal contra tu piel para sentirte presente en la realidad."
+                    },
+                    {
+                        "nombre": "Flashback Estético",
+                        "desc": "Recreas mentalmente tus mejores \"obras\" violentas cuando estás bajo estrés."
+                    }
+                ],
+                "grietas": [
+                    {
+                        "nombre": "Crueldad Estética",
+                        "desc": "Retrasas el final de un conflicto solo para ver cómo se desarrolla la \"composición\"."
+                    },
+                    {
+                        "nombre": "Mudez Selectiva",
+                        "desc": "Te niegas a hablar con personas que consideras \"poco interesantes\" o \"feas\" de espíritu."
+                    },
+                    {
+                        "nombre": "Irritabilidad Explosiva",
+                        "desc": "Reaccionas con violencia ante interrupciones en tu proceso o críticas a tu forma de actuar."
+                    },
+                    {
+                        "nombre": "Falta de Empatía Total",
+                        "desc": "Tratas el sufrimiento ajeno como material de trabajo, sin ninguna conexión humana."
+                    },
+                    {
+                        "nombre": "Improvisación Arriesgada",
+                        "desc": "Eliges el camino más difícil en combate solo porque visualmente es más impactante."
+                    },
+                    {
+                        "nombre": "Desprecio por la Vida",
+                        "desc": "Tu propia seguridad te importa menos que la calidad del \"espectáculo\" que estás dando."
+                    }
+                ]
             },
             {
-                "nombre": "Vacío",
-                "desc": "Tus emociones se quedaron en aquel lugar; ahora solo queda análisis frío."
+                "id": "el_investigador",
+                "name": "El Investigador",
+                "desc": "Tu mente es un imán para lo anómalo. No puedes evitar buscar el \"por qué\" detrás de cada tragedia o irregularidad. Has trabajado como detective privado o analista de riesgos. Tu problema es que la Ciudad no quiere ser comprendida, y cuanto más tiras del hilo, más se enreda en tu propio cuello.",
+                "quote": "Sigues buscando patrones en la sangre. Crees que hay una verdad. Pero la Ciudad es solo caos hambriento.",
+                "ideales": [
+                    {
+                        "nombre": "Verdad",
+                        "desc": "Una mentira es una herida en la realidad que debe ser cerrada."
+                    },
+                    {
+                        "nombre": "Justicia",
+                        "desc": "Alguien debe pagar por el desequilibrio."
+                    },
+                    {
+                        "nombre": "Persistencia",
+                        "desc": "No hay caso cerrado, solo investigadores rendidos."
+                    },
+                    {
+                        "nombre": "Curiosidad",
+                        "desc": "El misterio es mi único combustible."
+                    },
+                    {
+                        "nombre": "Escepticismo",
+                        "desc": "Lo obvio suele ser la capa superior de una mentira."
+                    },
+                    {
+                        "nombre": "Resolución",
+                        "desc": "Terminar lo que empiezo es mi única paz."
+                    },
+                    {
+                        "nombre": "Objetividad",
+                        "desc": "Los sentimientos no deben nublar las pruebas."
+                    },
+                    {
+                        "nombre": "Expiación",
+                        "desc": "Busco la verdad para otros; no encuentro la mía."
+                    }
+                ],
+                "vinculos": [
+                    {
+                        "nombre": "Pareidolia Compulsiva",
+                        "desc": "Ver mensajes en patrones aleatorios o estática."
+                    },
+                    {
+                        "nombre": "Insomnio Analítico",
+                        "desc": "Incapacidad de dormir con un enigma pendiente."
+                    },
+                    {
+                        "nombre": "Fijación Irrelevante",
+                        "desc": "Atraparse en un detalle mínimo e ignorar el peligro."
+                    },
+                    {
+                        "nombre": "Somatización de la Mentira",
+                        "desc": "Sabor metálico en la boca ante el engaño."
+                    },
+                    {
+                        "nombre": "Dependencia del Caos",
+                        "desc": "Necesidad del misterio para sentirse vivo."
+                    },
+                    {
+                        "nombre": "Anclaje de Evidencia",
+                        "desc": "Objeto de un caso que nunca pudiste cerrar."
+                    }
+                ],
+                "grietas": [
+                    {
+                        "nombre": "Obsesión Peligrosa",
+                        "desc": "Ignorar la seguridad por una última pista."
+                    },
+                    {
+                        "nombre": "Cinismo Investigativo",
+                        "desc": "Asumir que todo el mundo es culpable."
+                    },
+                    {
+                        "nombre": "Incapacidad de Soltar",
+                        "desc": "Investigar asuntos que ya no importan."
+                    },
+                    {
+                        "nombre": "Aislamiento Obsesivo",
+                        "desc": "Encerrarse en el mundo mental propio."
+                    },
+                    {
+                        "nombre": "Paranoia Selectiva",
+                        "desc": "Convicción de que los \"culpables\" te vigilan."
+                    },
+                    {
+                        "nombre": "Frialdad ante la Tragedia",
+                        "desc": "Importa el \"cómo\" y no el sufrimiento."
+                    }
+                ]
             },
             {
-                "nombre": "Temeridad",
-                "desc": "Estás convencido de que lo peor ya pasó; el riesgo ya no genera miedo."
+                "id": "el_sanador",
+                "name": "El Sanador",
+                "desc": "Coses carne para que el sistema siga girando. Has salvado vidas, pero cada cicatriz ajena abre una nueva en tu propia mente. Eres el que mantiene la vida en un lugar que la desprecia.",
+                "quote": "Coses y coses, pero la carne se pudre. ¿Cuántas piezas te faltan a ti por completar a otros?",
+                "ideales": [
+                    {
+                        "nombre": "Preservación",
+                        "desc": "La vida es el único valor absoluto."
+                    },
+                    {
+                        "nombre": "Compasión",
+                        "desc": "Aliviar el sufrimiento es la protesta real."
+                    },
+                    {
+                        "nombre": "Conocimiento",
+                        "desc": "Entender la carne es derrotar a la muerte."
+                    },
+                    {
+                        "nombre": "Pragmatismo",
+                        "desc": "Si sangras, te curo, no importa quién seas."
+                    },
+                    {
+                        "nombre": "Orden Médico",
+                        "desc": "La salud es el equilibrio; el resto caos."
+                    },
+                    {
+                        "nombre": "Resiliencia",
+                        "desc": "No rendirse mientras haya pulso."
+                    },
+                    {
+                        "nombre": "Autonomía",
+                        "desc": "Mi habilidad me hace necesario y seguro."
+                    },
+                    {
+                        "nombre": "Humildad",
+                        "desc": "Soy solo un técnico de la vida."
+                    }
+                ],
+                "vinculos": [
+                    {
+                        "nombre": "Hiper-fijación de Síntomas",
+                        "desc": "Analizar tics y respiración de aliados constantemente."
+                    },
+                    {
+                        "nombre": "Desensibilización al Horror",
+                        "desc": "Capacidad de dormir rodeado de gore; angustia ante lo emocional."
+                    },
+                    {
+                        "nombre": "Somatización del Fallo",
+                        "desc": "Dolor en las manos al no poder salvar a alguien."
+                    },
+                    {
+                        "nombre": "Compulsión de Limpieza",
+                        "desc": "Lavado obsesivo para \"limpiar\" la culpa."
+                    },
+                    {
+                        "nombre": "Fobia a la Fragilidad",
+                        "desc": "Rabia irracional ante la debilidad extrema ajena."
+                    },
+                    {
+                        "nombre": "Anclaje de Anatomía",
+                        "desc": "Recitar nombres de huesos para mantener la calma."
+                    }
+                ],
+                "grietas": [
+                    {
+                        "nombre": "Complejo de Mesías",
+                        "desc": "Creerse el único responsable de que el grupo viva."
+                    },
+                    {
+                        "nombre": "Frialdad Clínica",
+                        "desc": "Tratar a aliados como \"casos\" y no humanos."
+                    },
+                    {
+                        "nombre": "Abuso de Sustancias",
+                        "desc": "Uso de sedantes para soportar la carga emocional."
+                    },
+                    {
+                        "nombre": "Pesimismo Médico",
+                        "desc": "Convicción de que todos morirán pronto."
+                    },
+                    {
+                        "nombre": "Negligencia Propia",
+                        "desc": "Cuidar de todos e ignorar las heridas propias."
+                    },
+                    {
+                        "nombre": "Miedo al Error",
+                        "desc": "Bloqueo ante heridas que no sabes tratar inmediatamente."
+                    }
+                ]
             },
             {
-                "nombre": "Culpabilidad",
-                "desc": "Buscas constantemente una razón lógica de por qué tú sigues aquí."
+                "id": "el_adoctrinado",
+                "name": "El Adoctrinado",
+                "desc": "Tu voluntad no es tuya; es un conjunto de protocolos, órdenes y verdades absolutas que te fueron grabadas a fuego. Eres el ejecutor perfecto porque no cuestionas, no dudas y, sobre todo, no sientes la necesidad de elegir. Eres una extensión de una autoridad superior (una corporación, un culto o una familia) y tu mayor conflicto es el silencio que surge cuando no hay nadie dándote instrucciones.",
+                "quote": "No necesito razones, necesito instrucciones. Mi existencia es un contrato que ya fue firmado. Si no hay una orden, no hay un camino.",
+                "ideales": [
+                    {
+                        "nombre": "Obediencia",
+                        "desc": "El primer deber es seguir el protocolo; el segundo es no cuestionarlo."
+                    },
+                    {
+                        "nombre": "Orden",
+                        "desc": "La Ciudad solo sobrevive gracias a los que mantienen su puesto en la fila."
+                    },
+                    {
+                        "nombre": "Neutralidad",
+                        "desc": "No soy el responsable de mis actos, solo soy el medio por el cual se ejecutan."
+                    },
+                    {
+                        "nombre": "Utilidad",
+                        "desc": "Mi valor se mide por mi capacidad de cumplir la tarea asignada."
+                    },
+                    {
+                        "nombre": "Silencio",
+                        "desc": "Las palabras innecesarias solo ensucian la pureza de la ejecución."
+                    },
+                    {
+                        "nombre": "Disciplina",
+                        "desc": "El control sobre uno mismo es la única forma de no ser consumido por el caos."
+                    },
+                    {
+                        "nombre": "Paciencia",
+                        "desc": "Esperaré el tiempo que sea necesario hasta que llegue la siguiente instrucción."
+                    },
+                    {
+                        "nombre": "Pragmatismo",
+                        "desc": "Lo que es eficiente es correcto; lo que estorba es error."
+                    }
+                ],
+                "vinculos": [
+                    {
+                        "nombre": "Dampening Sensorial",
+                        "desc": "Has entrenado tu mente para ignorar el dolor o el miedo hasta que la tarea termine."
+                    },
+                    {
+                        "nombre": "Eco de la Autoridad",
+                        "desc": "Escuchas la voz de tu superior o de tu código de conducta en tu cabeza en cada momento de duda."
+                    },
+                    {
+                        "nombre": "Compulsión de Reporte",
+                        "desc": "Sientes la necesidad física de narrar tus acciones o justificarlas ante una figura de autoridad imaginaria."
+                    },
+                    {
+                        "nombre": "Anclaje de Protocolo",
+                        "desc": "Llevas un manual, una placa o un objeto que representa tus reglas y lo tocas compulsivamente."
+                    },
+                    {
+                        "nombre": "Somatización de la Duda",
+                        "desc": "Una parálisis motriz severa cuando te enfrentas a una situación que no está cubierta por tus órdenes."
+                    },
+                    {
+                        "nombre": "Morfología Rígida",
+                        "desc": "Tu cuerpo mantiene posturas militares o de servicio incluso cuando duermes."
+                    }
+                ],
+                "grietas": [
+                    {
+                        "nombre": "Literalismo Peligroso",
+                        "desc": "Sigues las instrucciones al pie de la letra, ignorando el sentido común o las consecuencias obvias."
+                    },
+                    {
+                        "nombre": "Falta de Iniciativa",
+                        "desc": "Eres incapaz de actuar por tu cuenta si no hay una figura que proyecte mando."
+                    },
+                    {
+                        "nombre": "Vacío Emocional",
+                        "desc": "Tratas las tragedias (propias o ajenas) con una indiferencia que resulta perturbadora."
+                    },
+                    {
+                        "nombre": "Dependencia Jerárquica",
+                        "desc": "Buscas desesperadamente a alguien que te diga qué hacer, incluso si esa persona no es de fiar."
+                    },
+                    {
+                        "nombre": "Rigidez Mental",
+                        "desc": "Te cuesta horrores adaptarte a cambios que rompan el \"plan establecido\"."
+                    },
+                    {
+                        "nombre": "Apatía Social",
+                        "desc": "No entiendes las bromas, el sarcasmo o las sutilezas emocionales; todo es dato u orden."
+                    }
+                ]
             },
             {
-                "nombre": "Secretismo",
-                "desc": "Si supieran tu nivel de distorsión, te tratarían como a un error del sistema."
+                "id": "el_testigo",
+                "name": "El Testigo",
+                "desc": "Creciste detrás de una cortina de seda, mirando el horror de la Ciudad como si fuera una obra de teatro fascinante pero distante. Tu linaje o tu fortuna te protegieron de la realidad cruda, y ahora que estás en la calle, todo te parece una curiosidad macabra. Tu mente está llena de una inocencia peligrosa y una desconexión total con el sufrimiento ajeno, tratándolo todo con una cortesía elegante que oculta una profunda incapacidad para empatizar.",
+                "quote": "Oh, ¿así es como sangra la gente común? Qué color tan vibrante, casi parece una pintura de vanguardia. ¿Podemos quedarnos a ver cómo termina?",
+                "ideales": [
+                    {
+                        "nombre": "Curiosidad",
+                        "desc": "El mundo es un museo de experiencias y yo quiero verlas todas."
+                    },
+                    {
+                        "nombre": "Estética",
+                        "desc": "La forma en que las cosas ocurren es más importante que el porqué."
+                    },
+                    {
+                        "nombre": "Cortesía",
+                        "desc": "Los modales son lo único que nos separa de las bestias que habitan los Distritos."
+                    },
+                    {
+                        "nombre": "Distanciamiento",
+                        "desc": "Yo solo soy un observador; nada de esto puede mancharme realmente."
+                    },
+                    {
+                        "nombre": "Fascinación",
+                        "desc": "El dolor y la miseria tienen una belleza trágica que merece ser estudiada."
+                    },
+                    {
+                        "nombre": "Optimismo",
+                        "desc": "Todo es una aventura interesante si se mira desde el ángulo correcto."
+                    },
+                    {
+                        "nombre": "Elegancia",
+                        "desc": "Incluso en el fango, uno debe mantener la compostura y la clase."
+                    },
+                    {
+                        "nombre": "Inocencia",
+                        "desc": "No entiendo por qué la gente está tan enojada; el mundo es un lugar lleno de maravillas."
+                    }
+                ],
+                "vinculos": [
+                    {
+                        "nombre": "Disonancia de Realidad",
+                        "desc": "Tratas situaciones de vida o muerte como si fueran un juego o una función social."
+                    },
+                    {
+                        "nombre": "Fetiche de Lujo",
+                        "desc": "Un objeto de tu pasado (un perfume, un pañuelo de seda) cuya textura es lo único que te calma."
+                    },
+                    {
+                        "nombre": "Percepción Selectiva",
+                        "desc": "Tu cerebro ignora instintivamente los olores fétidos o las imágenes grotescas por pura costumbre de comodidad."
+                    },
+                    {
+                        "nombre": "Somatización del Desprecio",
+                        "desc": "Sientes náuseas reales cuando tienes que tocar algo \"sucio\" o hablar con alguien de clase baja."
+                    },
+                    {
+                        "nombre": "Fijación Narrativa",
+                        "desc": "Intentas convertir todo lo que ocurre en una historia o un cuento para hacerlo digerible."
+                    },
+                    {
+                        "nombre": "Anclaje de Clase",
+                        "desc": "Te refieres a conceptos que nadie más entiende, buscando una conexión con un mundo que ya no tienes."
+                    }
+                ],
+                "grietas": [
+                    {
+                        "nombre": "Falta de Empatía Cruel",
+                        "desc": "Haces comentarios insensibles sobre el dolor de otros sin darte cuenta de que son ofensivos."
+                    },
+                    {
+                        "nombre": "Ignorancia del Peligro",
+                        "desc": "Te acercas a amenazas letales solo por la curiosidad de \"verlas de cerca\"."
+                    },
+                    {
+                        "nombre": "Vulnerabilidad a la Manipulación",
+                        "desc": "Eres presa fácil de cualquiera que use halagos o promesas de estatus."
+                    },
+                    {
+                        "nombre": "Capricho Impulsivo",
+                        "desc": "Pones en riesgo al grupo por un deseo momentáneo de obtener algo que te parece \"bonito\"."
+                    },
+                    {
+                        "nombre": "Incapacidad de Esfuerzo",
+                        "desc": "Te quejas constantemente de las incomodidades físicas básicas, agotando la paciencia del grupo."
+                    },
+                    {
+                        "nombre": "Arrogancia Involuntaria",
+                        "desc": "Tratas a tus aliados como si fueran tus sirvientes o guías turísticos."
+                    }
+                ]
+            },
+            {
+                "id": "el_rencoroso",
+                "name": "El Rencoroso",
+                "desc": "La Ciudad te ha tratado como a un animal durante tanto tiempo que terminaste por creerlo. Llevas una amargura que se siente como ácido en tus venas. Cada mirada, cada palabra y cada gesto de los demás es filtrado por tu resentimiento. No buscas justicia, buscas que los que están arriba (o los que tienen suerte) sientan al menos una fracción del desprecio que tú has recibido. Eres una bomba de tiempo con patas, alimentada por una furia que es lo único que te mantiene caliente por las noches.",
+                "quote": "No me mires así. Sé lo que piensas. Crees que eres mejor que yo, pero en este callejón todos sangramos igual. Y yo disfruto viendo cómo te manchas.",
+                "ideales": [
+                    {
+                        "nombre": "Venganza",
+                        "desc": "El mundo me debe una, y pienso cobrarla con intereses."
+                    },
+                    {
+                        "nombre": "Fuerza",
+                        "desc": "Si no puedes morder, no mereces tener un sitio en la mesa."
+                    },
+                    {
+                        "nombre": "Resentimiento",
+                        "desc": "El éxito ajeno es una afrenta personal contra mi propia miseria."
+                    },
+                    {
+                        "nombre": "Justicia (Personal)",
+                        "desc": "El equilibrio solo se restaura cuando los que humillaron son humillados."
+                    },
+                    {
+                        "nombre": "Desconfianza",
+                        "desc": "Todos tienen un motivo oculto; la amabilidad es solo una trampa."
+                    },
+                    {
+                        "nombre": "Supervivencia",
+                        "desc": "He salido del fango antes, y volveré a salir pasando por encima de quien sea."
+                    },
+                    {
+                        "nombre": "Ira",
+                        "desc": "La furia es el único motor que nunca me ha fallado."
+                    },
+                    {
+                        "nombre": "Cinismo",
+                        "desc": "La esperanza es para los que no han sido pateados suficientes veces."
+                    }
+                ],
+                "vinculos": [
+                    {
+                        "nombre": "Hiper-vigilancia del Desprecio",
+                        "desc": "Analizas los gestos de los demás buscando señales de burla o condescendencia."
+                    },
+                    {
+                        "nombre": "Somatización de la Rabia",
+                        "desc": "Un calor insoportable en el pecho y temblor en las manos cuando te sientes ignorado o humillado."
+                    },
+                    {
+                        "nombre": "Memoria de Cicatrices",
+                        "desc": "Tocas compulsivamente marcas de heridas viejas para alimentar tu odio antes de un combate."
+                    },
+                    {
+                        "nombre": "Fijación de Olor",
+                        "desc": "Un aroma específico (un tabaco barato, humedad, metal) que te transporta al momento de tu mayor humillación."
+                    },
+                    {
+                        "nombre": "Anclaje de Venganza",
+                        "desc": "Un objeto roto que perteneció a alguien que odias y que juraste devolver \"reparado\" con sangre."
+                    },
+                    {
+                        "nombre": "Flashback de Violencia",
+                        "desc": "Escuchas ecos de insultos pasados cuando alguien intenta darte una orden."
+                    }
+                ],
+                "grietas": [
+                    {
+                        "nombre": "Volatilidad Explosiva",
+                        "desc": "Reaccionas con violencia desmedida ante críticas menores o bromas inofensivas."
+                    },
+                    {
+                        "nombre": "Autosabotaje Social",
+                        "desc": "Arruinas relaciones útiles porque no puedes evitar insultar a quienes intentan ayudarte."
+                    },
+                    {
+                        "nombre": "Paranoia de Traición",
+                        "desc": "Estás convencido de que tus aliados te abandonarán en cuanto dejes de serles útil."
+                    },
+                    {
+                        "nombre": "Terquedad Agresiva",
+                        "desc": "Te niegas a seguir planes lógicos solo por no darle la razón a alguien que consideras \"superior\"."
+                    },
+                    {
+                        "nombre": "Falta de Tacto",
+                        "desc": "Tu lenguaje es crudo, hiriente y diseñado para alejar a la gente."
+                    },
+                    {
+                        "nombre": "Obsesión por la Fuerza",
+                        "desc": "Desprecias la diplomacia o la inteligencia, viéndolas como debilidades de cobardes."
+                    }
+                ]
+            },
+            {
+                "id": "el_naufragado",
+                "name": "El Naufragado",
+                "desc": "Sobreviviste a una catástrofe que devoró todo lo que conocías: una expedición fallida, una sucursal corporativa que colapsó o una Anomalía que borró tu mundo. Eres el único resto de un naufragio mental y físico. Tu vida ahora no es más que una línea recta hacia un objetivo difuso: encontrar a \"alguien\" o \"algo\" que estaba allí. Tu obsesión es tan densa que apenas te queda espacio para la realidad, y el frío de aquel suceso todavía vive en tus huesos.",
+                "quote": "Todavía escucho el sonido del agua... o quizás era el vacío. No importa. Alguien se fue y yo me quedé. No descansaré hasta que los dos estemos en el mismo lado de la orilla.",
+                "ideales": [
+                    {
+                        "nombre": "Persistencia",
+                        "desc": "No importa cuánto tiempo tome, la brújula de mi mente siempre apunta al mismo sitio."
+                    },
+                    {
+                        "nombre": "Cierre",
+                        "desc": "Mi vida no puede empezar de nuevo hasta que este capítulo sea terminado."
+                    },
+                    {
+                        "nombre": "Venganza",
+                        "desc": "El \"Capitán\" o la entidad responsable debe pagar por haberme dejado atrás."
+                    },
+                    {
+                        "nombre": "Obsesión",
+                        "desc": "La búsqueda es mi única identidad; sin ella, no soy nada."
+                    },
+                    {
+                        "nombre": "Deber",
+                        "desc": "Prometí encontrarlo/la, y las promesas de los muertos son las únicas que importan."
+                    },
+                    {
+                        "nombre": "Sacrificio",
+                        "desc": "No me importa lo que tenga que quemar en el camino, siempre que la meta esté cerca."
+                    },
+                    {
+                        "nombre": "Verdad",
+                        "desc": "Necesito saber qué fue lo que realmente ocurrió en el corazón del desastre."
+                    },
+                    {
+                        "nombre": "Finalidad",
+                        "desc": "Busco el final de mi historia, sea cual sea."
+                    }
+                ],
+                "vinculos": [
+                    {
+                        "nombre": "Frío Crónico",
+                        "desc": "Sientes una temperatura bajo cero en tus manos y pies que solo disminuye cuando estás cerca de una pista de tu búsqueda."
+                    },
+                    {
+                        "nombre": "Alucinación Auditiva",
+                        "desc": "El sonido rítmico de un motor, olas o pasos que te guían hacia donde \"debes\" ir."
+                    },
+                    {
+                        "nombre": "Fijación con el Objetivo",
+                        "desc": "Llevas un mapa, una brújula rota o un retrato desgastado que consultas obsesivamente."
+                    },
+                    {
+                        "nombre": "Somatización del Vacío",
+                        "desc": "Una sensación de asfixia o ahogamiento cuando te desvías de tu meta principal."
+                    },
+                    {
+                        "nombre": "Anclaje de Supervivencia",
+                        "desc": "Un objeto inútil del desastre (un trozo de metal, una cuerda, un botón) que crees que es tu amuleto de suerte."
+                    },
+                    {
+                        "nombre": "Compulsión de Rastreo",
+                        "desc": "Buscas marcas o señales de \"esa persona\" en cada rostro o callejón que visitas."
+                    }
+                ],
+                "grietas": [
+                    {
+                        "nombre": "Visión de Túnel",
+                        "desc": "Ignoras los peligros inmediatos o las necesidades del grupo si interfieren con tu búsqueda."
+                    },
+                    {
+                        "nombre": "Desconexión Emocional",
+                        "desc": "Eres incapaz de formar nuevos vínculos porque tu corazón está \"en otra parte\"."
+                    },
+                    {
+                        "nombre": "Fatiga Obsesiva",
+                        "desc": "No descansas ni comes bien, llevando tu cuerpo al límite del colapso por no perder tiempo."
+                    },
+                    {
+                        "nombre": "Temeridad Calculada",
+                        "desc": "Arriesgas la vida del grupo en maniobras peligrosas si crees que te acercan a tu objetivo."
+                    },
+                    {
+                        "nombre": "Paranoia de Encubrimiento",
+                        "desc": "Estás convencido de que la gente te oculta información sobre tu búsqueda de forma deliberada."
+                    },
+                    {
+                        "nombre": "Melancolía de Naufragio",
+                        "desc": "Entras en estados de depresión profunda cuando sientes que el rastro se ha enfriado."
+                    }
+                ]
             }
         ]
-    },
-    {
-        "id": "el_trasgresor",
-        "name": "El Trasgresor",
-        "desc": "Cruzaste una línea que juraste nunca tocar por miedo o ambición. El peso de ese acto es una mancha en tu conciencia. Eres un profesional del bajo mundo que descubrió que su propia moralidad tenía un precio, y ahora vives con el eco de la traición que lo cambió todo.",
-        "quote": "La lealtad es el chiste más viejo de la Ciudad. Afilaste el cuchillo, se lo pusiste en la mano y luego les diste la espalda. ¿De verdad te sorprendió sentir el acero?",
-        "ideales": [
-            {
-                "nombre": "Pragmatismo",
-                "desc": "Los principios son un lujo que los vivos no pueden permitirse."
-            },
-            {
-                "nombre": "Redención",
-                "desc": "Mis acciones actuales deben pesar más que mi crimen pasado."
-            },
-            {
-                "nombre": "Nihilismo",
-                "desc": "Si nada tiene valor moral, no hay por qué pedir perdón."
-            },
-            {
-                "nombre": "Orden",
-                "desc": "Crucé la línea para evitar un caos mayor."
-            },
-            {
-                "nombre": "Ambición",
-                "desc": "Solo los que se ensucian las manos llegan a la cima."
-            },
-            {
-                "nombre": "Castigo",
-                "desc": "Merezco cada gramo de dolor que el destino me arroje."
-            },
-            {
-                "nombre": "Autonomía",
-                "desc": "No sigo leyes, solo mis instintos de supervivencia."
-            },
-            {
-                "nombre": "Cinismo",
-                "desc": "Todos son trasgresores; yo solo fui el descubierto."
-            }
-        ],
-        "vinculos": [
-            {
-                "nombre": "Memoria Táctil",
-                "desc": "Peso imaginario de sangre en las manos; lavado compulsivo."
-            },
-            {
-                "nombre": "Anclaje de Culpa",
-                "desc": "El objeto obtenido por traición; náuseas al verlo pero incapaz de tirarlo."
-            },
-            {
-                "nombre": "Fijación Nominal",
-                "desc": "Repetir el nombre de tu víctima como mantra bajo presión."
-            },
-            {
-                "nombre": "Evitación de Reflejos",
-                "desc": "Incapacidad de mirar tu propio rostro en un espejo."
-            },
-            {
-                "nombre": "Flashback Auditivo",
-                "desc": "El sonido de la última súplica ignorada suena en el silencio."
-            },
-            {
-                "nombre": "Compulsión Reparadora",
-                "desc": "Necesidad irracional de ayudar a desconocidos que te recuerdan a tu víctima."
-            }
-        ],
-        "grietas": [
-            {
-                "nombre": "Autosabotaje",
-                "desc": "Arruinas tus planes porque sientes que no mereces el éxito."
-            },
-            {
-                "nombre": "Desconfianza Proyectada",
-                "desc": "Asumes que todos van a traicionarte."
-            },
-            {
-                "nombre": "Mudez Selectiva",
-                "desc": "Bloqueo mental ante palabras que disparan el recuerdo del acto."
-            },
-            {
-                "nombre": "Frigidez Emocional",
-                "desc": "Capacidad de sentir afecto anulada para evitar el peso moral."
-            },
-            {
-                "nombre": "Necesidad de Confesión",
-                "desc": "Impulso peligroso de contar la verdad en momentos vulnerables."
-            },
-            {
-                "nombre": "Justificación Agresiva",
-                "desc": "Violencia inmediata si alguien cuestiona tu moralidad."
-            }
-        ]
-    },
-    {
-        "id": "el_caido",
-        "name": "El Caído",
-        "desc": "Tuviste poder, nombre y respeto. La caída no fue solo financiera, fue una demolición de tu identidad. Caminas por las calles que antes mirabas desde las alturas, y la herida de tu fracaso se infecta con cada mirada de desprecio.",
-        "quote": "Estabas en la cima mirando a las ratas, hasta que el piso resultó ser de cristal. La caída siempre rompe más a los que vuelan alto.",
-        "ideales": [
-            {
-                "nombre": "Estatus",
-                "desc": "Sin poder no somos nada; debo recuperarlo."
-            },
-            {
-                "nombre": "Justicia",
-                "desc": "Manipularon el sistema para tirarme; la verdad debe salir."
-            },
-            {
-                "nombre": "Resentimiento",
-                "desc": "La Ciudad me dio la espalda; yo le mostraré mi peor cara."
-            },
-            {
-                "nombre": "Humildad",
-                "desc": "He visto el fondo y aprendido lo que realmente importa."
-            },
-            {
-                "nombre": "Superioridad",
-                "desc": "Mi intelecto no desapareció con mi dinero; sigo estando por encima."
-            },
-            {
-                "nombre": "Venganza",
-                "desc": "Solo quiero ver arder a quienes me quitaron mi vida."
-            },
-            {
-                "nombre": "Seguridad",
-                "desc": "Nunca volveré a ser vulnerable ante el capricho ajeno."
-            },
-            {
-                "nombre": "Legado",
-                "desc": "Mis acciones aún deben significar algo para el futuro."
-            }
-        ],
-        "vinculos": [
-            {
-                "nombre": "Disonancia Cognitiva",
-                "desc": "Sigues dando órdenes a gente que ya no te conoce."
-            },
-            {
-                "nombre": "Fetiche de Estatus",
-                "desc": "Un accesorio de lujo roto que es lo único que no te embargaron."
-            },
-            {
-                "nombre": "Lista de Agravios",
-                "desc": "Registro mental de cada persona que celebró tu ruina."
-            },
-            {
-                "nombre": "Agorafobia Selectiva",
-                "desc": "Pánico a ser reconocido en zonas donde antes eras importante."
-            },
-            {
-                "nombre": "Somatización del Fracaso",
-                "desc": "Asfixia al ver el logo de tu antigua corporación o grupo."
-            },
-            {
-                "nombre": "Idealización del Pasado",
-                "desc": "Distorsión donde tus errores desaparecen y solo queda el \"paraíso\"."
-            }
-        ],
-        "grietas": [
-            {
-                "nombre": "Arrogancia Defensiva",
-                "desc": "Tratar a otros como inferiores para ocultar tu inseguridad."
-            },
-            {
-                "nombre": "Incapacidad de Adaptación",
-                "desc": "Negativa a realizar tareas \"bajas\" aunque tu vida dependa de ello."
-            },
-            {
-                "nombre": "Despilfarro",
-                "desc": "Gastar recursos en lujos para mantener la ilusión de éxito."
-            },
-            {
-                "nombre": "Vulnerabilidad a la Adulación",
-                "desc": "Manipulable por cualquiera que te trate con \"respeto\"."
-            },
-            {
-                "nombre": "Vergüenza Paralizante",
-                "desc": "Incapacidad de pedir ayuda; prefieres morir antes que mendigar."
-            },
-            {
-                "nombre": "Mendacidad",
-                "desc": "Mentiras constantes sobre tu situación actual para no colapsar."
-            }
-        ]
-    },
-    {
-        "id": "la_herramienta_rota",
-        "name": "La Herramienta Rota",
-        "desc": "Fuiste diseñado o entrenado para una función. Pero algo falló: un error técnico o un colapso mental. Te desecharon como un engranaje desgastado. Ahora tienes una libertad que no sabes usar y un propósito que ya no existe.",
-        "quote": "La Ciudad no desperdicia nada. Si estás aquí afuera es porque ya no sirves ni para reciclaje. Eres el sobrante de una ecuación cerrada.",
-        "ideales": [
-            {
-                "nombre": "Eficiencia",
-                "desc": "El mundo funciona mejor cuando cada pieza hace lo que debe."
-            },
-            {
-                "nombre": "Libertad",
-                "desc": "Ser inútil es la única forma de ser libre del sistema."
-            },
-            {
-                "nombre": "Relevancia",
-                "desc": "Debo encontrar un nuevo propósito para no desaparecer."
-            },
-            {
-                "nombre": "Autodestrucción",
-                "desc": "Una herramienta rota solo sirve para ser destruida."
-            },
-            {
-                "nombre": "Curiosidad",
-                "desc": "Quiero saber qué hay fuera de mi protocolo original."
-            },
-            {
-                "nombre": "Resentimiento",
-                "desc": "Seré la arena en los engranajes de quienes me usaron."
-            },
-            {
-                "nombre": "Perfección",
-                "desc": "Me repararé para demostrar que se equivocaron conmigo."
-            },
-            {
-                "nombre": "Pertenencia",
-                "desc": "Busco desesperadamente a alguien que me diga qué hacer."
-            }
-        ],
-        "vinculos": [
-            {
-                "nombre": "Eco de Protocolo",
-                "desc": "Despertar y realizar rutinas de mantenimiento para equipo inexistente."
-            },
-            {
-                "nombre": "Fobia a la Inspección",
-                "desc": "Miedo irracional a que alguien encuentre el \"error\" en tu mente."
-            },
-            {
-                "nombre": "Despersonalización Funcional",
-                "desc": "Referirse a uno mismo en tercera persona o como objeto."
-            },
-            {
-                "nombre": "Dependencia de Órdenes",
-                "desc": "Ansiedad y desorientación si no hay instrucciones claras."
-            },
-            {
-                "nombre": "Somatización del Error",
-                "desc": "Tic nervioso que coincide con el momento en que \"fallaste\"."
-            },
-            {
-                "nombre": "Fijación con el Creador",
-                "desc": "Obsesión por encontrar a quien te fabricó o entrenó."
-            }
-        ],
-        "grietas": [
-            {
-                "nombre": "Apatía Programada",
-                "desc": "Incapacidad de sentir interés por nada que no sea una tarea."
-            },
-            {
-                "nombre": "Rigidez Mental",
-                "desc": "Dificultad extrema para improvisar si el plan se desvía."
-            },
-            {
-                "nombre": "Obsesión por la Limpieza",
-                "desc": "Limpieza compulsiva para evitar el \"desgaste\" final."
-            },
-            {
-                "nombre": "Sumisión Involuntaria",
-                "desc": "Obedecer a cualquier figura de autoridad sin cuestionar."
-            },
-            {
-                "nombre": "Falta de Instinto",
-                "desc": "Incapacidad de reconocer el peligro personal; no fuiste diseñado para ello."
-            },
-            {
-                "nombre": "Vacío de Identidad",
-                "desc": "No tener gustos propios; ser un reflejo de quienes te rodean."
-            }
-        ]
-    },
-    {
-        "id": "el_aspirante",
-        "name": "El Aspirante",
-        "desc": "Tu motor es la presión de un futuro que aún no alcanzas. Has memorizado protocolos y entrenado hasta el cansancio. Tu conflicto es la ansiedad de ser el \"novato perfecto\" en un mundo que devora a los inexpertos.",
-        "quote": "Mírate, tan limpio. Eres como un libro nuevo esperando que la Ciudad escriba su primera tragedia. ¿Crees que tu disciplina te salvará?",
-        "ideales": [
-            {
-                "nombre": "Ambición",
-                "desc": "La cima es el único lugar para respirar."
-            },
-            {
-                "nombre": "Disciplina",
-                "desc": "Si sigo el manual a la perfección, nada saldrá mal."
-            },
-            {
-                "nombre": "Reconocimiento",
-                "desc": "Mi nombre debe significar algo en los registros."
-            },
-            {
-                "nombre": "Superación",
-                "desc": "Cada fallo es un dato para mejorar mi siguiente versión."
-            },
-            {
-                "nombre": "Lealtad",
-                "desc": "Serviré a quien me dé la oportunidad de demostrar mi valor."
-            },
-            {
-                "nombre": "Perfección",
-                "desc": "El error no es una opción, es una mancha."
-            },
-            {
-                "nombre": "Curiosidad",
-                "desc": "Ver hasta dónde llega el agujero de este oficio."
-            },
-            {
-                "nombre": "Pragmatismo",
-                "desc": "Busco un contrato que me saque de la calle."
-            }
-        ],
-        "vinculos": [
-            {
-                "nombre": "Memoria Muscular Rígida",
-                "desc": "Posturas de combate automáticas ante ruidos fuertes."
-            },
-            {
-                "nombre": "Hiper-vigilancia de Estatus",
-                "desc": "Analizar equipo ajeno para medir peligrosidad instintivamente."
-            },
-            {
-                "nombre": "Anclaje de Rutina",
-                "desc": "Necesidad de ejercicios técnicos diarios para sentir control."
-            },
-            {
-                "nombre": "Fijación con el Mentor",
-                "desc": "Proyectar la voz de un superior criticando tus fallos."
-            },
-            {
-                "nombre": "Somatización del Rendimiento",
-                "desc": "Temblor en manos cuando no cumples expectativas."
-            },
-            {
-                "nombre": "Dependencia de Validación",
-                "desc": "Buscar la aprobación visual de aliados tras cada acción."
-            }
-        ],
-        "grietas": [
-            {
-                "nombre": "Exceso de Confianza",
-                "desc": "Creer que el manual es igual a la realidad del peligro."
-            },
-            {
-                "nombre": "Inflexibilidad",
-                "desc": "Bloqueo cuando la situación sale de los protocolos memorizados."
-            },
-            {
-                "nombre": "Ansiedad por el Éxito",
-                "desc": "Miedo paralizante a ser considerado \"promedio\"."
-            },
-            {
-                "nombre": "Temeridad Ingenua",
-                "desc": "Exposición innecesaria para impresionar a autoridades."
-            },
-            {
-                "nombre": "Ceguera Jerárquica",
-                "desc": "Ignorar consejos de quienes consideras de rango inferior."
-            },
-            {
-                "nombre": "Frustración Explosiva",
-                "desc": "Ira desmedida ante tus propios errores técnicos."
-            }
-        ]
-    },
-    {
-        "id": "el_archivista",
-        "name": "El Archivista",
-        "desc": "Eres un almacén de secretos ajenos. Tu mente es un catálogo de hechos y te cuesta distinguir entre tus recuerdos y los expedientes que has procesado.",
-        "quote": "Has pasado tanto tiempo leyendo vidas ajenas que olvidaste la tuya. ¿Qué harás cuando la realidad no tenga índice ni glosario?",
-        "ideales": [
-            {
-                "nombre": "Orden",
-                "desc": "El caos es solo información no clasificada."
-            },
-            {
-                "nombre": "Objetividad",
-                "desc": "Los sentimientos son ruido que ensucia los hechos."
-            },
-            {
-                "nombre": "Verdad",
-                "desc": "La historia es lo que quedó registrado."
-            },
-            {
-                "nombre": "Preservación",
-                "desc": "Nada debe perderse; el olvido es el enemigo."
-            },
-            {
-                "nombre": "Curiosidad",
-                "desc": "Cada secreto es un rompecabezas por resolver."
-            },
-            {
-                "nombre": "Neutralidad",
-                "desc": "Solo registro; no es mi función juzgar."
-            },
-            {
-                "nombre": "Utilidad",
-                "desc": "El conocimiento es la herramienta más afilada."
-            },
-            {
-                "nombre": "Discreción",
-                "desc": "El archivista es invisible; la información es lo que brilla."
-            }
-        ],
-        "vinculos": [
-            {
-                "nombre": "Filtrado Sensorial",
-                "desc": "Bloqueo de estímulos \"irrelevantes\" para la tarea actual."
-            },
-            {
-                "nombre": "Catalogación Compulsiva",
-                "desc": "Clasificar mentalmente a personas por utilidad o riesgo."
-            },
-            {
-                "nombre": "Disonancia de Memoria",
-                "desc": "Recordar traumas de expedientes leídos como propios."
-            },
-            {
-                "nombre": "Fijación con el Dato",
-                "desc": "Necesidad de tocar registros físicos para calmar la ansiedad."
-            },
-            {
-                "nombre": "Sinestesia Informativa",
-                "desc": "Datos complejos provocan sensaciones físicas (frío/calor)."
-            },
-            {
-                "nombre": "Desapego del Observador",
-                "desc": "Sentirse frente a una pantalla incluso en la acción real."
-            }
-        ],
-        "grietas": [
-            {
-                "nombre": "Indiferencia Social",
-                "desc": "Ver el dolor ajeno como una estadística más."
-            },
-            {
-                "nombre": "Parálisis por Análisis",
-                "desc": "Bloqueo intentando procesar todas las variables antes de actuar."
-            },
-            {
-                "nombre": "Obsesión por el Detalle",
-                "desc": "Perder de vista el problema general por un dato mínimo."
-            },
-            {
-                "nombre": "Arrogancia Intelectual",
-                "desc": "Desprecio a quienes no manejan la información con precisión."
-            },
-            {
-                "nombre": "Dificultad de Acción",
-                "desc": "Incomodidad física al decidir por intuición y no por datos."
-            },
-            {
-                "nombre": "Amnesia de lo Cotidiano",
-                "desc": "Recordar códigos antiguos pero olvidar dónde dejaste tu equipo."
-            }
-        ]
-    },
-    {
-        "id": "el_artesano",
-        "name": "El Artesano",
-        "desc": "Tu conexión con la materia es más fuerte que con las personas. En un mundo de desechables, tú entiendes cómo funcionan las tripas de la Ciudad.",
-        "quote": "Crees que arreglas cosas, pero solo retrasas lo inevitable. ¿Quién te arreglará a ti cuando el desgaste te alcance?",
-        "ideales": [
-            {
-                "nombre": "Calidad",
-                "desc": "Un trabajo bien hecho es la única inmortalidad."
-            },
-            {
-                "nombre": "Funcionalidad",
-                "desc": "Si no sirve para nada, no debería existir."
-            },
-            {
-                "nombre": "Innovación",
-                "desc": "Siempre hay una forma más eficiente."
-            },
-            {
-                "nombre": "Resiliencia",
-                "desc": "Todo puede repararse con las piezas correctas."
-            },
-            {
-                "nombre": "Autonomía",
-                "desc": "Mi valor reside en mi habilidad, no en quien me contrata."
-            },
-            {
-                "nombre": "Estética",
-                "desc": "La forma sigue a la función, con belleza cruel."
-            },
-            {
-                "nombre": "Honestidad",
-                "desc": "Los materiales te dicen la verdad si sabes escuchar."
-            },
-            {
-                "nombre": "Curiosidad Técnica",
-                "desc": "Necesidad de saber cómo está construido todo."
-            }
-        ],
-        "vinculos": [
-            {
-                "nombre": "Sensibilidad Háptica",
-                "desc": "Identificar fallos solo por la vibración en los dedos."
-            },
-            {
-                "nombre": "Fetiche de Herramienta",
-                "desc": "Ansiedad física extrema si te separan de tu equipo."
-            },
-            {
-                "nombre": "Visión de Despiece",
-                "desc": "Descomponer mentalmente todo (y a todos) en componentes."
-            },
-            {
-                "nombre": "Somatización del Desgaste",
-                "desc": "Dolor en articulaciones al ver máquinas mal mantenidas."
-            },
-            {
-                "nombre": "Compulsión de Ajuste",
-                "desc": "Intentar \"arreglar\" objetos ajenos sin permiso."
-            },
-            {
-                "nombre": "Silencio Operativo",
-                "desc": "Incapacidad de hablar mientras realizas una tarea técnica."
-            }
-        ],
-        "grietas": [
-            {
-                "nombre": "Materialismo Estricto",
-                "desc": "Si no se puede medir o tocar, no existe."
-            },
-            {
-                "nombre": "Perfeccionismo Paralizante",
-                "desc": "Negativa a terminar algo si no es perfecto."
-            },
-            {
-                "nombre": "Deshumanización",
-                "desc": "Tratar a aliados como piezas de equipo que se mantienen o reemplazan."
-            },
-            {
-                "nombre": "Rigidez Metódica",
-                "desc": "Ira si alguien altera el orden de tus herramientas."
-            },
-            {
-                "nombre": "Obsesión por el Reciclaje",
-                "desc": "Acumular chatarra con la convicción de que \"servirá\"."
-            },
-            {
-                "nombre": "Falta de Tacto Social",
-                "desc": "Decir verdades crudas como si fueras un informe técnico."
-            }
-        ]
-    },
-    {
-        "id": "el_residente",
-        "name": "El Residente",
-        "desc": "Eres el producto estándar de los Distritos. Sobrevives a base de rutinas y ruido. Eres la estadística que sigue caminando, pero la monotonía ha marcado tu mente.",
-        "quote": "Eres el ruido de fondo. El engranaje que nadie nota hasta que deja de girar. ¿Qué queda de ti sin tu rutina?",
-        "ideales": [
-            {
-                "nombre": "Estabilidad",
-                "desc": "El orden es lo único que nos salva del hambre."
-            },
-            {
-                "nombre": "Invisibilidad",
-                "desc": "Si nadie te nota, nadie te cobra deudas."
-            },
-            {
-                "nombre": "Solidaridad",
-                "desc": "Los de abajo somos los únicos que nos cuidamos."
-            },
-            {
-                "nombre": "Resiliencia",
-                "desc": "No necesito ser fuerte, solo durar un día más."
-            },
-            {
-                "nombre": "Curiosidad",
-                "desc": "Observar es la única forma de viajar que conozco."
-            },
-            {
-                "nombre": "Pragmatismo",
-                "desc": "No busco justicia, solo que no me corten la luz."
-            },
-            {
-                "nombre": "Paciencia",
-                "desc": "La Ciudad devora a los que corren demasiado."
-            },
-            {
-                "nombre": "Deseo",
-                "desc": "Algún día estaré del otro lado del cristal."
-            }
-        ],
-        "vinculos": [
-            {
-                "nombre": "Agorafobia Urbana",
-                "desc": "Necesidad del ruido de la multitud para no entrar en pánico."
-            },
-            {
-                "nombre": "Fijación con el Horario",
-                "desc": "La pérdida de tiempo provoca taquicardia real."
-            },
-            {
-                "nombre": "Somatización del Hambre",
-                "desc": "Vacío doloroso en el estómago al sentirse inseguro."
-            },
-            {
-                "nombre": "Dependencia de la Multitud",
-                "desc": "Sentir que dejas de existir si estás solo."
-            },
-            {
-                "nombre": "Memoria Táctil de Llaves",
-                "desc": "Tocar pertenencias constantemente por miedo al robo."
-            },
-            {
-                "nombre": "Respuesta a la Sirena",
-                "desc": "Alerta máxima automática ante alarmas corporativas."
-            }
-        ],
-        "grietas": [
-            {
-                "nombre": "Pasividad",
-                "desc": "Esperar que otros tomen las decisiones difíciles."
-            },
-            {
-                "nombre": "Miedo al Cambio",
-                "desc": "Bloqueo ante cualquier plan que requiera improvisar."
-            },
-            {
-                "nombre": "Falta de Aspiración",
-                "desc": "Desconfianza de cualquier oportunidad \"buena\"."
-            },
-            {
-                "nombre": "Cinismo Popular",
-                "desc": "Desprecio a ideales elevados; considerarlos mentiras."
-            },
-            {
-                "nombre": "Acumulación",
-                "desc": "Guardar basura por miedo irracional a necesitarla."
-            },
-            {
-                "nombre": "Sumisión al Uniforme",
-                "desc": "Dificultad para desobedecer a cualquier autoridad."
-            }
-        ]
-    },
-    {
-        "id": "el_mensajero",
-        "name": "El Mensajero",
-        "desc": "Tu vida es movimiento y velocidad. Conoces atajos y grietas, pero tu mente nunca se detiene. El miedo a llegar tarde es tu motor.",
-        "quote": "Corre, pequeño ratón. ¿Qué pasará cuando dejes de correr y el silencio te alcance?",
-        "ideales": [
-            {
-                "nombre": "Velocidad",
-                "desc": "El movimiento es la única libertad."
-            },
-            {
-                "nombre": "Neutralidad",
-                "desc": "No leo el mensaje; la información no es mi problema."
-            },
-            {
-                "nombre": "Confiabilidad",
-                "desc": "Mi palabra es lo único que poseo."
-            },
-            {
-                "nombre": "Autonomía",
-                "desc": "Nadie encadena a quien siempre va un paso por delante."
-            },
-            {
-                "nombre": "Conocimiento",
-                "desc": "Conocer los caminos es poseer la Ciudad."
-            },
-            {
-                "nombre": "Eficiencia",
-                "desc": "El camino más corto es el más valioso."
-            },
-            {
-                "nombre": "Sigilo",
-                "desc": "El éxito es ser un fantasma en el sistema."
-            },
-            {
-                "nombre": "Desapego",
-                "desc": "No me quedo lo suficiente para echar raíces."
-            }
-        ],
-        "vinculos": [
-            {
-                "nombre": "Inquietud Motora",
-                "desc": "Incapacidad de estar quieto; piernas en movimiento constante."
-            },
-            {
-                "nombre": "Hiper-fijación de Rutas",
-                "desc": "Calcular salidas de emergencia en cada habitación."
-            },
-            {
-                "nombre": "Sinestesia de Presión",
-                "desc": "Sentir el peso del tiempo como presión física."
-            },
-            {
-                "nombre": "Fobia al Encierro",
-                "desc": "Espacios sin múltiples salidas provocan asfixia."
-            },
-            {
-                "nombre": "Dependencia de Adrenalina",
-                "desc": "Vacío profundo si no hay riesgo o urgencia."
-            },
-            {
-                "nombre": "Anclaje Espacial",
-                "desc": "Memorizar puntos de referencia para mantener la identidad."
-            }
-        ],
-        "grietas": [
-            {
-                "nombre": "Impulsividad",
-                "desc": "Actuar antes de pensar; movimiento sobre estrategia."
-            },
-            {
-                "nombre": "Falta de Atención",
-                "desc": "Aburrimiento rápido de planes detallados."
-            },
-            {
-                "nombre": "Dificultad de Vínculo",
-                "desc": "No confías porque siempre planeas tu salida."
-            },
-            {
-                "nombre": "Ansiedad Anticipatoria",
-                "desc": "Preocupación obsesiva por problemas que no han pasado."
-            },
-            {
-                "nombre": "Irresponsabilidad",
-                "desc": "Ignorar el daño que causan tus entregas."
-            },
-            {
-                "nombre": "Fatiga Crónica Ignorada",
-                "desc": "Llevar el cuerpo al límite sin admitir cansancio."
-            }
-        ]
-    },
-    {
-        "id": "el_mediador",
-        "name": "El Mediador",
-        "desc": "Eres el lubricante social. Sabes qué decir y a quién, pero tu personalidad es un reflejo de lo que otros quieren ver. No sabes quién eres solo.",
-        "quote": "Qué máscara tan bonita. Si te la quitas descubrirás que debajo no queda nada.",
-        "ideales": [
-            {
-                "nombre": "Equilibrio",
-                "desc": "Todo conflicto es un fallo de comunicación."
-            },
-            {
-                "nombre": "Influencia",
-                "desc": "No necesito armas si controlo a quien las empuña."
-            },
-            {
-                "nombre": "Discreción",
-                "desc": "Los secretos son la moneda más valiosa."
-            },
-            {
-                "nombre": "Empatía",
-                "desc": "Entender el deseo ajeno es la clave para dominarlo."
-            },
-            {
-                "nombre": "Paz",
-                "desc": "La violencia es ineficiente; prefiero el comercio."
-            },
-            {
-                "nombre": "Pragmatismo",
-                "desc": "No hay amigos, solo intereses temporales."
-            },
-            {
-                "nombre": "Prestigio",
-                "desc": "Mi reputación es mi único escudo."
-            },
-            {
-                "nombre": "Adaptabilidad",
-                "desc": "Soy el agua que toma la forma del recipiente."
-            }
-        ],
-        "vinculos": [
-            {
-                "nombre": "Reflejo Especular",
-                "desc": "Copiar gestos y tono de voz ajenos inconscientemente."
-            },
-            {
-                "nombre": "Detección Somática",
-                "desc": "Náusea real ante mentiras o incongruencias."
-            },
-            {
-                "nombre": "Vacío de Identidad",
-                "desc": "Ansiedad al estar solo por no tener a quién proyectar."
-            },
-            {
-                "nombre": "Hiper-análisis",
-                "desc": "Incapacidad de aceptar amabilidad sin buscar el beneficio oculto."
-            },
-            {
-                "nombre": "Necesidad de Aprobación",
-                "desc": "Impulso de suavizar tensiones innecesariamente."
-            },
-            {
-                "nombre": "Somatización del Compromiso",
-                "desc": "Opresión en garganta al romper un acuerdo."
-            }
-        ],
-        "grietas": [
-            {
-                "nombre": "Manipulación Compulsiva",
-                "desc": "Intentar controlar situaciones sociales siempre."
-            },
-            {
-                "nombre": "Indecisión",
-                "desc": "Tratar de quedar bien con ambos bandos hasta que es tarde."
-            },
-            {
-                "nombre": "Falsedad Habitual",
-                "desc": "Mentiras pequeñas por pura costumbre."
-            },
-            {
-                "nombre": "Miedo a la Confrontación",
-                "desc": "Evitar problemas directos hasta que explotan."
-            },
-            {
-                "nombre": "Superficialidad",
-                "desc": "Centrarse en etiquetas e ignorar problemas reales."
-            },
-            {
-                "nombre": "Vulnerabilidad al Chantaje",
-                "desc": "Pánico a que tu verdadera opinión sea pública."
-            }
-        ]
-    }
-]
 ;
 
         const racesData = [


### PR DESCRIPTION
Added the second batch of psychological backgrounds.

This includes:
- El Idealista
- El Sabelotodo
- El Inocente
- El Arma
- El Investigador
- El Sanador
- El Adoctrinado
- El Testigo
- El Rencoroso
- El Naufragado

The new backgrounds were successfully appended to the `psychologicalBackgroundsData` array in `creacion_personaje.html`.

---
*PR created automatically by Jules for task [11425470622214925535](https://jules.google.com/task/11425470622214925535) started by @sokcrow*