### PR TITLE
Fix navbar visibility when phone UI is toggled

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -5116,5 +5116,6 @@ input[name="attr_tab"][value="settings"] ~ .sheet-phone-screen .sheet-tab-settin
 }
 
 .phone-hidden {
-    transform: translateY(120vh) !important;
+    transform: translateY(150vh) !important;
+    opacity: 0 !important;
 }

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -3314,7 +3314,6 @@
  </div>
  </div>
  </div>
-</div>
 
 
 </div> <!-- End Phone Screen -->
@@ -3322,6 +3321,7 @@
  <button type="action" name="act_tab_home" class="sheet-home-btn">🔲</button>
 </div>
 </div> <!-- End Phone Wrapper -->
+</div> <!-- End Limbus Main -->
 
 <!-- Toggle Button -->
 <button class="btn-toggle-phone" id="btn-toggle-phone" title="Alternar Celular">📱</button>


### PR DESCRIPTION
The bottom navigation bar and home button of the mobile UI were not hiding along with the rest of the phone when toggled, and instead appeared expanded on the page.

This was caused by two issues:
1. The `.sheet-phone-navbar` element in `hoja_personaje.html` was incorrectly positioned outside the `.sheet-phone-wrapper` element due to a premature `</div>` tag. 
2. The CSS transform for hiding the phone (`.phone-hidden`) did not translate far enough down for the expanded content and lacked an opacity hide.

These have been corrected to ensure a clean visual toggle.

---
*PR created automatically by Jules for task [2889567790889290802](https://jules.google.com/task/2889567790889290802) started by @sokcrow*