### PR TITLE
style: sync circular HUD icons from mobile to PC

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -6607,6 +6607,50 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
     box-shadow: 0 0 15px rgba(255, 51, 51, 0.6);
 }
 
+/* PC-specific styles to force circular buttons just like Mobile */
+@media (min-width: 769px) {
+    #btn-toggle-hud {
+        width: 36px !important;
+        height: 36px !important;
+        border-radius: 50% !important;
+        padding: 0 !important;
+        display: flex !important;
+        align-items: center;
+        justify-content: center;
+        font-size: 16px !important;
+    }
+    #btn-toggle-hud .text-long {
+        display: none !important;
+    }
+    #btn-toggle-hud .text-short {
+        display: inline !important;
+    }
+
+    #btn-toggle-theatre-log-player {
+        display: flex !important;
+        align-items: center;
+        justify-content: center;
+        position: fixed !important;
+        top: 45px !important;
+        left: 10px !important;
+        width: 36px !important;
+        height: 36px !important;
+        border-radius: 50% !important;
+        background: rgba(139, 0, 0, 0.8) !important;
+        border: 2px solid #d4af37 !important;
+        color: #fff !important;
+        font-size: 16px !important;
+        cursor: pointer !important;
+        z-index: 2015 !important;
+        padding: 0 !important;
+        box-shadow: 0 0 10px rgba(0,0,0,0.8);
+    }
+    #btn-toggle-theatre-log-player:hover {
+        background: rgba(180, 0, 0, 1) !important;
+        transform: scale(1.05);
+    }
+}
+
 #player-combat-hud {
     position: fixed;
     top: 70px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Changes:
- Added `min-width: 769px` media query block in `hoja_personaje.css`.
- `#btn-toggle-hud` on PC now forces the `.text-short` emoji and hides the `.text-long` label, mirroring mobile.
- `#btn-toggle-theatre-log-player` on PC is now visible and styled exactly as its mobile counterpart.
- Confirmed with Playwright via bounding box capture that dimensions are correctly set and mobile styles remain unmodified.

---
*PR created automatically by Jules for task [2440624512874456601](https://jules.google.com/task/2440624512874456601) started by @sokcrow*