### PR TITLE
⚡ Bolt: Batch DOM inserts in DM queue rendering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-26 - [DOM Attribute Thrashing in renderCharacterSheet]
 **Learning:** Found that assigning `.innerText` or `.value` unconditionally inside high-frequency real-time `on('value')` listeners (like Firebase data sync) causes unnecessary DOM layout recalculations and repaints, even if the value string hasn't changed.
 **Action:** Introduced strict equality checks (e.g., `if (el.innerText !== String(newVal))`) before applying data to DOM node attributes during iterative render loops.
+
+## 2025-03-26 - [DOM Fragment Batching in pantalla_dm.html Queue Rendering]
+**Learning:** Found another O(n) layout reflow pattern in the `pantalla_dm.html` `db.ref("campaña/teatro/cola").on` listener when rendering the theatre queue items.
+**Action:** Replaced iterative DOM appending with DocumentFragment appending to reduce reflows to O(1) in the tight Firebase sync callback loop. This reinforces the pattern that all lists generated via Realtime DB callbacks must use DocumentFragments.

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -7232,6 +7232,13 @@
             return;
           }
 
+          // ⚡ Bolt Optimization: Use DocumentFragment to batch DOM insertions.
+          // 💡 What: Replaced direct `queueContainer.appendChild` inside the loop with `fragmentQueue.appendChild`.
+          // 🎯 Why: Appending directly to the DOM in a loop causes O(n) layout reflows and repaints.
+          // 📊 Impact: Reduces DOM reflows from O(n) to O(1) per queue update, improving performance when many items are enqueued.
+          // 🔬 Measurement: Observe memory footprint and rendering speed during heavy theatre usage.
+          const fragmentQueue = document.createDocumentFragment();
+
           // Convert to array and maintain Firebase's push order (keys are chronological)
           for (const [key, msgData] of Object.entries(cola)) {
             queueItems.push({ key: key, ...msgData });
@@ -7292,8 +7299,11 @@
               db.ref(`campaña/teatro/cola/${key}`).remove();
             });
 
-            queueContainer.appendChild(itemDiv);
+            fragmentQueue.appendChild(itemDiv);
           }
+
+          // ⚡ Mount batched DOM nodes
+          queueContainer.appendChild(fragmentQueue);
 
           // Reactivar ciclo de avance continuo si estamos en dicho modo y la cola se llena
           const textBox = document.getElementById("theatre-dialogue-text");


### PR DESCRIPTION
⚡ Bolt: Batch DOM inserts in DM queue rendering

💡 What: Replaced direct `queueContainer.appendChild` inside the `db.ref("campaña/teatro/cola").on` loop in `pantalla_dm.html` with a `DocumentFragment` (`fragmentQueue.appendChild`), only appending to the live DOM once the loop completes.
🎯 Why: Appending directly to the DOM in a loop causes O(n) layout reflows and repaints. Batching updates reduces this to a single O(1) operation per real-time update.
📊 Impact: Significantly minimizes DOM layout thrashing during heavy theatre usage, reducing visual lag when many items enter the queue at once.
🔬 Measurement: Verified manually through visual verification tests. No logic has been changed. Recorded learning to `.jules/bolt.md`.

---
*PR created automatically by Jules for task [10766061780533183079](https://jules.google.com/task/10766061780533183079) started by @sokcrow*