### PR TITLE
Fix typewriter effect bugs (spaces & overflow)

### DIFF
--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -192,6 +192,9 @@
     box-shadow: none;
     text-shadow: none;
     z-index: 10;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
   }
 
   .theatre-dialogue-text::before {
@@ -4404,12 +4407,12 @@
           if (textBox.typewriterInterval) {
               clearInterval(textBox.typewriterInterval);
           }
-          textBox.innerText = '';
+          textBox.textContent = '';
           const fullText = state.mensaje || '';
           let charIndex = 0;
           if (fullText.length > 0) {
               textBox.typewriterInterval = setInterval(() => {
-                  textBox.innerText += fullText.charAt(charIndex);
+                  textBox.textContent += fullText.charAt(charIndex);
                   charIndex++;
                   if (charIndex >= fullText.length) {
                       clearInterval(textBox.typewriterInterval);

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -1179,6 +1179,9 @@
     box-shadow: none;
     text-shadow: none;
     z-index: 10;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
   }
 
   .theatre-dialogue-text::before {
@@ -3250,12 +3253,12 @@
         if (textBox.typewriterInterval) {
             clearInterval(textBox.typewriterInterval);
         }
-        textBox.innerText = '';
+        textBox.textContent = '';
         const fullText = state.mensaje || '';
         let charIndex = 0;
         if (fullText.length > 0) {
             textBox.typewriterInterval = setInterval(() => {
-                textBox.innerText += fullText.charAt(charIndex);
+                textBox.textContent += fullText.charAt(charIndex);
                 charIndex++;
                 if (charIndex >= fullText.length) {
                     clearInterval(textBox.typewriterInterval);


### PR DESCRIPTION
Fixes the bugs reported by the user where the typing effect failed to maintain spaces and went out of the screen.

**Changes:**
- Changed `.innerText +=` to `.textContent +=` in `hoja_personaje.html` and `pantalla_dm.html` typing loops.
- Added `white-space: pre-wrap;`, `word-wrap: break-word;`, and `overflow-wrap: break-word;` to `.theatre-dialogue-text` in both files.

---
*PR created automatically by Jules for task [16658433125744631558](https://jules.google.com/task/16658433125744631558) started by @sokcrow*