### PR TITLE
Add real-time player name editing for DM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -1926,6 +1926,11 @@
                       <div class="player-subinfo" style="font-size: 0.85em; color: #aaa; text-align: center; margin-bottom: 5px;">${clase} | ${raza}</div>
                       <div style="text-align:center; color:#FFD700; font-weight:bold; margin-bottom: 10px;"><span class="currency-symbol">₳</span> <span class="player-ahn">${data.ahn || 0}</span></div>
 
+                      <div style="display: flex; gap: 10px; align-items: center; justify-content: space-between; margin-bottom: 5px;">
+                          <input type="text" class="dm-edit-name" value="${data.characterName || ''}" placeholder="Nombre Personaje" style="flex: 1; padding:4px; background:#111; color:#0df; border:1px solid #0df; border-radius:3px; text-align:center; font-family:'BebasKai', sans-serif;">
+                          <button class="btn-save-name" data-id="${nombre}" style="background: #222; color: #0df; border: 1px solid #0df; padding: 4px 8px; border-radius: 3px; cursor: pointer; font-weight: bold; transition: all 0.2s; font-size:12px;">Guardar Nombre</button>
+                      </div>
+
                       <div style="display: flex; gap: 10px; align-items: center; justify-content: space-between;">
                           <label style="color:#c49a00; font-size:12px;">Level:</label>
                           <input type="number" class="input-lvl" value="${lvl}" style="width:60px; padding:3px; background:#222; color:#fff; border:1px solid #444; border-radius:3px; text-align:center;">
@@ -1946,6 +1951,26 @@
                       <button class="btn-guardar-perfil" style="margin-top: 10px; background: #004400; color: white; border: 1px solid #00ff00; padding: 8px; border-radius: 3px; cursor: pointer; font-weight: bold; transition: all 0.2s;">Guardar / Forzar Datos</button>
                       <button class="btn-ver-inventario" data-player="${nombre}" style="margin-top: 5px; background: #222; color: #0df; border: 1px solid #0df; padding: 8px; border-radius: 3px; cursor: pointer; font-weight: bold; transition: all 0.2s;">Ver Inventario</button>
                   `;
+
+                  const btnGuardarNombre = pCard.querySelector('.btn-save-name');
+                  const inputNombre = pCard.querySelector('.dm-edit-name');
+
+                  btnGuardarNombre.onclick = () => {
+                      const nuevoNombre = inputNombre.value;
+                      db.ref(`campaña/jugadores/${nombre}`).update({ characterName: nuevoNombre })
+                          .then(() => {
+                              const oldText = btnGuardarNombre.innerText;
+                              btnGuardarNombre.innerText = "¡Guardado!";
+                              btnGuardarNombre.style.background = "#0df";
+                              btnGuardarNombre.style.color = "#000";
+                              setTimeout(() => {
+                                  btnGuardarNombre.innerText = oldText;
+                                  btnGuardarNombre.style.background = "#222";
+                                  btnGuardarNombre.style.color = "#0df";
+                              }, 1000);
+                          })
+                          .catch(e => console.error("Error al actualizar nombre:", e));
+                  };
 
                   const btnGuardar = pCard.querySelector('.btn-guardar-perfil');
                   btnGuardar.onclick = () => {
@@ -1978,7 +2003,9 @@
                   const hpBaseInput = pCard.querySelector('.input-hpbase');
                   const hpMaxInput = pCard.querySelector('.input-hpmax');
                   const subInfo = pCard.querySelector('.player-subinfo');
+                  const nameInput = pCard.querySelector('.dm-edit-name');
 
+                  if (nameInput && document.activeElement !== nameInput) nameInput.value = data.characterName || '';
                   if (document.activeElement !== lvlInput) lvlInput.value = lvl;
                   if (document.activeElement !== xpInput) xpInput.value = xp;
                   if (document.activeElement !== hpBaseInput) hpBaseInput.value = hpBase;


### PR DESCRIPTION
- Added `<input type="text" class="dm-edit-name">` to player card generation in `pantalla_dm.html`.
- Added `<button class="btn-save-name">` to trigger the update.
- Implemented `db.ref('campaña/jugadores/' + nombre).update({ characterName: nuevoNombre })` inside the button click handler.
- Included visual feedback to the button.
- Added a safeguard `if (nameInput && document.activeElement !== nameInput) nameInput.value = data.characterName || '';` during DOM reconciliation to allow typing without interruption from real-time syncs.

---
*PR created automatically by Jules for task [14746692024460382391](https://jules.google.com/task/14746692024460382391) started by @sokcrow*