### PR TITLE
Fix Crafting System Bugs

### DIFF
--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -1494,10 +1494,10 @@ window.validarMesaCraft = function() {
                     previewSlot.style.filter = 'drop-shadow(0 0 5px rgba(0, 255, 255, 0.8))';
                 } else {
                     previewSlot.innerHTML = `
-                        <img src="${resultIconUrl}" class="craft-preview-img silhouetted" title="???" style="width: 100%; height: 100%; object-fit: contain; filter: brightness(0); pointer-events: none;">
+                        <div style="width: 100%; height: 100%; border-radius: 50%; background: #111; border: 2px solid #555; display: flex; align-items: center; justify-content: center; font-size: 40px; color: #888;" title="???">?</div>
                         <div class="item-tier-indicator tier-color-${resultTier}">${romanTier}</div>
                     `;
-                    previewSlot.classList.add('silhouetted');
+                    previewSlot.classList.remove('silhouetted');
                     previewSlot.style.filter = 'none';
                 }
             }
@@ -1720,8 +1720,19 @@ function limpiarVisorCrafteo() {
             slot.style.backgroundImage = 'none';
             slot.classList.remove('has-item', 'missing-item');
             slot.style.border = '2px solid rgba(0, 255, 255, 0.3)';
+            delete slot.dataset.idItem;
+            delete slot.dataset.linkedElId;
         }
     }
+
+    document.querySelectorAll('.item-slotted').forEach(el => {
+        el.classList.remove('item-slotted');
+        delete el.dataset.slotLinkId;
+    });
+
+    window.ingredientesSeleccionados = [];
+    window.itemResultado = null;
+    window.recetaEncontrada = false;
 
     currentSelectedRecetaId = null;
 
@@ -1802,7 +1813,7 @@ function seleccionarRecetaRadial(idReceta, receta, isDiscovered, resultIconUrl, 
     // Configurar Botón Fabricar
     const fabricarBtn = document.getElementById('btn-craft-fabricar');
     if (fabricarBtn) {
-        if (canCraft && isDiscovered) {
+        if (canCraft) {
             fabricarBtn.style.opacity = '1';
             fabricarBtn.style.cursor = 'pointer';
             fabricarBtn.disabled = false;

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -1416,6 +1416,18 @@
   <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-database.js"></script>
 
   <script>
+    window.addEventListener('DOMContentLoaded', () => {
+      const playerId = localStorage.getItem('playerId');
+      const isAdmin = localStorage.getItem('isAdmin');
+      const isDM = (playerId && playerId.toLowerCase() === 'dm') || isAdmin === 'true';
+      if (!isDM) {
+        document.querySelectorAll('#tab-crafteo input, #tab-crafteo select, #tab-crafteo textarea, #tab-crafteo button').forEach(el => {
+          el.disabled = true;
+          if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') el.readOnly = true;
+        });
+      }
+    });
+
     const firebaseConfig = {
       apiKey: "AIzaSyAIVIuKgXUsdrb9Mmss9PH7R3FpWAMG2hU",
       authDomain: "luminous-system.firebaseapp.com",


### PR DESCRIPTION
Resolves four critical issues related to the crafting and recipe management systems.

1. **Access Control:** Players can no longer edit recipe properties in the DM screen. Input elements are locked based on `playerId` or `isAdmin` local storage.
2. **Unknown Recipes:** Undiscovered recipes now correctly display a generic "?" incognito item rather than showing a blacked-out silhouette of the final item.
3. **Cancel Reset:** Pressing the 'Cancelar' button now performs a deep clean, un-slotting items from the inventory DOM and completely resetting all related variables (`ingredientesSeleccionados`, `itemResultado`, etc.).
4. **Crafting Trigger:** The 'Fabricar' button is no longer blocked when a recipe is valid but undiscovered. This allows players to roll the dice and potentially craft (and automatically discover) hidden recipes.

---
*PR created automatically by Jules for task [6568029690547657042](https://jules.google.com/task/6568029690547657042) started by @sokcrow*