### PR TITLE
style(teatro): increase theater sprite max-height for better balance

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -6116,7 +6116,7 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
 
 .theatre-stage img {
     aspect-ratio: 16 / 9;
-    max-height: 60vh;
+    max-height: 75vh;
     object-fit: contain;
     width: auto;
 }

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -937,7 +937,7 @@
     }
     .theatre-stage img {
       aspect-ratio: 16 / 9;
-      max-height: 60vh;
+      max-height: 75vh;
       object-fit: contain;
       width: auto;
     }


### PR DESCRIPTION
Increased the `max-height` of `.theatre-stage img` from 60vh to 75vh in both `hoja_personaje.css` and `pantalla_dm.html`. This ensures that character sprites in the Teatro de la Mente appear larger and are better balanced proportionally against the HUD.

---
*PR created automatically by Jules for task [18434008524121787060](https://jules.google.com/task/18434008524121787060) started by @sokcrow*