### PR TITLE
Enhance theatre dialogue with typewriter effect and pale yellow text

### DIFF
--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -185,7 +185,7 @@
     border-radius: 0;
     padding: 50px 70px 40px 70px;
     min-height: 180px;
-    color: #f0f0f0;
+    color: #fffacd; /* Amarillo pálido (LemonChiffon) */
     font-size: 1.1rem;
     line-height: 1.6;
     font-family: 'Roboto', sans-serif;
@@ -4393,7 +4393,22 @@
       }
 
       if (textBox) {
-          textBox.innerText = state.mensaje || '';
+          if (textBox.typewriterInterval) {
+              clearInterval(textBox.typewriterInterval);
+          }
+          textBox.innerText = '';
+          const fullText = state.mensaje || '';
+          let charIndex = 0;
+          if (fullText.length > 0) {
+              textBox.typewriterInterval = setInterval(() => {
+                  textBox.innerText += fullText.charAt(charIndex);
+                  charIndex++;
+                  if (charIndex >= fullText.length) {
+                      clearInterval(textBox.typewriterInterval);
+                      textBox.typewriterInterval = null;
+                  }
+              }, 30); // 30ms per character
+          }
       }
 
       const stage = document.getElementById('player-theatre-stage');

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -1167,7 +1167,7 @@
     border-radius: 0;
     padding: 50px 70px 40px 70px;
     min-height: 180px;
-    color: #f0f0f0;
+    color: #fffacd; /* Amarillo pálido (LemonChiffon) */
     font-size: 1.1rem;
     line-height: 1.6;
     font-family: 'Roboto', sans-serif;
@@ -3223,7 +3223,23 @@
         namePlate.style.backgroundColor = state.color_nombre || '#416268';
         namePlate.style.color = '#ffffff';
 
-        textBox.innerText = state.mensaje || '';
+        // Typewriter effect
+        if (textBox.typewriterInterval) {
+            clearInterval(textBox.typewriterInterval);
+        }
+        textBox.innerText = '';
+        const fullText = state.mensaje || '';
+        let charIndex = 0;
+        if (fullText.length > 0) {
+            textBox.typewriterInterval = setInterval(() => {
+                textBox.innerText += fullText.charAt(charIndex);
+                charIndex++;
+                if (charIndex >= fullText.length) {
+                    clearInterval(textBox.typewriterInterval);
+                    textBox.typewriterInterval = null;
+                }
+            }, 30); // 30ms per character
+        }
 
         // Manage Sprites on Stage
         const stage = document.getElementById('theatre-stage-container');


### PR DESCRIPTION
Implemented the requested visual enhancements for the Theatre of the Mind dialogue box. The text now appears progressively with a typewriter effect instead of instantly, and the font color has been updated to a pale yellow (`#fffacd` / LemonChiffon) as requested by the user. These changes have been applied consistently across both the Dungeon Master view (`pantalla_dm.html`) and the player view (`hoja_personaje.html`). Tested to ensure existing text is properly cleared and animations do not overlap when new messages arrive.

---
*PR created automatically by Jules for task [3679935416566581471](https://jules.google.com/task/3679935416566581471) started by @sokcrow*