### PR TITLE
feat: Add Theatre of the Mind (Visual Novel) UI structure

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -5979,6 +5979,166 @@ input[name="attr_tab"][value="settings"] ~ .sheet-phone-screen .sheet-tab-settin
     box-shadow: 0 0 20px rgba(0, 255, 255, 0.8), inset 0 0 5px rgba(0,0,0,0.8);
 }
 
+/* --- THEATRE OF THE MIND (Visual Novel View) --- */
+#theatre-view {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 15000; /* Superpuesto a todo */
+    background-color: #000;
+    overflow: hidden;
+}
+
+#theatre-view.active {
+    display: block;
+}
+
+.theatre-bg {
+    position: absolute;
+    top: 0; left: 0; width: 100%; height: 100%;
+    background-size: cover;
+    background-position: center;
+    filter: blur(2px) brightness(0.5); /* Difuminado por defecto */
+    z-index: -1;
+}
+
+.theatre-location-sign {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    background: rgba(10, 10, 10, 0.8);
+    border: 2px solid var(--border-accent);
+    padding: 10px 20px;
+    border-radius: 4px;
+    box-shadow: 0 4px 15px rgba(0,0,0,0.8), inset 0 0 10px rgba(196, 154, 0, 0.2);
+    z-index: 10;
+}
+
+#theatre-location-text {
+    color: #fff;
+    font-size: 1.2em;
+    font-family: 'Share Tech Mono', monospace;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+}
+
+.theatre-sprites-container {
+    position: absolute;
+    bottom: 150px; /* Sobre la caja de diálogo */
+    left: 0; right: 0;
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+    gap: 30px;
+    z-index: 5;
+    pointer-events: none; /* Dejar pasar clicks al fondo si aplica */
+}
+
+.theatre-sprite {
+    max-height: 70vh; /* Altura adaptable */
+    object-fit: contain;
+}
+
+.sprite-dimmed {
+    filter: brightness(0.3);
+    transform: scale(0.95);
+    transition: all 0.3s ease;
+    z-index: 1;
+}
+
+.sprite-active {
+    filter: brightness(1);
+    transform: scale(1.05);
+    transition: all 0.3s ease;
+    z-index: 10;
+}
+
+.theatre-dialog-container {
+    position: absolute;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 90%;
+    max-width: 1000px;
+    z-index: 20;
+    display: flex;
+    flex-direction: column;
+}
+
+.theatre-nameplates {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    margin-bottom: -5px; /* Solapamiento ligero con la caja principal */
+    z-index: 21;
+    margin-left: 20px;
+}
+
+.theatre-title-plate {
+    background: #3a2c22; /* Marrón oscuro */
+    color: #ccc;
+    font-size: 0.85em;
+    padding: 2px 10px;
+    border: 1px solid #222;
+    border-bottom: none;
+    font-family: inherit;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.theatre-name-plate {
+    background: var(--red-limbus); /* Default, JS puede inyectar otro */
+    color: #fff;
+    font-size: 1.4em;
+    font-weight: bold;
+    padding: 5px 20px;
+    border: 2px solid #222;
+    border-bottom: none;
+    box-shadow: 0 -2px 10px rgba(0,0,0,0.5);
+    text-transform: uppercase;
+}
+
+.theatre-dialog-box {
+    background: rgba(20, 20, 20, 0.85);
+    border: 1px solid #444;
+    border-radius: 4px;
+    padding: 25px 30px;
+    box-shadow: 0 5px 20px rgba(0,0,0,0.9);
+    position: relative;
+    overflow: hidden;
+    backdrop-filter: blur(10px);
+}
+
+/* Líneas horizontales sutiles */
+.theatre-dialog-box::after {
+    content: " ";
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: repeating-linear-gradient(
+        0deg,
+        transparent,
+        transparent 2px,
+        rgba(255, 255, 255, 0.03) 2px,
+        rgba(255, 255, 255, 0.03) 4px
+    );
+    pointer-events: none;
+}
+
+.theatre-dialog-text {
+    color: #eee;
+    font-size: 1.3em;
+    line-height: 1.5;
+    font-family: 'Share Tech Mono', monospace;
+    position: relative;
+    z-index: 2;
+    min-height: 60px; /* Asegurar altura mínima aunque el texto sea corto */
+}
+
+
 /* --- HUD MODALS --- */
 .hud-modal {
     display: none;
@@ -6044,7 +6204,8 @@ input[name="attr_tab"][value="notas"] ~ .sheet-phone-screen .sheet-tab-notas {
 input.sheet-state-hud-modal[value="stats"] ~ .modal-stats,
 input.sheet-state-hud-modal[value="perks"] ~ .modal-perks,
 input.sheet-state-hud-modal[value="skills"] ~ .modal-skills,
-input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
+input.sheet-state-hud-modal[value="apego"] ~ .modal-apego,
+input.sheet-state-hud-modal[value="theatre"] ~ .modal-theatre {
     display: flex !important;
     animation: fadeInModal 0.3s ease;
 }

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -1967,6 +1967,7 @@
     <button type="action" name="act_hud_perks" class="btn-hud" title="Perks">⭐</button>
     <button type="action" name="act_hud_skills" class="btn-hud" title="Skills">⚔️</button>
     <button type="action" name="act_hud_apego" class="btn-hud" title="Apego">🤝</button>
+    <button type="action" name="act_hud_theatre" class="btn-hud" title="Teatro de la Mente">🎭</button>
 </div>
 <input type="hidden" name="attr_active_hud_modal" class="sheet-state-hud-modal" value="" />
 
@@ -3556,7 +3557,69 @@
     </div>
 </div>
 
+</div>
+
+<div id="theatre-modal" class="hud-modal modal-theatre">
+    <div class="hud-modal-content">
+        <button type="action" name="act_hud_close" class="hud-modal-close">×</button>
+        <div class="hud-modal-body">
+            <div class="hud-tab-content">
+                <div class="sheet-app-header"><h2>🎭 Control de Diálogo</h2></div>
+                <div class="sheet-app-body" style="padding: 20px;">
+                    <div style="background: #111; padding: 15px; border: 1px solid #444; border-radius: 6px; display: flex; flex-direction: column; gap: 15px;">
+                        <div>
+                            <label style="color: #c49a00; display: block; margin-bottom: 5px;">Expresión (Sprite)</label>
+                            <select id="theatre-player-expression" style="width: 100%; background: #222; color: #fff; padding: 8px; border: 1px solid #555; border-radius: 4px;">
+                                <option value="normal">Normal</option>
+                                <option value="enojado">Enojado</option>
+                                <option value="feliz">Feliz</option>
+                                <option value="triste">Triste</option>
+                                <option value="sorprendido">Sorprendido</option>
+                                <option value="primera_persona">1ra Persona (Sin Sprite)</option>
+                            </select>
+                        </div>
+                        <div>
+                            <label style="color: #0df; display: block; margin-bottom: 5px;">Línea de Diálogo</label>
+                            <textarea id="theatre-player-text" style="width: 100%; background: #222; color: #fff; padding: 10px; border: 1px solid #555; border-radius: 4px; height: 100px; resize: vertical; font-family: 'Share Tech Mono', monospace; font-size: 1.1em;" placeholder="¿Qué vas a decir?..."></textarea>
+                        </div>
+                        <button id="btn-theatre-queue" style="background: #8b0000; color: #fff; border: 1px solid #ff4444; padding: 12px; border-radius: 4px; cursor: pointer; font-weight: bold; text-transform: uppercase; letter-spacing: 1px; transition: all 0.2s;">
+                            Poner en Cola
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
 </div> <!-- End Limbus Main -->
+
+<!-- === THEATRE OF THE MIND VIEW === -->
+<div id="theatre-view">
+    <div class="theatre-bg" id="theatre-background" style="background-image: url('https://i.imgur.com/someLimbusBg.jpg');"></div>
+
+    <div class="theatre-location-sign">
+        <span id="theatre-location-text">Aboard Mephistopheles</span>
+    </div>
+
+    <div class="theatre-sprites-container" id="theatre-sprites">
+        <!-- Ejemplo de sprites (Serán inyectados por JS) -->
+        <!-- <img src="..." class="theatre-sprite sprite-dimmed"> -->
+        <!-- <img src="..." class="theatre-sprite sprite-active"> -->
+    </div>
+
+    <div class="theatre-dialog-container">
+        <div class="theatre-nameplates" id="theatre-nameplates">
+            <div class="theatre-title-plate" id="theatre-title">Bus Driver</div>
+            <div class="theatre-name-plate" id="theatre-name" style="background: #8b0000;">Charon</div>
+        </div>
+        <div class="theatre-dialog-box">
+            <div class="theatre-dialog-text" id="theatre-dialog-content">
+                ...Vroom vroom.
+            </div>
+        </div>
+    </div>
+</div>
 
 <!-- Global Inventory Button -->
 <button class="btn-global-inventory" id="btn-global-inventory" title="Inventario Global">🎒</button>

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -2692,7 +2692,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
 
 // --- HUD MODAL LOGIC (Roll20 Compatible) ---
-const hudModalsList = ['stats', 'perks', 'skills', 'apego'];
+const hudModalsList = ['stats', 'perks', 'skills', 'apego', 'theatre'];
 hudModalsList.forEach(modal => {
     on(`clicked:hud_${modal}`, function() {
         setAttrs({ active_hud_modal: modal });

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -393,6 +393,194 @@
         font-weight: bold;
         box-shadow: 0 0 8px rgba(0, 221, 255, 0.3);
     }
+
+    /* --- THEATRE OF THE MIND (Visual Novel View) --- */
+    #theatre-view {
+        display: none;
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100vw;
+        height: 100vh;
+        z-index: 15000; /* Superpuesto a todo */
+        background-color: #000;
+        overflow: hidden;
+    }
+
+    #theatre-view.active {
+        display: block;
+    }
+
+    .theatre-bg {
+        position: absolute;
+        top: 0; left: 0; width: 100%; height: 100%;
+        background-size: cover;
+        background-position: center;
+        filter: blur(2px) brightness(0.5); /* Difuminado por defecto */
+        z-index: -1;
+    }
+
+    .theatre-location-sign {
+        position: absolute;
+        top: 20px;
+        left: 20px;
+        background: rgba(10, 10, 10, 0.8);
+        border: 2px solid #c49a00;
+        padding: 10px 20px;
+        border-radius: 4px;
+        box-shadow: 0 4px 15px rgba(0,0,0,0.8), inset 0 0 10px rgba(196, 154, 0, 0.2);
+        z-index: 10;
+    }
+
+    #theatre-location-text {
+        color: #fff;
+        font-size: 1.2em;
+        font-family: 'Share Tech Mono', monospace;
+        font-weight: bold;
+        text-transform: uppercase;
+        letter-spacing: 2px;
+    }
+
+    .theatre-sprites-container {
+        position: absolute;
+        bottom: 150px; /* Sobre la caja de diálogo */
+        left: 0; right: 0;
+        display: flex;
+        justify-content: center;
+        align-items: flex-end;
+        gap: 30px;
+        z-index: 5;
+        pointer-events: none; /* Dejar pasar clicks al fondo si aplica */
+    }
+
+    .theatre-sprite {
+        max-height: 70vh; /* Altura adaptable */
+        object-fit: contain;
+    }
+
+    .sprite-dimmed {
+        filter: brightness(0.3);
+        transform: scale(0.95);
+        transition: all 0.3s ease;
+        z-index: 1;
+    }
+
+    .sprite-active {
+        filter: brightness(1);
+        transform: scale(1.05);
+        transition: all 0.3s ease;
+        z-index: 10;
+    }
+
+    .theatre-dialog-container {
+        position: absolute;
+        bottom: 20px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 90%;
+        max-width: 1000px;
+        z-index: 20;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .theatre-nameplates {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        margin-bottom: -5px; /* Solapamiento ligero con la caja principal */
+        z-index: 21;
+        margin-left: 20px;
+    }
+
+    .theatre-title-plate {
+        background: #3a2c22; /* Marrón oscuro */
+        color: #ccc;
+        font-size: 0.85em;
+        padding: 2px 10px;
+        border: 1px solid #222;
+        border-bottom: none;
+        font-family: inherit;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+    }
+
+    .theatre-name-plate {
+        background: #8b0000; /* Default, JS puede inyectar otro */
+        color: #fff;
+        font-size: 1.4em;
+        font-weight: bold;
+        padding: 5px 20px;
+        border: 2px solid #222;
+        border-bottom: none;
+        box-shadow: 0 -2px 10px rgba(0,0,0,0.5);
+        text-transform: uppercase;
+    }
+
+    .theatre-dialog-box {
+        background: rgba(20, 20, 20, 0.85);
+        border: 1px solid #444;
+        border-radius: 4px;
+        padding: 25px 30px;
+        box-shadow: 0 5px 20px rgba(0,0,0,0.9);
+        position: relative;
+        overflow: hidden;
+        backdrop-filter: blur(10px);
+    }
+
+    /* Líneas horizontales sutiles */
+    .theatre-dialog-box::after {
+        content: " ";
+        position: absolute;
+        top: 0; left: 0; right: 0; bottom: 0;
+        background: repeating-linear-gradient(
+            0deg,
+            transparent,
+            transparent 2px,
+            rgba(255, 255, 255, 0.03) 2px,
+            rgba(255, 255, 255, 0.03) 4px
+        );
+        pointer-events: none;
+    }
+
+    .theatre-dialog-text {
+        color: #eee;
+        font-size: 1.3em;
+        line-height: 1.5;
+        font-family: 'Share Tech Mono', monospace;
+        position: relative;
+        z-index: 2;
+        min-height: 60px; /* Asegurar altura mínima aunque el texto sea corto */
+    }
+
+    .theatre-queue-item {
+        background: #222;
+        border: 1px solid #0df;
+        padding: 10px;
+        border-radius: 4px;
+        margin-bottom: 5px;
+        box-shadow: 0 0 10px rgba(0, 221, 255, 0.2);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        transition: all 0.3s;
+    }
+
+    .theatre-queue-item:hover {
+        box-shadow: 0 0 15px rgba(0, 221, 255, 0.5);
+        border-color: #fff;
+    }
+
+    .theatre-pulse {
+        animation: theatrePulse 2s infinite;
+    }
+
+    @keyframes theatrePulse {
+        0% { box-shadow: 0 0 5px rgba(0, 221, 255, 0.2); }
+        50% { box-shadow: 0 0 20px rgba(0, 221, 255, 0.8); }
+        100% { box-shadow: 0 0 5px rgba(0, 221, 255, 0.2); }
+    }
+
   </style>
 </head>
 <body>
@@ -592,6 +780,62 @@
         </div>
       </div>
     </div>
+  </div>
+
+  <!-- NUEVO DASHBOARD: TEATRO DE LA MENTE (Director) -->
+  <div id="dashboard-theatre" class="panel-cyber" style="margin-top: 20px;">
+    <h3>🎭 Control del Teatro de la Mente</h3>
+    <div class="form-cyber-container" style="justify-content: flex-start;">
+      <!-- Ajustes Globales -->
+      <div class="form-cyber">
+        <h4 style="color: #c49a00;">Escenario Global</h4>
+        <input type="text" id="dm-theatre-location" placeholder="Ej: Aboard Mephistopheles" />
+        <label style="color: #fff; display: flex; align-items: center; gap: 10px; margin-top: 10px;">
+          Bloquear Diálogos (Modo Lore)
+          <label class="switch">
+            <input type="checkbox" id="dm-theatre-lock">
+            <span class="slider"></span>
+          </label>
+        </label>
+      </div>
+
+      <!-- Cola de Diálogos -->
+      <div class="form-cyber" style="flex: 2; border: 1px solid #0df; box-shadow: 0 0 10px rgba(0,221,255,0.2);">
+        <h4 style="color: #0df;">Cola de Actuación</h4>
+        <div id="dm-theatre-queue" style="max-height: 200px; overflow-y: auto; background: #0a0a0c; padding: 10px; border-radius: 4px; border: 1px solid #333; margin-bottom: 10px;">
+            <!-- Aquí irán los .theatre-queue-item -->
+            <div style="color: #666; text-align: center; font-style: italic;">Esperando actores...</div>
+        </div>
+        <button id="btn-theatre-next" class="btn-cyber" style="background: #0df; color: #000; border: none; font-size: 18px;">▶ Siguiente Diálogo / Avanzar</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- === THEATRE OF THE MIND VIEW (Global DM Overlay) === -->
+  <div id="theatre-view">
+      <div class="theatre-bg" id="theatre-background" style="background-image: url('https://i.imgur.com/someLimbusBg.jpg');"></div>
+
+      <div class="theatre-location-sign">
+          <span id="theatre-location-text">Aboard Mephistopheles</span>
+      </div>
+
+      <div class="theatre-sprites-container" id="theatre-sprites">
+          <!-- Ejemplo de sprites (Serán inyectados por JS) -->
+          <!-- <img src="..." class="theatre-sprite sprite-dimmed"> -->
+          <!-- <img src="..." class="theatre-sprite sprite-active"> -->
+      </div>
+
+      <div class="theatre-dialog-container">
+          <div class="theatre-nameplates" id="theatre-nameplates">
+              <div class="theatre-title-plate" id="theatre-title">Director</div>
+              <div class="theatre-name-plate" id="theatre-name" style="background: #c49a00;">Dante</div>
+          </div>
+          <div class="theatre-dialog-box">
+              <div class="theatre-dialog-text" id="theatre-dialog-content">
+                  &lt;Tick Tock.&gt;
+              </div>
+          </div>
+      </div>
   </div>
 
   <!-- NUEVO DASHBOARD: GESTOR DE TABLAS DE BOTÍN -->


### PR DESCRIPTION
This PR introduces the structural foundation for Phase 6: "Teatro de la Mente" (Theatre of the Mind), effectively turning the character sheet into a visual novel interface.

Features included:
*   **Player UI:**
    *   Full-screen overlay `#theatre-view` matching a cyberpunk/Limbus aesthetic.
    *   Top-left location sign box (`#theatre-title`).
    *   Center flex container for sprites with dimming and active scaling CSS classes (`.sprite-dimmed`, `.sprite-active`).
    *   Bottom translucent dialog box with horizontal line background patterns.
    *   Stacked nameplates for profession/title and name with dynamic color backgrounds.
    *   New modal inside the player's HUD sidebar (`#theatre-modal`) containing an expression dropdown, text input, and an "Encolar" button.
*   **DM UI (`pantalla_dm.html`):**
    *   New "Control del Teatro de la Mente" panel.
    *   Input to set global Location Sign.
    *   Toggle for "Bloquear Diálogos (Modo Lore)".
    *   Interactive queue box (`#dm-theatre-queue`) where player lines appear with a pulsing cyan visual cue (`.theatre-pulse`).
    *   Button to advance to the next dialogue.

Visual tests were successfully created using Playwright and reviewed during Pre-commit.

---
*PR created automatically by Jules for task [13616818907762892423](https://jules.google.com/task/13616818907762892423) started by @sokcrow*