### PR TITLE
Fix DM scroll and Theatre text input overlap

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -7958,12 +7958,30 @@ input:checked + .slider-toggle:before { transform: translateX(20px); background-
 
 /* ==================== HOTFIXES ==================== */
 
+/* Limitar el wrapper para que no invada toda la pantalla baja */
 .theatre-dialogue-wrapper {
-    height: 25vh !important;
-    max-height: 25vh !important;
+    position: relative !important;
     display: flex !important;
     flex-direction: column !important;
-    z-index: 9000 !important;
+    justify-content: flex-end !important;
+    z-index: 8500 !important;
+}
+
+/* Aislar la zona donde se escribe para que SIEMPRE esté por encima y clickeable */
+.theatre-controls {
+    position: relative !important;
+    z-index: 9999 !important; /* Máxima prioridad sobre cualquier imagen o wrapper */
+    background-color: #050505 !important; /* Fondo negro sólido para no mezclarse con el fondo */
+    padding: 15px !important;
+    border-top: 2px solid var(--border-accent, #c49a00) !important;
+    pointer-events: auto !important;
+    display: flex !important;
+    gap: 10px !important;
+}
+
+/* Asegurar que el input específico tome el espacio y sea clickeable */
+.theatre-controls input[type="text"] {
+    flex-grow: 1 !important;
     pointer-events: auto !important;
 }
 
@@ -7971,11 +7989,6 @@ input:checked + .slider-toggle:before { transform: translateX(20px); background-
     flex-grow: 1 !important;
     overflow-y: auto !important;
     padding-bottom: 10px;
-}
-
-.theatre-controls {
-    flex-shrink: 0 !important;
-    margin-top: auto;
 }
 
 .theatre-stage {

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -13400,12 +13400,30 @@
 
 /* ==================== HOTFIXES ==================== */
 
+/* Limitar el wrapper para que no invada toda la pantalla baja */
 .theatre-dialogue-wrapper {
-    height: 25vh !important;
-    max-height: 25vh !important;
+    position: relative !important;
     display: flex !important;
     flex-direction: column !important;
-    z-index: 9000 !important;
+    justify-content: flex-end !important;
+    z-index: 8500 !important;
+}
+
+/* Aislar la zona donde se escribe para que SIEMPRE esté por encima y clickeable */
+.theatre-controls {
+    position: relative !important;
+    z-index: 9999 !important; /* Máxima prioridad sobre cualquier imagen o wrapper */
+    background-color: #050505 !important; /* Fondo negro sólido para no mezclarse con el fondo */
+    padding: 15px !important;
+    border-top: 2px solid var(--border-accent, #c49a00) !important;
+    pointer-events: auto !important;
+    display: flex !important;
+    gap: 10px !important;
+}
+
+/* Asegurar que el input específico tome el espacio y sea clickeable */
+.theatre-controls input[type="text"] {
+    flex-grow: 1 !important;
     pointer-events: auto !important;
 }
 
@@ -13413,11 +13431,6 @@
     flex-grow: 1 !important;
     overflow-y: auto !important;
     padding-bottom: 10px;
-}
-
-.theatre-controls {
-    flex-shrink: 0 !important;
-    margin-top: auto;
 }
 
 .theatre-stage {

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -18,7 +18,8 @@
         min-height: 100vh;
         padding: 0;
         margin: 0;
-        overflow: hidden;
+        overflow-y: auto !important; /* Revive el scroll de la pantalla del DM */
+        overflow-x: hidden !important;
       }
       #dm-time-panel {
         background-color: rgba(15, 15, 15, 0.95);
@@ -931,6 +932,33 @@
           height: 100%;
           object-fit: contain;
           filter: drop-shadow(0 0 5px rgba(255, 157, 0, 0.8));
+      }
+
+      /* Limitar el wrapper para que no invada toda la pantalla baja */
+      .theatre-dialogue-wrapper {
+          position: relative !important;
+          display: flex !important;
+          flex-direction: column !important;
+          justify-content: flex-end !important;
+          z-index: 8500 !important;
+      }
+
+      /* Aislar la zona donde se escribe para que SIEMPRE esté por encima y clickeable */
+      .theatre-controls {
+          position: relative !important;
+          z-index: 9999 !important; /* Máxima prioridad sobre cualquier imagen o wrapper */
+          background-color: #050505 !important; /* Fondo negro sólido para no mezclarse con el fondo */
+          padding: 15px !important;
+          border-top: 2px solid var(--border-accent, #c49a00) !important;
+          pointer-events: auto !important;
+          display: flex !important;
+          gap: 10px !important;
+      }
+
+      /* Asegurar que el input específico tome el espacio y sea clickeable */
+      .theatre-controls input[type="text"] {
+          flex-grow: 1 !important;
+          pointer-events: auto !important;
       }
 
     </style>


### PR DESCRIPTION
- Added overflow-y: auto !important to body in pantalla_dm.html to fix broken scroll.
- Applied relative positioning and fixed z-indexes to .theatre-dialogue-wrapper and .theatre-controls across pantalla_dm.html, hoja_personaje.html, and hoja_personaje.css to prevent overlap.
- Ensured theatre text input is clickable and styled correctly.

---
*PR created automatically by Jules for task [17342668235602050846](https://jules.google.com/task/17342668235602050846) started by @sokcrow*