### PR TITLE
Fix Javascript Syntax Error Blocking Button Functionality

### DIFF
--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -2616,29 +2616,6 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 
 
-
-    });
-
-    // Close buttons
-    hudCloses.forEach(closeBtn => {
-        closeBtn.addEventListener('click', (e) => {
-            const modal = e.target.closest('.hud-modal');
-            if (modal) {
-                modal.classList.remove('active');
-            }
-        });
-    });
-
-    // Background click to close
-    hudModals.forEach(modal => {
-        modal.addEventListener('click', (e) => {
-            if (e.target === modal) {
-                modal.classList.remove('active');
-            }
-        });
-    });
-});
-
 // --- HUD MODAL LOGIC (Roll20 Compatible) ---
 const hudModalsList = ['stats', 'perks', 'skills', 'apego'];
 hudModalsList.forEach(modal => {


### PR DESCRIPTION
Fixed a critical bug where a syntax error in `hoja_personaje.js` prevented any scripts from executing, breaking all buttons in the UI.

- Removed stray `});` tags left over from a previous refactor.
- Deleted obsolete DOM event listeners referring to undefined `hudCloses` and `hudModals` variables, relying instead on the existing Roll20-compatible `on('clicked:...')` pattern.

---
*PR created automatically by Jules for task [12530929074623349701](https://jules.google.com/task/12530929074623349701) started by @sokcrow*