### PR TITLE
fix(auth): implement strict traffic controller for user routing

### DIFF
--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -664,32 +664,54 @@ auth.onAuthStateChanged((user) => {
     return;
   }
 
-  // Check playerId strictly from localStorage
-  let localPlayerId = localStorage.getItem("playerId");
+  // Traffic Controller: Identity Search
+  db.ref("campaña/jugadores/")
+    .orderByChild("uid")
+    .equalTo(user.uid)
+    .once("value")
+    .then((snapshot) => {
+      if (snapshot.exists()) {
+        let matchFound = false;
+        snapshot.forEach((child) => {
+          const data = child.val();
+          if (data.status === "approved") {
+            playerId = child.key;
+            localStorage.setItem("playerId", child.key);
+            initializeCharacterSheet();
+            matchFound = true;
+            return true; // Stop iterating
+          } else if (data.status === "pending") {
+            window.location.replace("vinculacion.html");
+            matchFound = true;
+            return true;
+          }
+        });
 
-  if (!localPlayerId || localPlayerId.trim() === "") {
-    // Handle Null Player: Enviar a Reclutamiento
-    window.location.replace("vinculacion.html");
-  } else {
-    playerId = localPlayerId;
-
-    // Verificar estado de aprobación (Routing)
-    db.ref("campaña/jugadores/" + playerId).once("value").then((snap) => {
-      const data = snap.val();
-      if (data && data.uid === user.uid) {
-        if (data.status === "pending") {
-          window.location.replace("vinculacion.html"); // Volver a la sala de espera
-        } else {
-          // Aprobado o sin campo (legacy), iniciar sheet
-          initializeCharacterSheet();
+        // If it exists but has no status (legacy) or didn't match pending/approved logic
+        if (!matchFound) {
+          // Fallback for legacy approved characters
+          const child = Object.values(snapshot.val())[0];
+          const childKey = Object.keys(snapshot.val())[0];
+          if (child.uid === user.uid) {
+            playerId = childKey;
+            localStorage.setItem("playerId", childKey);
+            initializeCharacterSheet();
+          } else {
+            localStorage.removeItem("playerId");
+            window.location.replace("vinculacion.html");
+          }
         }
       } else {
-        // UID mismatch o personaje no existe, reset y al reclutamiento
+        // No match found
         localStorage.removeItem("playerId");
         window.location.replace("vinculacion.html");
       }
+    })
+    .catch((error) => {
+      console.error("Error during identity search:", error);
+      localStorage.removeItem("playerId");
+      window.location.replace("vinculacion.html");
     });
-  }
 });
 
 function initializeCharacterSheet() {

--- a/js/auth.js
+++ b/js/auth.js
@@ -17,6 +17,61 @@ if (!firebase.apps.length) {
 const auth = firebase.auth();
 const db = firebase.database();
 
+// --- Firebase Auth State Listener (Route Guard for Index) ---
+auth.onAuthStateChanged(user => {
+    if (user) {
+        // Already logged in, redirect immediately
+        redirectUser(user);
+    }
+});
+
+function redirectUser(user) {
+    if (user.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1') {
+        window.location.replace('pantalla_dm.html');
+        return;
+    }
+
+    // Traffic Controller: Identity Search
+    db.ref('campaña/jugadores/').orderByChild('uid').equalTo(user.uid).once('value')
+        .then(snapshot => {
+            if (snapshot.exists()) {
+                let matchFound = false;
+                snapshot.forEach(child => {
+                    const data = child.val();
+                    if (data.status === 'approved') {
+                        localStorage.setItem('playerId', child.key);
+                        window.location.replace('hoja_personaje.html');
+                        matchFound = true;
+                        return true; // Stop iterating
+                    } else if (data.status === 'pending') {
+                        window.location.replace('vinculacion.html');
+                        matchFound = true;
+                        return true;
+                    }
+                });
+
+                // If it exists but has no status (legacy) or didn't match pending/approved logic
+                if (!matchFound) {
+                    // Fallback for legacy approved characters
+                    const child = Object.values(snapshot.val())[0];
+                    const childKey = Object.keys(snapshot.val())[0];
+                    if (child.uid === user.uid) {
+                        localStorage.setItem('playerId', childKey);
+                        window.location.replace('hoja_personaje.html');
+                    } else {
+                         window.location.replace('vinculacion.html');
+                    }
+                }
+            } else {
+                window.location.replace('vinculacion.html');
+            }
+        })
+        .catch(error => {
+            console.error("Error during identity search:", error);
+            window.location.replace('vinculacion.html');
+        });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     // These IDs are mapped directly from index.html
     const loginEmailInput = document.getElementById('auth-email');
@@ -26,22 +81,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const btnRegisterSubmit = document.getElementById('btn-register-submit'); // Confirm Registration button
 
     const errorBox = document.getElementById('auth-error');
-
-    // --- Firebase Auth State Listener (Route Guard for Index) ---
-    auth.onAuthStateChanged(user => {
-        if (user) {
-            // Already logged in, redirect immediately
-            redirectUser(user);
-        }
-    });
-
-    function redirectUser(user) {
-        if (user.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1') {
-            window.location.replace('pantalla_dm.html');
-        } else {
-            window.location.replace('hoja_personaje.html');
-        }
-    }
 
     function showError(msg) {
         if (!errorBox) return;
@@ -125,8 +164,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     return;
                 }
 
-                // For everyone else, just go to hoja_personaje which now handles character linking
-                window.location.replace('hoja_personaje.html');
+                // For everyone else, route through redirectUser to ensure they hit the Traffic Controller
+                redirectUser(user);
             })
             .catch((error) => {
                 console.error("Registration error:", error);


### PR DESCRIPTION
This PR fixes the 'Bypass Failure' bug where authenticated users were immediately routed to the character sheet without an explicit check for an associated character node and approval status. It implements a strict 'Traffic Controller' in `js/auth.js` and `hoja_personaje.js` using `.once('value')` to asynchronously query `campaña/jugadores/` by UID, validating the status (approved vs pending/none) before deciding the correct route or initialization phase.

---
*PR created automatically by Jules for task [8546256160533604629](https://jules.google.com/task/8546256160533604629) started by @sokcrow*