### PR TITLE
Aesthetic/A11y: Limbus FAB Redesign and ARIA Labels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-20 - [Aesthetic Enforcement on Universal FABs]
+**Learning:** The prompt dictates that floating action buttons (FABs) must universally have a 36x36px ultra-compact circular icon relying entirely on emojis. However, the 'Limbus Company' visual design standards specify strict rectangular shapes (rounded-none) and matte styles, explicitly forbidding rounded pills and 'cyberpunk neon' aesthetics.
+**Action:** When designing universal FAB toggles, override standard circle presets and enforce `border-radius: 0 !important` along with matte beige/black backgrounds and thin #FFD700 borders to bridge compact size requirements with strict Limbus geometry. Avoid drop-shadows that mimic neon glows.

--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -5460,15 +5460,14 @@ input[name="attr_tab"][value="shop"] ~ .sheet-phone-screen .sheet-tab-shop {
     bottom: 90px;
     right: 20px;
     z-index: 9999;
-    background: #111;
-    color: var(--border-accent);
-    border: 2px solid var(--border-accent);
-    border-radius: 50%;
-    width: 60px;
-    height: 60px;
-    font-size: 24px;
+    background: #0f0f0f;
+    color: #F5F5DC;
+    border: 1px solid #FFD700;
+    border-radius: 0;
+    width: 36px !important;
+    height: 36px !important;
+    font-size: 16px !important;
     cursor: pointer;
-    box-shadow: 0 0 10px rgba(196, 154, 0, 0.5), inset 0 0 5px rgba(0,0,0,0.8);
     transition: all 0.3s ease;
     display: flex;
     align-items: center;
@@ -5476,9 +5475,10 @@ input[name="attr_tab"][value="shop"] ~ .sheet-phone-screen .sheet-tab-shop {
 }
 
 .btn-global-inventory:hover {
-    transform: scale(1.1);
-    background: #222;
-    box-shadow: 0 0 20px rgba(196, 154, 0, 0.8), inset 0 0 5px rgba(0,0,0,0.8);
+    transform: scale(1.05);
+    background: #F5F5DC;
+    color: #0f0f0f;
+    border: 1px solid #3E2723;
 }
 
 #tienda-fisica-badge {
@@ -6152,18 +6152,12 @@ input[name="attr_tab"][value="shop"] ~ .sheet-phone-screen .sheet-tab-shop {
     #btn-toggle-hud {
         width: 36px !important;
         height: 36px !important;
-        border-radius: 50% !important;
+        border-radius: 0 !important;
         padding: 0 !important;
         display: flex !important;
         align-items: center;
         justify-content: center;
         font-size: 16px !important;
-    }
-    #btn-toggle-hud .text-long {
-        display: none !important;
-    }
-    #btn-toggle-hud .text-short {
-        display: inline !important;
     }
 
     /* ---- Ultra Compact HUD Toggles (Phone & Inventory) ---- */
@@ -6173,6 +6167,7 @@ input[name="attr_tab"][value="shop"] ~ .sheet-phone-screen .sheet-tab-shop {
         font-size: 16px !important;
         bottom: 10px !important;
         right: 10px !important;
+        border-radius: 0 !important;
     }
     .btn-global-inventory {
         width: 36px !important;
@@ -6180,6 +6175,7 @@ input[name="attr_tab"][value="shop"] ~ .sheet-phone-screen .sheet-tab-shop {
         font-size: 16px !important;
         bottom: 50px !important; /* Positioned just above the phone toggle */
         right: 10px !important;
+        border-radius: 0 !important;
     }
 
 
@@ -6367,21 +6363,25 @@ input[name="attr_tab"][value="shop"] ~ .sheet-phone-screen .sheet-tab-shop {
     bottom: 20px;
     right: 20px;
     z-index: 9999;
-    background: var(--bg-card);
-    color: var(--border-accent);
-    border: 2px solid var(--border-accent);
-    border-radius: 50%;
-    width: 60px;
-    height: 60px;
-    font-size: 24px;
+    background: #0f0f0f;
+    color: #F5F5DC;
+    border: 1px solid #FFD700;
+    border-radius: 0;
+    width: 36px !important;
+    height: 36px !important;
+    font-size: 16px !important;
     cursor: pointer;
-    box-shadow: 0 0 10px rgba(196, 154, 0, 0.5);
     transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .btn-toggle-phone:hover {
-    transform: scale(1.1);
-    box-shadow: 0 0 20px rgba(196, 154, 0, 0.8);
+    transform: scale(1.05);
+    background: #F5F5DC;
+    color: #0f0f0f;
+    border: 1px solid #3E2723;
 }
 
 .phone-hidden {
@@ -6551,46 +6551,29 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
     top: 20px;
     right: 20px;
     z-index: 9999;
-    background: rgba(10, 10, 10, 0.85);
-    color: #ff3333;
-    border: 2px solid #ff3333;
-    padding: 10px 15px;
+    background: #0f0f0f;
+    color: #F5F5DC;
+    border: 1px solid #FFD700;
+    padding: 0 !important;
     font-family: 'Share Tech Mono', monospace;
-    font-size: 14px;
+    font-size: 16px !important;
     font-weight: bold;
     cursor: pointer;
-    box-shadow: 0 0 10px rgba(255, 51, 51, 0.4);
-    backdrop-filter: blur(5px);
     transition: all 0.3s ease;
-    border-radius: 4px;
+    border-radius: 0 !important;
+    width: 36px !important;
+    height: 36px !important;
+    display: flex !important;
+    align-items: center;
+    justify-content: center;
 }
 
 #btn-toggle-hud:hover {
-    background: rgba(20, 20, 20, 0.95);
-    box-shadow: 0 0 15px rgba(255, 51, 51, 0.6);
+    background: #F5F5DC;
+    color: #0f0f0f;
+    border: 1px solid #3E2723;
 }
 
-/* PC-specific styles to force circular buttons just like Mobile */
-@media (min-width: 769px) {
-    #btn-toggle-hud {
-        width: 36px !important;
-        height: 36px !important;
-        border-radius: 50% !important;
-        padding: 0 !important;
-        display: flex !important;
-        align-items: center;
-        justify-content: center;
-        font-size: 16px !important;
-    }
-    #btn-toggle-hud .text-long {
-        display: none !important;
-    }
-    #btn-toggle-hud .text-short {
-        display: inline !important;
-    }
-
-
-}
 
 #player-combat-hud {
     position: fixed;
@@ -7431,15 +7414,14 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
     left: 10px !important;
     width: 36px !important;
     height: 36px !important;
-    border-radius: 50% !important;
-    background: rgba(139, 0, 0, 0.8) !important;
-    border: 2px solid #d4af37 !important;
-    color: #fff !important;
+    border-radius: 0 !important;
+    background: #0f0f0f !important;
+    border: 1px solid #FFD700 !important;
+    color: #F5F5DC !important;
     font-size: 16px !important;
     cursor: pointer !important;
     z-index: 2015 !important;
     padding: 0 !important;
-    box-shadow: 0 0 10px rgba(0,0,0,0.8);
 }
 
 /* Only show the log button when the theatre view is actually active */
@@ -7450,7 +7432,9 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
 }
 
 #btn-toggle-theatre-log-player:hover {
-    background: rgba(180, 0, 0, 1) !important;
+    background: #F5F5DC !important;
+    color: #0f0f0f !important;
+    border: 1px solid #3E2723 !important;
     transform: scale(1.05);
 }
 

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -4036,7 +4036,7 @@
 </div> <!-- End Limbus Main -->
 
 <!-- Global Inventory Button -->
-<button class="btn-global-inventory" id="btn-global-inventory" title="Inventario Global">
+<button class="btn-global-inventory" id="btn-global-inventory" title="Inventario Global" aria-label="Inventario Global">
   🎒
   <img id="tienda-fisica-badge" src="" style="display: none;">
 </button>
@@ -4223,12 +4223,11 @@
 </div>
 
 <!-- Toggle Button -->
-<button class="btn-toggle-phone" id="btn-toggle-phone" title="Alternar Celular">📱</button>
+<button class="btn-toggle-phone" id="btn-toggle-phone" title="Alternar Celular" aria-label="Alternar Celular">📱</button>
 
 <!-- HUD DE COMBATE (VITALES) -->
-<button id="btn-toggle-hud" title="Alternar HUD de Combate">
-  <span class="text-long">[+] REVISAR VITALES</span>
-  <span class="text-short" style="display: none;">❤️</span>
+<button id="btn-toggle-hud" title="Alternar HUD de Combate" aria-label="Alternar HUD de Combate">
+  ❤️
 </button>
 <div id="player-combat-hud" class="theatre-player-hud">
     <div class="hud-section hud-hp-section">
@@ -4258,7 +4257,7 @@
     <span id="player-theatre-location-text">Unknown Location</span>
   </div>
 
-  <button id="btn-toggle-theatre-log-player" title="Ver Historial"><svg class="log-icon-svg log-icon-doc" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6zm-1 1.5L18.5 9H13V3.5zM18 20H6V4h6v6h6v10z"/><path d="M8 12h8v2H8zm0 4h8v2H8z"/></svg><svg class="log-icon-svg log-icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="display: none;"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/></svg></button>
+  <button id="btn-toggle-theatre-log-player" title="Ver Historial" aria-label="Ver Historial del Teatro">📜</button>
 
   <!-- Theatre Log Container -->
   <div id="theatre-log-container" style="display: none;">
@@ -4613,19 +4612,15 @@
       const logToggleBtnPlayer = document.getElementById('btn-toggle-theatre-log-player');
       if (logToggleBtnPlayer) {
           logToggleBtnPlayer.addEventListener('click', function() {
-              // The theatre log is typically unique per view or shared if same DOM.
-              // In this file, there is a '#theatre-log-container' for the player view.
               const logContainer = document.getElementById('theatre-log-container');
               if (logContainer) {
                   logContainer.classList.toggle('open');
-                  const logIcon = this.querySelector('.log-icon-doc');
-                  const closeIcon = this.querySelector('.log-icon-close');
                   if (logContainer.classList.contains('open')) {
-                      if (logIcon) logIcon.style.display = 'none';
-                      if (closeIcon) closeIcon.style.display = 'block';
+                      this.innerText = '❌';
+                      this.setAttribute('aria-expanded', 'true');
                   } else {
-                      if (logIcon) logIcon.style.display = 'block';
-                      if (closeIcon) closeIcon.style.display = 'none';
+                      this.innerText = '📜';
+                      this.setAttribute('aria-expanded', 'false');
                   }
 
               }

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -665,15 +665,14 @@
       left: 10px !important;
       width: 36px !important;
       height: 36px !important;
-      border-radius: 50% !important;
-      background: rgba(139, 0, 0, 0.8) !important;
-      border: 2px solid #d4af37 !important;
-      color: #fff !important;
+      border-radius: 0 !important;
+      background: #0f0f0f !important;
+      border: 1px solid #FFD700 !important;
+      color: #F5F5DC !important;
       font-size: 16px !important;
       cursor: pointer !important;
       z-index: 2015 !important;
       padding: 0 !important;
-      box-shadow: 0 0 10px rgba(0,0,0,0.8);
     }
 
     /* Only show the log button when the theatre view is active */
@@ -684,7 +683,9 @@
     }
 
     #btn-toggle-theatre-log:hover {
-      background: rgba(180, 0, 0, 1) !important;
+      background: #F5F5DC !important;
+      color: #0f0f0f !important;
+      border: 1px solid #3E2723 !important;
       transform: scale(1.05);
     }
 
@@ -1227,7 +1228,7 @@
       <span id="theatre-location-text">Unknown Location</span>
     </div>
 
-    <button id="btn-toggle-theatre-log" title="Ver Historial"><svg class="log-icon-svg log-icon-doc" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6zm-1 1.5L18.5 9H13V3.5zM18 20H6V4h6v6h6v10z"/><path d="M8 12h8v2H8zm0 4h8v2H8z"/></svg><svg class="log-icon-svg log-icon-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="display: none;"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/></svg></button>
+    <button id="btn-toggle-theatre-log" title="Ver Historial" aria-label="Ver Historial del Teatro">📜</button>
 
     <!-- Theatre Log Container -->
     <div id="theatre-log-container" style="display: none;">
@@ -1678,16 +1679,13 @@
                 const logContainer = document.getElementById('theatre-log-container');
                 if (logContainer) {
                     logContainer.classList.toggle('open');
-                    const logIcon = this.querySelector('.log-icon-doc');
-                    const closeIcon = this.querySelector('.log-icon-close');
                     if (logContainer.classList.contains('open')) {
-                        if (logIcon) logIcon.style.display = 'none';
-                        if (closeIcon) closeIcon.style.display = 'block';
+                        this.innerText = '❌';
+                        this.setAttribute('aria-expanded', 'true');
                     } else {
-                        if (logIcon) logIcon.style.display = 'block';
-                        if (closeIcon) closeIcon.style.display = 'none';
+                        this.innerText = '📜';
+                        this.setAttribute('aria-expanded', 'false');
                     }
-
                 }
             });
         }


### PR DESCRIPTION
This PR introduces accessibility updates and visual design refinements to conform to the strictly defined 'Limbus Company' design system.

- Added missing `aria-label` tags to icon-only interactive elements across `hoja_personaje.html` and `pantalla_dm.html`.
- Implemented `aria-expanded` tracking for collapsible menus (Theatre Log).
- Redesigned the combat HUD (`#btn-toggle-hud`), global inventory, and theatre log floating action buttons to adhere strictly to the requested rectangular bureaucracy aesthetic, swapping glowing rounded buttons for compact 36x36px matte geometric encasements with a dark and gold Limbus palette.

---
*PR created automatically by Jules for task [17794317243669296792](https://jules.google.com/task/17794317243669296792) started by @sokcrow*