### PR TITLE
Fix TypeError in DM screen caused by malformed titlePlate validation

### DIFF
--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -3913,10 +3913,15 @@
             }
         }
 
-        if(titlePlate.querySelector('span')) titlePlate.querySelector('span').innerText = state.titulo || ''; else if(titlePlate.querySelector('span')) {
-            titlePlate.querySelector('span').innerText = state.titulo || '';
-        } else {
-            titlePlate.querySelector('span').innerText = state.titulo || '';
+        if (titlePlate) {
+            const spanElement = titlePlate.querySelector('span');
+            if (spanElement) {
+                spanElement.innerText = state.titulo || '';
+            } else {
+                titlePlate.innerText = state.titulo || '';
+            }
+            titlePlate.style.color = state.color_titulo || '#d69c52';
+            titlePlate.style.borderColor = state.color_titulo || '#c49a00';
         }
         /* The title plate color requirement was: background dark brown, text gold.
            If the user wants the custom color to apply to text: */


### PR DESCRIPTION
Fixes a JavaScript `TypeError` crash in `pantalla_dm.html` by resolving a malformed validation block for `titlePlate` in the `campaña/teatro/estado_actual` listener. Applied strict null checking as requested by the user, ensuring Firebase interactions are no longer disrupted.

---
*PR created automatically by Jules for task [3288798285142502048](https://jules.google.com/task/3288798285142502048) started by @sokcrow*