### PR TITLE
Add Limbus Company styled Inventory UI with Detail Card

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -5481,50 +5481,173 @@ input[name="attr_tab"][value="settings"] ~ .sheet-phone-screen .sheet-tab-settin
     box-shadow: 0 0 10px rgba(0, 255, 255, 0.4);
 }
 
+.inventory-body-wrapper {
+    display: flex;
+    flex: 1;
+    overflow: hidden;
+}
+
+.inventory-left-panel {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+}
+
 .inventory-tab-content {
     display: none;
     flex: 1;
     padding: 20px;
-    overflow-y: auto;
 }
 
 .inventory-tab-content.active {
     display: block;
 }
 
-/* Tab: Inventario Activo */
-.inv-active-grid {
+/* Tabs: Inventario Activo & Stash */
+.inv-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
-    gap: 15px;
+    grid-template-columns: repeat(auto-fill, minmax(64px, 1fr));
+    gap: 10px;
 }
 
-.inv-slot {
+.item-slot {
     aspect-ratio: 1;
-    background: #0d0d0d;
-    border: 1px solid #333;
-    border-radius: 4px;
-    box-shadow: inset 0 0 10px rgba(0,0,0,0.8);
+    background: #0a0a0a;
+    border: 1px solid #444;
+    position: relative;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     transition: all 0.2s;
-}
-.inv-slot:hover { border-color: var(--cyan-tech); }
-
-/* Tab: Stash */
-.inv-stash-table {
-    width: 100%;
-    border-collapse: collapse;
+    box-shadow: inset 0 0 15px rgba(0,0,0,0.9);
 }
 
-.inv-stash-table th, .inv-stash-table td {
-    padding: 10px;
-    text-align: left;
-    border-bottom: 1px solid #333;
+.item-slot:hover, .item-slot.active {
+    border-color: #ffae00;
+    box-shadow: 0 0 10px rgba(255, 174, 0, 0.5), inset 0 0 15px rgba(0,0,0,0.9);
 }
 
-.inv-stash-table th {
-    color: var(--cyan-tech);
-    font-size: 0.9em;
+.item-slot img {
+    max-width: 80%;
+    max-height: 80%;
+    object-fit: contain;
+}
+
+.item-quantity {
+    position: absolute;
+    bottom: 2px;
+    right: 2px;
+    background: rgba(0,0,0,0.8);
+    color: #eee;
+    font-size: 0.7em;
+    padding: 1px 4px;
+    border: 1px solid #444;
+    border-radius: 2px;
+}
+
+/* Detail Card (Limbus E.G.O Gift Style) */
+.item-detail-card {
+    display: none;
+    width: 320px;
+    background: #100c0a; /* Very dark brown/black */
+    border-left: 4px solid #5a3c1f; /* Dark thick border */
+    border-top: 1px solid #5a3c1f;
+    border-bottom: 1px solid #5a3c1f;
+    border-right: 1px solid #5a3c1f;
+    box-shadow: -5px 0 15px rgba(0,0,0,0.8);
+    padding: 15px;
+    flex-direction: row;
+    gap: 15px;
+    overflow-y: auto;
+}
+
+.item-detail-card.active {
+    display: flex;
+}
+
+.detail-left {
+    flex: 0 0 80px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+
+.detail-icon-box {
+    width: 80px;
+    height: 80px;
+    background: #2a2522; /* Grayish brown */
+    border: 1px solid #443c36;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 10px;
+}
+
+.detail-icon-box img {
+    max-width: 90%;
+    max-height: 90%;
+    object-fit: contain;
+}
+
+.detail-tier {
+    font-size: 0.85em;
+    color: #aaa;
+    margin-bottom: 5px;
+}
+
+.tier-orange {
+    color: #ffae00;
+    font-weight: bold;
+    font-size: 1.1em;
+}
+
+.detail-cost {
+    font-size: 0.8em;
+    color: #ccc;
+    margin-bottom: 10px;
+}
+
+.detail-tags {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.detail-tag {
+    background: #3a1515; /* Dark red background */
+    color: #ff8c00;
+    border: 1px solid #8b0000;
+    font-size: 0.65em;
+    padding: 2px 4px;
     text-transform: uppercase;
+}
+
+.detail-right {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.detail-title-badge {
+    background: linear-gradient(90deg, #d35400 0%, #ff8c00 100%);
+    color: #fff;
+    font-weight: bold;
+    font-size: 1.1em;
+    padding: 4px 10px;
+    border-radius: 2px;
+    margin-bottom: 15px;
+    text-shadow: 1px 1px 2px rgba(0,0,0,0.5);
+    clip-path: polygon(0 0, 95% 0, 100% 50%, 95% 100%, 0 100%);
+}
+
+.detail-desc {
+    color: #dcdcdc;
+    font-size: 0.85em;
+    line-height: 1.6;
+    white-space: pre-wrap;
 }
 
 /* Tab: Shop */

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -3314,32 +3314,44 @@
             <button class="inv-tab-btn" data-tab="inv-shop">Tienda / Mercado</button>
         </div>
 
-        <div class="inventory-tab-content active" id="inv-active">
-            <div class="inv-active-grid">
-                <div class="inv-slot"></div><div class="inv-slot"></div><div class="inv-slot"></div><div class="inv-slot"></div><div class="inv-slot"></div>
-                <div class="inv-slot"></div><div class="inv-slot"></div><div class="inv-slot"></div><div class="inv-slot"></div><div class="inv-slot"></div>
+        <div class="inventory-body-wrapper">
+            <div class="inventory-left-panel">
+                <div class="inventory-tab-content active" id="inv-active">
+                    <div class="inv-grid" id="inv-active-grid">
+                        <!-- Items injectados via JS -->
+                    </div>
+                </div>
+
+                <div class="inventory-tab-content" id="inv-stash">
+                    <div class="inv-grid" id="inv-stash-grid">
+                        <!-- Items injectados via JS -->
+                    </div>
+                </div>
+
+                <div class="inventory-tab-content" id="inv-shop">
+                    <select id="shop-selector" style="width: 100%; margin-bottom: 15px; padding: 5px; background: #111; color: var(--cyan-tech); border: 1px solid var(--cyan-tech);">
+                        <option value="">Selecciona una tienda...</option>
+                    </select>
+                    <div class="inv-shop-grid" id="inv-shop-grid">
+                        <!-- Shop items will be injected here via JS -->
+                    </div>
+                </div>
             </div>
-        </div>
 
-        <div class="inventory-tab-content" id="inv-stash">
-            <table class="inv-stash-table">
-                <thead>
-                    <tr><th>Item</th><th>Tier</th><th>Cant.</th></tr>
-                </thead>
-                <tbody>
-                    <!-- Dummy items -->
-                    <tr><td>Balas LCB</td><td>1</td><td>30</td></tr>
-                    <tr><td>Módulo Cibernético Roto</td><td>2</td><td>1</td></tr>
-                </tbody>
-            </table>
-        </div>
-
-        <div class="inventory-tab-content" id="inv-shop">
-            <select id="shop-selector" style="width: 100%; margin-bottom: 15px; padding: 5px; background: #111; color: var(--cyan-tech); border: 1px solid var(--cyan-tech);">
-                <option value="">Selecciona una tienda...</option>
-            </select>
-            <div class="inv-shop-grid" id="inv-shop-grid">
-                <!-- Shop items will be injected here via JS -->
+            <!-- Detail Card (Inspirada en Limbus E.G.O Gift) -->
+            <div class="item-detail-card" id="item-detail-card">
+                <div class="detail-left">
+                    <div class="detail-icon-box">
+                        <img id="detail-icon" src="" alt="Icono" />
+                    </div>
+                    <div class="detail-tier">Tier: <span id="detail-tier-val" class="tier-orange">I</span></div>
+                    <div class="detail-cost">Costo: <span style="color:var(--border-accent);">[A]</span> <span id="detail-cost-val">0</span></div>
+                    <div class="detail-tags" id="detail-tags-val"></div>
+                </div>
+                <div class="detail-right">
+                    <div class="detail-title-badge" id="detail-title">Nombre del Item</div>
+                    <div class="detail-desc" id="detail-desc">Descripción del item detallada para lectura cómoda.</div>
+                </div>
             </div>
         </div>
     </div>

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -2274,8 +2274,77 @@ window.addEventListener('DOMContentLoaded', () => {
             if (targetContent) {
                 targetContent.classList.add('active');
             }
+
+            // Hide detail card and reset selection when switching tabs
+            const detailCard = document.getElementById('item-detail-card');
+            if (detailCard) detailCard.classList.remove('active');
+            document.querySelectorAll('.item-slot.active').forEach(s => s.classList.remove('active'));
         });
     });
+
+    // --- Mock Data & Rendering for Inventory Grids ---
+    const mockItems = [
+        { id: 1, name: "Balas LCB", tier: "I", cost: 10, tags: ["Consumible", "Munición"], desc: "Balas estándar emitidas por Limbus Company. Son baratas, confiables y matan lo que tengan en frente, la mayoría de las veces.", img: "https://i.imgur.com/yshLPnQ.png", cant: 30 },
+        { id: 2, name: "Cuchillo Térmico", tier: "II", cost: 150, tags: ["Arma", "Burn"], desc: "Una hoja que alcanza altas temperaturas. Cauteriza la herida al mismo tiempo que corta. Muy usada en los callejones traseros.", img: "https://i.imgur.com/Akf25L5.png", cant: 1 },
+        { id: 3, name: "Inyector de Enkephalina", tier: "III", cost: 500, tags: ["Medicina", "SP", "Peligro"], desc: "Un tubo brillante verde. Restaura cordura al instante, pero el abuso de esta sustancia te dejará babeando en un rincón.", img: "https://i.imgur.com/DCTX5Jy.png", cant: 3 },
+        { id: 4, name: "Módulo Cibernético Roto", tier: "I", cost: 25, tags: ["Chatarra", "Crafting"], desc: "Un pedazo de tecnología que fue arrancado de un cíborg menos afortunado. Todavía tiene algo de cobre aprovechable.", img: "https://i.imgur.com/0KArwDU.png", cant: 5 }
+    ];
+
+    function renderInventoryGrid(gridId, items) {
+        const grid = document.getElementById(gridId);
+        if (!grid) return;
+
+        grid.innerHTML = '';
+
+        // Fill slots with items
+        items.forEach(item => {
+            const slot = document.createElement('div');
+            slot.className = 'item-slot';
+            slot.innerHTML = `
+                <img src="${item.img}" alt="${item.name}" />
+                <div class="item-quantity">x${item.cant}</div>
+            `;
+
+            slot.addEventListener('click', () => {
+                // Remove active from all slots
+                document.querySelectorAll('.item-slot').forEach(s => s.classList.remove('active'));
+                slot.classList.add('active');
+
+                // Show detail card
+                const detailCard = document.getElementById('item-detail-card');
+                detailCard.classList.add('active');
+
+                // Populate data
+                document.getElementById('detail-icon').src = item.img;
+                document.getElementById('detail-tier-val').innerText = item.tier;
+                document.getElementById('detail-cost-val').innerText = item.cost;
+                document.getElementById('detail-title').innerText = item.name;
+                document.getElementById('detail-desc').innerText = item.desc;
+
+                const tagsContainer = document.getElementById('detail-tags-val');
+                tagsContainer.innerHTML = '';
+                item.tags.forEach(tag => {
+                    const t = document.createElement('span');
+                    t.className = 'detail-tag';
+                    t.innerText = `[${tag}]`;
+                    tagsContainer.appendChild(t);
+                });
+            });
+
+            grid.appendChild(slot);
+        });
+
+        // Fill remaining empty slots up to 25 to make it look like a grid
+        const emptySlotsNeeded = Math.max(0, 25 - items.length);
+        for(let i = 0; i < emptySlotsNeeded; i++) {
+            const emptySlot = document.createElement('div');
+            emptySlot.className = 'item-slot';
+            grid.appendChild(emptySlot);
+        }
+    }
+
+    renderInventoryGrid('inv-active-grid', mockItems.slice(0, 2)); // Just 2 in active
+    renderInventoryGrid('inv-stash-grid', mockItems); // All in stash
 
     // --- Dynamic Shop System Logic ---
     const shopSelector = document.getElementById('shop-selector');


### PR DESCRIPTION
I've fully implemented the requested Limbus Company-styled inventory UI:

1. **Inventory Grid (`.item-slot`)**: Constructed the CSS Grid displaying small dark squares with a dim border. Injected mock items to display their icons centrally. The quantity badge displays correctly in the bottom right. Hovering and clicking highlight the slot with the requested orange/gold glow.
2. **Detail Card (`.item-detail-card`)**: Built an adjacent Flexbox layout simulating an E.G.O. Gift interface. The dark brown theme, visual layout (gray-brown icon box, orange tier text, accent borders), title badge with gradient, tags, and description are all styled to specifications.
3. **Interactivity**: Added a lightweight JS script inside `hoja_personaje.js` that renders the mock data, sets up the empty slots, and populates the hidden detail card when a filled slot is clicked. The script also handles hiding the card when switching inventory tabs.

Everything is tested and looking great. Let me know if you need any adjustments to the aesthetics!

---
*PR created automatically by Jules for task [9843871031942797905](https://jules.google.com/task/9843871031942797905) started by @sokcrow*