### PR TITLE
Fix Coin Toss system and update UI

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -7340,21 +7340,29 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
 
 /* Coin Toss Modal */
 .coin-toss-modal {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    background: rgba(10, 10, 10, 0.95);
-    border: 2px solid var(--border-accent, #705820);
+    position: fixed !important;
+    top: 50% !important;
+    left: 50% !important;
+    transform: translate(-50%, -50%) !important;
+    background-color: #d8cdb8 !important;
+    background-image: repeating-linear-gradient(
+      transparent,
+      transparent 3px,
+      rgba(0, 0, 0, 0.04) 3px,
+      rgba(0, 0, 0, 0.04) 6px
+    ) !important;
+    border: 12px solid #2a1610 !important;
+    border-radius: 8px !important;
+    box-shadow: 0 0 0 4px #000 inset, 0 10px 30px rgba(0,0,0,0.8) !important;
     padding: 20px;
     z-index: 10000;
-    width: 300px;
-    box-shadow: 0 0 20px rgba(0, 0, 0, 0.8);
+    width: 400px;
+    max-width: 95vw;
     display: flex;
     flex-direction: column;
     align-items: center;
-    font-family: "Roboto", monospace;
-    color: #e0e0e0;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif !important;
+    color: #1a1a1a;
 }
 
 .coin-toss-content {

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -7406,26 +7406,6 @@
               </div>
               <div id="stats-container" class="sheet-attributes-section" style="position: relative;">
 
-                <!-- AUTO-TOSS TOGGLE -->
-                <div style="position: absolute; top: 10px; right: 10px; display: flex; align-items: center; gap: 8px; z-index: 10;">
-                  <span style="color: #ffd700; font-family: 'Courier New', monospace; font-size: 14px; text-transform: uppercase;">Auto-Toss</span>
-                  <label style="position: relative; display: inline-block; width: 40px; height: 20px;">
-                    <input type="checkbox" id="auto-toss-toggle" style="opacity: 0; width: 0; height: 0;">
-                    <span style="position: absolute; cursor: pointer; top: 0; left: 0; right: 0; bottom: 0; background-color: #3e2723; border: 1px solid #d32f2f; transition: .4s;">
-                      <span style="position: absolute; content: ''; height: 16px; width: 16px; left: 1px; bottom: 1px; background-color: #e8e4d9; transition: .4s;"></span>
-                    </span>
-                  </label>
-                  <style>
-                    #auto-toss-toggle:checked + span {
-                      background-color: #d32f2f;
-                    }
-                    #auto-toss-toggle:checked + span > span {
-                      transform: translateX(20px);
-                      background-color: #ffd700;
-                    }
-                  </style>
-                </div>
-
                 <div class="sheet-attributes-grid">
                   <!-- CUERPO -->
                   <div class="sheet-attr-group">
@@ -8481,10 +8461,12 @@
           <h2
             id="coin-toss-skill-name"
             style="
-              color: #ffd700;
+              color: #1a1a1a;
               font-size: 2em;
               margin-bottom: 20px;
-              text-shadow: 0 4px 10px rgba(241, 196, 15, 0.3);
+              text-shadow: none;
+              font-weight: 800;
+              text-transform: capitalize;
             "
           >
             Skill Name
@@ -8497,23 +8479,19 @@
           <p
             id="coin-toss-stats"
             style="
-              font-size: 1em;
-              color: #bdc3c7;
-              margin-bottom: 20px;
-              text-align: center;
-              font-family: 'Courier New', monospace;
+              display: none;
             "
           >
             Probabilidad de Heads: 50%
           </p>
 
-          <div class="coin-toss-result-box" style="margin-bottom: 20px; text-align: center;">
-            <div style="color: #e8e4d9; font-size: 1.2em; font-family: 'Courier New', monospace; margin-bottom: 5px;">
+          <div class="coin-toss-result-box" style="margin-bottom: 20px; text-align: center; border-color: #a39581;">
+            <div style="color: #1a1a1a; font-size: 1.2em; font-family: 'Courier New', monospace; margin-bottom: 5px; font-weight: bold;">
               PUNTAJE TOTAL
             </div>
             <span
               id="roll-total-score"
-              style="font-size: 3.5em; color: #ffd700; font-weight: bold; text-shadow: 0 0 10px rgba(255,215,0,0.5);"
+              style="font-size: 3.5em; color: #c59c5c; font-weight: bold; text-shadow: 1px 1px 2px rgba(0,0,0,0.5);"
               >0</span
             >
           </div>
@@ -8522,16 +8500,22 @@
             id="coin-toss-close-btn"
             disabled
             style="
-              background-color: #3e2723;
-              color: #e8e4d9;
-              border: 1px solid #d32f2f;
-              padding: 10px 30px;
-              font-size: 1.2em;
-              font-family: 'Arial Black', sans-serif;
+              background-color: #d8cdb8;
+              border: 3px solid #2a1610;
+              color: #1a1a1a;
+              font-size: 1.2rem;
+              font-weight: 900;
+              padding: 10px 60px;
               cursor: not-allowed;
+              box-shadow: 4px 4px 0px rgba(0,0,0,0.2);
+              transition: transform 0.1s, box-shadow 0.1s;
+              border-radius: 0;
+              font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
               opacity: 0.5;
-              transition: all 0.3s;
             "
+            onmousedown="if(!this.disabled) { this.style.transform='translate(2px, 2px)'; this.style.boxShadow='2px 2px 0px rgba(0,0,0,0.2)'; }"
+            onmouseup="if(!this.disabled) { this.style.transform='none'; this.style.boxShadow='4px 4px 0px rgba(0,0,0,0.2)'; }"
+            onmouseleave="if(!this.disabled) { this.style.transform='none'; this.style.boxShadow='4px 4px 0px rgba(0,0,0,0.2)'; }"
           >
             CERRAR
           </button>

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -3078,7 +3078,7 @@ function initializeCharacterSheet() {
               { transform: 'rotateY(360deg)' }
             ],
             {
-              duration: 400,
+              duration: 150,
               iterations: Infinity
             }
           );
@@ -3101,7 +3101,6 @@ function initializeCharacterSheet() {
               if (resultEl) resultEl.textContent = currentTotal;
             } else {
               coinImg.src = "https://imgur.com/XDx0ICt.png"; // Visual Cruz
-              coinImg.style.filter = "grayscale(100%)";
             }
 
             coinsStopped++;


### PR DESCRIPTION
Fixes and polishes the Coin Toss system based on user feedback. The redundant "Auto-Toss" toggle was removed, leaving only the functional "Modo Auto". Coin spin animation speed was increased to 150ms. Coins no longer turn grayscale when landing on Tails. The modal was redesigned to match the 'Teatro de la Mente' UI theme (cream/brown with scanlines), its width was increased to comfortably fit 5 coins, and the probability text was hidden to avoid metagaming.

---
*PR created automatically by Jules for task [5722457160682729610](https://jules.google.com/task/5722457160682729610) started by @sokcrow*