### PR TITLE
fix: remove lowercase conversion for login id

### DIFF
--- a/index.html
+++ b/index.html
@@ -326,7 +326,8 @@
                 const rawId = playerIdInput.value.trim();
                 if (!rawId) return;
 
-                const userId = rawId.toLowerCase().replace(/\s+/g, '');
+                // Quitamos .toLowerCase() para respetar mayúsculas de los perfiles existentes
+                const userId = rawId.replace(/\s+/g, '');
                 localStorage.setItem('playerId', userId);
 
                 loginStatus.textContent = "Verificando en la base de datos...";


### PR DESCRIPTION
This fixes the login bug where profiles with uppercase characters (e.g. "So") could not log in because their IDs were forced to lowercase before looking up in the Firebase Realtime Database. Since Firebase is case-sensitive, this fix ensures that the ID input respects case sensitivity but still removes spaces to correctly look up the player data.

---
*PR created automatically by Jules for task [11552561492297404257](https://jules.google.com/task/11552561492297404257) started by @sokcrow*