### PR TITLE
⚡ Bolt: Replace O(n²) stat lookups with O(1) hashmaps in character sheet

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-26 - [DOM Attribute Thrashing in renderCharacterSheet]
 **Learning:** Found that assigning `.innerText` or `.value` unconditionally inside high-frequency real-time `on('value')` listeners (like Firebase data sync) causes unnecessary DOM layout recalculations and repaints, even if the value string hasn't changed.
 **Action:** Introduced strict equality checks (e.g., `if (el.innerText !== String(newVal))`) before applying data to DOM node attributes during iterative render loops.
+
+## 2025-03-31 - [O(1) Map Lookups replacing O(N²) Object.keys().find() in Render Loop]
+**Learning:** Found an O(N²) performance bottleneck during UI rendering in `hoja_personaje.js`. `Object.keys(data).find(...)` for case-insensitive lookups was being executed iteratively inside `skillRows.forEach()`. This blocks the main thread during heavy Firebase synchronization. (Note: Avoided doing this inside single-event handlers like `click` as allocating temporary hashmaps to perform a single O(N) lookup creates unnecessary garbage collection pressure/is an anti-pattern).
+**Action:** Replaced iterative `Object.keys().find()` inside loops with pre-computed lowercase hashmaps (`baseStatsLower`, `modifiersLower`) constructed outside the loop, reducing lookup time from O(N) per iteration to O(1) direct property access.

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -742,34 +742,50 @@ function renderCharacterSheet(data) {
 
   // Update all skill rows (Base, Mod, Total)
   const skillRows = document.querySelectorAll(".sheet-skill-row");
+
+  // Pre-compute lowercased maps for O(1) lookups instead of O(N) Object.keys().find() inside loop
+  const baseStatsLower = {};
+  if (data.baseStats) {
+    for (const [k, v] of Object.entries(data.baseStats)) {
+      baseStatsLower[k.toLowerCase()] = v;
+    }
+  }
+  const modifiersLower = {};
+  if (data.modifiers) {
+    for (const [k, v] of Object.entries(data.modifiers)) {
+      modifiersLower[k.toLowerCase()] = v;
+    }
+  }
+
   skillRows.forEach((row) => {
     const btn = row.querySelector(".sheet-roll-skill-btn");
     if (btn) {
       const actName = btn.getAttribute("name");
       if (actName && actName.startsWith("act_roll_skill_")) {
         const skillNameRaw = actName.replace("act_roll_skill_", "");
+        const skillNameLower = skillNameRaw.toLowerCase();
+
         let bVal = parseInt(data[`skill_${skillNameRaw}_base`]);
         bVal = !isNaN(bVal) ? bVal : 0;
         let mVal = parseInt(data[`skill_${skillNameRaw}_mod`]);
         mVal = !isNaN(mVal) ? mVal : 0;
 
-        // fallback
+        // fallback using pre-computed maps
         if (
           data[`skill_${skillNameRaw}_base`] === undefined &&
           data.baseStats
         ) {
-          const baseKey = Object.keys(data.baseStats).find(
-            (k) => k.toLowerCase() === skillNameRaw.toLowerCase(),
-          );
-          if (baseKey) bVal = parseInt(data.baseStats[baseKey]) || 0;
+          const val = baseStatsLower[skillNameLower];
+          if (val !== undefined) bVal = parseInt(val) || 0;
         }
         if (data[`skill_${skillNameRaw}_mod`] === undefined && data.modifiers) {
-          const modKey = Object.keys(data.modifiers).find(
-            (k) =>
-              k.toLowerCase() === `skill_${skillNameRaw}`.toLowerCase() ||
-              k.toLowerCase() === skillNameRaw.toLowerCase(),
-          );
-          if (modKey) mVal = parseInt(data.modifiers[modKey]) || 0;
+          const modName1 = `skill_${skillNameLower}`;
+          const modName2 = skillNameLower;
+          if (modifiersLower[modName1] !== undefined) {
+            mVal = parseInt(modifiersLower[modName1]) || 0;
+          } else if (modifiersLower[modName2] !== undefined) {
+            mVal = parseInt(modifiersLower[modName2]) || 0;
+          }
         }
 
         // ⚡ Bolt Optimization: Skip DOM updates for unchanged skills


### PR DESCRIPTION
💡 What: Replaced iterative `Object.keys(data).find(...)` lookups inside the `skillRows.forEach` render loop in `hoja_personaje.js` with O(1) pre-computed hashmap lookups. Added a new critical learning entry to `.jules/bolt.md`.
🎯 Why: Iterating over all keys to perform a case-insensitive fallback lookup inside an N-sized loop creates an O(N²) complexity bottleneck that blocks the main thread and introduces severe lag during rapid Firebase real-time data synchronization.
📊 Impact: Lookups are reduced from O(N) per loop iteration down to O(1) direct property access. Drastically reduces execution time of `renderCharacterSheet`, leading to a much smoother UI and lowered memory overhead since we stop allocating multiple throwaway temporary Arrays during every frame update.
🔬 Measurement: Verify visually via the frontend Playwright test that the sheet renders identically. Measure execution latency of `renderCharacterSheet(data)` using Chrome DevTools Performance Profiler.

---
*PR created automatically by Jules for task [12406628082614815296](https://jules.google.com/task/12406628082614815296) started by @sokcrow*