### PR TITLE
Fix shop Firebase paths and overlay z-index

### DIFF
--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -13363,7 +13363,7 @@
     }
     #tienda-overlay {
         display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%;
-        background-color: rgba(8, 7, 6, 0.95); z-index: 1000000; justify-content: center; align-items: center;
+        background-color: rgba(8, 7, 6, 0.95); z-index: 9500; justify-content: center; align-items: center;
         perspective: 1500px; font-family: var(--fuente-texto);
     }
 
@@ -13373,7 +13373,7 @@
         position: fixed;
         top: 70px; /* Colocado debajo del botón de HUD que está en top: 20px */
         right: 20px;
-        z-index: 999999; /* Z-index masivo para estar sobre el inventario y teatro */
+        z-index: 9000; /* Ajustado para estar por debajo de la pantalla de carga pero sobre otras UI */
         background: rgba(0, 0, 0, 0.8);
         color: #ff9d00;
         border: 2px solid #ff9d00;

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -3246,7 +3246,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
 // --- LÓGICA DE TIENDAS DINÁMICAS ---
 window.abrirTiendaDinamica = function(tiendaId) {
-  db.ref(`campaña/tiendas_config/${tiendaId}`).once('value', (snap) => {
+  db.ref(`campaña/tiendas/${tiendaId}`).once('value', (snap) => {
     const data = snap.val();
     if (!data) return;
 
@@ -3306,7 +3306,7 @@ window.comprarItemTienda = function(tiendaId, itemIndex, precio) {
   if (!playerId) return alert("Error: Jugador no identificado.");
 
   // Validar el precio exacto desde Firebase para evitar manipulación del DOM
-  db.ref(`campaña/tiendas_config/${tiendaId}/items/${itemIndex}`).once('value', (snap) => {
+  db.ref(`campaña/tiendas/${tiendaId}/items/${itemIndex}`).once('value', (snap) => {
     const itemData = snap.val();
     if (!itemData) return alert("El objeto ya no está disponible.");
 


### PR DESCRIPTION
This PR addresses two issues with the dynamic shop interface:
1. **Broken Store Loading/Validation:** Replaced erroneous Firebase calls querying `campaña/tiendas_config/` with the correct live structure `campaña/tiendas/` to fix shop data loading and price validations.
2. **Overlapping UI:** Adjusted `z-index` properties on `#btn-shop-notifier` (now 9000) and `#tienda-overlay` (now 9500) to ensure the shop correctly stays underneath the symbolic loading overlay (`z-index: 10000`) but above other game UI elements.

---
*PR created automatically by Jules for task [17335413784008399793](https://jules.google.com/task/17335413784008399793) started by @sokcrow*