### PR TITLE
fix: priorizar icono de actor en el marco de HP de la hoja de personaje

### DIFF
--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -612,8 +612,8 @@ window.renderCharacterSheet = function(data) {
 
             if (selectedActorId && selectedActorId !== 'base' && window.actoresJugador && window.actoresJugador[selectedActorId]) {
                 const dataActor = window.actoresJugador[selectedActorId];
-                if (dataActor && dataActor.sprite) {
-                    currentDisplayAvatar = dataActor.sprite;
+                if (dataActor) {
+                    currentDisplayAvatar = dataActor.icono || dataActor.sprite || currentDisplayAvatar;
                 }
             }
 


### PR DESCRIPTION
- Modificada la lógica de asignación de `currentDisplayAvatar` en `hoja_personaje.js`.
- Se evalúa primero `dataActor.icono`, seguido de `dataActor.sprite` y finalmente el actual `avatar_url` de fallback.
- Se mantiene el comportamiento donde las expresiones activas sobrescriben temporalmente la visualización.

---
*PR created automatically by Jules for task [11838575618182650808](https://jules.google.com/task/11838575618182650808) started by @sokcrow*