### PR TITLE
Redesign Profile Tab (ID Card View & DM Config Collapse)

### DIFF
--- a/check_html.py
+++ b/check_html.py
@@ -1,0 +1,40 @@
+from html.parser import HTMLParser
+import sys
+
+class StrictHTMLParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.stack = []
+        self.void_elements = {'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'param', 'source', 'track', 'wbr'}
+
+    def handle_starttag(self, tag, attrs):
+        if tag not in self.void_elements:
+            self.stack.append(tag)
+
+    def handle_endtag(self, tag):
+        if tag in self.void_elements:
+            return
+        if not self.stack:
+            print(f"Error: Encountered closing tag </{tag}> but no tags are open.")
+            return
+        if self.stack[-1] != tag:
+            # Try to recover by looking up the stack
+            if tag in self.stack:
+                idx = len(self.stack) - 1 - self.stack[::-1].index(tag)
+                print(f"Error: Missing closing tags for {self.stack[idx+1:]} before </{tag}>.")
+                self.stack = self.stack[:idx]
+            else:
+                print(f"Error: Encountered unexpected closing tag </{tag}>. Expected </{self.stack[-1]}>.")
+        else:
+            self.stack.pop()
+
+    def close(self):
+        super().close()
+        if self.stack:
+            print(f"Error: Unclosed tags at EOF: {self.stack}")
+
+with open('hoja_personaje.html', 'r', encoding='utf-8') as f:
+    parser = StrictHTMLParser()
+    parser.feed(f.read())
+    parser.close()
+    print("Check complete.")

--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -1518,12 +1518,71 @@ button[type="action"].sheet-ahn-edit-btn:hover,
     border: 1px solid #333;
     border-radius: 8px;
 }
+
 .sheet-limbus-main .sheet-tab-profile h3 {
     color: #FFD700;
     margin-top: 0;
     border-bottom: 1px solid #333;
     padding-bottom: 5px;
     margin-bottom: 15px;
+}
+
+/* --- Profile View vs Edit Toggle --- */
+.sheet-limbus-main input.sheet-state-profile-edit[value="0"] ~ .sheet-profile-edit-form {
+    display: none;
+}
+.sheet-limbus-main input.sheet-state-profile-edit[value="1"] ~ .sheet-profile-view-card {
+    display: none;
+}
+
+/* Profile ID Card View */
+.sheet-limbus-main .sheet-profile-view-card {
+    background: linear-gradient(135deg, #111 0%, #1a0000 100%);
+    border: 2px solid var(--border-accent);
+    border-radius: 8px;
+    padding: 15px;
+    position: relative;
+    box-shadow: 0 0 15px rgba(139, 0, 0, 0.4), inset 0 0 20px rgba(0,0,0,0.8);
+    overflow: hidden;
+}
+
+.sheet-limbus-main .sheet-profile-view-card::after {
+    content: '';
+    position: absolute;
+    top: 0; right: 0; bottom: 0; width: 40%;
+    background: repeating-linear-gradient(45deg, transparent, transparent 10px, rgba(196, 154, 0, 0.03) 10px, rgba(196, 154, 0, 0.03) 20px);
+    pointer-events: none;
+}
+
+.sheet-limbus-main .sheet-profile-edit-form {
+    background: #111;
+    border: 1px dashed #444;
+    padding: 15px;
+    border-radius: 6px;
+}
+
+.sheet-limbus-main .sheet-dm-advanced-config {
+    margin-top: 20px;
+    background: #080808;
+    border: 1px solid #ff4444;
+    border-radius: 4px;
+    padding: 10px;
+}
+
+.sheet-limbus-main .sheet-dm-advanced-config summary {
+    color: #ff4444;
+    font-weight: bold;
+    cursor: pointer;
+    font-size: 1.1em;
+    text-transform: uppercase;
+    padding: 5px;
+    list-style: none;
+}
+.sheet-limbus-main .sheet-dm-advanced-config summary::-webkit-details-marker {
+    display: none;
+}
+.sheet-limbus-main .sheet-dm-advanced-config summary:hover {
+    text-shadow: 0 0 5px #ff4444;
 }
 
 /* SP Logic (States using Attribute Selectors) */

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -3128,14 +3128,6 @@
                         <span name="attr_xp_reward" class="sheet-xp-reward-value">0</span>
                     </div>
                 </div>
-
-                <div class="sheet-ahn-row">
-                    <input type="hidden" name="attr_character_type" class="sheet-state-char-type" value="player" />
-                    <div class="sheet-ahn-player-container">
-                        <label>Ahn:</label>
-                        <span name="attr_ahn_display" class="sheet-ahn-display">0</span>
-                    </div>
-                </div>
             </div>
         </div>
 
@@ -3189,15 +3181,6 @@
                 <div class="sheet-col">
                     <label>XP</label>
                     <input type="number" name="attr_xp" value="0" />
-                </div>
-                <div class="sheet-col">
-                    <label>Ahn</label>
-                    <div class="sheet-ahn-mod-container" style="margin-left: 0; justify-content: flex-start;">
-                        <input type="number" name="attr_ahn" value="0" class="sheet-ahn-total" title="Ahn Total" />
-                        <input type="number" name="attr_ahn_mod" value="0" class="sheet-ahn-mod" />
-                        <button type="action" name="act_add_ahn" class="sheet-ahn-btn"><span style="pointer-events: none;">+</span></button>
-                        <button type="action" name="act_sub_ahn" class="sheet-ahn-btn"><span style="pointer-events: none;">-</span></button>
-                    </div>
                 </div>
             </div>
 

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -3075,223 +3075,249 @@
 
  <!-- Abnormality Parts List (Moved from Parts Tab) -->
  <div class="sheet-tab-content sheet-tab-profile">
-<div class="sheet-app-header"><h2>Perfil</h2></div>
-<div class="sheet-app-body">
-<div class="sheet-header-left">
- <div class="sheet-avatar-row">
- <div class="sheet-avatar-container">
- <!-- Roll20 Avatar Injection -->
- <img name="attr_character_avatar" class="sheet-avatar-img" />
- <div class="sheet-level-hex">
- <span name="attr_level">1</span>
- </div>
- </div>
- <div class="sheet-identity-info">
- <div class="sheet-id-row"><span name="attr_character_name" class="sheet-id-name">Nombre</span></div>
- <div class="sheet-id-row"><span name="attr_identity" class="sheet-id-sub">Identidad</span></div>
- <div class="sheet-id-row-small">
- <span name="attr_class">Clase</span> • <span name="attr_race">Raza</span>
- </div>
- <div class="sheet-id-row-small">
- <span name="attr_background">Trasfondo</span>
- </div>
- </div>
- </div>
- <div class="sheet-xp-row">
- <input type="hidden" name="attr_character_type" class="sheet-state-char-type" value="player" />
+    <div class="sheet-app-header">
+        <h2>Perfil</h2>
+        <button type="action" name="act_toggle_profile_edit" class="sheet-icon-btn">⚙️</button>
+    </div>
+    <div class="sheet-app-body">
 
- <!-- Player XP Bar -->
- <div class="sheet-xp-player-container">
- <label>XP:</label>
- <input type="number" name="attr_xp" value="0" class="sheet-xp-small" />
- <div class="sheet-xp-bar-container">
- <input type="hidden" name="attr_xp_bar_class" class="sheet-state-xp-bar" value="sheet-xp-0" />
- <div class="sheet-xp-progress-wrapper">
- <span class="sheet-xp-text">Faltan: <span name="attr_xp_missing">0</span></span>
- <div class="sheet-xp-fill"></div>
- </div>
- </div>
- </div>
+        <input type="hidden" name="attr_show_profile_edit" class="sheet-state-profile-edit" value="0" />
 
- <!-- NPC/Abnormality XP Reward -->
- <div class="sheet-xp-reward-container">
- <label style="color: #FFD700; font-weight: bold;">XP REWARD:</label>
- <span name="attr_xp_reward" class="sheet-xp-reward-value">0</span>
- </div>
- </div>
+        <!-- ID Card View (Read-Only) -->
+        <div class="sheet-profile-view-card">
+            <div class="sheet-header-left">
+                <div class="sheet-avatar-row">
+                    <div class="sheet-avatar-container">
+                        <!-- Roll20 Avatar Injection -->
+                        <img name="attr_character_avatar" class="sheet-avatar-img" />
+                        <div class="sheet-level-hex">
+                            <span name="attr_level">1</span>
+                        </div>
+                    </div>
+                    <div class="sheet-identity-info">
+                        <div class="sheet-id-row"><span name="attr_character_name" class="sheet-id-name">Nombre</span></div>
+                        <div class="sheet-id-row"><span name="attr_identity" class="sheet-id-sub">Identidad</span></div>
+                        <div class="sheet-id-row-small">
+                            <span name="attr_class">Clase</span> • <span name="attr_race">Raza</span>
+                        </div>
+                        <div class="sheet-id-row-small">
+                            <span name="attr_background">Trasfondo</span>
+                        </div>
+                    </div>
+                </div>
 
- <div class="sheet-ahn-row">
- <input type="hidden" name="attr_character_type" class="sheet-state-char-type" value="player" />
- <div class="sheet-ahn-player-container">
- <input type="hidden" name="attr_show_ahn_edit" class="sheet-ahn-edit-toggle" value="0" />
- <button type="action" name="act_toggle_ahn_edit" class="sheet-ahn-edit-btn">⚙️</button>
+                <div class="sheet-xp-row">
+                    <input type="hidden" name="attr_character_type" class="sheet-state-char-type" value="player" />
 
- <div class="sheet-ahn-edit-menu">
- <input type="number" name="attr_ahn" value="0" class="sheet-ahn-total" title="Ahn Total (Edit Directly)" />
- </div>
+                    <!-- Player XP Bar -->
+                    <div class="sheet-xp-player-container">
+                        <label>XP:</label>
+                        <span name="attr_xp" class="sheet-xp-read-only">0</span>
+                        <div class="sheet-xp-bar-container">
+                            <input type="hidden" name="attr_xp_bar_class" class="sheet-state-xp-bar" value="sheet-xp-0" />
+                            <div class="sheet-xp-progress-wrapper">
+                                <span class="sheet-xp-text">Faltan: <span name="attr_xp_missing">0</span></span>
+                                <div class="sheet-xp-fill"></div>
+                            </div>
+                        </div>
+                    </div>
 
- <label>Ahn:</label>
- <span name="attr_ahn_display" class="sheet-ahn-display">0</span>
+                    <!-- NPC/Abnormality XP Reward -->
+                    <div class="sheet-xp-reward-container">
+                        <label style="color: #FFD700; font-weight: bold;">XP REWARD:</label>
+                        <span name="attr_xp_reward" class="sheet-xp-reward-value">0</span>
+                    </div>
+                </div>
 
- <div class="sheet-ahn-mod-container">
- <input type="number" name="attr_ahn_mod" value="0" class="sheet-ahn-mod" />
- <button type="action" name="act_add_ahn" class="sheet-ahn-btn"><span style="pointer-events: none;">+</span></button>
- <button type="action" name="act_sub_ahn" class="sheet-ahn-btn"><span style="pointer-events: none;">-</span></button>
- </div>
- </div>
- </div>
- </div>
+                <div class="sheet-ahn-row">
+                    <input type="hidden" name="attr_character_type" class="sheet-state-char-type" value="player" />
+                    <div class="sheet-ahn-player-container">
+                        <label>Ahn:</label>
+                        <span name="attr_ahn_display" class="sheet-ahn-display">0</span>
+                    </div>
+                </div>
+            </div>
+        </div>
 
- <h3 class="sheet-config-title">Datos del Personaje</h3>
- <div class="sheet-row">
- <div class="sheet-col">
- <label>Tipo de Personaje</label>
- <select name="attr_character_type" style="width: 100%; background: #111; color: #fff; border: 1px solid #444;">
- <option value="player">Jugador</option>
- <option value="npc">NPC (Minion)</option>
- <option value="abnormality">NPC (Abnormality)</option>
- </select>
- </div>
- </div>
- <div class="sheet-row">
- <div class="sheet-col">
- <label>Nombre</label>
- <input type="text" name="attr_character_name" />
- </div>
- <div class="sheet-col">
- <label>Identidad</label>
- <input type="text" name="attr_identity" />
- </div>
- </div>
- <div class="sheet-row">
- <div class="sheet-col">
- <label>Clase</label>
- <input type="text" name="attr_class" />
- </div>
- <div class="sheet-col">
- <label>Raza</label>
- <input type="text" name="attr_race" />
- </div>
- <div class="sheet-col">
- <label>Trasfondo</label>
- <input type="text" name="attr_background" />
- </div>
- </div>
- <div class="sheet-row">
- <div class="sheet-col">
- <label>Avatar URL</label>
- <input type="text" name="attr_avatar_url" placeholder="https://..." />
- </div>
- <div class="sheet-col sheet-col-small">
- <label>Nivel</label>
- <input type="number" name="attr_level" class="sheet-level-player" readonly style="background: #222; color: #888;" />
- <input type="number" name="attr_level" class="sheet-level-manual" placeholder="Lvl" />
- </div>
- <div class="sheet-col sheet-col-small">
- <label>Rango (Grade)</label>
- <input type="number" name="attr_rank" placeholder="9" />
- </div>
- </div>
+        <!-- Edit Form -->
+        <div class="sheet-profile-edit-form">
+            <h3 class="sheet-config-title">Datos del Personaje</h3>
 
- <h3 class="sheet-config-title">Configuración de Velocidad</h3>
- <div class="sheet-row">
- <div class="sheet-col">
- <label>Min Speed</label>
- <input type="number" name="attr_MinSpeed" value="1" />
- </div>
- <div class="sheet-col">
- <label>Max Speed</label>
- <input type="number" name="attr_MaxSpeed" value="6" />
- </div>
- </div>
+            <div class="sheet-row">
+                <div class="sheet-col">
+                    <label>Nombre</label>
+                    <input type="text" name="attr_character_name" />
+                </div>
+                <div class="sheet-col">
+                    <label>Identidad</label>
+                    <input type="text" name="attr_identity" />
+                </div>
+            </div>
 
- <h3 class="sheet-config-title">Configuración de Slots</h3>
- <div class="sheet-row">
- <div class="sheet-col">
- <label>Action Slots</label>
- <input type="number" name="attr_action_slots" value="1" />
- </div>
- <div class="sheet-col">
- <label>Slot Weight</label>
- <input type="number" name="attr_slot_weight" value="1" />
- </div>
- </div>
+            <div class="sheet-row">
+                <div class="sheet-col">
+                    <label>Clase</label>
+                    <input type="text" name="attr_class" />
+                </div>
+                <div class="sheet-col">
+                    <label>Raza</label>
+                    <input type="text" name="attr_race" />
+                </div>
+                <div class="sheet-col">
+                    <label>Trasfondo</label>
+                    <input type="text" name="attr_background" />
+                </div>
+            </div>
 
- <h3 class="sheet-config-title">Configuración de Suerte</h3>
- <div class="sheet-row">
- <div class="sheet-col">
- <label>Max Luck</label>
- <input type="number" name="attr_luck_max" value="0" />
- </div>
- </div>
+            <div class="sheet-row">
+                <div class="sheet-col">
+                    <label>Avatar URL</label>
+                    <input type="text" name="attr_avatar_url" placeholder="https://..." />
+                </div>
+                <div class="sheet-col sheet-col-small">
+                    <label>Nivel</label>
+                    <input type="number" name="attr_level" class="sheet-level-player" readonly style="background: #222; color: #888;" />
+                    <input type="number" name="attr_level" class="sheet-level-manual" placeholder="Lvl" />
+                </div>
+                <div class="sheet-col sheet-col-small">
+                    <label>Rango (Grade)</label>
+                    <input type="number" name="attr_rank" placeholder="9" />
+                </div>
+            </div>
 
- <h3 class="sheet-config-title">Configuración de HP</h3>
- <div class="sheet-row">
- <div class="sheet-col">
- <label>Base HP</label>
- <input type="number" name="attr_hp_base" value="0" />
- </div>
- <div class="sheet-col">
- <label>Multiplicador (X) (x Def Lvl)</label>
- <input type="number" name="attr_hp_coefficient" value="0" step="0.01" />
- </div>
- <div class="sheet-col">
- <label>Calc. Max HP</label>
- <input type="number" name="attr_hp_max" />
- </div>
- </div>
+            <div class="sheet-row">
+                <div class="sheet-col">
+                    <label>XP</label>
+                    <input type="number" name="attr_xp" value="0" />
+                </div>
+                <div class="sheet-col">
+                    <label>Ahn</label>
+                    <div class="sheet-ahn-mod-container" style="margin-left: 0; justify-content: flex-start;">
+                        <input type="number" name="attr_ahn" value="0" class="sheet-ahn-total" title="Ahn Total" />
+                        <input type="number" name="attr_ahn_mod" value="0" class="sheet-ahn-mod" />
+                        <button type="action" name="act_add_ahn" class="sheet-ahn-btn"><span style="pointer-events: none;">+</span></button>
+                        <button type="action" name="act_sub_ahn" class="sheet-ahn-btn"><span style="pointer-events: none;">-</span></button>
+                    </div>
+                </div>
+            </div>
 
- <h3 class="sheet-config-title">Configuración Stagger</h3>
- <div class="sheet-row">
- <div class="sheet-col">
- <label>Thresholds Visibles</label>
- <select name="attr_stagger_count" style="width: 100%; background: #111; color: #fff; border: 1px solid #444;">
- <option value="1">1 Threshold</option>
- <option value="2">2 Thresholds</option>
- <option value="3" selected>3 Thresholds</option>
- </select>
- </div>
- <div class="sheet-col">
- <label>% Stagger I</label>
- <input type="number" name="attr_stagger_1_percent" value="70" />
- </div>
- <div class="sheet-col">
- <label>% Stagger II</label>
- <input type="number" name="attr_stagger_2_percent" value="40" />
- </div>
- <div class="sheet-col">
- <label>% Stagger III</label>
- <input type="number" name="attr_stagger_3_percent" value="20" />
- </div>
- </div>
+            <!-- Advanced DM Config -->
+            <details class="sheet-dm-advanced-config">
+                <summary>⚠️ Configuración Avanzada (Solo DM)</summary>
 
- <h3 class="sheet-config-title">Modificadores Globales</h3>
- <div class="sheet-row">
- <div class="sheet-col">
- <label>Mod. Raza (OFF)</label>
- <input type="number" name="attr_mod_race_off" value="0" />
- </div>
- <div class="sheet-col">
- <label>Mod. Raza (DEF)</label>
- <input type="number" name="attr_mod_race_def" value="0" />
- </div>
- <div class="sheet-col">
- <label>Mod. Identidad (OFF)</label>
- <input type="number" name="attr_mod_identity_off" value="0" />
- </div>
- <div class="sheet-col">
- <label>Mod. Identidad (DEF)</label>
- <input type="number" name="attr_mod_identity_def" value="0" />
- </div>
- </div>
- <div class="sheet-row">
- <div class="sheet-col">
- <label>Clase/Identidad Notas</label>
- <textarea name="attr_identity_notes" style="height: 100px; width: 100%; background: #111; color: #fff; border: 1px solid #444; resize: vertical;"></textarea>
- </div>
- </div>
- </div>
- </div>
+                <div class="sheet-row" style="margin-top: 15px;">
+                    <div class="sheet-col">
+                        <label>Tipo de Personaje</label>
+                        <select name="attr_character_type" style="width: 100%; background: #111; color: #fff; border: 1px solid #444;">
+                            <option value="player">Jugador</option>
+                            <option value="npc">NPC (Minion)</option>
+                            <option value="abnormality">NPC (Abnormality)</option>
+                        </select>
+                    </div>
+                </div>
+
+                <h3 class="sheet-config-title">Configuración de Velocidad</h3>
+                <div class="sheet-row">
+                    <div class="sheet-col">
+                        <label>Min Speed</label>
+                        <input type="number" name="attr_MinSpeed" value="1" />
+                    </div>
+                    <div class="sheet-col">
+                        <label>Max Speed</label>
+                        <input type="number" name="attr_MaxSpeed" value="6" />
+                    </div>
+                </div>
+
+                <h3 class="sheet-config-title">Configuración de Slots</h3>
+                <div class="sheet-row">
+                    <div class="sheet-col">
+                        <label>Action Slots</label>
+                        <input type="number" name="attr_action_slots" value="1" />
+                    </div>
+                    <div class="sheet-col">
+                        <label>Slot Weight</label>
+                        <input type="number" name="attr_slot_weight" value="1" />
+                    </div>
+                </div>
+
+                <h3 class="sheet-config-title">Configuración de Suerte</h3>
+                <div class="sheet-row">
+                    <div class="sheet-col">
+                        <label>Max Luck</label>
+                        <input type="number" name="attr_luck_max" value="0" />
+                    </div>
+                </div>
+
+                <h3 class="sheet-config-title">Configuración de HP</h3>
+                <div class="sheet-row">
+                    <div class="sheet-col">
+                        <label>Base HP</label>
+                        <input type="number" name="attr_hp_base" value="0" />
+                    </div>
+                    <div class="sheet-col">
+                        <label>Multiplicador (X) (x Def Lvl)</label>
+                        <input type="number" name="attr_hp_coefficient" value="0" step="0.01" />
+                    </div>
+                    <div class="sheet-col">
+                        <label>Calc. Max HP</label>
+                        <input type="number" name="attr_hp_max" />
+                    </div>
+                </div>
+
+                <h3 class="sheet-config-title">Configuración Stagger</h3>
+                <div class="sheet-row">
+                    <div class="sheet-col">
+                        <label>Thresholds Visibles</label>
+                        <select name="attr_stagger_count" style="width: 100%; background: #111; color: #fff; border: 1px solid #444;">
+                            <option value="1">1 Threshold</option>
+                            <option value="2">2 Thresholds</option>
+                            <option value="3" selected>3 Thresholds</option>
+                        </select>
+                    </div>
+                    <div class="sheet-col">
+                        <label>% Stagger I</label>
+                        <input type="number" name="attr_stagger_1_percent" value="70" />
+                    </div>
+                    <div class="sheet-col">
+                        <label>% Stagger II</label>
+                        <input type="number" name="attr_stagger_2_percent" value="40" />
+                    </div>
+                    <div class="sheet-col">
+                        <label>% Stagger III</label>
+                        <input type="number" name="attr_stagger_3_percent" value="20" />
+                    </div>
+                </div>
+
+                <h3 class="sheet-config-title">Modificadores Globales</h3>
+                <div class="sheet-row">
+                    <div class="sheet-col">
+                        <label>Mod. Raza (OFF)</label>
+                        <input type="number" name="attr_mod_race_off" value="0" />
+                    </div>
+                    <div class="sheet-col">
+                        <label>Mod. Raza (DEF)</label>
+                        <input type="number" name="attr_mod_race_def" value="0" />
+                    </div>
+                    <div class="sheet-col">
+                        <label>Mod. Identidad (OFF)</label>
+                        <input type="number" name="attr_mod_identity_off" value="0" />
+                    </div>
+                    <div class="sheet-col">
+                        <label>Mod. Identidad (DEF)</label>
+                        <input type="number" name="attr_mod_identity_def" value="0" />
+                    </div>
+                </div>
+                <div class="sheet-row">
+                    <div class="sheet-col">
+                        <label>Clase/Identidad Notas</label>
+                        <textarea name="attr_identity_notes" style="height: 100px; width: 100%; background: #111; color: #fff; border: 1px solid #444; resize: vertical;"></textarea>
+                    </div>
+                </div>
+            </details>
+        </div>
+
+    </div>
+</div>
 
 
 </div> <!-- End Phone Screen -->

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -695,6 +695,15 @@ try {
         });
     });
 
+    on('clicked:toggle_profile_edit', () => {
+        getAttrs(['show_profile_edit'], (v) => {
+            const current = parseIntOr0(v.show_profile_edit);
+            setAttrs({
+                show_profile_edit: current === 0 ? 1 : 0
+            });
+        });
+    });
+
     on('clicked:toggle_perk_creator', () => {
         getAttrs(['show_perk_creator'], (v) => {
             const current = parseIntOr0(v.show_perk_creator);

--- a/screenshot_profile.py
+++ b/screenshot_profile.py
@@ -1,0 +1,28 @@
+from playwright.sync_api import sync_playwright
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    page = browser.new_page(viewport={"width": 400, "height": 800})
+    page.goto("http://localhost:8000/hoja_personaje.html")
+
+    # Wait for the shim and custom code to initialize
+    page.wait_for_timeout(1000)
+
+    # Navigate to Profile tab
+    page.evaluate("document.querySelector('button[name=\"act_tab_profile\"]').click()")
+    page.wait_for_timeout(500)
+
+    # Take screenshot of View Mode
+    page.screenshot(path="profile_view_no_ahn.png")
+
+    # Toggle to Edit Mode
+    page.evaluate("document.querySelector('button[name=\"act_toggle_profile_edit\"]').click()")
+    page.wait_for_timeout(500)
+
+    # Take screenshot of Edit Mode
+    page.screenshot(path="profile_edit_no_ahn.png")
+
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/test_plan.md
+++ b/test_plan.md
@@ -1,0 +1,25 @@
+1. **Update `hoja_personaje.html`**
+   - In `.sheet-tab-profile`, add the toggle state: `<input type="hidden" name="attr_show_profile_edit" class="sheet-state-profile-edit" value="0" />`
+   - Modify the header to include the settings button: `<button type="action" name="act_toggle_profile_edit" class="sheet-icon-btn">⚙️</button>`.
+   - Add `.sheet-profile-view-card` which displays the Avatar, Nivel, Character Name, Identity, Class, Race as read-only spans, alongside the XP and Ahn displays.
+   - Add `.sheet-profile-edit-form` containing the text/number inputs for Avatar URL, Level, Rank, Name, Identity, Class, Race, and Background.
+   - Wrap the remaining technical configuration sections (Speed, Slots, Luck, HP, Stagger, Modifiers) inside `<details class="sheet-dm-advanced-config"><summary>⚠️ Configuración Avanzada (Solo DM)</summary> ... </details>`.
+
+2. **Update `hoja_personaje.css`**
+   - Use `replace_with_git_merge_diff` to add classes for the new profile UI:
+     - Toggle visibility: `.sheet-state-profile-edit[value="0"] ~ .sheet-profile-edit-form { display: none; }` and `.sheet-state-profile-edit[value="1"] ~ .sheet-profile-view-card { display: none; }`
+     - Styles for `.sheet-profile-view-card`, `.sheet-id-card-body`, `.sheet-id-card-avatar`, etc.
+     - Styles for the `.sheet-dm-advanced-config` (details and summary tags).
+
+3. **Update `hoja_personaje.js`**
+   - Use `replace_with_git_merge_diff` to add an event listener for `clicked:toggle_profile_edit` to flip the value of `show_profile_edit` between "0" and "1".
+
+4. **Verify Changes**
+   - Use a short Python script to check for unclosed HTML tags and syntax issues.
+   - Use `read_file` to review modified sections and ensure everything is placed properly.
+
+5. **Pre-commit verification**
+   - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+
+6. **Submit**
+   - Commit the changes and submit.


### PR DESCRIPTION
This PR implements the requested redesign of the "Profile" tab to improve immersion. 

Changes include:
- A new settings gear button in the header toggles a hidden `attr_show_profile_edit` input.
- A "Read-Only" ID Card view displays the character's core details (Avatar, Name, Identity, Class, Race, XP, and Ahn) using styled spans and an updated layout.
- The "Edit Mode" contains the standard text and number inputs for updating character data.
- All technical settings (e.g., Speed, Action Slots, Max Luck, HP Configuration, Stagger Thresholds, and Global Modifiers) are now nested within a collapsible `<details class="sheet-dm-advanced-config">` to declutter the player's view while remaining accessible to the DM.

---
*PR created automatically by Jules for task [1435164859731323220](https://jules.google.com/task/1435164859731323220) started by @sokcrow*