### PR TITLE
Theatre of the Mind: Background Sync and Dynamic Sprites

### DIFF
--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -3842,6 +3842,7 @@
 
   <!-- Player Input Area -->
   <div class="theatre-player-input-area" style="position: absolute; bottom: 0; left: 0; width: 100%; background: rgba(0,0,0,0.9); border-top: 2px solid #0df; padding: 15px; display: flex; gap: 15px; z-index: 2030; align-items: center; justify-content: center; box-sizing: border-box;">
+    <select id="player-expression-select" style="padding: 15px; background: #222; color: #0df; border: 1px solid #444; border-radius: 4px; font-size: 16px; min-width: 120px; display: none;"></select>
     <input type="text" id="player-theatre-input" placeholder="¿Qué quieres decir o hacer? (Escribe aquí...)" style="flex: 1; max-width: 800px; padding: 15px; background: #111; color: #fff; border: 1px solid #555; border-radius: 4px; font-family: inherit; font-size: 16px;" />
     <button id="btn-player-theatre-send" style="background: #0df; color: #000; border: 1px solid #fff; padding: 15px 30px; font-size: 16px; font-weight: bold; cursor: pointer; text-transform: uppercase; border-radius: 4px; box-shadow: 0 0 15px rgba(0, 221, 255, 0.6);">ENVIAR</button>
   </div>
@@ -4291,6 +4292,13 @@
       if (locText && loc) locText.innerText = loc;
   });
 
+  // Listen to background
+  db.ref('campaña/teatro/fondo').on('value', (snap) => {
+      const bg = snap.val();
+      const view = document.getElementById('theatre-view-player');
+      if (view && bg) view.style.backgroundImage = `url('${bg}')`;
+  });
+
   // Listen to current state (the actual dialogue and sprites)
   db.ref('campaña/teatro/estado_actual').on('value', (snap) => {
       const state = snap.val();
@@ -4326,30 +4334,49 @@
       if (!stage) return;
 
       const activeSpriteUrl = state.sprite;
+      const activeName = state.nombre || 'Desconocido';
       if (!activeSpriteUrl) return;
 
-      if (!playerSpritesEnEscena.has(activeSpriteUrl)) {
-          playerSpritesEnEscena.add(activeSpriteUrl);
+      let existingSprite = Array.from(stage.children).find(img => img.dataset.name === activeName);
+
+      if (existingSprite) {
+          existingSprite.src = activeSpriteUrl;
+          existingSprite.dataset.url = activeSpriteUrl;
+          existingSprite.dataset.lastActive = Date.now();
+      } else {
+          playerSpritesEnEscena.add(activeName);
           const img = document.createElement('img');
           img.src = activeSpriteUrl;
           img.dataset.url = activeSpriteUrl;
+          img.dataset.name = activeName;
+          img.dataset.lastActive = Date.now();
           img.style.cssText = 'max-height: 80vh; max-width: 400px; object-fit: contain; transition: all 0.4s ease;';
           stage.appendChild(img);
 
-          if (playerSpritesEnEscena.size > 3) {
-              const oldestImg = stage.firstChild;
-              if (oldestImg) {
-                  playerSpritesEnEscena.delete(oldestImg.dataset.url);
-                  stage.removeChild(oldestImg);
+          while (stage.children.length > 4) {
+              let oldestSprite = Array.from(stage.children).reduce((oldest, current) => {
+                  let oldestTime = parseInt(oldest.dataset.lastActive || 0);
+                  let currentTime = parseInt(current.dataset.lastActive || 0);
+                  return oldestTime < currentTime ? oldest : current;
+              });
+              if (oldestSprite) {
+                  playerSpritesEnEscena.delete(oldestSprite.dataset.name);
+                  stage.removeChild(oldestSprite);
+              } else {
+                  break;
               }
           }
       }
 
       Array.from(stage.children).forEach(img => {
-          if (img.dataset.url === activeSpriteUrl) {
+          if (img.dataset.name === activeName && img.dataset.url === activeSpriteUrl) {
               img.className = 'sprite-active';
+              img.style.filter = 'none'; // Ensure no dimming
+              img.style.transform = 'scale(1)';
           } else {
               img.className = 'sprite-dimmed';
+              img.style.filter = 'brightness(0.4) grayscale(0.5)';
+              img.style.transform = 'scale(0.95)';
           }
       });
   });
@@ -4362,9 +4389,28 @@
               if (actorId) {
                   db.ref(`campaña/actores/${actorId}`).once('value').then(actorSnap => {
                       currentAssignedActor = actorSnap.val();
+                      const selectExp = document.getElementById('player-expression-select');
+                      if (currentAssignedActor && currentAssignedActor.expresiones) {
+                          selectExp.style.display = 'block';
+                          // Only populate if empty or changed to avoid resetting selection constantly
+                          if (selectExp.options.length === 0 || selectExp.getAttribute('data-actor') !== actorId) {
+                              selectExp.innerHTML = '';
+                              for (const [name, url] of Object.entries(currentAssignedActor.expresiones)) {
+                                  const opt = document.createElement('option');
+                                  opt.value = url;
+                                  opt.textContent = name;
+                                  selectExp.appendChild(opt);
+                              }
+                              selectExp.setAttribute('data-actor', actorId);
+                          }
+                      } else {
+                          if (selectExp) selectExp.style.display = 'none';
+                      }
                   });
               } else {
                   currentAssignedActor = null;
+                  const selectExp = document.getElementById('player-expression-select');
+                  if (selectExp) selectExp.style.display = 'none';
               }
           });
       }
@@ -4393,12 +4439,15 @@
               };
           }
 
+          const selectExp = document.getElementById('player-expression-select');
+          const selectedSprite = selectExp && selectExp.style.display !== 'none' ? selectExp.value : actorData.sprite;
+
           const payload = {
               nombre: actorData.nombre,
               titulo: actorData.titulo,
               color_nombre: actorData.color_nombre,
               color_titulo: actorData.color_titulo,
-              sprite: actorData.sprite,
+              sprite: selectedSprite,
               mensaje: msg,
               timestamp: Date.now()
           };

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -801,7 +801,12 @@
               <input type="color" id="actor-color-titulo" value="#c49a00" style="flex: 1; padding: 0; height: 30px; cursor: pointer;" />
             </div>
 
-            <input type="url" id="actor-sprite" placeholder="URL del Sprite Base (.png transparente)" />
+            <h5 style="color: #aaa; margin: 5px 0;">Expresiones (URLs):</h5>
+            <input type="url" id="actor-sprite" placeholder="Sprite Base/Neutral (Requerido)" />
+            <input type="url" id="actor-sprite-feliz" placeholder="Sprite Feliz (Opcional)" />
+            <input type="url" id="actor-sprite-triste" placeholder="Sprite Triste (Opcional)" />
+            <input type="url" id="actor-sprite-enojado" placeholder="Sprite Enojado (Opcional)" />
+            <input type="url" id="actor-sprite-sorprendido" placeholder="Sprite Sorprendido (Opcional)" />
 
             <button id="btn-crear-actor" class="btn-cyber btn-green">Crear Actor</button>
           </div>
@@ -829,7 +834,7 @@
   </div> <!-- Fin dm-tabs-content -->
 
   <!-- VISTA DEL TEATRO (MODO DIRECTOR) -->
-  <div id="theatre-view-dm" style="display: none; position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; z-index: 2000; background: linear-gradient(135deg, #1a1c23 0%, #111 100%) center/cover no-repeat; flex-direction: column; overflow: hidden;">
+  <div id="theatre-view-dm" style="display: none; position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; z-index: 2000; background: linear-gradient(135deg, #1a1c23 0%, #111 100%); background-size: cover; background-position: center; background-repeat: no-repeat; flex-direction: column; overflow: hidden;">
     <!-- Location Sign -->
     <div class="theatre-location">
       <span id="theatre-location-text">Unknown Location</span>
@@ -870,6 +875,9 @@
       <!-- Center: Controls -->
       <div style="flex: 2; display: flex; flex-direction: column; gap: 10px;">
         <div style="display: flex; gap: 10px; align-items: center;">
+          <input type="url" id="dm-theatre-bg" placeholder="URL Fondo Teatro..." style="flex: 1; padding: 8px; background: #222; color: #0df; border: 1px solid #444; border-radius: 4px;" />
+          <button id="btn-update-bg" class="btn-cyber" style="background: #222; color: #c49a00; border: 1px solid #c49a00; padding: 8px;">Fijar Fondo</button>
+
           <input type="text" id="dm-theatre-location" placeholder="Actualizar Letrero de Locación..." style="flex: 1; padding: 8px; background: #222; color: #0df; border: 1px solid #444; border-radius: 4px;" />
           <button id="btn-update-location" class="btn-cyber" style="background: #222; color: #c49a00; border: 1px solid #c49a00; padding: 8px;">Fijar Locación</button>
 
@@ -2554,10 +2562,25 @@
         }
     });
 
+    // Update Background
+    document.getElementById('btn-update-bg').addEventListener('click', () => {
+        const bg = document.getElementById('dm-theatre-bg').value.trim();
+        if (bg) {
+            db.ref('campaña/teatro').update({ fondo: bg });
+        }
+    });
+
     // Listen to Location
     db.ref('campaña/teatro/locacion').on('value', (snap) => {
         const loc = snap.val();
         if (loc) document.getElementById('theatre-location-text').innerText = loc;
+    });
+
+    // Listen to Background
+    db.ref('campaña/teatro/fondo').on('value', (snap) => {
+        const bg = snap.val();
+        const view = document.getElementById('theatre-view-dm');
+        if (view && bg) view.style.backgroundImage = `url('${bg}')`;
     });
 
     // Populate DM Actor Select
@@ -2636,33 +2659,52 @@
         if (!stage) return;
 
         const activeSpriteUrl = state.sprite;
+        const activeName = state.nombre || 'Desconocido';
         if (!activeSpriteUrl) return;
 
-        // If the sprite isn't on stage yet, add it
-        if (!currentSpritesEnEscena.has(activeSpriteUrl)) {
-            currentSpritesEnEscena.add(activeSpriteUrl);
+        // Ensure we track by name to update expressions instead of duplicating
+        let existingSprite = Array.from(stage.children).find(img => img.dataset.name === activeName);
+
+        if (existingSprite) {
+            existingSprite.src = activeSpriteUrl;
+            existingSprite.dataset.url = activeSpriteUrl;
+            existingSprite.dataset.lastActive = Date.now();
+        } else {
+            currentSpritesEnEscena.add(activeName);
             const img = document.createElement('img');
             img.src = activeSpriteUrl;
             img.dataset.url = activeSpriteUrl;
+            img.dataset.name = activeName;
+            img.dataset.lastActive = Date.now();
             img.style.cssText = 'max-height: 80vh; max-width: 400px; object-fit: contain; transition: all 0.4s ease;';
             stage.appendChild(img);
 
-            // Limit to max 3 sprites for visual clarity, remove oldest if needed
-            if (currentSpritesEnEscena.size > 3) {
-                const oldestImg = stage.firstChild;
-                if (oldestImg) {
-                    currentSpritesEnEscena.delete(oldestImg.dataset.url);
-                    stage.removeChild(oldestImg);
+            // Limit to max 4 sprites for visual clarity, remove oldest if needed
+            while (stage.children.length > 4) {
+                let oldestSprite = Array.from(stage.children).reduce((oldest, current) => {
+                    let oldestTime = parseInt(oldest.dataset.lastActive || 0);
+                    let currentTime = parseInt(current.dataset.lastActive || 0);
+                    return oldestTime < currentTime ? oldest : current;
+                });
+                if (oldestSprite) {
+                    currentSpritesEnEscena.delete(oldestSprite.dataset.name);
+                    stage.removeChild(oldestSprite);
+                } else {
+                    break;
                 }
             }
         }
 
         // Apply active/dimmed classes
         Array.from(stage.children).forEach(img => {
-            if (img.dataset.url === activeSpriteUrl) {
+            if (img.dataset.name === activeName && img.dataset.url === activeSpriteUrl) {
                 img.className = 'sprite-active';
+                img.style.filter = 'none'; // Ensure no dimming
+                img.style.transform = 'scale(1)';
             } else {
                 img.className = 'sprite-dimmed';
+                img.style.filter = 'brightness(0.4) grayscale(0.5)';
+                img.style.transform = 'scale(0.95)';
             }
         });
     });
@@ -2728,12 +2770,22 @@
 
       const idActor = nombre.toLowerCase().replace(/[^a-z0-9]/g, '_');
 
+      const expresiones = {
+          "Neutral": sprite,
+          "Feliz": document.getElementById('actor-sprite-feliz') ? document.getElementById('actor-sprite-feliz').value.trim() : "",
+          "Triste": document.getElementById('actor-sprite-triste') ? document.getElementById('actor-sprite-triste').value.trim() : "",
+          "Enojado": document.getElementById('actor-sprite-enojado') ? document.getElementById('actor-sprite-enojado').value.trim() : "",
+          "Sorprendido": document.getElementById('actor-sprite-sorprendido') ? document.getElementById('actor-sprite-sorprendido').value.trim() : ""
+      };
+      Object.keys(expresiones).forEach(key => !expresiones[key] && delete expresiones[key]);
+
       db.ref(`campaña/actores/${idActor}`).set({
         nombre: nombre,
         titulo: titulo,
         color_nombre: colorNombre,
         color_titulo: colorTitulo,
-        sprite: sprite
+        sprite: sprite,
+        expresiones: expresiones
       }).then(() => {
         alert(`Actor '${nombre}' creado exitosamente.`);
         document.getElementById('actor-nombre').value = '';
@@ -2741,6 +2793,10 @@
         document.getElementById('actor-color-nombre').value = '#ffffff';
         document.getElementById('actor-color-titulo').value = '#c49a00';
         document.getElementById('actor-sprite').value = '';
+        if (document.getElementById('actor-sprite-feliz')) document.getElementById('actor-sprite-feliz').value = '';
+        if (document.getElementById('actor-sprite-triste')) document.getElementById('actor-sprite-triste').value = '';
+        if (document.getElementById('actor-sprite-enojado')) document.getElementById('actor-sprite-enojado').value = '';
+        if (document.getElementById('actor-sprite-sorprendido')) document.getElementById('actor-sprite-sorprendido').value = '';
       }).catch(e => alert('Error creando actor: ' + e));
     });
 


### PR DESCRIPTION
Implemented user requests for the "Teatro de la Mente":
1. Added background controls in `pantalla_dm.html` that sync via Firebase.
2. Expanded the DM's actor creation to support multiple expressions.
3. Added an expression selector dropdown to the player's theatre input in `hoja_personaje.html`.
4. Limited the on-screen sprites to 4 maximum using a `lastActive` timestamp tracking system.
5. Implemented a dimming effect (brightness, grayscale, scaling) for sprites that are not currently speaking.

---
*PR created automatically by Jules for task [10480242199495360258](https://jules.google.com/task/10480242199495360258) started by @sokcrow*