### PR TITLE
Fix Theatre of Mind to strictly use selected Actor ID

### DIFF
--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -4428,48 +4428,6 @@
       });
   });
 
-  // Updated from hoja_personaje.js listener
-  let currentPlayerName = "Jugador";
-  window.updatePlayerTheatreData = function(actorData, playerName) {
-      currentAssignedActor = actorData;
-      if (playerName) {
-          currentPlayerName = playerName;
-      }
-      const selectExp = document.getElementById('player-expression-select');
-      if (currentAssignedActor && currentAssignedActor.expresiones) {
-          const numExpresiones = Object.keys(currentAssignedActor.expresiones).length;
-          if (numExpresiones > 0) {
-              selectExp.style.display = 'block';
-          } else {
-              selectExp.style.display = 'none';
-          }
-          const actorId = actorData.id || playerName; // Fallback for ID
-          // Only populate if empty, changed actor, or number of expressions changed
-          if (selectExp.options.length === 0 || selectExp.getAttribute('data-actor') !== actorId || parseInt(selectExp.getAttribute('data-count')) !== numExpresiones) {
-              const currentVal = selectExp.value;
-              selectExp.innerHTML = '';
-              for (const [name, url] of Object.entries(currentAssignedActor.expresiones)) {
-                  const opt = document.createElement('option');
-                  opt.value = url;
-                  opt.textContent = name;
-                  selectExp.appendChild(opt);
-              }
-              selectExp.setAttribute('data-actor', actorId);
-              selectExp.setAttribute('data-count', numExpresiones);
-              if (currentVal) {
-                  // Restore selection if the url is still valid
-                  const exists = Array.from(selectExp.options).some(opt => opt.value === currentVal);
-                  if (exists) selectExp.value = currentVal;
-              }
-          }
-      } else {
-          if (selectExp) {
-              selectExp.style.display = 'none';
-              selectExp.removeAttribute('data-count');
-          }
-      }
-  };
-
   // Send Dialogue logic
   const btnSend = document.getElementById('btn-player-theatre-send');
   const inputEl = document.getElementById('player-theatre-input');

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -4476,16 +4476,15 @@
 
 function sendTheatreMessage(msgText) {
     const actorSelect = document.getElementById('player-actor-select');
-    const selectedKey = actorSelect ? actorSelect.value : 'base';
+    const selectedActorId = actorSelect ? actorSelect.value : 'base'; // LEE EL ACTOR ID
 
     let actorParaEnviar;
 
-    // 1. ¿Eligió a un actor de la lista?
-    if (selectedKey !== 'base' && window.actoresJugador && window.actoresJugador[selectedKey]) {
-        actorParaEnviar = window.actoresJugador[selectedKey];
-    }
-    // 2. ¿Eligió su personaje base?
-    else {
+    // ¿Eligió un Actor ID válido de la lista?
+    if (selectedActorId !== 'base' && window.actoresJugador && window.actoresJugador[selectedActorId]) {
+        actorParaEnviar = window.actoresJugador[selectedActorId];
+    } else {
+        // Fallback al personaje base
         const nombreBase = (window.datosJugador && window.datosJugador.characterName) ? window.datosJugador.characterName : "Jugador";
         actorParaEnviar = {
             nombre: nombreBase,
@@ -4493,17 +4492,16 @@ function sendTheatreMessage(msgText) {
             color_nombre: "#ffffff",
             color_titulo: "#aaaaaa",
             escala: 1.0,
-            sprite: "https://i.imgur.com/Z8N4rG9.png" // Transparente
+            sprite: "https://i.imgur.com/Z8N4rG9.png"
         };
     }
 
-    // 3. Revisar el selector de expresiones
+    // Leer la cara seleccionada
     const selectExp = document.getElementById('player-expression-select');
     const selectedSprite = (selectExp && selectExp.style.display !== 'none' && selectExp.value)
                             ? selectExp.value
                             : actorParaEnviar.sprite;
 
-    // 4. Empaquetar y enviar
     const payload = {
         nombre: actorParaEnviar.nombre || "Desconocido",
         titulo: actorParaEnviar.titulo || "",
@@ -4515,7 +4513,6 @@ function sendTheatreMessage(msgText) {
         timestamp: Date.now()
     };
 
-    // 5. Enviar a Firebase
     const inputEl = document.getElementById('player-theatre-input');
     db.ref('campaña/teatro/cola').push(payload).then(() => {
         if (inputEl) inputEl.value = '';

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -160,11 +160,12 @@ window.actualizarExpresionesDesdeDropdown = function() {
     selectExp.style.display = 'none';
 };
 
-// 4. Asignar el evento para que cambien las caras cuando cambie el actor
-document.addEventListener('DOMContentLoaded', () => {
-    const actorSelectElement = document.getElementById('player-actor-select');
-    if (actorSelectElement) {
-        actorSelectElement.addEventListener('change', window.actualizarExpresionesDesdeDropdown);
+// 4. Asignar el evento GLOBALMENTE (Event Delegation) a prueba de fallos
+document.addEventListener('change', (e) => {
+    if (e.target && e.target.id === 'player-actor-select') {
+        if (typeof window.actualizarExpresionesDesdeDropdown === 'function') {
+            window.actualizarExpresionesDesdeDropdown();
+        }
     }
 });
 

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -146,13 +146,37 @@ window.actualizarExpresionesDesdeDropdown = function() {
         const actor = window.actoresJugador[selectedActorId];
         if (actor.expresiones) {
             selectExp.style.display = 'inline-block';
-            for (const [nombreExp, urlSprite] of Object.entries(actor.expresiones)) {
-                const option = document.createElement('option');
-                option.value = urlSprite;
-                option.textContent = nombreExp;
-                selectExp.appendChild(option);
+
+            // Handle array of objects format (e.g. [{nombre: '...', url: '...'}] from Firebase)
+            if (Array.isArray(actor.expresiones)) {
+                actor.expresiones.forEach(exp => {
+                    if (exp && exp.nombre && exp.url) {
+                        const option = document.createElement('option');
+                        option.value = exp.url;
+                        option.textContent = exp.nombre;
+                        selectExp.appendChild(option);
+                    }
+                });
+            } else {
+                // Legacy dictionary format ({'Feliz': 'url...', ...})
+                for (const [nombreExp, urlSprite] of Object.entries(actor.expresiones)) {
+                    // Check if the value is actually an object (malformed dictionary from Firebase array mutation)
+                    if (typeof urlSprite === 'object' && urlSprite !== null) {
+                       const option = document.createElement('option');
+                       option.value = urlSprite.url || urlSprite.sprite || '';
+                       option.textContent = urlSprite.nombre || urlSprite.name || nombreExp;
+                       if (option.value) selectExp.appendChild(option);
+                    } else {
+                        const option = document.createElement('option');
+                        option.value = urlSprite;
+                        option.textContent = nombreExp;
+                        selectExp.appendChild(option);
+                    }
+                }
             }
-            return; // Termina la función aquí si hay éxito
+
+            // Si después de todo no hay opciones, ocultar
+            if (selectExp.options.length > 0) return;
         }
     }
 

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -96,9 +96,9 @@ let currentActorListener = null;
 
 // VARIABLES GLOBALES ESTRICTAS
 window.datosJugador = null;
-window.actoresJugador = {}; // Guardará todos los actores tipo "Jugador"
+window.actoresJugador = {}; // Diccionario global por Actor ID
 
-// Listener del personaje
+// 1. Descargar datos base del jugador
 db.ref('campaña/jugadores/' + playerId).on('value', (snapshot) => {
     if (snapshot.exists()) {
         window.datosJugador = snapshot.val();
@@ -106,7 +106,7 @@ db.ref('campaña/jugadores/' + playerId).on('value', (snapshot) => {
     }
 });
 
-// Listener para llenar el menú con los Actores tipo "Jugador"
+// 2. Llenar el menú principal con los Actores (Usando el Actor ID)
 db.ref('campaña/actores').on('value', (snapshot) => {
     const actorSelect = document.getElementById('player-actor-select');
     if (!actorSelect || !snapshot.exists()) return;
@@ -114,21 +114,57 @@ db.ref('campaña/actores').on('value', (snapshot) => {
     const currentSelection = actorSelect.value;
     const nombreBase = (window.datosJugador && window.datosJugador.characterName) ? window.datosJugador.characterName : "Mi Personaje";
 
-    // Reiniciar menú
     actorSelect.innerHTML = `<option value="base">${nombreBase}</option>`;
     window.actoresJugador = {};
 
     const actores = snapshot.val();
-    for (const [key, actor] of Object.entries(actores)) {
-        if (actor.tipo === "Jugador") {
-            window.actoresJugador[key] = actor; // Guardar en el diccionario global
-            actorSelect.innerHTML += `<option value="${key}">[Actor] ${actor.nombre}</option>`;
+    for (const [actorId, actorData] of Object.entries(actores)) {
+        if (actorData.tipo === "Jugador") {
+            // Guardamos en el diccionario usando el Actor ID exacto
+            window.actoresJugador[actorId] = actorData;
+            actorSelect.innerHTML += `<option value="${actorId}">[Actor] ${actorData.nombre}</option>`;
         }
     }
 
-    // Restaurar la selección previa si el jugador ya había escogido uno
     if (currentSelection && actorSelect.querySelector(`option[value="${currentSelection}"]`)) {
         actorSelect.value = currentSelection;
+    }
+
+    window.actualizarExpresionesDesdeDropdown();
+});
+
+// 3. Función que inyecta las expresiones basada en el Actor ID seleccionado
+window.actualizarExpresionesDesdeDropdown = function() {
+    const actorSelect = document.getElementById('player-actor-select');
+    const selectExp = document.getElementById('player-expression-select');
+    if (!actorSelect || !selectExp) return;
+
+    const selectedActorId = actorSelect.value; // ESTE ES EL ACTOR ID
+    selectExp.innerHTML = '';
+
+    if (selectedActorId !== 'base' && window.actoresJugador && window.actoresJugador[selectedActorId]) {
+        const actor = window.actoresJugador[selectedActorId];
+        if (actor.expresiones) {
+            selectExp.style.display = 'inline-block';
+            for (const [nombreExp, urlSprite] of Object.entries(actor.expresiones)) {
+                const option = document.createElement('option');
+                option.value = urlSprite;
+                option.textContent = nombreExp;
+                selectExp.appendChild(option);
+            }
+            return; // Termina la función aquí si hay éxito
+        }
+    }
+
+    // Ocultar si es el personaje base o no tiene expresiones
+    selectExp.style.display = 'none';
+};
+
+// 4. Asignar el evento para que cambien las caras cuando cambie el actor
+document.addEventListener('DOMContentLoaded', () => {
+    const actorSelectElement = document.getElementById('player-actor-select');
+    if (actorSelectElement) {
+        actorSelectElement.addEventListener('change', window.actualizarExpresionesDesdeDropdown);
     }
 });
 


### PR DESCRIPTION
This branch refactors the logic powering the Theatre of Mind functionality in `hoja_personaje.js` and `hoja_personaje.html`. It completely ignores any `activeEntity` logic and directly relies on the selected Actor ID from the UI dropdown. The global mapping now accurately keys players to their Actor ID, allowing `sendTheatreMessage` to correctly bundle the expression sprites for the active character or fall back to the base character attributes.

---
*PR created automatically by Jules for task [7579522635649076804](https://jules.google.com/task/7579522635649076804) started by @sokcrow*