### PR TITLE
feat(theatre): implement dynamic player actor selection

### DIFF
--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -4476,15 +4476,15 @@
 
 function sendTheatreMessage(msgText) {
     const actorSelect = document.getElementById('player-actor-select');
-    const isActorSelected = (actorSelect && actorSelect.value === 'actor');
+    const selectedKey = actorSelect ? actorSelect.value : 'base';
 
     let actorParaEnviar;
 
-    // 1. ¿Eligió hablar como el Actor Asignado (Dothy/Charon)?
-    if (isActorSelected && window.actorActual) {
-        actorParaEnviar = window.actorActual;
+    // 1. ¿Eligió a un actor de la lista?
+    if (selectedKey !== 'base' && window.actoresJugador && window.actoresJugador[selectedKey]) {
+        actorParaEnviar = window.actoresJugador[selectedKey];
     }
-    // 2. ¿Eligió hablar como su Personaje Base (So)?
+    // 2. ¿Eligió su personaje base?
     else {
         const nombreBase = (window.datosJugador && window.datosJugador.characterName) ? window.datosJugador.characterName : "Jugador";
         actorParaEnviar = {

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -96,55 +96,39 @@ let currentActorListener = null;
 
 // VARIABLES GLOBALES ESTRICTAS
 window.datosJugador = null;
-window.actorActual = null;
+window.actoresJugador = {}; // Guardará todos los actores tipo "Jugador"
 
+// Listener del personaje
 db.ref('campaña/jugadores/' + playerId).on('value', (snapshot) => {
     if (snapshot.exists()) {
         window.datosJugador = snapshot.val();
         renderCharacterSheet(window.datosJugador);
+    }
+});
 
-        // El puente: Leer el actor asignado (Ej. "dothy")
-        const entidadAsignada = window.datosJugador.activeEntity;
-        if (entidadAsignada && entidadAsignada !== "") {
-            db.ref('campaña/actores/' + entidadAsignada).on('value', (actorSnap) => {
-                if (actorSnap.exists()) {
-                    window.actorActual = actorSnap.val();
-                } else {
-                    window.actorActual = null;
-                }
+// Listener para llenar el menú con los Actores tipo "Jugador"
+db.ref('campaña/actores').on('value', (snapshot) => {
+    const actorSelect = document.getElementById('player-actor-select');
+    if (!actorSelect || !snapshot.exists()) return;
 
-                // --- LLENAR EL MENÚ DE ACTOR DEL JUGADOR ---
-                const actorSelect = document.getElementById('player-actor-select');
-                if (actorSelect && window.datosJugador) {
-                    // Guardar qué tenía seleccionado el jugador para no borrárselo
-                    const currentSelection = actorSelect.value;
+    const currentSelection = actorSelect.value;
+    const nombreBase = (window.datosJugador && window.datosJugador.characterName) ? window.datosJugador.characterName : "Mi Personaje";
 
-                    // Opción 1: Su personaje base
-                    actorSelect.innerHTML = `<option value="base">${window.datosJugador.characterName || "Mi Personaje"}</option>`;
+    // Reiniciar menú
+    actorSelect.innerHTML = `<option value="base">${nombreBase}</option>`;
+    window.actoresJugador = {};
 
-                    // Opción 2: Si el DM le asignó un actor, añadirlo
-                    if (window.actorActual) {
-                        actorSelect.innerHTML += `<option value="actor">[Actor] ${window.actorActual.nombre}</option>`;
-                        // Si apenas se lo asignaron y estaba en base, auto-seleccionar el actor
-                        if (currentSelection !== 'actor') {
-                            actorSelect.value = 'actor';
-                        } else {
-                            actorSelect.value = currentSelection;
-                        }
-                    }
-                }
-            });
-        } else {
-            window.actorActual = null;
-
-            // --- LLENAR EL MENÚ DE ACTOR DEL JUGADOR ---
-            const actorSelect = document.getElementById('player-actor-select');
-            if (actorSelect && window.datosJugador) {
-                // Opción 1: Su personaje base
-                actorSelect.innerHTML = `<option value="base">${window.datosJugador.characterName || "Mi Personaje"}</option>`;
-                actorSelect.value = 'base';
-            }
+    const actores = snapshot.val();
+    for (const [key, actor] of Object.entries(actores)) {
+        if (actor.tipo === "Jugador") {
+            window.actoresJugador[key] = actor; // Guardar en el diccionario global
+            actorSelect.innerHTML += `<option value="${key}">[Actor] ${actor.nombre}</option>`;
         }
+    }
+
+    // Restaurar la selección previa si el jugador ya había escogido uno
+    if (currentSelection && actorSelect.querySelector(`option[value="${currentSelection}"]`)) {
+        actorSelect.value = currentSelection;
     }
 });
 


### PR DESCRIPTION
This PR updates the "Teatro de la Mente" chat logic in the character sheet. Players are no longer restricted to a single assigned actor (`activeEntity`). Instead, a new Firebase listener fetches all actors of type "Jugador" and populates a dropdown menu. Players can now freely choose which actor to speak as, or default to their base character. The message sending logic has been refactored to read directly from this selection and a new global `window.actoresJugador` object.

---
*PR created automatically by Jules for task [4245361471979631216](https://jules.google.com/task/4245361471979631216) started by @sokcrow*