### PR TITLE
Fix Sprite alignment with Dialogue Box in Theatre Views

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -6316,6 +6316,15 @@ input[name="attr_tab"][value="shop"] ~ .sheet-phone-screen .sheet-tab-shop {
         bottom: 75px !important; /* Approx height of open ultra-compact menu */
     }
 
+    #theatre-view-player .sprite-wrapper img {
+        bottom: 35px !important;
+        transition: bottom 0.4s ease-out !important;
+    }
+
+    #theatre-view-player:has(#player-theatre-tools-wrapper.open) .sprite-wrapper img {
+        bottom: 75px !important;
+    }
+
     /* Keep the dialogue box itself ultra compact */
     #theatre-view-player .theatre-dialogue-text {
         padding: 20px 10px 10px 10px !important;
@@ -6718,7 +6727,7 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
 }
 .sprite-wrapper img {
     position: absolute;
-    bottom: 0;
+    bottom: 50px;
     left: 50%;
     transform-origin: bottom center;
     transform: translateX(-50%);

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -618,6 +618,15 @@
          bottom: 130px !important;
       }
 
+      #theatre-view-dm .sprite-wrapper img {
+         bottom: 35px !important;
+         transition: bottom 0.4s ease-out !important;
+      }
+
+      #theatre-view-dm:has(#dm-tools-wrapper.open) .sprite-wrapper img {
+         bottom: 130px !important;
+      }
+
       .theatre-dialogue-text {
         padding: 20px 10px 10px 10px !important;
         font-size: 11px !important;
@@ -1250,7 +1259,7 @@
     }
     .sprite-wrapper img {
       position: absolute;
-      bottom: 0;
+      bottom: 50px;
       left: 50%;
       transform-origin: bottom center;
       transform: translateX(-50%);


### PR DESCRIPTION
# Descripción de Cambios

Se ajustó la alineación vertical de los sprites (`.sprite-wrapper img`) en el Teatro de la Mente para que siempre comiencen alineados a la misma altura en la parte inferior (bottom) que la caja de diálogo.

- **Escritorio:** Se cambió el valor `bottom` estático de los sprites de `0` a `50px` para que comiencen exactamente donde lo hace la `.theatre-dialogue-wrapper` en la vista de escritorio por defecto.
- **Móvil (Landscape):** Se replicaron las reglas dinámicas usadas por `.theatre-dialogue-wrapper` (que utiliza la pseudo-clase `:has()`) para ajustar de manera idéntica los valores del `bottom` en los sprites, manteniéndose siempre alineados independientemente de si la barra de herramientas del Jugador o DM está minimizada (bottom: 35px) o desplegada.

Esto asegura que en ningún caso los personajes floten por debajo o por encima de la caja del diálogo principal de la escena. Se ha comprobado el resultado visualmente a través de las capturas dinámicas.

---
*PR created automatically by Jules for task [2724080702048926066](https://jules.google.com/task/2724080702048926066) started by @sokcrow*