### PR TITLE
fix: strictly advance global time by 5 minutes on button click

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,23 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@playwright/test": "^1.58.2",
         "playwright": "^1.58.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fsevents": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/sokcrow/Luminos-Character-Maker#readme",
   "dependencies": {
+    "@playwright/test": "^1.58.2",
     "playwright": "^1.58.2"
   }
 }

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -545,7 +545,7 @@
         <div style="display: flex; gap: 10px;">
           <input type="time" id="dm-time-input">
           <button id="btn-fijar-hora">Fijar Hora</button>
-          <button id="btn-avanzar-hora">+ 5-10 Min</button>
+          <button id="btn-avanzar-hora">+ 5 Min</button>
         </div>
       </div>
 
@@ -1640,8 +1640,7 @@
       if (currentTime) {
         let [hours, minutes] = currentTime.split(':').map(Number);
 
-        // Random amount between 5 and 10 minutes
-        const minutesToAdd = Math.floor(Math.random() * (10 - 5 + 1)) + 5;
+        const minutesToAdd = 5;
 
         minutes += minutesToAdd;
 

--- a/test_time.js
+++ b/test_time.js
@@ -1,0 +1,47 @@
+const { chromium } = require('playwright');
+const path = require('path');
+
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const filePath = path.join(__dirname, 'pantalla_dm.html');
+  await page.goto(`file://${filePath}`);
+
+  // Set initial time
+  await page.fill('#dm-time-input', '12:00');
+  await page.click('#btn-fijar-hora');
+
+  // Wait a bit
+  await page.waitForTimeout(500);
+
+  // Read initial time
+  let initialTime = await page.inputValue('#dm-time-input');
+  console.log(`Initial time set to: ${initialTime}`);
+
+  if (initialTime !== '12:00') {
+    console.error('Failed to set initial time');
+    process.exit(1);
+  }
+
+  // Click the +5 min button
+  await page.click('#btn-avanzar-hora');
+
+  // Wait a bit
+  await page.waitForTimeout(500);
+
+  // Read updated time
+  let updatedTime = await page.inputValue('#dm-time-input');
+  console.log(`Updated time is: ${updatedTime}`);
+
+  if (updatedTime === '12:05') {
+    console.log('SUCCESS: Time incremented exactly by 5 minutes.');
+    await browser.close();
+    process.exit(0);
+  } else {
+    console.error(`ERROR: Expected 12:05 but got ${updatedTime}`);
+    await browser.close();
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
Modified the "Avanzar Hora" logic in the DM terminal to correctly advance the clock by exactly 5 minutes.
- Updated button text from `+ 5-10 Min` to `+ 5 Min`.
- Modified JS logic to remove randomization and set `minutesToAdd` to exactly 5.

---
*PR created automatically by Jules for task [9257390942182315234](https://jules.google.com/task/9257390942182315234) started by @sokcrow*