### PR TITLE
feat: dynamic tier colors for items

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -5632,7 +5632,7 @@ input[name="attr_tab"][value="settings"] ~ .sheet-phone-screen .sheet-tab-settin
 }
 
 .detail-title-badge {
-    background: linear-gradient(90deg, #d35400 0%, #ff8c00 100%);
+    background: linear-gradient(90deg, #555555 0%, #777777 100%); /* Default / Tier I-II */
     color: #fff;
     font-weight: bold;
     font-size: 1.1em;
@@ -5641,6 +5641,24 @@ input[name="attr_tab"][value="settings"] ~ .sheet-phone-screen .sheet-tab-settin
     margin-bottom: 15px;
     text-shadow: 1px 1px 2px rgba(0,0,0,0.5);
     clip-path: polygon(0 0, 95% 0, 100% 50%, 95% 100%, 0 100%);
+    transition: background 0.3s ease;
+}
+
+/* Modificadores de color por Tier */
+.detail-title-badge.tier-i-ii {
+    background: linear-gradient(90deg, #5c4a44 0%, #8b6b5d 100%); /* Tonos óxido/marrón apagado */
+}
+.detail-title-badge.tier-iii-iv {
+    background: linear-gradient(90deg, #0f5c3b 0%, #20b2aa 100%); /* Tonos verde neón o cian apagado */
+}
+.detail-title-badge.tier-v-vi {
+    background: linear-gradient(90deg, #002366 0%, #1e90ff 100%); /* Tonos azul eléctrico/cobalto */
+}
+.detail-title-badge.tier-vii-viii {
+    background: linear-gradient(90deg, #4b0082 0%, #8b008b 100%); /* Tonos púrpura o magenta oscuro */
+}
+.detail-title-badge.tier-ix-x {
+    background: linear-gradient(90deg, #d35400 0%, #ff0000 100%); /* Naranja vibrante, dorado o rojo sangre */
 }
 
 .detail-desc {

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -2318,7 +2318,28 @@ window.addEventListener('DOMContentLoaded', () => {
                 document.getElementById('detail-icon').src = item.img;
                 document.getElementById('detail-tier-val').innerText = item.tier;
                 document.getElementById('detail-cost-val').innerText = item.cost;
-                document.getElementById('detail-title').innerText = item.name;
+
+                const titleBadge = document.getElementById('detail-title');
+                titleBadge.innerText = item.name;
+
+                // Limpiar clases de tier anteriores
+                titleBadge.classList.remove('tier-i-ii', 'tier-iii-iv', 'tier-v-vi', 'tier-vii-viii', 'tier-ix-x');
+
+                // Aplicar nueva clase según el tier
+                if (item.tier === 'I' || item.tier === 'II') {
+                    titleBadge.classList.add('tier-i-ii');
+                } else if (item.tier === 'III' || item.tier === 'IV') {
+                    titleBadge.classList.add('tier-iii-iv');
+                } else if (item.tier === 'V' || item.tier === 'VI') {
+                    titleBadge.classList.add('tier-v-vi');
+                } else if (item.tier === 'VII' || item.tier === 'VIII') {
+                    titleBadge.classList.add('tier-vii-viii');
+                } else if (item.tier === 'IX' || item.tier === 'X') {
+                    titleBadge.classList.add('tier-ix-x');
+                } else {
+                    titleBadge.classList.add('tier-i-ii'); // Default fallback
+                }
+
                 document.getElementById('detail-desc').innerText = item.desc;
 
                 const tagsContainer = document.getElementById('detail-tags-val');

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -408,6 +408,18 @@
           <option value="Consumible">Consumible</option>
           <option value="Clave">Clave</option>
         </select>
+        <select id="forja-tier">
+          <option value="I">Tier I</option>
+          <option value="II">Tier II</option>
+          <option value="III">Tier III</option>
+          <option value="IV">Tier IV</option>
+          <option value="V">Tier V</option>
+          <option value="VI">Tier VI</option>
+          <option value="VII">Tier VII</option>
+          <option value="VIII">Tier VIII</option>
+          <option value="IX">Tier IX</option>
+          <option value="X">Tier X</option>
+        </select>
         <input type="number" id="forja-costo" placeholder="Costo Base en Ahn" />
         <input type="number" id="forja-usos" placeholder="Usos Máximos (opcional)" />
         <textarea id="forja-desc" placeholder="Descripción" rows="2"></textarea>
@@ -832,11 +844,12 @@
 
        const icono = document.getElementById('forja-icono').value.trim();
        const tipo = document.getElementById('forja-tipo').value;
+       const tier = document.getElementById('forja-tier').value;
        const costo = parseInt(document.getElementById('forja-costo').value) || 0;
        const usos = parseInt(document.getElementById('forja-usos').value) || 0;
        const desc = document.getElementById('forja-desc').value.trim();
 
-       const item = { nombre, icono, tipo, costo, usos, descripcion: desc };
+       const item = { nombre, icono, tipo, tier, costo, usos, descripcion: desc };
 
        db.ref(`campaña/base_datos_items/${nombre}`).set(item)
          .then(() => {


### PR DESCRIPTION
Implemented a dynamic color system for the title badge in the item detail card based on the item's tier.

Changes:
1. `hoja_personaje.css`: Added CSS classes `.tier-i-ii`, `.tier-iii-iv`, `.tier-v-vi`, `.tier-vii-viii`, and `.tier-ix-x` with corresponding cyberpunk color gradients. Included a fallback default background.
2. `pantalla_dm.html`: Added a `<select id="forja-tier">` to the global item creation form ("Forjar Nuevo Ítem Global") to assign a tier (I to X) to new items. Updated the item creation script to capture and save the tier to Firebase.
3. `hoja_personaje.js`: Updated the function that populates the item detail card (`#item-detail-card`) to dynamically apply the correct tier CSS class to the title badge (`#detail-title`) based on the item's tier property.

---
*PR created automatically by Jules for task [14312397851906553376](https://jules.google.com/task/14312397851906553376) started by @sokcrow*