### PR TITLE
Decouple Vitals HUD from Actor System

### DIFF
--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -881,6 +881,40 @@ function renderCharacterSheet(data) {
         '<div style="color: #666;">Sin transacciones recientes.</div>';
     }
   }
+
+  // --- ACTUALIZAR HUD DE VITALES (MECÁNICAS DE JUGADOR) ---
+  const hpActual =
+    data.combatStats?.hp_actual !== undefined
+      ? data.combatStats.hp_actual
+      : data.hp || 0;
+  const hpMax =
+    data.combatStats?.hp_max !== undefined
+      ? data.combatStats.hp_max
+      : data.hp_max || 0;
+  const spActual =
+    data.combatStats?.sp_actual !== undefined
+      ? data.combatStats.sp_actual
+      : data.sp || 0;
+
+  const hudPortrait = document.querySelector(
+    "#player-combat-hud img, .hud-portrait",
+  );
+  const hudHpDisplay = document.querySelector(
+    "#player-combat-hud .hp-display, .hud-hp-text, .sheet-hud-hp",
+  );
+  const hudSpDisplay = document.querySelector(
+    "#player-combat-hud .sp-display, .hud-sp-text, .sheet-hud-sp",
+  );
+
+  if (hudPortrait && data.icono_jugador) {
+    hudPortrait.src = data.icono_jugador;
+  }
+  if (hudHpDisplay) {
+    hudHpDisplay.innerText = `${hpActual} / ${hpMax}`;
+  }
+  if (hudSpDisplay) {
+    hudSpDisplay.innerText = spActual;
+  }
 }
 
 async function runBootSequence() {
@@ -1048,31 +1082,31 @@ function initializeCharacterSheet() {
     if (!actorListenerActive) {
       actorListenerActive = true;
       db.ref("campaña/actores").on("value", (snap) => {
-          window.actoresJugador = snap.val() || {};
-          window.allActoresCache = snap.val() || {}; // Usado para pintar iconos en el chat
+        window.actoresJugador = snap.val() || {};
+        window.allActoresCache = snap.val() || {}; // Usado para pintar iconos en el chat
 
-          const assignedActorId = window.datosJugador?.actorId;
-          const exprSelect = document.getElementById("player-expression-select");
+        const assignedActorId = window.datosJugador?.actorId;
+        const exprSelect = document.getElementById("player-expression-select");
 
-          if (assignedActorId && window.actoresJugador[assignedActorId]) {
-              const actorData = window.actoresJugador[assignedActorId];
+        if (assignedActorId && window.actoresJugador[assignedActorId]) {
+          const actorData = window.actoresJugador[assignedActorId];
 
-              if (exprSelect && actorData.expresiones) {
-                  exprSelect.innerHTML = "";
-                  const expKeys = Object.keys(actorData.expresiones);
-                  if (expKeys.length > 1) {
-                      exprSelect.style.display = "block";
-                      for (const [name, url] of Object.entries(actorData.expresiones)) {
-                          const opt = document.createElement("option");
-                          opt.value = url;
-                          opt.innerText = name;
-                          exprSelect.appendChild(opt);
-                      }
-                  } else {
-                      exprSelect.style.display = "none";
-                  }
+          if (exprSelect && actorData.expresiones) {
+            exprSelect.innerHTML = "";
+            const expKeys = Object.keys(actorData.expresiones);
+            if (expKeys.length > 1) {
+              exprSelect.style.display = "block";
+              for (const [name, url] of Object.entries(actorData.expresiones)) {
+                const opt = document.createElement("option");
+                opt.value = url;
+                opt.innerText = name;
+                exprSelect.appendChild(opt);
               }
+            } else {
+              exprSelect.style.display = "none";
+            }
           }
+        }
       });
     }
   }
@@ -2099,20 +2133,26 @@ function initializeCharacterSheet() {
         playerInventoryListenerActive = true;
 
         // Listen to Stash usando playerId directo
-        db.ref(`campaña/jugadores/${playerId}/inventario_stash`).on("value", (snap) => {
+        db.ref(`campaña/jugadores/${playerId}/inventario_stash`).on(
+          "value",
+          (snap) => {
             const items = snap.val() || {};
             if (typeof window.renderInventoryGrid === "function") {
               window.renderInventoryGrid("inv-stash-grid", items, true);
             }
-        });
+          },
+        );
 
         // Listen to Activo usando playerId directo
-        db.ref(`campaña/jugadores/${playerId}/inventario_activo`).on("value", (snap) => {
+        db.ref(`campaña/jugadores/${playerId}/inventario_activo`).on(
+          "value",
+          (snap) => {
             const items = snap.val() || {};
             if (typeof window.renderInventoryGrid === "function") {
               window.renderInventoryGrid("inv-active-grid", items, false);
             }
-        });
+          },
+        );
       }
     }
   }
@@ -3095,7 +3135,10 @@ function initializeCharacterSheet() {
         const textLong = btnToggleHud.querySelector(".text-long");
         const textShort = btnToggleHud.querySelector(".text-short");
 
-        if (combatHud.style.display === "none" || combatHud.style.display === "") {
+        if (
+          combatHud.style.display === "none" ||
+          combatHud.style.display === ""
+        ) {
           combatHud.style.display = "flex";
           if (textLong) textLong.innerText = "[-] OCULTAR VITALES";
           if (textShort) textShort.innerText = "❌";
@@ -3120,17 +3163,25 @@ document.addEventListener("DOMContentLoaded", () => {
     btnLogout.addEventListener("click", () => {
       if (confirm("¿Estás seguro de que deseas cerrar sesión?")) {
         // Opcional: Marcar como offline antes de salir
-        if (typeof playerId !== 'undefined' && playerId && typeof db !== 'undefined') {
-            db.ref("campaña/jugadores/" + playerId).update({ online: false });
+        if (
+          typeof playerId !== "undefined" &&
+          playerId &&
+          typeof db !== "undefined"
+        ) {
+          db.ref("campaña/jugadores/" + playerId).update({ online: false });
         }
 
-        firebase.auth().signOut().then(() => {
-          localStorage.removeItem("playerId");
-          window.location.replace("index.html");
-        }).catch((error) => {
-          console.error("Error al cerrar sesión:", error);
-          alert("Hubo un error al intentar cerrar sesión.");
-        });
+        firebase
+          .auth()
+          .signOut()
+          .then(() => {
+            localStorage.removeItem("playerId");
+            window.location.replace("index.html");
+          })
+          .catch((error) => {
+            console.error("Error al cerrar sesión:", error);
+            alert("Hubo un error al intentar cerrar sesión.");
+          });
       }
     });
   }

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -4397,12 +4397,16 @@
                           ${nombre}
                           <span class="player-online-indicator">${onlineIndicator}</span>
                       </h4>
-                      <div class="player-subinfo" style="font-size: 0.85em; color: #aaa; text-align: center; margin-bottom: 5px;">${clase} | ${raza}</div>
+
+                      <img src="${data.icono_jugador || "https://via.placeholder.com/60/222222/00ddff?text=" + nombre.charAt(0)}" style="width:60px; height:60px; border-radius:50%; object-fit:cover; margin: 10px auto 0 auto; display: block; border: 2px solid #0df;">
+
+                      <div class="player-subinfo" style="font-size: 0.85em; color: #aaa; text-align: center; margin-bottom: 5px; margin-top: 5px;">${clase} | ${raza}</div>
                       <div style="text-align:center; color:#FFD700; font-weight:bold; margin-bottom: 10px;"><span class="currency-symbol">₳</span> <span class="player-ahn">${data.ahn || 0}</span></div>
 
-                      <div style="display: flex; gap: 10px; align-items: center; justify-content: space-between; margin-bottom: 5px;">
-                          <input type="text" class="dm-edit-name" value="${data.characterName || ""}" placeholder="Nombre Personaje" style="flex: 1; padding:4px; background:#111; color:#0df; border:1px solid #0df; border-radius:3px; text-align:center; font-family:'BebasKai', sans-serif;">
-                          <button class="btn-save-name" data-id="${nombre}" style="background: #222; color: #0df; border: 1px solid #0df; padding: 4px 8px; border-radius: 3px; cursor: pointer; font-weight: bold; transition: all 0.2s; font-size:12px;">Guardar Nombre</button>
+                      <div style="display: flex; flex-direction: column; gap: 5px; margin-bottom: 10px;">
+                          <input type="text" class="dm-edit-name" value="${data.characterName || ""}" placeholder="Nombre Personaje" style="width: 100%; box-sizing: border-box; padding:4px; background:#111; color:#0df; border:1px solid #0df; border-radius:3px; text-align:center; font-family:'BebasKai', sans-serif;">
+                          <input type="url" class="dm-edit-icon" value="${data.icono_jugador || ""}" placeholder="URL Ícono de Vitales" style="width: 100%; box-sizing: border-box; padding:4px; background:#111; color:#0df; border:1px solid #0df; border-radius:3px; text-align:center; font-size:10px;">
+                          <button class="btn-save-name" data-id="${nombre}" style="background: #222; color: #0df; border: 1px solid #0df; padding: 4px 8px; border-radius: 3px; cursor: pointer; font-weight: bold; transition: all 0.2s; font-size:12px;">Guardar Datos</button>
                       </div>
 
                       <div style="display: flex; gap: 10px; align-items: center; justify-content: space-between; border-bottom: 1px solid #333; padding-bottom: 5px; margin-bottom: 5px;">
@@ -4434,11 +4438,17 @@
                   const btnGuardarNombre =
                     pCard.querySelector(".btn-save-name");
                   const inputNombre = pCard.querySelector(".dm-edit-name");
+                  const inputIcono = pCard.querySelector(".dm-edit-icon"); // <--- NUEVO SELECTOR
 
                   btnGuardarNombre.onclick = () => {
                     const nuevoNombre = inputNombre.value;
+                    const nuevoIcono = inputIcono.value; // <--- NUEVO VALOR
+
                     db.ref(`campaña/jugadores/${nombre}`)
-                      .update({ characterName: nuevoNombre })
+                      .update({
+                        characterName: nuevoNombre,
+                        icono_jugador: nuevoIcono, // <--- GUARDAR EN FIREBASE
+                      })
                       .then(() => {
                         const oldText = btnGuardarNombre.innerText;
                         btnGuardarNombre.innerText = "¡Guardado!";
@@ -4451,7 +4461,7 @@
                         }, 1000);
                       })
                       .catch((e) =>
-                        console.error("Error al actualizar nombre:", e),
+                        console.error("Error al actualizar datos:", e),
                       );
                   };
 


### PR DESCRIPTION
Decoupled the Roleplay Actor system from the Vitals HUD. The DM can now assign a specific icon just for the player's Vitals frame on `pantalla_dm.html`, and `hoja_personaje.js` correctly maps it and reads the exact combat stats rather than relying on the general actor payload.

---
*PR created automatically by Jules for task [3762859736370110693](https://jules.google.com/task/3762859736370110693) started by @sokcrow*