### PR TITLE
Increase size of theatre stage sprites

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -6116,7 +6116,7 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
 
 .theatre-stage img {
     aspect-ratio: 16 / 9;
-    max-height: 75vh;
+    height: 100vh;
     object-fit: contain;
     width: auto;
 }

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -4362,7 +4362,7 @@
           img.dataset.url = activeSpriteUrl;
           img.dataset.name = activeName;
           img.dataset.lastActive = Date.now();
-          img.style.cssText = 'max-height: 80vh; max-width: 400px; object-fit: contain; transition: all 0.4s ease;';
+          img.style.cssText = 'max-height: 100vh; max-width: 1500px; object-fit: contain; transition: all 0.4s ease;';
           stage.appendChild(img);
 
           while (stage.children.length > 4) {

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -937,7 +937,7 @@
     }
     .theatre-stage img {
       aspect-ratio: 16 / 9;
-      max-height: 75vh;
+      height: 100vh;
       object-fit: contain;
       width: auto;
     }
@@ -2864,7 +2864,7 @@
             img.dataset.url = activeSpriteUrl;
             img.dataset.name = activeName;
             img.dataset.lastActive = Date.now();
-            img.style.cssText = 'max-height: 80vh; max-width: 400px; object-fit: contain; transition: all 0.4s ease;';
+            img.style.cssText = 'height: 100vh; max-width: 1500px; object-fit: contain; transition: all 0.4s ease;';
             stage.appendChild(img);
 
             // Limit to max 4 sprites for visual clarity, remove oldest if needed


### PR DESCRIPTION
Update CSS constraints for Theatre of the Mind sprites in both player and DM views to ensure they scale maximally and occupy vertical screen space (`100vh`) without arbitrary maximum bounds (`400px` max-width removed in favor of `1500px`), per user request.

---
*PR created automatically by Jules for task [11654293192924054609](https://jules.google.com/task/11654293192924054609) started by @sokcrow*