### PR TITLE
feat: Implement Bank UI and Global Inventory Modal

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -55,7 +55,7 @@
         }
 
         .sheet-state-tab[value="stats"] ~ * .sheet-tab-stats,
-        .sheet-state-tab[value="equipment"] ~ * .sheet-tab-equipment,
+        .sheet-state-tab[value="banco"] ~ * .sheet-tab-banco,
         .sheet-state-tab[value="skills"] ~ * .sheet-tab-skills,
         .sheet-state-tab[value="abilities"] ~ * .sheet-tab-abilities,
         .sheet-state-tab[value="parts"] ~ * .sheet-tab-parts,
@@ -99,7 +99,7 @@
         }
 
         .sheet-state-tab[value="stats"] ~ .sheet-tabs .sheet-nav-btn[name="act_tab_stats"],
-        .sheet-state-tab[value="equipment"] ~ .sheet-tabs .sheet-nav-btn[name="act_tab_equipment"],
+        .sheet-state-tab[value="banco"] ~ .sheet-tabs .sheet-nav-btn[name="act_tab_banco"],
         .sheet-state-tab[value="skills"] ~ .sheet-tabs .sheet-nav-btn[name="act_tab_skills"],
         .sheet-state-tab[value="abilities"] ~ .sheet-tabs .sheet-nav-btn[name="act_tab_abilities"],
         .sheet-state-tab[value="parts"] ~ .sheet-tabs .sheet-nav-btn[name="act_tab_parts"],
@@ -1302,7 +1302,7 @@ button[type="action"].sheet-ahn-edit-btn:hover,
 
 /* Mostrar el tab activo leyendo el atributo directamente */
 .sheet-limbus-main input[name="attr_tab"][value="stats"] ~ .sheet-main-content .sheet-tab-stats,
-.sheet-limbus-main input[name="attr_tab"][value="equipment"] ~ .sheet-main-content .sheet-tab-equipment,
+.sheet-limbus-main input[name="attr_tab"][value="banco"] ~ .sheet-main-content .sheet-tab-banco,
 .sheet-limbus-main input[name="attr_tab"][value="abilities"] ~ .sheet-main-content .sheet-tab-abilities,
 .sheet-limbus-main input[name="attr_tab"][value="skills"] ~ .sheet-main-content .sheet-tab-skills,
 .sheet-limbus-main input[name="attr_tab"][value="parts"] ~ .sheet-main-content .sheet-tab-parts,
@@ -1330,7 +1330,7 @@ button[type="action"].sheet-ahn-edit-btn:hover,
 
 /* Active Tab Logic (Hidden Text Input Attribute Selectors) */
 .sheet-limbus-main input[name="attr_tab"][value="stats"] ~ .sheet-tabs button[name="act_tab_stats"],
-.sheet-limbus-main input[name="attr_tab"][value="equipment"] ~ .sheet-tabs button[name="act_tab_equipment"],
+.sheet-limbus-main input[name="attr_tab"][value="banco"] ~ .sheet-tabs button[name="act_tab_banco"],
 .sheet-limbus-main input[name="attr_tab"][value="skills"] ~ .sheet-tabs button[name="act_tab_skills"],
 .sheet-limbus-main input[name="attr_tab"][value="abilities"] ~ .sheet-tabs button[name="act_tab_abilities"],
 .sheet-limbus-main input[name="attr_tab"][value="parts"] ~ .sheet-tabs button[name="act_tab_parts"],
@@ -5176,7 +5176,7 @@ input.sheet-state-theme[value="gold"] ~ * .sheet-app-header { border-bottom-colo
 .sheet-tab-apego { pointer-events: auto !important; }
 input[name="attr_tab"][value="home"] ~ .sheet-phone-screen .sheet-tab-home,
 input[name="attr_tab"][value="stats"] ~ .sheet-phone-screen .sheet-tab-stats,
-input[name="attr_tab"][value="equipment"] ~ .sheet-phone-screen .sheet-tab-equipment,
+input[name="attr_tab"][value="banco"] ~ .sheet-phone-screen .sheet-tab-banco,
 input[name="attr_tab"][value="skills"] ~ .sheet-phone-screen .sheet-tab-skills,
 input[name="attr_tab"][value="abilities"] ~ .sheet-phone-screen .sheet-tab-abilities,
 input[name="attr_tab"][value="parts"] ~ .sheet-phone-screen .sheet-tab-parts,
@@ -5221,6 +5221,351 @@ input[name="attr_tab"][value="settings"] ~ .sheet-phone-screen .sheet-tab-settin
     width: 100%;
     margin-bottom: 5px;
 }
+
+
+/* --- BANCO TAB STYLES --- */
+.sheet-banco-balance-card {
+    background: linear-gradient(135deg, #1a1a1a 0%, #0a0a0a 100%);
+    border: 2px solid var(--border-accent);
+    border-radius: 8px;
+    padding: 20px;
+    text-align: center;
+    box-shadow: 0 0 15px rgba(196, 154, 0, 0.2), inset 0 0 10px rgba(0,0,0,0.8);
+    margin-bottom: 20px;
+    position: relative;
+    overflow: hidden;
+}
+
+.sheet-banco-balance-card::before {
+    content: '';
+    position: absolute;
+    top: -50%; left: -50%; width: 200%; height: 200%;
+    background: repeating-linear-gradient(45deg, transparent, transparent 10px, rgba(196, 154, 0, 0.03) 10px, rgba(196, 154, 0, 0.03) 20px);
+    pointer-events: none;
+    z-index: 1;
+}
+
+.sheet-banco-title {
+    color: var(--text-muted);
+    font-size: 0.9em;
+    margin: 0 0 10px 0;
+    letter-spacing: 2px;
+    position: relative;
+    z-index: 2;
+}
+
+.sheet-banco-amount-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: baseline;
+    gap: 10px;
+    position: relative;
+    z-index: 2;
+}
+
+.sheet-banco-currency-icon {
+    font-size: 1.5em;
+    color: var(--border-accent);
+    font-weight: bold;
+}
+
+.sheet-banco-amount-display {
+    font-size: 3em;
+    font-weight: 900;
+    color: var(--cyan-tech);
+    text-shadow: 0 0 15px rgba(0, 255, 255, 0.6);
+    line-height: 1;
+}
+
+.sheet-banco-account-info {
+    margin-top: 15px;
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.75em;
+    color: #666;
+    border-top: 1px dashed #333;
+    padding-top: 10px;
+    position: relative;
+    z-index: 2;
+}
+
+.sheet-banco-status-active {
+    color: var(--green-success);
+    font-weight: bold;
+}
+
+.sheet-banco-transactions {
+    background: #0d0d0d;
+    border: 1px solid #222;
+    border-radius: 6px;
+    padding: 15px;
+}
+
+.sheet-banco-subtitle {
+    color: #888;
+    border-bottom: 1px solid #333;
+    padding-bottom: 5px;
+    margin-top: 0;
+    margin-bottom: 10px;
+    font-size: 0.9em;
+    text-transform: uppercase;
+}
+
+.sheet-transaction-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.sheet-transaction-item {
+    display: flex;
+    align-items: center;
+    background: #111;
+    padding: 10px;
+    border-radius: 4px;
+    border-left: 2px solid #444;
+}
+
+.sheet-tx-icon {
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    margin-right: 10px;
+    font-weight: bold;
+}
+
+.sheet-tx-in {
+    background: rgba(51, 255, 51, 0.2);
+    color: var(--green-success);
+    border: 1px solid var(--green-success);
+}
+
+.sheet-tx-out {
+    background: rgba(255, 51, 51, 0.2);
+    color: var(--red-neon);
+    border: 1px solid var(--red-neon);
+}
+
+.sheet-tx-details {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.sheet-tx-title {
+    color: #ccc;
+    font-size: 0.9em;
+    font-weight: bold;
+}
+
+.sheet-tx-date {
+    color: #666;
+    font-size: 0.75em;
+}
+
+.sheet-tx-amount {
+    font-weight: bold;
+    font-size: 0.9em;
+}
+
+.sheet-tx-in-amount { color: var(--green-success); }
+.sheet-tx-out-amount { color: var(--red-neon); }
+
+/* --- GLOBAL INVENTORY BUTTON --- */
+.btn-global-inventory {
+    position: fixed;
+    bottom: 90px;
+    right: 20px;
+    z-index: 9999;
+    background: #111;
+    color: var(--border-accent);
+    border: 2px solid var(--border-accent);
+    border-radius: 50%;
+    width: 60px;
+    height: 60px;
+    font-size: 24px;
+    cursor: pointer;
+    box-shadow: 0 0 10px rgba(196, 154, 0, 0.5), inset 0 0 5px rgba(0,0,0,0.8);
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.btn-global-inventory:hover {
+    transform: scale(1.1);
+    background: #222;
+    box-shadow: 0 0 20px rgba(196, 154, 0, 0.8), inset 0 0 5px rgba(0,0,0,0.8);
+}
+
+/* --- INVENTORY MODAL --- */
+.inventory-modal {
+    display: none;
+    position: fixed;
+    top: 0; left: 0; width: 100%; height: 100%;
+    background: rgba(0, 0, 0, 0.85);
+    z-index: 10000;
+    align-items: center;
+    justify-content: center;
+    backdrop-filter: blur(5px);
+}
+
+.inventory-modal.active {
+    display: flex;
+    animation: fadeInModal 0.3s ease;
+}
+
+@keyframes fadeInModal {
+    from { opacity: 0; transform: scale(0.95); }
+    to { opacity: 1; transform: scale(1); }
+}
+
+.inventory-modal-content {
+    background: linear-gradient(135deg, #111 0%, #0a0a0a 100%);
+    border: 2px solid var(--cyan-tech);
+    width: 90%;
+    max-width: 800px;
+    height: 80vh;
+    border-radius: 8px;
+    box-shadow: 0 0 30px rgba(0, 255, 255, 0.2), inset 0 0 20px rgba(0,0,0,0.8);
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.inventory-modal-close {
+    position: absolute;
+    top: 10px; right: 10px;
+    background: transparent;
+    color: var(--text-muted);
+    border: none;
+    font-size: 28px;
+    cursor: pointer;
+    z-index: 10;
+    line-height: 1;
+}
+
+.inventory-modal-close:hover { color: var(--red-neon); }
+
+.inventory-tabs {
+    display: flex;
+    background: #1a1a1a;
+    border-bottom: 2px solid var(--cyan-tech);
+    padding: 15px 15px 0 15px;
+    gap: 10px;
+}
+
+.inv-tab-btn {
+    background: #0d0d0d;
+    color: var(--text-muted);
+    border: 1px solid #333;
+    border-bottom: none;
+    padding: 10px 20px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 1em;
+    border-radius: 6px 6px 0 0;
+    transition: all 0.2s;
+    text-transform: uppercase;
+}
+
+.inv-tab-btn.active {
+    background: var(--cyan-tech);
+    color: #000;
+    border-color: var(--cyan-tech);
+    font-weight: bold;
+    box-shadow: 0 0 10px rgba(0, 255, 255, 0.4);
+}
+
+.inventory-tab-content {
+    display: none;
+    flex: 1;
+    padding: 20px;
+    overflow-y: auto;
+}
+
+.inventory-tab-content.active {
+    display: block;
+}
+
+/* Tab: Inventario Activo */
+.inv-active-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+    gap: 15px;
+}
+
+.inv-slot {
+    aspect-ratio: 1;
+    background: #0d0d0d;
+    border: 1px solid #333;
+    border-radius: 4px;
+    box-shadow: inset 0 0 10px rgba(0,0,0,0.8);
+    transition: all 0.2s;
+}
+.inv-slot:hover { border-color: var(--cyan-tech); }
+
+/* Tab: Stash */
+.inv-stash-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.inv-stash-table th, .inv-stash-table td {
+    padding: 10px;
+    text-align: left;
+    border-bottom: 1px solid #333;
+}
+
+.inv-stash-table th {
+    color: var(--cyan-tech);
+    font-size: 0.9em;
+    text-transform: uppercase;
+}
+
+/* Tab: Shop */
+.inv-shop-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 20px;
+}
+
+.inv-shop-item {
+    background: #111;
+    border: 1px solid #444;
+    padding: 15px;
+    border-radius: 6px;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.inv-shop-item-name {
+    color: #fff;
+    font-weight: bold;
+}
+
+.inv-shop-item-price {
+    color: var(--border-accent);
+    font-size: 1.2em;
+}
+
+.inv-shop-buy-btn {
+    background: var(--green-success);
+    color: #000;
+    border: none;
+    padding: 5px;
+    cursor: pointer;
+    font-weight: bold;
+    border-radius: 3px;
+    text-transform: uppercase;
+}
+.inv-shop-buy-btn:hover { box-shadow: 0 0 10px rgba(51, 255, 51, 0.5); }
 
 
 /* Make the phone wrapper take full width and height on mobile devices */

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -130,7 +130,7 @@
  <button type="action" name="act_tab_profile" class="sheet-app-btn"><div class="sheet-app-icon">👤</div><span>Perfil</span></button>
  <button type="action" name="act_tab_vitals" class="sheet-app-btn"><div class="sheet-app-icon">❤️</div><span>Vitales</span></button>
  <button type="action" name="act_tab_stats" class="sheet-app-btn"><div class="sheet-app-icon">📊</div><span>Stats</span></button>
- <button type="action" name="act_tab_equipment" class="sheet-app-btn"><div class="sheet-app-icon">🎒</div><span>Equipo</span></button>
+ <button type="action" name="act_tab_banco" class="sheet-app-btn"><div class="sheet-app-icon">🏦</div><span>Banco</span></button>
  <button type="action" name="act_tab_skills" class="sheet-app-btn"><div class="sheet-app-icon">⭐</div><span>Perks</span></button>
  <button type="action" name="act_tab_abilities" class="sheet-app-btn"><div class="sheet-app-icon">⚔️</div><span>Skills</span></button>
  <button type="action" name="act_tab_apego" class="sheet-app-btn"><div class="sheet-app-icon">🤝</div><span>Apego</span></button>
@@ -421,73 +421,53 @@
 
 
  </div>
-        <!-- Equipo Tab -->
- <div class="sheet-tab-content sheet-tab-equipment">
- <input type="hidden" name="attr_show_equip_creator" class="sheet-state-equip-creator" value="0" />
+        <!-- Banco Tab -->
+ <div class="sheet-tab-content sheet-tab-banco">
+    <div class="sheet-app-header"><h2>Banco</h2></div>
+    <div class="sheet-app-body">
+        <div class="sheet-banco-balance-card">
+            <h3 class="sheet-banco-title">BALANCE ACTUAL</h3>
+            <div class="sheet-banco-amount-wrapper">
+                <span class="sheet-banco-currency-icon">Ahn</span>
+                <span name="attr_ahn" class="sheet-banco-amount-display">0</span>
+                <input type="hidden" name="attr_ahn" value="0" />
+            </div>
+            <div class="sheet-banco-account-info">
+                <span>CUENTA: L-CORP-984</span>
+                <span class="sheet-banco-status-active">ACTIVA</span>
+            </div>
+        </div>
 
- <div style="display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid #333; margin-bottom: 15px; padding-bottom: 5px;">
- <h3 class="sheet-config-title" style="margin: 0; border: none; padding: 0;">EQUIPAMIENTO</h3>
- <button type="action" name="act_toggle_equip_creator" class="sheet-btn-rest" style="width: auto; padding: 0 10px; font-size: 0.8em;">TOGGLE CREATOR</button>
- </div>
-
- <!-- Equipment Creator Area -->
- <div class="sheet-equip-creator-container" style="background: #1a1a1a; padding: 15px; border: 1px solid #FFD700; margin-bottom: 20px; border-radius: 5px;">
- <div class="sheet-row" style="margin-bottom: 10px;">
- <div class="sheet-col" style="flex: 2;">
- <label style="color: #FFD700;">Nombre del Equipo</label>
- <input type="text" name="attr_new_weapon_name" placeholder="Ej: LCB Espada Larga" style="width: 100%; background: #111; color: #fff; border: 1px solid #444;" />
- </div>
- <div class="sheet-col" style="flex: 2;">
- <label style="color: #FFD700;">Etiquetas</label>
- <input type="text" name="attr_new_weapon_tags" placeholder="Ej: LCB, Filo" style="width: 100%; background: #111; color: #fff; border: 1px solid #444;" />
- </div>
- </div>
- <div class="sheet-row" style="margin-bottom: 10px; gap: 10px;">
- <div class="sheet-col">
- <label style="color: #FFD700;">Offense Level Mod</label>
- <input type="number" name="attr_new_weapon_offense" value="0" style="width: 100%; background: #111; color: #fff; border: 1px solid #444;" />
- </div>
- <div class="sheet-col">
- <label style="color: #FFD700;">Defense Level Mod</label>
- <input type="number" name="attr_new_weapon_defense" value="0" style="width: 100%; background: #111; color: #fff; border: 1px solid #444;" />
- </div>
- </div>
- <div style="text-align: right;">
- <button type="action" name="act_add_equipment" class="sheet-btn-rest" style="width: 150px; border-color: #00ff00; color: #00ff00;">ADD EQUIP</button>
- </div>
- </div>
-
- <fieldset class="repeating_equipment">
- <div class="sheet-skill-card" style="padding: 10px; border: 1px solid #FFD700; background: #0a0a0a; margin-bottom: 5px; display: flex; align-items: center; justify-content: flex-start;">
-
- <input type="checkbox" name="attr_equipped" class="sheet-equip-active-toggle" value="1" title="Equipar/Desequipar" style="width: 20px; height: 20px; accent-color: #ffae00; margin-right: 15px;" />
-
- <div class="sheet-equip-content" style="display: flex; flex: 1; justify-content: space-between; align-items: center;">
- <div style="display: flex; flex-direction: column;">
- <input type="text" name="attr_weapon_name" placeholder="Nombre del Equipo" style="background: transparent; border: none; color: #fff; font-size: 1.1em; font-weight: bold; width: 250px;" />
- <div style="margin-top: 5px; display: flex; gap: 5px; flex-wrap: wrap;">
- <input type="hidden" name="attr_weapon_tags" />
- <input type="hidden" name="attr_tag_1" class="sheet-tag-hide" value="" /><span name="attr_tag_1" class="sheet-equip-badge"></span>
- <input type="hidden" name="attr_tag_2" class="sheet-tag-hide" value="" /><span name="attr_tag_2" class="sheet-equip-badge"></span>
- <input type="hidden" name="attr_tag_3" class="sheet-tag-hide" value="" /><span name="attr_tag_3" class="sheet-equip-badge"></span>
- <input type="hidden" name="attr_tag_4" class="sheet-tag-hide" value="" /><span name="attr_tag_4" class="sheet-equip-badge"></span>
- </div>
- </div>
-
- <div style="display: flex; gap: 15px; align-items: center;">
- <div class="sheet-col" style="text-align: center;">
- <label style="font-size: 0.7em; color: #aaa;">OFF LVL</label>
- <input type="number" name="attr_weapon_offense" value="0" style="width: 50px; background: #111; color: #fff; border: 1px solid #333; text-align: center;" />
- </div>
- <div class="sheet-col" style="text-align: center;">
- <label style="font-size: 0.7em; color: #aaa;">DEF LVL</label>
- <input type="number" name="attr_weapon_defense" value="0" style="width: 50px; background: #111; color: #fff; border: 1px solid #333; text-align: center;" />
- </div>
- </div>
- </div>
-
- </div>
- </fieldset>
+        <div class="sheet-banco-transactions">
+            <h4 class="sheet-banco-subtitle">ÚLTIMAS TRANSACCIONES</h4>
+            <div class="sheet-transaction-list">
+                <div class="sheet-transaction-item">
+                    <div class="sheet-tx-icon sheet-tx-in">↓</div>
+                    <div class="sheet-tx-details">
+                        <span class="sheet-tx-title">Transferencia L-Corp</span>
+                        <span class="sheet-tx-date">12:00 | Hoy</span>
+                    </div>
+                    <div class="sheet-tx-amount sheet-tx-in-amount">+500 Ahn</div>
+                </div>
+                <div class="sheet-transaction-item">
+                    <div class="sheet-tx-icon sheet-tx-out">↑</div>
+                    <div class="sheet-tx-details">
+                        <span class="sheet-tx-title">Compra - Vending Machine</span>
+                        <span class="sheet-tx-date">Ayer</span>
+                    </div>
+                    <div class="sheet-tx-amount sheet-tx-out-amount">-120 Ahn</div>
+                </div>
+                <div class="sheet-transaction-item">
+                    <div class="sheet-tx-icon sheet-tx-out">↑</div>
+                    <div class="sheet-tx-details">
+                        <span class="sheet-tx-title">Mantenimiento de Equipo</span>
+                        <span class="sheet-tx-date">Hace 3 días</span>
+                    </div>
+                    <div class="sheet-tx-amount sheet-tx-out-amount">-350 Ahn</div>
+                </div>
+            </div>
+        </div>
+    </div>
  </div>
 
  <!-- Perks Tab -->
@@ -3343,6 +3323,52 @@
 </div>
 </div> <!-- End Phone Wrapper -->
 </div> <!-- End Limbus Main -->
+
+<!-- Global Inventory Button -->
+<button class="btn-global-inventory" id="btn-global-inventory" title="Inventario Global">🎒</button>
+
+<!-- Inventory Modal -->
+<div id="inventory-modal" class="inventory-modal">
+    <div class="inventory-modal-content">
+        <button id="inventory-modal-close" class="inventory-modal-close">×</button>
+        <div class="inventory-tabs">
+            <button class="inv-tab-btn active" data-tab="inv-active">Inventario Activo</button>
+            <button class="inv-tab-btn" data-tab="inv-stash">Stash/Alijo</button>
+            <button class="inv-tab-btn" data-tab="inv-shop">Tienda / Mercado</button>
+        </div>
+
+        <div class="inventory-tab-content active" id="inv-active">
+            <div class="inv-active-grid">
+                <div class="inv-slot"></div><div class="inv-slot"></div><div class="inv-slot"></div><div class="inv-slot"></div><div class="inv-slot"></div>
+                <div class="inv-slot"></div><div class="inv-slot"></div><div class="inv-slot"></div><div class="inv-slot"></div><div class="inv-slot"></div>
+            </div>
+        </div>
+
+        <div class="inventory-tab-content" id="inv-stash">
+            <table class="inv-stash-table">
+                <thead>
+                    <tr><th>Item</th><th>Tier</th><th>Cant.</th></tr>
+                </thead>
+                <tbody>
+                    <!-- Dummy items -->
+                    <tr><td>Balas LCB</td><td>1</td><td>30</td></tr>
+                    <tr><td>Módulo Cibernético Roto</td><td>2</td><td>1</td></tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div class="inventory-tab-content" id="inv-shop">
+            <div class="inv-shop-grid">
+                <!-- Shop item dummy -->
+                <div class="inv-shop-item">
+                    <div class="inv-shop-item-name">Estimulante Básico</div>
+                    <div class="inv-shop-item-price">50 Ahn</div>
+                    <button class="inv-shop-buy-btn">Comprar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
 
 <!-- Toggle Button -->
 <button class="btn-toggle-phone" id="btn-toggle-phone" title="Alternar Celular">📱</button>

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -498,7 +498,7 @@
                 try {
                     savedAttrs = JSON.parse(charsheetSaveStr);
                     // Ensure 'tab' is valid so we don't get a blank screen on load
-                    const validTabs = ['home', 'stats', 'equipment', 'skills', 'abilities', 'parts', 'profile', 'apego', 'vitals', 'settings'];
+                    const validTabs = ['home', 'stats', 'banco', 'skills', 'abilities', 'parts', 'profile', 'apego', 'vitals', 'settings'];
                     if (!savedAttrs.tab || !validTabs.includes(savedAttrs.tab)) {
                         savedAttrs.tab = 'home';
                     }
@@ -1096,7 +1096,7 @@ try {
     // clicked:tab_profile
     // clicked:tab_apego
     // clicked:tab_equipment
-    const tabsList = ["stats", "abilities", "skills", "profile", "parts", "apego", "equipment"];
+    const tabsList = ["stats", "abilities", "skills", "profile", "parts", "apego", "banco"];
     tabsList.forEach(tab => {
         on(`clicked:tab_${tab}`, function() {
             setAttrs({
@@ -2220,11 +2220,60 @@ try {
     });
 
 // --- Navigation Tabs ---
-const tabs = ['home', 'stats', 'equipment', 'skills', 'abilities', 'parts', 'profile', 'apego', 'vitals', 'settings'];
+const tabs = ['home', 'stats', 'banco', 'skills', 'abilities', 'parts', 'profile', 'apego', 'vitals', 'settings'];
 tabs.forEach(tab => {
     on(`clicked:tab_${tab}`, function() {
         setAttrs({
             tab: tab
+        });
+    });
+});
+
+// --- Inventory Modal Logic ---
+window.addEventListener('DOMContentLoaded', () => {
+    const invBtn = document.getElementById('btn-global-inventory');
+    const invModal = document.getElementById('inventory-modal');
+    const invClose = document.getElementById('inventory-modal-close');
+    const invTabBtns = document.querySelectorAll('.inv-tab-btn');
+    const invTabContents = document.querySelectorAll('.inventory-tab-content');
+
+    if (invBtn && invModal) {
+        invBtn.addEventListener('click', () => {
+            invModal.classList.add('active');
+        });
+    }
+
+    if (invClose && invModal) {
+        invClose.addEventListener('click', () => {
+            invModal.classList.remove('active');
+        });
+    }
+
+    // Modal background click to close
+    if (invModal) {
+        invModal.addEventListener('click', (e) => {
+            if (e.target === invModal) {
+                invModal.classList.remove('active');
+            }
+        });
+    }
+
+    // Tab switching inside modal
+    invTabBtns.forEach(btn => {
+        btn.addEventListener('click', () => {
+            // Remove active from all buttons and contents
+            invTabBtns.forEach(b => b.classList.remove('active'));
+            invTabContents.forEach(c => c.classList.remove('active'));
+
+            // Add active to clicked button
+            btn.classList.add('active');
+
+            // Show target content
+            const targetId = btn.getAttribute('data-tab');
+            const targetContent = document.getElementById(targetId);
+            if (targetContent) {
+                targetContent.classList.add('active');
+            }
         });
     });
 });


### PR DESCRIPTION
# Description

This PR implements the Phase 4.1 features requested for the Bank and Inventory systems.

Changes include:
- Modified the app grid to change "Equipo" into "Banco".
- Created a dark cyberpunk bank UI displaying the `attr_ahn` balance and a dummy transactions list.
- Added a global floating inventory button outside the phone interface.
- Created a global inventory modal with internal tab navigation supporting 'Inventario Activo' (10 empty slots), 'Stash/Alijo', and 'Tienda/Mercado' (with a basic shop item dummy).
- Relevant JavaScript code to handle the opening/closing of the inventory modal and its sub-tabs.
- Relevant CSS updates matching the project's aesthetic.

---
*PR created automatically by Jules for task [9873346329176727778](https://jules.google.com/task/9873346329176727778) started by @sokcrow*