### PR TITLE
Fix codex tabs not working

### DIFF
--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -432,6 +432,17 @@ window.addEventListener('DOMContentLoaded', () => {
             }
 
             // Lógica para cerrar ventanas
+
+            // Lógica para pestañas del Codex
+            if (actionName.startsWith('act_codex_')) {
+                const tabName = actionName.replace('act_codex_', '');
+                const codexStateInputs = document.querySelectorAll('.sheet-state-codex-tab');
+                codexStateInputs.forEach(input => {
+                    input.value = tabName;
+                    input.setAttribute('value', tabName);
+                });
+            }
+
             if (actionName === 'act_hud_close') {
                 document.querySelectorAll('.sheet-modal-container, .sheet-modal, .hud-modal').forEach(m => {
                     m.style.display = 'none';


### PR DESCRIPTION
The user reported that the codex tabs are not working, causing them to lose access to valuable information. 
The issue is that the tabs in the HTML rely on CSS sibling combinators with hidden `.sheet-state-codex-tab` inputs but lacked the JS listeners to update the inputs upon clicking the buttons (`act_codex_mechanics`, `act_codex_stats`, `act_codex_skills`).
Added event listeners in `hoja_personaje.js` for `act_codex_*` buttons to extract the tab name and update the value of `.sheet-state-codex-tab` inputs correctly. Tested visually and functionally.

---
*PR created automatically by Jules for task [6988373001672097344](https://jules.google.com/task/6988373001672097344) started by @sokcrow*