### PR TITLE
⚡ Bolt: Optimize renderizarLog layout thrashing and O(N^2) lookups

### DIFF
--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -1198,11 +1198,23 @@ function initializeCharacterSheet() {
 
         if (logs) {
           let isFirst = true;
+          const fragment = document.createDocumentFragment();
+
+          // Pre-compute actor cache map to avoid O(N^2) lookups inside the loop
+          const actorIconMap = new Map();
+          if (window.allActoresCache) {
+            for (const actor of Object.values(window.allActoresCache)) {
+              if (actor.nombre && actor.icono) {
+                actorIconMap.set(actor.nombre.toLowerCase(), actor.icono);
+              }
+            }
+          }
+
           for (const [key, msg] of Object.entries(logs)) {
             if (!isFirst) {
               const divider = document.createElement("hr");
               divider.className = "dialogue-divider";
-              scrollArea.appendChild(divider);
+              fragment.appendChild(divider);
             }
             isFirst = false;
 
@@ -1213,18 +1225,7 @@ function initializeCharacterSheet() {
             // Generate a default icon just in case one is missing
             const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
-            let dynamicIcon = null;
-            if (window.allActoresCache) {
-              const actorMatch = Object.values(window.allActoresCache).find(
-                (actor) =>
-                  actor.nombre &&
-                  msg.nombre &&
-                  actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-              );
-              if (actorMatch && actorMatch.icono) {
-                dynamicIcon = actorMatch.icono;
-              }
-            }
+            let dynamicIcon = msg.nombre ? actorIconMap.get(msg.nombre.toLowerCase()) : null;
 
             const iconoSrc = dynamicIcon || msg.icono || defaultFallbackIcon;
 
@@ -1242,8 +1243,9 @@ function initializeCharacterSheet() {
                         </div>
                       `;
 
-            scrollArea.appendChild(row);
+            fragment.appendChild(row);
           }
+          scrollArea.appendChild(fragment);
           scrollArea.scrollTop = scrollArea.scrollHeight;
         }
       };

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -6960,11 +6960,23 @@
 
             if (logs) {
               let isFirst = true;
+              const fragment = document.createDocumentFragment();
+
+              // Pre-compute actor cache map to avoid O(N^2) lookups inside the loop
+              const actorIconMap = new Map();
+              if (typeof dbActoresCache !== "undefined" && dbActoresCache) {
+                for (const actor of Object.values(dbActoresCache)) {
+                  if (actor.nombre && actor.icono) {
+                    actorIconMap.set(actor.nombre.toLowerCase(), actor.icono);
+                  }
+                }
+              }
+
               for (const [key, msg] of Object.entries(logs)) {
                 if (!isFirst) {
                   const divider = document.createElement("hr");
                   divider.className = "dialogue-divider";
-                  scrollArea.appendChild(divider);
+                  fragment.appendChild(divider);
                 }
                 isFirst = false;
 
@@ -6974,18 +6986,7 @@
                 const charHexColor = msg.color_nombre || "#fff";
                 const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
-                let dynamicIcon = null;
-                if (typeof dbActoresCache !== "undefined" && dbActoresCache) {
-                  const actorMatch = Object.values(dbActoresCache).find(
-                    (actor) =>
-                      actor.nombre &&
-                      msg.nombre &&
-                      actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-                  );
-                  if (actorMatch && actorMatch.icono) {
-                    dynamicIcon = actorMatch.icono;
-                  }
-                }
+                let dynamicIcon = msg.nombre ? actorIconMap.get(msg.nombre.toLowerCase()) : null;
 
                 const iconoSrc =
                   dynamicIcon || msg.icono || defaultFallbackIcon;
@@ -7003,8 +7004,9 @@
                     <p>${msg.mensaje}</p>
                   </div>
                 `;
-                scrollArea.appendChild(row);
+                fragment.appendChild(row);
               }
+              scrollArea.appendChild(fragment);
 
               // Create confirm button footer if it doesn't exist
               let footer = logContainer.querySelector(".dialogue-footer");


### PR DESCRIPTION
💡 **What**: Optimized `renderizarLog` in both `hoja_personaje.js` and `pantalla_dm.html`. Converted the `dbActoresCache`/`window.allActoresCache` object to a Map prior to the loop to replace the `Object.values(cache).find()` call. Wrapped the `divider` and `row` creation inside a `DocumentFragment` before applying it to the DOM.
🎯 **Why**: When `renderizarLog` ran previously, it executed an O(N) `find()` over the actors cache for *every* message in the log, resulting in O(N^2) lookups. Additionally, appending elements directly to `scrollArea` inside the loop triggered multiple DOM reflows and repaints, severely impacting performance as the log size grew.
📊 **Impact**: Reduces CPU lookup time from O(N^2) to O(1) per loop, and reduces DOM reflows from O(N) to exactly 1 reflow per log render event.
🔬 **Measurement**: In performance profiles, `renderizarLog` execution time should drop drastically, and layout thrashing will no longer appear when new messages arrive.

---
*PR created automatically by Jules for task [2888968499524670792](https://jules.google.com/task/2888968499524670792) started by @sokcrow*