### PR TITLE
feat: Implement Drag & Drop for Equipment System

### DIFF
--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -4090,7 +4090,7 @@
     <h3 class="cyber-panel-title">EQUIPAMIENTO TÁCTICO</h3>
     <div class="equipment-grid">
         <!-- Armadura -->
-        <div class="equip-slot">
+        <div class="equip-slot" data-slot-id="armadura">
             <span class="slot-label">Armadura</span>
             <div class="item-display">
                 <div class="item-icon"></div>
@@ -4104,7 +4104,7 @@
             <span class="slot-stat">DEF LVL: +0</span>
         </div>
         <!-- Arma Principal -->
-        <div class="equip-slot">
+        <div class="equip-slot" data-slot-id="arma_principal">
             <span class="slot-label">Arma Principal</span>
             <div class="item-display">
                 <div class="item-icon"></div>
@@ -4118,7 +4118,7 @@
             <span class="slot-stat">OFF LVL: +0</span>
         </div>
         <!-- Arma Secundaria / Escudo -->
-        <div class="equip-slot">
+        <div class="equip-slot" data-slot-id="arma_secundaria">
             <span class="slot-label">Arma Sec. / Escudo</span>
             <div class="item-display">
                 <div class="item-icon"></div>
@@ -4132,7 +4132,7 @@
             <span class="slot-stat">OFF LVL: +0</span>
         </div>
         <!-- Munición / Carcaj -->
-        <div class="equip-slot">
+        <div class="equip-slot" data-slot-id="municion">
             <span class="slot-label">Munición / Carcaj</span>
             <div class="item-display">
                 <div class="item-icon"></div>
@@ -4146,7 +4146,7 @@
             <span class="slot-stat">OFF LVL: +0</span>
         </div>
         <!-- Accesorio 1 -->
-        <div class="equip-slot">
+        <div class="equip-slot" data-slot-id="accesorio_1">
             <span class="slot-label">Accesorio 1</span>
             <div class="item-display">
                 <div class="item-icon"></div>
@@ -4159,7 +4159,7 @@
             </div>
         </div>
         <!-- Accesorio 2 -->
-        <div class="equip-slot">
+        <div class="equip-slot" data-slot-id="accesorio_2">
             <span class="slot-label">Accesorio 2</span>
             <div class="item-display">
                 <div class="item-icon"></div>

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -113,6 +113,66 @@ db.ref('campaña/jugadores/' + playerId).on('value', (snapshot) => {
     }
 });
 
+// Set up Drop Zones for Equipment Panel
+document.addEventListener('DOMContentLoaded', () => {
+    const equipSlots = document.querySelectorAll('.equip-slot');
+    const activeInvGrid = document.getElementById('inv-active-grid');
+
+    // Allow dropping on equip slots
+    equipSlots.forEach(slot => {
+         slot.addEventListener('dragover', (e) => {
+             e.preventDefault(); // allow drop
+         });
+         slot.addEventListener('drop', async (e) => {
+             e.preventDefault();
+             const itemKey = e.dataTransfer.getData('text/plain');
+             const slotId = slot.getAttribute('data-slot-id');
+             if (!itemKey || !slotId) return;
+
+             const playerId = localStorage.getItem('playerId');
+             if (!playerId) return;
+
+             const invRef = db.ref(`campaña/jugadores/${playerId}/inventario_activo`);
+
+             // Check if slot already has an item equipped
+             const snap = await invRef.once('value');
+             const items = snap.val() || {};
+
+             const updates = {};
+             // Find previously equipped item in this slot and unequip it
+             for (const [key, item] of Object.entries(items)) {
+                 if (item.equipped_slot === slotId && key !== itemKey) {
+                     updates[`${key}/equipped_slot`] = null;
+                 }
+             }
+             // Equip new item
+             updates[`${itemKey}/equipped_slot`] = slotId;
+
+             invRef.update(updates);
+         });
+    });
+
+    // Allow dropping back to active inventory (Unequip)
+    if (activeInvGrid) {
+         activeInvGrid.addEventListener('dragover', (e) => {
+             e.preventDefault(); // allow drop
+         });
+         activeInvGrid.addEventListener('drop', (e) => {
+             e.preventDefault();
+             const itemKey = e.dataTransfer.getData('text/plain');
+             if (!itemKey) return;
+
+             const playerId = localStorage.getItem('playerId');
+             if (!playerId) return;
+
+             // Unequip item
+             db.ref(`campaña/jugadores/${playerId}/inventario_activo/${itemKey}`).update({
+                 equipped_slot: null
+             });
+         });
+    }
+});
+
 // 2. Llenar el menú principal con los Actores (Usando el Actor ID)
 db.ref('campaña/actores').on('value', (snapshot) => {
     const actorSelect = document.getElementById('player-actor-select');
@@ -842,10 +902,68 @@ window.addEventListener('DOMContentLoaded', () => {
         grid.innerHTML = '';
         const items = itemsObj ? Object.entries(itemsObj).map(([key, val]) => ({ key, ...val })) : [];
 
+        // Helper func to clean equipment slots
+        const cleanEquipSlots = () => {
+             document.querySelectorAll('.equip-slot').forEach(slot => {
+                 const iconContainer = slot.querySelector('.item-icon');
+                 if(iconContainer) iconContainer.innerHTML = '';
+                 const nameContainer = slot.querySelector('.item-name');
+                 if(nameContainer) nameContainer.innerText = 'Vacío';
+                 slot.querySelectorAll('.keyword-node').forEach(node => {
+                     node.className = 'keyword-node empty';
+                 });
+                 slot.removeAttribute('draggable');
+                 slot.ondragstart = null;
+                 slot.dataset.equippedItemKey = "";
+             });
+        }
+        if (!isStash) {
+             cleanEquipSlots();
+        }
+
         // Fill slots with items
         items.forEach(item => {
+            // Check if equipped
+            if (!isStash && item.equipped_slot) {
+                const targetSlot = document.querySelector(`.equip-slot[data-slot-id="${item.equipped_slot}"]`);
+                if (targetSlot) {
+                    const iconContainer = targetSlot.querySelector('.item-icon');
+                    if(iconContainer) {
+                         const imgSrc = item.icono || "https://via.placeholder.com/40";
+                         iconContainer.innerHTML = `<img src="${imgSrc}" style="width:100%; height:100%; object-fit:contain;" />`;
+                    }
+                    const nameContainer = targetSlot.querySelector('.item-name');
+                    if(nameContainer) {
+                         nameContainer.innerText = item.nombre || 'Desconocido';
+                    }
+                    const nodes = targetSlot.querySelectorAll('.keyword-node');
+                    const tierCount = parseInt(item.tier) || 1;
+                    for (let i = 0; i < nodes.length; i++) {
+                         if (i < tierCount) {
+                             nodes[i].className = 'keyword-node active-glow';
+                         } else {
+                             nodes[i].className = 'keyword-node empty';
+                         }
+                    }
+                    targetSlot.dataset.equippedItemKey = item.key;
+                    targetSlot.setAttribute('draggable', 'true');
+                    targetSlot.ondragstart = (e) => {
+                         e.dataTransfer.setData('text/plain', item.key);
+                    };
+                }
+                return; // Skip rendering in normal grid
+            }
+
             const slot = document.createElement('div');
             slot.className = 'item-slot';
+
+            // Drag and drop for inventory grid items
+            if (!isStash) {
+                slot.setAttribute('draggable', 'true');
+                slot.ondragstart = (e) => {
+                    e.dataTransfer.setData('text/plain', item.key);
+                };
+            }
 
             // Ensure array format for tags
             let itemTags = item.tags && Array.isArray(item.tags) ? item.tags : (item.tipo ? [item.tipo] : []);


### PR DESCRIPTION
This PR introduces the second phase of the Equipment System by implementing native Drag & Drop functionality for items in the Active Inventory.

### Changes:
- **`hoja_personaje.html`**: Assigned `data-slot-id` attributes to all `.equip-slot` elements (`armadura`, `arma_principal`, `arma_secundaria`, `municion`, `accesorio_1`, `accesorio_2`) to serve as valid drop targets.
- **`hoja_personaje.js`**: 
  - Updated `renderInventoryGrid` to assign the `draggable="true"` attribute and a `dragstart` event listener to unequipped inventory items, passing their Firebase key.
  - Intercepted equipped items during rendering to display them inside their respective `.equip-slot` instead of the main grid.
  - Populated equipped slots visually with the item's icon, name, and illuminated `.keyword-node` elements based on the item's `tier`.
  - Added global `dragover` and `drop` event listeners to `.equip-slot` elements. Dropping an item updates its `equipped_slot` property in Firebase and safely unequips any previously slotted item.
  - Added global `dragover` and `drop` event listeners to the `#inv-active-grid` to handle unequipping items back into the inventory.
  - **Crucial Fix**: Ensured the Firebase update logic uses `localStorage.getItem('playerId')` rather than relying on brittle DOM queries for character names.

### Verification:
- Unit tests (`tests/utils.test.js`, `tests/utils_xp.test.js`) and E2E tests (`tests/test_hud.spec.js`) passed successfully.
- Visual verification was performed using a local Playwright script, confirming that dragging items correctly updates the UI and properly unequips existing items.

---
*PR created automatically by Jules for task [9968091018336977859](https://jules.google.com/task/9968091018336977859) started by @sokcrow*