### PR TITLE
⚡ Bolt: [performance improvement] Pre-compute lowercase data maps for O(1) lookups in renderCharacterSheet()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2025-03-26 - [DOM Attribute Thrashing in renderCharacterSheet]
 **Learning:** Found that assigning `.innerText` or `.value` unconditionally inside high-frequency real-time `on('value')` listeners (like Firebase data sync) causes unnecessary DOM layout recalculations and repaints, even if the value string hasn't changed.
 **Action:** Introduced strict equality checks (e.g., `if (el.innerText !== String(newVal))`) before applying data to DOM node attributes during iterative render loops.
+## 2025-05-19 - [O(N^2) Performance Bottleneck during DOM Renders]
+**Learning:** During UI generation, calling `Object.keys(obj).find(...)` inside loops creates significant performance bottlenecks when processing dynamic properties like `baseStats` and `modifiers`. Repeated `find()` lookups coupled with `.toLowerCase()` manipulation scaled linearly with array length per loop iteration.
+**Action:** In `renderCharacterSheet()`, pre-compute lowercased versions of the dynamically retrieved data maps (`baseStats` and `modifiers`) outside the `forEach` loop. This transforms $O(N)$ lookup checks into $O(1)$ property access checks per skill row, dramatically speeding up `hoja_personaje.js` runtime during Firebase sync events.

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -741,6 +741,23 @@ function renderCharacterSheet(data) {
   });
 
   // Update all skill rows (Base, Mod, Total)
+  // ⚡ Bolt Optimization: Pre-compute lowercase hashmaps for O(1) lookups
+  // 💡 What: Created lowercased maps of baseStats and modifiers keys outside the loop.
+  // 🎯 Why: Calling Object.keys().find() inside a loop causes O(N²) performance bottlenecks during UI generation.
+  // 📊 Impact: Transforms N property lookups inside the skill loop from O(N) to O(1), significantly speeding up re-renders.
+  const baseStatsLower = {};
+  if (data.baseStats) {
+    for (const [k, v] of Object.entries(data.baseStats)) {
+      baseStatsLower[k.toLowerCase()] = v;
+    }
+  }
+  const modifiersLower = {};
+  if (data.modifiers) {
+    for (const [k, v] of Object.entries(data.modifiers)) {
+      modifiersLower[k.toLowerCase()] = v;
+    }
+  }
+
   const skillRows = document.querySelectorAll(".sheet-skill-row");
   skillRows.forEach((row) => {
     const btn = row.querySelector(".sheet-roll-skill-btn");
@@ -748,6 +765,7 @@ function renderCharacterSheet(data) {
       const actName = btn.getAttribute("name");
       if (actName && actName.startsWith("act_roll_skill_")) {
         const skillNameRaw = actName.replace("act_roll_skill_", "");
+        const skillLower = skillNameRaw.toLowerCase();
         let bVal = parseInt(data[`skill_${skillNameRaw}_base`]);
         bVal = !isNaN(bVal) ? bVal : 0;
         let mVal = parseInt(data[`skill_${skillNameRaw}_mod`]);
@@ -758,18 +776,16 @@ function renderCharacterSheet(data) {
           data[`skill_${skillNameRaw}_base`] === undefined &&
           data.baseStats
         ) {
-          const baseKey = Object.keys(data.baseStats).find(
-            (k) => k.toLowerCase() === skillNameRaw.toLowerCase(),
-          );
-          if (baseKey) bVal = parseInt(data.baseStats[baseKey]) || 0;
+          if (baseStatsLower[skillLower] !== undefined) {
+            bVal = parseInt(baseStatsLower[skillLower]) || 0;
+          }
         }
         if (data[`skill_${skillNameRaw}_mod`] === undefined && data.modifiers) {
-          const modKey = Object.keys(data.modifiers).find(
-            (k) =>
-              k.toLowerCase() === `skill_${skillNameRaw}`.toLowerCase() ||
-              k.toLowerCase() === skillNameRaw.toLowerCase(),
-          );
-          if (modKey) mVal = parseInt(data.modifiers[modKey]) || 0;
+          if (modifiersLower[`skill_${skillLower}`] !== undefined) {
+            mVal = parseInt(modifiersLower[`skill_${skillLower}`]) || 0;
+          } else if (modifiersLower[skillLower] !== undefined) {
+            mVal = parseInt(modifiersLower[skillLower]) || 0;
+          }
         }
 
         // ⚡ Bolt Optimization: Skip DOM updates for unchanged skills


### PR DESCRIPTION
💡 **What:** Added pre-computed lowercase hashmaps (`baseStatsLower` and `modifiersLower`) directly outside of the `skillRows.forEach` loop in `renderCharacterSheet()`.
🎯 **Why:** Previously, evaluating modified stats executed a linear `.find()` coupled with repeated `.toLowerCase()` manipulations for each parsed property *during* the DOM update loop, causing an expensive O(N²) scaling profile.
📊 **Impact:** Reduces lookup overhead per skill rendering iteration from O(N) back to an efficient O(1) property lookup, speeding up rendering of the character sheet directly proportional to the amount of modifiers applied.
🔬 **Measurement:** Analyzed execution bounds; simulated matching via node `JSDOM` test to ensure matching fallback parameters accurately mapped to respective casing.

---
*PR created automatically by Jules for task [14889509208572115375](https://jules.google.com/task/14889509208572115375) started by @sokcrow*