### PR TITLE
Fix inventory grid to have 10 active slots and 10 column stash

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -5580,7 +5580,8 @@ input[name="attr_tab"][value="shop"] ~ .sheet-phone-screen .sheet-tab-shop {
 /* Tabs: Inventario Activo & Stash */
 .inv-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, 64px);
+    grid-template-columns: repeat(10, 64px);
+    width: max-content; /* Ensure it expands horizontally */
     grid-auto-rows: 64px;
     gap: 10px;
     min-height: 360px;
@@ -6131,4 +6132,15 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
     height: 100vh;
     object-fit: contain;
     width: auto;
+}
+
+
+
+
+/* El inventario Activo solo debe mostrar 10 slots exactos */
+#inv-active-grid {
+    grid-template-columns: repeat(10, 64px); /* 10 de ancho */
+    width: max-content; /* Ensure it expands horizontally */
+    min-height: 74px; /* Exactamente una fila (64px + 10px padding) */
+    height: 74px; /* Limita el background-image para que no dibuje ms filas vacas */
 }


### PR DESCRIPTION
Fix for active inventory grid and stash column layout based on user feedback. Active menu now accurately shows 10 slots, while stash correctly wraps by 10 columns indefinitely.

---
*PR created automatically by Jules for task [4831552953126752320](https://jules.google.com/task/4831552953126752320) started by @sokcrow*