### PR TITLE
Fix/heptagon buttons visual alignment and outlines

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -7932,7 +7932,7 @@ input:checked + .slider-toggle:before { transform: translateX(20px); background-
     min-width: 70px;
     min-height: 70px;
     background-color: #050505 !important; /* Fondo negro sólido */
-    clip-path: polygon(50% 0%, 90% 20%, 100% 60%, 75% 100%, 25% 100%, 0% 60%, 10% 20%) !important; /* Recorte de Heptágono */
+    clip-path: polygon(50% 0%, 85% 18%, 100% 55%, 78% 100%, 22% 100%, 0% 55%, 15% 18%) !important; /* Recorte de Heptágono */
     border: none !important;
     box-shadow: none !important;
     display: flex !important;
@@ -7989,4 +7989,14 @@ input:checked + .slider-toggle:before { transform: translateX(20px); background-
     gap: 15px !important;
     width: 100%;
     padding-right: 20px; /* Separación del borde de la pantalla */
+}
+
+.btn-icon-base, .control-btn,
+.btn-icon-base:focus, .control-btn:focus,
+.btn-icon-base:active, .control-btn:active,
+.btn-icon-base:hover, .control-btn:hover {
+    border: none !important;
+    outline: none !important;
+    box-shadow: none !important;
+    -webkit-tap-highlight-color: transparent;
 }

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -909,7 +909,7 @@
           min-width: 70px;
           min-height: 70px;
           background-color: #050505 !important; /* Fondo negro sólido */
-          clip-path: polygon(50% 0%, 90% 20%, 100% 60%, 75% 100%, 25% 100%, 0% 60%, 10% 20%) !important; /* Recorte de Heptágono */
+          clip-path: polygon(50% 0%, 85% 18%, 100% 55%, 78% 100%, 22% 100%, 0% 55%, 15% 18%) !important; /* Recorte de Heptágono */
           border: none !important;
           box-shadow: none !important;
           display: flex !important;
@@ -923,6 +923,16 @@
       .btn-icon-base:active, .control-btn:active {
           transform: scale(0.95);
       }
+      .btn-icon-base, .control-btn,
+      .btn-icon-base:focus, .control-btn:focus,
+      .btn-icon-base:active, .control-btn:active,
+      .btn-icon-base:hover, .control-btn:hover {
+          border: none !important;
+          outline: none !important;
+          box-shadow: none !important;
+          -webkit-tap-highlight-color: transparent;
+      }
+
 
       /* El SVG o Imagen dentro del Heptágono mantiene su brillo de silueta */
       .btn-icon-base svg, .btn-icon-base img,


### PR DESCRIPTION
This PR implements the requested visual critical patch for the heptagon floating action buttons (FABs).

**Changes included:**
* **Corrected clip-path:** Replaced the irregular and visually 'inverted' `clip-path` with the specified exact symmetrical coordinates `polygon(50% 0%, 85% 18%, 100% 55%, 78% 100%, 22% 100%, 0% 55%, 15% 18%)`. This ensures buttons look uniform and balanced.
* **Eliminated Yellow Focus/Hover outlines:** Bound `:focus`, `:hover`, and `:active` pseudo-classes to `.btn-icon-base` and `.control-btn` setting `border: none !important`, `outline: none !important`, and `box-shadow: none !important`. This completely prevents the browser's default highlight behaviors (yellow outlines) across all contexts.
* **Applied to DM and Player Views:** Patched `hoja_personaje.css` and the embedded `<style>` block in `pantalla_dm.html` ensuring total consistency across the application UI.

**Verification:**
* Deployed a Playwright headless script navigating to `hoja_personaje.html` rendering the DOM.
* Mocked Firebase Auth and realtime DB.
* Verified that on hovering `#btn-toggle-hud` no outlines appeared and the clip-path visually rendered correctly as requested.

---
*PR created automatically by Jules for task [17975357129893824600](https://jules.google.com/task/17975357129893824600) started by @sokcrow*