### PR TITLE
⚡ Bolt: [O(N) Reflow and O(N^2) Array Lookup in Theatre Log]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-26 - [DOM Attribute Thrashing in renderCharacterSheet]
 **Learning:** Found that assigning `.innerText` or `.value` unconditionally inside high-frequency real-time `on('value')` listeners (like Firebase data sync) causes unnecessary DOM layout recalculations and repaints, even if the value string hasn't changed.
 **Action:** Introduced strict equality checks (e.g., `if (el.innerText !== String(newVal))`) before applying data to DOM node attributes during iterative render loops.
+
+## 2024-05-23 - O(N^2) Array Find in Render Loop & Reflow Thrashing
+**Learning:** Legacy UI rendering logic within real-time Firebase `.on('value')` handlers commonly executes `Object.values(cache).find()` sequentially on each item iteration, resulting in `O(N * M)` time complexity. In addition, appending nodes sequentially to a live scrollArea DOM element on each iteration (`scrollArea.appendChild(row)`) causes expensive `O(N)` layout reflows/thrashing. This is especially impactful in real-time listeners for logs, queues, or inventories.
+**Action:** When refactoring real-time rendering logic, pre-compute cache values into an `O(1)` Map lookup outside the loop. Secondarily, batch all DOM tree generation into an isolated `document.createDocumentFragment()` outside the live tree, and only append it to the live DOM container once after the loop finishes.

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -12967,11 +12967,23 @@
           const logs = snap.val();
           if (logs) {
             let isFirst = true;
+            const fragment = document.createDocumentFragment();
+
+            // Pre-compute actors map for O(1) lookup
+            const actorsMap = new Map();
+            if (window.allActoresCache) {
+              Object.values(window.allActoresCache).forEach((actor) => {
+                if (actor.nombre) {
+                  actorsMap.set(actor.nombre.toLowerCase(), actor);
+                }
+              });
+            }
+
             for (const [key, msg] of Object.entries(logs)) {
               if (!isFirst) {
                 const divider = document.createElement("hr");
                 divider.className = "dialogue-divider";
-                scrollArea.appendChild(divider);
+                fragment.appendChild(divider);
               }
               isFirst = false;
 
@@ -12982,13 +12994,8 @@
               const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
               let dynamicIcon = null;
-              if (window.allActoresCache) {
-                const actorMatch = Object.values(window.allActoresCache).find(
-                  (actor) =>
-                    actor.nombre &&
-                    msg.nombre &&
-                    actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-                );
+              if (msg.nombre) {
+                const actorMatch = actorsMap.get(msg.nombre.toLowerCase());
                 if (actorMatch && actorMatch.icono) {
                   dynamicIcon = actorMatch.icono;
                 }
@@ -13009,8 +13016,9 @@
                   <p>${msg.mensaje}</p>
                 </div>
               `;
-              scrollArea.appendChild(row);
+              fragment.appendChild(row);
             }
+            scrollArea.appendChild(fragment);
 
             // Create confirm button footer if it doesn't exist
             let footer = logContainer.querySelector(".dialogue-footer");

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -1198,11 +1198,23 @@ function initializeCharacterSheet() {
 
         if (logs) {
           let isFirst = true;
+          const fragment = document.createDocumentFragment();
+
+          // Pre-compute actors map for O(1) lookup
+          const actorsMap = new Map();
+          if (window.allActoresCache) {
+            Object.values(window.allActoresCache).forEach((actor) => {
+              if (actor.nombre) {
+                actorsMap.set(actor.nombre.toLowerCase(), actor);
+              }
+            });
+          }
+
           for (const [key, msg] of Object.entries(logs)) {
             if (!isFirst) {
               const divider = document.createElement("hr");
               divider.className = "dialogue-divider";
-              scrollArea.appendChild(divider);
+              fragment.appendChild(divider);
             }
             isFirst = false;
 
@@ -1214,13 +1226,8 @@ function initializeCharacterSheet() {
             const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
             let dynamicIcon = null;
-            if (window.allActoresCache) {
-              const actorMatch = Object.values(window.allActoresCache).find(
-                (actor) =>
-                  actor.nombre &&
-                  msg.nombre &&
-                  actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-              );
+            if (msg.nombre) {
+              const actorMatch = actorsMap.get(msg.nombre.toLowerCase());
               if (actorMatch && actorMatch.icono) {
                 dynamicIcon = actorMatch.icono;
               }
@@ -1242,8 +1249,9 @@ function initializeCharacterSheet() {
                         </div>
                       `;
 
-            scrollArea.appendChild(row);
+            fragment.appendChild(row);
           }
+          scrollArea.appendChild(fragment);
           scrollArea.scrollTop = scrollArea.scrollHeight;
         }
       };

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -6960,11 +6960,23 @@
 
             if (logs) {
               let isFirst = true;
+              const fragment = document.createDocumentFragment();
+
+              // Pre-compute actors map for O(1) lookup
+              const actorsMap = new Map();
+              if (typeof dbActoresCache !== "undefined" && dbActoresCache) {
+                Object.values(dbActoresCache).forEach((actor) => {
+                  if (actor.nombre) {
+                    actorsMap.set(actor.nombre.toLowerCase(), actor);
+                  }
+                });
+              }
+
               for (const [key, msg] of Object.entries(logs)) {
                 if (!isFirst) {
                   const divider = document.createElement("hr");
                   divider.className = "dialogue-divider";
-                  scrollArea.appendChild(divider);
+                  fragment.appendChild(divider);
                 }
                 isFirst = false;
 
@@ -6975,13 +6987,8 @@
                 const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
                 let dynamicIcon = null;
-                if (typeof dbActoresCache !== "undefined" && dbActoresCache) {
-                  const actorMatch = Object.values(dbActoresCache).find(
-                    (actor) =>
-                      actor.nombre &&
-                      msg.nombre &&
-                      actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-                  );
+                if (msg.nombre) {
+                  const actorMatch = actorsMap.get(msg.nombre.toLowerCase());
                   if (actorMatch && actorMatch.icono) {
                     dynamicIcon = actorMatch.icono;
                   }
@@ -7003,8 +7010,9 @@
                     <p>${msg.mensaje}</p>
                   </div>
                 `;
-                scrollArea.appendChild(row);
+                fragment.appendChild(row);
               }
+              scrollArea.appendChild(fragment);
 
               // Create confirm button footer if it doesn't exist
               let footer = logContainer.querySelector(".dialogue-footer");


### PR DESCRIPTION
💡 **What:** Refactored the `campaña/teatro/log` real-time listener rendering logic in `hoja_personaje.html`, `hoja_personaje.js`, and `pantalla_dm.html`. Replaced the $O(N \times M)$ `Array.find()` loop over the actors cache with a pre-computed $O(1)$ Map. Replaced iterative `scrollArea.appendChild(row)` calls with a batch-appended `DocumentFragment`.

🎯 **Why:** The previous logic searched the entire actors cache for *every* incoming message inside the render loop, creating a significant bottleneck when logs were large. Furthermore, appending each individual chat node sequentially to the live DOM caused repetitive layout reflow thrashing.

📊 **Impact:** Reduces time complexity of rendering the Theatre Log from $O(N \times M)$ to $O(N + M)$ and reduces reflows from $O(N)$ to $O(1)$. This prevents visual stuttering when new log histories are synchronized across clients.

🔬 **Measurement:** Validate that the "Teatro de la Mente" dialogue history still properly maps names and custom icon sprites by matching characters and appending the dialogue smoothly without browser lag.

---
*PR created automatically by Jules for task [15088383229296851982](https://jules.google.com/task/15088383229296851982) started by @sokcrow*