### PR TITLE
Fix Theatre View Overlaying Player HUD

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -6372,7 +6372,7 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
     position: fixed;
     top: 0; left: 0;
     width: 100vw; height: 100vh;
-    z-index: 99999; /* Above everything */
+    z-index: 2000; /* Under phone wrapper */
     pointer-events: auto;
     background: url('https://i.imgur.com/13k5YtK.jpg') center/cover no-repeat;
     display: flex;


### PR DESCRIPTION
Fixes an issue where the Theatre of the Mind view covered the player's HUD, preventing item usage or viewing rolls. Adjusted the `z-index` of `#theatre-view-player` from 99999 to 2000.

---
*PR created automatically by Jules for task [568982784421294743](https://jules.google.com/task/568982784421294743) started by @sokcrow*