### PR TITLE
Simplify Crafting System Mechanics

### DIFF
--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -1340,92 +1340,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 const slider = document.getElementById('craft-cantidad');
                 const cantidadFabricar = slider ? parseInt(slider.value) || 1 : 1;
 
-                // Obtener Variables
-                const dc = parseInt(receta.dc) || 10;
-                const habilidadReq = receta.habilidad ? receta.habilidad.toLowerCase() : 'mente';
-                let skillMod = 0;
-                if (currentPlayerData.modifiers && currentPlayerData.modifiers[habilidadReq] !== undefined) {
-                    skillMod = parseInt(currentPlayerData.modifiers[habilidadReq]);
-                } else if (currentPlayerData.baseStats && currentPlayerData.baseStats[habilidadReq] !== undefined) {
-                    skillMod = parseInt(currentPlayerData.baseStats[habilidadReq]);
-                }
+                const playerName = document.querySelector('input[name="attr_character_name"]')?.value.trim() || 'Jugador';
 
-                let spValue = 0;
-                if (currentPlayerData.attributes && currentPlayerData.attributes.sp !== undefined) {
-                    spValue = parseInt(currentPlayerData.attributes.sp);
-                }
-                let probCara = 50 + spValue;
-                if (probCara < 5) probCara = 5;
-                if (probCara > 95) probCara = 95;
+                // Determinar destino dinámico
+                const isAlijoActive = document.querySelector('.inv-tab-btn[data-tab="inv-stash"]')?.classList.contains('active');
+                const destination = isAlijoActive ? 'inventario_stash' : 'inventario';
 
-                // Disparar la función del panel flotante de monedas
-                const coinTossPanel = document.getElementById('coin-toss-panel');
-                const coinTossSkillName = document.getElementById('coin-toss-skill-name');
-                const coinContainer = document.getElementById('coin-toss-coins-container');
-                const totalResultText = document.getElementById('coin-toss-total-result');
-
-                if (coinTossPanel && coinTossSkillName && coinContainer && totalResultText) {
-                    coinTossPanel.style.display = 'flex';
-                    coinTossSkillName.innerText = `Crafteo: ${habilidadReq.toUpperCase()} vs DC ${dc}`;
-                    coinContainer.innerHTML = '';
-                    totalResultText.innerText = '...';
-
-                    let caras = 0;
-                    let animationTimeouts = [];
-
-                    for (let i = 0; i < 5; i++) {
-                        const isHeads = (Math.random() * 100) < probCara;
-                        if (isHeads) caras++;
-
-                        const img = document.createElement('img');
-                        img.src = "https://i.imgur.com/yshLPnQ.png"; // base coin
-                        img.className = "coin-img";
-                        img.style.width = "40px";
-                        img.style.height = "40px";
-                        coinContainer.appendChild(img);
-
-                        // Animate
-                        const to1 = setTimeout(() => {
-                            img.style.transform = "scaleY(0)";
-                        }, 100 + (i * 200));
-
-                        const to2 = setTimeout(() => {
-                            img.src = isHeads ? "https://i.imgur.com/yshLPnQ.png" : "https://i.imgur.com/5uKjL5U.png";
-                            img.style.transform = "scaleY(1)";
-                            if (isHeads) {
-                                img.style.filter = "drop-shadow(0 0 5px gold)";
-                            } else {
-                                img.style.filter = "grayscale(1) brightness(0.5)";
-                            }
-                        }, 250 + (i * 200));
-                        animationTimeouts.push(to1, to2);
-                    }
-
-                    const to3 = setTimeout(() => {
-                        const total = (caras * 3) + skillMod;
-                        totalResultText.innerText = total;
-                        totalResultText.style.color = (total >= dc) ? "var(--green-success)" : "var(--red-neon)";
-
-                        const rollInfo = { total, caras, skillMod };
-                        const playerName = document.querySelector('input[name="attr_character_name"]')?.value.trim();
-
-                        // Determinar destino dinámico
-                        const isAlijoActive = document.querySelector('.inv-tab-btn[data-tab="inv-stash"]')?.classList.contains('active');
-                        const destination = isAlijoActive ? 'inventario_stash' : 'inventario';
-
-                        setTimeout(() => {
-                            if (total >= dc) {
-                                ejecutarSintesisDin(playerName, receta, cantidadFabricar, currentPlayerData[destination] || {}, true, rollInfo, destination);
-                            } else {
-                                ejecutarSintesisDin(playerName, receta, cantidadFabricar, currentPlayerData[destination] || {}, false, rollInfo, destination);
-                            }
-                            limpiarVisorCrafteo();
-                        }, 1500); // 1.5 secs after result is shown
-
-                    }, 250 + (5 * 200));
-                    animationTimeouts.push(to3);
-
-                }
+                ejecutarSintesisDin(playerName, receta, cantidadFabricar, currentPlayerData[destination] || {}, destination);
             });
         }
     }, 1500);
@@ -1514,18 +1435,6 @@ window.validarMesaCraft = function() {
 
         const previewSlot = document.getElementById('craft-result-preview');
         const fabricarBtn = document.getElementById('btn-craft-fabricar');
-        const skillReqDisplay = document.getElementById('craft-skill-req') || (function() {
-            // Create a small display for required skill if it doesn't exist
-            if (fabricarBtn && fabricarBtn.parentElement) {
-                const div = document.createElement('div');
-                div.id = 'craft-skill-req';
-                div.style.cssText = 'color: #0df; font-size: 12px; margin-top: 5px; text-align: center; font-family: "ExcelsiorSans", sans-serif;';
-                fabricarBtn.parentElement.appendChild(div);
-                return div;
-            }
-            return null;
-        })();
-
         const { matchingRecipeId, matchingRecipe } = window.verificarRecetaOculta(slotsIds, slotsNames);
 
         if (matchingRecipe) {
@@ -1540,9 +1449,6 @@ window.validarMesaCraft = function() {
                     slot.style.border = '';
                 }
             }
-
-            const currentPlayerData = window.datosJugador || {};
-            const discovered = currentPlayerData.recetas_aprendidas && currentPlayerData.recetas_aprendidas[matchingRecipeId];
 
             let resultIconUrl = 'https://i.imgur.com/tHq85mJ.png'; // Fallback
             let resultItemName = 'Unknown Item';
@@ -1562,21 +1468,12 @@ window.validarMesaCraft = function() {
             if (previewSlot) {
                 const romanTier = ["I","II","III","IV","V","VI","VII","VIII","IX","X"][resultTier - 1] || "I";
 
-                if (discovered) {
-                    previewSlot.innerHTML = `
-                        <img src="${resultIconUrl}" class="craft-preview-img" title="${resultItemName}\n${resultDesc}" style="width: 100%; height: 100%; object-fit: contain; pointer-events: none;">
-                        <div class="item-tier-indicator tier-color-${resultTier}">${romanTier}</div>
-                    `;
-                    previewSlot.classList.remove('silhouetted');
-                    previewSlot.style.filter = 'drop-shadow(0 0 5px rgba(0, 255, 255, 0.8))';
-                } else {
-                    previewSlot.innerHTML = `
-                        <img src="${resultIconUrl}" class="craft-preview-img silhouetted" title="???" style="width: 100%; height: 100%; object-fit: contain; filter: brightness(0); pointer-events: none;">
-                        <div class="item-tier-indicator tier-color-${resultTier}">${romanTier}</div>
-                    `;
-                    previewSlot.classList.add('silhouetted');
-                    previewSlot.style.filter = 'none';
-                }
+                previewSlot.innerHTML = `
+                    <img src="${resultIconUrl}" class="craft-preview-img" title="${resultItemName}\n${resultDesc}" style="width: 100%; height: 100%; object-fit: contain; pointer-events: none;">
+                    <div class="item-tier-indicator tier-color-${resultTier}">${romanTier}</div>
+                `;
+                previewSlot.classList.remove('silhouetted');
+                previewSlot.style.filter = 'drop-shadow(0 0 5px rgba(0, 255, 255, 0.8))';
             }
 
             if (fabricarBtn) {
@@ -1584,15 +1481,6 @@ window.validarMesaCraft = function() {
                 fabricarBtn.style.opacity = '1';
                 fabricarBtn.style.cursor = 'pointer';
                 fabricarBtn.classList.remove('btn-apagado');
-
-                // Show required roll/skill on the button or near it
-                const habRequerida = matchingRecipe.habilidad || 'Ninguna';
-                const dcRequerido = matchingRecipe.dificultad || 0;
-
-                if (skillReqDisplay) {
-                    skillReqDisplay.innerText = `Requiere tirada de: ${habRequerida} (DC: ${dcRequerido})`;
-                    skillReqDisplay.style.display = 'block';
-                }
             }
 
             // Calculate max slider
@@ -2854,7 +2742,7 @@ document.addEventListener('input', (e) => {
     }
 });
 
-window.ejecutarSintesisDin = function(playerName, receta, multi, destObj, exito, rollInfo, destKey) {
+window.ejecutarSintesisDin = function(playerName, receta, multi, destObj, destKey) {
     try {
         const playerId = localStorage.getItem('playerId');
         if (!playerId) return;
@@ -2868,11 +2756,6 @@ window.ejecutarSintesisDin = function(playerName, receta, multi, destObj, exito,
         if (receta.ingredientes) {
             receta.ingredientes.forEach(ing => {
                 let required = ing.cantidad * multi;
-                if (!exito) {
-                    // Si Fracaso: Descuenta materiales al azar como penalización y no entregues nada.
-                    // penalty: 1 to 2 items
-                    required = Math.floor(Math.random() * 2) + 1;
-                }
 
                 // Search in both inventario_stash and inventario
                 const searchPaths = [
@@ -2897,7 +2780,7 @@ window.ejecutarSintesisDin = function(playerName, receta, multi, destObj, exito,
             });
         }
 
-        if (exito && receta.item_resultado) {
+        if (receta.item_resultado) {
             const newKey = firebase.database().ref().child(destPath).push().key;
             const resDef = window.dbItemsCacheGlobal ? window.dbItemsCacheGlobal[receta.item_resultado] : null;
 
@@ -2945,7 +2828,7 @@ window.ejecutarSintesisDin = function(playerName, receta, multi, destObj, exito,
 
         firebase.database().ref().update(updates).then(() => {
             console.log("Crafteo terminado.");
-            if (exito && typeof window.limpiarVisorCrafteo === 'function') {
+            if (typeof window.limpiarVisorCrafteo === 'function') {
                 window.limpiarVisorCrafteo();
             }
         }).catch(err => console.error("Error updates:", err));

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,99 @@
+<<<<<<< SEARCH
+                // Obtener Variables
+                const dc = parseInt(receta.dc) || 10;
+                const habilidadReq = receta.habilidad ? receta.habilidad.toLowerCase() : 'mente';
+                let skillMod = 0;
+                if (currentPlayerData.modifiers && currentPlayerData.modifiers[habilidadReq] !== undefined) {
+                    skillMod = parseInt(currentPlayerData.modifiers[habilidadReq]);
+                } else if (currentPlayerData.baseStats && currentPlayerData.baseStats[habilidadReq] !== undefined) {
+                    skillMod = parseInt(currentPlayerData.baseStats[habilidadReq]);
+                }
+
+                let spValue = 0;
+                if (currentPlayerData.attributes && currentPlayerData.attributes.sp !== undefined) {
+                    spValue = parseInt(currentPlayerData.attributes.sp);
+                }
+                let probCara = 50 + spValue;
+                if (probCara < 5) probCara = 5;
+                if (probCara > 95) probCara = 95;
+
+                // Disparar la función del panel flotante de monedas
+                const coinTossPanel = document.getElementById('coin-toss-panel');
+                const coinTossSkillName = document.getElementById('coin-toss-skill-name');
+                const coinContainer = document.getElementById('coin-toss-coins-container');
+                const totalResultText = document.getElementById('coin-toss-total-result');
+
+                if (coinTossPanel && coinTossSkillName && coinContainer && totalResultText) {
+                    coinTossPanel.style.display = 'flex';
+                    coinTossSkillName.innerText = `Crafteo: ${habilidadReq.toUpperCase()} vs DC ${dc}`;
+                    coinContainer.innerHTML = '';
+                    totalResultText.innerText = '...';
+
+                    let caras = 0;
+                    let animationTimeouts = [];
+
+                    for (let i = 0; i < 5; i++) {
+                        const isHeads = (Math.random() * 100) < probCara;
+                        if (isHeads) caras++;
+
+                        const img = document.createElement('img');
+                        img.src = "https://i.imgur.com/yshLPnQ.png"; // base coin
+                        img.className = "coin-img";
+                        img.style.width = "40px";
+                        img.style.height = "40px";
+                        coinContainer.appendChild(img);
+
+                        // Animate
+                        const to1 = setTimeout(() => {
+                            img.style.transform = "scaleY(0)";
+                        }, 100 + (i * 200));
+
+                        const to2 = setTimeout(() => {
+                            img.src = isHeads ? "https://i.imgur.com/yshLPnQ.png" : "https://i.imgur.com/5uKjL5U.png";
+                            img.style.transform = "scaleY(1)";
+                            if (isHeads) {
+                                img.style.filter = "drop-shadow(0 0 5px gold)";
+                            } else {
+                                img.style.filter = "grayscale(1) brightness(0.5)";
+                            }
+                        }, 250 + (i * 200));
+                        animationTimeouts.push(to1, to2);
+                    }
+
+                    const to3 = setTimeout(() => {
+                        const total = (caras * 3) + skillMod;
+                        totalResultText.innerText = total;
+                        totalResultText.style.color = (total >= dc) ? "var(--green-success)" : "var(--red-neon)";
+
+                        const rollInfo = { total, caras, skillMod };
+                        const playerName = document.querySelector('input[name="attr_character_name"]')?.value.trim();
+
+                        // Determinar destino dinámico
+                        const isAlijoActive = document.querySelector('.inv-tab-btn[data-tab="inv-stash"]')?.classList.contains('active');
+                        const destination = isAlijoActive ? 'inventario_stash' : 'inventario';
+
+                        setTimeout(() => {
+                            if (total >= dc) {
+                                ejecutarSintesisDin(playerName, receta, cantidadFabricar, currentPlayerData[destination] || {}, true, rollInfo, destination);
+                            } else {
+                                ejecutarSintesisDin(playerName, receta, cantidadFabricar, currentPlayerData[destination] || {}, false, rollInfo, destination);
+                            }
+                            limpiarVisorCrafteo();
+                        }, 1500); // 1.5 secs after result is shown
+
+                    }, 250 + (5 * 200));
+                    animationTimeouts.push(to3);
+
+                }
+=======
+                const playerName = document.querySelector('input[name="attr_character_name"]')?.value.trim() || 'Jugador';
+
+                // Determinar destino dinámico
+                const isAlijoActive = document.querySelector('.inv-tab-btn[data-tab="inv-stash"]')?.classList.contains('active');
+                const destination = isAlijoActive ? 'inventario_stash' : 'inventario';
+
+                ejecutarSintesisDin(playerName, receta, cantidadFabricar, currentPlayerData[destination] || {}, destination);
+                if (typeof window.limpiarVisorCrafteo === 'function') {
+                    window.limpiarVisorCrafteo();
+                }
+>>>>>>> REPLACE

--- a/patch2.diff
+++ b/patch2.diff
@@ -1,0 +1,130 @@
+<<<<<<< SEARCH
+        const skillReqDisplay = document.getElementById('craft-skill-req') || (function() {
+            // Create a small display for required skill if it doesn't exist
+            if (fabricarBtn && fabricarBtn.parentElement) {
+                const div = document.createElement('div');
+                div.id = 'craft-skill-req';
+                div.style.cssText = 'color: #0df; font-size: 12px; margin-top: 5px; text-align: center; font-family: "ExcelsiorSans", sans-serif;';
+                fabricarBtn.parentElement.appendChild(div);
+                return div;
+            }
+            return null;
+        })();
+
+        const { matchingRecipeId, matchingRecipe } = window.verificarRecetaOculta(slotsIds, slotsNames);
+
+        if (matchingRecipe) {
+            window.currentSelectedRecetaId = matchingRecipeId;
+            window.recetaEncontrada = matchingRecipe;
+
+            // Highlight slots that are part of the recipe
+            for (let i = 1; i <= 5; i++) {
+                const slot = document.getElementById(`craft-slot-${i}`);
+                if (slot && slot.classList.contains('has-item') && slot.dataset.idItem) {
+                    slot.classList.add('active-recipe');
+                    slot.style.border = '';
+                }
+            }
+
+            const currentPlayerData = window.datosJugador || {};
+            const discovered = currentPlayerData.recetas_aprendidas && currentPlayerData.recetas_aprendidas[matchingRecipeId];
+
+            let resultIconUrl = 'https://i.imgur.com/tHq85mJ.png'; // Fallback
+            let resultItemName = 'Unknown Item';
+            let resultTier = 1;
+            let resultDesc = '???';
+
+            if (matchingRecipe.item_resultado && typeof window.dbItemsCacheGlobal !== 'undefined') {
+                const resItemDef = window.dbItemsCacheGlobal[matchingRecipe.item_resultado];
+                if (resItemDef) {
+                    resultIconUrl = resItemDef.icono || resItemDef.url_imagen || resItemDef.url_icono || resultIconUrl;
+                    resultItemName = resItemDef.nombre || resultItemName;
+                    resultTier = resItemDef.tier || 1;
+                    resultDesc = resItemDef.descripcion || 'Sin descripción';
+                }
+            }
+
+            if (previewSlot) {
+                const romanTier = ["I","II","III","IV","V","VI","VII","VIII","IX","X"][resultTier - 1] || "I";
+
+                if (discovered) {
+                    previewSlot.innerHTML = `
+                        <img src="${resultIconUrl}" class="craft-preview-img" title="${resultItemName}\n${resultDesc}" style="width: 100%; height: 100%; object-fit: contain; pointer-events: none;">
+                        <div class="item-tier-indicator tier-color-${resultTier}">${romanTier}</div>
+                    `;
+                    previewSlot.classList.remove('silhouetted');
+                    previewSlot.style.filter = 'drop-shadow(0 0 5px rgba(0, 255, 255, 0.8))';
+                } else {
+                    previewSlot.innerHTML = `
+                        <img src="${resultIconUrl}" class="craft-preview-img silhouetted" title="???" style="width: 100%; height: 100%; object-fit: contain; filter: brightness(0); pointer-events: none;">
+                        <div class="item-tier-indicator tier-color-${resultTier}">${romanTier}</div>
+                    `;
+                    previewSlot.classList.add('silhouetted');
+                    previewSlot.style.filter = 'none';
+                }
+            }
+
+            if (fabricarBtn) {
+                fabricarBtn.disabled = false;
+                fabricarBtn.style.opacity = '1';
+                fabricarBtn.style.cursor = 'pointer';
+                fabricarBtn.classList.remove('btn-apagado');
+
+                // Show required roll/skill on the button or near it
+                const habRequerida = matchingRecipe.habilidad || 'Ninguna';
+                const dcRequerido = matchingRecipe.dificultad || 0;
+
+                if (skillReqDisplay) {
+                    skillReqDisplay.innerText = `Requiere tirada de: ${habRequerida} (DC: ${dcRequerido})`;
+                    skillReqDisplay.style.display = 'block';
+                }
+            }
+=======
+        const { matchingRecipeId, matchingRecipe } = window.verificarRecetaOculta(slotsIds, slotsNames);
+
+        if (matchingRecipe) {
+            window.currentSelectedRecetaId = matchingRecipeId;
+            window.recetaEncontrada = matchingRecipe;
+
+            // Highlight slots that are part of the recipe
+            for (let i = 1; i <= 5; i++) {
+                const slot = document.getElementById(`craft-slot-${i}`);
+                if (slot && slot.classList.contains('has-item') && slot.dataset.idItem) {
+                    slot.classList.add('active-recipe');
+                    slot.style.border = '';
+                }
+            }
+
+            let resultIconUrl = 'https://i.imgur.com/tHq85mJ.png'; // Fallback
+            let resultItemName = 'Unknown Item';
+            let resultTier = 1;
+            let resultDesc = '???';
+
+            if (matchingRecipe.item_resultado && typeof window.dbItemsCacheGlobal !== 'undefined') {
+                const resItemDef = window.dbItemsCacheGlobal[matchingRecipe.item_resultado];
+                if (resItemDef) {
+                    resultIconUrl = resItemDef.icono || resItemDef.url_imagen || resItemDef.url_icono || resultIconUrl;
+                    resultItemName = resItemDef.nombre || resultItemName;
+                    resultTier = resItemDef.tier || 1;
+                    resultDesc = resItemDef.descripcion || 'Sin descripción';
+                }
+            }
+
+            if (previewSlot) {
+                const romanTier = ["I","II","III","IV","V","VI","VII","VIII","IX","X"][resultTier - 1] || "I";
+
+                previewSlot.innerHTML = `
+                    <img src="${resultIconUrl}" class="craft-preview-img" title="${resultItemName}\n${resultDesc}" style="width: 100%; height: 100%; object-fit: contain; pointer-events: none;">
+                    <div class="item-tier-indicator tier-color-${resultTier}">${romanTier}</div>
+                `;
+                previewSlot.classList.remove('silhouetted');
+                previewSlot.style.filter = 'drop-shadow(0 0 5px rgba(0, 255, 255, 0.8))';
+            }
+
+            if (fabricarBtn) {
+                fabricarBtn.disabled = false;
+                fabricarBtn.style.opacity = '1';
+                fabricarBtn.style.cursor = 'pointer';
+                fabricarBtn.classList.remove('btn-apagado');
+            }
+>>>>>>> REPLACE

--- a/plan_review_request.md
+++ b/plan_review_request.md
@@ -1,0 +1,18 @@
+The user wants to simplify the crafting system:
+1. They want the crafting system to simply know what items are on the crafting table, without needing to learn the recipe beforehand. So any items placed on the table that match a recipe will produce the result, without skill checks or coin tosses.
+2. "Tengo X1 y X2 y estos hacen Y y ya, sin tiradas ni nada". So, I need to remove the whole `dc`, `habilidadReq`, `spValue`, probability calculation, and coin toss animation from the `fabricarBtn` click listener.
+3. Upon clicking `btn-craft-fabricar`, if there's a matching recipe, it should immediately execute the synthesis (deduct ingredients and give the result) successfully (`exito = true`), without any random failure penalty or roll information.
+
+Steps:
+1. Modify the `fabricarBtn` click listener (lines 1335 to 1430 in `hoja_personaje.js`):
+   - Replace the entire block that calculates `dc`, `habilidadReq`, `skillMod`, `spValue`, `probCara`, and triggers `coinTossPanel`.
+   - Instead, simply determine the destination (`inventario_stash` or `inventario`), get the slider value for quantity, and directly call `ejecutarSintesisDin(playerName, receta, cantidadFabricar, currentPlayerData[destination] || {}, true, null, destination)`.
+   - The user's playerName can be retrieved with `document.querySelector('input[name="attr_character_name"]')?.value.trim()`.
+2. Modify `validarMesaCraft` in `hoja_personaje.js`:
+   - Remove the code that checks if the recipe is `discovered` (lines 1563-1577).
+   - Instead, always show the actual item preview (`previewSlot.innerHTML` with full `resultIconUrl`, `resultItemName`, `resultDesc` without `silhouetted` class or `brightness(0)` filter) so the user can see what they are making even before making it.
+   - Remove the `skillReqDisplay` logic (lines 1518-1526, 1592-1596) that displays required rolls or DC.
+3. Modify `ejecutarSintesisDin` in `hoja_personaje.js` (lines 2872-2877):
+   - Remove the `!exito` check and penalty deduction logic, since all crafting will now succeed.
+4. Verify the changes using `read_file` or running playwright tests (`npx playwright test test_crafting.spec.js` / `test_crafting_ui.spec.js` if applicable, although maybe tests need to be updated due to UI changes).
+5. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.


### PR DESCRIPTION
The crafting system has been drastically simplified per user request. 
Instead of requiring skill rolls against DC thresholds, rolling coins based on SP, and risking material destruction on failure, the system simply checks if the ingredients slotted match a valid recipe. 
If X1 and X2 make Y, Y is clearly displayed as the output. Clicking 'Fabricar' instantly and reliably produces the output item directly without failure chance.

The UI no longer applies the `brightness(0) drop-shadow` silhouette filters when a recipe is matching but not "learned". It behaves strictly as "these items make this item", fulfilling the user's intent.

---
*PR created automatically by Jules for task [8005248854533891666](https://jules.google.com/task/8005248854533891666) started by @sokcrow*