### PR TITLE
Sync DM Shop Toggle with Global State

### DIFF
--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -5621,10 +5621,12 @@
                     updates[`${otherId}/activa`] = otherId === idTienda;
                   }
                   db.ref("campaña/tiendas").update(updates);
+                  db.ref("campaña/estado_mundo/tienda_activa").set(idTienda);
                 } else {
                   db.ref(`campaña/tiendas/${idTienda}`).update({
                     activa: false,
                   });
+                  db.ref("campaña/estado_mundo/tienda_activa").set(null);
                 }
               });
 


### PR DESCRIPTION
This update links the existing "Activa" toggle switch in the "Tiendas Activas" list on the DM's dashboard directly to the `campaña/estado_mundo/tienda_activa` Firebase node. 

When a store is toggled **on**, its ID is stored globally. When it is toggled **off**, the global node is explicitly set to `null`. This resolves the desync between the DM turning on a shop and the players not seeing the shop icon appear.

---
*PR created automatically by Jules for task [14631754615538436343](https://jules.google.com/task/14631754615538436343) started by @sokcrow*