### PR TITLE
Enforce 16:9 Aspect Ratio on Theatre Sprites

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -6113,3 +6113,10 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
     z-index: 10;
     transition: all 0.4s ease;
 }
+
+.theatre-stage img {
+    aspect-ratio: 16 / 9;
+    max-height: 60vh;
+    object-fit: contain;
+    width: auto;
+}

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -931,6 +931,12 @@
       z-index: 10;
       transition: all 0.4s ease;
     }
+    .theatre-stage img {
+      aspect-ratio: 16 / 9;
+      max-height: 60vh;
+      object-fit: contain;
+      width: auto;
+    }
     .queue-item-blink {
       animation: blinkText 1s infinite alternate;
       color: #0df;


### PR DESCRIPTION
Enforces a uniform 16:9 aspect ratio for all character sprites in the Visual Novel Theatre view. This prevents images of different shapes and sizes from rendering disproportionately on the stage.

Changes:
* Applied `aspect-ratio: 16 / 9` and `object-fit: contain` to `.theatre-stage img`
* Included `max-height: 60vh` and `width: auto` to properly size and align the new bounding box while preserving responsiveness.
* Covered both `hoja_personaje.css` (Player view) and `pantalla_dm.html` (DM view).

---
*PR created automatically by Jules for task [3478150255424760303](https://jules.google.com/task/3478150255424760303) started by @sokcrow*