### PR TITLE
Fix crafting UI overlapping and display roman tiers

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -6716,13 +6716,11 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
 /* Crafting Tab specific styles for Inventory Modal */
 #inv-crafting {
     /* To override the default flex layout of inventory-body-wrapper when this tab is active */
-    position: absolute;
-    top: 0;
-    left: 0;
+    position: relative;
     width: 100%;
     height: 100%;
     background-color: #1a1a1a;
-    z-index: 10;
+    display: none;
 }
 
 #inv-crafting.active {

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -4103,7 +4103,7 @@
                     </div>
                 </div>
 
-                <div class="inventory-tab-content" id="inv-crafting" style="display: none; height: 100%; width: 100%;">
+                <div class="inventory-tab-content" id="inv-crafting" style="height: 100%; width: 100%;">
                     <div class="crafteo-avanzado-container">
                         <!-- Panel Izquierdo: Tabs y Listas -->
                         <div class="crafteo-side-panel">

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -4102,7 +4102,7 @@
                         <!-- Items injectados via JS -->
                     </div>
                 </div>
-            </div>
+
                 <div class="inventory-tab-content" id="inv-crafting" style="display: none; height: 100%; width: 100%;">
                     <div class="crafteo-avanzado-container">
                         <!-- Panel Izquierdo: Tabs y Listas -->
@@ -4153,6 +4153,7 @@
                         </div>
                     </div>
                 </div>
+            </div> <!-- End of inventory-left-panel -->
 
             <!-- Detail Card (Inspirada en Limbus E.G.O Gift) -->
             <div class="item-detail-card" id="item-detail-card">

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -1341,11 +1341,20 @@ function limpiarVisorCrafteo() {
 function seleccionarRecetaRadial(idReceta, receta, isDiscovered, resultIconUrl, resultItemName, resultTier) {
     currentSelectedRecetaId = idReceta;
 
+    // Helper array local si no está disponible romanTiersShop globalmente
+    const romanTiersLocal = ["", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"];
+
     // Configurar Vista Previa Central
     const resultPreview = document.getElementById('craft-result-preview');
     if (resultPreview) {
+        let resultTierStr = '';
+        if (resultTier && parseInt(resultTier) > 0) {
+             resultTierStr = `<div class="item-tier-indicator">${romanTiersLocal[parseInt(resultTier)] || resultTier}</div>`;
+        }
+
         resultPreview.innerHTML = `
             <div style="width: 100%; height: 100%; border-radius: 50%; background: url('${resultIconUrl}') center/cover; filter: ${isDiscovered ? 'none' : 'brightness(0)'};"></div>
+            ${resultTierStr}
             ${isDiscovered ? `<div style="position: absolute; bottom: -20px; text-align: center; color: #fff; font-family: 'Mikodacs', sans-serif; font-size: 14px; width: 200px; left: -60px; text-shadow: 1px 1px 2px #000;">${resultItemName}</div>` : ''}
         `;
     }
@@ -1363,6 +1372,7 @@ function seleccionarRecetaRadial(idReceta, receta, isDiscovered, resultIconUrl, 
             const ing = receta.ingredientes[i];
             const globalIng = dbItemsCacheGlobal[ing.id_item] || {};
             const ingIconUrl = globalIng.icono || 'https://i.imgur.com/8QZ7XqY.png';
+            const ingTier = globalIng.tier;
 
             // Calculate owned quantity
             let ownedQty = 0;
@@ -1377,8 +1387,14 @@ function seleccionarRecetaRadial(idReceta, receta, isDiscovered, resultIconUrl, 
 
             const slot = document.getElementById(`craft-slot-${i + 1}`);
             if (slot) {
+                let ingTierStr = '';
+                if (ingTier && parseInt(ingTier) > 0) {
+                     ingTierStr = `<div class="item-tier-indicator">${romanTiersLocal[parseInt(ingTier)] || ingTier}</div>`;
+                }
+
                 slot.innerHTML = `
                     <div style="width: 100%; height: 100%; border-radius: 50%; background: url('${ingIconUrl}') center/cover; filter: ${hasEnough ? 'none' : 'brightness(0.5) sepia(1) hue-rotate(-50deg) saturate(3)'};"></div>
+                    ${ingTierStr}
                     <div style="position: absolute; bottom: -5px; right: -5px; background: #000; color: ${hasEnough ? '#0df' : '#f44'}; border: 1px solid ${hasEnough ? '#0df' : '#f44'}; border-radius: 10px; padding: 0 4px; font-family: monospace; font-size: 10px; z-index: 10;">${ownedQty}/${ing.cantidad}</div>
                 `;
                 slot.style.border = `2px solid ${hasEnough ? 'var(--cyan-tech)' : '#f44'}`;


### PR DESCRIPTION
Fixes two issues with the Crafting UI (Mesa de Trabajo):
1. **Missing Tiers in Crafting:** The central preview and circular ingredient slots in the crafting UI now display their item tiers in Roman numerals (e.g., I, II, III), mirroring the regular inventory behavior.
2. **Tab Overlapping Issue:** Removed the `position: absolute` styling from the crafting tab (`#inv-crafting`) that caused it to incorrectly float above other active tabs (like Inventory or Stash). Added `display: none;` as the default state to ensure the tab correctly hides and flexes when not the active `.tab-content`.

---
*PR created automatically by Jules for task [6886654244579903836](https://jules.google.com/task/6886654244579903836) started by @sokcrow*