### PR TITLE
Refactor Player HUD for EKG and SP visual updates

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -6633,6 +6633,10 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
     width: 100%;
     height: 14px;
     background: #222;
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20" preserveAspectRatio="none"><path d="M0,10 L30,10 L35,2 L40,18 L45,10 L100,10" stroke="%2333ff33" stroke-width="0.5" fill="none" opacity="0.3"/></svg>');
+    background-repeat: repeat-x;
+    background-size: 50px 100%;
+    background-position: center;
     border: 1px solid #444;
     border-radius: 4px;
     overflow: hidden;
@@ -6643,6 +6647,7 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
     height: 100%;
     background: linear-gradient(90deg, #8b0000, #ff3333);
     width: 100%;
+    opacity: 0.85;
     transition: width 0.3s ease, background 0.3s, box-shadow 0.3s;
 }
 
@@ -6650,6 +6655,45 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
     font-size: 1.8em;
     font-weight: bold;
     text-shadow: 1px 1px 2px #000;
+}
+
+.hud-sp-sphere {
+    border-radius: 50%;
+    width: 60px;
+    height: 60px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: #222;
+    transition: background-color 0.3s ease, box-shadow 0.3s ease;
+    border: 1px solid #444;
+}
+
+#hud-sp-text {
+    color: #fff;
+    text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+    font-weight: bold;
+    font-size: 1.5rem;
+}
+
+@keyframes pulse-red-sphere {
+    0% { box-shadow: 0 0 5px rgba(255, 0, 0, 0.5); background-color: rgba(139, 0, 0, 0.8); }
+    100% { box-shadow: 0 0 20px rgba(255, 0, 0, 1); background-color: rgba(255, 0, 0, 1); }
+}
+
+@keyframes pulse-cyan-sphere {
+    0% { box-shadow: 0 0 5px rgba(0, 255, 255, 0.5); background-color: rgba(0, 139, 139, 0.8); }
+    100% { box-shadow: 0 0 20px rgba(0, 255, 255, 1); background-color: rgba(0, 255, 255, 1); }
+}
+
+.sp-extreme-neg {
+    animation: pulse-red-sphere 1s infinite alternate;
+    background-color: #8b0000; /* fallback */
+}
+
+.sp-extreme-pos {
+    animation: pulse-cyan-sphere 1s infinite alternate;
+    background-color: #008b8b; /* fallback */
 }
 
 /* Regla Visual HP (Aplicada por JS via clase) */

--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -6670,7 +6670,7 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
     display: flex;
     justify-content: center;
     align-items: center;
-    background-color: #222;
+    background-color: #79c5c5; /* Cyan Pálido */
     transition: background-color 0.3s ease, box-shadow 0.3s ease;
     border: 1px solid #444;
 }

--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -6636,11 +6636,17 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
     background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20" preserveAspectRatio="none"><path d="M0,10 L30,10 L35,2 L40,18 L45,10 L100,10" stroke="%2333ff33" stroke-width="0.5" fill="none" opacity="0.3"/></svg>');
     background-repeat: repeat-x;
     background-size: 50px 100%;
-    background-position: center;
+    background-position: 0 0;
+    animation: scroll-ekg 2s linear infinite;
     border: 1px solid #444;
     border-radius: 4px;
     overflow: hidden;
     position: relative;
+}
+
+@keyframes scroll-ekg {
+    0% { background-position: 0 0; }
+    100% { background-position: 50px 0; }
 }
 
 #hud-hp-bar {

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -4153,7 +4153,7 @@
     </div>
     <div class="hud-section hud-sp-section">
         <span class="hud-label">SP CORDURA</span>
-        <span id="hud-sp-text">0</span>
+        <div id="hud-sp-sphere" class="hud-sp-sphere"><span id="hud-sp-text">0</span></div>
     </div>
     <div class="hud-section hud-coin-section">
         <span class="hud-label">Suerte Monedas</span>

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -243,6 +243,17 @@ document.addEventListener('change', (e) => {
     }
 });
 
+function interpolateColor(color1, color2, factor) {
+    if (arguments.length < 3) {
+        factor = 0.5;
+    }
+    const result = color1.slice();
+    for (let i = 0; i < 3; i++) {
+        result[i] = Math.round(result[i] + factor * (color2[i] - color1[i]));
+    }
+    return `rgb(${result[0]}, ${result[1]}, ${result[2]})`;
+}
+
 window.renderCharacterSheet = function(data) {
     // 1. Stats Principales (Cuerpo, Mente, Alma)
     const coreStats = ['cuerpo', 'mente', 'alma'];
@@ -307,6 +318,7 @@ window.renderCharacterSheet = function(data) {
         const hpMaxEl = document.getElementById('hud-hp-max');
         const hpBarEl = document.getElementById('hud-hp-bar');
         const spTextEl = document.getElementById('hud-sp-text');
+        const spSphere = document.getElementById('hud-sp-sphere');
         const coinTextEl = document.getElementById('hud-coin-text');
 
         if (hpActualEl) hpActualEl.innerText = hpActual;
@@ -325,7 +337,35 @@ window.renderCharacterSheet = function(data) {
 
         if (spTextEl) {
             spTextEl.innerText = spActual > 0 ? `+${spActual}` : spActual;
-            spTextEl.style.color = spActual > 0 ? '#00ffff' : (spActual < 0 ? '#ff4444' : '#ffffff');
+        }
+
+        if (spSphere) {
+            const neutralColor = [34, 34, 34]; // #222222
+            const maxRed = [255, 0, 0];        // #ff0000
+            const maxCyan = [0, 255, 255];     // #00ffff
+
+            if (spActual === -45) {
+                spSphere.classList.add('sp-extreme-neg');
+                spSphere.classList.remove('sp-extreme-pos');
+                spSphere.style.backgroundColor = ''; // let class handle it
+            } else if (spActual === 45) {
+                spSphere.classList.add('sp-extreme-pos');
+                spSphere.classList.remove('sp-extreme-neg');
+                spSphere.style.backgroundColor = ''; // let class handle it
+            } else {
+                spSphere.classList.remove('sp-extreme-neg');
+                spSphere.classList.remove('sp-extreme-pos');
+
+                let colorCalculado;
+                if (spActual < 0) {
+                    colorCalculado = interpolateColor(neutralColor, maxRed, Math.abs(spActual) / 45);
+                } else if (spActual > 0) {
+                    colorCalculado = interpolateColor(neutralColor, maxCyan, spActual / 45);
+                } else {
+                    colorCalculado = 'rgb(34, 34, 34)';
+                }
+                spSphere.style.backgroundColor = colorCalculado;
+            }
         }
 
         if (coinTextEl) {

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -317,6 +317,7 @@ window.renderCharacterSheet = function(data) {
         const hpActualEl = document.getElementById('hud-hp-actual');
         const hpMaxEl = document.getElementById('hud-hp-max');
         const hpBarEl = document.getElementById('hud-hp-bar');
+        const hpTrackEl = document.querySelector('.hud-hp-track');
         const spTextEl = document.getElementById('hud-sp-text');
         const spSphere = document.getElementById('hud-sp-sphere');
         const coinTextEl = document.getElementById('hud-coin-text');
@@ -332,6 +333,24 @@ window.renderCharacterSheet = function(data) {
                 hpBarEl.classList.add('hp-danger');
             } else {
                 hpBarEl.classList.remove('hp-danger');
+            }
+
+            // Dynamic EKG Monitor Logic
+            if (hpTrackEl) {
+                let ekgColor = '%2333ff33'; // Default Green #33ff33
+                let animDuration = '2s';    // Normal speed
+
+                if (hpPercent <= 30) {
+                    ekgColor = '%23ff3333'; // Red #ff3333
+                    animDuration = '6s';    // Slow speed (low heart rate)
+                } else if (hpPercent <= 60) {
+                    ekgColor = '%23ffff33'; // Yellow #ffff33
+                    animDuration = '4s';    // Medium speed
+                }
+
+                const svgData = `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20" preserveAspectRatio="none"><path d="M0,10 L30,10 L35,2 L40,18 L45,10 L100,10" stroke="${ekgColor}" stroke-width="0.5" fill="none" opacity="0.3"/></svg>')`;
+                hpTrackEl.style.backgroundImage = svgData;
+                hpTrackEl.style.animationDuration = animDuration;
             }
         }
 

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -359,9 +359,9 @@ window.renderCharacterSheet = function(data) {
         }
 
         if (spSphere) {
-            const neutralColor = [34, 34, 34]; // #222222
-            const maxRed = [255, 0, 0];        // #ff0000
-            const maxCyan = [0, 255, 255];     // #00ffff
+            const neutralColor = [121, 197, 197]; // Pale Cyan #79c5c5
+            const maxRed = [255, 0, 0];           // #ff0000
+            const maxCyan = [0, 255, 255];        // Bright Cyan #00ffff
 
             if (spActual === -45) {
                 spSphere.classList.add('sp-extreme-neg');
@@ -381,7 +381,7 @@ window.renderCharacterSheet = function(data) {
                 } else if (spActual > 0) {
                     colorCalculado = interpolateColor(neutralColor, maxCyan, spActual / 45);
                 } else {
-                    colorCalculado = 'rgb(34, 34, 34)';
+                    colorCalculado = 'rgb(121, 197, 197)';
                 }
                 spSphere.style.backgroundColor = colorCalculado;
             }

--- a/tests/test_hud.spec.js
+++ b/tests/test_hud.spec.js
@@ -1,0 +1,67 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+test('Verify Player HUD elements', async ({ page }) => {
+  // We need to inject a playerId to pass the initial check
+  await page.addInitScript(() => {
+    localStorage.setItem('playerId', 'test_player');
+  });
+
+  const filePath = `file://${path.resolve(__dirname, '../hoja_personaje.html')}`;
+  await page.goto(filePath);
+
+  // Mock Firebase data to trigger renderCharacterSheet with specific SP values
+  await page.evaluate(() => {
+    // Expose a way to inject mock data
+    window.injectMockPlayerData = (spValue) => {
+        window.datosJugador = {
+            characterName: "Test Character",
+            combatStats: {
+                hp_actual: 50,
+                hp_max: 100,
+                sp_actual: spValue
+            }
+        };
+        // Explicitly call the render function
+        if (window.renderCharacterSheet) {
+            window.renderCharacterSheet(window.datosJugador);
+        }
+    };
+  });
+
+  // Verify elements are present first
+  const hudToggle = page.locator('#btn-toggle-hud');
+  await hudToggle.click(); // ensure HUD is visible
+
+  const hpTrack = page.locator('.hud-hp-track');
+  await expect(hpTrack).toBeVisible();
+
+  // Verify background image has svg
+  const hpTrackStyle = await hpTrack.evaluate(el => window.getComputedStyle(el).backgroundImage);
+  expect(hpTrackStyle).toContain('data:image/svg+xml');
+
+  const hpBar = page.locator('#hud-hp-bar');
+  await expect(hpBar).toBeVisible();
+  const hpBarStyle = await hpBar.evaluate(el => window.getComputedStyle(el).opacity);
+  expect(parseFloat(hpBarStyle)).toBeCloseTo(0.85, 2);
+
+  const spSphere = page.locator('#hud-sp-sphere');
+  await expect(spSphere).toBeVisible();
+
+  // Test neutral SP
+  await page.evaluate(() => window.injectMockPlayerData(0));
+  await expect(spSphere).toHaveClass(/hud-sp-sphere/);
+  await expect(spSphere).not.toHaveClass(/sp-extreme-neg/);
+  await expect(spSphere).not.toHaveClass(/sp-extreme-pos/);
+
+  // Test Max SP
+  await page.evaluate(() => window.injectMockPlayerData(45));
+  await expect(spSphere).toHaveClass(/sp-extreme-pos/);
+  await expect(spSphere).not.toHaveClass(/sp-extreme-neg/);
+
+  // Test Min SP
+  await page.evaluate(() => window.injectMockPlayerData(-45));
+  await expect(spSphere).toHaveClass(/sp-extreme-neg/);
+  await expect(spSphere).not.toHaveClass(/sp-extreme-pos/);
+
+});


### PR DESCRIPTION
Updates the "Checador de Vitales" (Player HUD) in `hoja_personaje.html` to not rely on external image files per the user's request. Modifies `hoja_personaje.html` to add a new `hud-sp-sphere` structural div. Modifies `hoja_personaje.css` to add the requested SVG EKG background via a Data URI, new classes for `.hud-sp-sphere`, and keyframes for the pulse animations. Finally, updates `hoja_personaje.js` to handle color interpolation based on SP level limits (-45 to 45), applying extreme CSS classes accordingly. Added a helper method `interpolateColor` to perform the transition calculation smoothly.

---
*PR created automatically by Jules for task [14957774660063115159](https://jules.google.com/task/14957774660063115159) started by @sokcrow*