### PR TITLE
feat: Add Phone UI toggle button

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -4789,6 +4789,7 @@ input.sheet-part-link-state[value~="12"] ~ .sheet-part-view-bar .sheet-stagger-v
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    transition: transform 0.4s ease-in-out;
 }
 
 /* Phone Notch / Status Bar */
@@ -5089,4 +5090,31 @@ input[name="attr_tab"][value="settings"] ~ .sheet-phone-screen .sheet-tab-settin
     .sheet-limbus-main .sheet-hp-bar-container { max-width: 100% !important; width: 100% !important; }
     .sheet-limbus-main .sheet-vitals-hud { flex-direction: column !important; align-items: center !important; }
     .sheet-limbus-main .sheet-vital-box { width: 100% !important; max-width: 150px !important; }
+}
+
+/* Toggle Button Styles */
+.btn-toggle-phone {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    z-index: 9999;
+    background: var(--bg-card);
+    color: var(--border-accent);
+    border: 2px solid var(--border-accent);
+    border-radius: 50%;
+    width: 60px;
+    height: 60px;
+    font-size: 24px;
+    cursor: pointer;
+    box-shadow: 0 0 10px rgba(196, 154, 0, 0.5);
+    transition: all 0.3s ease;
+}
+
+.btn-toggle-phone:hover {
+    transform: scale(1.1);
+    box-shadow: 0 0 20px rgba(196, 154, 0, 0.8);
+}
+
+.phone-hidden {
+    transform: translateY(120vh) !important;
 }

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -3323,7 +3323,8 @@
 </div>
 </div> <!-- End Phone Wrapper -->
 
-
+<!-- Toggle Button -->
+<button class="btn-toggle-phone" id="btn-toggle-phone" title="Alternar Celular">📱</button>
 
 
 

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -477,6 +477,15 @@
         });
 
         window.addEventListener('DOMContentLoaded', () => {
+            // Toggle Phone Logic
+            const toggleBtn = document.getElementById('btn-toggle-phone');
+            const phoneWrapper = document.querySelector('.sheet-phone-wrapper');
+            if (toggleBtn && phoneWrapper) {
+                toggleBtn.addEventListener('click', () => {
+                    phoneWrapper.classList.toggle('phone-hidden');
+                });
+            }
+
             document.querySelectorAll('fieldset[class^="repeating_"]').forEach(fieldset => {
                 const section = fieldset.className.split(' ')[0];
                 templates[section] = fieldset.innerHTML;

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "failed",
+  "failedTests": []
+}


### PR DESCRIPTION
Implementa el botón flotante solicitado por el usuario para alternar la visibilidad de la interfaz del celular en la hoja de personaje. Utiliza una animación CSS (`transform: translateY()`) con una transición suave (0.4s) gestionada mediante una pequeña lógica en Vanilla JS.

---
*PR created automatically by Jules for task [13592886515948263764](https://jules.google.com/task/13592886515948263764) started by @sokcrow*