### PR TITLE
Fix Cellphone Tab Navigation

### DIFF
--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -425,25 +425,29 @@ window.addEventListener('DOMContentLoaded', () => {
     const tabsList = ["home", "stats", "abilities", "skills", "profile", "parts", "apego", "banco", "contratos", "codex", "mapa", "notas", "shop", "crafteo"];
 
     // Tab switching logic for Main Nav
-    document.querySelectorAll('button[name^="act_tab_"]').forEach(btn => {
-        btn.addEventListener('click', (e) => {
-            let tabName = btn.getAttribute('name').replace('act_tab_', '');
+    document.addEventListener('click', (e) => {
+        const btn = e.target.closest('button[type="action"]');
+        if (!btn || !btn.name || !btn.name.startsWith('act_tab_')) return;
 
-            // Esconder todas las pestañas
-            document.querySelectorAll('.sheet-tab-content').forEach(el => {
-                el.style.display = 'none';
-            });
+        const tabName = btn.name.replace('act_tab_', '');
 
-            // Mostrar la seleccionada
-            const targetTab = document.querySelector(`.sheet-tab-${tabName}`);
-            if (targetTab) {
-                targetTab.style.display = 'block';
-            }
+        const tabInput = document.querySelector('input[name="attr_tab"]') || document.querySelector('.sheet-state-tab');
+        if (tabInput) {
+            tabInput.setAttribute('value', tabName);
+            tabInput.value = tabName;
+        }
 
-            // Set state input for CSS if any uses it
-            const stateInput = document.querySelector('.sheet-state-tab');
-            if (stateInput) stateInput.value = tabName;
+        // Keep the JS display logic as a fallback to ensure tabs actually show/hide
+        // even if CSS doesn't fully handle it. The user said CSS reacts to the attribute change,
+        // but just in case, we also update the display block/none.
+        document.querySelectorAll('.sheet-tab-content').forEach(el => {
+            el.style.display = 'none';
         });
+
+        const targetTab = document.querySelector(`.sheet-tab-${tabName}`);
+        if (targetTab) {
+            targetTab.style.display = 'block';
+        }
     });
 
     // Show Home by default

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Replaced the legacy Roll20-dependent tab button logic with a document-level event delegation listener in `hoja_personaje.js`. The new listener explicitly sets the `value` attribute on the hidden state input (`input[name="attr_tab"]`) to ensure CSS visibility rules trigger correctly, fixing the broken cellphone UI navigation.

---
*PR created automatically by Jules for task [6491373405352156219](https://jules.google.com/task/6491373405352156219) started by @sokcrow*