### PR TITLE
⚡ Bolt: O(1) Map Pre-computation in Theater Log Render Loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-26 - [DOM Attribute Thrashing in renderCharacterSheet]
 **Learning:** Found that assigning `.innerText` or `.value` unconditionally inside high-frequency real-time `on('value')` listeners (like Firebase data sync) causes unnecessary DOM layout recalculations and repaints, even if the value string hasn't changed.
 **Action:** Introduced strict equality checks (e.g., `if (el.innerText !== String(newVal))`) before applying data to DOM node attributes during iterative render loops.
+
+## 2025-06-09 - [O(1) Map Pre-computation in Render Loops]
+**Learning:** Found a performance bottleneck where array lookup (`Object.values(cache).find()`) was executed iteratively inside real-time Firebase `.on('value')` rendering loops, causing O(N^2) complexity.
+**Action:** Replaced the array lookups inside the rendering loops with a pre-computed O(1) hash map (`new Map()`) built outside the loop. Avoided applying this pattern to single-event listeners to prevent overhead.

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -12966,6 +12966,16 @@
 
           const logs = snap.val();
           if (logs) {
+            // Pre-compute O(1) lookup map for actors to avoid O(N^2) search inside the render loop
+            const actoresMap = new Map();
+            if (window.allActoresCache) {
+              for (const actor of Object.values(window.allActoresCache)) {
+                if (actor && actor.nombre) {
+                  actoresMap.set(actor.nombre.toLowerCase(), actor);
+                }
+              }
+            }
+
             let isFirst = true;
             for (const [key, msg] of Object.entries(logs)) {
               if (!isFirst) {
@@ -12982,13 +12992,8 @@
               const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
               let dynamicIcon = null;
-              if (window.allActoresCache) {
-                const actorMatch = Object.values(window.allActoresCache).find(
-                  (actor) =>
-                    actor.nombre &&
-                    msg.nombre &&
-                    actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-                );
+              if (msg.nombre) {
+                const actorMatch = actoresMap.get(msg.nombre.toLowerCase());
                 if (actorMatch && actorMatch.icono) {
                   dynamicIcon = actorMatch.icono;
                 }

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -1197,6 +1197,16 @@ function initializeCharacterSheet() {
         }
 
         if (logs) {
+          // Pre-compute O(1) lookup map for actors to avoid O(N^2) search inside the render loop
+          const actoresMap = new Map();
+          if (window.allActoresCache) {
+            for (const actor of Object.values(window.allActoresCache)) {
+              if (actor && actor.nombre) {
+                actoresMap.set(actor.nombre.toLowerCase(), actor);
+              }
+            }
+          }
+
           let isFirst = true;
           for (const [key, msg] of Object.entries(logs)) {
             if (!isFirst) {
@@ -1214,13 +1224,8 @@ function initializeCharacterSheet() {
             const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
             let dynamicIcon = null;
-            if (window.allActoresCache) {
-              const actorMatch = Object.values(window.allActoresCache).find(
-                (actor) =>
-                  actor.nombre &&
-                  msg.nombre &&
-                  actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-              );
+            if (msg.nombre) {
+              const actorMatch = actoresMap.get(msg.nombre.toLowerCase());
               if (actorMatch && actorMatch.icono) {
                 dynamicIcon = actorMatch.icono;
               }

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -6959,6 +6959,16 @@
             }
 
             if (logs) {
+              // Pre-compute O(1) lookup map for actors to avoid O(N^2) search inside the render loop
+              const actoresMap = new Map();
+              if (typeof dbActoresCache !== "undefined" && dbActoresCache) {
+                for (const actor of Object.values(dbActoresCache)) {
+                  if (actor && actor.nombre) {
+                    actoresMap.set(actor.nombre.toLowerCase(), actor);
+                  }
+                }
+              }
+
               let isFirst = true;
               for (const [key, msg] of Object.entries(logs)) {
                 if (!isFirst) {
@@ -6975,13 +6985,8 @@
                 const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
                 let dynamicIcon = null;
-                if (typeof dbActoresCache !== "undefined" && dbActoresCache) {
-                  const actorMatch = Object.values(dbActoresCache).find(
-                    (actor) =>
-                      actor.nombre &&
-                      msg.nombre &&
-                      actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-                  );
+                if (msg.nombre) {
+                  const actorMatch = actoresMap.get(msg.nombre.toLowerCase());
                   if (actorMatch && actorMatch.icono) {
                     dynamicIcon = actorMatch.icono;
                   }


### PR DESCRIPTION
💡 What: Replaced the iterative array `Object.values().find()` lookup for actors with an O(1) Map pre-computation in the theatre log render loops across `hoja_personaje.js`, `hoja_personaje.html`, and `pantalla_dm.html`. Added a journal entry detailing the bottleneck and resolution.
🎯 Why: Iterating over Firebase logs and performing an O(N) array search inside the loop for each log results in an overall O(M * N) time complexity, potentially causing significant performance drops and UI stuttering as the number of actors and logs grows.
📊 Impact: Reduces actor lookup from O(N) to O(1) during loop execution, bringing the time complexity of the render operation down to O(M + N).
🔬 Measurement: Can be verified using performance traces in the browser console when opening the theatre log while processing high volumes of actors and messages.

---
*PR created automatically by Jules for task [15395811225814568494](https://jules.google.com/task/15395811225814568494) started by @sokcrow*