### PR TITLE
fix: Simplify currency display to text symbol ₳

### DIFF
--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -13489,7 +13489,7 @@
         <div class="currency-display" id="shop-currency-display">
             <span class="currency-label">FONDOS</span>
             <div class="currency-val">
-                <img src="img/ahn_icon.png" class="ahn-icon-shop" alt="Ahn">
+                <span style="color: var(--brillo-ambar);">₳</span>
                 <span id="shop-player-balance">0</span>
             </div>
         </div>

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -3298,7 +3298,7 @@ window.abrirTiendaDinamica = function(tiendaId) {
             <div class="item-details">
                 <span class="item-name">${item.nombre || 'Objeto'}</span>
                 <span class="item-cost">
-                    ${precioItem} <img src="img/ahn_icon.png" class="ahn-icon-shop" style="width: 18px; height: 18px; vertical-align: middle;" alt="Ahn">
+                    ${precioItem} <span style="color: var(--brillo-ambar);">₳</span>
                 </span>
             </div>
           `;
@@ -3316,11 +3316,8 @@ window.abrirTiendaDinamica = function(tiendaId) {
               }
               document.getElementById("panel-item-qty").innerText = stockDisplay;
 
-              btnComprar.style.display = "flex";
-              btnComprar.style.justifyContent = "center";
-              btnComprar.style.alignItems = "center";
-              btnComprar.style.gap = "10px";
-              btnComprar.innerHTML = `COMPRAR [${precioItem} <img src="img/ahn_icon.png" class="ahn-icon-shop" style="width: 20px;" alt="Ahn">]`;
+              btnComprar.style.display = "block";
+              btnComprar.innerHTML = `COMPRAR [${precioItem} ₳]`;
 
               const passKey = item._key !== undefined ? item._key : index;
               btnComprar.onclick = () => comprarItemTienda(tiendaId, passKey, precioItem);


### PR DESCRIPTION
Replaced all image-based Ahn icons in the dynamic shop UI with a stylized text symbol '₳'. Updated the main shop currency display and the dynamic item cost and buy buttons as requested. Removed unneeded flexbox styles from the buy button.

---
*PR created automatically by Jules for task [11154722857124240423](https://jules.google.com/task/11154722857124240423) started by @sokcrow*