### PR TITLE
Fix Stats layout to maximize modal width utilization

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -5261,10 +5261,10 @@ input[name="attr_tab"][value="settings"] ~ .sheet-phone-screen .sheet-tab-settin
     padding: 15px;
 }
 
-.sheet-attributes-grid {
+.sheet-limbus-main .sheet-attributes-grid {
     flex-direction: column;
 }
-.sheet-attr-group {
+.sheet-limbus-main .sheet-attr-group {
     width: 100%;
 }
 


### PR DESCRIPTION
The stats modal (`hud-modal-content`) components, specifically `.sheet-attributes-grid` and `.sheet-attr-group`, were previously constrained because the responsive CSS overriding `.sheet-limbus-main` defaults lacked the correct prefix specification. By correctly prefixing them, they override the previous rigid `195px` width with `100%` within the modal context, resulting in a significantly better utilization of space. This directly matches user request 'Ni se está aprovechando todo el espacio de Stats'. Verified visually via Playwright headless screenshot.

---
*PR created automatically by Jules for task [15100771441567900372](https://jules.google.com/task/15100771441567900372) started by @sokcrow*