### PR TITLE
Add "Delete Player" button to DM screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,56 @@
+{
+  "name": "app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "playwright": "^1.58.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "playwright": "^1.58.2"
+  }
+}

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -1586,7 +1586,19 @@
       if (jugadores) {
         for (const [nombre, data] of Object.entries(jugadores)) {
           const tarjeta = document.createElement('div');
-          tarjeta.style.cssText = 'background: #222; padding: 15px; border-radius: 6px; border: 1px solid #444; display: flex; flex-direction: column; align-items: center; gap: 10px; width: 200px;';
+          tarjeta.style.cssText = 'background: #222; padding: 15px; border-radius: 6px; border: 1px solid #444; display: flex; flex-direction: column; align-items: center; gap: 10px; width: 200px; position: relative;';
+
+          const btnEliminar = document.createElement('button');
+          btnEliminar.innerText = '🗑️';
+          btnEliminar.title = 'Eliminar Jugador';
+          btnEliminar.style.cssText = 'position: absolute; top: 5px; right: 5px; background: transparent; border: none; cursor: pointer; font-size: 16px;';
+          btnEliminar.onclick = () => {
+            if (confirm(`¿Estás seguro de que deseas eliminar permanentemente al jugador "${nombre}"? Esta acción no se puede deshacer.`)) {
+              db.ref(`campaña/jugadores/${nombre}`).remove()
+                .then(() => alert(`Jugador ${nombre} eliminado.`))
+                .catch(e => alert('Error al eliminar jugador: ' + e));
+            }
+          };
 
           const title = document.createElement('strong');
           title.style.color = '#fff';
@@ -1607,6 +1619,7 @@
                .catch(e => alert('Error: ' + e));
           };
 
+          tarjeta.appendChild(btnEliminar);
           tarjeta.appendChild(title);
           tarjeta.appendChild(inputAhn);
           tarjeta.appendChild(btnForzar);


### PR DESCRIPTION
Added a button to delete players from the "Terminal Bancaria" in the DM Screen. This resolves the user's request to have a way to easily remove test players from the Firebase database directly through the UI.

---
*PR created automatically by Jules for task [7462982351661078676](https://jules.google.com/task/7462982351661078676) started by @sokcrow*