### PR TITLE
Fix theatre font and CSS stroke rendering

### DIFF
--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -12,8 +12,8 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap');
 @font-face {
-  font-family: 'Mikodacs';
-  src: url('Fonts/Mikodacs.otf') format('opentype');
+  font-family: 'BebasKai';
+  src: url('Fonts/BebasKai.otf') format('opentype');
 }
 
 
@@ -30,11 +30,15 @@
     padding: 12px 30px;
     color: #f5f5dc;
     font-size: 24px;
-    font-family: 'Mikodacs', impact, sans-serif;
+    font-family: 'BebasKai', impact, sans-serif;
+    letter-spacing: 1px;
+    text-transform: uppercase;
     font-weight: bold;
     box-shadow: 5px 5px 15px rgba(0,0,0,0.8);
     z-index: 2010;
     letter-spacing: 1px;
+    -webkit-text-stroke: 2px black;
+    paint-order: stroke fill;
     text-shadow: 1px 1px 2px black;
     transform: rotate(-15deg);
     transform-origin: top left;
@@ -132,7 +136,9 @@
     border: none;
     border-left: 4px solid #d4af37;
     padding: 2px 40px 2px 20px;
-    font-family: 'Mikodacs', impact, sans-serif;
+    font-family: 'BebasKai', impact, sans-serif;
+    letter-spacing: 1px;
+    text-transform: uppercase;
     font-weight: bold;
     font-size: 16px;
     box-shadow: 2px 2px 5px rgba(0,0,0,0.8);
@@ -154,10 +160,13 @@
     border: none;
     border-left: 6px solid #1a1a1a;
     padding: 4px 60px 4px 30px;
-    font-family: 'Mikodacs', impact, sans-serif;
+    font-family: 'BebasKai', impact, sans-serif;
+    letter-spacing: 1px;
+    text-transform: uppercase;
     font-weight: 900;
     font-size: 32px;
-    -webkit-text-stroke: 1px black;
+    -webkit-text-stroke: 2px black;
+    paint-order: stroke fill;
     text-shadow: 2px 2px 4px rgba(0,0,0,0.8);
     box-shadow: 2px 2px 5px rgba(0,0,0,0.8);
     position: relative;

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -439,8 +439,8 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap');
 @font-face {
-  font-family: 'Mikodacs';
-  src: url('Fonts/Mikodacs.otf') format('opentype');
+  font-family: 'BebasKai';
+  src: url('Fonts/BebasKai.otf') format('opentype');
 }
 
   </style>
@@ -984,11 +984,15 @@
     padding: 12px 30px;
     color: #f5f5dc;
     font-size: 24px;
-    font-family: 'Mikodacs', impact, sans-serif;
+    font-family: 'BebasKai', impact, sans-serif;
+    letter-spacing: 1px;
+    text-transform: uppercase;
     font-weight: bold;
     box-shadow: 5px 5px 15px rgba(0,0,0,0.8);
     z-index: 2010;
     letter-spacing: 1px;
+    -webkit-text-stroke: 2px black;
+    paint-order: stroke fill;
     text-shadow: 1px 1px 2px black;
     transform: rotate(-15deg);
     transform-origin: top left;
@@ -1086,7 +1090,9 @@
     border: none;
     border-left: 4px solid #d4af37;
     padding: 2px 40px 2px 20px;
-    font-family: 'Mikodacs', impact, sans-serif;
+    font-family: 'BebasKai', impact, sans-serif;
+    letter-spacing: 1px;
+    text-transform: uppercase;
     font-weight: bold;
     font-size: 16px;
     box-shadow: 2px 2px 5px rgba(0,0,0,0.8);
@@ -1108,10 +1114,13 @@
     border: none;
     border-left: 6px solid #1a1a1a;
     padding: 4px 60px 4px 30px;
-    font-family: 'Mikodacs', impact, sans-serif;
+    font-family: 'BebasKai', impact, sans-serif;
+    letter-spacing: 1px;
+    text-transform: uppercase;
     font-weight: 900;
     font-size: 32px;
-    -webkit-text-stroke: 1px black;
+    -webkit-text-stroke: 2px black;
+    paint-order: stroke fill;
     text-shadow: 2px 2px 4px rgba(0,0,0,0.8);
     box-shadow: 2px 2px 5px rgba(0,0,0,0.8);
     position: relative;


### PR DESCRIPTION
Replaced the corrupted Mikodacs font and overhauled the typography and styling for all theatre components (`.theatre-location`, `.theatre-plate-name`, `.theatre-plate-title`) in both `hoja_personaje.html` and `pantalla_dm.html`. Utilizing `BebasKai` combined with `paint-order: stroke fill` for the text outlines to cleanly achieve the desired visual novel aesthetic and fix the "ugly" rendering.

---
*PR created automatically by Jules for task [2101301646351224622](https://jules.google.com/task/2101301646351224622) started by @sokcrow*