### PR TITLE
fix: Allow players to type in the Theatre message input

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -6372,7 +6372,8 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
     position: fixed;
     top: 0; left: 0;
     width: 100vw; height: 100vh;
-    z-index: 3000; /* Above everything */
+    z-index: 99999; /* Above everything */
+    pointer-events: auto;
     background: url('https://i.imgur.com/13k5YtK.jpg') center/cover no-repeat;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Players (like Dothy) were unable to type in the message input of the "Teatro de la Mente" view because the main app grid (`.sheet-app-grid`) had a higher `z-index` and intercepted all pointer events over the player's view (`#theatre-view-player`). The DM view was functioning properly because it was natively configured with a higher z-index (`#dm-theatre-controls`).

This fix elevates `#theatre-view-player` to `z-index: 99999` and explicitly adds `pointer-events: auto` to ensure the player's theatre input container is fully clickable and interactive without being blocked by the character sheet underneath it.

A Playwright test simulating player "Dothy" verified the input is now selectable and text can be fully typed and sent.

---
*PR created automatically by Jules for task [17307580493350165354](https://jules.google.com/task/17307580493350165354) started by @sokcrow*