### PR TITLE
feat(inventory): limit active inventory to 10 slots

### DIFF
--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -2483,8 +2483,17 @@ window.addEventListener('DOMContentLoaded', () => {
             grid.appendChild(slot);
         });
 
-        // Fill remaining empty slots up to 25 to make it look like a grid
-        const emptySlotsNeeded = Math.max(0, 25 - items.length);
+        // Fill remaining empty slots to make it look like a grid
+        // Active inventory has exactly 10 slots. Stash expands.
+        let emptySlotsNeeded = 0;
+        if (!isStash) {
+            emptySlotsNeeded = Math.max(0, 10 - items.length);
+        } else {
+            // Stash expands: Minimum 25, then adds rows (multiples of 5)
+            const targetSlots = Math.max(25, Math.ceil(items.length / 5) * 5);
+            emptySlotsNeeded = Math.max(0, targetSlots - items.length);
+        }
+
         for(let i = 0; i < emptySlotsNeeded; i++) {
             const emptySlot = document.createElement('div');
             emptySlot.className = 'item-slot empty-slot';
@@ -2566,6 +2575,12 @@ window.addEventListener('DOMContentLoaded', () => {
                     targetCurrentCant = targetItem.cantidad || 1;
                     break;
                 }
+            }
+
+            // Check 10 slots limit for active inventory
+            if (fromStash && !foundKey && Object.keys(targetData).length >= 10) {
+                alert("El Inventario Activo está lleno. Solo puedes llevar 10 espacios.");
+                return;
             }
 
             let promiseAdd;


### PR DESCRIPTION
Limited the active inventory to exactly 10 slots while allowing the stash to remain limitless but visually structured in multiples of 5 slots (minimum 25). Added validation when moving an item from the stash to the active inventory to prevent exceeding the 10-slot limit.

---
*PR created automatically by Jules for task [16014977129741172680](https://jules.google.com/task/16014977129741172680) started by @sokcrow*