### PR TITLE
Fix empty mobile screen when loading character sheet

### DIFF
--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -449,6 +449,11 @@
             if (charsheetSaveStr) {
                 try {
                     savedAttrs = JSON.parse(charsheetSaveStr);
+                    // Ensure 'tab' is valid so we don't get a blank screen on load
+                    const validTabs = ['home', 'stats', 'equipment', 'skills', 'abilities', 'parts', 'profile', 'apego', 'vitals', 'settings'];
+                    if (!savedAttrs.tab || !validTabs.includes(savedAttrs.tab)) {
+                        savedAttrs.tab = 'home';
+                    }
                 } catch(e) {}
             }
 
@@ -2165,3 +2170,13 @@ try {
             setAttrs(update);
         }
     });
+
+// --- Navigation Tabs ---
+const tabs = ['home', 'stats', 'equipment', 'skills', 'abilities', 'parts', 'profile', 'apego', 'vitals', 'settings'];
+tabs.forEach(tab => {
+    on(`clicked:tab_${tab}`, function() {
+        setAttrs({
+            tab: tab
+        });
+    });
+});


### PR DESCRIPTION
Fixes an issue where the mobile UI apps (home screen grid) would not appear and the screen would be entirely blank on load. This was caused by the `attr_tab` state being restored from `localStorage` with either an empty string or an invalid tab string, which caused all `.sheet-tab-content` elements to become hidden via CSS. This patch ensures `tab` always falls back to `'home'` if invalid.

---
*PR created automatically by Jules for task [14833170076661958771](https://jules.google.com/task/14833170076661958771) started by @sokcrow*