### PR TITLE
feat: implement secure player logout and clean up obsolete navigation buttons

### DIFF
--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -312,36 +312,6 @@
       </div>
     </div>
 
-    <div
-      style="
-        margin: 0 auto;
-        max-width: 1200px;
-        padding: 10px;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-      "
-    >
-      <button class="btn-back" onclick="window.location.replace('index.html')">
-        &lt; Volver al Menú
-      </button>
-      <button
-        id="btn-cerrar-sesion"
-        style="
-          background: transparent;
-          color: var(--red-neon);
-          border: 1px solid var(--red-neon);
-          padding: 5px 10px;
-          font-family: &quot;Share Tech Mono&quot;, monospace;
-          text-transform: uppercase;
-          cursor: pointer;
-          transition: all 0.3s;
-          font-size: 0.9rem;
-        "
-      >
-        Cerrar Sesión
-      </button>
-    </div>
     <!-- Main Wrapper -->
     <div class="sheet-limbus-main">
       <!-- Global Phone Wrapper -->
@@ -5545,6 +5515,28 @@
                     </div>
                   </div>
                 </div>
+              </div>
+
+              <div style="margin-top: 15px; display: flex; justify-content: center;">
+                <button
+                  id="btn-player-logout"
+                  style="
+                    background: transparent;
+                    color: var(--red-neon);
+                    border: 1px solid var(--red-neon);
+                    padding: 8px 16px;
+                    font-family: &quot;Share Tech Mono&quot;, monospace;
+                    text-transform: uppercase;
+                    cursor: pointer;
+                    transition: all 0.3s;
+                    font-size: 1rem;
+                    font-weight: bold;
+                  "
+                  onmouseover="this.style.backgroundColor='var(--red-neon)'; this.style.color='#000'; this.style.boxShadow='0 0 10px var(--red-neon)';"
+                  onmouseout="this.style.backgroundColor='transparent'; this.style.color='var(--red-neon)'; this.style.boxShadow='none';"
+                >
+                  Cerrar Sesión
+                </button>
               </div>
 
               <!-- Edit Form -->

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -3112,3 +3112,26 @@ function initializeCharacterSheet() {
     });
   } // Cierra el bloque de UI EVENT LISTENERS
 } // Cierra la función initializeCharacterSheet()
+
+// --- LÓGICA PARA CERRAR SESIÓN DEL JUGADOR ---
+document.addEventListener("DOMContentLoaded", () => {
+  const btnLogout = document.getElementById("btn-player-logout");
+  if (btnLogout) {
+    btnLogout.addEventListener("click", () => {
+      if (confirm("¿Estás seguro de que deseas cerrar sesión?")) {
+        // Opcional: Marcar como offline antes de salir
+        if (typeof playerId !== 'undefined' && playerId && typeof db !== 'undefined') {
+            db.ref("campaña/jugadores/" + playerId).update({ online: false });
+        }
+
+        firebase.auth().signOut().then(() => {
+          localStorage.removeItem("playerId");
+          window.location.replace("index.html");
+        }).catch((error) => {
+          console.error("Error al cerrar sesión:", error);
+          alert("Hubo un error al intentar cerrar sesión.");
+        });
+      }
+    });
+  }
+});


### PR DESCRIPTION
This commit implements the requested changes to the player character sheet:
1.  **Removed Obsolete Navigation**: The `< Volver al Menú` button and the old detached `Cerrar Sesión` button have been completely removed from the header of `hoja_personaje.html`, cleaning up the UI since strict authentication handles routing.
2.  **Relocated Logout**: A new `CERRAR SESIÓN` button has been added below the ID card inside the "Perfil" tab (`.sheet-tab-profile`). It uses the requested Limbus aesthetic (red neon text, transparent background, red borders, aggressive hover).
3.  **Secure Logout Logic**: Added a `DOMContentLoaded` event listener at the end of `hoja_personaje.js` that securely handles the logout process by confirming with the user, updating their Firebase status to offline, wiping the local storage `playerId`, and redirecting back to `index.html`.

---
*PR created automatically by Jules for task [1075344883321130363](https://jules.google.com/task/1075344883321130363) started by @sokcrow*