### PR TITLE
Redesign Shop UI to match Limbus Company Style

### DIFF
--- a/fix_css.py
+++ b/fix_css.py
@@ -1,0 +1,101 @@
+import re
+
+with open('hoja_personaje.css', 'r') as f:
+    css = f.read()
+
+# Make sure we add styles for the missing classes:
+# .shop-item-header
+# .shop-item-tag
+# .shop-item-description
+# .shop-item-meta
+# .shop-item-possession
+# .shop-item-possession-label
+# .shop-item-possession-value
+
+new_css = """
+.shop-item-header {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.shop-item-name {
+    color: #fffacd;
+    font-size: 20px;
+    font-family: 'Mikodacs', sans-serif;
+    font-weight: normal;
+    text-transform: uppercase;
+    text-align: left;
+    margin: 0;
+    line-height: 1.1;
+    text-shadow: 1px 1px 2px #000;
+}
+
+.shop-item-tag {
+    color: #a0a0a0;
+    font-family: 'ExcelsiorSans', sans-serif;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.shop-item-description {
+    color: #cccccc;
+    font-family: 'ExcelsiorSans', sans-serif;
+    font-size: 13px;
+    line-height: 1.4;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+}
+
+.shop-item-meta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    justify-content: space-between;
+    width: 25%;
+    min-width: 120px;
+    padding: 10px 15px;
+    background: rgba(0, 0, 0, 0.3);
+    border-left: 1px solid #222;
+}
+
+.shop-item-possession {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: #111;
+    border: 1px solid #333;
+    padding: 4px 8px;
+    border-radius: 2px;
+}
+
+.shop-item-possession-label {
+    color: #888;
+    font-family: 'ExcelsiorSans', sans-serif;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.shop-item-possession-value {
+    color: #fff;
+    font-family: 'Mikodacs', sans-serif;
+    font-size: 16px;
+}
+
+.shop-item-tier {
+    position: static;
+    color: #ffd700;
+    font-weight: bold;
+    font-size: 18px;
+    text-shadow: 0 0 5px #ff8c00, 0 0 2px #000;
+    align-self: flex-end;
+}
+"""
+
+css = re.sub(r'\.shop-item-name \{[^}]+\}', '', css)
+css = re.sub(r'\.shop-item-tier \{[^}]+\}', '', css)
+
+with open('hoja_personaje.css', 'w') as f:
+    f.write(css + "\n" + new_css)

--- a/fix_css.sh
+++ b/fix_css.sh
@@ -1,0 +1,4 @@
+cat hoja_personaje.css | grep -A 10 '\.shop-item-details'
+cat hoja_personaje.css | grep -A 10 '\.shop-item-name'
+cat hoja_personaje.css | grep -A 10 '\.shop-item-meta'
+cat hoja_personaje.css | grep -A 10 '\.shop-item-possession'

--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -5588,39 +5588,43 @@ input[name="attr_tab"][value="crafteo"] ~ .sheet-phone-screen .sheet-tab-crafteo
 
 .shop-items-grid {
     flex: 1;
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    gap: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
     padding: 20px;
     overflow-y: auto;
 }
 
 .shop-item-card {
-    background: #1a1a1a;
-    border: 1px solid #333;
-    border-radius: 6px;
+    background: #0d0d0d;
+    border: 1px solid #222;
+    border-radius: 4px;
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     position: relative;
     overflow: hidden;
     transition: all 0.2s ease;
     box-shadow: 0 4px 10px rgba(0,0,0,0.8);
+    height: auto;
+    min-height: 120px;
 }
 
 .shop-item-card:hover {
     border-color: #00ffff;
-    transform: translateY(-5px);
-    box-shadow: 0 8px 15px rgba(0,255,255,0.2);
+    transform: translateX(5px);
+    box-shadow: 0 8px 15px rgba(0,255,255,0.1);
 }
 
 .shop-item-image-container {
-    height: 120px;
-    background: #0d0d0d;
+    width: 20%;
+    min-width: 120px;
+    max-width: 150px;
+    background: #050505;
     display: flex;
     justify-content: center;
     align-items: center;
     position: relative;
-    border-bottom: 1px solid #333;
+    border-right: 1px solid #222;
 }
 
 .shop-item-image-container img {
@@ -5630,16 +5634,7 @@ input[name="attr_tab"][value="crafteo"] ~ .sheet-phone-screen .sheet-tab-crafteo
     z-index: 2;
 }
 
-.shop-item-tier {
-    position: absolute;
-    top: 5px;
-    left: 10px;
-    color: #ffd700;
-    font-weight: bold;
-    font-size: 16px;
-    text-shadow: 0 0 5px #ff8c00, 0 0 2px #000;
-    z-index: 3;
-}
+
 
 .shop-item-details {
     padding: 15px;
@@ -5649,16 +5644,7 @@ input[name="attr_tab"][value="crafteo"] ~ .sheet-phone-screen .sheet-tab-crafteo
     flex: 1;
 }
 
-.shop-item-name {
-    color: #fff;
-    font-size: 14px;
-    font-family: inherit;
-    font-weight: bold;
-    text-transform: uppercase;
-    text-align: center;
-    margin: 0;
-    line-height: 1.2;
-}
+
 
 .shop-item-buy-btn {
     background: linear-gradient(180deg, #ffd700 0%, #c49a00 100%);
@@ -5685,6 +5671,60 @@ input[name="attr_tab"][value="crafteo"] ~ .sheet-phone-screen .sheet-tab-crafteo
 }
 
 .shop-item-buy-btn:disabled {
+    background: #333;
+    color: #666;
+    border-color: #444;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.shop-footer {
+    height: 60px;
+    background: #000;
+    border-top: 1px solid #333;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 20px;
+    box-shadow: 0 -2px 10px rgba(0,0,0,0.8);
+}
+
+.shop-footer-money {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.shop-footer-ahn-val {
+    color: #00ffff;
+    font-family: 'Mikodacs', sans-serif;
+    font-size: 32px;
+    text-shadow: 0 0 10px #00ffff, 0 0 5px #00ffff;
+    letter-spacing: 2px;
+}
+
+.shop-footer-buy-btn {
+    background: linear-gradient(180deg, #ffd700 0%, #c49a00 100%);
+    color: #000;
+    border: 1px solid #ffcc00;
+    padding: 10px 40px;
+    font-weight: bold;
+    font-size: 18px;
+    font-family: 'Mikodacs', sans-serif;
+    cursor: pointer;
+    border-radius: 4px;
+    text-transform: uppercase;
+    transition: all 0.2s;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.5);
+}
+
+.shop-footer-buy-btn:hover:not(:disabled) {
+    background: linear-gradient(180deg, #ffe033 0%, #d4a900 100%);
+    box-shadow: 0 0 15px #ffd700;
+    transform: scale(1.02);
+}
+
+.shop-footer-buy-btn:disabled {
     background: #333;
     color: #666;
     border-color: #444;
@@ -6590,4 +6630,85 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
 .btn-equip:hover, .btn-unequip:hover {
     background-color: var(--text-main);
     color: #000;
+}
+
+
+.shop-item-header {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.shop-item-name {
+    color: #fffacd;
+    font-size: 20px;
+    font-family: 'Mikodacs', sans-serif;
+    font-weight: normal;
+    text-transform: uppercase;
+    text-align: left;
+    margin: 0;
+    line-height: 1.1;
+    text-shadow: 1px 1px 2px #000;
+}
+
+.shop-item-tag {
+    color: #a0a0a0;
+    font-family: 'ExcelsiorSans', sans-serif;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.shop-item-description {
+    color: #cccccc;
+    font-family: 'ExcelsiorSans', sans-serif;
+    font-size: 13px;
+    line-height: 1.4;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+}
+
+.shop-item-meta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    justify-content: space-between;
+    width: 25%;
+    min-width: 120px;
+    padding: 10px 15px;
+    background: rgba(0, 0, 0, 0.3);
+    border-left: 1px solid #222;
+}
+
+.shop-item-possession {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: #111;
+    border: 1px solid #333;
+    padding: 4px 8px;
+    border-radius: 2px;
+}
+
+.shop-item-possession-label {
+    color: #888;
+    font-family: 'ExcelsiorSans', sans-serif;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.shop-item-possession-value {
+    color: #fff;
+    font-family: 'Mikodacs', sans-serif;
+    font-size: 16px;
+}
+
+.shop-item-tier {
+    position: static;
+    color: #ffd700;
+    font-weight: bold;
+    font-size: 18px;
+    text-shadow: 0 0 5px #ff8c00, 0 0 2px #000;
+    align-self: flex-end;
 }

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -3863,6 +3863,13 @@
                 <div id="shop-items-grid" class="shop-items-grid">
                     <!-- Items injected via JS -->
                 </div>
+                <div class="shop-footer">
+                    <div class="shop-footer-money">
+                        <span class="currency-symbol" style="color:#00ffff; text-shadow:0 0 5px #00ffff;">₳</span>
+                        <span id="shop-display-ahn" class="shop-footer-ahn-val">0</span>
+                    </div>
+                    <button class="shop-footer-buy-btn">COMPRAR</button>
+                </div>
             </div>
         </div>
     </div>

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -251,6 +251,12 @@ window.renderCharacterSheet = function(data) {
             // Only update text content safely
             bancoBalance.textContent = new Intl.NumberFormat('en-US').format(data.ahn || 0);
         }
+
+        // Update new Shop Modal Ahn display
+        const shopAhn = document.getElementById('shop-display-ahn');
+        if (shopAhn) {
+            shopAhn.textContent = new Intl.NumberFormat('en-US').format(data.ahn || 0);
+        }
     }
 
     // Subtitulos y avatares
@@ -1560,32 +1566,59 @@ window.addEventListener('DOMContentLoaded', () => {
             return;
         }
 
-        for (const [itemId, item] of Object.entries(items)) {
-            const itemTier = parseInt(item.tier) || 1;
-            const valorConTier = Math.floor((item.costo || 0) * (1 + ((itemTier - 1) * 0.25)));
-            const precio = Math.floor(valorConTier * (modVenta / 100));
-            const isAgotado = item.stock_actual === 0;
-            const stockStr = item.stock_actual === -1 ? '∞' : item.stock_actual;
-            const tierStr = romanTiersShop[Math.min(itemTier, 10)] || 'I';
+        const playerName = document.querySelector('input[name="attr_character_name"]')?.value.trim();
 
-            const card = document.createElement('div');
-            card.className = 'shop-item-card';
+        db.ref(`campaña/jugadores/${playerName}/inventario_stash`).once('value', snap => {
+            const userStash = snap.val() || {};
+            const stashCounts = {};
+            for (const itemStash of Object.values(userStash)) {
+                if (itemStash.nombre) {
+                    stashCounts[itemStash.nombre] = (stashCounts[itemStash.nombre] || 0) + (parseInt(itemStash.cantidad) || 1);
+                }
+            }
 
-            card.innerHTML = `
-                <div class="shop-item-image-container">
-                    <div class="shop-item-tier">${tierStr}</div>
-                    <img src="${item.icono || 'https://via.placeholder.com/80'}" alt="${item.nombre}">
-                </div>
-                <div class="shop-item-details">
-                    <h4 class="shop-item-name">${item.nombre}</h4>
-                    <div style="font-size: 12px; color: #888; text-align: center;">Stock: ${stockStr}</div>
-                    <button class="shop-item-buy-btn btn-comprar-fisico" data-tienda="${idTienda}" data-item="${itemId}" data-precio="${precio}" ${isAgotado ? 'disabled' : ''}>
-                        <span class="currency-symbol">₳</span> ${precio}
-                    </button>
-                </div>
-            `;
-            grid.appendChild(card);
-        }
+            for (const [itemId, item] of Object.entries(items)) {
+                const itemTier = parseInt(item.tier) || 1;
+                const valorConTier = Math.floor((item.costo || 0) * (1 + ((itemTier - 1) * 0.25)));
+                const precio = Math.floor(valorConTier * (modVenta / 100));
+                const isAgotado = item.stock_actual === 0;
+                const stockStr = item.stock_actual === -1 ? '∞' : item.stock_actual;
+                const tierStr = romanTiersShop[Math.min(itemTier, 10)] || 'I';
+                const countOwned = stashCounts[item.nombre] || 0;
+                const tagStr = item.tag || 'Objeto';
+                const descStr = item.descripcion || item.desc || 'Sin descripción disponible.';
+
+                const card = document.createElement('div');
+                card.className = 'shop-item-card';
+
+                card.innerHTML = `
+                    <div class="shop-item-image-container">
+                        <img src="${item.icono || 'https://via.placeholder.com/80'}" alt="${item.nombre}">
+                    </div>
+                    <div class="shop-item-details">
+                        <div class="shop-item-header">
+                            <h4 class="shop-item-name">${item.nombre}</h4>
+                            <span class="shop-item-tag">${tagStr}</span>
+                        </div>
+                        <div class="shop-item-description">${descStr}</div>
+                        <div style="font-size: 11px; color: #555; margin-top: auto;">Stock en tienda: ${stockStr}</div>
+                    </div>
+                    <div class="shop-item-meta">
+                        <div class="shop-item-possession">
+                            <span class="shop-item-possession-label">POSEES</span>
+                            <span class="shop-item-possession-value">${countOwned}</span>
+                        </div>
+                        <div style="display: flex; flex-direction: column; align-items: flex-end; gap: 10px;">
+                            <div class="shop-item-tier">${tierStr}</div>
+                            <button class="shop-item-buy-btn btn-comprar-fisico" data-tienda="${idTienda}" data-item="${itemId}" data-precio="${precio}" ${isAgotado ? 'disabled' : ''}>
+                                <span class="currency-symbol">₳</span> ${precio}
+                            </button>
+                        </div>
+                    </div>
+                `;
+                grid.appendChild(card);
+            }
+        });
     }
 
     // Función para manejar las pestañas internas de la app de tienda


### PR DESCRIPTION
Redesigned the shop UI modal in `hoja_personaje` to perfectly align with the requested 'Limbus Company' visual style. The layout was changed from a grid to a vertical list of horizontal item rows. Each item row correctly displays the item image, prominently styled name, tag, and description, and a metadata section including a Roman numeral tier and a dynamic possession counter that calculates owned items directly from Firebase stash data. A persistent footer was added that actively listens to the global Firebase data stream to display the player's current Ahn currency in a glowing neon style, alongside a new global purchase button. Playwright visual verification was completed and confirms the UI matches the reference layout.

---
*PR created automatically by Jules for task [5976099349228274905](https://jules.google.com/task/5976099349228274905) started by @sokcrow*