### PR TITLE
Restore Visual Novel UI and Implement Modal Input (Player Only)

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -6795,33 +6795,32 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
     transition: all 0.4s ease;
 }
 
-/* Escenario donde van las imágenes */
-.theatre-visuals, .theatre-stage {
-    flex-grow: 1 !important;
-    display: flex !important;
-    align-items: flex-end !important; /* Gravedad: empuja los sprites al fondo del contenedor */
-    justify-content: center !important;
-    padding: 0 !important;
-    margin: 0 !important;
-    position: relative;
-    height: 75vh !important; /* Toma el espacio superior que no usa el diálogo */
-}
-
-/* Las imágenes (sprites) de los personajes */
-.theatre-stage img, .character-sprite {
-    max-height: 100% !important;
-    object-fit: contain !important;
-    align-self: flex-end !important; /* Doble seguro para anclarlos abajo */
-    margin-bottom: 0 !important;
-    vertical-align: bottom !important;
-}
-
-/* Asegurar que el contenedor global mantenga la estructura de columna */
-.theatre-container, .theatre-wrapper {
+/* Restaurar contenedor principal */
+.theatre-wrapper, .theatre-container {
+    position: relative !important;
+    height: 100vh !important;
     display: flex !important;
     flex-direction: column !important;
-    height: 100vh !important;
-    justify-content: flex-end !important;
+    overflow: hidden !important;
+}
+
+/* El Escenario: Sprites horizontales y al fondo */
+.theatre-stage, .theatre-visuals {
+    position: absolute !important;
+    top: 0; left: 0; width: 100%; height: 100%;
+    display: flex !important;
+    flex-direction: row !important; /* HORIZONTAL, NUNCA VERTICAL */
+    justify-content: center !important;
+    align-items: flex-end !important; /* Gravedad hacia abajo */
+    padding-bottom: 22vh !important; /* Espacio para que el diálogo no tape las caras */
+    z-index: 10 !important;
+}
+
+/* Los Sprites */
+.theatre-stage img, .character-sprite {
+    max-height: 75vh !important;
+    object-fit: contain !important;
+    margin: 0 -5% !important; /* Permite que los sprites se traslapen ligeramente si son muchos */
 }
 .sprite-wrapper {
     position: relative;
@@ -7976,13 +7975,18 @@ input:checked + .slider-toggle:before { transform: translateX(20px); background-
 
 /* ==================== HOTFIXES ==================== */
 
-/* Limitar el wrapper para que no invada toda la pantalla baja */
+/* El cuadro de diálogo flotando ENCIMA de los sprites */
 .theatre-dialogue-wrapper {
-    position: relative !important;
+    position: absolute !important;
+    bottom: 0 !important;
+    left: 0 !important;
+    width: 100% !important;
+    height: 25vh !important;
+    z-index: 20 !important; /* Mayor que el stage para estar al frente */
+    background: rgba(5, 5, 5, 0.85) !important;
+    border-top: 2px solid #c49a00 !important;
     display: flex !important;
     flex-direction: column !important;
-    justify-content: flex-end !important;
-    z-index: 8500 !important;
 }
 
 /* Aislar la zona donde se escribe para que SIEMPRE esté por encima y clickeable */

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -12428,115 +12428,6 @@
         </div>
       </div>
 
-      <!-- Player Input Area -->
-      <div
-        class="theatre-player-input-area"
-        style="
-          position: absolute;
-          bottom: 0;
-          left: 0;
-          width: 100%;
-          background: rgba(0, 0, 0, 0.9);
-          border-top: 2px solid #0df;
-          padding: 15px;
-          display: flex;
-          flex-direction: column;
-          gap: 10px;
-          z-index: 2030;
-          box-sizing: border-box;
-        "
-      >
-        <button
-          id="btn-toggle-player-theatre-tools"
-          class="btn-cyber"
-          style="
-            display: none;
-            width: 100%;
-            background: #222;
-            color: #0df;
-            border: 1px solid #0df;
-            padding: 10px;
-            font-size: 14px;
-            font-weight: bold;
-            cursor: pointer;
-            text-transform: uppercase;
-          "
-        >
-          💬 Mostrar Chat y Opciones
-        </button>
-
-        <div
-          id="player-theatre-tools-wrapper"
-          style="
-            display: flex;
-            gap: 15px;
-            width: 100%;
-            align-items: center;
-            justify-content: center;
-            flex-wrap: wrap;
-          "
-        >
-          <select
-            id="player-actor-select"
-            style="
-              background: #111;
-              color: #c49a00;
-              border: 1px solid #c49a00;
-              padding: 5px;
-              font-family: &quot;Share Tech Mono&quot;;
-              outline: none;
-            "
-          >
-            <option value="base">Mi Personaje</option>
-          </select>
-          <select
-            id="player-expression-select"
-            style="
-              padding: 15px;
-              background: #222;
-              color: #0df;
-              border: 1px solid #444;
-              border-radius: 4px;
-              font-size: 16px;
-              min-width: 120px;
-              display: none;
-            "
-          ></select>
-          <input
-            type="text"
-            id="player-theatre-input"
-            placeholder="¿Qué quieres decir o hacer? (Escribe aquí...)"
-            style="
-              flex: 1;
-              max-width: 800px;
-              padding: 15px;
-              background: #111;
-              color: #fff;
-              border: 1px solid #555;
-              border-radius: 4px;
-              font-family: inherit;
-              font-size: 16px;
-            "
-          />
-          <button
-            id="btn-player-theatre-send"
-            style="
-              background: #0df;
-              color: #000;
-              border: 1px solid #fff;
-              padding: 15px 30px;
-              font-size: 16px;
-              font-weight: bold;
-              cursor: pointer;
-              text-transform: uppercase;
-              border-radius: 4px;
-              box-shadow: 0 0 15px rgba(0, 221, 255, 0.6);
-            "
-          >
-            ENVIAR
-          </button>
-        </div>
-      </div>
     </div>
 
     <!-- Script de Emergencia -->
@@ -13493,7 +13384,55 @@
     </div>
 </div>
 
+    <button id="btn-abrir-escritura" class="control-btn" title="Actuar en el Teatro" style="position: fixed; bottom: 20px; left: 20px; z-index: 9999;">
+        <svg viewBox="0 0 24 24" fill="none" stroke="#e0e0e0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 60%; height: 60%; filter: drop-shadow(0 0 5px rgba(255, 157, 0, 0.8));">
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+        </svg>
+    </button>
     <button id="btn-shop-notifier" class="btn-icon-base size-50"><img src="Assets/Images/Buttons/Shop.svg" class="svg-icon" alt="Shop" /></button>
+
+    <div id="modal-escritura-teatro" style="display: none; position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; background: rgba(0,0,0,0.6); z-index: 9999; justify-content: center; align-items: center;">
+        <div style="background: #0b0a0a; border: 1px solid #c49a00; padding: 20px; width: 90%; max-width: 500px; display: flex; flex-direction: column; gap: 15px;">
+            <h3 style="margin: 0; color: #c49a00;">Modo Actuación</h3>
+
+            <div id="contenedor-selectores-emocion" style="display: flex; gap: 10px;">
+                <select
+                    id="player-actor-select"
+                    style="
+                    background: #111;
+                    color: #c49a00;
+                    border: 1px solid #c49a00;
+                    padding: 5px;
+                    font-family: 'Share Tech Mono';
+                    outline: none;
+                    flex: 1;
+                    "
+                >
+                    <option value="base">Mi Personaje</option>
+                </select>
+                <select
+                    id="player-expression-select"
+                    style="
+                    padding: 5px;
+                    background: #222;
+                    color: #0df;
+                    border: 1px solid #444;
+                    border-radius: 4px;
+                    font-size: 16px;
+                    flex: 1;
+                    display: none;
+                    "
+                ></select>
+            </div>
+
+            <textarea id="input-teatro-modal" rows="4" placeholder="Escribe tu acción o diálogo..." style="width: 100%; background: #050505; color: #fff; border: 1px solid #444; font-family: 'Share Tech Mono'; resize: none; padding: 10px;"></textarea>
+
+            <div style="display: flex; justify-content: flex-end; gap: 10px;">
+                <button id="btn-cerrar-escritura" style="background: #333; color: white; border: none; padding: 10px 20px; cursor: pointer;">Cancelar</button>
+                <button id="btn-enviar-teatro-modal" style="background: #8b0000; color: white; border: none; padding: 10px 20px; cursor: pointer; font-weight: bold;">Enviar</button>
+            </div>
+        </div>
+    </div>
 
     <script src="js/utils.js"></script>
     <script src="hoja_personaje.js"></script>

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -1217,24 +1217,24 @@ function initializeCharacterSheet() {
       // 2. Lectura de estado de bloqueo (Modo Lore)
       db.ref("campaña/teatro/bloqueo_interaccion").on("value", (snap) => {
         const isBlocked = snap.val();
-        const input = document.getElementById("player-theatre-input");
-        const btn = document.getElementById("btn-player-theatre-send");
+        const input = document.getElementById("input-teatro-modal");
+        const btn = document.getElementById("btn-enviar-teatro-modal");
         if (input && btn) {
           input.disabled = isBlocked;
           btn.disabled = isBlocked;
           input.placeholder = isBlocked
             ? "El Director ha bloqueado las interacciones (Modo Lore)..."
-            : "¿Qué quieres decir o hacer? (Escribe aquí...)";
+            : "Escribe tu acción o diálogo...";
         }
       });
     }
 
     // === ENVÍO AL TEATRO DE LA MENTE ===
-    const btnSend = document.getElementById("btn-player-theatre-send");
-    const inputEl = document.getElementById("player-theatre-input");
+    const btnSend = document.getElementById("btn-enviar-teatro-modal");
+    const inputEl = document.getElementById("input-teatro-modal");
 
     const sendTheatreMessage = () => {
-      const domInput = document.getElementById("player-theatre-input");
+      const domInput = document.getElementById("input-teatro-modal");
       if (!domInput || !domInput.value.trim() || typeof db === "undefined")
         return;
 
@@ -1324,8 +1324,11 @@ function initializeCharacterSheet() {
           db.ref("campaña/teatro/cola")
             .push(payload)
             .then(() => {
-              const domInput = document.getElementById("player-theatre-input");
+              const domInput = document.getElementById("input-teatro-modal");
               if (domInput) domInput.value = ""; // Limpiar input directo post-envío
+
+              const modal = document.getElementById('modal-escritura-teatro');
+              if (modal) modal.style.display = 'none';
             })
             .catch((e) => {
               console.error("Error en Firebase enviando a la cola:", e);
@@ -1341,7 +1344,7 @@ function initializeCharacterSheet() {
     // Listeners Limpios globales
     // Reasignamos usando query selector al documento real porque el original se copió
     if (btnSend) {
-      const currentBtn = document.getElementById("btn-player-theatre-send");
+      const currentBtn = document.getElementById("btn-enviar-teatro-modal");
       if (currentBtn) {
         const newBtnSend = currentBtn.cloneNode(true);
         currentBtn.parentNode.replaceChild(newBtnSend, currentBtn);
@@ -1350,7 +1353,7 @@ function initializeCharacterSheet() {
     }
 
     if (inputEl) {
-      const currentInput = document.getElementById("player-theatre-input");
+      const currentInput = document.getElementById("input-teatro-modal");
       if (currentInput) {
         const newInputEl = currentInput.cloneNode(true);
         currentInput.parentNode.replaceChild(newInputEl, currentInput);
@@ -1363,6 +1366,26 @@ function initializeCharacterSheet() {
         });
       }
     }
+  }
+
+  const btnAbrirModal = document.getElementById('btn-abrir-escritura');
+  if (btnAbrirModal) {
+      btnAbrirModal.addEventListener('click', () => {
+          const modal = document.getElementById('modal-escritura-teatro');
+          if (modal) {
+              modal.style.display = 'flex';
+              const input = document.getElementById('input-teatro-modal');
+              if (input) input.focus();
+          }
+      });
+  }
+
+  const btnCerrarModal = document.getElementById('btn-cerrar-escritura');
+  if (btnCerrarModal) {
+      btnCerrarModal.addEventListener('click', () => {
+          const modal = document.getElementById('modal-escritura-teatro');
+          if (modal) modal.style.display = 'none';
+      });
   }
 
   // Cierra la función renderCharacterSheet


### PR DESCRIPTION
Reverts recent structural failures and strictly reapplies a Visual Novel UI aesthetic strictly to the Player view (`hoja_personaje.html`), while introducing a floating action button and input modal.

Key fixes:
* **Visual Novel layout restored:** `position: absolute` is forced on `.theatre-dialogue-wrapper` to keep the dialogue box overlapping horizontally anchored sprites (no more stacking).
* **Floating Input System:** Removed the inline bottom input row for players, replacing it with the requested `#btn-abrir-escritura` floating button (using SVG dialogue icon and standard 70x70px heptagon style).
* **Semi-transparent Modal:** Created `#modal-escritura-teatro` to house the textarea, character select, and emotion select so players can type without losing view of the scene.
* **Preserved DM integrity:** Per explicit instructions, all changes apply *only* to `hoja_personaje.*`. The DM view (`pantalla_dm.html`) remains entirely unchanged.

---
*PR created automatically by Jules for task [13423736363311586718](https://jules.google.com/task/13423736363311586718) started by @sokcrow*