### PR TITLE
Fix broken layout in character sheet (hoja_personaje.html)

### DIFF
--- a/Sheet-base.css
+++ b/Sheet-base.css
@@ -1,0 +1,657 @@
+@import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Special+Elite&display=swap');
+
+        :root {
+            --bg-main: #0a0a0a;
+            --bg-card: #141414;
+            --border-accent: #c49a00;
+            --text-main: #e0e0e0;
+            --text-muted: #888888;
+            --red-limbus: #8b0000;
+            --red-neon: #ff3333;
+            --cyan-tech: #00ffff;
+            --green-success: #33ff33;
+        }
+
+        body {
+            font-family: 'Share Tech Mono', monospace;
+            background-color: var(--bg-main);
+            color: var(--text-main);
+            margin: 0;
+            padding: 20px;
+            background-image: linear-gradient(rgba(10, 10, 10, 0.95), rgba(10, 10, 10, 0.95)), url('data:image/svg+xml;utf8,<svg width="40" height="40" xmlns="http://www.w3.org/2000/svg"><rect width="40" height="40" fill="none"/><path d="M0,0 L40,40 M40,0 L0,40" stroke="rgba(255,0,0,0.05)" stroke-width="1"/></svg>');
+        }
+
+        .sheet-limbus-main {
+            max-width: 1200px;
+            margin: 0 auto;
+            background: var(--bg-card);
+            border: 4px solid var(--red-limbus);
+            box-shadow: 0 0 30px rgba(139, 0, 0, 0.6), inset 0 0 20px rgba(0,0,0,0.8);
+            padding: 20px;
+            border-radius: 4px;
+            position: relative;
+        }
+
+        .sheet-limbus-main::before {
+            content: '';
+            position: absolute;
+            top: -10px;
+            left: -10px;
+            right: -10px;
+            bottom: -10px;
+            border: 1px solid rgba(139, 0, 0, 0.3);
+            pointer-events: none;
+            z-index: -1;
+        }
+
+        /* Basic CSS to make tabs work visually */
+        .sheet-main-content {
+            margin-top: 20px;
+        }
+
+        .sheet-tab-content {
+            display: none;
+        }
+
+        .sheet-state-tab[value="stats"] ~ * .sheet-tab-stats,
+        .sheet-state-tab[value="equipment"] ~ * .sheet-tab-equipment,
+        .sheet-state-tab[value="skills"] ~ * .sheet-tab-skills,
+        .sheet-state-tab[value="abilities"] ~ * .sheet-tab-abilities,
+        .sheet-state-tab[value="parts"] ~ * .sheet-tab-parts,
+        .sheet-state-tab[value="profile"] ~ * .sheet-tab-profile,
+        .sheet-state-tab[value="apego"] ~ * .sheet-tab-apego {
+            display: block;
+            animation: fadeIn 0.5s ease;
+        }
+
+        @keyframes fadeIn {
+            from { opacity: 0; transform: translateY(10px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+
+        .sheet-tabs {
+            display: flex;
+            gap: 10px;
+            border-bottom: 2px solid var(--red-limbus);
+            padding-bottom: 10px;
+            margin-bottom: 20px;
+            flex-wrap: wrap;
+        }
+
+        .sheet-nav-btn {
+            background: #111;
+            color: var(--text-muted);
+            border: 1px solid #333;
+            border-bottom: none;
+            padding: 10px 20px;
+            font-family: 'Share Tech Mono', monospace;
+            font-size: 16px;
+            cursor: pointer;
+            text-transform: uppercase;
+            transition: all 0.2s ease;
+            border-radius: 4px 4px 0 0;
+        }
+
+        .sheet-nav-btn:hover {
+            color: var(--text-main);
+            background: #222;
+        }
+
+        .sheet-state-tab[value="stats"] ~ .sheet-tabs .sheet-nav-btn[name="act_tab_stats"],
+        .sheet-state-tab[value="equipment"] ~ .sheet-tabs .sheet-nav-btn[name="act_tab_equipment"],
+        .sheet-state-tab[value="skills"] ~ .sheet-tabs .sheet-nav-btn[name="act_tab_skills"],
+        .sheet-state-tab[value="abilities"] ~ .sheet-tabs .sheet-nav-btn[name="act_tab_abilities"],
+        .sheet-state-tab[value="parts"] ~ .sheet-tabs .sheet-nav-btn[name="act_tab_parts"],
+        .sheet-state-tab[value="profile"] ~ .sheet-tabs .sheet-nav-btn[name="act_tab_profile"],
+        .sheet-state-tab[value="apego"] ~ .sheet-tabs .sheet-nav-btn[name="act_tab_apego"] {
+            color: var(--border-accent);
+            border-color: var(--border-accent);
+            background: var(--bg-card);
+            text-shadow: 0 0 5px rgba(255, 174, 0, 0.5);
+        }
+
+
+        .sheet-row { display: flex; gap: 10px; margin-bottom: 10px; flex-wrap: wrap; }
+        .sheet-col { flex: 1; display: flex; flex-direction: column; }
+        .sheet-col-small { flex: 0.5; }
+
+        /* FASE 2: Notebook Desk Aesthetics for parts */
+        .sheet-parts-editor-container {
+            background: linear-gradient(135deg, #1c1815 0%, #29231f 50%, #151210 100%);
+            box-shadow: inset 0 0 50px rgba(0,0,0,0.8);
+            padding: 20px;
+            border-radius: 8px;
+            border: 2px solid #3d3228;
+            margin-top: 15px;
+        }
+
+        .sheet-part-edit-box {
+            background-color: #fdf5e6;
+            color: #222;
+            font-family: 'Special Elite', cursive, monospace;
+            padding: 20px;
+            border-radius: 4px;
+            box-shadow: 5px 5px 15px rgba(0,0,0,0.5), -2px 0 5px rgba(0,0,0,0.2);
+            position: relative;
+            background-image: linear-gradient(#99ccff 1px, transparent 1px);
+            background-size: 100% 30px;
+            line-height: 30px;
+            margin-bottom: 20px;
+        }
+
+        .sheet-part-edit-box::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            left: 20px;
+            width: 2px;
+            background-color: #ff6666;
+            opacity: 0.7;
+        }
+
+        .sheet-part-edit-box input[type="text"],
+        .sheet-part-edit-box input[type="number"],
+        .sheet-part-edit-box select {
+            background: transparent;
+            color: #003366;
+            border: none;
+            border-bottom: 2px dashed #000;
+            font-family: 'Special Elite', cursive, monospace;
+        }
+
+        /* HP/SP Bars */
+        .sheet-hp-sp-row { display: flex; gap: 20px; margin: 20px 0; }
+        .sheet-hp-bar-container { flex: 1; background: #222; height: 30px; position: relative; border: 1px solid #444; }
+        .sheet-hp-bar-fill { background: var(--red-limbus); height: 100%; width: 100%; transition: width 0.3s; }
+
+        .sheet-state-hp-bar[value="sheet-hp-100"] ~ * .sheet-hp-bar-fill { width: 100%; }
+        .sheet-state-hp-bar[value="sheet-hp-95"] ~ * .sheet-hp-bar-fill { width: 95%; }
+        .sheet-state-hp-bar[value="sheet-hp-90"] ~ * .sheet-hp-bar-fill { width: 90%; }
+        .sheet-state-hp-bar[value="sheet-hp-85"] ~ * .sheet-hp-bar-fill { width: 85%; }
+        .sheet-state-hp-bar[value="sheet-hp-80"] ~ * .sheet-hp-bar-fill { width: 80%; }
+        .sheet-state-hp-bar[value="sheet-hp-75"] ~ * .sheet-hp-bar-fill { width: 75%; }
+        .sheet-state-hp-bar[value="sheet-hp-70"] ~ * .sheet-hp-bar-fill { width: 70%; }
+        .sheet-state-hp-bar[value="sheet-hp-65"] ~ * .sheet-hp-bar-fill { width: 65%; }
+        .sheet-state-hp-bar[value="sheet-hp-60"] ~ * .sheet-hp-bar-fill { width: 60%; }
+        .sheet-state-hp-bar[value="sheet-hp-55"] ~ * .sheet-hp-bar-fill { width: 55%; }
+        .sheet-state-hp-bar[value="sheet-hp-50"] ~ * .sheet-hp-bar-fill { width: 50%; }
+        .sheet-state-hp-bar[value="sheet-hp-45"] ~ * .sheet-hp-bar-fill { width: 45%; }
+        .sheet-state-hp-bar[value="sheet-hp-40"] ~ * .sheet-hp-bar-fill { width: 40%; }
+        .sheet-state-hp-bar[value="sheet-hp-35"] ~ * .sheet-hp-bar-fill { width: 35%; }
+        .sheet-state-hp-bar[value="sheet-hp-30"] ~ * .sheet-hp-bar-fill { width: 30%; }
+        .sheet-state-hp-bar[value="sheet-hp-25"] ~ * .sheet-hp-bar-fill { width: 25%; }
+        .sheet-state-hp-bar[value="sheet-hp-20"] ~ * .sheet-hp-bar-fill { width: 20%; }
+        .sheet-state-hp-bar[value="sheet-hp-15"] ~ * .sheet-hp-bar-fill { width: 15%; }
+        .sheet-state-hp-bar[value="sheet-hp-10"] ~ * .sheet-hp-bar-fill { width: 10%; }
+        .sheet-state-hp-bar[value="sheet-hp-5"] ~ * .sheet-hp-bar-fill { width: 5%; }
+        .sheet-state-hp-bar[value="sheet-hp-0"] ~ * .sheet-hp-bar-fill { width: 0%; }
+
+        .sheet-stagger-marker { position: absolute; top: 0; bottom: 0; width: 2px; background: yellow; z-index: 2; }
+
+        .sheet-pos-s1[value="70"] ~ * .sheet-marker-1 { left: 70%; }
+        .sheet-pos-s2[value="40"] ~ * .sheet-marker-2 { left: 40%; }
+        .sheet-pos-s3[value="20"] ~ * .sheet-marker-3 { left: 20%; }
+
+        .sheet-state-s1[value="0"] ~ * .sheet-marker-1 { display: none; }
+        .sheet-state-s2[value="0"] ~ * .sheet-marker-2 { display: none; }
+        .sheet-state-s3[value="0"] ~ * .sheet-marker-3 { display: none; }
+
+        .sheet-header {
+            position: relative;
+            overflow: hidden;
+            background: linear-gradient(to right, #3a0000, #141414);
+            padding: 25px 30px;
+            border-bottom: 3px solid var(--border-accent);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            box-shadow: 0 5px 15px rgba(0,0,0,0.5);
+            margin-bottom: 20px;
+        }
+
+        .sheet-header::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            width: 30%;
+            background: repeating-linear-gradient(
+                45deg,
+                transparent,
+                transparent 10px,
+                rgba(196, 154, 0, 0.05) 10px,
+                rgba(196, 154, 0, 0.05) 20px
+            );
+            pointer-events: none;
+        }
+
+        .sheet-header-left { flex: 2; }
+        .sheet-header-right { flex: 1; }
+        .sheet-avatar-row { display: flex; gap: 15px; }
+        .sheet-avatar-container { width: 100px; height: 100px; background: #222; border: 1px solid var(--border-accent); position: relative; }
+        .sheet-avatar-img { width: 100%; height: 100%; object-fit: cover; }
+        .sheet-level-hex { position: absolute; bottom: -10px; right: -10px; background: var(--red-limbus); width: 30px; height: 30px; border-radius: 50%; display: flex; align-items: center; justify-content: center; border: 2px solid var(--border-accent); font-weight: bold;}
+        .sheet-id-name { font-size: 2em; font-weight: bold; color: var(--border-accent); text-transform: uppercase; letter-spacing: 2px; text-shadow: 0 0 5px rgba(196, 154, 0, 0.5); }
+        .sheet-id-sub { font-size: 16px; color: #ccc; }
+
+        .sheet-xp-row, .sheet-ahn-row { margin-top: 10px; display: flex; align-items: center; gap: 10px; }
+
+        .sheet-resistance-row { display: flex; flex-wrap: wrap; gap: 5px; margin-bottom: 15px; }
+        .sheet-res-block { display: flex; flex-direction: column; align-items: center; background: #111; border: 1px solid #333; padding: 5px; border-radius: 3px; }
+        .sheet-res-icon { width: 24px; height: 24px; }
+        .sheet-res-input { width: 40px; background: transparent; border: none; color: white; text-align: center; font-family: inherit; }
+
+        .sheet-vitals-hud { display: flex; gap: 20px; align-items: center; }
+        .sheet-vital-box { background: #111; border: 1px solid var(--border-accent); padding: 10px; display: flex; flex-direction: column; align-items: center; flex: 1; }
+        .sheet-vital-box label { color: var(--border-accent); font-size: 12px; margin-bottom: 5px; }
+        .sheet-vital-values input { width: 50px; background: transparent; border: none; color: white; font-size: 20px; text-align: center; }
+        .sheet-btn-rest { background: var(--red-dark); color: var(--text-main); border: 1px solid var(--red-bright); padding: 5px 10px; cursor: pointer; transition: 0.2s; font-family: inherit; width: 100%; margin-bottom: 5px; text-transform: uppercase; }
+        .sheet-btn-rest:hover { background: var(--red-bright); box-shadow: 0 0 15px rgba(255, 0, 0, 0.6); }
+
+        .sheet-config-title {
+            color: var(--border-accent);
+            border-bottom: 2px solid #333;
+            padding-bottom: 8px;
+            margin-top: 0;
+            margin-bottom: 20px;
+            font-size: 1.3em;
+            text-transform: uppercase;
+            display: flex;
+            align-items: center;
+            letter-spacing: 1px;
+        }
+
+        .sheet-config-title::before {
+            content: '>';
+            color: var(--red-neon);
+            margin-right: 10px;
+            font-weight: bold;
+        }
+
+        .sheet-attributes-grid { display: flex; gap: 20px; margin-top: 20px; }
+        .sheet-attr-group { flex: 1; display: flex; flex-direction: column; gap: 10px; }
+        .sheet-attr-card { background: #0d0d0d; border: 1px solid #333; padding: 15px; text-align: center; position: relative; border-radius: 2px;}
+
+        .sheet-attr-card::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 2px;
+            background: linear-gradient(to right, transparent, var(--border-accent), transparent);
+        }
+
+        .sheet-attr-card h3 { color: var(--border-accent); margin: 0 0 10px 0; border-bottom: 1px solid #333; padding-bottom: 5px; text-transform: uppercase;}
+        .sheet-roll-attr { background: transparent; border: none; color: var(--cyan-tech); font-size: 2.5em; font-weight: bold; cursor: pointer; text-shadow: 0 0 10px rgba(0, 255, 255, 0.3); font-family: inherit;}
+        .sheet-roll-attr:hover { color: white; }
+        .sheet-attr-inputs { display: flex; justify-content: center; gap: 10px; margin-top: 10px; }
+        .sheet-attr-inputs input { width: 40px; background: #222; border: 1px solid #444; color: white; text-align: center; }
+
+        .sheet-skill-list { background: transparent; padding: 0; display: flex; flex-direction: column; gap: 5px; }
+        .sheet-skill-row { display: flex; justify-content: space-between; align-items: center; background-color: #0d0d0d; padding: 5px 15px; border-left: 4px solid var(--border-accent); border-bottom: 1px solid #222; border-right: 1px solid #222; border-top: 1px solid #222; transition: background-color 0.2s;}
+        .sheet-skill-row:hover { background-color: #1a1a1a; border-left-color: var(--red-neon); }
+        .sheet-roll-skill { background: transparent; border: none; color: var(--text-main); cursor: pointer; text-align: left; flex: 1; font-family: inherit; font-size: 0.9em;}
+        .sheet-roll-skill:hover { color: white; }
+        .sheet-skill-inputs { display: flex; gap: 5px; align-items: center; }
+        .sheet-skill-inputs input { width: 30px; background: #222; border: 1px solid #444; color: white; text-align: center; }
+        .sheet-skill-total { width: 30px; text-align: center; font-weight: bold; color: var(--green-success); }
+
+        input[type="text"], input[type="number"], select, textarea {
+            background: #111;
+            border: 1px solid #444;
+            color: white;
+            padding: 5px;
+            font-family: inherit;
+        }
+
+        .sheet-config-panel { display: none; background: #1a1a1a; padding: 15px; border: 1px solid #444; margin-top: 10px; }
+        .sheet-state-config[value="1"] ~ * .sheet-config-panel { display: block; }
+
+        .sheet-stagger-bar { display: flex; gap: 10px; background: #111; padding: 10px; border: 1px solid #333; margin-bottom: 20px;}
+        .sheet-stagger-item { display: flex; flex-direction: column; align-items: center; flex: 1; border-right: 1px solid #333; }
+        .sheet-stagger-item:last-child { border: none; }
+
+        /* Creator displays */
+        .sheet-perk-creator-container, .sheet-skill-creator-container, .sheet-equip-creator-container, .sheet-apego-creator-container { display: none; margin-bottom: 20px; }
+        .sheet-state-perk-creator[value="1"] ~ * .sheet-perk-creator-container { display: block; }
+        .sheet-state-skill-creator[value="1"] ~ * .sheet-skill-creator-container { display: block; }
+        .sheet-state-equip-creator[value="1"] ~ * .sheet-equip-creator-container { display: block; }
+        .sheet-state-apego-creator[value="1"] ~ * .sheet-apego-creator-container { display: block; }
+
+        /* Repeating rows styling */
+        .repcontainer { display: flex; flex-direction: column; gap: 10px; }
+        .reprow { background: #0f0f0f; border: 1px solid #222; padding: 10px; position: relative; margin-bottom: 15px;}
+        .repcontrol { margin-top: 10px; display: flex; gap: 10px; }
+        .btn { background: #222; color: white; border: 1px solid #555; padding: 5px 10px; cursor: pointer; }
+
+        /* Skill views */
+        .sheet-perk-edit { display: none; flex-direction: column; gap: 5px; }
+        .sheet-state-edit-mode[value="1"] ~ .sheet-perk-edit { display: flex; }
+        .sheet-state-edit-mode[value="1"] ~ .sheet-perk-view { display: none; }
+
+        .sheet-skill-card { border: 1px solid var(--border-accent); padding: 10px; background: #1a1a1a; display: flex; flex-direction: column; gap: 10px;}
+
+        textarea { width: 100%; min-height: 60px; resize: vertical; }
+
+        /* Navigation btn back */
+        .btn-back {
+            display: inline-block;
+            margin-bottom: 20px;
+            color: var(--text-muted);
+            text-decoration: none;
+            border: 1px solid #333;
+            padding: 5px 10px;
+            transition: all 0.2s;
+            background: transparent;
+            font-family: inherit;
+            cursor: pointer;
+        }
+        .btn-back:hover {
+            color: var(--text-main);
+            border-color: var(--text-main);
+            background: #222;
+        }
+
+        .sheet-hide { display: none; }
+
+        /* Added for abilities */
+        .sheet-rolltemplate-coin .sheet-rt-container,
+        .sheet-rolltemplate-perk .sheet-rt-container {
+            border: 2px solid var(--red-limbus);
+            background-color: var(--bg-card);
+            border-radius: 4px;
+            overflow: hidden;
+            font-family: 'Share Tech Mono', monospace;
+            color: var(--text-main);
+            margin-bottom: 10px;
+        }
+        .sheet-rolltemplate-coin .sheet-rt-header,
+        .sheet-rolltemplate-perk .sheet-rt-header {
+            background-color: var(--red-limbus);
+            color: white;
+            padding: 5px 10px;
+            font-weight: bold;
+            font-size: 1.1em;
+            text-align: center;
+        }
+        .sheet-rolltemplate-coin .sheet-rt-content,
+        .sheet-rolltemplate-perk .sheet-rt-content {
+            padding: 10px;
+        }
+
+        .sheet-rt-row {
+            display: flex;
+            justify-content: space-between;
+            padding: 2px 0;
+            border-bottom: 1px solid #333;
+        }
+        .sheet-rt-coins {
+            display: flex;
+            justify-content: center;
+            gap: 5px;
+            margin: 10px 0;
+        }
+        .sheet-coin-wrapper img {
+            width: 30px;
+            height: 30px;
+        }
+        .sheet-rt-result {
+            text-align: center;
+            font-size: 1.5em;
+            font-weight: bold;
+            color: var(--border-accent);
+            margin-top: 10px;
+        }
+
+        /* Modal for dice rolls */
+        #roll-modal {
+            display: none;
+            position: fixed;
+            top: 0; left: 0; width: 100%; height: 100%;
+            background: rgba(0,0,0,0.8);
+            z-index: 1000;
+            justify-content: center;
+            align-items: center;
+        }
+        #roll-modal-content {
+            background: var(--bg-card);
+            border: 2px solid var(--red-limbus);
+            padding: 20px;
+            border-radius: 5px;
+            min-width: 300px;
+            max-width: 500px;
+        }
+        #roll-modal-close {
+            background: #222;
+            color: white;
+            border: 1px solid #555;
+            padding: 5px 10px;
+            cursor: pointer;
+            margin-top: 15px;
+            width: 100%;
+        }
+
+
+        .sheet-hide-empty:empty { display: none; }
+
+        /* XP Bar */
+        .sheet-xp-player-container { display: flex; align-items: center; gap: 10px; width: 100%; }
+        .sheet-xp-small { width: 60px; background: #222; color: #fff; border: 1px solid #444; text-align: center; }
+        .sheet-xp-bar-container { flex: 1; background: #222; height: 18px; border: 1px solid #444; border-radius: 3px; position: relative; overflow: hidden; }
+        .sheet-xp-progress-wrapper { width: 100%; height: 100%; position: relative; }
+        .sheet-xp-fill { position: absolute; left: 0; top: 0; height: 100%; background: #9b59b6; box-shadow: 0 0 5px #9b59b6; z-index: 1; transition: width 0.3s; }
+        .sheet-xp-text { position: absolute; left: 0; right: 0; text-align: center; color: #fff; font-size: 0.8em; line-height: 18px; z-index: 2; font-weight: bold; text-shadow: 1px 1px 2px #000; }
+
+        .sheet-state-xp-bar[value="sheet-xp-0"] ~ * .sheet-xp-fill { width: 0%; }
+        .sheet-state-xp-bar[value="sheet-xp-5"] ~ * .sheet-xp-fill { width: 5%; }
+        .sheet-state-xp-bar[value="sheet-xp-10"] ~ * .sheet-xp-fill { width: 10%; }
+        .sheet-state-xp-bar[value="sheet-xp-15"] ~ * .sheet-xp-fill { width: 15%; }
+        .sheet-state-xp-bar[value="sheet-xp-20"] ~ * .sheet-xp-fill { width: 20%; }
+        .sheet-state-xp-bar[value="sheet-xp-25"] ~ * .sheet-xp-fill { width: 25%; }
+        .sheet-state-xp-bar[value="sheet-xp-30"] ~ * .sheet-xp-fill { width: 30%; }
+        .sheet-state-xp-bar[value="sheet-xp-35"] ~ * .sheet-xp-fill { width: 35%; }
+        .sheet-state-xp-bar[value="sheet-xp-40"] ~ * .sheet-xp-fill { width: 40%; }
+        .sheet-state-xp-bar[value="sheet-xp-45"] ~ * .sheet-xp-fill { width: 45%; }
+        .sheet-state-xp-bar[value="sheet-xp-50"] ~ * .sheet-xp-fill { width: 50%; }
+        .sheet-state-xp-bar[value="sheet-xp-55"] ~ * .sheet-xp-fill { width: 55%; }
+        .sheet-state-xp-bar[value="sheet-xp-60"] ~ * .sheet-xp-fill { width: 60%; }
+        .sheet-state-xp-bar[value="sheet-xp-65"] ~ * .sheet-xp-fill { width: 65%; }
+        .sheet-state-xp-bar[value="sheet-xp-70"] ~ * .sheet-xp-fill { width: 70%; }
+        .sheet-state-xp-bar[value="sheet-xp-75"] ~ * .sheet-xp-fill { width: 75%; }
+        .sheet-state-xp-bar[value="sheet-xp-80"] ~ * .sheet-xp-fill { width: 80%; }
+        .sheet-state-xp-bar[value="sheet-xp-85"] ~ * .sheet-xp-fill { width: 85%; }
+        .sheet-state-xp-bar[value="sheet-xp-90"] ~ * .sheet-xp-fill { width: 90%; }
+        .sheet-state-xp-bar[value="sheet-xp-95"] ~ * .sheet-xp-fill { width: 95%; }
+        .sheet-state-xp-bar[value="sheet-xp-100"] ~ * .sheet-xp-fill { width: 100%; }
+
+        /* Ahn display */
+        .sheet-ahn-display { color: #FFD700; font-size: 1.2em; font-weight: bold; }
+        .sheet-ahn-mod-container { display: flex; align-items: center; gap: 5px; }
+        .sheet-ahn-mod { width: 60px; text-align: center; }
+        .sheet-ahn-btn { background: #333; color: white; border: 1px solid #555; padding: 2px 8px; cursor: pointer; }
+
+        .sheet-ahn-edit-menu { display: none; }
+        .sheet-ahn-edit-toggle[value="1"] ~ .sheet-ahn-edit-menu { display: flex; flex-direction: column; gap: 5px; margin-bottom: 5px; }
+
+        .sheet-read-only { color: #aaa; font-weight: bold; }
+        .sheet-slash { color: #aaa; margin: 0 5px; }
+
+        /* Switch */
+        .sheet-switch { position: relative; display: inline-block; width: 40px; height: 20px; }
+        .sheet-switch input { opacity: 0; width: 0; height: 0; }
+        .sheet-slider { position: absolute; cursor: pointer; top: 0; left: 0; right: 0; bottom: 0; background-color: #555; transition: .4s; border-radius: 20px; }
+        .sheet-slider:before { position: absolute; content: ""; height: 16px; width: 16px; left: 2px; bottom: 2px; background-color: white; transition: .4s; border-radius: 50%; }
+        input:checked + .sheet-slider { background-color: var(--green-success); }
+        input:checked + .sheet-slider:before { transform: translateX(20px); }
+
+        .sheet-part-header-label { font-weight: bold; margin-left: 10px; color: #333; }
+        .sheet-part-name-input { margin-left: 10px; border-bottom: 1px solid #999; }
+        .sheet-part-icon-select { width: auto; }
+
+        /* View specific styles */
+        .sheet-part-view-bar { display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid #333; padding-bottom: 5px; margin-bottom: 10px; }
+        .sheet-part-view-left { display: flex; align-items: center; }
+        .sheet-part-view-center { flex: 1; padding: 0 15px; }
+        .sheet-part-view-right { display: flex; align-items: center; gap: 5px; }
+
+        .sheet-part-icon-bar { width: 30px; height: 30px; object-fit: contain; margin-right: 10px; }
+        .sheet-part-name-bar { font-size: 1.1em; font-weight: bold; color: var(--border-accent); }
+        .sheet-part-hp-track { width: 100%; height: 20px; background: #222; border: 1px solid #444; position: relative; }
+        .sheet-part-hp-fill { height: 100%; background: var(--red-limbus); transition: width 0.3s; }
+        .sheet-part-hp-text { position: absolute; top: 0; left: 0; right: 0; text-align: center; color: white; font-size: 0.8em; line-height: 20px; text-shadow: 1px 1px 2px #000; }
+        .sheet-part-hp-input { width: 40px; background: transparent; border: none; color: white; text-align: right; }
+
+        /* Bar percentages */
+        .sheet-state-part-bar[value="sheet-bar-p100"] ~ * .sheet-part-hp-fill { width: 100%; }
+        .sheet-state-part-bar[value="sheet-bar-p95"] ~ * .sheet-part-hp-fill { width: 95%; }
+        .sheet-state-part-bar[value="sheet-bar-p90"] ~ * .sheet-part-hp-fill { width: 90%; }
+        .sheet-state-part-bar[value="sheet-bar-p85"] ~ * .sheet-part-hp-fill { width: 85%; }
+        .sheet-state-part-bar[value="sheet-bar-p80"] ~ * .sheet-part-hp-fill { width: 80%; }
+        .sheet-state-part-bar[value="sheet-bar-p75"] ~ * .sheet-part-hp-fill { width: 75%; }
+        .sheet-state-part-bar[value="sheet-bar-p70"] ~ * .sheet-part-hp-fill { width: 70%; }
+        .sheet-state-part-bar[value="sheet-bar-p65"] ~ * .sheet-part-hp-fill { width: 65%; }
+        .sheet-state-part-bar[value="sheet-bar-p60"] ~ * .sheet-part-hp-fill { width: 60%; }
+        .sheet-state-part-bar[value="sheet-bar-p55"] ~ * .sheet-part-hp-fill { width: 55%; }
+        .sheet-state-part-bar[value="sheet-bar-p50"] ~ * .sheet-part-hp-fill { width: 50%; }
+        .sheet-state-part-bar[value="sheet-bar-p45"] ~ * .sheet-part-hp-fill { width: 45%; }
+        .sheet-state-part-bar[value="sheet-bar-p40"] ~ * .sheet-part-hp-fill { width: 40%; }
+        .sheet-state-part-bar[value="sheet-bar-p35"] ~ * .sheet-part-hp-fill { width: 35%; }
+        .sheet-state-part-bar[value="sheet-bar-p30"] ~ * .sheet-part-hp-fill { width: 30%; }
+        .sheet-state-part-bar[value="sheet-bar-p25"] ~ * .sheet-part-hp-fill { width: 25%; }
+        .sheet-state-part-bar[value="sheet-bar-p20"] ~ * .sheet-part-hp-fill { width: 20%; }
+        .sheet-state-part-bar[value="sheet-bar-p15"] ~ * .sheet-part-hp-fill { width: 15%; }
+        .sheet-state-part-bar[value="sheet-bar-p10"] ~ * .sheet-part-hp-fill { width: 10%; }
+        .sheet-state-part-bar[value="sheet-bar-p5"] ~ * .sheet-part-hp-fill { width: 5%; }
+        .sheet-state-part-bar[value="sheet-bar-p0"] ~ * .sheet-part-hp-fill { width: 0%; }
+
+        .sheet-stagger-val-sub { color: #888; font-size: 0.8em; margin-right: 5px; }
+        .sheet-part-tremor-input { width: 30px; background: transparent; border: none; border-bottom: 1px solid #ffae00; color: #ffae00; text-align: center; }
+        .sheet-part-status-text { text-transform: uppercase; font-weight: bold; margin-left: 10px; }
+        .sheet-part-status-text[value="active"] { color: var(--green-success); }
+        .sheet-part-status-text[value="broken"] { color: var(--red-neon); }
+        .sheet-part-status-text[value="severed"] { color: #888; text-decoration: line-through; }
+
+        .sheet-part-resistances { display: flex; flex-wrap: wrap; gap: 5px; justify-content: center; }
+        .sheet-res-sep { width: 2px; height: 24px; background: #333; margin: 0 5px; }
+        .sheet-res-block-mini { display: flex; align-items: center; background: #111; padding: 2px; border: 1px solid #333; border-radius: 3px; }
+        .sheet-res-block-mini img { width: 16px; height: 16px; margin-right: 2px; }
+        .sheet-res-block-mini input { width: 35px; height: 16px; font-size: 0.8em; background: transparent; border: none; color: white; text-align: center; }
+
+        /* Modifiers badges */
+        .sheet-skill-badge, .sheet-equip-badge { background: #222; color: #ccc; border: 1px solid #444; padding: 2px 5px; font-size: 0.7em; border-radius: 3px; }
+
+        /* Visibility of elements depending on toggle/state */
+        .sheet-state-parts-editor[value="1"] ~ .sheet-parts-editor-container { display: block; }
+        .sheet-state-parts-editor[value="0"] ~ .sheet-parts-editor-container { display: none; }
+
+        /* Fix abnormality parts visibility based on active state */
+        .sheet-state-part-active[value="0"] ~ .sheet-part-view-bar,
+        .sheet-state-part-active[value="0"] ~ .sheet-part-resistances { display: none; }
+
+        /* Abnormality logic */
+        .sheet-state-char-type[value="player"] ~ * .sheet-abno-parts-container,
+        .sheet-state-char-type[value="npc"] ~ * .sheet-abno-parts-container,
+        .sheet-state-char-type[value="player"] ~ * .sheet-abno-stagger-values,
+        .sheet-state-char-type[value="npc"] ~ * .sheet-abno-stagger-values,
+        .sheet-state-char-type[value="player"] ~ * .sheet-abno-stagger-markers,
+        .sheet-state-char-type[value="npc"] ~ * .sheet-abno-stagger-markers,
+        .sheet-state-char-type[value="player"] ~ .sheet-tabs .sheet-show-parts-btn,
+        .sheet-state-char-type[value="npc"] ~ .sheet-tabs .sheet-show-parts-btn { display: none !important; }
+
+        /* Abilities List */
+        .sheet-skill-content { flex: 1; display: flex; flex-direction: column; justify-content: center; }
+        .sheet-skill-header { display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid #333; padding-bottom: 5px; margin-bottom: 5px; }
+        .sheet-skill-name-text { font-size: 1.1em; font-weight: bold; color: var(--border-accent); margin-right: 10px; }
+        .sheet-btn-clash { background: var(--border-accent); color: #000; border: none; padding: 2px 8px; font-weight: bold; cursor: pointer; text-transform: uppercase; border-radius: 2px; }
+        .sheet-btn-damage { background: var(--red-neon); color: #000; border: none; padding: 2px 8px; font-weight: bold; cursor: pointer; text-transform: uppercase; border-radius: 2px; }
+        .sheet-btn-defend { background: var(--cyan-tech); color: #000; border: none; padding: 2px 8px; font-weight: bold; cursor: pointer; text-transform: uppercase; border-radius: 2px; }
+        .sheet-skill-stats { display: flex; gap: 15px; font-size: 0.9em; color: #ccc; }
+        .sheet-skill-coins { display: flex; gap: 2px; }
+        .sheet-coin-icon { width: 14px; height: 14px; }
+        .sheet-dmg-type-icon { width: 16px; height: 16px; vertical-align: middle; }
+
+        .sheet-skill-effects-view { font-size: 0.85em; color: #aaa; margin-top: 5px; }
+        .sheet-clash-power { font-weight: bold; color: var(--border-accent); font-size: 1.1em; }
+
+        /* Icons */
+        .sheet-sin-icon { width: 40px; height: 40px; border-radius: 5px; }
+        .sheet-sin-overlay-container { position: relative; width: 40px; height: 40px; margin-right: 10px; }
+        .sheet-sin-overlay-img { position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: contain; }
+
+        /* Attack vs Defense Toggles */
+        .sheet-state-skill-type[value="attack"] ~ * .sheet-creator-attack { display: block; }
+        .sheet-state-skill-type[value="defense"] ~ * .sheet-creator-attack { display: none; }
+        .sheet-state-skill-type[value="defense"] ~ * .sheet-creator-defense { display: block; }
+        .sheet-state-skill-type[value="attack"] ~ * .sheet-creator-defense { display: none; }
+
+        .sheet-state-skill-type-row[value="attack"] ~ .sheet-skill-view .sheet-show-attack { display: block; }
+        .sheet-state-skill-type-row[value="defense"] ~ .sheet-skill-view .sheet-show-attack { display: none; }
+        .sheet-state-skill-type-row[value="defense"] ~ .sheet-skill-view .sheet-show-defense { display: block; }
+        .sheet-state-skill-type-row[value="attack"] ~ .sheet-skill-view .sheet-show-defense { display: none; }
+
+        .sheet-state-def-type-row[value="Guard"] ~ .sheet-skill-view .sheet-show-guard-evade,
+        .sheet-state-def-type-row[value="Evade"] ~ .sheet-skill-view .sheet-show-guard-evade { display: block; }
+        .sheet-state-def-type-row[value="Counter"] ~ .sheet-skill-view .sheet-show-guard-evade { display: none; }
+        .sheet-state-def-type-row[value="Counter"] ~ .sheet-skill-view .sheet-show-counter { display: block; }
+        .sheet-state-def-type-row[value="Guard"] ~ .sheet-skill-view .sheet-show-counter,
+        .sheet-state-def-type-row[value="Evade"] ~ .sheet-skill-view .sheet-show-counter { display: none; }
+
+        .sheet-state-def-level-row[value="Main"] ~ .sheet-skill-view .sheet-show-def-main { display: inline; }
+        .sheet-state-def-level-row[value="Sub"] ~ .sheet-skill-view .sheet-show-def-main { display: none; }
+
+        /* Stats */
+        .sheet-stat-base { font-size: 1.2em; font-weight: bold; color: white; margin-right: 5px; }
+        .sheet-stat-coin { font-size: 1.1em; color: var(--cyan-tech); }
+        .sheet-stat-atk-weight { font-weight: bold; color: var(--red-neon); letter-spacing: 2px; }
+
+        .sheet-skill-header-group { display: flex; align-items: center; }
+
+        /* Fixes for overlapping */
+        .sheet-xp-reward-value { color: white; margin-left: 5px; }
+
+        /* CRT Scanlines */
+        body::before {
+            content: " ";
+            display: block;
+            position: fixed;
+            top: 0;
+            left: 0;
+            bottom: 0;
+            right: 0;
+            background: linear-gradient(
+                to bottom,
+                rgba(18, 16, 16, 0) 50%,
+                rgba(0, 0, 0, 0.25) 50%
+            );
+            background-size: 100% 4px;
+            z-index: 999;
+            pointer-events: none;
+        }
+        body::after {
+            content: " ";
+            display: block;
+            position: fixed;
+            top: 0;
+            left: 0;
+            bottom: 0;
+            right: 0;
+            background: linear-gradient(
+                to bottom,
+                rgba(0, 255, 255, 0) 0%,
+                rgba(0, 255, 255, 0.05) 10%,
+                rgba(0, 255, 255, 0) 100%
+            );
+            opacity: 0.5;
+            background-size: 100% 100%;
+            animation: scanline 8s linear infinite;
+            z-index: 998;
+            pointer-events: none;
+        }
+        @keyframes scanline {
+            0% { transform: translateY(-100vh); }
+            100% { transform: translateY(100vh); }
+        }

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -119,6 +119,11 @@
             text-shadow: 0 0 5px rgba(255, 174, 0, 0.5);
         }
 
+
+        .sheet-row { display: flex; gap: 10px; margin-bottom: 10px; flex-wrap: wrap; }
+        .sheet-col { flex: 1; display: flex; flex-direction: column; }
+        .sheet-col-small { flex: 0.5; }
+
         /* FASE 2: Notebook Desk Aesthetics for parts */
         .sheet-parts-editor-container {
             background: linear-gradient(135deg, #1c1815 0%, #29231f 50%, #151210 100%);
@@ -437,6 +442,184 @@
             margin-top: 15px;
             width: 100%;
         }
+
+
+        .sheet-hide-empty:empty { display: none; }
+
+        /* XP Bar */
+        .sheet-xp-player-container { display: flex; align-items: center; gap: 10px; width: 100%; }
+        .sheet-xp-small { width: 60px; background: #222; color: #fff; border: 1px solid #444; text-align: center; }
+        .sheet-xp-bar-container { flex: 1; background: #222; height: 18px; border: 1px solid #444; border-radius: 3px; position: relative; overflow: hidden; }
+        .sheet-xp-progress-wrapper { width: 100%; height: 100%; position: relative; }
+        .sheet-xp-fill { position: absolute; left: 0; top: 0; height: 100%; background: #9b59b6; box-shadow: 0 0 5px #9b59b6; z-index: 1; transition: width 0.3s; }
+        .sheet-xp-text { position: absolute; left: 0; right: 0; text-align: center; color: #fff; font-size: 0.8em; line-height: 18px; z-index: 2; font-weight: bold; text-shadow: 1px 1px 2px #000; }
+
+        .sheet-state-xp-bar[value="sheet-xp-0"] ~ * .sheet-xp-fill { width: 0%; }
+        .sheet-state-xp-bar[value="sheet-xp-5"] ~ * .sheet-xp-fill { width: 5%; }
+        .sheet-state-xp-bar[value="sheet-xp-10"] ~ * .sheet-xp-fill { width: 10%; }
+        .sheet-state-xp-bar[value="sheet-xp-15"] ~ * .sheet-xp-fill { width: 15%; }
+        .sheet-state-xp-bar[value="sheet-xp-20"] ~ * .sheet-xp-fill { width: 20%; }
+        .sheet-state-xp-bar[value="sheet-xp-25"] ~ * .sheet-xp-fill { width: 25%; }
+        .sheet-state-xp-bar[value="sheet-xp-30"] ~ * .sheet-xp-fill { width: 30%; }
+        .sheet-state-xp-bar[value="sheet-xp-35"] ~ * .sheet-xp-fill { width: 35%; }
+        .sheet-state-xp-bar[value="sheet-xp-40"] ~ * .sheet-xp-fill { width: 40%; }
+        .sheet-state-xp-bar[value="sheet-xp-45"] ~ * .sheet-xp-fill { width: 45%; }
+        .sheet-state-xp-bar[value="sheet-xp-50"] ~ * .sheet-xp-fill { width: 50%; }
+        .sheet-state-xp-bar[value="sheet-xp-55"] ~ * .sheet-xp-fill { width: 55%; }
+        .sheet-state-xp-bar[value="sheet-xp-60"] ~ * .sheet-xp-fill { width: 60%; }
+        .sheet-state-xp-bar[value="sheet-xp-65"] ~ * .sheet-xp-fill { width: 65%; }
+        .sheet-state-xp-bar[value="sheet-xp-70"] ~ * .sheet-xp-fill { width: 70%; }
+        .sheet-state-xp-bar[value="sheet-xp-75"] ~ * .sheet-xp-fill { width: 75%; }
+        .sheet-state-xp-bar[value="sheet-xp-80"] ~ * .sheet-xp-fill { width: 80%; }
+        .sheet-state-xp-bar[value="sheet-xp-85"] ~ * .sheet-xp-fill { width: 85%; }
+        .sheet-state-xp-bar[value="sheet-xp-90"] ~ * .sheet-xp-fill { width: 90%; }
+        .sheet-state-xp-bar[value="sheet-xp-95"] ~ * .sheet-xp-fill { width: 95%; }
+        .sheet-state-xp-bar[value="sheet-xp-100"] ~ * .sheet-xp-fill { width: 100%; }
+
+        /* Ahn display */
+        .sheet-ahn-display { color: #FFD700; font-size: 1.2em; font-weight: bold; }
+        .sheet-ahn-mod-container { display: flex; align-items: center; gap: 5px; }
+        .sheet-ahn-mod { width: 60px; text-align: center; }
+        .sheet-ahn-btn { background: #333; color: white; border: 1px solid #555; padding: 2px 8px; cursor: pointer; }
+
+        .sheet-ahn-edit-menu { display: none; }
+        .sheet-ahn-edit-toggle[value="1"] ~ .sheet-ahn-edit-menu { display: flex; flex-direction: column; gap: 5px; margin-bottom: 5px; }
+
+        .sheet-read-only { color: #aaa; font-weight: bold; }
+        .sheet-slash { color: #aaa; margin: 0 5px; }
+
+        /* Switch */
+        .sheet-switch { position: relative; display: inline-block; width: 40px; height: 20px; }
+        .sheet-switch input { opacity: 0; width: 0; height: 0; }
+        .sheet-slider { position: absolute; cursor: pointer; top: 0; left: 0; right: 0; bottom: 0; background-color: #555; transition: .4s; border-radius: 20px; }
+        .sheet-slider:before { position: absolute; content: ""; height: 16px; width: 16px; left: 2px; bottom: 2px; background-color: white; transition: .4s; border-radius: 50%; }
+        input:checked + .sheet-slider { background-color: var(--green-success); }
+        input:checked + .sheet-slider:before { transform: translateX(20px); }
+
+        .sheet-part-header-label { font-weight: bold; margin-left: 10px; color: #333; }
+        .sheet-part-name-input { margin-left: 10px; border-bottom: 1px solid #999; }
+        .sheet-part-icon-select { width: auto; }
+
+        /* View specific styles */
+        .sheet-part-view-bar { display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid #333; padding-bottom: 5px; margin-bottom: 10px; }
+        .sheet-part-view-left { display: flex; align-items: center; }
+        .sheet-part-view-center { flex: 1; padding: 0 15px; }
+        .sheet-part-view-right { display: flex; align-items: center; gap: 5px; }
+
+        .sheet-part-icon-bar { width: 30px; height: 30px; object-fit: contain; margin-right: 10px; }
+        .sheet-part-name-bar { font-size: 1.1em; font-weight: bold; color: var(--border-accent); }
+        .sheet-part-hp-track { width: 100%; height: 20px; background: #222; border: 1px solid #444; position: relative; }
+        .sheet-part-hp-fill { height: 100%; background: var(--red-limbus); transition: width 0.3s; }
+        .sheet-part-hp-text { position: absolute; top: 0; left: 0; right: 0; text-align: center; color: white; font-size: 0.8em; line-height: 20px; text-shadow: 1px 1px 2px #000; }
+        .sheet-part-hp-input { width: 40px; background: transparent; border: none; color: white; text-align: right; }
+
+        /* Bar percentages */
+        .sheet-state-part-bar[value="sheet-bar-p100"] ~ * .sheet-part-hp-fill { width: 100%; }
+        .sheet-state-part-bar[value="sheet-bar-p95"] ~ * .sheet-part-hp-fill { width: 95%; }
+        .sheet-state-part-bar[value="sheet-bar-p90"] ~ * .sheet-part-hp-fill { width: 90%; }
+        .sheet-state-part-bar[value="sheet-bar-p85"] ~ * .sheet-part-hp-fill { width: 85%; }
+        .sheet-state-part-bar[value="sheet-bar-p80"] ~ * .sheet-part-hp-fill { width: 80%; }
+        .sheet-state-part-bar[value="sheet-bar-p75"] ~ * .sheet-part-hp-fill { width: 75%; }
+        .sheet-state-part-bar[value="sheet-bar-p70"] ~ * .sheet-part-hp-fill { width: 70%; }
+        .sheet-state-part-bar[value="sheet-bar-p65"] ~ * .sheet-part-hp-fill { width: 65%; }
+        .sheet-state-part-bar[value="sheet-bar-p60"] ~ * .sheet-part-hp-fill { width: 60%; }
+        .sheet-state-part-bar[value="sheet-bar-p55"] ~ * .sheet-part-hp-fill { width: 55%; }
+        .sheet-state-part-bar[value="sheet-bar-p50"] ~ * .sheet-part-hp-fill { width: 50%; }
+        .sheet-state-part-bar[value="sheet-bar-p45"] ~ * .sheet-part-hp-fill { width: 45%; }
+        .sheet-state-part-bar[value="sheet-bar-p40"] ~ * .sheet-part-hp-fill { width: 40%; }
+        .sheet-state-part-bar[value="sheet-bar-p35"] ~ * .sheet-part-hp-fill { width: 35%; }
+        .sheet-state-part-bar[value="sheet-bar-p30"] ~ * .sheet-part-hp-fill { width: 30%; }
+        .sheet-state-part-bar[value="sheet-bar-p25"] ~ * .sheet-part-hp-fill { width: 25%; }
+        .sheet-state-part-bar[value="sheet-bar-p20"] ~ * .sheet-part-hp-fill { width: 20%; }
+        .sheet-state-part-bar[value="sheet-bar-p15"] ~ * .sheet-part-hp-fill { width: 15%; }
+        .sheet-state-part-bar[value="sheet-bar-p10"] ~ * .sheet-part-hp-fill { width: 10%; }
+        .sheet-state-part-bar[value="sheet-bar-p5"] ~ * .sheet-part-hp-fill { width: 5%; }
+        .sheet-state-part-bar[value="sheet-bar-p0"] ~ * .sheet-part-hp-fill { width: 0%; }
+
+        .sheet-stagger-val-sub { color: #888; font-size: 0.8em; margin-right: 5px; }
+        .sheet-part-tremor-input { width: 30px; background: transparent; border: none; border-bottom: 1px solid #ffae00; color: #ffae00; text-align: center; }
+        .sheet-part-status-text { text-transform: uppercase; font-weight: bold; margin-left: 10px; }
+        .sheet-part-status-text[value="active"] { color: var(--green-success); }
+        .sheet-part-status-text[value="broken"] { color: var(--red-neon); }
+        .sheet-part-status-text[value="severed"] { color: #888; text-decoration: line-through; }
+
+        .sheet-part-resistances { display: flex; flex-wrap: wrap; gap: 5px; justify-content: center; }
+        .sheet-res-sep { width: 2px; height: 24px; background: #333; margin: 0 5px; }
+        .sheet-res-block-mini { display: flex; align-items: center; background: #111; padding: 2px; border: 1px solid #333; border-radius: 3px; }
+        .sheet-res-block-mini img { width: 16px; height: 16px; margin-right: 2px; }
+        .sheet-res-block-mini input { width: 35px; height: 16px; font-size: 0.8em; background: transparent; border: none; color: white; text-align: center; }
+
+        /* Modifiers badges */
+        .sheet-skill-badge, .sheet-equip-badge { background: #222; color: #ccc; border: 1px solid #444; padding: 2px 5px; font-size: 0.7em; border-radius: 3px; }
+
+        /* Visibility of elements depending on toggle/state */
+        .sheet-state-parts-editor[value="1"] ~ .sheet-parts-editor-container { display: block; }
+        .sheet-state-parts-editor[value="0"] ~ .sheet-parts-editor-container { display: none; }
+
+        /* Fix abnormality parts visibility based on active state */
+        .sheet-state-part-active[value="0"] ~ .sheet-part-view-bar,
+        .sheet-state-part-active[value="0"] ~ .sheet-part-resistances { display: none; }
+
+        /* Abnormality logic */
+        .sheet-state-char-type[value="player"] ~ * .sheet-abno-parts-container,
+        .sheet-state-char-type[value="npc"] ~ * .sheet-abno-parts-container,
+        .sheet-state-char-type[value="player"] ~ * .sheet-abno-stagger-values,
+        .sheet-state-char-type[value="npc"] ~ * .sheet-abno-stagger-values,
+        .sheet-state-char-type[value="player"] ~ * .sheet-abno-stagger-markers,
+        .sheet-state-char-type[value="npc"] ~ * .sheet-abno-stagger-markers,
+        .sheet-state-char-type[value="player"] ~ .sheet-tabs .sheet-show-parts-btn,
+        .sheet-state-char-type[value="npc"] ~ .sheet-tabs .sheet-show-parts-btn { display: none !important; }
+
+        /* Abilities List */
+        .sheet-skill-content { flex: 1; display: flex; flex-direction: column; justify-content: center; }
+        .sheet-skill-header { display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid #333; padding-bottom: 5px; margin-bottom: 5px; }
+        .sheet-skill-name-text { font-size: 1.1em; font-weight: bold; color: var(--border-accent); margin-right: 10px; }
+        .sheet-btn-clash { background: var(--border-accent); color: #000; border: none; padding: 2px 8px; font-weight: bold; cursor: pointer; text-transform: uppercase; border-radius: 2px; }
+        .sheet-btn-damage { background: var(--red-neon); color: #000; border: none; padding: 2px 8px; font-weight: bold; cursor: pointer; text-transform: uppercase; border-radius: 2px; }
+        .sheet-btn-defend { background: var(--cyan-tech); color: #000; border: none; padding: 2px 8px; font-weight: bold; cursor: pointer; text-transform: uppercase; border-radius: 2px; }
+        .sheet-skill-stats { display: flex; gap: 15px; font-size: 0.9em; color: #ccc; }
+        .sheet-skill-coins { display: flex; gap: 2px; }
+        .sheet-coin-icon { width: 14px; height: 14px; }
+        .sheet-dmg-type-icon { width: 16px; height: 16px; vertical-align: middle; }
+
+        .sheet-skill-effects-view { font-size: 0.85em; color: #aaa; margin-top: 5px; }
+        .sheet-clash-power { font-weight: bold; color: var(--border-accent); font-size: 1.1em; }
+
+        /* Icons */
+        .sheet-sin-icon { width: 40px; height: 40px; border-radius: 5px; }
+        .sheet-sin-overlay-container { position: relative; width: 40px; height: 40px; margin-right: 10px; }
+        .sheet-sin-overlay-img { position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: contain; }
+
+        /* Attack vs Defense Toggles */
+        .sheet-state-skill-type[value="attack"] ~ * .sheet-creator-attack { display: block; }
+        .sheet-state-skill-type[value="defense"] ~ * .sheet-creator-attack { display: none; }
+        .sheet-state-skill-type[value="defense"] ~ * .sheet-creator-defense { display: block; }
+        .sheet-state-skill-type[value="attack"] ~ * .sheet-creator-defense { display: none; }
+
+        .sheet-state-skill-type-row[value="attack"] ~ .sheet-skill-view .sheet-show-attack { display: block; }
+        .sheet-state-skill-type-row[value="defense"] ~ .sheet-skill-view .sheet-show-attack { display: none; }
+        .sheet-state-skill-type-row[value="defense"] ~ .sheet-skill-view .sheet-show-defense { display: block; }
+        .sheet-state-skill-type-row[value="attack"] ~ .sheet-skill-view .sheet-show-defense { display: none; }
+
+        .sheet-state-def-type-row[value="Guard"] ~ .sheet-skill-view .sheet-show-guard-evade,
+        .sheet-state-def-type-row[value="Evade"] ~ .sheet-skill-view .sheet-show-guard-evade { display: block; }
+        .sheet-state-def-type-row[value="Counter"] ~ .sheet-skill-view .sheet-show-guard-evade { display: none; }
+        .sheet-state-def-type-row[value="Counter"] ~ .sheet-skill-view .sheet-show-counter { display: block; }
+        .sheet-state-def-type-row[value="Guard"] ~ .sheet-skill-view .sheet-show-counter,
+        .sheet-state-def-type-row[value="Evade"] ~ .sheet-skill-view .sheet-show-counter { display: none; }
+
+        .sheet-state-def-level-row[value="Main"] ~ .sheet-skill-view .sheet-show-def-main { display: inline; }
+        .sheet-state-def-level-row[value="Sub"] ~ .sheet-skill-view .sheet-show-def-main { display: none; }
+
+        /* Stats */
+        .sheet-stat-base { font-size: 1.2em; font-weight: bold; color: white; margin-right: 5px; }
+        .sheet-stat-coin { font-size: 1.1em; color: var(--cyan-tech); }
+        .sheet-stat-atk-weight { font-weight: bold; color: var(--red-neon); letter-spacing: 2px; }
+
+        .sheet-skill-header-group { display: flex; align-items: center; }
+
+        /* Fixes for overlapping */
+        .sheet-xp-reward-value { color: white; margin-left: 5px; }
 
         /* CRT Scanlines */
         body::before {


### PR DESCRIPTION
I have successfully resolved the issue where the character sheet (`hoja_personaje.html`) had a broken layout. The problem stemmed from various missing CSS structural classes referenced in the HTML (like `.sheet-row`, `.sheet-col`, and the XP/Abnormality parts components) that were previously absent from the file's `<style>` block. 

I've integrated all the necessary CSS declarations directly into the `hoja_personaje.html` `<style>` tag to ensure local testing works out of the box. Additionally, per Roll20 integration standards, I extracted these styles into a separate, standalone `Sheet-base.css` file so it can be uploaded directly to the platform alongside the HTML template.

I also ran a local Playwright UI visual test, injecting mock character data, which confirmed the structure and styling were completely fixed. Finally, the workspace has been cleaned of temporary scripts, and the changes have successfully passed automated code review.

---
*PR created automatically by Jules for task [5933337987642874134](https://jules.google.com/task/5933337987642874134) started by @sokcrow*