### PR TITLE
Fix Theatre Log Layer Stacking and Interactions

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -7471,7 +7471,7 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
     max-width: 95% !important;
     height: 60vh !important;
     max-height: 500px !important;
-    z-index: 2050 !important;
+    z-index: 99999 !important;
 
     background-color: var(--bg-color) !important;
     background-image: repeating-linear-gradient(

--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -8008,12 +8008,26 @@ input:checked + .slider-toggle:before { transform: translateX(20px); background-
 }
 
 #theatre-dialogue-history {
-    flex-grow: 1 !important;
+    position: absolute !important;
+    bottom: 0 !important;
+    left: 0 !important;
+    width: 100% !important;
+    height: 25vh !important;
+    z-index: 999 !important; /* MÁXIMA PRIORIDAD para que nada lo tape */
+    pointer-events: auto !important; /* Habilita el scroll y los clics dentro del log */
+    background: rgba(5, 5, 5, 0.85) !important;
+    border-top: 2px solid #c49a00 !important;
     overflow-y: auto !important;
-    padding-bottom: 10px;
+    padding: 15px !important;
+    box-sizing: border-box !important;
+    display: block !important;
 }
 
-.theatre-stage {
+.theatre-stage, .theatre-visuals {
+    z-index: 10 !important; /* Debe mantenerse muy por debajo del z-index 999 del log */
+    pointer-events: none !important; /* IMPORTANTE: Evita que el fondo transparente bloquee los clics */
+}
+.theatre-stage img, .character-sprite {
     pointer-events: none !important;
 }
 

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -688,7 +688,7 @@
         max-width: 95% !important;
         height: 60vh !important;
         max-height: 500px !important;
-        z-index: 2050 !important;
+        z-index: 99999 !important;
 
         background-color: var(--bg-color) !important;
         background-image: repeating-linear-gradient(

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -971,6 +971,30 @@
           pointer-events: auto !important;
       }
 
+      #theatre-dialogue-history {
+          position: absolute !important;
+          bottom: 0 !important;
+          left: 0 !important;
+          width: 100% !important;
+          height: 25vh !important;
+          z-index: 999 !important; /* MÁXIMA PRIORIDAD para que nada lo tape */
+          pointer-events: auto !important; /* Habilita el scroll y los clics dentro del log */
+          background: rgba(5, 5, 5, 0.85) !important;
+          border-top: 2px solid #c49a00 !important;
+          overflow-y: auto !important;
+          padding: 15px !important;
+          box-sizing: border-box !important;
+          display: block !important;
+      }
+
+      .theatre-stage, .theatre-visuals {
+          z-index: 10 !important; /* Debe mantenerse muy por debajo del z-index 999 del log */
+          pointer-events: none !important; /* IMPORTANTE: Evita que el fondo transparente bloquee los clics */
+      }
+      .theatre-stage img, .character-sprite {
+          pointer-events: none !important;
+      }
+
     </style>
 
     <style>


### PR DESCRIPTION
Fixing the z-index stacking and mouse event capture to resolve the issue where the Theatre of the Mind log became trapped behind other layers and blocked user interaction. The logs and stages are now updated in `hoja_personaje.css` and `pantalla_dm.html`.

---
*PR created automatically by Jules for task [11834110179076057754](https://jules.google.com/task/11834110179076057754) started by @sokcrow*