### PR TITLE
Add batch 3 of psychological backgrounds

### DIFF
--- a/creacion_personaje.html
+++ b/creacion_personaje.html
@@ -1314,6 +1314,377 @@
         ];
 
                 const psychologicalBackgroundsData = [
+
+            {
+                        "id": "el_apostador",
+                        "name": "El Apostador",
+                        "desc": "Crees en la suerte porque es lo único que no te ha matado todavía. Apostaste algo que no te pertenecía —vidas, secretos, el futuro de un Distrito— y perdiste. O peor, ganaste y ahora no puedes dejar de jugar. Vives en una euforia maníaca que oculta una culpa asfixiante. Te convences de que eres \"especial\", de que el próximo movimiento lo arreglará todo, mientras el vacío debajo de tus pies se hace cada vez más grande.",
+                        "quote": "Todo al rojo, ¿verdad? El problema es que en esta Ciudad el único rojo que siempre sale es el de la sangre. Disfruta tu racha mientras dure, ganador de papel.",
+                        "ideales": [
+                                    {
+                                                "nombre": "Destino",
+                                                "desc": "Hay una mano invisible guiando mi suerte; nací para algo grande."
+                                    },
+                                    {
+                                                "nombre": "Generosidad",
+                                                "desc": "Reparto lo que gano porque me aterra que el dinero se quede conmigo."
+                                    },
+                                    {
+                                                "nombre": "Riesgo",
+                                                "desc": "Si no hay nada que perder, la victoria no sabe a nada."
+                                    },
+                                    {
+                                                "nombre": "Oportunismo",
+                                                "desc": "La Ciudad es un tablero y yo soy el único que sabe leer las probabilidades."
+                                    },
+                                    {
+                                                "nombre": "Justicia",
+                                                "desc": "Robar a los que tienen para dar a los que no es el único juego que vale la pena."
+                                    },
+                                    {
+                                                "nombre": "Euforia",
+                                                "desc": "El brillo del éxito es la única medicina contra la oscuridad de mi pasado."
+                                    },
+                                    {
+                                                "nombre": "Control",
+                                                "desc": "Si puedo manipular la apuesta, puedo manipular mi destino."
+                                    },
+                                    {
+                                                "nombre": "Resiliencia",
+                                                "desc": "He caído mil veces, pero la mil uno será la definitiva."
+                                    }
+                        ],
+                        "vinculos": [
+                                    {
+                                                "nombre": "Manía Numérica",
+                                                "desc": "Cuentas pasos, objetos o ruidos obsesivamente para predecir si tendrás \"suerte\"."
+                                    },
+                                    {
+                                                "nombre": "Somatización de la Apuesta",
+                                                "desc": "Una descarga eléctrica en la columna cada vez que te enfrentas a una decisión de vida o muerte."
+                                    },
+                                    {
+                                                "nombre": "Fetiche de Azar",
+                                                "desc": "Una moneda, dado o ficha de casino que no dejas de manipular; si la pierdes, entras en pacatonia."
+                                    },
+                                    {
+                                                "nombre": "Alucinación de Ganancia",
+                                                "desc": "Ves destellos de luz o colores brillantes cuando estás a punto de tomar una decisión arriesgada."
+                                    },
+                                    {
+                                                "nombre": "Anclaje de Culpa",
+                                                "desc": "Un objeto que perteneció a alguien que perdió todo por tu culpa y que llevas como un recordatorio punzante."
+                                    },
+                                    {
+                                                "nombre": "Sinestesia de Valor",
+                                                "desc": "Hueles el metal o el ozono cuando detectas una oportunidad de beneficio."
+                                    }
+                        ],
+                        "grietas": [
+                                    {
+                                                "nombre": "Adicción al Riesgo",
+                                                "desc": "Saboteas planes seguros solo para añadir una variable de azar que te haga sentir vivo."
+                                    },
+                                    {
+                                                "nombre": "Impulsividad Carismática",
+                                                "desc": "Convences a los demás de seguir tus planes locos con una sonrisa que esconde desesperación."
+                                    },
+                                    {
+                                                "nombre": "Negación de la Pérdida",
+                                                "desc": "Te niegas a aceptar cuando un plan ha fallado, insistiendo en \"doblar la apuesta\" hasta el desastre."
+                                    },
+                                    {
+                                                "nombre": "Despilfarro Compulsivo",
+                                                "desc": "Gastas recursos críticos en lujos o tonterías para mantener la ilusión de que eres rico."
+                                    },
+                                    {
+                                                "nombre": "Irresponsabilidad Consecuencial",
+                                                "desc": "No mides cómo tus \"apuestas\" afectan la seguridad física de tus aliados."
+                                    },
+                                    {
+                                                "nombre": "Miedo al Silencio",
+                                                "desc": "Necesitas ruido y acción constante para no escuchar la voz de tu conciencia."
+                                    }
+                        ]
+            },
+            {
+                        "id": "el_inestable",
+                        "name": "El Inestable",
+                        "desc": "Eres un nudo de nervios y traumas reprimidos que amenazan con estallar. Hay una versión de ti que es frágil e inocente, y otra que es capaz de una violencia que ni tú mismo comprendes. Te aterra lo que hay dentro de ti, esa \"marca\" o ese recuerdo que dispara una respuesta de combate absoluta. Eres el niño que vio demasiado y que ahora camina por la Ciudad intentando que nadie note que su cordura está pegada con alfileres.",
+                        "quote": "Tienes miedo de tus propias manos, ¿verdad? Sabes que si te rompes un poco más, no quedará nada del niño que eras. Solo quedará el cuchillo.",
+                        "ideales": [
+                                    {
+                                                "nombre": "Pureza",
+                                                "desc": "Debo proteger lo poco que queda de mi bondad frente a la mugre de la Ciudad."
+                                    },
+                                    {
+                                                "nombre": "Justicia",
+                                                "desc": "Solo la violencia contra los malvados puede justificar mi propia oscuridad."
+                                    },
+                                    {
+                                                "nombre": "Verdad",
+                                                "desc": "Necesito entender qué me hicieron (o qué hice) para poder ser libre."
+                                    },
+                                    {
+                                                "nombre": "Lealtad",
+                                                "desc": "Mis amigos son mi única ancla; si los pierdo, me pierdo yo."
+                                    },
+                                    {
+                                                "nombre": "Paz",
+                                                "desc": "Mi mayor deseo es un día donde no tenga que sentir miedo de mí mismo."
+                                    },
+                                    {
+                                                "nombre": "Expiación",
+                                                "desc": "Cada acto de ayuda es una gota de agua en el incendio de mi culpa."
+                                    },
+                                    {
+                                                "nombre": "Valentía",
+                                                "desc": "El verdadero valor es seguir adelante cuando tu propia mente te pide que te rindas."
+                                    },
+                                    {
+                                                "nombre": "Orden",
+                                                "desc": "La rutina es lo único que mantiene a la bestia bajo llave."
+                                    }
+                        ],
+                        "vinculos": [
+                                    {
+                                                "nombre": "Hiperestesia Emocional",
+                                                "desc": "El llanto o los gritos ajenos te provocan un dolor físico real en los oídos y la cabeza."
+                                    },
+                                    {
+                                                "nombre": "Flashback Sensorial",
+                                                "desc": "Un olor dulce o una canción de cuna que dispara una respuesta de pánico o de furia ciega."
+                                    },
+                                    {
+                                                "nombre": "Somatización del Trauma",
+                                                "desc": "Marcas en tu piel (reales o imaginarias) que arden cuando estás cerca de algo que recuerda tu origen."
+                                    },
+                                    {
+                                                "nombre": "Disonancia de Personalidad",
+                                                "desc": "Hablas contigo mismo en momentos de estrés, tratando de convencerte de \"no hacerlo\"."
+                                    },
+                                    {
+                                                "nombre": "Anclaje de Inocencia",
+                                                "desc": "Un objeto infantil o delicado que guardas con un celo violento."
+                                    },
+                                    {
+                                                "nombre": "Parálisis por Sobrecarga",
+                                                "desc": "Te quedas catatónico unos segundos cuando hay demasiados estímulos violentos a tu alrededor."
+                                    }
+                        ],
+                        "grietas": [
+                                    {
+                                                "nombre": "Volatilidad Extrema",
+                                                "desc": "Pasas del llanto a la violencia absoluta en un parpadeo."
+                                    },
+                                    {
+                                                "nombre": "Dependencia Emocional",
+                                                "desc": "Te aferras a una figura de autoridad del grupo de forma asfixiante."
+                                    },
+                                    {
+                                                "nombre": "Autoflagelación",
+                                                "desc": "Te culpas por todo lo que sale mal, incluso si no tuviste nada que ver."
+                                    },
+                                    {
+                                                "nombre": "Ceguera de Furia",
+                                                "desc": "Cuando entras en combate, a veces olvidas quién es aliado y quién enemigo por unos instantes."
+                                    },
+                                    {
+                                                "nombre": "Terror al Contacto",
+                                                "desc": "Evitas que te toquen físicamente, reaccionando con espasmos o agresividad defensiva."
+                                    },
+                                    {
+                                                "nombre": "Miedo al Poder",
+                                                "desc": "Te niegas a usar tus habilidades al máximo por miedo a perder el control para siempre."
+                                    }
+                        ]
+            },
+            {
+                        "id": "el_ex_soldado",
+                        "name": "El Ex-Soldado",
+                        "desc": "Tu vida fue una serie de órdenes, coordenadas y bajas confirmadas en una guerra que la Ciudad ya borró de los libros. Eres un profesional de la muerte que ya no tiene un frente que defender. Tu mente está atrapada en una cadena de mando fantasma, buscando objetivos y evaluando riesgos en cada conversación. Eres eficiente, letal y profundamente desconfiado; sabes que en la guerra la primera baja siempre es la verdad, y tú eres un experto en mentir para sobrevivir.",
+                        "quote": "El uniforme ya no te queda, pero el fusil sigue siendo parte de tu brazo. ¿Sigues esperando la orden de retirada? Mala suerte, soldado. Aquí nadie se retira.",
+                        "ideales": [
+                                    {
+                                                "nombre": "Eficiencia",
+                                                "desc": "La victoria se logra con el mínimo gasto de recursos y el máximo de resultados."
+                                    },
+                                    {
+                                                "nombre": "Misión",
+                                                "desc": "El objetivo está por encima de cualquier sentimiento personal."
+                                    },
+                                    {
+                                                "nombre": "Jerarquía",
+                                                "desc": "Un grupo sin líder es solo un montón de cadáveres esperando su turno."
+                                    },
+                                    {
+                                                "nombre": "Lealtad",
+                                                "desc": "No por honor, sino por necesidad táctica; un flanco débil nos mata a todos."
+                                    },
+                                    {
+                                                "nombre": "Pragmatismo",
+                                                "desc": "La moralidad no gana batallas; la logística y el fuego de cobertura sí."
+                                    },
+                                    {
+                                                "nombre": "Sigilo",
+                                                "desc": "La mejor batalla es la que termina antes de que el enemigo sepa que ha empezado."
+                                    },
+                                    {
+                                                "nombre": "Experiencia",
+                                                "desc": "He visto cómo cae el mundo; nada de lo que pase aquí me sorprende."
+                                    },
+                                    {
+                                                "nombre": "Finalidad",
+                                                "desc": "Busco el último conflicto que me permita dejar de ser un arma."
+                                    }
+                        ],
+                        "vinculos": [
+                                    {
+                                                "nombre": "Hiper-vigilancia Táctica",
+                                                "desc": "Analizas la cobertura, los puntos de emboscada y las armas de todos los que entran en una habitación."
+                                    },
+                                    {
+                                                "nombre": "Somatización del Rango",
+                                                "desc": "Una tensión en el cuello que solo se relaja cuando sientes que tienes el control de la situación."
+                                    },
+                                    {
+                                                "nombre": "Flashback de Combate",
+                                                "desc": "El sonido de la lluvia o el vapor te transporta a un campo de batalla específico."
+                                    },
+                                    {
+                                                "nombre": "Anclaje de Equipo",
+                                                "desc": "Limpias y revisas tu equipo de forma rítmica; es tu forma de meditar."
+                                    },
+                                    {
+                                                "nombre": "Detección de Amenaza",
+                                                "desc": "Sientes un hormigueo en las cicatrices de guerra justo antes de que ocurra una emboscada."
+                                    },
+                                    {
+                                                "nombre": "Respuesta de Mando",
+                                                "desc": "Te pones firme o respondes con terminología militar ante ruidos fuertes o gritos de mando."
+                                    }
+                        ],
+                        "grietas": [
+                                    {
+                                                "nombre": "Paranoia Jerárquica",
+                                                "desc": "Estás convencido de que tus aliados o jefes tienen una agenda oculta para sacrificarte."
+                                    },
+                                    {
+                                                "nombre": "Frialdad Operativa",
+                                                "desc": "Ignoras el sufrimiento de los civiles o aliados si eso asegura el éxito de la misión."
+                                    },
+                                    {
+                                                "nombre": "Secretismo Patológico",
+                                                "desc": "Mientes sobre tu pasado y tus intenciones incluso cuando no es necesario."
+                                    },
+                                    {
+                                                "nombre": "Obsesión por el Plan",
+                                                "desc": "Te vuelves agresivo y autoritario si alguien sugiere cambiar la estrategia establecida."
+                                    },
+                                    {
+                                                "nombre": "Desprecio por los \"Civiles\"",
+                                                "desc": "Consideras que los que no han luchado no tienen derecho a opinar sobre la realidad del mundo."
+                                    },
+                                    {
+                                                "nombre": "Fatiga de Guerra",
+                                                "desc": "Tienes momentos de vacío absoluto donde simplemente dejas de verle el sentido a seguir luchando."
+                                    }
+                        ]
+            },
+            {
+                        "id": "el_paria",
+                        "name": "El Paria",
+                        "desc": "Eres el resultado de un experimento que salió mal, o quizás demasiado bien. Tu cuerpo ha sido alterado de forma irreversible —biotecnología, prótesis orgánicas, mutaciones— convirtiéndote en algo que la Ciudad usa pero desprecia. Eres una herramienta de guerra que intenta recordar cómo ser humano. Vives con el rechazo social y el dolor constante de una fisiología que no debería existir, sintiéndote como una anomalía que camina entre gente que te mira con una mezcla de asco y miedo.",
+                        "quote": "Te dieron ese brazo, esa piel, ese don... y se olvidaron de darte un lugar donde vivir. Eres un monstruo con sentimientos. Qué tragedia tan aburrida.",
+                        "ideales": [
+                                    {
+                                                "nombre": "Humanidad",
+                                                "desc": "Debo demostrar que soy algo más que las partes que me componen."
+                                    },
+                                    {
+                                                "nombre": "Resiliencia",
+                                                "desc": "Si la Ciudad intentó borrarme y no pudo, nada podrá hacerlo."
+                                    },
+                                    {
+                                                "nombre": "Compasión",
+                                                "desc": "Ayudo a los que, como yo, han sido desechados por el sistema."
+                                    },
+                                    {
+                                                "nombre": "Aceptación",
+                                                "desc": "Mi cuerpo es mi historia; no pediré perdón por existir."
+                                    },
+                                    {
+                                                "nombre": "Libertad",
+                                                "desc": "Ya fui propiedad de alguien una vez; nunca volverá a pasar."
+                                    },
+                                    {
+                                                "nombre": "Pragmatismo",
+                                                "desc": "Mi alteración es una herramienta; la usaré para sobrevivir y nada más."
+                                    },
+                                    {
+                                                "nombre": "Curiosidad",
+                                                "desc": "Quiero saber qué más puedo llegar a ser si tomo el control de mis cambios."
+                                    },
+                                    {
+                                                "nombre": "Hogar",
+                                                "desc": "Busco un lugar donde mi aspecto sea lo de menos y mi palabra lo sea todo."
+                                    }
+                        ],
+                        "vinculos": [
+                                    {
+                                                "nombre": "Síndrome del Miembro Fantasma",
+                                                "desc": "Sientes sensaciones (dolor, picor) en partes de tu cuerpo que han sido reemplazadas o alteradas."
+                                    },
+                                    {
+                                                "nombre": "Disonancia Biológica",
+                                                "desc": "Tu cuerpo reacciona de forma autónoma (temblores, cambios de color, calor) ante estímulos químicos o eléctricos."
+                                    },
+                                    {
+                                                "nombre": "Fobia al Espejo",
+                                                "desc": "Evitas ver tu propia imagen para no tener que procesar la pérdida de tu forma original."
+                                    },
+                                    {
+                                                "nombre": "Somatización del Rechazo",
+                                                "desc": "Una sensación de asfixia o picazón en las zonas alteradas cuando te sientes juzgado o despreciado."
+                                    },
+                                    {
+                                                "nombre": "Anclaje de Carne",
+                                                "desc": "Un objeto pequeño que conservas de antes de tu \"transformación\"."
+                                    },
+                                    {
+                                                "nombre": "Sintonía con lo Anómalo",
+                                                "desc": "Sientes una extraña calma o conexión cuando estás cerca de otras criaturas o tecnologías distorsionadas."
+                                    }
+                        ],
+                        "grietas": [
+                                    {
+                                                "nombre": "Odio a Uno Mismo",
+                                                "desc": "Tratas tu cuerpo con una violencia o descuido que roza la autodestrucción."
+                                    },
+                                    {
+                                                "nombre": "Aislamiento Defensivo",
+                                                "desc": "Te alejas de los demás antes de que ellos puedan rechazarte a ti."
+                                    },
+                                    {
+                                                "nombre": "Cinismo Biológico",
+                                                "desc": "Consideras que los humanos \"puros\" son débiles y merecen lo que les pase."
+                                    },
+                                    {
+                                                "nombre": "Miedo a la \"Activación\"",
+                                                "desc": "Te aterra que algo externo (una señal, una orden) tome el control de tus partes alteradas."
+                                    },
+                                    {
+                                                "nombre": "Complejo de Monstruo",
+                                                "desc": "Actúas de forma ruda o violenta porque crees que es lo que el mundo espera de alguien como tú."
+                                    },
+                                    {
+                                                "nombre": "Dependencia Médica/Técnica",
+                                                "desc": "Tienes pánico a que tus partes alteradas fallen y te vuelvas inútil o mueras."
+                                    }
+                        ]
+            }
+,
+
             {
                 "id": "el_atormentado",
                 "name": "El Atormentado",


### PR DESCRIPTION
This pull request adds the third batch of psychological backgrounds requested by the user, specifically "El Apostador", "El Inestable", "El Ex-Soldado", and "El Paria".

The changes were made to the `psychologicalBackgroundsData` array inside `creacion_personaje.html` where I appended JSON objects containing their respective name, description, quote, ideals, bonds, and mental cracks as provided. I also verified the changes by running Playwright locally to ensure the character creator rendered phase 4 without issues and that the correct amount of cards displayed. All tests pass successfully.

---
*PR created automatically by Jules for task [12492052390233110693](https://jules.google.com/task/12492052390233110693) started by @sokcrow*