### PR TITLE
fix: update HP max calculation to include def_lvl_mod

### DIFF
--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -2164,7 +2164,9 @@
               const combatStats = data.combatStats || {};
               const hpBase = combatStats.hp_base || data.hp_base || perfil.hp_base || 0;
               const hpCoef = combatStats.hp_coefficient || data.hp_coefficient || 0;
-              const hpMax = combatStats.hp_max || data.hp_max || perfil.hp_max || Math.floor(hpBase + (lvl * hpCoef)) || 0;
+              const defLvlMod = combatStats.def_lvl_mod || 0;
+              const totalDefLvl = lvl + defLvlMod;
+              const hpMax = combatStats.hp_max || data.hp_max || perfil.hp_max || Math.floor(hpBase + (totalDefLvl * hpCoef)) || 0;
               const hpActual = combatStats.hp_actual !== undefined ? combatStats.hp_actual : hpMax;
 
               const clase = data.class || perfil.clase || 'Desconocida';
@@ -4409,7 +4411,9 @@
             const xp = playerData.xp || 0;
             const hpBase = combatStats.hp_base || playerData.hp_base || 0;
             const hpCoef = combatStats.hp_coefficient || playerData.hp_coefficient || 0;
-            const calcHpMax = Math.floor(hpBase + (lvl * hpCoef));
+            const defLvlMod = combatStats.def_lvl_mod || 0;
+            const totalDefLvl = lvl + defLvlMod;
+            const calcHpMax = Math.floor(hpBase + (totalDefLvl * hpCoef));
             const hpMax = combatStats.hp_max || playerData.hp_max || calcHpMax || 0;
             const hpActual = combatStats.hp_actual !== undefined ? combatStats.hp_actual : hpMax;
 

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
The HP max formula requires Defensive Level to be equal to the character's level plus any Defensive Level modifiers. The calculation in the DM screen previously used just the character's level multiplied by the coefficient. It has been corrected to use (lvl + defLvlMod) multiplied by the coefficient, correctly incorporating the modifier.

---
*PR created automatically by Jules for task [13084275093894968273](https://jules.google.com/task/13084275093894968273) started by @sokcrow*