### PR TITLE
Fix: Dynamic actor icons in Theatre of the Mind log

### DIFF
--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -4780,7 +4780,18 @@
 
               const charHexColor = msg.color_nombre || '#fff';
               const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace('#', '')}?text=${msg.nombre ? msg.nombre.charAt(0) : '?'}`;
-              const iconoSrc = msg.icono || defaultFallbackIcon;
+
+              let dynamicIcon = null;
+              if (window.allActoresCache) {
+                  const actorMatch = Object.values(window.allActoresCache).find(actor =>
+                      actor.nombre && msg.nombre && actor.nombre.toLowerCase() === msg.nombre.toLowerCase()
+                  );
+                  if (actorMatch && actorMatch.icono) {
+                      dynamicIcon = actorMatch.icono;
+                  }
+              }
+
+              const iconoSrc = dynamicIcon || msg.icono || defaultFallbackIcon;
 
               row.innerHTML = `
                 <div class="character-col">

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -249,7 +249,12 @@ document.addEventListener('DOMContentLoaded', () => {
 // 2. Llenar el menú principal con los Actores (Usando el Actor ID)
 db.ref('campaña/actores').on('value', (snapshot) => {
     const actorSelect = document.getElementById('player-actor-select');
-    if (!actorSelect || !snapshot.exists()) return;
+    if (!snapshot.exists()) return;
+
+    // Global cache for all actors so the Theatre log can fetch any actor's icon
+    window.allActoresCache = snapshot.val() || {};
+
+    if (!actorSelect) return;
 
     const currentSelection = actorSelect.value;
     const nombreBase = (window.datosJugador && window.datosJugador.characterName) ? window.datosJugador.characterName : "Mi Personaje";

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -4129,7 +4129,18 @@
 
                 const charHexColor = msg.color_nombre || '#fff';
                 const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace('#', '')}?text=${msg.nombre ? msg.nombre.charAt(0) : '?'}`;
-                const iconoSrc = msg.icono || defaultFallbackIcon;
+
+                let dynamicIcon = null;
+                if (typeof dbActoresCache !== 'undefined' && dbActoresCache) {
+                    const actorMatch = Object.values(dbActoresCache).find(actor =>
+                        actor.nombre && msg.nombre && actor.nombre.toLowerCase() === msg.nombre.toLowerCase()
+                    );
+                    if (actorMatch && actorMatch.icono) {
+                        dynamicIcon = actorMatch.icono;
+                    }
+                }
+
+                const iconoSrc = dynamicIcon || msg.icono || defaultFallbackIcon;
 
                 row.innerHTML = `
                   <div class="character-col">


### PR DESCRIPTION
Fixes the Theatre of the Mind log to dynamically look up the active character's icon rather than just using a fallback or empty placeholder, aligning its behavior with the Combat HUD. This was implemented on both the DM Screen and the Player Sheet by caching the actors object.

---
*PR created automatically by Jules for task [16549329956336479004](https://jules.google.com/task/16549329956336479004) started by @sokcrow*