### PR TITLE
Fix unclickable login input field on hover

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,6 +146,7 @@
             height: 15px;
             border: 2px solid transparent;
             transition: all 0.3s ease;
+            pointer-events: none;
         }
 
         .save-slot-card::before {


### PR DESCRIPTION
This commit fixes an issue where the user was unable to click or type into the login input field when their mouse was hovering over the login card.

The issue was caused by the CSS hover effect on the `.save-slot-card` element, which uses `::before` and `::after` pseudo-elements to create a cyberpunk-style border animation. These pseudo-elements expanded to cover the entire card on hover but lacked `pointer-events: none;`, meaning they intercepted all mouse clicks intended for the actual input field underneath.

Adding `pointer-events: none;` to these pseudo-elements allows clicks to properly pass through to the `player-id-input` element, resolving the bug.

---
*PR created automatically by Jules for task [12152659110182412218](https://jules.google.com/task/12152659110182412218) started by @sokcrow*