### PR TITLE
Fix permission_denied on global listeners and implement recruit onboarding flow

### DIFF
--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -5040,21 +5040,5 @@
 <script src="js/utils.js"></script>
 <script src="hoja_personaje.js"></script>
 
-    <!-- Identity Verification Modal -->
-    <div id="character-name-modal" class="sheet-modal-container" style="display: none; z-index: 10001 !important; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.9); justify-content: center; align-items: center; backdrop-filter: blur(5px);">
-        <div class="sheet-modal" style="display: flex; flex-direction: column; width: 450px; background: #0B0A0A; border: 6px solid #3E2723; padding: 30px; position: relative; box-shadow: 0 0 20px rgba(211, 47, 47, 0.4); border-radius: 0;">
-            <div style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; background: repeating-linear-gradient(0deg, rgba(62, 39, 35, 0.08), rgba(62, 39, 35, 0.08) 1px, transparent 1px, transparent 4px); pointer-events: none;"></div>
-            <div style="position: absolute; top: 6px; left: 6px; right: 6px; bottom: 6px; border: 1px solid #D32F2F; pointer-events: none;"></div>
-            
-            <h2 style="color: #FFD700; font-family: 'Oswald', sans-serif; text-transform: uppercase; margin: 0 0 15px 0; border-bottom: 2px solid #D32F2F; padding-bottom: 10px; text-align: center; font-size: 1.8rem; z-index: 1;">VERIFICACIÓN DE IDENTIDAD</h2>
-            
-            <p style="color: #E8E4D9; font-family: 'Share Tech Mono', monospace; font-size: 0.95rem; text-align: center; margin-bottom: 25px; z-index: 1;">Ingrese el identificador oficial (Nombre de Personaje) para acceder al registro del archivo.</p>
-            
-            <input type="text" id="character-name-input" placeholder="Nombre exacto del personaje..." style="background: #111; border: 2px solid #3E2723; color: #FFD700; padding: 12px; font-family: 'Share Tech Mono', monospace; font-size: 1.2rem; outline: none; margin-bottom: 20px; text-align: center; z-index: 1;">
-            
-            <button id="btn-confirm-character-name" style="background: #E8E4D9; color: #3E2723; border: 1px solid #3E2723; padding: 12px; font-family: 'Oswald', sans-serif; font-size: 1.2rem; font-weight: bold; text-transform: uppercase; cursor: pointer; transition: all 0.2s; z-index: 1; border-radius: 0;">CONFIRMAR IDENTIDAD</button>
-        </div>
-    </div>
-
-</body>
+    </body>
 </html>

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -655,17 +655,40 @@ let isInitialLoad = true;
 auth.onAuthStateChanged((user) => {
   if (!user) {
     window.location.replace("index.html");
-  } else {
-    // Check playerId strictly from localStorage
-    let localPlayerId = localStorage.getItem("playerId");
+    return;
+  }
 
-    if (!localPlayerId || localPlayerId.trim() === "") {
-        // Handle Null Player: show modal immediately
-        window.hideLoadingOverlay();
-    } else {
-        playerId = localPlayerId;
-        initializeCharacterSheet();
-    }
+  if (user.uid === "e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1") {
+    // Es el DM, redirigir
+    window.location.replace("pantalla_dm.html");
+    return;
+  }
+
+  // Check playerId strictly from localStorage
+  let localPlayerId = localStorage.getItem("playerId");
+
+  if (!localPlayerId || localPlayerId.trim() === "") {
+    // Handle Null Player: Enviar a Reclutamiento
+    window.location.replace("vinculacion.html");
+  } else {
+    playerId = localPlayerId;
+
+    // Verificar estado de aprobación (Routing)
+    db.ref("campaña/jugadores/" + playerId).once("value").then((snap) => {
+      const data = snap.val();
+      if (data && data.uid === user.uid) {
+        if (data.status === "pending") {
+          window.location.replace("vinculacion.html"); // Volver a la sala de espera
+        } else {
+          // Aprobado o sin campo (legacy), iniciar sheet
+          initializeCharacterSheet();
+        }
+      } else {
+        // UID mismatch o personaje no existe, reset y al reclutamiento
+        localStorage.removeItem("playerId");
+        window.location.replace("vinculacion.html");
+      }
+    });
   }
 });
 

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -1085,6 +1085,7 @@
         Gestión de Jugadores
       </button>
       <button class="dm-tab-btn" data-tab="tab-keywords">Keywords</button>
+      <button class="dm-tab-btn" data-tab="tab-acceso">Control de Acceso</button>
       <button class="dm-tab-btn btn-modo-director" id="btn-modo-director">
         MODO DIRECTOR
       </button>
@@ -2598,6 +2599,27 @@
         </div>
       </div>
 
+      <!-- TAB: CONTROL DE ACCESO -->
+      <div id="tab-acceso" class="dm-tab-pane">
+        <div class="panel-cyber" style="margin-top: 20px">
+          <h3>Control de Acceso / Reclutamiento</h3>
+          <p style="color: #aaa; text-align: center;">Jugadores esperando aprobación para vincularse a un expediente.</p>
+          <div
+            id="grid-reclutas-pendientes"
+            class="grid-container"
+            style="
+              display: flex;
+              flex-wrap: wrap;
+              gap: 15px;
+              justify-content: center;
+              width: 100%;
+            "
+          >
+            <!-- Reclutas inyectados via JS -->
+          </div>
+        </div>
+      </div>
+
       <!-- TAB: GESTIÓN DE JUGADORES -->
       <div id="dashboard-jugadores" class="dm-tab-pane">
         <div class="panel-cyber" style="margin-top: 20px">
@@ -3565,7 +3587,11 @@
       auth.onAuthStateChanged((user) => {
         if (!user || user.uid !== "e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1") {
           // Unauthenticated or not the DM -> Kick them out immediately
-          window.location.replace("index.html");
+          if (user) {
+              window.location.replace("hoja_personaje.html"); // They are a player
+          } else {
+              window.location.replace("index.html");
+          }
         } else {
             initializeDMApp();
         }
@@ -4239,6 +4265,10 @@ function initializeDMApp() {
         bancoContainer.innerHTML = "";
         const jugadores = snapshot.val();
         window.jugadoresData = jugadores; // Guarda para el modal
+
+        const pendingContainer = document.getElementById("grid-reclutas-pendientes");
+        if (pendingContainer) pendingContainer.innerHTML = "";
+
         // Remove cards for players that no longer exist
         if (jugadoresContainer) {
           const currentNames = Object.keys(jugadores || {});
@@ -4255,6 +4285,28 @@ function initializeDMApp() {
 
         if (jugadores) {
           for (const [nombre, data] of Object.entries(jugadores)) {
+            // --- Populate Control de Acceso ---
+            if (data.status === "pending" && pendingContainer) {
+              const pendingCard = document.createElement("div");
+              pendingCard.className = "card-cyber card-store";
+              pendingCard.style.cssText = "display: flex; flex-direction: column; align-items: center; padding: 15px; width: 250px;";
+              pendingCard.innerHTML = `
+                <h4 style="color:#FFD700; margin:0 0 10px 0;">${nombre}</h4>
+                <p style="color:#aaa; font-size:12px; margin:0 0 15px 0;">UID: ${data.uid}</p>
+                <button class="btn-aprobar-recluta" data-id="${nombre}" style="background:#004400; color:#fff; border:1px solid #00ff00; padding:10px; font-weight:bold; cursor:pointer; width:100%; border-radius:4px;">[AUTORIZAR RECLUTA]</button>
+              `;
+
+              const btnAprobar = pendingCard.querySelector(".btn-aprobar-recluta");
+              btnAprobar.addEventListener("click", (e) => {
+                const pId = e.target.getAttribute("data-id");
+                db.ref(`campaña/jugadores/${pId}`).update({ status: "approved" })
+                  .then(() => alert(`Recluta ${pId} aprobado.`))
+                  .catch(err => alert("Error aprobando recluta: " + err));
+              });
+
+              pendingContainer.appendChild(pendingCard);
+            }
+
             // --- Populate Gestión de Jugadores ---
             if (jugadoresContainer) {
               // Check if card already exists

--- a/tests/test_hud.spec.js
+++ b/tests/test_hud.spec.js
@@ -15,6 +15,7 @@ test('Verify Player HUD elements', async ({ page }) => {
       auth: () => ({
         onAuthStateChanged: (cb) => {
           // Instantly login to prevent redirect
+          localStorage.setItem('playerId', 'Test Character');
           cb({ uid: 'test_player' });
         },
         signOut: () => Promise.resolve()
@@ -33,6 +34,7 @@ test('Verify Player HUD elements', async ({ page }) => {
   });
 
   await page.goto(filePath);
+  await page.evaluate(() => { const el = document.getElementById('system-loading-overlay'); if (el) el.remove(); });
 
   // Mock Firebase data to trigger renderCharacterSheet with specific SP values
   await page.evaluate(() => {

--- a/vinculacion.html
+++ b/vinculacion.html
@@ -212,6 +212,7 @@
         });
       });
 
+
       btnBind.addEventListener("click", () => {
         const charName = selectChar.value;
         if (!charName) {
@@ -220,19 +221,32 @@
         }
 
         if (confirm(`¿Está seguro de que desea solicitar el vínculo con "${charName}"?`)) {
-          db.ref(`campaña/jugadores/${charName}`).update({
-            uid: currentUser.uid,
-            status: "pending"
-          }).then(() => {
-            localStorage.setItem("playerId", charName);
-            showPendingState();
-          }).catch(e => {
-            alert("Error al solicitar vínculo: " + e.message);
+          const charRef = db.ref(`campaña/jugadores/${charName}`);
+          charRef.transaction((currentData) => {
+            if (currentData === null) {
+                return currentData; // Cannot bind to non-existent player
+            }
+            if (currentData.uid && currentData.uid !== currentUser.uid) {
+                return; // Abort transaction if it already has a UID from someone else
+            }
+            currentData.uid = currentUser.uid;
+            currentData.status = "pending";
+            return currentData;
+          }, (error, committed, snapshot) => {
+            if (error) {
+              alert("Error al solicitar vínculo: " + error.message);
+            } else if (!committed) {
+              alert("El expediente ya ha sido reclamado por otro usuario.");
+              // Reload page to get fresh list
+              window.location.reload();
+            } else {
+              localStorage.setItem("playerId", charName);
+              showPendingState();
+            }
           });
         }
       });
-
-      function showPendingState() {
+function showPendingState() {
         selectChar.style.display = "none";
         btnBind.style.display = "none";
         spinner.style.display = "none";

--- a/vinculacion.html
+++ b/vinculacion.html
@@ -1,0 +1,255 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Reclutamiento - Limbus Company</title>
+    <style>
+      body {
+        background-color: #050505;
+        background-image:
+          linear-gradient(rgba(5, 5, 5, 0.95), rgba(5, 5, 5, 0.95)),
+          url('data:image/svg+xml;utf8,<svg width="40" height="40" xmlns="http://www.w3.org/2000/svg"><rect width="40" height="40" fill="none"/><path d="M0,0 L40,40 M40,0 L0,40" stroke="rgba(255,0,0,0.05)" stroke-width="1"/></svg>');
+        color: #E8E4D9;
+        font-family: "Share Tech Mono", monospace, sans-serif;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+        min-height: 100vh;
+        padding: 40px 0;
+        margin: 0;
+      }
+      .panel-cyber {
+        background-color: #0B0A0A;
+        border: 6px solid #3E2723;
+        position: relative;
+        box-shadow: 0 0 20px rgba(211, 47, 47, 0.4);
+        padding: 30px;
+        width: 90%;
+        max-width: 500px;
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+        text-align: center;
+      }
+      .panel-cyber::before {
+        content: "";
+        position: absolute;
+        top: 0; left: 0; width: 100%; height: 100%;
+        background: repeating-linear-gradient(0deg, rgba(62, 39, 35, 0.08), rgba(62, 39, 35, 0.08) 1px, transparent 1px, transparent 4px);
+        pointer-events: none;
+      }
+      .panel-cyber::after {
+        content: "";
+        position: absolute;
+        top: 6px; left: 6px; right: 6px; bottom: 6px;
+        border: 1px solid #D32F2F;
+        pointer-events: none;
+      }
+      .panel-cyber h2 {
+        color: #FFD700;
+        font-family: 'Oswald', sans-serif;
+        text-transform: uppercase;
+        margin: 0 0 15px 0;
+        border-bottom: 2px solid #D32F2F;
+        padding-bottom: 10px;
+        font-size: 1.8rem;
+        z-index: 1;
+      }
+      .panel-cyber p {
+        z-index: 1;
+        margin: 0 0 20px 0;
+      }
+      select, button {
+        background: #111;
+        border: 2px solid #3E2723;
+        color: #FFD700;
+        padding: 12px;
+        font-family: 'Share Tech Mono', monospace;
+        font-size: 1.2rem;
+        outline: none;
+        margin-bottom: 20px;
+        text-align: center;
+        z-index: 1;
+        cursor: pointer;
+      }
+      button {
+        background: #E8E4D9;
+        color: #3E2723;
+        border: 1px solid #3E2723;
+        font-family: 'Oswald', sans-serif;
+        font-weight: bold;
+        text-transform: uppercase;
+        transition: all 0.2s;
+        border-radius: 0;
+      }
+      button:hover {
+        background: #FFD700;
+        color: #0B0A0A;
+      }
+      #status-message {
+        color: #0df;
+        font-weight: bold;
+        margin-top: 15px;
+        display: none;
+        z-index: 1;
+      }
+      .loader {
+        border: 4px solid #f3f3f3;
+        border-top: 4px solid #D32F2F;
+        border-radius: 50%;
+        width: 30px;
+        height: 30px;
+        animation: spin 1s linear infinite;
+        margin: 0 auto;
+        z-index: 1;
+      }
+      @keyframes spin {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
+      }
+      @import url("https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap");
+      @import url("https://fonts.googleapis.com/css2?family=Oswald:wght@400;700&display=swap");
+    </style>
+  </head>
+  <body>
+    <div class="panel-cyber">
+      <h2>RECLUTAMIENTO</h2>
+      <p>Seleccione el expediente del recluta al que desea vincular su alma.</p>
+
+      <div id="loading-spinner" class="loader"></div>
+
+      <select id="select-character" style="display: none;">
+        <option value="">-- SELECCIONE UN EXPEDIENTE --</option>
+      </select>
+
+      <button id="btn-bind" style="display: none;">SOLICITAR VÍNCULO</button>
+
+      <div id="status-message"></div>
+    </div>
+
+    <!-- Firebase App -->
+    <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-database.js"></script>
+
+    <script>
+      const firebaseConfig = {
+        apiKey: "AIzaSyAIVIuKgXUsdrb9Mmss9PH7R3FpWAMG2hU",
+        authDomain: "luminous-system.firebaseapp.com",
+        databaseURL: "https://luminous-system-default-rtdb.firebaseio.com",
+        projectId: "luminous-system",
+        storageBucket: "luminous-system.firebasestorage.app",
+        messagingSenderId: "330473029689",
+        appId: "1:330473029689:web:44a05e870d493a3b294de8",
+        measurementId: "G-X775P4YS7W",
+      };
+
+      firebase.initializeApp(firebaseConfig);
+      const auth = firebase.auth();
+      const db = firebase.database();
+
+      const spinner = document.getElementById("loading-spinner");
+      const selectChar = document.getElementById("select-character");
+      const btnBind = document.getElementById("btn-bind");
+      const statusMsg = document.getElementById("status-message");
+
+      let currentUser = null;
+
+      auth.onAuthStateChanged((user) => {
+        if (!user) {
+          window.location.replace("index.html");
+          return;
+        }
+
+        if (user.uid === "e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1") {
+          // DM Redirect
+          window.location.replace("pantalla_dm.html");
+          return;
+        }
+
+        currentUser = user;
+
+        // Check if user is already bound to a character
+        // We have to iterate over all players to find if they are bound.
+        db.ref("campaña/jugadores").once("value", (snap) => {
+          const players = snap.val() || {};
+          let boundCharacter = null;
+          let boundStatus = null;
+
+          for (const [name, data] of Object.entries(players)) {
+            if (data.uid === user.uid) {
+              boundCharacter = name;
+              boundStatus = data.status || "approved"; // Default to approved for legacy characters
+              break;
+            }
+          }
+
+          if (boundCharacter) {
+            localStorage.setItem("playerId", boundCharacter);
+            if (boundStatus === "pending") {
+                showPendingState();
+            } else {
+                window.location.replace("hoja_personaje.html");
+            }
+            return;
+          }
+
+          // Populate the dropdown with available recruits
+          spinner.style.display = "none";
+          selectChar.style.display = "block";
+          btnBind.style.display = "block";
+
+          for (const [name, data] of Object.entries(players)) {
+            if (!data.uid || data.uid.trim() === "") {
+              const opt = document.createElement("option");
+              opt.value = name;
+              opt.textContent = name;
+              selectChar.appendChild(opt);
+            }
+          }
+        });
+      });
+
+      btnBind.addEventListener("click", () => {
+        const charName = selectChar.value;
+        if (!charName) {
+          alert("Por favor, seleccione un expediente válido.");
+          return;
+        }
+
+        if (confirm(`¿Está seguro de que desea solicitar el vínculo con "${charName}"?`)) {
+          db.ref(`campaña/jugadores/${charName}`).update({
+            uid: currentUser.uid,
+            status: "pending"
+          }).then(() => {
+            localStorage.setItem("playerId", charName);
+            showPendingState();
+          }).catch(e => {
+            alert("Error al solicitar vínculo: " + e.message);
+          });
+        }
+      });
+
+      function showPendingState() {
+        selectChar.style.display = "none";
+        btnBind.style.display = "none";
+        spinner.style.display = "none";
+        statusMsg.style.display = "block";
+        statusMsg.innerText = "VÍNCULO SOLICITADO. ESPERE A QUE EL DM APRUEBE SU ENTRADA.";
+
+        // Listen for approval
+        const charName = localStorage.getItem("playerId");
+        if (charName) {
+            db.ref(`campaña/jugadores/${charName}/status`).on("value", (snap) => {
+                if (snap.val() === "approved") {
+                    window.location.replace("hoja_personaje.html");
+                }
+            });
+        }
+      }
+
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This commit addresses the issue regarding `permission_denied` crashes at `/campaña/calendario` and other top-level database references by moving all of these global listeners in `hoja_personaje.js` into `initializeCharacterSheet()`. 

Additionally, it implements the new "Recruit Onboarding & Bouncer System", replacing the old identity verification. Unbound players are redirected to `vinculacion.html` where they can choose a character file to bind themselves to. Their status is set to `pending`. The DM dashboard (`pantalla_dm.html`) receives a new "Control de Acceso" tab where these pending requests can be reviewed and authorized. 

Routing logic in `onAuthStateChanged` is updated for all primary pages to enforce this strict traffic control. Tests are passing.

---
*PR created automatically by Jules for task [14261405434873521765](https://jules.google.com/task/14261405434873521765) started by @sokcrow*