### PR TITLE
Revert Reaccionar Button and fix expressions

### DIFF
--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -3940,7 +3940,6 @@
   <div class="theatre-player-input-area" style="position: absolute; bottom: 0; left: 0; width: 100%; background: rgba(0,0,0,0.9); border-top: 2px solid #0df; padding: 15px; display: flex; gap: 15px; z-index: 2030; align-items: center; justify-content: center; box-sizing: border-box;">
     <select id="player-expression-select" style="padding: 15px; background: #222; color: #0df; border: 1px solid #444; border-radius: 4px; font-size: 16px; min-width: 120px; display: none;"></select>
     <input type="text" id="player-theatre-input" placeholder="¿Qué quieres decir o hacer? (Escribe aquí...)" style="flex: 1; max-width: 800px; padding: 15px; background: #111; color: #fff; border: 1px solid #555; border-radius: 4px; font-family: inherit; font-size: 16px;" />
-    <button id="btn-player-theatre-react" style="background: #222; color: #0df; border: 1px solid #0df; padding: 15px 30px; font-size: 16px; font-weight: bold; cursor: pointer; text-transform: uppercase; border-radius: 4px; box-shadow: 0 0 10px rgba(0, 221, 255, 0.3);">REACCIONAR</button>
     <button id="btn-player-theatre-send" style="background: #0df; color: #000; border: 1px solid #fff; padding: 15px 30px; font-size: 16px; font-weight: bold; cursor: pointer; text-transform: uppercase; border-radius: 4px; box-shadow: 0 0 15px rgba(0, 221, 255, 0.6);">ENVIAR</button>
   </div>
 </div>
@@ -4404,17 +4403,14 @@
       isTheatreBlocked = snap.val();
       const input = document.getElementById('player-theatre-input');
       const btn = document.getElementById('btn-player-theatre-send');
-      const btnReact = document.getElementById('btn-player-theatre-react');
       if (input && btn) {
           if (isTheatreBlocked) {
               input.disabled = true;
               btn.disabled = true;
-              if (btnReact) btnReact.disabled = true;
               input.placeholder = "El Director ha bloqueado las interacciones (Modo Lore)...";
           } else {
               input.disabled = false;
               btn.disabled = false;
-              if (btnReact) btnReact.disabled = false;
               input.placeholder = "¿Qué quieres decir o hacer? (Escribe aquí...)";
           }
       }
@@ -4586,7 +4582,6 @@
 
   // Send Dialogue logic
   const btnSend = document.getElementById('btn-player-theatre-send');
-  const btnReact = document.getElementById('btn-player-theatre-react');
   const inputEl = document.getElementById('player-theatre-input');
 
   function sendTheatreMessage(msgText) {
@@ -4633,12 +4628,6 @@
           if (!msg) return;
           sendTheatreMessage(msg);
       });
-
-      if (btnReact) {
-          btnReact.addEventListener('click', () => {
-              sendTheatreMessage("");
-          });
-      }
 
       inputEl.addEventListener('keypress', (e) => {
           if (e.key === 'Enter') {

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -1048,7 +1048,6 @@
           <select id="dm-expression-select" style="padding: 8px; background: #222; color: #fff; border: 1px solid #444; border-radius: 4px; width: 150px; display: none;">
             <!-- Injected via JS -->
           </select>
-          <button id="btn-dm-theatre-react" class="btn-cyber" style="background: #222; color: #0df; border: 1px solid #0df; padding: 8px; height: 40px; box-sizing: border-box;" title="Cambiar Expresión sin diálogo">REACCIONAR</button>
           <textarea id="dm-theatre-input" placeholder="Escribe el diálogo del actor seleccionado..." style="flex: 1; height: 40px; background: #111; color: #fff; border: 1px solid #555; padding: 5px; resize: none; font-family: inherit; border-radius: 4px;"></textarea>
         </div>
       </div>
@@ -3739,32 +3738,6 @@
                 img.style.transform = 'scale(0.95)';
             }
         });
-    });
-
-    // Reaccionar sin diálogo
-    document.getElementById('btn-dm-theatre-react').addEventListener('click', () => {
-        const selectedNpcId = activeSpeakerId;
-        if (selectedNpcId) {
-            const actorData = dbActoresCache[selectedNpcId];
-            if (actorData) {
-                const exprSelect = document.getElementById('dm-expression-select');
-                const selectedSprite = exprSelect && exprSelect.style.display !== 'none' ? exprSelect.value : actorData.sprite;
-
-                const state = {
-                    nombre: actorData.nombre,
-                    titulo: actorData.titulo,
-                    color_nombre: actorData.color_nombre,
-                    color_titulo: actorData.color_titulo,
-                    escala: actorData.escala !== undefined ? actorData.escala : 1.0,
-                    sprite: selectedSprite,
-                    mensaje: "",
-                    timestamp: Date.now()
-                };
-                db.ref('campaña/teatro/estado_actual').set(state);
-            }
-        } else {
-            alert("Selecciona un actor en el escenario primero.");
-        }
     });
 
     // Entrar a Escena / Avanzar


### PR DESCRIPTION
- Removed the 'REACCIONAR' button in `hoja_personaje.html`.
- Cleaned up event listeners and references pointing to `btn-player-theatre-react`.
- Maintained the core expression loading functionality for player characters.

---
*PR created automatically by Jules for task [16915490355430688813](https://jules.google.com/task/16915490355430688813) started by @sokcrow*