### PR TITLE
Add explicit actor selection dropdown in Theatre of the Mind

### DIFF
--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -3961,6 +3961,9 @@
 
   <!-- Player Input Area -->
   <div class="theatre-player-input-area" style="position: absolute; bottom: 0; left: 0; width: 100%; background: rgba(0,0,0,0.9); border-top: 2px solid #0df; padding: 15px; display: flex; gap: 15px; z-index: 2030; align-items: center; justify-content: center; box-sizing: border-box;">
+    <select id="player-actor-select" style="background: #111; color: #c49a00; border: 1px solid #c49a00; padding: 5px; font-family: 'Share Tech Mono'; outline: none;">
+        <option value="base">Mi Personaje</option>
+    </select>
     <select id="player-expression-select" style="padding: 15px; background: #222; color: #0df; border: 1px solid #444; border-radius: 4px; font-size: 16px; min-width: 120px; display: none;"></select>
     <input type="text" id="player-theatre-input" placeholder="¿Qué quieres decir o hacer? (Escribe aquí...)" style="flex: 1; max-width: 800px; padding: 15px; background: #111; color: #fff; border: 1px solid #555; border-radius: 4px; font-family: inherit; font-size: 16px;" />
     <button id="btn-player-theatre-send" style="background: #0df; color: #000; border: 1px solid #fff; padding: 15px 30px; font-size: 16px; font-weight: bold; cursor: pointer; text-transform: uppercase; border-radius: 4px; box-shadow: 0 0 15px rgba(0, 221, 255, 0.6);">ENVIAR</button>
@@ -4472,45 +4475,50 @@
   const inputEl = document.getElementById('player-theatre-input');
 
 function sendTheatreMessage(msgText) {
-    // 1. Tomar los datos de las variables globales directamente
-    let actor = window.actorActual;
-    let jugador = window.datosJugador;
+    const actorSelect = document.getElementById('player-actor-select');
+    const isActorSelected = (actorSelect && actorSelect.value === 'actor');
 
-    // 2. Si el DM no le ha puesto actor, crear uno de emergencia (Fallback)
-    if (!actor) {
-        const charName = (jugador && jugador.characterName) ? jugador.characterName : "Jugador";
-        actor = {
-            nombre: charName,
+    let actorParaEnviar;
+
+    // 1. ¿Eligió hablar como el Actor Asignado (Dothy/Charon)?
+    if (isActorSelected && window.actorActual) {
+        actorParaEnviar = window.actorActual;
+    }
+    // 2. ¿Eligió hablar como su Personaje Base (So)?
+    else {
+        const nombreBase = (window.datosJugador && window.datosJugador.characterName) ? window.datosJugador.characterName : "Jugador";
+        actorParaEnviar = {
+            nombre: nombreBase,
             titulo: "",
             color_nombre: "#ffffff",
             color_titulo: "#aaaaaa",
             escala: 1.0,
-            sprite: "https://i.imgur.com/Z8N4rG9.png"
+            sprite: "https://i.imgur.com/Z8N4rG9.png" // Transparente
         };
     }
 
-    // 3. Revisar si cambió de cara en el menú (Opcional)
+    // 3. Revisar el selector de expresiones
     const selectExp = document.getElementById('player-expression-select');
     const selectedSprite = (selectExp && selectExp.style.display !== 'none' && selectExp.value)
                             ? selectExp.value
-                            : actor.sprite;
+                            : actorParaEnviar.sprite;
 
     // 4. Empaquetar y enviar
     const payload = {
-        nombre: actor.nombre || "Desconocido",
-        titulo: actor.titulo || "",
-        color_nombre: actor.color_nombre || "#ffffff",
-        color_titulo: actor.color_titulo || "#aaaaaa",
-        escala: actor.escala !== undefined ? actor.escala : 1.0,
-        sprite: selectedSprite || actor.sprite,
+        nombre: actorParaEnviar.nombre || "Desconocido",
+        titulo: actorParaEnviar.titulo || "",
+        color_nombre: actorParaEnviar.color_nombre || "#ffffff",
+        color_titulo: actorParaEnviar.color_titulo || "#aaaaaa",
+        escala: actorParaEnviar.escala !== undefined ? actorParaEnviar.escala : 1.0,
+        sprite: selectedSprite || actorParaEnviar.sprite,
         mensaje: msgText,
         timestamp: Date.now()
     };
 
-    // 5. Empujar a Firebase
-    const inputEl = document.getElementById('theatre-chat-input');
+    // 5. Enviar a Firebase
+    const inputEl = document.getElementById('player-theatre-input');
     db.ref('campaña/teatro/cola').push(payload).then(() => {
-        if (inputEl) inputEl.value = ''; // Limpiar la caja de texto
+        if (inputEl) inputEl.value = '';
     }).catch(e => console.error("Error enviando mensaje:", e));
 }
 

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -112,9 +112,38 @@ db.ref('campaña/jugadores/' + playerId).on('value', (snapshot) => {
                 } else {
                     window.actorActual = null;
                 }
+
+                // --- LLENAR EL MENÚ DE ACTOR DEL JUGADOR ---
+                const actorSelect = document.getElementById('player-actor-select');
+                if (actorSelect && window.datosJugador) {
+                    // Guardar qué tenía seleccionado el jugador para no borrárselo
+                    const currentSelection = actorSelect.value;
+
+                    // Opción 1: Su personaje base
+                    actorSelect.innerHTML = `<option value="base">${window.datosJugador.characterName || "Mi Personaje"}</option>`;
+
+                    // Opción 2: Si el DM le asignó un actor, añadirlo
+                    if (window.actorActual) {
+                        actorSelect.innerHTML += `<option value="actor">[Actor] ${window.actorActual.nombre}</option>`;
+                        // Si apenas se lo asignaron y estaba en base, auto-seleccionar el actor
+                        if (currentSelection !== 'actor') {
+                            actorSelect.value = 'actor';
+                        } else {
+                            actorSelect.value = currentSelection;
+                        }
+                    }
+                }
             });
         } else {
             window.actorActual = null;
+
+            // --- LLENAR EL MENÚ DE ACTOR DEL JUGADOR ---
+            const actorSelect = document.getElementById('player-actor-select');
+            if (actorSelect && window.datosJugador) {
+                // Opción 1: Su personaje base
+                actorSelect.innerHTML = `<option value="base">${window.datosJugador.characterName || "Mi Personaje"}</option>`;
+                actorSelect.value = 'base';
+            }
         }
     }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,60 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "app",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "playwright": "^1.58.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "description": "Test character creation.",
+  "main": "hoja_personaje.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sokcrow/Luminos-Character-Maker.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/sokcrow/Luminos-Character-Maker/issues"
+  },
+  "homepage": "https://github.com/sokcrow/Luminos-Character-Maker#readme",
+  "dependencies": {
+    "playwright": "^1.58.2"
+  }
+}


### PR DESCRIPTION
Implemented an explicit actor selection dropdown for the 'Teatro de la Mente' system. Previously, the system used invisible forced assignment, which is now replaced with a user-facing `<select>` that explicitly lets players switch between their 'Base Character' and their 'Assigned Actor'. Modified both the HTML and JS payload sender (`sendTheatreMessage`) to respect this dropdown. Also fixed a bug in the old code where the text input wouldn't clear upon send.

---
*PR created automatically by Jules for task [11673362193853804829](https://jules.google.com/task/11673362193853804829) started by @sokcrow*