### PR TITLE
Filter DM player assignment dropdown to show only 'Jugador' actors

### DIFF
--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -3440,11 +3440,12 @@
             select.appendChild(defaultOpt);
 
             for (const [actorId, actorData] of Object.entries(dbActoresCache)) {
+                if (actorData.tipo !== 'Jugador') continue;
                 const opt = document.createElement('option');
                 opt.value = actorId;
                 const tag = actorData.tipo ? `[${actorData.tipo}] ` : '[NPC] ';
                 opt.innerText = tag + actorData.nombre;
-                if (playerData.actor_asignado === actorId) {
+                if (playerData.activeEntity === actorId) {
                     opt.selected = true;
                 }
                 select.appendChild(opt);
@@ -3453,7 +3454,7 @@
             select.addEventListener('change', (e) => {
                 const selectedActorId = e.target.value;
                 db.ref(`campaña/jugadores/${playerName}`).update({
-                    actor_asignado: selectedActorId
+                    activeEntity: selectedActorId
                 }).then(() => {
                     console.log(`Actor asignado a ${playerName}: ${selectedActorId}`);
                 }).catch(err => alert("Error al asignar actor: " + err));


### PR DESCRIPTION
This commit resolves the issue where the dropdown menu for assigning characters to players showed all available actors, including NPCs. It filters the actor database strictly for 'Jugador' type entities when populating the dropdown. In addition, it standardizes the object property used to track this relationship across the codebase to `activeEntity`, ensuring correct bidirectional syncing with the character sheet UI.

---
*PR created automatically by Jules for task [2752555177153165241](https://jules.google.com/task/2752555177153165241) started by @sokcrow*