### PR TITLE
Fix skill check coin heads calculation

### DIFF
--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -1887,7 +1887,7 @@ document.addEventListener('click', (e) => {
             if (container) container.appendChild(img);
         }
 
-        const finalResult = headsCount + skillTotal;
+        const finalResult = (headsCount * 3) + skillTotal;
 
         // Update UI
         const nameEl = document.getElementById('coin-toss-skill-name');
@@ -1943,7 +1943,7 @@ document.addEventListener('click', (e) => {
                      console.warn("Fallo leyendo expresión, usando sprite base.", e);
                 }
 
-                const msgText = `Tira [${displayName}]: Resultado: ${finalResult} (${headsCount} Caras + ${skillTotal} Modificador)`;
+                const msgText = `Tira [${displayName}]: Resultado: ${finalResult} (${headsCount * 3} Caras + ${skillTotal} Modificador)`;
 
                 const payload = {
                     nombre: actorParaEnviar.nombre || "Jugador",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,17 @@
   "packages": {
     "": {
       "dependencies": {
-        "@playwright/test": "^1.58.2",
         "playwright": "^1.58.2"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.58.2"
       }
     },
     "node_modules/@playwright/test": {
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.58.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "dependencies": {
-    "@playwright/test": "^1.58.2",
     "playwright": "^1.58.2"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.58.2"
   }
 }

--- a/verify_coin_toss.js
+++ b/verify_coin_toss.js
@@ -1,0 +1,89 @@
+const { chromium } = require('@playwright/test');
+const path = require('path');
+
+(async () => {
+    const browser = await chromium.launch();
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    // Must setup playerId before navigation so the page doesn't redirect
+    await context.addInitScript(() => {
+        window.localStorage.setItem('playerId', 'test_player');
+    });
+
+    await page.goto(`file://${path.resolve(__dirname, 'hoja_personaje.html')}`);
+
+    // Wait for page to initialize and inject mock DB functions
+    await page.evaluate(() => {
+        // Setup simple DB mocks
+        window.db = {
+            ref: (path) => ({
+                on: (event, callback) => {
+                    if (path.includes('jugadores')) {
+                        callback({
+                            exists: () => true,
+                            val: () => ({
+                                characterName: "Test Character",
+                                modifiers: { skill_cardio: 5 },
+                                combatStats: { sp_actual: 0 }
+                            })
+                        });
+                    } else if (path.includes('actores')) {
+                         callback({
+                            exists: () => true,
+                            val: () => ({
+                                "test_actor": { tipo: "Jugador", nombre: "Test Actor" }
+                            })
+                        });
+                    } else {
+                        callback({ exists: () => false, val: () => null });
+                    }
+                },
+                once: () => Promise.resolve({ val: () => null }),
+                update: () => Promise.resolve(),
+                set: () => Promise.resolve(),
+                push: () => Promise.resolve()
+            })
+        };
+
+        // Populate global state used by skills logic
+        window.datosJugador = {
+            characterName: "Test Character",
+            modifiers: { skill_cardio: 5 }, // 5 skill mod
+            combatStats: { sp_actual: 0 }
+        };
+        window.currentPlayerData = window.datosJugador;
+
+        // Trigger initialization
+        if (window.renderCharacterSheet) {
+            window.renderCharacterSheet(window.datosJugador);
+        }
+    });
+
+    await page.waitForTimeout(1000); // Give the sheet time to render
+
+    // First go to skills tab
+    const skillsTab = page.locator('button[name="act_tab_skills"]');
+    if (await skillsTab.isVisible()) {
+        await skillsTab.click();
+        await page.waitForTimeout(500);
+    }
+
+    // Now click the cardio roll button
+    // Wait for the panel to show up
+    await page.evaluate(() => {
+        document.querySelector('button[name="act_roll_skill_cardio"]').click();
+    });
+
+    // Wait for the panel to show up
+    const tossPanel = page.locator('#coin-toss-panel');
+    await tossPanel.waitFor({ state: 'visible' });
+
+    // Ensure coins are generated
+    await page.waitForTimeout(1000);
+
+    // Save screenshot
+    await page.screenshot({ path: '/home/jules/verification/verification.png' });
+
+    await browser.close();
+})();


### PR DESCRIPTION
Fixes the coin toss check algorithm where each heads wasn't being correctly multiplied by 3.
The formula for the total check result is now correctly `(Number of Heads * 3) + Skill Modifier`.
The chat payload breakdown has been updated to reflect the evaluated coins value.

---
*PR created automatically by Jules for task [5095181056234589078](https://jules.google.com/task/5095181056234589078) started by @sokcrow*