### PR TITLE
UI: Enforce strict Split-Screen layout for Theatre vs Controls

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -6271,15 +6271,9 @@ input[name="attr_tab"][value="shop"] ~ .sheet-phone-screen .sheet-tab-shop {
     }
 
     /* Dynamically shift the dialogue box tracking the drawer animation */
-    #theatre-view-player .theatre-dialogue-wrapper {
-        bottom: 35px !important; /* height of closed toggle button */
-        width: 95% !important;
-        transition: bottom 0.4s ease-out !important;
-    }
+    #theatre-view-player .theatre-dialogue-wrapper { /* removed bottom */ }
 
-    #theatre-view-player:has(#player-theatre-tools-wrapper.open) .theatre-dialogue-wrapper {
-        bottom: 75px !important; /* Approx height of open ultra-compact menu */
-    }
+
 
     #theatre-view-player .sprite-wrapper img {
         bottom: 35px !important;
@@ -7976,7 +7970,29 @@ input:checked + .slider-toggle:before { transform: translateX(20px); background-
 
 /* ==================== HOTFIXES ==================== */
 
-/* Limitar el wrapper para que no invada toda la pantalla baja */
+/* 1. Contenedor Principal en Columna Estricta */
+body, .main-wrapper, .dm-container, #theatre-view-player, #theatre-view-dm {
+    display: flex !important;
+    flex-direction: column !important;
+    height: 100vh !important;
+    overflow: hidden !important;
+    justify-content: space-between !important;
+}
+
+/* 2. Bloque Superior: Pantalla del Teatro (70% - 75%) */
+.theatre-wrapper, .theatre-container, .theatre-visuals, .theatre-stage {
+    flex: 1 1 auto !important; /* Toma todo el espacio superior */
+    height: 70vh !important; /* Altura máxima */
+    position: relative !important;
+    display: flex !important;
+    flex-direction: column !important;
+    justify-content: flex-end !important;
+    overflow: hidden !important;
+    padding-bottom: 0 !important;
+    margin-bottom: 0 !important;
+}
+
+/* El cuadro donde se leen los mensajes se queda anclado al fondo de este bloque superior */
 .theatre-dialogue-wrapper {
     position: relative !important;
     display: flex !important;
@@ -7985,32 +8001,32 @@ input:checked + .slider-toggle:before { transform: translateX(20px); background-
     z-index: 8500 !important;
 }
 
-/* Aislar la zona donde se escribe para que SIEMPRE esté por encima y clickeable */
-.theatre-controls {
-    position: relative !important;
-    z-index: 9999 !important; /* Máxima prioridad sobre cualquier imagen o wrapper */
-    background-color: #050505 !important; /* Fondo negro sólido para no mezclarse con el fondo */
-    padding: 15px !important;
-    border-top: 2px solid var(--border-accent, #c49a00) !important;
-    pointer-events: auto !important;
+.theatre-dialogue-history {
+    max-height: 30vh !important;
+    overflow-y: auto !important;
+    background: rgba(5, 5, 5, 0.8) !important; /* Fondo semi-transparente para lectura */
+}
+
+/* 3. Bloque Inferior: Controles e Interfaz (25% - 30%) */
+.theatre-controls, .theatre-player-input-area, .bottom-nav, .hud-bottom-container, .controls-panel {
+    flex: 0 0 auto !important; /* Bloque estático, no crece */
+    position: relative !important; /* ELIMINA el fixed o absolute */
+    height: auto !important;
+    min-height: 25vh !important;
+    background-color: #050505 !important; /* Fondo negro sólido para ocultar lo de atrás */
+    border-top: 2px solid #c49a00 !important; /* Línea divisoria visual (Acento ámbar) */
+    z-index: 100 !important;
     display: flex !important;
-    gap: 10px !important;
+    flex-direction: column !important;
+    justify-content: center !important;
+    padding: 15px !important;
+    box-sizing: border-box !important;
 }
 
 /* Asegurar que el input específico tome el espacio y sea clickeable */
-.theatre-controls input[type="text"] {
+.theatre-controls input[type="text"], .theatre-player-input-area input[type="text"] {
     flex-grow: 1 !important;
     pointer-events: auto !important;
-}
-
-#theatre-dialogue-history {
-    flex-grow: 1 !important;
-    overflow-y: auto !important;
-    padding-bottom: 10px;
-}
-
-.theatre-stage {
-    pointer-events: none !important;
 }
 
 .top-nav, .hud-right-container, .theater-toolbar {

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -141,19 +141,7 @@
         transform: none;
       }
 
-      .theatre-dialogue-wrapper {
-        position: absolute;
-        bottom: 50px;
-        left: 50%;
-        transform: translateX(-50%);
-        width: 95%;
-        max-width: 1400px;
-        z-index: 2020;
-        filter: drop-shadow(0px 5px 5px rgba(0, 0, 0, 0.8));
-        pointer-events: none; /* Let clicks pass through empty areas */
-        height: 25vh !important;
-        max-height: 25% !important;
-      }
+      .theatre-dialogue-wrapper { /* removed bottom */ }
 
       .theatre-dialogue-wrapper > * {
         pointer-events: auto; /* Enable clicks on actual content like plates and text */
@@ -13400,7 +13388,29 @@
 
 /* ==================== HOTFIXES ==================== */
 
-/* Limitar el wrapper para que no invada toda la pantalla baja */
+/* 1. Contenedor Principal en Columna Estricta */
+body, .main-wrapper, .dm-container, #theatre-view-dm, #theatre-view-player {
+    display: flex !important;
+    flex-direction: column !important;
+    height: 100vh !important;
+    overflow: hidden !important;
+    justify-content: space-between !important;
+}
+
+/* 2. Bloque Superior: Pantalla del Teatro (70% - 75%) */
+.theatre-wrapper, .theatre-container, .theatre-visuals, .theatre-stage {
+    flex: 1 1 auto !important; /* Toma todo el espacio superior */
+    height: 70vh !important; /* Altura máxima */
+    position: relative !important;
+    display: flex !important;
+    flex-direction: column !important;
+    justify-content: flex-end !important;
+    overflow: hidden !important;
+    padding-bottom: 0 !important;
+    margin-bottom: 0 !important;
+}
+
+/* El cuadro donde se leen los mensajes se queda anclado al fondo de este bloque superior */
 .theatre-dialogue-wrapper {
     position: relative !important;
     display: flex !important;
@@ -13409,54 +13419,52 @@
     z-index: 8500 !important;
 }
 
-/* Aislar la zona donde se escribe para que SIEMPRE esté por encima y clickeable */
-.theatre-controls {
-    position: relative !important;
-    z-index: 9999 !important; /* Máxima prioridad sobre cualquier imagen o wrapper */
-    background-color: #050505 !important; /* Fondo negro sólido para no mezclarse con el fondo */
-    padding: 15px !important;
-    border-top: 2px solid var(--border-accent, #c49a00) !important;
-    pointer-events: auto !important;
+.theatre-dialogue-history {
+    max-height: 30vh !important;
+    overflow-y: auto !important;
+    background: rgba(5, 5, 5, 0.8) !important; /* Fondo semi-transparente para lectura */
+}
+
+/* 3. Bloque Inferior: Controles e Interfaz (25% - 30%) */
+.theatre-controls, .theatre-player-input-area, .bottom-nav, .hud-bottom-container, .controls-panel {
+    flex: 0 0 auto !important; /* Bloque estático, no crece */
+    position: relative !important; /* ELIMINA el fixed o absolute */
+    height: auto !important;
+    min-height: 25vh !important;
+    background-color: #050505 !important; /* Fondo negro sólido para ocultar lo de atrás */
+    border-top: 2px solid #c49a00 !important; /* Línea divisoria visual (Acento ámbar) */
+    z-index: 100 !important;
     display: flex !important;
-    gap: 10px !important;
+    flex-direction: column !important;
+    justify-content: center !important;
+    padding: 15px !important;
+    box-sizing: border-box !important;
 }
 
 /* Asegurar que el input específico tome el espacio y sea clickeable */
-.theatre-controls input[type="text"] {
+.theatre-controls input[type="text"], .theatre-player-input-area input[type="text"] {
     flex-grow: 1 !important;
     pointer-events: auto !important;
-}
-
-#theatre-dialogue-history {
-    flex-grow: 1 !important;
-    overflow-y: auto !important;
-    padding-bottom: 10px;
-}
-
-.theatre-stage {
-    pointer-events: none !important;
-}
-
-.btn-icon-base, .control-btn {
-    background: transparent !important;
-    border: none !important;
-    box-shadow: none !important;
-}
-
-.btn-icon-base svg, .btn-icon-base img,
-.control-btn svg, .control-btn img {
-    filter: drop-shadow(0 0 8px rgba(255, 157, 0, 0.8));
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
 }
 
 .top-nav, .hud-right-container, .theater-toolbar {
     display: flex !important;
     justify-content: flex-end !important;
-    gap: 15px;
+    align-items: center !important;
+    gap: 15px !important;
+    width: 100%;
+    padding-right: 20px; /* Separación del borde de la pantalla */
 }
 
+.btn-icon-base, .control-btn,
+.btn-icon-base:focus, .control-btn:focus,
+.btn-icon-base:active, .control-btn:active,
+.btn-icon-base:hover, .control-btn:hover {
+    border: none !important;
+    outline: none !important;
+    box-shadow: none !important;
+    -webkit-tap-highlight-color: transparent;
+}
 </style>
 
 <div id="tienda-overlay">

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -612,16 +612,10 @@
         }
 
         /* Ajustes de diálogo ultra-compactos (Sigue el movimiento del drawer) */
-        .theatre-dialogue-wrapper {
-          bottom: 35px !important; /* Desciende hasta el botón cuando el drawer está oculto */
-          width: 95% !important;
-          transition: bottom 0.4s ease-out !important; /* Misma duración y curva que el drawer */
-        }
+        .theatre-dialogue-wrapper { /* removed bottom */ }
 
         /* Si el panel está abierto, el diálogo sube empujado por el grid */
-        #theatre-view-dm:has(#dm-tools-wrapper.open) .theatre-dialogue-wrapper {
-          bottom: 130px !important;
-        }
+        #theatre-view-dm:has(#dm-tools-wrapper.open) .theatre-dialogue-wrapper { /* removed bottom */ }
 
         #theatre-view-dm .sprite-wrapper img {
           bottom: 35px !important;
@@ -3359,18 +3353,7 @@
         transform: none;
       }
 
-      .theatre-dialogue-wrapper {
-        position: absolute;
-        bottom: 50px;
-        left: 50%;
-        transform: translateX(-50%);
-        width: 95%;
-        max-width: 1400px;
-        z-index: 2020;
-        filter: drop-shadow(0px 5px 5px rgba(0, 0, 0, 0.8));
-        height: 25vh !important;
-        max-height: 25% !important;
-      }
+      .theatre-dialogue-wrapper { /* removed bottom */ }
 
       .theatre-plates-container {
         position: absolute;
@@ -3519,28 +3502,63 @@
 
 /* ==================== HOTFIXES ==================== */
 
-.theatre-dialogue-wrapper {
-    height: 25vh !important;
-    max-height: 25vh !important;
+/* 1. Contenedor Principal en Columna Estricta */
+body, .main-wrapper, .dm-container, #theatre-view-dm, #theatre-view-player {
     display: flex !important;
     flex-direction: column !important;
-    z-index: 9000 !important;
-    pointer-events: auto !important;
+    height: 100vh !important;
+    overflow: hidden !important;
+    justify-content: space-between !important;
 }
 
-#theatre-dialogue-history {
-    flex-grow: 1 !important;
+/* 2. Bloque Superior: Pantalla del Teatro (70% - 75%) */
+.theatre-wrapper, .theatre-container, .theatre-visuals, .theatre-stage {
+    flex: 1 1 auto !important; /* Toma todo el espacio superior */
+    height: 70vh !important; /* Altura máxima */
+    position: relative !important;
+    display: flex !important;
+    flex-direction: column !important;
+    justify-content: flex-end !important;
+    overflow: hidden !important;
+    padding-bottom: 0 !important;
+    margin-bottom: 0 !important;
+}
+
+/* El cuadro donde se leen los mensajes se queda anclado al fondo de este bloque superior */
+.theatre-dialogue-wrapper {
+    position: relative !important;
+    display: flex !important;
+    flex-direction: column !important;
+    justify-content: flex-end !important;
+    z-index: 8500 !important;
+}
+
+.theatre-dialogue-history {
+    max-height: 30vh !important;
     overflow-y: auto !important;
-    padding-bottom: 10px;
+    background: rgba(5, 5, 5, 0.8) !important; /* Fondo semi-transparente para lectura */
 }
 
-.theatre-controls {
-    flex-shrink: 0 !important;
-    margin-top: auto;
+/* 3. Bloque Inferior: Controles e Interfaz (25% - 30%) */
+.theatre-controls, .bottom-nav, .hud-bottom-container, .controls-panel, .theatre-player-input-area {
+    flex: 0 0 auto !important; /* Bloque estático, no crece */
+    position: relative !important; /* ELIMINA el fixed o absolute */
+    height: auto !important;
+    min-height: 25vh !important;
+    background-color: #050505 !important; /* Fondo negro sólido para ocultar lo de atrás */
+    border-top: 2px solid #c49a00 !important; /* Línea divisoria visual (Acento ámbar) */
+    z-index: 100 !important;
+    display: flex !important;
+    flex-direction: column !important;
+    justify-content: center !important;
+    padding: 15px !important;
+    box-sizing: border-box !important;
 }
 
-.theatre-stage {
-    pointer-events: none !important;
+/* Asegurar que el input específico tome el espacio y sea clickeable */
+.theatre-controls input[type="text"] {
+    flex-grow: 1 !important;
+    pointer-events: auto !important;
 }
 
 .top-nav, .hud-right-container, .theater-toolbar {
@@ -3552,6 +3570,15 @@
     padding-right: 20px; /* Separación del borde de la pantalla */
 }
 
+.btn-icon-base, .control-btn,
+.btn-icon-base:focus, .control-btn:focus,
+.btn-icon-base:active, .control-btn:active,
+.btn-icon-base:hover, .control-btn:hover {
+    border: none !important;
+    outline: none !important;
+    box-shadow: none !important;
+    -webkit-tap-highlight-color: transparent;
+}
 </style>
 
     <!-- MODAL: EDITOR INTERACTIVO DE TIENDAS -->


### PR DESCRIPTION
This PR fixes a critical usability issue where control overlays would cover up the Theatre of the Mind visual stage and dialogue history. 

It accomplishes this by applying the requested `flex-direction: column` strict layout model to the main `body` elements on both player and DM views. The top visual section is allowed to flex to 70-75% height, while the bottom control panel is given a fixed layout at the bottom with a solid `#050505` background, effectively eliminating any z-index overlap problems.

---
*PR created automatically by Jules for task [7023069613532897812](https://jules.google.com/task/7023069613532897812) started by @sokcrow*