### PR TITLE
fix: Hide Base and Mod skill inputs in CSS

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -7448,3 +7448,18 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
     height: 20px;
     fill: currentColor;
 }
+
+/* Hide Base and Mod inputs for skills and attributes while keeping total */
+.sheet-attr-inputs label,
+.sheet-attr-inputs input {
+    display: none !important;
+}
+
+.sheet-skill-inputs input,
+.sheet-skill-separator {
+    display: none !important;
+}
+
+.sheet-skill-inputs {
+    justify-content: flex-end !important;
+}


### PR DESCRIPTION
This PR successfully hides the Base and Mod inputs for skills and attributes from the player interface using CSS (`display: none !important`).

**Context**: Previously, removing the actual HTML `<input>` elements caused the Javascript rendering logic to fail because it couldn't find the `bVal` and `mVal` inputs to calculate and display the green total numbers. The previous PR reverted the deletion, restoring functionality.

**Changes in this PR**:
1. Leaves the original HTML structure and JS logic intact (preventing any regression in calculation).
2. Uses CSS rules in `hoja_personaje.css` to hide `.sheet-attr-inputs input`, `.sheet-skill-inputs input`, and `.sheet-skill-separator`.
3. Ensures layout consistency by aligning the remaining element (the green total) to the right edge via `justify-content: flex-end`.
4. Tests correctly verified via Playwright screenshot capturing `#stats-modal` output for green text rendering without Base/Mod inputs.

---
*PR created automatically by Jules for task [16098220644841228838](https://jules.google.com/task/16098220644841228838) started by @sokcrow*