### PR TITLE
Refactor Store Access & UI to Limbus Dispensary Style

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -5475,6 +5475,223 @@ input[name="attr_tab"][value="crafteo"] ~ .sheet-phone-screen .sheet-tab-crafteo
     box-shadow: 0 0 20px rgba(196, 154, 0, 0.8), inset 0 0 5px rgba(0,0,0,0.8);
 }
 
+#tienda-fisica-badge {
+    position: absolute;
+    top: -15px;
+    right: -15px;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    border: 2px solid #00ffff;
+    box-shadow: 0 0 10px #00ffff;
+    object-fit: cover;
+    animation: pulse 1.5s infinite;
+}
+
+@keyframes pulse {
+    0% { transform: scale(1); box-shadow: 0 0 5px #00ffff; }
+    50% { transform: scale(1.2); box-shadow: 0 0 15px #00ffff; }
+    100% { transform: scale(1); box-shadow: 0 0 5px #00ffff; }
+}
+
+/* Limbus Dispensary Style Shop Modal */
+.shop-modal-content {
+    background: rgba(10, 10, 10, 0.95);
+    border: 2px solid #00ffff;
+    width: 95%;
+    max-width: 1200px;
+    height: 85vh;
+    border-radius: 8px;
+    box-shadow: 0 0 30px rgba(0, 255, 255, 0.3), inset 0 0 20px rgba(0,0,0,0.9);
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.shop-modal-body {
+    display: flex;
+    flex: 1;
+    overflow: hidden;
+}
+
+.shop-sidebar {
+    width: 250px;
+    background: rgba(0, 0, 0, 0.8);
+    border-right: 2px solid #333;
+    display: flex;
+    flex-direction: column;
+    padding: 20px 10px;
+    gap: 15px;
+    overflow-y: auto;
+}
+
+.shop-btn {
+    background: linear-gradient(90deg, #111, #222);
+    color: #fff;
+    border: 1px solid #444;
+    border-left: 4px solid #00ffff;
+    padding: 15px 10px;
+    font-size: 16px;
+    font-weight: bold;
+    font-family: inherit;
+    text-transform: uppercase;
+    text-align: left;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    border-radius: 0 4px 4px 0;
+    box-shadow: 2px 2px 5px rgba(0,0,0,0.5);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.shop-btn:hover, .shop-btn.active {
+    background: linear-gradient(90deg, #1a1a1a, #00ffff);
+    color: #000;
+    border-color: #00ffff;
+    box-shadow: 0 0 10px rgba(0, 255, 255, 0.5);
+}
+
+.shop-btn img {
+    width: 24px;
+    height: 24px;
+    object-fit: cover;
+    border-radius: 4px;
+}
+
+.shop-main-panel {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    background: repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0, 255, 255, 0.03) 2px, rgba(0, 255, 255, 0.03) 4px);
+    position: relative;
+}
+
+.shop-header {
+    padding: 20px;
+    border-bottom: 2px solid #333;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: linear-gradient(90deg, rgba(0,0,0,0.8), transparent);
+}
+
+.shop-header h2 {
+    margin: 0;
+    color: #00ffff;
+    text-transform: uppercase;
+    font-size: 24px;
+    letter-spacing: 2px;
+    text-shadow: 0 0 10px rgba(0,255,255,0.5);
+}
+
+.shop-items-grid {
+    flex: 1;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 20px;
+    padding: 20px;
+    overflow-y: auto;
+}
+
+.shop-item-card {
+    background: #1a1a1a;
+    border: 1px solid #333;
+    border-radius: 6px;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    overflow: hidden;
+    transition: all 0.2s ease;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.8);
+}
+
+.shop-item-card:hover {
+    border-color: #00ffff;
+    transform: translateY(-5px);
+    box-shadow: 0 8px 15px rgba(0,255,255,0.2);
+}
+
+.shop-item-image-container {
+    height: 120px;
+    background: #0d0d0d;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+    border-bottom: 1px solid #333;
+}
+
+.shop-item-image-container img {
+    max-width: 80%;
+    max-height: 80%;
+    object-fit: contain;
+    z-index: 2;
+}
+
+.shop-item-tier {
+    position: absolute;
+    top: 5px;
+    left: 10px;
+    color: #ffd700;
+    font-weight: bold;
+    font-size: 16px;
+    text-shadow: 0 0 5px #ff8c00, 0 0 2px #000;
+    z-index: 3;
+}
+
+.shop-item-details {
+    padding: 15px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    flex: 1;
+}
+
+.shop-item-name {
+    color: #fff;
+    font-size: 14px;
+    font-family: inherit;
+    font-weight: bold;
+    text-transform: uppercase;
+    text-align: center;
+    margin: 0;
+    line-height: 1.2;
+}
+
+.shop-item-buy-btn {
+    background: linear-gradient(180deg, #ffd700 0%, #c49a00 100%);
+    color: #000;
+    border: 1px solid #ffcc00;
+    padding: 8px;
+    font-weight: bold;
+    font-size: 14px;
+    cursor: pointer;
+    border-radius: 4px;
+    text-transform: uppercase;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 5px;
+    margin-top: auto;
+    transition: all 0.2s;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.5);
+}
+
+.shop-item-buy-btn:hover:not(:disabled) {
+    background: linear-gradient(180deg, #ffe033 0%, #d4a900 100%);
+    box-shadow: 0 0 10px #ffd700;
+}
+
+.shop-item-buy-btn:disabled {
+    background: #333;
+    color: #666;
+    border-color: #444;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
 /* --- INVENTORY MODAL --- */
 .inventory-modal {
     display: none;

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -3843,7 +3843,30 @@
 </div> <!-- End Limbus Main -->
 
 <!-- Global Inventory Button -->
-<button class="btn-global-inventory" id="btn-global-inventory" title="Inventario Global">🎒</button>
+<button class="btn-global-inventory" id="btn-global-inventory" title="Inventario Global">
+  🎒
+  <img id="tienda-fisica-badge" src="" style="display: none;">
+</button>
+
+<!-- Shop Modal (Limbus Dispensary Style) -->
+<div id="shop-modal" class="inventory-modal">
+    <div class="shop-modal-content">
+        <button id="shop-modal-close" class="inventory-modal-close">×</button>
+        <div class="shop-modal-body">
+            <div class="shop-sidebar" id="shop-sidebar-list">
+                <!-- Shop buttons injected via JS -->
+            </div>
+            <div class="shop-main-panel">
+                <div class="shop-header">
+                    <h2 id="shop-active-name">Selecciona una tienda</h2>
+                </div>
+                <div id="shop-items-grid" class="shop-items-grid">
+                    <!-- Items injected via JS -->
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
 
 <!-- Inventory Modal -->
 <div id="inventory-modal" class="inventory-modal">

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -3083,24 +3083,65 @@ window.addEventListener('DOMContentLoaded', () => {
 // LÓGICA DE TIENDA DINÁMICA (COMPRAR / VENDER)
 let tiendaActivaData = null;
 let tiendaActivaId = null;
+let tiendasFisicasDisponibles = {}; // Para el modal físico
+let tiendaFisicaActivaId = null; // ID de la tienda seleccionada en el modal
+
+// Helper array para convertir Tier en romano (ya existe en otro lado pero lo necesitamos aquí)
+const romanTiersShop = ["", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"];
 
 // Esperar a que el DOM y window.db existan
 window.addEventListener('DOMContentLoaded', () => {
     if (!window.db) return;
 
+    // Abrir/Cerrar el modal de tienda física
+    const badgeFisica = document.getElementById('tienda-fisica-badge');
+    const shopModal = document.getElementById('shop-modal');
+    const shopModalClose = document.getElementById('shop-modal-close');
+
+    if (badgeFisica && shopModal) {
+        badgeFisica.addEventListener('click', (e) => {
+            e.stopPropagation(); // Evitar que abra el inventario normal
+            shopModal.classList.add('active');
+            // Por defecto, seleccionar la primera tienda de la lista si hay
+            const storeKeys = Object.keys(tiendasFisicasDisponibles);
+            if (storeKeys.length > 0) {
+                seleccionarTiendaFisica(storeKeys[0]);
+            }
+        });
+    }
+
+    if (shopModalClose && shopModal) {
+        shopModalClose.addEventListener('click', () => {
+            shopModal.classList.remove('active');
+            tiendaFisicaActivaId = null;
+        });
+    }
+
     db.ref('campaña/tiendas').on('value', (snapshot) => {
         const tiendas = snapshot.val() || {};
         let encontrada = false;
 
+        const playerName = document.querySelector('input[name="attr_character_name"]')?.value.trim();
+
+        tiendasFisicasDisponibles = {};
+        let badgeImageSrc = null;
+
         for (const [id, data] of Object.entries(tiendas)) {
+            // Lógica App (En línea)
             if (data.activa === true) {
                 encontrada = true;
                 tiendaActivaId = id;
                 tiendaActivaData = data;
-                break;
+            }
+
+            // Lógica Física
+            if (data.fisica_activa === true && playerName && data.jugadores_presentes && data.jugadores_presentes[playerName]) {
+                tiendasFisicasDisponibles[id] = data;
+                if (!badgeImageSrc) badgeImageSrc = data.icono_fisico || data.icono || 'https://i.imgur.com/kP8s7Ww.png';
             }
         }
 
+        // Actualizar UI App
         const btnShop = document.getElementById('btn-app-shop');
         const shopApp = document.getElementById('shop-app');
 
@@ -3112,7 +3153,6 @@ window.addEventListener('DOMContentLoaded', () => {
             if (btnShop) btnShop.style.display = 'none';
             tiendaActivaData = null;
             tiendaActivaId = null;
-            // Si el jugador está dentro de la app, sacarlo al home
             const tabInput = document.querySelector('input[name="attr_tab"]');
             if (tabInput && tabInput.value === 'shop') {
                 if (window.setAttrs) {
@@ -3122,7 +3162,105 @@ window.addEventListener('DOMContentLoaded', () => {
                 }
             }
         }
+
+        // Actualizar UI Física (Badge)
+        if (badgeFisica) {
+            if (Object.keys(tiendasFisicasDisponibles).length > 0) {
+                badgeFisica.src = badgeImageSrc;
+                badgeFisica.style.display = 'block';
+                renderizarSidebarFisica();
+
+                // Si el modal está abierto, re-renderizar la grid actual
+                if (shopModal && shopModal.classList.contains('active') && tiendaFisicaActivaId) {
+                    if (tiendasFisicasDisponibles[tiendaFisicaActivaId]) {
+                        renderizarGridFisica(tiendaFisicaActivaId);
+                    } else {
+                        const storeKeys = Object.keys(tiendasFisicasDisponibles);
+                        if (storeKeys.length > 0) seleccionarTiendaFisica(storeKeys[0]);
+                        else shopModal.classList.remove('active');
+                    }
+                }
+            } else {
+                badgeFisica.style.display = 'none';
+                if (shopModal) shopModal.classList.remove('active');
+            }
+        }
     });
+
+    function renderizarSidebarFisica() {
+        const sidebar = document.getElementById('shop-sidebar-list');
+        if (!sidebar) return;
+
+        sidebar.innerHTML = '';
+
+        for (const [id, data] of Object.entries(tiendasFisicasDisponibles)) {
+            const btn = document.createElement('button');
+            btn.className = 'shop-btn';
+            if (id === tiendaFisicaActivaId) btn.classList.add('active');
+
+            const iconUrl = data.icono_fisico || data.icono || 'https://i.imgur.com/kP8s7Ww.png';
+            btn.innerHTML = `<img src="${iconUrl}" alt="${data.nombre}"> ${data.nombre}`;
+
+            btn.addEventListener('click', () => {
+                seleccionarTiendaFisica(id);
+            });
+
+            sidebar.appendChild(btn);
+        }
+    }
+
+    function seleccionarTiendaFisica(id) {
+        tiendaFisicaActivaId = id;
+        renderizarSidebarFisica();
+        renderizarGridFisica(id);
+    }
+
+    function renderizarGridFisica(idTienda) {
+        const grid = document.getElementById('shop-items-grid');
+        const title = document.getElementById('shop-active-name');
+        if (!grid || !title) return;
+
+        const data = tiendasFisicasDisponibles[idTienda];
+        if (!data) return;
+
+        title.innerText = data.nombre;
+        grid.innerHTML = '';
+
+        const items = data.items || {};
+        const modVenta = data.mod_venta || 100;
+
+        if (Object.keys(items).length === 0) {
+            grid.innerHTML = '<div style="color:#666; font-size: 20px; padding: 20px; grid-column: 1 / -1; text-align: center;">Sin inventario.</div>';
+            return;
+        }
+
+        for (const [itemId, item] of Object.entries(items)) {
+            const itemTier = parseInt(item.tier) || 1;
+            const valorConTier = Math.floor((item.costo || 0) * (1 + ((itemTier - 1) * 0.25)));
+            const precio = Math.floor(valorConTier * (modVenta / 100));
+            const isAgotado = item.stock_actual === 0;
+            const stockStr = item.stock_actual === -1 ? '∞' : item.stock_actual;
+            const tierStr = romanTiersShop[Math.min(itemTier, 10)] || 'I';
+
+            const card = document.createElement('div');
+            card.className = 'shop-item-card';
+
+            card.innerHTML = `
+                <div class="shop-item-image-container">
+                    <div class="shop-item-tier">${tierStr}</div>
+                    <img src="${item.icono || 'https://via.placeholder.com/80'}" alt="${item.nombre}">
+                </div>
+                <div class="shop-item-details">
+                    <h4 class="shop-item-name">${item.nombre}</h4>
+                    <div style="font-size: 12px; color: #888; text-align: center;">Stock: ${stockStr}</div>
+                    <button class="shop-item-buy-btn btn-comprar-fisico" data-tienda="${idTienda}" data-item="${itemId}" data-precio="${precio}" ${isAgotado ? 'disabled' : ''}>
+                        <span class="currency-symbol">₳</span> ${precio}
+                    </button>
+                </div>
+            `;
+            grid.appendChild(card);
+        }
+    }
 
     // Función para manejar las pestañas internas de la app de tienda
     document.addEventListener('click', (e) => {
@@ -3148,72 +3286,122 @@ window.addEventListener('DOMContentLoaded', () => {
         const playerName = document.querySelector('input[name="attr_character_name"]')?.value.trim();
         if (!playerName) return;
 
-        // LÓGICA DE COMPRAR
-        if (e.target.classList.contains('btn-comprar-item') && !e.target.disabled) {
-            const itemId = e.target.getAttribute('data-id');
-            const precio = parseInt(e.target.getAttribute('data-precio'));
-            const itemTienda = tiendaActivaData.items[itemId];
+        // LÓGICA DE COMPRAR (App u Offline/Física)
+        const btnCompra = e.target.closest('.btn-comprar-item, .btn-comprar-fisico');
+        if (btnCompra && !btnCompra.disabled) {
+
+            const isFisico = btnCompra.classList.contains('btn-comprar-fisico');
+
+            const itemId = isFisico ? btnCompra.getAttribute('data-item') : btnCompra.getAttribute('data-id');
+            const precio = parseInt(btnCompra.getAttribute('data-precio'));
+
+            let idTiendaActual = null;
+            let tiendaActualData = null;
+
+            if (isFisico) {
+                idTiendaActual = btnCompra.getAttribute('data-tienda');
+                tiendaActualData = tiendasFisicasDisponibles[idTiendaActual];
+            } else {
+                idTiendaActual = tiendaActivaId;
+                tiendaActualData = tiendaActivaData;
+            }
+
+            if (!tiendaActualData || !tiendaActualData.items || !tiendaActualData.items[itemId]) return;
+            const itemTienda = tiendaActualData.items[itemId];
 
             db.ref(`campaña/jugadores/${playerName}/ahn`).once('value', snap => {
-                const currentAhn = snap.val() || 0;
-                if (currentAhn < precio) {
-                    alert('Ahn insuficiente.');
+                const ahn_actual = snap.val() || 0;
+                if (ahn_actual < precio) {
+                    alert('Fondos insuficientes.');
                     return;
                 }
 
-                // Restar Ahn
-                db.ref(`campaña/jugadores/${playerName}`).update({ ahn: currentAhn - precio });
+                // Restar Ahn estrictamente
+                db.ref(`campaña/jugadores/${playerName}/ahn`).set(ahn_actual - precio);
 
                 // Reducir Stock
                 if (itemTienda.stock_actual !== -1) {
-                    db.ref(`campaña/tiendas/${tiendaActivaId}/items/${itemId}/stock_actual`).transaction(current => {
+                    db.ref(`campaña/tiendas/${idTiendaActual}/items/${itemId}/stock_actual`).transaction(current => {
                         return (current || 0) - 1;
                     });
                 }
 
-                // Añadir al Stash (Update si existe, Push si no)
-                const stashRef = db.ref(`campaña/jugadores/${playerName}/inventario_stash`);
-                stashRef.once('value', stashSnap => {
-                    let foundKey = null;
-                    let currentCant = 0;
-                    stashSnap.forEach(child => {
-                        if (child.val().id === itemId && (child.val().tier || 1) == (itemTienda.tier || 1)) {
-                            foundKey = child.key;
-                            currentCant = child.val().cantidad || 1;
+                const itemToSave = {
+                    id: itemId,
+                    nombre: itemTienda.nombre,
+                    valorBase: itemTienda.costo, // Costo base
+                    tier: parseInt(itemTienda.tier) || 1,
+                    tipo: itemTienda.tipo || "Consumible",
+                    icono: itemTienda.icono || "",
+                    descripcion: itemTienda.descripcion || "",
+                    cantidad: 1
+                };
+                if (itemTienda.tags) itemToSave.tags = itemTienda.tags;
+
+
+                if (isFisico) {
+                    // Añadir directo al Stash (Física)
+                    const stashRef = db.ref(`campaña/jugadores/${playerName}/inventario_stash`);
+                    stashRef.once('value', stashSnap => {
+                        let foundKey = null;
+                        let currentCant = 0;
+                        stashSnap.forEach(child => {
+                            if (child.val().id === itemId && (child.val().tier || 1) == (itemTienda.tier || 1)) {
+                                foundKey = child.key;
+                                currentCant = child.val().cantidad || 1;
+                            }
+                        });
+
+                        if (foundKey) {
+                            stashRef.child(foundKey).update({ cantidad: currentCant + 1 });
+                        } else {
+                            stashRef.push(itemToSave);
                         }
+
+                        // Feedback visual Físico
+                        const originalHtml = btnCompra.innerHTML;
+                        btnCompra.innerText = "COMPRADO";
+                        btnCompra.style.background = "#0df";
+                        btnCompra.style.color = "#000";
+                        setTimeout(() => {
+                            if(btnCompra) {
+                                btnCompra.innerHTML = originalHtml;
+                                btnCompra.style.background = "";
+                                btnCompra.style.color = "";
+                            }
+                        }, 500);
                     });
+                } else {
+                    // Añadir a entregas pendientes (App En línea)
+                    const diasEntrega = tiendaActualData.dias_entrega || 0;
 
-                    if (foundKey) {
-                        stashRef.child(foundKey).update({ cantidad: currentCant + 1 });
-                    } else {
-                        // Construir el objeto a guardar
-                        const itemToSave = {
-                            id: itemId,
-                            nombre: itemTienda.nombre,
-                            valorBase: itemTienda.costo, // Costo base
-                            tier: parseInt(itemTienda.tier) || 1,
-                            tipo: itemTienda.tipo || "Consumible",
-                            icono: itemTienda.icono || "",
-                            descripcion: itemTienda.descripcion || "",
-                            cantidad: 1
-                        };
-                        if (itemTienda.tags) itemToSave.tags = itemTienda.tags;
-
-                        stashRef.push(itemToSave);
-                    }
-
-                    // Feedback visual
-                    const originalText = e.target.innerText;
-                    const originalBg = e.target.style.background;
-                    e.target.innerText = "¡OK!";
-                    e.target.style.background = "#0df";
-                    setTimeout(() => {
-                        if(e.target) {
-                            e.target.innerText = originalText;
-                            e.target.style.background = originalBg;
+                    db.ref('campaña/calendario').once('value').then(calSnap => {
+                        let diaLlegada = diasEntrega; // Fallback si no hay calendario
+                        const calendario = calSnap.val();
+                        if (calendario) {
+                            diaLlegada = calendario.dia + diasEntrega;
                         }
-                    }, 500);
-                });
+
+                        const entrega = {
+                            ...itemToSave,
+                            diaDeLlegada: diaLlegada
+                        };
+
+                        db.ref(`campaña/jugadores/${playerName}/entregasPendientes`).push(entrega).then(() => {
+                            // Feedback visual App
+                            const originalText = btnCompra.innerText;
+                            const originalBg = btnCompra.style.background;
+                            btnCompra.innerText = "¡OK!";
+                            btnCompra.style.background = "#0df";
+                            setTimeout(() => {
+                                if(btnCompra) {
+                                    btnCompra.innerText = originalText;
+                                    btnCompra.style.background = originalBg;
+                                }
+                            }, 500);
+                        });
+                    });
+                }
             });
         }
 

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -697,7 +697,18 @@
             <h4>Registrar Nueva Tienda</h4>
             <input type="text" id="tienda-nombre" placeholder="Nombre de la Tienda" />
             <input type="url" id="tienda-icono" placeholder="URL de Imagen/Ícono de Tienda" />
-            <select id="tienda-restock-dia">
+            <input type="url" id="tienda-icono-fisico" placeholder="URL de Icono Físico (Mapa/HUD)" />
+            <div style="display:flex;gap:10px;align-items:center;">
+              <label style="color:#0df; font-size:14px; cursor:pointer;"><input type="checkbox" id="tienda-fisica-activa" /> Tienda Física Activa</label>
+              <input type="number" id="tienda-dias-entrega" placeholder="Días Envío (App)" style="flex:1;" />
+            </div>
+            <div style="display:flex;gap:10px;align-items:center; margin-top:5px; border-bottom: 1px dashed #444; padding-bottom: 10px;">
+                <label style="color:#aaa; font-size:12px;">Jugadores Presentes:</label>
+                <div id="tienda-jugadores-presentes" style="display:flex; gap:5px; flex-wrap:wrap; flex:1;">
+                    <!-- Se inyectarán checkboxes de jugadores aquí -->
+                </div>
+            </div>
+            <select id="tienda-restock-dia" style="margin-top: 10px;">
               <option value="Lunes">Lunes</option>
               <option value="Martes">Martes</option>
               <option value="Miércoles">Miércoles</option>
@@ -1987,8 +1998,22 @@
                 recetaJugadores.appendChild(lbl);
             }
         }
+
+        // --- Populate Tienda Jugadores Presentes Checkboxes ---
+        const tiendaJugadoresPresentes = document.getElementById('tienda-jugadores-presentes');
+        if (tiendaJugadoresPresentes) {
+            tiendaJugadoresPresentes.innerHTML = '';
+            for (const nombre of Object.keys(jugadores)) {
+                const lbl = document.createElement('label');
+                lbl.style.cssText = 'color:#fff; font-size:12px; display:flex; align-items:center; gap:3px; background:#111; padding:3px 6px; border-radius:3px; border:1px solid #333; cursor:pointer;';
+                lbl.innerHTML = `<input type="checkbox" value="${nombre}" class="tienda-jugador-cb" /> ${nombre}`;
+                tiendaJugadoresPresentes.appendChild(lbl);
+            }
+        }
       } else {
         bancoContainer.innerHTML = '<span style="color: #888;">No hay jugadores activos.</span>';
+        const tiendaJugadoresPresentes = document.getElementById('tienda-jugadores-presentes');
+        if (tiendaJugadoresPresentes) tiendaJugadoresPresentes.innerHTML = '<span style="color:#888; font-size:12px;">Sin jugadores</span>';
       }
     });
 
@@ -2552,6 +2577,10 @@
     function resetTiendaForm() {
         document.getElementById('tienda-nombre').value = '';
         document.getElementById('tienda-icono').value = '';
+        document.getElementById('tienda-icono-fisico').value = '';
+        document.getElementById('tienda-fisica-activa').checked = false;
+        document.getElementById('tienda-dias-entrega').value = '';
+        document.querySelectorAll('.tienda-jugador-cb').forEach(cb => cb.checked = false);
         document.getElementById('tienda-restock-dia').value = 'Lunes';
         document.getElementById('tienda-mod-venta').value = '';
         document.getElementById('tienda-tasa-defecto').value = '';
@@ -2568,12 +2597,26 @@
     document.getElementById('btn-crear-tienda').addEventListener('click', () => {
         const nombre = document.getElementById('tienda-nombre').value.trim();
         const icono = document.getElementById('tienda-icono').value.trim();
+        let iconoFisico = document.getElementById('tienda-icono-fisico').value.trim();
+        const fisicaActiva = document.getElementById('tienda-fisica-activa').checked;
+        const diasEntrega = parseInt(document.getElementById('tienda-dias-entrega').value) || 0;
         const diaRestock = document.getElementById('tienda-restock-dia').value;
         const modVenta = parseInt(document.getElementById('tienda-mod-venta').value) || 100;
         const tasaDefecto = parseInt(document.getElementById('tienda-tasa-defecto').value);
 
         if (!nombre) { alert("El nombre de la tienda es requerido."); return; }
         if (isNaN(tasaDefecto)) { alert("La tasa por defecto es requerida."); return; }
+
+        if (fisicaActiva && !iconoFisico) {
+            iconoFisico = 'https://i.imgur.com/kP8s7Ww.png'; // Ciberpunk default icon
+        }
+
+        const jugadoresPresentes = {};
+        document.querySelectorAll('.tienda-jugador-cb').forEach(cb => {
+            if (cb.checked) {
+                jugadoresPresentes[cb.value] = true;
+            }
+        });
 
         const isEditing = editModeTiendaKey !== null;
         // In edit mode, if name didn't change enough to alter ID, we use the original.
@@ -2582,6 +2625,10 @@
         const tiendaData = {
             nombre: nombre,
             icono: icono,
+            icono_fisico: iconoFisico,
+            fisica_activa: fisicaActiva,
+            dias_entrega: diasEntrega,
+            jugadores_presentes: jugadoresPresentes,
             dia_restock: diaRestock,
             mod_venta: modVenta,
             tasas_por_etiqueta: currentTiendaReglas,
@@ -2634,6 +2681,12 @@
                     editModeTiendaKey = idTienda;
                     document.getElementById('tienda-nombre').value = data.nombre || '';
                     document.getElementById('tienda-icono').value = data.icono || '';
+                    document.getElementById('tienda-icono-fisico').value = data.icono_fisico || '';
+                    document.getElementById('tienda-fisica-activa').checked = data.fisica_activa || false;
+                    document.getElementById('tienda-dias-entrega').value = data.dias_entrega !== undefined ? data.dias_entrega : '';
+                    document.querySelectorAll('.tienda-jugador-cb').forEach(cb => {
+                        cb.checked = !!(data.jugadores_presentes && data.jugadores_presentes[cb.value]);
+                    });
                     document.getElementById('tienda-restock-dia').value = data.dia_restock || 'Lunes';
                     document.getElementById('tienda-mod-venta').value = data.mod_venta !== undefined ? data.mod_venta : '';
                     document.getElementById('tienda-tasa-defecto').value = data.tasa_defecto !== undefined ? data.tasa_defecto : '';


### PR DESCRIPTION
This PR completely refactors the shopping experience to emulate the Limbus Company Dispensary visual style, and adds new mechanics for separating "Online App" purchases from "Physical Location" purchases. 

**Key Changes:**
1. **DM Screen (`pantalla_dm.html`):** DMs can now check a `Tienda Física Activa` box, assign an icon for the HUD, set delivery delays for online usage, and manually check which players are present at the location.
2. **Player HUD (`hoja_personaje.html` & `.css`):** An animated, glowing cyan badge now appears over the global inventory button when the player is physically present at a store.
3. **New Interface:** Clicking the badge opens a fullscreen, immersive modal matching the prompt's specifications (dark sidebar for locations, `.shop-item-card` style grids).
4. **Strict Logic (`hoja_personaje.js`):** The `comprar` event listener was refactored to handle both physical and online modes simultaneously. It explicitly reads the current balance, halts if insufficient, and correctly routes the items. Physical purchases push directly to the stash (combining quantities if the item already exists), while online app purchases queue into `entregasPendientes` calculated against the current game day and the store's delivery delay.

---
*PR created automatically by Jules for task [2670045341469458633](https://jules.google.com/task/2670045341469458633) started by @sokcrow*