### PR TITLE
Implement crafting coin roll logic and resolution alerts

### DIFF
--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -1131,9 +1131,13 @@ document.addEventListener('DOMContentLoaded', () => {
                     ? parseInt(currentPlayerData.modifiers[receta.habilidad])
                     : 0;
 
-                const roll = Math.floor(Math.random() * 20) + 1;
-                const total = roll + skillMod;
-                const dc = parseInt(receta.dc);
+                let caras = 0;
+                for (let i = 0; i < 5; i++) {
+                    if (Math.random() >= 0.5) caras++;
+                }
+                const total = (caras * 3) + skillMod;
+                const rollInfo = { total, caras, skillMod };
+                const dc = parseInt(receta.dc) || 10;
                 const currentStash = window.datosJugador.inventario_stash || {};
                 const playerName = document.querySelector('input[name="attr_character_name"]')?.value.trim();
 
@@ -1143,12 +1147,21 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 setTimeout(() => {
                     if (total >= dc) {
-                        ejecutarSintesis(playerName, receta, 1, currentStash, true, total);
+                        ejecutarSintesis(playerName, receta, 1, currentStash, true, rollInfo);
                     } else {
-                        ejecutarSintesis(playerName, receta, 1, currentStash, false, total);
+                        ejecutarSintesis(playerName, receta, 1, currentStash, false, rollInfo);
                     }
                     fabricarBtn.innerText = 'Fabricar';
                     limpiarVisorCrafteo();
+
+                    // Clear selection in recipe list (simulando "Cancelar")
+                    const listaRecetas = document.getElementById('craft-recetas');
+                    if (listaRecetas) {
+                        Array.from(listaRecetas.children).forEach(c => {
+                            c.style.borderColor = c.innerHTML.includes('brightness(0)') ? '#222' : '#444';
+                            c.style.background = '#1a1a1a';
+                        });
+                    }
                 }, 1000);
             });
         }
@@ -1289,7 +1302,7 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 
 /* OLD SELECCIONAR RECETA LOGIC REMOVED */
-function ejecutarSintesis(playerName, receta, multi, currentStash, exito, rollTotal) {
+function ejecutarSintesis(playerName, receta, multi, currentStash, exito, rollInfo) {
     const stashRef = db.ref(`campaña/jugadores/${playerName}/inventario_stash`);
     const updates = {};
     const removes = [];
@@ -1366,10 +1379,10 @@ function ejecutarSintesis(playerName, receta, multi, currentStash, exito, rollTo
         }
 
     } else {
-        // FALLO: Eliminar 1-3 mats aleatorios por cada intento fallido
+        // FALLO: Eliminar 1-2 mats aleatorios por cada intento fallido
         let matsParaPerder = [];
         for (let i = 0; i < multi; i++) {
-            const numPerder = Math.floor(Math.random() * 3) + 1; // 1 to 3
+            const numPerder = Math.floor(Math.random() * 2) + 1; // 1 to 2
             // Aplanar ingredientes para elegir aleatoriamente
             const pool = [];
             receta.ingredientes.forEach(ing => {
@@ -1382,7 +1395,7 @@ function ejecutarSintesis(playerName, receta, multi, currentStash, exito, rollTo
         }
 
         // Apply reductions based on matsParaPerder
-        const lostCounts = {};
+        var lostCounts = {}; // Using var so it is scoped to function and available in closure
         matsParaPerder.forEach(id => {
             lostCounts[id] = (lostCounts[id] || 0) + 1;
         });
@@ -1420,20 +1433,36 @@ function ejecutarSintesis(playerName, receta, multi, currentStash, exito, rollTo
 
     Promise.all(promises).then(() => {
         const btnSintetizar = document.getElementById('btn-sintetizar');
-        btnSintetizar.innerText = 'SINTETIZAR';
-        btnSintetizar.disabled = false;
+        if (btnSintetizar) {
+            btnSintetizar.innerText = 'SINTETIZAR';
+            btnSintetizar.disabled = false;
+        }
+
+        const total = rollInfo.total;
+        const caras = rollInfo.caras;
+        const mod = rollInfo.skillMod;
 
         if (exito) {
-            alert(`¡Síntesis Exitosa! (Roll: ${rollTotal} vs DC ${receta.dc})\nItems añadidos al alijo.`);
+            alert(`¡Fabricación Exitosa!\nCaras: ${caras} (+${caras * 3})\nModificador: ${mod}\nResultado: ${total} vs DC ${receta.dc}\nItems añadidos al alijo.`);
         } else {
-            alert(`Síntesis Fallida. (Roll: ${rollTotal} vs DC ${receta.dc})\nMateriales inestables destruidos.`);
+            // Find lost materials names
+            const lostNames = [];
+            if (typeof lostCounts !== 'undefined') {
+                for (const [idLost, amountLost] of Object.entries(lostCounts)) {
+                    const itemName = (dbItemsCacheGlobal && dbItemsCacheGlobal[idLost]) ? dbItemsCacheGlobal[idLost].nombre : 'Material desconocido';
+                    lostNames.push(`${amountLost}x ${itemName}`);
+                }
+            }
+            const lostStr = lostNames.length > 0 ? `\nSe perdieron los siguientes materiales:\n- ${lostNames.join('\n- ')}` : '';
+            alert(`Fabricación Fallida.\nCaras: ${caras} (+${caras * 3})\nModificador: ${mod}\nResultado: ${total} vs DC ${receta.dc}${lostStr}`);
         }
 
         // Recalcular vista
-        seleccionarReceta(currentSelectedRecetaId, receta);
+        if (typeof seleccionarReceta === 'function') seleccionarReceta(currentSelectedRecetaId, receta);
     }).catch(err => {
         alert('Error en la síntesis: ' + err);
-        document.getElementById('btn-sintetizar').innerText = 'SINTETIZAR';
+        const btnSintetizar = document.getElementById('btn-sintetizar');
+        if (btnSintetizar) btnSintetizar.innerText = 'SINTETIZAR';
     });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,71 @@
+{
+  "name": "app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@playwright/test": "^1.58.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@playwright/test": "^1.58.2"
+  }
+}

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/test_crafting.spec.js
+++ b/test_crafting.spec.js
@@ -1,0 +1,19 @@
+const { test, expect } = require('@playwright/test');
+
+test('Test crafting page loads without syntax errors', async ({ page }) => {
+    let errors = [];
+    page.on('pageerror', error => errors.push(error.message));
+
+    // Serve locally or just load the file
+    await page.goto('file://' + __dirname + '/hoja_personaje.html');
+
+    // We mock localStorage so it thinks it has a player
+    await page.evaluate(() => {
+        localStorage.setItem('playerId', 'TestPlayer');
+    });
+
+    await page.reload();
+
+    // Just check if the file load and parsed JS without throwing syntax errors
+    expect(errors.length).toBe(0);
+});


### PR DESCRIPTION
This PR implements the requested crafting mechanic updates for the "Fabricar" button in the character sheet. The core roll logic has been updated to use a 5-coin toss simulation, where each 'heads' grants a +3 bonus to the roll, added to the character's skill modifier. It also includes comprehensive success and failure alerts detailing the roll, the difficulty class, and any materials lost. The penalty for failing a craft has been tightened to accurately reflect destroying 1 or 2 random required items, and variable scoping inside the synthesis execution was fixed. Finally, the UI properly resets (clears the recipe selection and visual slots) after resolving a crafting attempt.

---
*PR created automatically by Jules for task [4269832063475445508](https://jules.google.com/task/4269832063475445508) started by @sokcrow*