### PR TITLE
⚡ Bolt: Optimize Teatro de la Mente Log Rendering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,4 @@
 ## 2025-03-26 - [DOM Attribute Thrashing in renderCharacterSheet]
 **Learning:** Found that assigning `.innerText` or `.value` unconditionally inside high-frequency real-time `on('value')` listeners (like Firebase data sync) causes unnecessary DOM layout recalculations and repaints, even if the value string hasn't changed.
 **Action:** Introduced strict equality checks (e.g., `if (el.innerText !== String(newVal))`) before applying data to DOM node attributes during iterative render loops.
+## 2026-04-16 - [Optimize Teatro Log Rendering]\n**Learning:** Re-rendering chat logs using DocumentFragment in Firebase .on() listeners significantly reduces layout thrashing, and substituting loop-based N*M object lookups with a Map drastically improves computation time to O(N).\n**Action:** Always map-cache lookup references outside of DOM-generation loops and utilize DocumentFragments for batch appending.

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -1198,11 +1198,23 @@ function initializeCharacterSheet() {
 
         if (logs) {
           let isFirst = true;
+          const fragment = document.createDocumentFragment();
+
+          // 💡 What: O(1) map lookup for actors instead of O(N) find inside loop
+          const actorsMap = new Map();
+          if (window.allActoresCache) {
+            Object.values(window.allActoresCache).forEach((actor) => {
+              if (actor.nombre) {
+                actorsMap.set(actor.nombre.toLowerCase(), actor);
+              }
+            });
+          }
+
           for (const [key, msg] of Object.entries(logs)) {
             if (!isFirst) {
               const divider = document.createElement("hr");
               divider.className = "dialogue-divider";
-              scrollArea.appendChild(divider);
+              fragment.appendChild(divider);
             }
             isFirst = false;
 
@@ -1214,13 +1226,8 @@ function initializeCharacterSheet() {
             const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
             let dynamicIcon = null;
-            if (window.allActoresCache) {
-              const actorMatch = Object.values(window.allActoresCache).find(
-                (actor) =>
-                  actor.nombre &&
-                  msg.nombre &&
-                  actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-              );
+            if (msg.nombre) {
+              const actorMatch = actorsMap.get(msg.nombre.toLowerCase());
               if (actorMatch && actorMatch.icono) {
                 dynamicIcon = actorMatch.icono;
               }
@@ -1242,8 +1249,11 @@ function initializeCharacterSheet() {
                         </div>
                       `;
 
-            scrollArea.appendChild(row);
+            fragment.appendChild(row);
           }
+
+          // 💡 What: Append all messages at once using a DocumentFragment
+          scrollArea.appendChild(fragment);
           scrollArea.scrollTop = scrollArea.scrollHeight;
         }
       };

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -6960,11 +6960,23 @@
 
             if (logs) {
               let isFirst = true;
+              const fragment = document.createDocumentFragment();
+
+              // 💡 What: O(1) map lookup for actors instead of O(N) find inside loop
+              const actorsMap = new Map();
+              if (typeof dbActoresCache !== "undefined" && dbActoresCache) {
+                Object.values(dbActoresCache).forEach((actor) => {
+                  if (actor.nombre) {
+                    actorsMap.set(actor.nombre.toLowerCase(), actor);
+                  }
+                });
+              }
+
               for (const [key, msg] of Object.entries(logs)) {
                 if (!isFirst) {
                   const divider = document.createElement("hr");
                   divider.className = "dialogue-divider";
-                  scrollArea.appendChild(divider);
+                  fragment.appendChild(divider);
                 }
                 isFirst = false;
 
@@ -6975,13 +6987,8 @@
                 const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
                 let dynamicIcon = null;
-                if (typeof dbActoresCache !== "undefined" && dbActoresCache) {
-                  const actorMatch = Object.values(dbActoresCache).find(
-                    (actor) =>
-                      actor.nombre &&
-                      msg.nombre &&
-                      actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-                  );
+                if (msg.nombre) {
+                  const actorMatch = actorsMap.get(msg.nombre.toLowerCase());
                   if (actorMatch && actorMatch.icono) {
                     dynamicIcon = actorMatch.icono;
                   }
@@ -7003,8 +7010,11 @@
                     <p>${msg.mensaje}</p>
                   </div>
                 `;
-                scrollArea.appendChild(row);
+                fragment.appendChild(row);
               }
+
+              // 💡 What: Append all messages at once using a DocumentFragment
+              scrollArea.appendChild(fragment);
 
               // Create confirm button footer if it doesn't exist
               let footer = logContainer.querySelector(".dialogue-footer");


### PR DESCRIPTION
💡 What: Replaced direct `appendChild` with a `DocumentFragment` to batch DOM insertions, and introduced an O(1) `Map` lookup for actors to replace an O(N) `.find()` lookup inside the loop across `hoja_personaje.js` and `pantalla_dm.html`.
🎯 Why: Rendering the Teatro de la Mente log was causing an O(N²) bottleneck due to repeated O(N) array lookups within a loop, and direct `appendChild` insertions on every message were causing O(N) layout reflows, lagging the UI significantly as messages populated.
📊 Impact: Reduces UI reflows to 1 per render cycle, and reduces actor lookup computational overhead from O(N*M) to O(N).
🔬 Measurement: Verify by executing node tests locally with `jsdom` or testing the Theatre Log rendering visually via browser profiling.

---
*PR created automatically by Jules for task [16884552725109194869](https://jules.google.com/task/16884552725109194869) started by @sokcrow*