### PR TITLE
Add "Limpiar" button for Theatre Queue

### DIFF
--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -1047,7 +1047,10 @@
 
       <!-- Left: Queue -->
       <div style="flex: 1; border-right: 1px solid #444; padding-right: 15px; display: flex; flex-direction: column; max-height: 100px;">
-        <h5 style="margin: 0 0 5px 0; color: #0df;">Cola de Actuación</h5>
+        <div style="display: flex; justify-content: space-between; align-items: center; margin: 0 0 5px 0;">
+          <h5 style="margin: 0; color: #0df;">Cola de Actuación</h5>
+          <button id="btn-clear-queue" class="btn-cyber" style="background: #222; color: #ff4444; border: 1px solid #ff4444; padding: 2px 6px; font-size: 10px; cursor: pointer;">Limpiar</button>
+        </div>
         <div id="dm-theatre-queue" style="flex: 1; overflow-y: auto; background: #111; border: 1px solid #333; padding: 5px; font-size: 14px; color: #aaa; display: flex; flex-direction: column; gap: 5px;">
           <!-- Queue items injected here -->
         </div>
@@ -3633,6 +3636,12 @@
         const bg = document.getElementById('dm-theatre-bg').value.trim();
         if (bg) {
             db.ref('campaña/teatro').update({ fondo: bg });
+        }
+    });
+
+    document.getElementById('btn-clear-queue').addEventListener('click', () => {
+        if (confirm('¿Estás seguro de que quieres limpiar toda la cola de actuación?')) {
+            db.ref('campaña/teatro/cola').remove();
         }
     });
 

--- a/test_clear_queue.spec.js
+++ b/test_clear_queue.spec.js
@@ -1,0 +1,45 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Botón Limpiar Cola', () => {
+
+    test('Limpiar cola elimina los elementos', async ({ page }) => {
+        await page.goto(`file://${__dirname}/pantalla_dm.html`);
+
+        // We override the firebase function to detect if it was called
+        await page.evaluate(() => {
+            window.calledRemove = false;
+            // Original `db` is already loaded from firebase scripts.
+            // We just override the specific function locally without breaking the whole object if possible,
+            // or just rely on overriding db for the button. The event listener uses global `db`.
+            const originalRef = db.ref;
+            db.ref = function(path) {
+                if (path === 'campaña/teatro/cola') {
+                    const refObj = originalRef.call(db, path);
+                    const originalRemove = refObj.remove;
+                    refObj.remove = function() {
+                        window.calledRemove = true;
+                        // Not calling actual remove to avoid touching real DB or mocking it entirely
+                        return Promise.resolve();
+                    };
+                    return refObj;
+                }
+                return originalRef.call(db, path);
+            };
+        });
+
+        const btn = page.locator('#btn-clear-queue');
+        await btn.waitFor({ state: 'attached', timeout: 5000 });
+
+        page.on('dialog', async dialog => {
+            expect(dialog.message()).toBe('¿Estás seguro de que quieres limpiar toda la cola de actuación?');
+            await dialog.accept();
+        });
+
+        await page.evaluate(() => {
+           document.getElementById('btn-clear-queue').click();
+        });
+
+        const calledRemove = await page.evaluate(() => window.calledRemove);
+        expect(calledRemove).toBe(true);
+    });
+});


### PR DESCRIPTION
This adds a simple button for the DM to clear the Theatre queue instead of having to delete entries manually one by one.

---
*PR created automatically by Jules for task [16809116558754900850](https://jules.google.com/task/16809116558754900850) started by @sokcrow*