### PR TITLE
Fix Theatre Log overlay visibility and layout across all devices

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -7352,7 +7352,7 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
 }
 
 #btn-toggle-theatre-log-player {
-    display: flex !important;
+    display: none !important; /* Hidden by default unless theatre active */
     align-items: center;
     justify-content: center;
     position: fixed !important;
@@ -7371,7 +7371,20 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
     box-shadow: 0 0 10px rgba(0,0,0,0.8);
 }
 
+/* Only show the log button when the theatre view is actually active */
+#theatre-view-player.theatre-active #btn-toggle-theatre-log-player,
+#theatre-view-player[style*="display: flex"] #btn-toggle-theatre-log-player,
+#theatre-view-player:not([style*="display: none"]) #btn-toggle-theatre-log-player {
+    display: flex !important;
+}
+
 #btn-toggle-theatre-log-player:hover {
     background: rgba(180, 0, 0, 1) !important;
     transform: scale(1.05);
+}
+
+.log-icon-svg {
+    width: 20px;
+    height: 20px;
+    fill: currentColor;
 }

--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -6175,51 +6175,7 @@ input[name="attr_tab"][value="shop"] ~ .sheet-phone-screen .sheet-tab-shop {
         right: 10px !important;
     }
 
-    /* ---- Theatre Location & Log Adjustments ---- */
-    #theatre-view-player #theatre-log-container {
-        display: none !important;
-        position: fixed !important;
-        top: 50% !important;
-        left: 50% !important;
-        transform: translate(-50%, -50%) !important;
-        width: 80% !important;
-        max-width: 400px !important;
-        height: 60vh !important;
-        max-height: 400px !important;
-        z-index: 2050 !important;
-        background: rgba(0,0,0,0.95) !important;
-        border: 2px solid #444 !important;
-        box-shadow: 0 0 20px rgba(0,0,0,0.8) !important;
-    }
 
-    #theatre-view-player #theatre-log-container.open {
-        display: flex !important;
-    }
-
-    #btn-toggle-theatre-log-player {
-        display: flex !important;
-        align-items: center;
-        justify-content: center;
-        position: fixed !important;
-        top: 45px !important;
-        left: 10px !important;
-        width: 36px !important;
-        height: 36px !important;
-        border-radius: 50% !important;
-        background: rgba(139, 0, 0, 0.8) !important;
-        border: 2px solid #d4af37 !important;
-        color: #fff !important;
-        font-size: 16px !important;
-        cursor: pointer !important;
-        z-index: 2015 !important;
-        padding: 0 !important;
-        box-shadow: 0 0 10px rgba(0,0,0,0.8);
-    }
-
-    #btn-toggle-theatre-log-player:hover {
-        background: rgba(180, 0, 0, 1) !important;
-        transform: scale(1.05);
-    }
 
     /* Restaurar location tag en tamaño compacto */
     #theatre-view-player .theatre-location {
@@ -6626,29 +6582,7 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
         display: inline !important;
     }
 
-    #btn-toggle-theatre-log-player {
-        display: flex !important;
-        align-items: center;
-        justify-content: center;
-        position: fixed !important;
-        top: 45px !important;
-        left: 10px !important;
-        width: 36px !important;
-        height: 36px !important;
-        border-radius: 50% !important;
-        background: rgba(139, 0, 0, 0.8) !important;
-        border: 2px solid #d4af37 !important;
-        color: #fff !important;
-        font-size: 16px !important;
-        cursor: pointer !important;
-        z-index: 2015 !important;
-        padding: 0 !important;
-        box-shadow: 0 0 10px rgba(0,0,0,0.8);
-    }
-    #btn-toggle-theatre-log-player:hover {
-        background: rgba(180, 0, 0, 1) !important;
-        transform: scale(1.05);
-    }
+
 }
 
 #player-combat-hud {
@@ -7388,4 +7322,56 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
 .item-slotted {
     opacity: 0.4;
     pointer-events: none;
+}
+
+/* ---- Global Theatre Log Adjustments ---- */
+#theatre-view-player #theatre-log-container {
+    display: none !important;
+    position: fixed !important;
+    top: 50% !important;
+    left: 50% !important;
+    transform: translate(-50%, -50%) !important;
+    width: 80% !important;
+    max-width: 400px !important;
+    height: 60vh !important;
+    max-height: 400px !important;
+    z-index: 2050 !important;
+    background: rgba(0,0,0,0.95) !important;
+    border: 2px solid #444 !important;
+    box-shadow: 0 0 20px rgba(0,0,0,0.8) !important;
+    overflow-y: auto !important;
+    padding: 10px !important;
+    font-size: 13px !important;
+    color: #ccc !important;
+    flex-direction: column !important;
+    gap: 5px !important;
+}
+
+#theatre-view-player #theatre-log-container.open {
+    display: flex !important;
+}
+
+#btn-toggle-theatre-log-player {
+    display: flex !important;
+    align-items: center;
+    justify-content: center;
+    position: fixed !important;
+    top: 45px !important;
+    left: 10px !important;
+    width: 36px !important;
+    height: 36px !important;
+    border-radius: 50% !important;
+    background: rgba(139, 0, 0, 0.8) !important;
+    border: 2px solid #d4af37 !important;
+    color: #fff !important;
+    font-size: 16px !important;
+    cursor: pointer !important;
+    z-index: 2015 !important;
+    padding: 0 !important;
+    box-shadow: 0 0 10px rgba(0,0,0,0.8);
+}
+
+#btn-toggle-theatre-log-player:hover {
+    background: rgba(180, 0, 0, 1) !important;
+    transform: scale(1.05);
 }

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -4168,10 +4168,10 @@
     <span id="player-theatre-location-text">Unknown Location</span>
   </div>
 
-  <button id="btn-toggle-theatre-log-player" title="Ver Historial" style="display: none;">📜</button>
+  <button id="btn-toggle-theatre-log-player" title="Ver Historial">📜</button>
 
   <!-- Theatre Log Container -->
-  <div id="theatre-log-container" style="position: absolute; top: 120px; left: 40px; width: 300px; max-height: 400px; background: rgba(0,0,0,0.6); border: 1px solid #444; border-radius: 4px; overflow-y: auto; padding: 10px; font-size: 13px; color: #ccc; z-index: 2010; display: flex; flex-direction: column; gap: 5px;">
+  <div id="theatre-log-container" style="display: none;">
     <!-- Log items injected here -->
   </div>
 

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -4168,7 +4168,7 @@
     <span id="player-theatre-location-text">Unknown Location</span>
   </div>
 
-  <button id="btn-toggle-theatre-log-player" title="Ver Historial">📜</button>
+  <button id="btn-toggle-theatre-log-player" title="Ver Historial"><svg class="log-icon-svg log-icon-doc" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6zm-1 1.5L18.5 9H13V3.5zM18 20H6V4h6v6h6v10z"/><path d="M8 12h8v2H8zm0 4h8v2H8z"/></svg><svg class="log-icon-svg log-icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="display: none;"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/></svg></button>
 
   <!-- Theatre Log Container -->
   <div id="theatre-log-container" style="display: none;">
@@ -4528,8 +4528,16 @@
               const logContainer = document.getElementById('theatre-log-container');
               if (logContainer) {
                   logContainer.classList.toggle('open');
-                  // Keep text small and single-character for the 36x36px circular button
-                  this.innerText = logContainer.classList.contains('open') ? '❌' : '📜';
+                  const logIcon = this.querySelector('.log-icon-doc');
+                  const closeIcon = this.querySelector('.log-icon-close');
+                  if (logContainer.classList.contains('open')) {
+                      if (logIcon) logIcon.style.display = 'none';
+                      if (closeIcon) closeIcon.style.display = 'block';
+                  } else {
+                      if (logIcon) logIcon.style.display = 'block';
+                      if (closeIcon) closeIcon.style.display = 'none';
+                  }
+
               }
           });
       }

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -451,51 +451,7 @@
     }
 
     @media (max-width: 768px) {
-      /* Ocultar el contenedor de log por defecto en móvil */
-      #theatre-log-container {
-        display: none !important;
-        position: fixed !important;
-        top: 50% !important;
-        left: 50% !important;
-        transform: translate(-50%, -50%) !important;
-        width: 80% !important;
-        max-width: 400px !important;
-        height: 60vh !important;
-        max-height: 400px !important;
-        z-index: 2050 !important;
-        background: rgba(0,0,0,0.95) !important;
-        border: 2px solid #444 !important;
-        box-shadow: 0 0 20px rgba(0,0,0,0.8) !important;
-      }
 
-      #theatre-log-container.open {
-        display: flex !important;
-      }
-
-      #btn-toggle-theatre-log {
-        display: flex !important;
-        align-items: center;
-        justify-content: center;
-        position: fixed !important;
-        top: 45px !important;
-        left: 10px !important;
-        width: 36px !important;
-        height: 36px !important;
-        border-radius: 50% !important;
-        background: rgba(139, 0, 0, 0.8) !important;
-        border: 2px solid #d4af37 !important;
-        color: #fff !important;
-        font-size: 16px !important;
-        cursor: pointer !important;
-        z-index: 2015 !important;
-        padding: 0 !important;
-        box-shadow: 0 0 10px rgba(0,0,0,0.8);
-      }
-
-      #btn-toggle-theatre-log:hover {
-        background: rgba(180, 0, 0, 1) !important;
-        transform: scale(1.05);
-      }
 
       /* Restaurar location tag en tamaño compacto */
       .theatre-location {
@@ -665,7 +621,59 @@
         flex: 1 1 100% !important;
       }
     }
-  </style>
+
+    /* ---- Global Theatre Log Adjustments ---- */
+    #theatre-log-container {
+      display: none !important;
+      position: fixed !important;
+      top: 50% !important;
+      left: 50% !important;
+      transform: translate(-50%, -50%) !important;
+      width: 80% !important;
+      max-width: 400px !important;
+      height: 60vh !important;
+      max-height: 400px !important;
+      z-index: 2050 !important;
+      background: rgba(0,0,0,0.95) !important;
+      border: 2px solid #444 !important;
+      box-shadow: 0 0 20px rgba(0,0,0,0.8) !important;
+      overflow-y: auto !important;
+      padding: 10px !important;
+      font-size: 13px !important;
+      color: #ccc !important;
+      flex-direction: column !important;
+      gap: 5px !important;
+    }
+
+    #theatre-log-container.open {
+      display: flex !important;
+    }
+
+    #btn-toggle-theatre-log {
+      display: flex !important;
+      align-items: center;
+      justify-content: center;
+      position: fixed !important;
+      top: 45px !important;
+      left: 10px !important;
+      width: 36px !important;
+      height: 36px !important;
+      border-radius: 50% !important;
+      background: rgba(139, 0, 0, 0.8) !important;
+      border: 2px solid #d4af37 !important;
+      color: #fff !important;
+      font-size: 16px !important;
+      cursor: pointer !important;
+      z-index: 2015 !important;
+      padding: 0 !important;
+      box-shadow: 0 0 10px rgba(0,0,0,0.8);
+    }
+
+    #btn-toggle-theatre-log:hover {
+      background: rgba(180, 0, 0, 1) !important;
+      transform: scale(1.05);
+    }
+</style>
 
 <style>
 
@@ -1144,10 +1152,10 @@
       <span id="theatre-location-text">Unknown Location</span>
     </div>
 
-    <button id="btn-toggle-theatre-log" title="Ver Historial" style="display: none;">📜</button>
+    <button id="btn-toggle-theatre-log" title="Ver Historial">📜</button>
 
     <!-- Theatre Log Container -->
-    <div id="theatre-log-container" style="position: absolute; top: 120px; left: 40px; width: 300px; max-height: 400px; background: rgba(0,0,0,0.6); border: 1px solid #444; border-radius: 4px; overflow-y: auto; padding: 10px; font-size: 13px; color: #ccc; z-index: 2010; display: flex; flex-direction: column; gap: 5px;">
+    <div id="theatre-log-container" style="display: none;">
       <!-- Log items injected here -->
     </div>
 

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -650,7 +650,7 @@
     }
 
     #btn-toggle-theatre-log {
-      display: flex !important;
+      display: none !important; /* Hidden by default unless theatre active */
       align-items: center;
       justify-content: center;
       position: fixed !important;
@@ -669,9 +669,22 @@
       box-shadow: 0 0 10px rgba(0,0,0,0.8);
     }
 
+    /* Only show the log button when the theatre view is active */
+    #theatre-view-dm[style*="display: flex"] #btn-toggle-theatre-log,
+    #theatre-view-dm:not([style*="display: none"]) #btn-toggle-theatre-log,
+    #theatre-view-dm.theatre-active #btn-toggle-theatre-log {
+        display: flex !important;
+    }
+
     #btn-toggle-theatre-log:hover {
       background: rgba(180, 0, 0, 1) !important;
       transform: scale(1.05);
+    }
+
+    .log-icon-svg {
+        width: 20px;
+        height: 20px;
+        fill: currentColor;
     }
 </style>
 
@@ -1152,7 +1165,7 @@
       <span id="theatre-location-text">Unknown Location</span>
     </div>
 
-    <button id="btn-toggle-theatre-log" title="Ver Historial">📜</button>
+    <button id="btn-toggle-theatre-log" title="Ver Historial"><svg class="log-icon-svg log-icon-doc" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6zm-1 1.5L18.5 9H13V3.5zM18 20H6V4h6v6h6v10z"/><path d="M8 12h8v2H8zm0 4h8v2H8z"/></svg><svg class="log-icon-svg log-icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="display: none;"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/></svg></button>
 
     <!-- Theatre Log Container -->
     <div id="theatre-log-container" style="display: none;">
@@ -1603,8 +1616,16 @@
                 const logContainer = document.getElementById('theatre-log-container');
                 if (logContainer) {
                     logContainer.classList.toggle('open');
-                    // On mobile, the button is a small circle, so we just toggle icons. On desktop it's hidden anyway.
-                    this.innerText = logContainer.classList.contains('open') ? '❌' : '📜';
+                    const logIcon = this.querySelector('.log-icon-doc');
+                    const closeIcon = this.querySelector('.log-icon-close');
+                    if (logContainer.classList.contains('open')) {
+                        if (logIcon) logIcon.style.display = 'none';
+                        if (closeIcon) closeIcon.style.display = 'block';
+                    } else {
+                        if (logIcon) logIcon.style.display = 'block';
+                        if (closeIcon) closeIcon.style.display = 'none';
+                    }
+
                 }
             });
         }


### PR DESCRIPTION
The CSS rules governing the `theatre-log-container` and its toggle button were erroneously trapped inside restrictive `@media` queries (e.g. `max-width: 768px`) in both the player sheet's stylesheet and the DM screen's inline `<style>`. Furthermore, there were conflicting inline styles directly on the HTML elements that disrupted the flexbox layout intended for the log.

This patch extracts these specific rules, globalizes them, cleans up the inline styles to default to `display: none;`, and ensures that toggling the `.open` class consistently opens the dark, centered modal overlay for the Theatre log history across both desktop and mobile viewports for all users.

---
*PR created automatically by Jules for task [11065558777104126091](https://jules.google.com/task/11065558777104126091) started by @sokcrow*