### PR TITLE
Fix mobile layout and remove unused roll templates

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -4945,3 +4945,15 @@ input.sheet-state-theme[value="gold"] ~ * .sheet-app-header { border-bottom-colo
     width: 100%;
     margin-bottom: 5px;
 }
+
+
+/* Make the phone wrapper take full width and height on mobile devices */
+@media (max-width: 600px) {
+    .sheet-phone-wrapper {
+        max-width: 100%;
+        height: 100vh;
+        border: none;
+        border-radius: 0;
+        box-shadow: none;
+    }
+}

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -3326,66 +3326,7 @@
 </div>
 </div> <!-- End Phone Wrapper -->
 
-<!-- Roll Template -->
-<rolltemplate class="sheet-rolltemplate-coin">
-    <div class="sheet-rt-container">
-        <div class="sheet-rt-header">{{name}}</div>
-        <div class="sheet-rt-content">
-            {{#base}}
-            <div class="sheet-rt-row">
-                <span class="sheet-rt-label">Base Power:</span>
-                <span class="sheet-rt-value">{{base}}</span>
-            </div>
-            {{/base}}
 
-            <div class="sheet-rt-coins">
-                <div class="sheet-coin-wrapper">
-                    {{#rollTotal() c1 1}}<img src="https://i.imgur.com/yshLPnQ.png" class="sheet-coin-head">{{/rollTotal() c1 1}}
-                    {{#rollTotal() c1 0}}<img src="https://i.imgur.com/XDx0ICt.png" class="sheet-coin-tail">{{/rollTotal() c1 0}}
-                </div>
-                <div class="sheet-coin-wrapper">
-                    {{#rollTotal() c2 1}}<img src="https://i.imgur.com/yshLPnQ.png" class="sheet-coin-head">{{/rollTotal() c2 1}}
-                    {{#rollTotal() c2 0}}<img src="https://i.imgur.com/XDx0ICt.png" class="sheet-coin-tail">{{/rollTotal() c2 0}}
-                </div>
-                <div class="sheet-coin-wrapper">
-                    {{#rollTotal() c3 1}}<img src="https://i.imgur.com/yshLPnQ.png" class="sheet-coin-head">{{/rollTotal() c3 1}}
-                    {{#rollTotal() c3 0}}<img src="https://i.imgur.com/XDx0ICt.png" class="sheet-coin-tail">{{/rollTotal() c3 0}}
-                </div>
-                <div class="sheet-coin-wrapper">
-                    {{#rollTotal() c4 1}}<img src="https://i.imgur.com/yshLPnQ.png" class="sheet-coin-head">{{/rollTotal() c4 1}}
-                    {{#rollTotal() c4 0}}<img src="https://i.imgur.com/XDx0ICt.png" class="sheet-coin-tail">{{/rollTotal() c4 0}}
-                </div>
-                <div class="sheet-coin-wrapper">
-                    {{#rollTotal() c5 1}}<img src="https://i.imgur.com/yshLPnQ.png" class="sheet-coin-head">{{/rollTotal() c5 1}}
-                    {{#rollTotal() c5 0}}<img src="https://i.imgur.com/XDx0ICt.png" class="sheet-coin-tail">{{/rollTotal() c5 0}}
-                </div>
-            </div>
-
-            <div class="sheet-rt-result">
-                <span class="sheet-rt-result-value">{{computed::result}}</span>
-            </div>
-        </div>
-    </div>
-</rolltemplate>
-
-<rolltemplate class="sheet-rolltemplate-perk">
-    <div class="sheet-rt-container">
-        <div class="sheet-rt-header">{{name}}</div>
-        <div class="sheet-rt-content">
-            {{#allprops() name description}}
-            <div class="sheet-rt-row" style="display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid #333; padding: 4px 0;">
-                <span class="sheet-rt-label" style="font-size: 0.9em; color: #aaa; padding-right: 10px;">{{key}}</span>
-                <span class="sheet-rt-value" style="font-size: 1em; font-weight: bold;">{{value}}</span>
-            </div>
-            {{/allprops() name description}}
-            {{#description}}
-            <div class="sheet-rt-row" style="margin-top: 5px;">
-                <span class="sheet-rt-value" style="text-align: left; font-weight: normal; white-space: pre-wrap;">{{description}}</span>
-            </div>
-            {{/description}}
-        </div>
-    </div>
-</rolltemplate>
 
 
 

--- a/update_css.py
+++ b/update_css.py
@@ -1,0 +1,25 @@
+import re
+
+with open('hoja_personaje.css', 'r') as f:
+    content = f.read()
+
+# Replace the phone wrapper to remove the border and fixed width in mobile
+new_css = """
+
+/* Make the phone wrapper take full width and height on mobile devices */
+@media (max-width: 600px) {
+    .sheet-phone-wrapper {
+        max-width: 100%;
+        height: 100vh;
+        border: none;
+        border-radius: 0;
+        box-shadow: none;
+    }
+}
+"""
+
+if "max-width: 100%;\n        height: 100vh;\n        border: none;\n        border-radius: 0;\n        box-shadow: none;" not in content:
+    content += new_css
+
+    with open('hoja_personaje.css', 'w') as f:
+        f.write(content)


### PR DESCRIPTION
This PR addresses the user's feedback by:
1. Removing the unused and "ugly" roll templates at the bottom of the character sheet (`sheet-rolltemplate-coin` and `sheet-rolltemplate-perk`).
2. Fixing the mobile layout by adjusting the `.sheet-phone-wrapper` on smaller screens. It now expands to full width (`max-width: 100%`) and full height without borders or box-shadow, avoiding the interface looking squashed ("aplastada").

---
*PR created automatically by Jules for task [14478451709929545629](https://jules.google.com/task/14478451709929545629) started by @sokcrow*