### PR TITLE
⚡ Bolt: Fix O(N²) array searches and layout reflows in Theatre Log

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-26 - [DOM Attribute Thrashing in renderCharacterSheet]
 **Learning:** Found that assigning `.innerText` or `.value` unconditionally inside high-frequency real-time `on('value')` listeners (like Firebase data sync) causes unnecessary DOM layout recalculations and repaints, even if the value string hasn't changed.
 **Action:** Introduced strict equality checks (e.g., `if (el.innerText !== String(newVal))`) before applying data to DOM node attributes during iterative render loops.
+
+## 2024-04-22 - [Teatro de la Mente Log O(N²) + Layout Reflows]
+**Learning:** Found an O(N²) bottleneck in Firebase `.on('value')` listeners processing 'Teatro de la Mente' logs. `Object.values().find(...)` was called for every log message in a loop to match actor icons. Combined with direct `appendChild` to a visible container inside the loop, it caused massive CPU spikes and layout reflows during initialization of large chat logs.
+**Action:** Always extract static reference data (like `window.allActoresCache`) into pre-computed `Map` objects before the loop for O(1) lookups, and batch DOM updates using `document.createDocumentFragment()` before appending to the live DOM.

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -1197,12 +1197,25 @@ function initializeCharacterSheet() {
         }
 
         if (logs) {
+          // ⚡ Bolt: Prevent O(N) layout reflows by using DocumentFragment
+          const fragment = document.createDocumentFragment();
+
+          // ⚡ Bolt: Pre-compute actor map for O(1) lookups instead of O(N²) array searches inside loop
+          const actorMap = new Map();
+          if (window.allActoresCache) {
+            Object.values(window.allActoresCache).forEach((actor) => {
+              if (actor.nombre) {
+                actorMap.set(actor.nombre.toLowerCase(), actor);
+              }
+            });
+          }
+
           let isFirst = true;
           for (const [key, msg] of Object.entries(logs)) {
             if (!isFirst) {
               const divider = document.createElement("hr");
               divider.className = "dialogue-divider";
-              scrollArea.appendChild(divider);
+              fragment.appendChild(divider);
             }
             isFirst = false;
 
@@ -1214,13 +1227,8 @@ function initializeCharacterSheet() {
             const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
             let dynamicIcon = null;
-            if (window.allActoresCache) {
-              const actorMatch = Object.values(window.allActoresCache).find(
-                (actor) =>
-                  actor.nombre &&
-                  msg.nombre &&
-                  actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-              );
+            if (msg.nombre) {
+              const actorMatch = actorMap.get(msg.nombre.toLowerCase());
               if (actorMatch && actorMatch.icono) {
                 dynamicIcon = actorMatch.icono;
               }
@@ -1242,8 +1250,9 @@ function initializeCharacterSheet() {
                         </div>
                       `;
 
-            scrollArea.appendChild(row);
+            fragment.appendChild(row);
           }
+          scrollArea.appendChild(fragment);
           scrollArea.scrollTop = scrollArea.scrollHeight;
         }
       };

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -6959,12 +6959,25 @@
             }
 
             if (logs) {
+              // ⚡ Bolt: Prevent O(N) layout reflows by using DocumentFragment
+              const fragment = document.createDocumentFragment();
+
+              // ⚡ Bolt: Pre-compute actor map for O(1) lookups instead of O(N²) array searches inside loop
+              const actorMap = new Map();
+              if (typeof dbActoresCache !== "undefined" && dbActoresCache) {
+                Object.values(dbActoresCache).forEach((actor) => {
+                  if (actor.nombre) {
+                    actorMap.set(actor.nombre.toLowerCase(), actor);
+                  }
+                });
+              }
+
               let isFirst = true;
               for (const [key, msg] of Object.entries(logs)) {
                 if (!isFirst) {
                   const divider = document.createElement("hr");
                   divider.className = "dialogue-divider";
-                  scrollArea.appendChild(divider);
+                  fragment.appendChild(divider);
                 }
                 isFirst = false;
 
@@ -6975,13 +6988,8 @@
                 const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
                 let dynamicIcon = null;
-                if (typeof dbActoresCache !== "undefined" && dbActoresCache) {
-                  const actorMatch = Object.values(dbActoresCache).find(
-                    (actor) =>
-                      actor.nombre &&
-                      msg.nombre &&
-                      actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-                  );
+                if (msg.nombre) {
+                  const actorMatch = actorMap.get(msg.nombre.toLowerCase());
                   if (actorMatch && actorMatch.icono) {
                     dynamicIcon = actorMatch.icono;
                   }
@@ -7003,8 +7011,10 @@
                     <p>${msg.mensaje}</p>
                   </div>
                 `;
-                scrollArea.appendChild(row);
+                fragment.appendChild(row);
               }
+
+              scrollArea.appendChild(fragment);
 
               // Create confirm button footer if it doesn't exist
               let footer = logContainer.querySelector(".dialogue-footer");


### PR DESCRIPTION
💡 **What:** Replaced sequential `scrollArea.appendChild(row)` with `DocumentFragment` inside the Firebase `.on('value')` listener for the Teatro de la Mente chat log (`hoja_personaje.js` and `pantalla_dm.html`). Also swapped an `O(N)` `Array.prototype.find()` lookup inside the loop with an `O(1)` pre-computed `Map`.

🎯 **Why:** Rendering large chat logs was causing severe UI blocking and reflows. The inner loop iterated through all `logs` (N), and for every log, it executed `Object.values().find()` over the entire `actoresCache` array (M), resulting in an `O(N * M)` complexity and dropping frames. Additionally, appending directly to the live DOM caused sequential layout reflows per message.

📊 **Impact:** Reduces log render initialization time significantly for large message histories by dropping time complexity to O(N + M) and layout reflow complexity to O(1). 

🔬 **Measurement:** Verify by rendering a large message log; visually, frames no longer drop when toggling or receiving bursts of theater log data. Check `.jules/bolt.md` for logged learnings.

---
*PR created automatically by Jules for task [8976646819697287985](https://jules.google.com/task/8976646819697287985) started by @sokcrow*