### PR TITLE
⚡ Bolt: Optimize skill row rendering to use O(1) dictionary lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,10 @@
 ## 2025-03-26 - [DOM Attribute Thrashing in renderCharacterSheet]
 **Learning:** Found that assigning `.innerText` or `.value` unconditionally inside high-frequency real-time `on('value')` listeners (like Firebase data sync) causes unnecessary DOM layout recalculations and repaints, even if the value string hasn't changed.
 **Action:** Introduced strict equality checks (e.g., `if (el.innerText !== String(newVal))`) before applying data to DOM node attributes during iterative render loops.
+
+## 2024-05-24 - [Avoid O(N^2) Bottlenecks in DOM Generation]
+**Learning:** Using `Object.keys().find()` for case-insensitive lookups inside an iteration that processes numerous DOM elements (like skill rows) results in severe O(N²) layout thrashing and computational overhead, significantly slowing down UI rendering.
+**Action:** Always pre-compute lowercase hashmaps (e.g., `lowerMap[key.toLowerCase()] = key`) before looping over DOM elements to transform N*M string comparisons into O(1) dictionary lookups.
+## 2025-05-24 - [Avoid Real-Time Caches in Click Handlers]
+**Learning:** Found that globally caching real-time Firebase payloads (like character `baseStats`) during an initial boot sequence causes bugs when the data later syncs dynamically, as the cache becomes dangerously stale during interactions. Furthermore, trying to over-optimize single-element interactions (like a single click handler) is often premature, as the true O(N²) bottlenecks originate within massive iterative UI rendering loops, not $O(M)$ single user clicks.
+**Action:** Focus O(1) dictionary optimizations strictly within large iterative loops (like `skillRows.forEach`), computing the cache per iteration block rather than globally, and leave single-interaction event handlers simple unless they are definitively blocking the main thread.

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -742,12 +742,24 @@ function renderCharacterSheet(data) {
 
   // Update all skill rows (Base, Mod, Total)
   const skillRows = document.querySelectorAll(".sheet-skill-row");
+
+  // ⚡ Bolt Optimization: Pre-compute lowercase maps for O(1) lookups inside the loop
+  const lowerBaseStats = {};
+  if (data.baseStats) {
+    Object.keys(data.baseStats).forEach(k => lowerBaseStats[k.toLowerCase()] = k);
+  }
+  const lowerModifiers = {};
+  if (data.modifiers) {
+    Object.keys(data.modifiers).forEach(k => lowerModifiers[k.toLowerCase()] = k);
+  }
+
   skillRows.forEach((row) => {
     const btn = row.querySelector(".sheet-roll-skill-btn");
     if (btn) {
       const actName = btn.getAttribute("name");
       if (actName && actName.startsWith("act_roll_skill_")) {
         const skillNameRaw = actName.replace("act_roll_skill_", "");
+        const skillNameLower = skillNameRaw.toLowerCase();
         let bVal = parseInt(data[`skill_${skillNameRaw}_base`]);
         bVal = !isNaN(bVal) ? bVal : 0;
         let mVal = parseInt(data[`skill_${skillNameRaw}_mod`]);
@@ -758,17 +770,11 @@ function renderCharacterSheet(data) {
           data[`skill_${skillNameRaw}_base`] === undefined &&
           data.baseStats
         ) {
-          const baseKey = Object.keys(data.baseStats).find(
-            (k) => k.toLowerCase() === skillNameRaw.toLowerCase(),
-          );
+          const baseKey = lowerBaseStats[skillNameLower];
           if (baseKey) bVal = parseInt(data.baseStats[baseKey]) || 0;
         }
         if (data[`skill_${skillNameRaw}_mod`] === undefined && data.modifiers) {
-          const modKey = Object.keys(data.modifiers).find(
-            (k) =>
-              k.toLowerCase() === `skill_${skillNameRaw}`.toLowerCase() ||
-              k.toLowerCase() === skillNameRaw.toLowerCase(),
-          );
+          const modKey = lowerModifiers[`skill_${skillNameLower}`] || lowerModifiers[skillNameLower];
           if (modKey) mVal = parseInt(data.modifiers[modKey]) || 0;
         }
 
@@ -1071,6 +1077,7 @@ async function runBootSequence() {
 
           window.datosJugador = snap.val();
           currentPlayerData = snap.val();
+
 
           // Cache data
           localStorage.setItem(


### PR DESCRIPTION
💡 What: Replaced an $O(N \times M)$ sequence of `Object.keys().find()` and `.toLowerCase()` operations during `renderCharacterSheet` with pre-computed $O(1)$ dictionary lookups (`lowerBaseStats` and `lowerModifiers`).
🎯 Why: The original logic iterated over dozens of DOM `.sheet-skill-row` elements and on every loop iteration, reconstructed arrays of object keys and mapped string lowercasing arrays to find specific core stats/modifiers. This caused unnecessary heavy CPU computation and layout thrashing.
📊 Impact: Reduces array allocations and nested string comparisons significantly per UI re-render, transitioning the DOM logic inner block overhead from $O(M)$ to $O(1)$.
🔬 Measurement: Run a CPU profiling trace and interact with elements that invoke `renderCharacterSheet()` (e.g., initial boot up, crafting render updates). The time spent in `skillRows.forEach()` will measure demonstrably faster with zero redundant `Object.keys()` memory allocations. Visual regression verified via Playwright.

---
*PR created automatically by Jules for task [12445371212328585315](https://jules.google.com/task/12445371212328585315) started by @sokcrow*