### PR TITLE
⚡ Bolt: [performance improvement] O(1) map precomputation and DOM batching for Theatre Log

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-26 - [DOM Attribute Thrashing in renderCharacterSheet]
 **Learning:** Found that assigning `.innerText` or `.value` unconditionally inside high-frequency real-time `on('value')` listeners (like Firebase data sync) causes unnecessary DOM layout recalculations and repaints, even if the value string hasn't changed.
 **Action:** Introduced strict equality checks (e.g., `if (el.innerText !== String(newVal))`) before applying data to DOM node attributes during iterative render loops.
+
+## 2025-03-27 - [Pre-computing O(1) Maps inside Firebase Realtime Rendering]
+**Learning:** Found an $O(N \times M)$ performance bottleneck where an `Object.values(cache).find()` lookup was executing inside the loop for every single log message received during a Firebase `.on('value')` re-render in the Theatre Log.
+**Action:** Lifted the array lookup out of the render loop by pre-computing a lowercase `new Map()` of actors *before* iterating over the real-time messages, reducing lookup complexity to $O(1)$ and significantly speeding up the iterative DOM generation when scrolling/rendering large theatre histories.

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -12967,11 +12967,23 @@
           const logs = snap.val();
           if (logs) {
             let isFirst = true;
+            const fragment = document.createDocumentFragment();
+
+            // Pre-compute actor map for O(1) lookups
+            const actorMap = new Map();
+            if (window.allActoresCache) {
+              for (const actor of Object.values(window.allActoresCache)) {
+                if (actor.nombre && actor.icono) {
+                  actorMap.set(actor.nombre.toLowerCase(), actor.icono);
+                }
+              }
+            }
+
             for (const [key, msg] of Object.entries(logs)) {
               if (!isFirst) {
                 const divider = document.createElement("hr");
                 divider.className = "dialogue-divider";
-                scrollArea.appendChild(divider);
+                fragment.appendChild(divider);
               }
               isFirst = false;
 
@@ -12982,16 +12994,8 @@
               const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
               let dynamicIcon = null;
-              if (window.allActoresCache) {
-                const actorMatch = Object.values(window.allActoresCache).find(
-                  (actor) =>
-                    actor.nombre &&
-                    msg.nombre &&
-                    actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-                );
-                if (actorMatch && actorMatch.icono) {
-                  dynamicIcon = actorMatch.icono;
-                }
+              if (msg.nombre) {
+                dynamicIcon = actorMap.get(msg.nombre.toLowerCase());
               }
 
               const iconoSrc = dynamicIcon || msg.icono || defaultFallbackIcon;
@@ -13009,8 +13013,9 @@
                   <p>${msg.mensaje}</p>
                 </div>
               `;
-              scrollArea.appendChild(row);
+              fragment.appendChild(row);
             }
+            scrollArea.appendChild(fragment);
 
             // Create confirm button footer if it doesn't exist
             let footer = logContainer.querySelector(".dialogue-footer");

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -1198,11 +1198,23 @@ function initializeCharacterSheet() {
 
         if (logs) {
           let isFirst = true;
+          const fragment = document.createDocumentFragment();
+
+          // Pre-compute actor map for O(1) lookups
+          const actorMap = new Map();
+          if (window.allActoresCache) {
+            for (const actor of Object.values(window.allActoresCache)) {
+              if (actor.nombre && actor.icono) {
+                actorMap.set(actor.nombre.toLowerCase(), actor.icono);
+              }
+            }
+          }
+
           for (const [key, msg] of Object.entries(logs)) {
             if (!isFirst) {
               const divider = document.createElement("hr");
               divider.className = "dialogue-divider";
-              scrollArea.appendChild(divider);
+              fragment.appendChild(divider);
             }
             isFirst = false;
 
@@ -1214,16 +1226,8 @@ function initializeCharacterSheet() {
             const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
             let dynamicIcon = null;
-            if (window.allActoresCache) {
-              const actorMatch = Object.values(window.allActoresCache).find(
-                (actor) =>
-                  actor.nombre &&
-                  msg.nombre &&
-                  actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-              );
-              if (actorMatch && actorMatch.icono) {
-                dynamicIcon = actorMatch.icono;
-              }
+            if (msg.nombre) {
+              dynamicIcon = actorMap.get(msg.nombre.toLowerCase());
             }
 
             const iconoSrc = dynamicIcon || msg.icono || defaultFallbackIcon;
@@ -1242,8 +1246,9 @@ function initializeCharacterSheet() {
                         </div>
                       `;
 
-            scrollArea.appendChild(row);
+            fragment.appendChild(row);
           }
+          scrollArea.appendChild(fragment);
           scrollArea.scrollTop = scrollArea.scrollHeight;
         }
       };

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -6960,11 +6960,23 @@
 
             if (logs) {
               let isFirst = true;
+              const fragment = document.createDocumentFragment();
+
+              // Pre-compute actor map for O(1) lookups
+              const actorMap = new Map();
+              if (typeof dbActoresCache !== "undefined" && dbActoresCache) {
+                for (const actor of Object.values(dbActoresCache)) {
+                  if (actor.nombre && actor.icono) {
+                    actorMap.set(actor.nombre.toLowerCase(), actor.icono);
+                  }
+                }
+              }
+
               for (const [key, msg] of Object.entries(logs)) {
                 if (!isFirst) {
                   const divider = document.createElement("hr");
                   divider.className = "dialogue-divider";
-                  scrollArea.appendChild(divider);
+                  fragment.appendChild(divider);
                 }
                 isFirst = false;
 
@@ -6975,16 +6987,8 @@
                 const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
                 let dynamicIcon = null;
-                if (typeof dbActoresCache !== "undefined" && dbActoresCache) {
-                  const actorMatch = Object.values(dbActoresCache).find(
-                    (actor) =>
-                      actor.nombre &&
-                      msg.nombre &&
-                      actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-                  );
-                  if (actorMatch && actorMatch.icono) {
-                    dynamicIcon = actorMatch.icono;
-                  }
+                if (msg.nombre) {
+                  dynamicIcon = actorMap.get(msg.nombre.toLowerCase());
                 }
 
                 const iconoSrc =
@@ -7003,8 +7007,9 @@
                     <p>${msg.mensaje}</p>
                   </div>
                 `;
-                scrollArea.appendChild(row);
+                fragment.appendChild(row);
               }
+              scrollArea.appendChild(fragment);
 
               // Create confirm button footer if it doesn't exist
               let footer = logContainer.querySelector(".dialogue-footer");


### PR DESCRIPTION
⚡ **Bolt: [performance improvement]**

💡 **What:** 
- Lifted `Object.values(window.allActoresCache).find(...)` out of the Theatre Log loop by pre-computing a lowercase `new Map()` of actors before iterating over logs.
- Replaced iterative direct `appendChild` operations inside the loop with a single `DocumentFragment` that gets appended to the DOM at the end.
- Updated `hoja_personaje.js`, `hoja_personaje.html`, and `pantalla_dm.html` to keep the duplicated rendering logic in sync.
- Logged the learning to `.jules/bolt.md`.

🎯 **Why:** 
- The application was doing an `O(N)` loop to find actors for *each* of the `M` log messages during Firebase's `.on('value')` re-render event. As both the actor count and the log limit scale, this creates massive iteration bottlenecks (`O(N * M)`).
- Modifying the live DOM iteratively causes reflow and layout thrashing, which severely hurts frame rates.

📊 **Impact:** 
- Reduces actor lookup inside the loop from $O(N)$ to $O(1)$.
- Reduces reflow operations per render pass from $M$ to $1$. 
- Result: Smoother UI rendering during heavy chat operations and less main-thread blocking.

🔬 **Measurement:**
- Playwright screenshot/video verification performed, demonstrating the Theatre Log still renders identical messages with identical icons as before, successfully matching the data mock logic natively.

---
*PR created automatically by Jules for task [11056265401860988159](https://jules.google.com/task/11056265401860988159) started by @sokcrow*