### PR TITLE
Fix tier logic for pricing and inventory stacking

### DIFF
--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -3410,7 +3410,9 @@ function renderizarComprar() {
     }
 
     for (const [itemId, item] of Object.entries(items)) {
-        const precio = Math.floor(item.costo * (modVenta / 100));
+        const itemTier = parseInt(item.tier) || 1;
+        const valorConTier = Math.floor((item.costo || 0) * (1 + ((itemTier - 1) * 0.25)));
+        const precio = Math.floor(valorConTier * (modVenta / 100));
         const isAgotado = item.stock_actual === 0;
         const stockStr = item.stock_actual === -1 ? '∞' : item.stock_actual;
 

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -2902,7 +2902,7 @@
 
             // Check if it already exists to increment quantity instead
             for (const [k, item] of Object.entries(targetData)) {
-                if (item.nombre === dataGlobal.nombre) {
+                if (item.nombre === dataGlobal.nombre && (parseInt(item.tier) || 1) === (parseInt(dataGlobal.tier) || 1)) {
                     foundKey = k;
                     currentCant = item.cantidad || 1;
                     break;
@@ -3008,7 +3008,7 @@
                         let targetCurrentCant = 0;
 
                         for (const [k, targetItem] of Object.entries(targetData)) {
-                            if (targetItem.nombre === item.nombre) {
+                            if (targetItem.nombre === item.nombre && (parseInt(targetItem.tier) || 1) === (parseInt(item.tier) || 1)) {
                                 foundKey = k;
                                 targetCurrentCant = targetItem.cantidad || 1;
                                 break;


### PR DESCRIPTION
Fixed store price scaling by adding the tier multiplier `(1 + ((Tier - 1) * 0.25))` logic as requested. Also fixed an issue where different tier items were incorrectly stacked together in the DM panel by adding strict tier matching when moving items between active and stash inventories or adding new items to players.

---
*PR created automatically by Jules for task [3702115062163553302](https://jules.google.com/task/3702115062163553302) started by @sokcrow*