### PR TITLE
feat: Multiply background funds and allow up to 3 professions with accumulated debt

### DIFF
--- a/creacion_personaje.html
+++ b/creacion_personaje.html
@@ -646,7 +646,7 @@
                 "category": "La Alta Sociedad",
                 "desc": "Nacido en la opulencia, educado por tutores privados y protegido de la crudeza del mundo exterior. Tu vida siempre ha estado planificada.",
                 "benefit": "+1 Empatía, +1 Negociación, -1 Supervivencia",
-                "funds": "375,000 Ahn",
+                "funds": "7,500,000 Ahn",
                 "entityResponse": "Oro y seda. Qué fragilidad. Veamos si tus modales de salón te sirven aquí."
             },
             {
@@ -655,7 +655,7 @@
                 "category": "La Alta Sociedad",
                 "desc": "Tu linaje proviene de exitosos comerciantes. Entiendes el valor de un Ahn y cómo manipular el mercado.",
                 "benefit": "+2 Negociación, +1 Engaño, -1 Vigor",
-                "funds": "450,000 Ahn",
+                "funds": "9,000,000 Ahn",
                 "entityResponse": "El valor lo es todo, ¿verdad? Dime, ¿a cuánto cotiza tu alma hoy?"
             },
             {
@@ -664,7 +664,7 @@
                 "category": "La Alta Sociedad",
                 "desc": "Tu apellido alguna vez inspiró respeto, pero ahora solo quedan deudas y el recuerdo de la grandeza. Tienes que sobrevivir con tu ingenio.",
                 "benefit": "+1 Presencia, +1 Sigilo",
-                "funds": "75,000 Ahn",
+                "funds": "1,500,000 Ahn",
                 "entityResponse": "Las grandes caídas resuenan más fuerte. Tu orgullo es tu única riqueza restante."
             },
             {
@@ -673,7 +673,7 @@
                 "category": "La Alta Sociedad",
                 "desc": "Creciste rodeado de bibliotecas y laboratorios. La búsqueda del conocimiento siempre fue más importante que las relaciones sociales.",
                 "benefit": "+2 Ciencia, +1 Lore, -1 Carisma",
-                "funds": "225,000 Ahn",
+                "funds": "4,500,000 Ahn",
                 "entityResponse": "Tantos libros leídos, tantas pantallas escudriñadas. Y aún así, ignoras lo fundamental."
             },
             // TRABAJADORES, MILICIA Y GREMIOS
@@ -683,7 +683,7 @@
                 "category": "Trabajadores, Milicia y Gremios",
                 "desc": "Las historias antes de dormir eran sobre batallas y tácticas. Naciste para seguir órdenes y liderar escuadrones.",
                 "benefit": "+1 Fortaleza, +1 Manejo",
-                "funds": "120,000 Ahn",
+                "funds": "2,400,000 Ahn",
                 "entityResponse": "Soldaditos de plomo marchando hacia el abismo. Al menos sabes cómo formar fila."
             },
             {
@@ -692,7 +692,7 @@
                 "category": "Trabajadores, Milicia y Gremios",
                 "desc": "Trabajo duro bajo soles artificiales o naturales. Conoces el ciclo de la vida, la tierra y el sudor honesto.",
                 "benefit": "+1 Vigor, +1 Supervivencia",
-                "funds": "45,000 Ahn",
+                "funds": "900,000 Ahn",
                 "entityResponse": "Polvo eres y en polvo te convertirás. Estás muy familiarizado con tu destino."
             },
             {
@@ -701,7 +701,7 @@
                 "category": "Trabajadores, Milicia y Gremios",
                 "desc": "Manos callosas y atención al detalle. Aprendiste un oficio que te permite ganarte la vida, pero siempre al borde de la quiebra.",
                 "benefit": "+1 Reflejos, +1 Análisis",
-                "funds": "90,000 Ahn",
+                "funds": "1,800,000 Ahn",
                 "entityResponse": "Crear para que otros destruyan. Una existencia admirablemente fútil."
             },
             {
@@ -710,7 +710,7 @@
                 "category": "Trabajadores, Milicia y Gremios",
                 "desc": "La ley y el orden, o al menos la versión que imponen los de arriba. Has visto lo peor de la sociedad de cerca.",
                 "benefit": "+1 Percepción, +1 Voluntad",
-                "funds": "105,000 Ahn",
+                "funds": "2,100,000 Ahn",
                 "entityResponse": "El perro guardián del amo. ¿Qué se siente morder a los de tu propia clase?"
             },
             {
@@ -719,7 +719,7 @@
                 "category": "Trabajadores, Milicia y Gremios",
                 "desc": "Sellos, formularios y la lenta muerte por aburrimiento. Eres parte de la maquinaria que mantiene el sistema girando.",
                 "benefit": "+1 Memoria, +1 Prudencia",
-                "funds": "67,500 Ahn",
+                "funds": "1,350,000 Ahn",
                 "entityResponse": "El infierno está pavimentado con formularios triplicados. Tú serías un excelente demonio burócrata."
             },
             // LOS BAJOS FONDOS Y OLVIDADOS
@@ -729,7 +729,7 @@
                 "category": "Los Bajos Fondos y Olvidados",
                 "desc": "Criado por las ratas y el neón parpadeante. Aprendiste a ser invisible y a tomar lo que no es tuyo para sobrevivir.",
                 "benefit": "+2 Sigilo, +1 Agilidad, -1 Educación Formal (Lore)",
-                "funds": "7,500 Ahn",
+                "funds": "150,000 Ahn",
                 "entityResponse": "Nadie lloró tu nacimiento. Asegúrate de que lloren tu muerte."
             },
             {
@@ -738,7 +738,7 @@
                 "category": "Los Bajos Fondos y Olvidados",
                 "desc": "Las leyes son sugerencias; la supervivencia es mandato. Extorsión, contrabando o robos menores fueron tu escuela.",
                 "benefit": "+1 Engaño, +1 Seducción",
-                "funds": "30,000 Ahn",
+                "funds": "600,000 Ahn",
                 "entityResponse": "El crimen no paga, pero al menos da de comer... a veces. Tu moralidad es tan flexible como tus lealtades."
             },
             {
@@ -747,7 +747,7 @@
                 "category": "Los Bajos Fondos y Olvidados",
                 "desc": "Alguien te quería muerto o lejos. Conseguiste lo segundo. Aprendiste a vivir en los márgenes de la civilización.",
                 "benefit": "+2 Supervivencia, +1 Instinto, -1 Carisma",
-                "funds": "15,000 Ahn",
+                "funds": "300,000 Ahn",
                 "entityResponse": "Correr es cansado. ¿Cuándo te darás la vuelta y enfrentarás a tus cazadores?"
             },
             {
@@ -756,7 +756,7 @@
                 "category": "Los Bajos Fondos y Olvidados",
                 "desc": "Conoces el peso de las cadenas. Escapaste o compraste tu libertad, pero las cicatrices mentales y físicas permanecen.",
                 "benefit": "+2 Voluntad, +1 Templanza, -1 Confianza (Empatía)",
-                "funds": "3,000 Ahn",
+                "funds": "60,000 Ahn",
                 "entityResponse": "La libertad tiene un precio. Y tú todavía lo estás pagando. Esas cadenas te sientan demasiado bien."
             },
             {
@@ -775,7 +775,7 @@
                 "category": "Eruditos, Siervos y Deudores",
                 "desc": "Descubriste una verdad incómoda o cometiste un error fatal. Te quitaron tus credenciales, pero no lo que sabes.",
                 "benefit": "+2 Investigación, +1 Ciencia, -1 Reputación (Perspicacia)",
-                "funds": "22,500 Ahn",
+                "funds": "450,000 Ahn",
                 "entityResponse": "La verdad duele. Especialmente cuando a nadie le importa y te cuesta la vida que conocías."
             },
             {
@@ -784,7 +784,7 @@
                 "category": "Eruditos, Siervos y Deudores",
                 "desc": "Tu vida pertenece a un logo. Eres prescindible, un engranaje reemplazable en la colosal máquina corporativa.",
                 "benefit": "+1 Represión, +1 Negociación",
-                "funds": "37,500 Ahn",
+                "funds": "750,000 Ahn",
                 "entityResponse": "Una hormiga en un nido de plástico y metal. Qué vida tan... eficiente y prescindible."
             },
             {
@@ -802,7 +802,7 @@
                 "category": "Eruditos, Siervos y Deudores",
                 "desc": "Promesas de salvación susurradas en sótanos oscuros. Dedicaste tu vida a un dogma marginal que exige fe ciega.",
                 "benefit": "+2 Fe, +1 Lore, -1 Razón (Análisis)",
-                "funds": "12,000 Ahn",
+                "funds": "240,000 Ahn",
                 "entityResponse": "Falsos dioses para mentes débiles. Pero... la fe mueve montañas, o al menos, nubla el juicio maravillosamente."
             }
         ];
@@ -4445,8 +4445,8 @@
             originId: null,
             subraceId: null,
             backgroundId: null,
-            professionId: null,
-            professionPerkId: null,
+            professionIds: [],
+            professionPerkIds: [],
             psychologicalBackgroundId: null,
             psychologicalIdeal: null,
             psychologicalVinculo: null,
@@ -6039,11 +6039,22 @@
             }
 
             function seleccionarProfesion(id) {
-                luminousState.professionId = id;
+                if (!luminousState.professionIds) {
+                    luminousState.professionIds = [];
+                }
+
+                const index = luminousState.professionIds.indexOf(id);
+                if (index > -1) {
+                    luminousState.professionIds.splice(index, 1);
+                } else {
+                    if (luminousState.professionIds.length < 3) {
+                        luminousState.professionIds.push(id);
+                    }
+                }
 
                 const cards = document.querySelectorAll('#profession-grid .profession-card');
                 cards.forEach(card => {
-                    if (card.dataset.id === id) {
+                    if (luminousState.professionIds.includes(card.dataset.id)) {
                         card.classList.add('selected');
                     } else {
                         card.classList.remove('selected');
@@ -6051,7 +6062,7 @@
                 });
 
                 const profGridContainer = document.getElementById('profession-grid');
-                if (id) {
+                if (luminousState.professionIds.length > 0) {
                     profGridContainer.classList.add('has-selection');
                 } else {
                     profGridContainer.classList.remove('has-selection');
@@ -6237,39 +6248,49 @@
 
             function validarProfesion() {
                 const btnConfirmarProfesion = document.getElementById('btn-confirmar-profesion');
-                if (!luminousState.professionId) {
+                if (!luminousState.professionIds || luminousState.professionIds.length === 0) {
                     btnConfirmarProfesion.disabled = true;
                     return;
                 }
 
-                const selectedCard = document.querySelector(`.profession-card[data-id="${luminousState.professionId}"]`);
-                if (!selectedCard) {
-                    btnConfirmarProfesion.disabled = true;
-                    return;
+                let allValid = true;
+                luminousState.professionPerkIds = [];
+
+                for (let i = 0; i < luminousState.professionIds.length; i++) {
+                    const profId = luminousState.professionIds[i];
+                    const selectedCard = document.querySelector(`.profession-card[data-id="${profId}"]`);
+                    if (!selectedCard) {
+                        allValid = false;
+                        break;
+                    }
+
+                    const select = selectedCard.querySelector('.profession-perk-select');
+                    if (!select || !select.value) {
+                        allValid = false;
+                        break;
+                    } else {
+                        luminousState.professionPerkIds.push(select.value);
+                    }
                 }
 
-                const select = selectedCard.querySelector('.profession-perk-select');
-                if (!select || !select.value) {
-                    btnConfirmarProfesion.disabled = true;
-                } else {
-                    luminousState.professionPerkId = select.value;
-                    btnConfirmarProfesion.disabled = false;
-                }
+                btnConfirmarProfesion.disabled = !allValid;
             }
 
-            const btnConfirmarProfesion = document.getElementById('btn-confirmar-profesion');
+                        const btnConfirmarProfesion = document.getElementById('btn-confirmar-profesion');
             if(btnConfirmarProfesion) {
                 const handleConfirmProfClick = (e) => {
                     if (e.type === 'touchstart') e.preventDefault();
                     if (btnConfirmarProfesion.disabled) return;
 
                     // Apply profession attributes to state
-                    const prof = professionsData.find(p => p.id === luminousState.professionId);
-                    if (prof && prof.mods) {
-                        for (const [key, val] of Object.entries(prof.mods)) {
-                            luminousState.modifiers[key] = (luminousState.modifiers[key] || 0) + val;
+                    luminousState.professionIds.forEach(profId => {
+                        const prof = professionsData.find(p => p.id === profId);
+                        if (prof && prof.mods) {
+                            for (const [key, val] of Object.entries(prof.mods)) {
+                                luminousState.modifiers[key] = (luminousState.modifiers[key] || 0) + val;
+                            }
                         }
-                    }
+                    });
 
                     // For now, save state locally (or send it somewhere if you want)
                     localStorage.setItem('luminousState', JSON.stringify(luminousState));
@@ -6304,7 +6325,7 @@
 
             function startDialogue4() {
                 if (luminousState.activeEntity === 'dothy') {
-                    const reaction = dothyResponses.profesiones[luminousState.professionId] || "Muy bien... ya tenemos una idea clara.";
+                    const reaction = dothyResponses.profesiones[luminousState.professionIds?.[0]] || "Muy bien... ya tenemos una idea clara.";
                     dialogue4Phrases = [
                         reaction,
                         "Pero nadie escapa de su pasado, todos cargamos con algún fantasma.",

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -23,24 +23,24 @@
     ];
 
     const backgroundsData = [
-        { id: "alta_cuna", name: "Alta Cuna", funds: "375,000 Ahn", benefit: "+1 Empatía, +1 Negociación, -1 Supervivencia" },
-        { id: "aristocracia_mercantil", name: "Aristocracia Mercantil", funds: "450,000 Ahn", benefit: "+2 Negociación, +1 Engaño, -1 Vigor" },
-        { id: "nobleza_caida", name: "Nobleza Caída", funds: "75,000 Ahn", benefit: "+1 Presencia, +1 Sigilo" },
-        { id: "cuna_de_eruditos", name: "Cuna de Eruditos", funds: "225,000 Ahn", benefit: "+2 Ciencia, +1 Lore, -1 Carisma" },
-        { id: "linaje_militar", name: "Linaje Militar", funds: "120,000 Ahn", benefit: "+1 Fortaleza, +1 Manejo" },
-        { id: "familia_de_granjeros", name: "Familia de Granjeros", funds: "45,000 Ahn", benefit: "+1 Vigor, +1 Supervivencia" },
-        { id: "artesano_independiente", name: "Artesano Independiente", funds: "90,000 Ahn", benefit: "+1 Reflejos, +1 Análisis" },
-        { id: "fuerzas_de_seguridad", name: "Fuerzas de Seguridad (Bajas)", funds: "105,000 Ahn", benefit: "+1 Percepción, +1 Voluntad" },
-        { id: "burocracia_menor", name: "Burocracia Menor", funds: "67,500 Ahn", benefit: "+1 Memoria, +1 Prudencia" },
-        { id: "huerfano_callejero", name: "Huérfano Callejero", funds: "7,500 Ahn", benefit: "+2 Sigilo, +1 Agilidad, -1 Educación Formal (Lore)" },
-        { id: "escoria_criminal", name: "Escoria Criminal", funds: "30,000 Ahn", benefit: "+1 Engaño, +1 Seducción" },
-        { id: "exiliado_proscrito", name: "Exiliado / Proscrito", funds: "15,000 Ahn", benefit: "+2 Supervivencia, +1 Instinto, -1 Carisma" },
-        { id: "esclavo_liberado", name: "Esclavo Liberado / Fugitivo", funds: "3,000 Ahn", benefit: "+2 Voluntad, +1 Templanza, -1 Confianza (Empatía)" },
+        { id: "alta_cuna", name: "Alta Cuna", funds: "7,500,000 Ahn", benefit: "+1 Empatía, +1 Negociación, -1 Supervivencia" },
+        { id: "aristocracia_mercantil", name: "Aristocracia Mercantil", funds: "9,000,000 Ahn", benefit: "+2 Negociación, +1 Engaño, -1 Vigor" },
+        { id: "nobleza_caida", name: "Nobleza Caída", funds: "1,500,000 Ahn", benefit: "+1 Presencia, +1 Sigilo" },
+        { id: "cuna_de_eruditos", name: "Cuna de Eruditos", funds: "4,500,000 Ahn", benefit: "+2 Ciencia, +1 Lore, -1 Carisma" },
+        { id: "linaje_militar", name: "Linaje Militar", funds: "2,400,000 Ahn", benefit: "+1 Fortaleza, +1 Manejo" },
+        { id: "familia_de_granjeros", name: "Familia de Granjeros", funds: "900,000 Ahn", benefit: "+1 Vigor, +1 Supervivencia" },
+        { id: "artesano_independiente", name: "Artesano Independiente", funds: "1,800,000 Ahn", benefit: "+1 Reflejos, +1 Análisis" },
+        { id: "fuerzas_de_seguridad", name: "Fuerzas de Seguridad (Bajas)", funds: "2,100,000 Ahn", benefit: "+1 Percepción, +1 Voluntad" },
+        { id: "burocracia_menor", name: "Burocracia Menor", funds: "1,350,000 Ahn", benefit: "+1 Memoria, +1 Prudencia" },
+        { id: "huerfano_callejero", name: "Huérfano Callejero", funds: "150,000 Ahn", benefit: "+2 Sigilo, +1 Agilidad, -1 Educación Formal (Lore)" },
+        { id: "escoria_criminal", name: "Escoria Criminal", funds: "600,000 Ahn", benefit: "+1 Engaño, +1 Seducción" },
+        { id: "exiliado_proscrito", name: "Exiliado / Proscrito", funds: "300,000 Ahn", benefit: "+2 Supervivencia, +1 Instinto, -1 Carisma" },
+        { id: "esclavo_liberado", name: "Esclavo Liberado / Fugitivo", funds: "60,000 Ahn", benefit: "+2 Voluntad, +1 Templanza, -1 Confianza (Empatía)" },
         { id: "experimento_fallido", name: "Experimento Fallido", funds: "0 Ahn", benefit: "+2 Resistencia (Fortaleza), +1 Arcana, -1 Apariencia (Presencia)" },
-        { id: "academico_desacreditado", name: "Académico Desacreditado", funds: "22,500 Ahn", benefit: "+2 Investigación, +1 Ciencia, -1 Reputación (Perspicacia)" },
-        { id: "siervo_corporativo", name: "Siervo Corporativo (Bajo Rango)", funds: "37,500 Ahn", benefit: "+1 Represión, +1 Negociación" },
-        { id: "deudor_vitalicio", name: "Deudor Vitalicio", funds: "-1,500,000 Ahn", benefit: "+2 Agilidad (huyendo de cobradores), +1 Supervivencia, -1 Tranquilidad (Templanza)" },
-        { id: "miembro_culto", name: "Miembro de Culto Menor", funds: "12,000 Ahn", benefit: "+2 Fe, +1 Lore, -1 Razón (Análisis)" }
+        { id: "academico_desacreditado", name: "Académico Desacreditado", funds: "450,000 Ahn", benefit: "+2 Investigación, +1 Ciencia, -1 Reputación (Perspicacia)" },
+        { id: "siervo_corporativo", name: "Siervo Corporativo (Bajo Rango)", funds: "750,000 Ahn", benefit: "+1 Represión, +1 Negociación" },
+        { id: "deudor_vitalicio", name: "Deudor Vitalicio", funds: "-30,000,000 Ahn", benefit: "+2 Agilidad (huyendo de cobradores), +1 Supervivencia, -1 Tranquilidad (Templanza)" },
+        { id: "miembro_culto", name: "Miembro de Culto Menor", funds: "240,000 Ahn", benefit: "+2 Fe, +1 Lore, -1 Razón (Análisis)" }
     ];
 
     const professionsData = [
@@ -571,9 +571,18 @@ try {
                         const bData = backgroundsData.find(b => b.id === state.backgroundId);
                         if (bData) bgName = bData.name;
 
-                        let profName = state.professionId;
-                        const pData = professionsData.find(p => p.id === state.professionId);
-                        if (pData) profName = pData.name;
+
+                        let profName = "";
+                        if (state.professionIds && state.professionIds.length > 0) {
+                            profName = state.professionIds.map(id => {
+                                const pData = professionsData.find(p => p.id === id);
+                                return pData ? pData.name : id;
+                            }).join(' / ');
+                        } else if (state.professionId) {
+                            const pData = professionsData.find(p => p.id === state.professionId);
+                            if (pData) profName = pData.name;
+                        }
+
 
                         let psychoName = state.psychologicalBackgroundId;
                         const psData = psychoData.find(ps => ps.id === state.psychologicalBackgroundId);
@@ -596,14 +605,34 @@ try {
                             update.character_name = state.characterName;
                         }
 
-                        // Give starting Ahn based on background
+
+                        // Give starting Ahn based on background and deduct profession costs
+                        let startingAhn = 0;
                         if (bData && bData.funds) {
-                            // Extract numeric value from funds
-                            const numAhn = bData.funds.replace(/[^0-9-]/g, '');
-                            if (numAhn) {
-                                update.ahn = parseInt(numAhn);
+                            // Extract numeric value from funds (allowing negative numbers)
+                            const numAhnMatch = bData.funds.match(/-?\d[\d,]*/);
+                            if (numAhnMatch) {
+                                startingAhn = parseInt(numAhnMatch[0].replace(/,/g, ''));
                             }
                         }
+
+                        // Deduct profession costs
+                        if (state.professionIds && state.professionIds.length > 0) {
+                            state.professionIds.forEach(id => {
+                                const pData = professionsData.find(p => p.id === id);
+                                if (pData && pData.cost) {
+                                    startingAhn -= pData.cost;
+                                }
+                            });
+                        } else if (state.professionId) {
+                             const pData = professionsData.find(p => p.id === state.professionId);
+                             if (pData && pData.cost) {
+                                  startingAhn -= pData.cost;
+                             }
+                        }
+
+                        update.ahn = startingAhn;
+
 
                         setAttrs(update);
 
@@ -619,8 +648,25 @@ try {
                             });
                         }
 
-                        // Render Profession Perk
-                        if (state.professionId && state.professionPerkId) {
+
+                        // Render Profession Perks
+                        if (state.professionIds && state.professionPerkIds) {
+                            state.professionIds.forEach((profId, i) => {
+                                const pData = professionsData.find(p => p.id === profId);
+                                const perkId = state.professionPerkIds[i];
+                                if (pData && pData.perks && perkId) {
+                                    const perk = pData.perks.find(pk => pk.id === perkId);
+                                    if (perk) {
+                                        const rowId = generateRowID();
+                                        setAttrs({
+                                            [`repeating_skills_${rowId}_skill_name`]: perk.nombre,
+                                            [`repeating_skills_${rowId}_skill_description`]: perk.desc,
+                                            [`repeating_skills_${rowId}_edit_mode`]: "0"
+                                        });
+                                    }
+                                }
+                            });
+                        } else if (state.professionId && state.professionPerkId) {
                             const pData = professionsData.find(p => p.id === state.professionId);
                             if (pData && pData.perks) {
                                 const perk = pData.perks.find(pk => pk.id === state.professionPerkId);
@@ -634,6 +680,7 @@ try {
                                 }
                             }
                         }
+
 
                         // Also add background benefit as a perk
                         if (bData && bData.benefit) {


### PR DESCRIPTION
- Multiplied `funds` property of `backgroundsData` by 20 in both `creacion_personaje.html` and `hoja_personaje.js`.
- Modified `seleccionarProfesion()` in `creacion_personaje.html` to toggle up to 3 professions in the `professionIds` array.
- Updated `validarProfesion()` to ensure at least 1 profession is selected and that all selected professions have a chosen perk, stored in `professionPerkIds`.
- Updated `hoja_personaje.js` to iterate over `professionIds` when calculating starting Ahn, accumulating the cost of all selected professions as debt.
- Updated `hoja_personaje.js` to render repeating skill rows for every chosen perk across all selected professions.

---
*PR created automatically by Jules for task [12899066495608241851](https://jules.google.com/task/12899066495608241851) started by @sokcrow*