### PR TITLE
Fix Theatre View UI layout and overlapping

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -4847,6 +4847,7 @@ input.sheet-part-link-state[value~="12"] ~ .sheet-part-view-bar .sheet-stagger-v
     border-radius: 30px;
     box-shadow: 0 20px 50px rgba(0,0,0,0.8), inset 0 0 10px rgba(0,0,0,0.5);
     position: relative;
+    z-index: 3010;
     display: flex;
     flex-direction: column;
     overflow: hidden;

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -862,7 +862,7 @@
     </div>
 
     <!-- DM Control Panel Overlay -->
-    <div class="theatre-controls" style="position: absolute; bottom: 0; left: 0; width: 100%; background: rgba(0,0,0,0.9); border-top: 2px solid #0df; padding: 15px; display: flex; gap: 20px; z-index: 2030; align-items: center; justify-content: space-between; box-sizing: border-box;">
+    <div class="theatre-controls" style="position: absolute; bottom: 0; left: 0; width: 100%; background: rgba(0,0,0,0.9); border-top: 2px solid #0df; padding: 15px; display: flex; flex-wrap: wrap; gap: 20px; z-index: 2030; align-items: center; justify-content: space-between; box-sizing: border-box;">
 
       <!-- Left: Queue -->
       <div style="flex: 1; border-right: 1px solid #444; padding-right: 15px; display: flex; flex-direction: column; max-height: 100px;">


### PR DESCRIPTION
Fixes layout and overlapping issues in the Theatre of the Mind view for both DM and Player screens.

1. **DM Screen:** The 'ENTRAR A ESCENA / AVANZAR' button was being cut off horizontally on smaller screens. Added `flex-wrap: wrap` to the `.theatre-controls` container so the components safely wrap to the next line.
2. **Player Screen:** The character cellphone (`.sheet-phone-wrapper`) was hidden behind the Theatre background, meaning players couldn't check stats/items during dialogue. Bumped its `z-index` to `3010` (theatre is `3000`) so it correctly renders on top when toggled open.

---
*PR created automatically by Jules for task [5090649330530847293](https://jules.google.com/task/5090649330530847293) started by @sokcrow*