### PR TITLE
Fix coin toss logic and result formatting in character sheet

### DIFF
--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -1808,7 +1808,7 @@ document.addEventListener('click', (e) => {
         if (nameEl) nameEl.textContent = displayName;
 
         const resultEl = document.getElementById('coin-toss-total-result');
-        if (resultEl) resultEl.textContent = `Resultado: ${finalResult} (${headsCount} Caras + ${skillTotal} Modificador)`;
+        if (resultEl) resultEl.textContent = finalResult;
 
         const panel = document.getElementById('coin-toss-panel');
         if (panel) panel.style.display = 'flex';

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -1747,17 +1747,33 @@ document.addEventListener('click', (e) => {
         const displaySpan = row.querySelector('.sheet-skill-name');
         const displayName = displaySpan ? displaySpan.textContent : skillNameRaw;
 
-        // Read Base + Mod from inputs in the same row
-        const baseInput = row.querySelector('input[title="Base"]');
-        const modInput = row.querySelector('input[title="Mod"]');
+        // SP Calculation & Data Lookup
+        // currentPlayerData may be defined as an empty object in global scope.
+        // We ensure we read `window.datosJugador` or global `currentPlayerData` if populated.
+        const pd = Object.keys(currentPlayerData || {}).length > 0 ? currentPlayerData : (window.datosJugador || {});
 
-        const baseVal = baseInput ? parseInt(baseInput.value) || 0 : 0;
-        const modVal = modInput ? parseInt(modInput.value) || 0 : 0;
+        // Read Base + Mod from player data securely
+        let baseVal = 0;
+        let modVal = 0;
+
+        if (pd) {
+            // For Core Stats (cuerpo, mente, alma)
+            if (['cuerpo', 'mente', 'alma'].includes(skillNameRaw.toLowerCase())) {
+                baseVal = pd.baseStats && pd.baseStats[skillNameRaw.toLowerCase()] ? parseInt(pd.baseStats[skillNameRaw.toLowerCase()]) || 0 : 0;
+                modVal = pd.modifiers && pd.modifiers[skillNameRaw.toLowerCase()] ? parseInt(pd.modifiers[skillNameRaw.toLowerCase()]) || 0 : 0;
+            } else {
+                // For Skills, base is usually derived or 0, check modifiers
+                const modKey = `skill_${skillNameRaw.toLowerCase()}`;
+                modVal = pd.modifiers && pd.modifiers[modKey] ? parseInt(pd.modifiers[modKey]) || 0 :
+                         (pd.modifiers && pd.modifiers[skillNameRaw.toLowerCase()] ? parseInt(pd.modifiers[skillNameRaw.toLowerCase()]) || 0 : 0);
+                // Also fallback to check if there is a base value stored
+                baseVal = pd.baseStats && pd.baseStats[skillNameRaw.toLowerCase()] ? parseInt(pd.baseStats[skillNameRaw.toLowerCase()]) || 0 : 0;
+            }
+        }
+
         const skillTotal = baseVal + modVal;
 
-        // SP Calculation
-        const pd = typeof currentPlayerData !== "undefined" ? currentPlayerData : (window.datosJugador || {});
-        let sp = parseInt(pd.sp) || 0;
+        let sp = parseInt(pd.combatStats?.sp_actual ?? pd.sp) || 0;
         if (sp > 45) sp = 45;
         if (sp < -45) sp = -45;
 
@@ -1785,17 +1801,82 @@ document.addEventListener('click', (e) => {
             if (container) container.appendChild(img);
         }
 
-        const finalResult = (headsCount * 3) + skillTotal;
+        const finalResult = headsCount + skillTotal;
 
         // Update UI
         const nameEl = document.getElementById('coin-toss-skill-name');
         if (nameEl) nameEl.textContent = displayName;
 
         const resultEl = document.getElementById('coin-toss-total-result');
-        if (resultEl) resultEl.textContent = finalResult;
+        if (resultEl) resultEl.textContent = `Resultado: ${finalResult} (${headsCount} Caras + ${skillTotal} Modificador)`;
 
         const panel = document.getElementById('coin-toss-panel');
         if (panel) panel.style.display = 'flex';
+
+        // Send to Theatre of the Mind Log
+        if (typeof db !== 'undefined' && db.ref) {
+            try {
+                const actorSelect = document.getElementById('player-actor-select');
+                const selectExp = document.getElementById('player-expression-select');
+
+                const assignedActorId = window.datosJugador?.actorId || null;
+                const selectedActorId = assignedActorId ? assignedActorId : (actorSelect ? actorSelect.value : 'base');
+
+                let actorParaEnviar = {
+                    nombre: pd.characterName || "Jugador",
+                    titulo: "",
+                    color_nombre: "#ffffff",
+                    color_titulo: "#aaaaaa",
+                    escala: 1.0,
+                    sprite: "https://i.imgur.com/Z8N4rG9.png"
+                };
+
+                if (selectedActorId && selectedActorId !== 'base' && window.actoresJugador && window.actoresJugador[selectedActorId]) {
+                    const dataActor = window.actoresJugador[selectedActorId];
+                    if (dataActor) {
+                        actorParaEnviar = {
+                            nombre: dataActor.nombre || actorParaEnviar.nombre,
+                            titulo: dataActor.titulo || "",
+                            color_nombre: dataActor.color_nombre || "#ffffff",
+                            color_titulo: dataActor.color_titulo || "#aaaaaa",
+                            escala: dataActor.escala !== undefined ? parseFloat(dataActor.escala) : 1.0,
+                            sprite: dataActor.sprite || actorParaEnviar.sprite
+                        };
+                    }
+                }
+
+                let selectedSprite = actorParaEnviar.sprite;
+                try {
+                     if (selectExp && selectExp.style.display !== 'none' && selectExp.options.length > 0) {
+                         const val = selectExp.value;
+                         if (val && val.trim() !== '') {
+                             selectedSprite = val;
+                         }
+                     }
+                } catch (e) {
+                     console.warn("Fallo leyendo expresión, usando sprite base.", e);
+                }
+
+                const msgText = `Tira [${displayName}]: Resultado: ${finalResult} (${headsCount} Caras + ${skillTotal} Modificador)`;
+
+                const payload = {
+                    nombre: actorParaEnviar.nombre || "Jugador",
+                    titulo: actorParaEnviar.titulo || "",
+                    color_nombre: actorParaEnviar.color_nombre || "#ffffff",
+                    color_titulo: actorParaEnviar.color_titulo || "#aaaaaa",
+                    escala: isNaN(actorParaEnviar.escala) ? 1.0 : actorParaEnviar.escala,
+                    sprite: selectedSprite || "https://i.imgur.com/Z8N4rG9.png",
+                    mensaje: msgText,
+                    timestamp: Date.now()
+                };
+
+                db.ref('campaña/teatro/cola').push(payload).catch(e => {
+                    console.error("Error enviando tirada a la cola del teatro:", e);
+                });
+            } catch (err) {
+                console.error("Fallo enviando tirada al teatro de la mente:", err);
+            }
+        }
     }
 
     // Close Coin Toss Panel

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,72 @@
+{
+  "name": "app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@playwright/test": "^1.58.2",
+        "playwright": "^1.58.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@playwright/test": "^1.58.2",
+    "playwright": "^1.58.2"
+  }
+}

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}


### PR DESCRIPTION
Fix coin toss logic in `hoja_personaje.js`. Previously, `finalResult` was calculated incorrectly based on unreliable DOM inputs, and the UI displayed just the total number. Now, the math explicitly computes `headsCount + skillTotal` using verified data from the global `window.datosJugador` object, and visually updates the UI/chat to clearly output `"Resultado: 7 (4 Caras + 3 Modificador)"`.

---
*PR created automatically by Jules for task [10652921218124920148](https://jules.google.com/task/10652921218124920148) started by @sokcrow*