### PR TITLE
Enable Narrator Mode in Theatre of Mind

### DIFF
--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -4425,16 +4425,11 @@
       });
   });
 
-  function getCurrentPlayerName() {
-      const el = document.querySelector('input[name="attr_character_name"]');
-      return el ? el.value.trim() : null;
-  }
-
   // Watch for current player's actor assignment
   setInterval(() => {
-      const currentPlayerName = getCurrentPlayerName();
-      if (currentPlayerName) {
-          db.ref(`campaña/jugadores/${currentPlayerName}/actor_id`).once('value').then(snap => {
+      const playerId = localStorage.getItem('playerId');
+      if (playerId) {
+          db.ref(`campaña/jugadores/${playerId}/actor_id`).once('value').then(snap => {
               const actorId = snap.val();
               if (actorId) {
                   db.ref(`campaña/actores/${actorId}`).once('value').then(actorSnap => {
@@ -4492,9 +4487,10 @@
 
       // Fallback if no actor assigned
       if (!actorData) {
-          const currentPlayerName = getCurrentPlayerName();
+          const charNameInput = document.querySelector('input[name="attr_character_name"]');
+          const fallbackName = charNameInput && charNameInput.value.trim() ? charNameInput.value.trim() : (localStorage.getItem('playerId') || "Jugador");
           actorData = {
-              nombre: currentPlayerName || "Jugador",
+              nombre: fallbackName,
               titulo: "Sin Asignar",
               color_nombre: "#ffffff",
               color_titulo: "#aaaaaa",

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -4307,6 +4307,15 @@
       const namePlate = document.getElementById('player-theatre-plate-name');
       const textBox = document.getElementById('player-theatre-dialogue-text');
 
+      const platesContainer = document.querySelector('.theatre-plates-container');
+      if (platesContainer) {
+          if (!state.nombre || state.nombre.trim() === "") {
+              platesContainer.style.display = 'none';
+          } else {
+              platesContainer.style.display = 'flex';
+          }
+      }
+
       if (titlePlate) {
           if(titlePlate.querySelector('span')) titlePlate.querySelector('span').innerText = state.titulo || ''; else if(titlePlate.querySelector('span')) {
             titlePlate.querySelector('span').innerText = state.titulo || '';
@@ -4351,7 +4360,18 @@
       const activeName = state.nombre || 'Desconocido';
       const actorEscala = state.escala !== undefined ? state.escala : 1.0;
 
-      if (!activeSpriteUrl) return;
+      if (!activeSpriteUrl || activeSpriteUrl.trim() === "") {
+          // Narrator mode: dim all existing sprites and return
+          Array.from(stage.children).forEach(wrapper => {
+              let img = wrapper.querySelector('img');
+              if (img) {
+                  img.className = 'sprite-dimmed';
+                  img.style.filter = 'brightness(0.4) grayscale(0.5)';
+                  img.style.transform = 'translateX(-50%) scale(0.95)';
+              }
+          });
+          return;
+      }
 
       let existingWrapper = Array.from(stage.children).find(wrapper => wrapper.dataset.name === activeName);
 
@@ -4405,8 +4425,14 @@
       });
   });
 
+  function getCurrentPlayerName() {
+      const el = document.querySelector('input[name="attr_character_name"]');
+      return el ? el.value.trim() : null;
+  }
+
   // Watch for current player's actor assignment
   setInterval(() => {
+      const currentPlayerName = getCurrentPlayerName();
       if (currentPlayerName) {
           db.ref(`campaña/jugadores/${currentPlayerName}/actor_id`).once('value').then(snap => {
               const actorId = snap.val();
@@ -4466,6 +4492,7 @@
 
       // Fallback if no actor assigned
       if (!actorData) {
+          const currentPlayerName = getCurrentPlayerName();
           actorData = {
               nombre: currentPlayerName || "Jugador",
               titulo: "Sin Asignar",

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -3718,6 +3718,15 @@
         const namePlate = document.getElementById('theatre-plate-name');
         const textBox = document.getElementById('theatre-dialogue-text');
 
+        const platesContainer = document.querySelector('.theatre-plates-container');
+        if (platesContainer) {
+            if (!state.nombre || state.nombre.trim() === "") {
+                platesContainer.style.display = 'none';
+            } else {
+                platesContainer.style.display = 'flex';
+            }
+        }
+
         if(titlePlate.querySelector('span')) titlePlate.querySelector('span').innerText = state.titulo || ''; else if(titlePlate.querySelector('span')) {
             titlePlate.querySelector('span').innerText = state.titulo || '';
         } else {
@@ -3758,7 +3767,18 @@
         const activeName = state.nombre || 'Desconocido';
         const actorEscala = state.escala !== undefined ? state.escala : 1.0;
 
-        if (!activeSpriteUrl) return;
+        if (!activeSpriteUrl || activeSpriteUrl.trim() === "") {
+            // Narrator mode: dim all existing sprites and return
+            Array.from(stage.children).forEach(wrapper => {
+                let img = wrapper.querySelector('img');
+                if (img) {
+                    img.className = 'sprite-dimmed';
+                    img.style.filter = 'brightness(0.4) grayscale(0.5)';
+                    img.style.transform = 'translateX(-50%) scale(0.95)';
+                }
+            });
+            return;
+        }
 
         // Ensure we track by name to update expressions instead of duplicating
         let existingWrapper = Array.from(stage.children).find(wrapper => wrapper.dataset.name === activeName);
@@ -3821,22 +3841,40 @@
         const selectedNpcId = activeSpeakerId;
 
         // Priority 1: DM Input (Overrides Queue)
-        if (dmInput && selectedNpcId) {
-            const actorData = dbActoresCache[selectedNpcId];
-            if (actorData) {
-                const exprSelect = document.getElementById('dm-expression-select');
-                const selectedSprite = exprSelect && exprSelect.style.display !== 'none' ? exprSelect.value : actorData.sprite;
+        if (dmInput) {
+            let state;
+            if (selectedNpcId) {
+                const actorData = dbActoresCache[selectedNpcId];
+                if (actorData) {
+                    const exprSelect = document.getElementById('dm-expression-select');
+                    const selectedSprite = exprSelect && exprSelect.style.display !== 'none' ? exprSelect.value : actorData.sprite;
 
-                const state = {
-                    nombre: actorData.nombre,
-                    titulo: actorData.titulo,
-                    color_nombre: actorData.color_nombre,
-                    color_titulo: actorData.color_titulo,
-                    escala: actorData.escala !== undefined ? actorData.escala : 1.0,
-                    sprite: selectedSprite,
+                    state = {
+                        nombre: actorData.nombre,
+                        titulo: actorData.titulo,
+                        color_nombre: actorData.color_nombre,
+                        color_titulo: actorData.color_titulo,
+                        escala: actorData.escala !== undefined ? actorData.escala : 1.0,
+                        sprite: selectedSprite,
+                        mensaje: dmInput,
+                        timestamp: Date.now()
+                    };
+                }
+            } else {
+                // Narrator Mode (No NPC selected)
+                state = {
+                    nombre: "",
+                    titulo: "",
+                    color_nombre: "transparent",
+                    color_titulo: "transparent",
+                    escala: 1.0,
+                    sprite: "",
                     mensaje: dmInput,
                     timestamp: Date.now()
                 };
+            }
+
+            if (state) {
                 db.ref('campaña/teatro/estado_actual').set(state);
                 document.getElementById('dm-theatre-input').value = ''; // clear input
                 return;


### PR DESCRIPTION
Implemented a feature requested by the user to allow the DM to describe scenes in the "Teatro de la Mente" without an actor's nameplate showing. This allows for ambient "narrator" text. 

Changes include:
1.  **DM Output:** The `btn-theatre-avanzar` action in `pantalla_dm.html` now falls back to a special "narrator" state when no NPC is selected from the stage, sending empty strings for the name, title, and sprite properties.
2.  **Display Toggle:** The Firebase real-time listener for `estado_actual` in both the DM and Player HTML files now hides the `.theatre-plates-container` completely if the incoming state has an empty or null `nombre`.
3.  **Sprite Dimming:** If the incoming state has an empty `sprite` (typical for ambient narration), the UI iterates through any currently visible sprites on stage and dims them (applying the `.sprite-dimmed` class), keeping the focus on the text instead of a specific character.
4.  **Bugfix:** Discovered and fixed an uninitialized `currentPlayerName` variable in `hoja_personaje.html`'s theatre logic, replacing it with a DOM lookup function `getCurrentPlayerName()` mapped to `attr_character_name`.

---
*PR created automatically by Jules for task [10594312938256824183](https://jules.google.com/task/10594312938256824183) started by @sokcrow*