### PR TITLE
Fix perk selection on mobile

### DIFF
--- a/creacion_personaje.html
+++ b/creacion_personaje.html
@@ -5161,9 +5161,9 @@
 
                     // Handle card click
                     const handleCardClick = (e) => {
-                        if (e.type === 'touchstart') e.preventDefault();
                         // Don't select the card if clicking the dropdown itself
                         if (e.target.tagName === 'SELECT' || e.target.tagName === 'OPTION') return;
+                        if (e.type === 'touchstart') e.preventDefault();
                         seleccionarProfesion(prof.id);
                     };
                     card.addEventListener('click', handleCardClick);
@@ -5289,8 +5289,8 @@
 
                     // Handle card click
                     const handleCardClick = (e) => {
-                        if (e.type === 'touchstart') e.preventDefault();
                         if (e.target.tagName === 'SELECT' || e.target.tagName === 'OPTION') return;
+                        if (e.type === 'touchstart') e.preventDefault();
                         seleccionarPsychologicalBackground(bg.id);
                     };
                     card.addEventListener('click', handleCardClick);

--- a/render_test.py
+++ b/render_test.py
@@ -1,0 +1,13 @@
+from bs4 import BeautifulSoup
+
+with open('creacion_personaje.html', 'r') as f:
+    soup = BeautifulSoup(f.read(), 'html.parser')
+
+print("Options generated dynamically for perks in renderProfessions()")
+# The code has this:
+# let perksOptionsHtml = '<option value="" disabled selected>Selecciona UN Perk</option>';
+# if (prof.perks) {
+#    prof.perks.forEach(p => {
+#        perksOptionsHtml += `<option value="${p.id}">${p.nombre}</option>`;
+#    });
+# }

--- a/test_screenshot.py
+++ b/test_screenshot.py
@@ -1,0 +1,33 @@
+from playwright.sync_api import sync_playwright
+
+def run():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        # We use a desktop viewport this time to see more
+        context = browser.new_context(viewport={'width': 1280, 'height': 800})
+        page = context.new_page()
+        page.goto("file:///app/creacion_personaje.html")
+        page.evaluate("localStorage.setItem('sok_hasSeenPurpleIntro', 'true');")
+        page.goto("file:///app/creacion_personaje.html")
+
+        # Skip to phase 3
+        page.evaluate("""
+            document.getElementById('phase-intro').classList.add('hidden');
+            document.getElementById('phase3').classList.remove('hidden');
+            renderProfessions();
+        """)
+
+        page.wait_for_selector("#phase3", state="visible")
+        page.wait_for_timeout(2000)
+
+        # Let's take a screenshot of just the first card
+        card = page.locator(".profession-card").first
+        card.screenshot(path="card_screenshot.png")
+
+        # Take a screenshot of the whole page
+        page.screenshot(path="full_page_screenshot.png")
+
+        browser.close()
+
+if __name__ == "__main__":
+    run()

--- a/test_screenshot2.py
+++ b/test_screenshot2.py
@@ -1,0 +1,43 @@
+from playwright.sync_api import sync_playwright
+
+def run():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        # We use a desktop viewport this time to see more
+        context = browser.new_context(viewport={'width': 1280, 'height': 800})
+        page = context.new_page()
+        page.goto("file:///app/creacion_personaje.html")
+        page.evaluate("localStorage.setItem('sok_hasSeenPurpleIntro', 'true');")
+        page.goto("file:///app/creacion_personaje.html")
+
+        # Skip to phase 3 by directly simulating the end of phase 2 and purple intro
+        page.evaluate("""
+            window.startDialogue3 = function() {
+                document.getElementById('phase-purple-intervention').classList.add('hidden');
+                document.getElementById('phase3').classList.remove('hidden');
+                // The function is bound to the module
+                // We'll extract renderProfessions and run it.
+            };
+        """)
+
+        # Click through phase intro
+        page.wait_for_selector("#phase-intro", state="visible")
+        for _ in range(5):
+            page.click("#phase-intro")
+            page.wait_for_timeout(100)
+        page.type("#character-name-input", "Test")
+        page.click("#confirm-name-btn")
+        page.wait_for_timeout(100)
+        page.click("#phase-intro")
+        page.wait_for_timeout(100)
+        page.click("#phase-intro")
+        page.wait_for_timeout(2000)
+
+        # We should be in Phase 1
+        page.wait_for_selector("#phase1", state="visible")
+        # Just to jump to phase 3 quickly... actually let's just edit HTML
+
+        browser.close()
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
Fixed an issue where users were unable to select perks on mobile devices in Phase 3 (Professions) and Phase 4 (Psychological Backgrounds). The `e.preventDefault()` inside the `touchstart` event handler was being triggered before checking if the target element was a `<select>` or `<option>`, preventing native dropdown interactions on mobile browsers. Swapping the order correctly fixes the issue.

---
*PR created automatically by Jules for task [2150666332029609874](https://jules.google.com/task/2150666332029609874) started by @sokcrow*