### PR TITLE
⚡ Bolt: [performance improvement] Pre-compute hashmaps for O(1) skill lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-26 - [DOM Attribute Thrashing in renderCharacterSheet]
 **Learning:** Found that assigning `.innerText` or `.value` unconditionally inside high-frequency real-time `on('value')` listeners (like Firebase data sync) causes unnecessary DOM layout recalculations and repaints, even if the value string hasn't changed.
 **Action:** Introduced strict equality checks (e.g., `if (el.innerText !== String(newVal))`) before applying data to DOM node attributes during iterative render loops.
+
+## 2025-03-26 - [O(N²) Array Search Bottleneck in renderCharacterSheet]
+**Learning:** Found that `Object.keys(data).find()` inside a loop over DOM elements causes O(N²) layout rendering bottlenecks on every real-time Firebase data sync.
+**Action:** Pre-compute lowercase key-value hashmaps outside loops, while preserving `.find()` patterns in single-event contexts (such as `click` handlers) to avoid unnecessary map allocation overhead.

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -740,6 +740,23 @@ function renderCharacterSheet(data) {
     }
   });
 
+  // ⚡ Bolt Optimization: Pre-compute lowercase keys to prevent O(N²) layout bottlenecks inside the loop
+  // 💡 What: Created baseStatsLower and modifiersLower maps for O(1) lookups.
+  // 🎯 Why: Using Object.keys().find() inside a loop causes unnecessary overhead.
+  // 📊 Impact: Changes O(N²) loop complexity to O(N).
+  const baseStatsLower = {};
+  if (data.baseStats) {
+    for (const [k, v] of Object.entries(data.baseStats)) {
+      baseStatsLower[k.toLowerCase()] = v;
+    }
+  }
+  const modifiersLower = {};
+  if (data.modifiers) {
+    for (const [k, v] of Object.entries(data.modifiers)) {
+      modifiersLower[k.toLowerCase()] = v;
+    }
+  }
+
   // Update all skill rows (Base, Mod, Total)
   const skillRows = document.querySelectorAll(".sheet-skill-row");
   skillRows.forEach((row) => {
@@ -748,6 +765,7 @@ function renderCharacterSheet(data) {
       const actName = btn.getAttribute("name");
       if (actName && actName.startsWith("act_roll_skill_")) {
         const skillNameRaw = actName.replace("act_roll_skill_", "");
+        const rawLower = skillNameRaw.toLowerCase();
         let bVal = parseInt(data[`skill_${skillNameRaw}_base`]);
         bVal = !isNaN(bVal) ? bVal : 0;
         let mVal = parseInt(data[`skill_${skillNameRaw}_mod`]);
@@ -758,18 +776,13 @@ function renderCharacterSheet(data) {
           data[`skill_${skillNameRaw}_base`] === undefined &&
           data.baseStats
         ) {
-          const baseKey = Object.keys(data.baseStats).find(
-            (k) => k.toLowerCase() === skillNameRaw.toLowerCase(),
-          );
-          if (baseKey) bVal = parseInt(data.baseStats[baseKey]) || 0;
+          const baseValRaw = baseStatsLower[rawLower];
+          if (baseValRaw !== undefined) bVal = parseInt(baseValRaw) || 0;
         }
         if (data[`skill_${skillNameRaw}_mod`] === undefined && data.modifiers) {
-          const modKey = Object.keys(data.modifiers).find(
-            (k) =>
-              k.toLowerCase() === `skill_${skillNameRaw}`.toLowerCase() ||
-              k.toLowerCase() === skillNameRaw.toLowerCase(),
-          );
-          if (modKey) mVal = parseInt(data.modifiers[modKey]) || 0;
+          let modValRaw = modifiersLower[`skill_${rawLower}`];
+          if (modValRaw === undefined) modValRaw = modifiersLower[rawLower];
+          if (modValRaw !== undefined) mVal = parseInt(modValRaw) || 0;
         }
 
         // ⚡ Bolt Optimization: Skip DOM updates for unchanged skills


### PR DESCRIPTION
### 💡 What:
Replaced the `Object.keys().find()` lookups with pre-computed O(1) lowercased hash map queries within the `renderCharacterSheet` loop in `hoja_personaje.js`.

### 🎯 Why:
Inside `renderCharacterSheet`, the system loops over all `.sheet-skill-row` elements. On every single iteration, it was calling `Object.keys(data.baseStats).find(...)` and `Object.keys(data.modifiers).find(...)` twice to do case-insensitive lookups. Because this function runs aggressively on every real-time data push from Firebase (`on('value')`), the O(N²) search architecture acted as a significant layout and main thread bottleneck during rendering.

### 📊 Impact:
Transforms an O(N²) DOM generation bottleneck into an O(N) loop with O(1) map lookups, significantly reducing script execution time and minimizing DOM-blocking when frequent sync events are fired from Firebase.

### 🔬 Measurement:
- Syntax checked via `node -c hoja_personaje.js`.
- Verified component stability by running Playwright verification script to visually assert `hoja_personaje.html` renders skills and layout accurately without introducing regressions.

---
*PR created automatically by Jules for task [14518580612260007290](https://jules.google.com/task/14518580612260007290) started by @sokcrow*