### PR TITLE
⚡ Bolt: [performance improvement] O(N^2) Theatre Log Rendering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2025-03-26 - [DOM Attribute Thrashing in renderCharacterSheet]
 **Learning:** Found that assigning `.innerText` or `.value` unconditionally inside high-frequency real-time `on('value')` listeners (like Firebase data sync) causes unnecessary DOM layout recalculations and repaints, even if the value string hasn't changed.
 **Action:** Introduced strict equality checks (e.g., `if (el.innerText !== String(newVal))`) before applying data to DOM node attributes during iterative render loops.
+## 2026-05-18 - Optimized Theatre Log Rendering O(N^2) Bottleneck
+**Learning:** Legacy UI rendering logic executing inside frequent \`firebase.on('value')\` loops using nested \`.find()\` against array structures can introduce severe $O(N^2)$ algorithmic complexity as the dataset grows (e.g., chat logs matched against actors). Additionally, appending elements directly inside these loops forces individual DOM layout reflows per item.
+**Action:** Always pre-compute a lowercase lookup hash map (e.g., \`new Map()\`) *outside* the render loop for $O(1)$ property mapping, and accumulate new DOM structures into a \`document.createDocumentFragment()\` to batch the final rendering phase and prevent layout thrashing.

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -12966,12 +12966,23 @@
 
           const logs = snap.val();
           if (logs) {
+            // 💡 What: Pre-compute actors map for O(1) lookups and use DocumentFragment to prevent layout reflows
+            const fragment = document.createDocumentFragment();
+            const actoresMap = new Map();
+            if (window.allActoresCache) {
+              for (const actor of Object.values(window.allActoresCache)) {
+                if (actor.nombre) {
+                  actoresMap.set(actor.nombre.toLowerCase(), actor);
+                }
+              }
+            }
+
             let isFirst = true;
             for (const [key, msg] of Object.entries(logs)) {
               if (!isFirst) {
                 const divider = document.createElement("hr");
                 divider.className = "dialogue-divider";
-                scrollArea.appendChild(divider);
+                fragment.appendChild(divider);
               }
               isFirst = false;
 
@@ -12982,13 +12993,8 @@
               const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
               let dynamicIcon = null;
-              if (window.allActoresCache) {
-                const actorMatch = Object.values(window.allActoresCache).find(
-                  (actor) =>
-                    actor.nombre &&
-                    msg.nombre &&
-                    actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-                );
+              if (msg.nombre) {
+                const actorMatch = actoresMap.get(msg.nombre.toLowerCase());
                 if (actorMatch && actorMatch.icono) {
                   dynamicIcon = actorMatch.icono;
                 }
@@ -13009,8 +13015,9 @@
                   <p>${msg.mensaje}</p>
                 </div>
               `;
-              scrollArea.appendChild(row);
+              fragment.appendChild(row);
             }
+            scrollArea.appendChild(fragment);
 
             // Create confirm button footer if it doesn't exist
             let footer = logContainer.querySelector(".dialogue-footer");

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -1197,12 +1197,23 @@ function initializeCharacterSheet() {
         }
 
         if (logs) {
+          // 💡 What: Pre-compute actors map for O(1) lookups and use DocumentFragment to prevent layout reflows
+          const fragment = document.createDocumentFragment();
+          const actoresMap = new Map();
+          if (window.allActoresCache) {
+            for (const actor of Object.values(window.allActoresCache)) {
+              if (actor.nombre) {
+                actoresMap.set(actor.nombre.toLowerCase(), actor);
+              }
+            }
+          }
+
           let isFirst = true;
           for (const [key, msg] of Object.entries(logs)) {
             if (!isFirst) {
               const divider = document.createElement("hr");
               divider.className = "dialogue-divider";
-              scrollArea.appendChild(divider);
+              fragment.appendChild(divider);
             }
             isFirst = false;
 
@@ -1214,13 +1225,8 @@ function initializeCharacterSheet() {
             const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
             let dynamicIcon = null;
-            if (window.allActoresCache) {
-              const actorMatch = Object.values(window.allActoresCache).find(
-                (actor) =>
-                  actor.nombre &&
-                  msg.nombre &&
-                  actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-              );
+            if (msg.nombre) {
+              const actorMatch = actoresMap.get(msg.nombre.toLowerCase());
               if (actorMatch && actorMatch.icono) {
                 dynamicIcon = actorMatch.icono;
               }
@@ -1242,8 +1248,9 @@ function initializeCharacterSheet() {
                         </div>
                       `;
 
-            scrollArea.appendChild(row);
+            fragment.appendChild(row);
           }
+          scrollArea.appendChild(fragment);
           scrollArea.scrollTop = scrollArea.scrollHeight;
         }
       };

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -6959,12 +6959,23 @@
             }
 
             if (logs) {
+              // 💡 What: Pre-compute actors map for O(1) lookups and use DocumentFragment to prevent layout reflows
+              const fragment = document.createDocumentFragment();
+              const actoresMap = new Map();
+              if (typeof dbActoresCache !== "undefined" && dbActoresCache) {
+                for (const actor of Object.values(dbActoresCache)) {
+                  if (actor.nombre) {
+                    actoresMap.set(actor.nombre.toLowerCase(), actor);
+                  }
+                }
+              }
+
               let isFirst = true;
               for (const [key, msg] of Object.entries(logs)) {
                 if (!isFirst) {
                   const divider = document.createElement("hr");
                   divider.className = "dialogue-divider";
-                  scrollArea.appendChild(divider);
+                  fragment.appendChild(divider);
                 }
                 isFirst = false;
 
@@ -6975,13 +6986,8 @@
                 const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
                 let dynamicIcon = null;
-                if (typeof dbActoresCache !== "undefined" && dbActoresCache) {
-                  const actorMatch = Object.values(dbActoresCache).find(
-                    (actor) =>
-                      actor.nombre &&
-                      msg.nombre &&
-                      actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-                  );
+                if (msg.nombre) {
+                  const actorMatch = actoresMap.get(msg.nombre.toLowerCase());
                   if (actorMatch && actorMatch.icono) {
                     dynamicIcon = actorMatch.icono;
                   }
@@ -7003,8 +7009,9 @@
                     <p>${msg.mensaje}</p>
                   </div>
                 `;
-                scrollArea.appendChild(row);
+                fragment.appendChild(row);
               }
+              scrollArea.appendChild(fragment);
 
               // Create confirm button footer if it doesn't exist
               let footer = logContainer.querySelector(".dialogue-footer");


### PR DESCRIPTION
💡 **What**: Pre-compute actors map for O(1) lookups and use DocumentFragment to prevent layout reflows in Theatre log rendering.

🎯 **Why**: The theater log rendering runs frequently and iterates over every single message. Inside that loop, it was running `Object.values(allActoresCache).find(...)` to match actor icons, leading to an O(N^2) operation. Furthermore, it appended directly to the DOM for every message, causing massive layout reflows.

📊 **Impact**: Reduces algorithm time complexity from O(N*M) to O(N+M) and removes 100% of intermediate layout thrashing by batching updates.

🔬 **Measurement**: Render the theater log UI and view the performance tab. DOM elements insert at once rather than incrementally, and JS loop executes almost instantly for 20+ messages.

---
*PR created automatically by Jules for task [5475612304364152497](https://jules.google.com/task/5475612304364152497) started by @sokcrow*