### PR TITLE
Fix actor selection dropdown freezing UI for players

### DIFF
--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -133,12 +133,24 @@ db.ref('campaña/actores').on('value', (snapshot) => {
         }
     }
 
-    if (window.datosJugador && window.datosJugador.activeActor && actorSelect.querySelector(`option[value="${window.datosJugador.activeActor}"]`)) {
-        actorSelect.value = window.datosJugador.activeActor;
+    // Si el DM asignó un actorId, eso toma prioridad absoluta
+    if (window.datosJugador && window.datosJugador.actorId && actorSelect.querySelector(`option[value="${window.datosJugador.actorId}"]`)) {
+        actorSelect.value = window.datosJugador.actorId;
         actorSelect.disabled = true;
         actorSelect.dispatchEvent(new Event('change'));
-    } else if (currentSelection && actorSelect.querySelector(`option[value="${currentSelection}"]`)) {
+    }
+    // De lo contrario, usamos la selección activa del jugador (activeActor) sin bloquear el dropdown
+    else if (window.datosJugador && window.datosJugador.activeActor && actorSelect.querySelector(`option[value="${window.datosJugador.activeActor}"]`)) {
+        actorSelect.value = window.datosJugador.activeActor;
+        actorSelect.disabled = false;
+        actorSelect.dispatchEvent(new Event('change'));
+    }
+    // Fallback a la selección que ya tenía en el DOM si es válida
+    else if (currentSelection && actorSelect.querySelector(`option[value="${currentSelection}"]`)) {
         actorSelect.value = currentSelection;
+        actorSelect.disabled = false;
+    } else {
+        actorSelect.disabled = false;
     }
     
     window.actualizarExpresionesDesdeDropdown();

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "@playwright/test": "^1.58.2"
+        "@playwright/test": "^1.58.2",
+        "playwright": "^1.58.2"
       }
     },
     "node_modules/@playwright/test": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "@playwright/test": "^1.58.2"
+    "@playwright/test": "^1.58.2",
+    "playwright": "^1.58.2"
   }
 }

--- a/test_freeze6.js
+++ b/test_freeze6.js
@@ -1,0 +1,103 @@
+const { chromium } = require('playwright');
+
+(async () => {
+    const browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage();
+
+    // Check if the issue is because we rerender the whole page on player updates!
+    await page.addInitScript(() => {
+        window.localStorage.setItem('playerId', 'testplayer');
+
+        let updateCount = 0;
+
+        window.dbMock = {
+            callbacks: {},
+            ref: function(path) {
+                const self = this;
+                return {
+                    on: function(event, callback) {
+                        self.callbacks[path] = self.callbacks[path] || [];
+                        self.callbacks[path].push(callback);
+
+                        if (path === 'campaña/jugadores/testplayer') {
+                            callback({ exists: () => true, val: () => ({
+                                characterName: 'Test Name',
+                                activeActor: 'base',
+                                actorId: null,
+                                baseStats: { cuerpo: 1, mente: 1, alma: 1 }
+                            }) });
+                        } else if (path === 'campaña/actores') {
+                            callback({ exists: () => true, val: () => ({
+                                actor1: { tipo: 'Jugador', nombre: 'Actor 1', expresiones: [] },
+                                actor2: { tipo: 'Jugador', nombre: 'Actor 2', expresiones: [] }
+                            })});
+                        }
+                    },
+                    once: async function(event) {
+                        return { exists: () => true, val: () => ({}) };
+                    },
+                    update: async function(data) {
+                        console.log("Mock update called for path:", path, "with data:", data);
+
+                        if (path === 'campaña/jugadores/testplayer') {
+                            updateCount++;
+                            // Trigger callback synchronously as real firebase would
+                            const updatedData = {
+                                characterName: 'Test Name',
+                                baseStats: { cuerpo: 1, mente: 1, alma: 1 },
+                                ...data
+                            };
+
+                            setTimeout(() => {
+                                if (self.callbacks[path]) {
+                                    self.callbacks[path].forEach(cb => cb({ exists: () => true, val: () => updatedData }));
+                                }
+                            }, 50);
+                        }
+                    },
+                    push: async function(data) {
+                        return { key: 'newKey' };
+                    }
+                };
+            }
+        };
+
+        window.db = window.dbMock;
+        window.firebase = {
+            initializeApp: () => ({
+                database: () => window.dbMock
+            }),
+            database: () => window.dbMock
+        };
+    });
+
+    await page.goto('file://' + process.cwd() + '/hoja_personaje.html', { waitUntil: 'load' });
+
+    await page.waitForTimeout(1000);
+
+    // Let's trigger actor select change directly
+    console.log("Changing actor select using actual page.selectOption()");
+
+    // Just click it using Playwright
+    await page.selectOption('#player-actor-select', 'actor1');
+
+    await page.waitForTimeout(500);
+
+    console.log("Typing in input after change");
+    try {
+        await page.focus('#player-theatre-input');
+        await page.keyboard.type('Hello', { delay: 50 });
+        const val2 = await page.inputValue('#player-theatre-input');
+        console.log("Input value after change:", val2);
+
+        // Wait another bit and type
+        await page.waitForTimeout(1000);
+        await page.keyboard.type(' world!', { delay: 50 });
+        const val3 = await page.inputValue('#player-theatre-input');
+        console.log("Input value final:", val3);
+    } catch (e) {
+        console.error("Failed to type after change:", e);
+    }
+
+    await browser.close();
+})();

--- a/test_freeze7.js
+++ b/test_freeze7.js
@@ -1,0 +1,106 @@
+const { chromium } = require('playwright');
+
+(async () => {
+    const browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage();
+
+    // Check if the issue is because we rerender the whole page on player updates!
+    await page.addInitScript(() => {
+        window.localStorage.setItem('playerId', 'testplayer');
+
+        let updateCount = 0;
+
+        window.dbMock = {
+            callbacks: {},
+            ref: function(path) {
+                const self = this;
+                return {
+                    on: function(event, callback) {
+                        self.callbacks[path] = self.callbacks[path] || [];
+                        self.callbacks[path].push(callback);
+
+                        if (path === 'campaña/jugadores/testplayer') {
+                            callback({ exists: () => true, val: () => ({
+                                characterName: 'Test Name',
+                                activeActor: 'base',
+                                actorId: null,
+                                baseStats: { cuerpo: 1, mente: 1, alma: 1 }
+                            }) });
+                        } else if (path === 'campaña/actores') {
+                            callback({ exists: () => true, val: () => ({
+                                actor1: { tipo: 'Jugador', nombre: 'Actor 1', expresiones: [] },
+                                actor2: { tipo: 'Jugador', nombre: 'Actor 2', expresiones: [] }
+                            })});
+                        }
+                    },
+                    once: async function(event) {
+                        return { exists: () => true, val: () => ({}) };
+                    },
+                    update: async function(data) {
+                        console.log("Mock update called for path:", path, "with data:", data);
+
+                        if (path === 'campaña/jugadores/testplayer') {
+                            updateCount++;
+                            // Trigger callback synchronously as real firebase would
+                            const updatedData = {
+                                characterName: 'Test Name',
+                                baseStats: { cuerpo: 1, mente: 1, alma: 1 },
+                                ...data
+                            };
+
+                            setTimeout(() => {
+                                if (self.callbacks[path]) {
+                                    self.callbacks[path].forEach(cb => cb({ exists: () => true, val: () => updatedData }));
+                                }
+                            }, 50);
+                        }
+                    },
+                    push: async function(data) {
+                        return { key: 'newKey' };
+                    }
+                };
+            }
+        };
+
+        window.db = window.dbMock;
+        window.firebase = {
+            initializeApp: () => ({
+                database: () => window.dbMock
+            }),
+            database: () => window.dbMock
+        };
+    });
+
+    await page.goto('file://' + process.cwd() + '/hoja_personaje.html', { waitUntil: 'load' });
+
+    await page.waitForTimeout(1000);
+
+    // Let's trigger actor select change directly
+    console.log("Changing actor select using JS Event Dispatch");
+
+    await page.evaluate(() => {
+        const select = document.getElementById('player-actor-select');
+        select.value = 'actor1';
+        select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    await page.waitForTimeout(500);
+
+    console.log("Typing in input after change");
+    try {
+        await page.focus('#player-theatre-input');
+        await page.keyboard.type('Hello', { delay: 50 });
+        const val2 = await page.inputValue('#player-theatre-input');
+        console.log("Input value after change:", val2);
+
+        // Wait another bit and type
+        await page.waitForTimeout(1000);
+        await page.keyboard.type(' world!', { delay: 50 });
+        const val3 = await page.inputValue('#player-theatre-input');
+        console.log("Input value final:", val3);
+    } catch (e) {
+        console.error("Failed to type after change:", e);
+    }
+
+    await browser.close();
+})();

--- a/test_freeze8.js
+++ b/test_freeze8.js
@@ -1,0 +1,94 @@
+const { chromium } = require('playwright');
+
+(async () => {
+    const browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage();
+
+    // Check if the issue is because we rerender the whole page on player updates!
+    await page.addInitScript(() => {
+        window.localStorage.setItem('playerId', 'testplayer');
+
+        let updateCount = 0;
+
+        window.dbMock = {
+            callbacks: {},
+            ref: function(path) {
+                const self = this;
+                return {
+                    on: function(event, callback) {
+                        self.callbacks[path] = self.callbacks[path] || [];
+                        self.callbacks[path].push(callback);
+
+                        if (path === 'campaña/jugadores/testplayer') {
+                            callback({ exists: () => true, val: () => ({
+                                characterName: 'Test Name',
+                                activeActor: 'base',
+                                actorId: null,
+                                baseStats: { cuerpo: 1, mente: 1, alma: 1 }
+                            }) });
+                        } else if (path === 'campaña/actores') {
+                            callback({ exists: () => true, val: () => ({
+                                actor1: { tipo: 'Jugador', nombre: 'Actor 1', expresiones: [] },
+                                actor2: { tipo: 'Jugador', nombre: 'Actor 2', expresiones: [] }
+                            })});
+                        }
+                    },
+                    once: async function(event) {
+                        return { exists: () => true, val: () => ({}) };
+                    },
+                    update: async function(data) {
+                        console.log("Mock update called for path:", path, "with data:", data);
+
+                        if (path === 'campaña/jugadores/testplayer') {
+                            updateCount++;
+                            // Trigger callback synchronously as real firebase would
+                            const updatedData = {
+                                characterName: 'Test Name',
+                                baseStats: { cuerpo: 1, mente: 1, alma: 1 },
+                                ...data
+                            };
+
+                            setTimeout(() => {
+                                if (self.callbacks[path]) {
+                                    self.callbacks[path].forEach(cb => cb({ exists: () => true, val: () => updatedData }));
+                                }
+                            }, 50);
+                        }
+                    },
+                    push: async function(data) {
+                        return { key: 'newKey' };
+                    }
+                };
+            }
+        };
+
+        window.db = window.dbMock;
+        window.firebase = {
+            initializeApp: () => ({
+                database: () => window.dbMock
+            }),
+            database: () => window.dbMock
+        };
+    });
+
+    await page.goto('file://' + process.cwd() + '/hoja_personaje.html', { waitUntil: 'load' });
+
+    await page.waitForTimeout(1000);
+
+    // Let's trigger actor select change directly
+    console.log("Changing actor select using JS Event Dispatch");
+
+    await page.evaluate(() => {
+        const select = document.getElementById('player-actor-select');
+        select.value = 'actor1';
+        select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    await page.waitForTimeout(500);
+
+    // Check if input is disabled and its current text
+    const disabled = await page.evaluate(() => document.getElementById('player-theatre-input').disabled);
+    console.log("Input disabled?", disabled);
+
+    await browser.close();
+})();


### PR DESCRIPTION
The actor selection dropdown previously set itself to `disabled = true` upon every Firebase update when it found `window.datosJugador.activeActor`, regardless of who triggered the change.

This commit updates the Firebase listener logic in `hoja_personaje.js` for `campaña/actores` to differentiate between:
- A DM-assigned actor (`window.datosJugador.actorId`), which correctly freezes and hides the manual selector.
- A player's active selection (`window.datosJugador.activeActor`), which correctly preserves the selection visually but ensures the dropdown remains interactive (`disabled = false`) so the user can still interact with the page, type in the message box without it hanging, or change their selection later.

---
*PR created automatically by Jules for task [13927697061635141752](https://jules.google.com/task/13927697061635141752) started by @sokcrow*