### PR TITLE
Fix unequip stash UI disappearance bug

### DIFF
--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -708,7 +708,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
     function filterStashItems() {
         const query = searchInputStash ? searchInputStash.value.toLowerCase() : '';
-        let activeFilter = 'Todo';
+        let activeFilter = 'todo';
 
         filterBtnsStash.forEach(btn => {
             if (btn.classList.contains('active')) {


### PR DESCRIPTION
Resolves a bug reported by users where unequipping an item from the active inventory caused it to seemingly disappear rather than going to the stash (`inventario_stash`).

**Root Cause:**
While the backend Firebase logic correctly updated both `inventario_activo` and `inventario_stash`, the UI re-render triggered a `filterStashItems` method call. The default `activeFilter` was mistakenly capitalized as `'Todo'`. Because the filtering function compares tags strictly using lowercase strings (`tags.includes(activeFilter) || activeFilter === 'todo'`), the mismatched `'Todo'` evaluated to false. This resulted in the UI hiding all valid stash items via `display: none`. 

**Fix:**
Changed the `activeFilter` initialization in `hoja_personaje.js` from `'Todo'` to `'todo'`, ensuring the default fallback filter passes the conditional checks and appropriately displays stash items. Evaluated and confirmed visually via Playwright headless verification tests.

---
*PR created automatically by Jules for task [13524771392810320967](https://jules.google.com/task/13524771392810320967) started by @sokcrow*