### PR TITLE
feat(hud): render EKG monitor as green overlay on HP bar

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -6633,15 +6633,25 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
     width: 100%;
     height: 14px;
     background: #222;
+    border: 1px solid #444;
+    border-radius: 4px;
+    overflow: hidden;
+    position: relative;
+}
+
+#hud-ekg-line {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 10;
+    pointer-events: none;
     background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20" preserveAspectRatio="none"><path d="M0,10 L30,10 L35,2 L40,18 L45,10 L100,10" stroke="%2333ff33" stroke-width="0.8" fill="none" opacity="0.6"/></svg>');
     background-repeat: repeat-x;
     background-size: 50px 100%;
     background-position: 0 0;
     animation: scroll-ekg 1.5s linear infinite;
-    border: 1px solid #444;
-    border-radius: 4px;
-    overflow: hidden;
-    position: relative;
 }
 
 @keyframes scroll-ekg {

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -4149,6 +4149,7 @@
         </div>
         <div class="hud-hp-track">
             <div id="hud-hp-bar"></div>
+            <div id="hud-ekg-line"></div>
         </div>
     </div>
     <div class="hud-section hud-sp-section">

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -342,27 +342,32 @@ window.renderCharacterSheet = function(data) {
             }
 
             // Dynamic EKG Monitor Logic
-            if (hpTrackEl) {
-                let ekgColor = '%2333ff33'; // Default Green #33ff33
+            const ekgLineEl = document.getElementById('hud-ekg-line');
+            if (ekgLineEl) {
+                let ekgColor = '%2333ff33'; // Always Green #33ff33
                 let animDuration = '1.5s';  // Normal speed
                 let strokeWidth = '0.8';
                 let svgOpacity = '0.6';
 
                 if (hpPercent <= 30) {
-                    ekgColor = '%23ff3333'; // Red #ff3333
                     animDuration = '0.4s';  // Fast speed
                     strokeWidth = '1.2';
                     svgOpacity = '1.0';
                 } else if (hpPercent <= 60) {
-                    ekgColor = '%23ffff33'; // Yellow #ffff33
                     animDuration = '0.8s';  // Medium speed
                     strokeWidth = '1.0';
                     svgOpacity = '0.8';
                 }
 
                 const svgData = `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20" preserveAspectRatio="none"><path d="M0,10 L30,10 L35,2 L40,18 L45,10 L100,10" stroke="${ekgColor}" stroke-width="${strokeWidth}" fill="none" opacity="${svgOpacity}"/></svg>')`;
-                hpTrackEl.style.backgroundImage = svgData;
-                hpTrackEl.style.animationDuration = animDuration;
+                ekgLineEl.style.backgroundImage = svgData;
+                ekgLineEl.style.animationDuration = animDuration;
+
+                // Remove legacy styles from hpTrackEl if it was previously set
+                if (hpTrackEl) {
+                    hpTrackEl.style.backgroundImage = 'none';
+                    hpTrackEl.style.animationDuration = '0s';
+                }
             }
         }
 

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/tests/test_hud.spec.js
+++ b/tests/test_hud.spec.js
@@ -36,9 +36,11 @@ test('Verify Player HUD elements', async ({ page }) => {
   const hpTrack = page.locator('.hud-hp-track');
   await expect(hpTrack).toBeVisible();
 
-  // Verify background image has svg
-  const hpTrackStyle = await hpTrack.evaluate(el => window.getComputedStyle(el).backgroundImage);
-  expect(hpTrackStyle).toContain('data:image/svg+xml');
+  // Verify background image has svg on the new ekg line element
+  const ekgLine = page.locator('#hud-ekg-line');
+  await expect(ekgLine).toBeAttached();
+  const ekgLineStyle = await ekgLine.evaluate(el => window.getComputedStyle(el).backgroundImage);
+  expect(ekgLineStyle).toContain('data:image/svg+xml');
 
   const hpBar = page.locator('#hud-hp-bar');
   // It may not be visible in some test runs, so we ensure we wait for it or just check opacity


### PR DESCRIPTION
This PR addresses the user's request to have the dynamic EKG monitor line rendered on top of the HP bar instead of underneath/behind it. Additionally, the line is now locked to always be bright green (`#33ff33`), regardless of the character's HP level. It still correctly increases its animation speed as HP falls.

Changes made:
- **HTML**: Added a new element `<div id="hud-ekg-line"></div>` layered over the HP track element.
- **JS**: Modified the HP-update loop inside `hoja_personaje.js` so it no longer changes the SVG color string based on health percent (forcing it to remain `#33ff33`), but maintains the dynamic `animDuration` changes.
- **CSS**: Created styles for `#hud-ekg-line` to position it absolutely over the bar, applying the appropriate `z-index` and pointer event limits. Removed the redundant `background` and `animation` rules from the parent track.
- **Tests**: Adjusted `tests/test_hud.spec.js` to assert the visibility and exact background properties of `#hud-ekg-line` rather than `.hud-hp-track`.

---
*PR created automatically by Jules for task [7826300608564042595](https://jules.google.com/task/7826300608564042595) started by @sokcrow*