### PR TITLE
⚡ Bolt: [performance improvement] Batched DOM insertions in tienda modal

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-26 - [DOM Attribute Thrashing in renderCharacterSheet]
 **Learning:** Found that assigning `.innerText` or `.value` unconditionally inside high-frequency real-time `on('value')` listeners (like Firebase data sync) causes unnecessary DOM layout recalculations and repaints, even if the value string hasn't changed.
 **Action:** Introduced strict equality checks (e.g., `if (el.innerText !== String(newVal))`) before applying data to DOM node attributes during iterative render loops.
+
+## 2025-03-26 - [DOM Fragment Batching in pantalla_dm.html]
+**Learning:** Found an O(n) layout reflow pattern when opening the Store Editor modal in DM screen.
+**Action:** Replaced iterative DOM appending (`listaItemsModal.appendChild(row)`) with DocumentFragment appending to reduce reflows to O(1) inside `abrirModalTienda`.

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -5884,6 +5884,12 @@
           listaItemsModal.innerHTML = "";
           const itemsTienda = dataTienda.items || {};
 
+          // ⚡ Bolt Optimization: Use DocumentFragment to batch DOM insertions.
+          // 💡 What: Replaced direct `listaItemsModal.appendChild` with `fragment.appendChild`.
+          // 🎯 Why: Appending directly to the DOM in a loop causes O(n) layout reflows and repaints.
+          // 📊 Impact: Reduces DOM reflows from O(n) to O(1) per render loop, improving modal load speed when store has many items.
+          const fragment = document.createDocumentFragment();
+
           // Iterar sobre TODOS los ítems globales para mostrarlos
           for (const [keyItem, dataGlobal] of Object.entries(dbItemsCache)) {
             const itemEnTienda = itemsTienda[keyItem]; // Existe en la tienda?
@@ -5943,8 +5949,10 @@
                 </label>
             `;
 
-            listaItemsModal.appendChild(row);
+            fragment.appendChild(row);
           }
+
+          listaItemsModal.appendChild(fragment);
 
           modalEditar.style.display = "flex";
         }


### PR DESCRIPTION
⚡ Bolt: [performance improvement] Batched DOM insertions in tienda modal

**What:** Replaced iterative, direct `appendChild` insertions into `listaItemsModal` with a `DocumentFragment` in the `abrirModalTienda` function.
**Why:** Directly appending to the live DOM in a loop triggers O(n) layout reflows and repaints, making modal load times sluggish when rendering a large global items cache.
**Impact:** Significantly improves modal opening performance by batching all operations into a single O(1) DOM reflow.
**Measurement:** Profile load times before and after opening the DM Store Editor modal (`modal-editar-tienda`).

---
*PR created automatically by Jules for task [17017460369457797985](https://jules.google.com/task/17017460369457797985) started by @sokcrow*