### PR TITLE
⚡ Bolt: [performance improvement] Pre-compute cache maps and use DocumentFragments in Teatro renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-26 - [DOM Attribute Thrashing in renderCharacterSheet]
 **Learning:** Found that assigning `.innerText` or `.value` unconditionally inside high-frequency real-time `on('value')` listeners (like Firebase data sync) causes unnecessary DOM layout recalculations and repaints, even if the value string hasn't changed.
 **Action:** Introduced strict equality checks (e.g., `if (el.innerText !== String(newVal))`) before applying data to DOM node attributes during iterative render loops.
+
+## 2025-03-26 - [DOM Fragment Batching and O(1) Cache lookups in Teatro Rendering]
+**Learning:** Found an O(N) array `.find()` loop wrapped inside another loop resulting in O(N*M) lookups inside real-time Firebase `.on('value')` listeners. Combined with iterative `appendChild` DOM manipulation, this caused significant layout thrashing on message syncs.
+**Action:** Replaced the array `.find()` with an O(1) Map pre-computed outside the loop and wrapped all log row creation in a `DocumentFragment` before appending to the DOM to minimize reflows. Applied this across all three theatre implementations (`hoja_personaje.js`, `hoja_personaje.html`, `pantalla_dm.html`).

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -12967,11 +12967,23 @@
           const logs = snap.val();
           if (logs) {
             let isFirst = true;
+            const fragment = document.createDocumentFragment();
+
+            // Pre-compute actors hash map for O(1) lookups
+            const actorMap = new Map();
+            if (window.allActoresCache) {
+              Object.values(window.allActoresCache).forEach(actor => {
+                if (actor.nombre) {
+                  actorMap.set(actor.nombre.toLowerCase(), actor);
+                }
+              });
+            }
+
             for (const [key, msg] of Object.entries(logs)) {
               if (!isFirst) {
                 const divider = document.createElement("hr");
                 divider.className = "dialogue-divider";
-                scrollArea.appendChild(divider);
+                fragment.appendChild(divider);
               }
               isFirst = false;
 
@@ -12982,13 +12994,8 @@
               const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
               let dynamicIcon = null;
-              if (window.allActoresCache) {
-                const actorMatch = Object.values(window.allActoresCache).find(
-                  (actor) =>
-                    actor.nombre &&
-                    msg.nombre &&
-                    actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-                );
+              if (msg.nombre && actorMap.has(msg.nombre.toLowerCase())) {
+                const actorMatch = actorMap.get(msg.nombre.toLowerCase());
                 if (actorMatch && actorMatch.icono) {
                   dynamicIcon = actorMatch.icono;
                 }
@@ -13009,8 +13016,9 @@
                   <p>${msg.mensaje}</p>
                 </div>
               `;
-              scrollArea.appendChild(row);
+              fragment.appendChild(row);
             }
+            scrollArea.appendChild(fragment);
 
             // Create confirm button footer if it doesn't exist
             let footer = logContainer.querySelector(".dialogue-footer");

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -1198,11 +1198,23 @@ function initializeCharacterSheet() {
 
         if (logs) {
           let isFirst = true;
+          const fragment = document.createDocumentFragment();
+
+          // Pre-compute actors hash map for O(1) lookups
+          const actorMap = new Map();
+          if (window.allActoresCache) {
+            Object.values(window.allActoresCache).forEach(actor => {
+              if (actor.nombre) {
+                actorMap.set(actor.nombre.toLowerCase(), actor);
+              }
+            });
+          }
+
           for (const [key, msg] of Object.entries(logs)) {
             if (!isFirst) {
               const divider = document.createElement("hr");
               divider.className = "dialogue-divider";
-              scrollArea.appendChild(divider);
+              fragment.appendChild(divider);
             }
             isFirst = false;
 
@@ -1214,13 +1226,8 @@ function initializeCharacterSheet() {
             const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
             let dynamicIcon = null;
-            if (window.allActoresCache) {
-              const actorMatch = Object.values(window.allActoresCache).find(
-                (actor) =>
-                  actor.nombre &&
-                  msg.nombre &&
-                  actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-              );
+            if (msg.nombre && actorMap.has(msg.nombre.toLowerCase())) {
+              const actorMatch = actorMap.get(msg.nombre.toLowerCase());
               if (actorMatch && actorMatch.icono) {
                 dynamicIcon = actorMatch.icono;
               }
@@ -1242,8 +1249,9 @@ function initializeCharacterSheet() {
                         </div>
                       `;
 
-            scrollArea.appendChild(row);
+            fragment.appendChild(row);
           }
+          scrollArea.appendChild(fragment);
           scrollArea.scrollTop = scrollArea.scrollHeight;
         }
       };

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -6960,11 +6960,23 @@
 
             if (logs) {
               let isFirst = true;
+              const fragment = document.createDocumentFragment();
+
+              // Pre-compute actors hash map for O(1) lookups
+              const actorMap = new Map();
+              if (typeof dbActoresCache !== "undefined" && dbActoresCache) {
+                Object.values(dbActoresCache).forEach(actor => {
+                  if (actor.nombre) {
+                    actorMap.set(actor.nombre.toLowerCase(), actor);
+                  }
+                });
+              }
+
               for (const [key, msg] of Object.entries(logs)) {
                 if (!isFirst) {
                   const divider = document.createElement("hr");
                   divider.className = "dialogue-divider";
-                  scrollArea.appendChild(divider);
+                  fragment.appendChild(divider);
                 }
                 isFirst = false;
 
@@ -6975,13 +6987,8 @@
                 const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
                 let dynamicIcon = null;
-                if (typeof dbActoresCache !== "undefined" && dbActoresCache) {
-                  const actorMatch = Object.values(dbActoresCache).find(
-                    (actor) =>
-                      actor.nombre &&
-                      msg.nombre &&
-                      actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-                  );
+                if (msg.nombre && actorMap.has(msg.nombre.toLowerCase())) {
+                  const actorMatch = actorMap.get(msg.nombre.toLowerCase());
                   if (actorMatch && actorMatch.icono) {
                     dynamicIcon = actorMatch.icono;
                   }
@@ -7003,8 +7010,9 @@
                     <p>${msg.mensaje}</p>
                   </div>
                 `;
-                scrollArea.appendChild(row);
+                fragment.appendChild(row);
               }
+              scrollArea.appendChild(fragment);
 
               // Create confirm button footer if it doesn't exist
               let footer = logContainer.querySelector(".dialogue-footer");


### PR DESCRIPTION
💡 What: Replaced iterative O(n) array `.find()` lookups with an O(1) pre-computed Map inside the `campaña/teatro/log` real-time listeners. Also batched DOM insertions using a `DocumentFragment`.
🎯 Why: The previous code performed `Object.values().find()` and `scrollArea.appendChild()` on every single message item in the loop. This created an O(N*M) bottleneck that triggered sequential layout reflows, lagging the UI during massive message syncs.
📊 Impact: Reduces time complexity of actor lookups from O(N*M) to O(N+M) and reduces layout thrashing from N repaints to exactly 1.
🔬 Measurement: Verified locally using mock fragment execution. The DOM should only insert the fragment once, and hash lookups work correctly. Applied consistently across `hoja_personaje.js`, `hoja_personaje.html`, and `pantalla_dm.html`.

---
*PR created automatically by Jules for task [5542947942210510926](https://jules.google.com/task/5542947942210510926) started by @sokcrow*