### PR TITLE
fix(ui): prevent horizontal scroll on long theatre logs

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -7547,11 +7547,15 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
     line-height: 1.4;
     font-weight: 500;
     padding-right: 15px;
+    min-width: 0; /* Ensures flex child doesn't exceed parent width */
 }
 
 #theatre-view-player #theatre-log-container .text-col p {
     margin: 0;
     color: var(--text-color);
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-wrap: break-word;
 }
 
 #theatre-view-player #theatre-log-container .dialogue-footer {

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -757,11 +757,15 @@
       line-height: 1.4;
       font-weight: 500;
       padding-right: 15px;
+      min-width: 0; /* Ensures flex child doesn't exceed parent width */
     }
 
     #theatre-log-container .text-col p {
       margin: 0;
       color: var(--text-color);
+      white-space: pre-wrap;
+      word-break: break-word;
+      overflow-wrap: break-word;
     }
 
     #theatre-log-container .dialogue-footer {


### PR DESCRIPTION
Fixes an issue where sending very long dialogue strings without spaces in the Theatre of the Mind log would cause horizontal scrolling and layout overflow. Applied CSS fixes to force wrapping.

---
*PR created automatically by Jules for task [1128937904905545658](https://jules.google.com/task/1128937904905545658) started by @sokcrow*