### PR TITLE
⚡ Bolt: [performance improvement] O(N²) lookups and DOM reflows in Theatre Log

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-26 - [DOM Attribute Thrashing in renderCharacterSheet]
 **Learning:** Found that assigning `.innerText` or `.value` unconditionally inside high-frequency real-time `on('value')` listeners (like Firebase data sync) causes unnecessary DOM layout recalculations and repaints, even if the value string hasn't changed.
 **Action:** Introduced strict equality checks (e.g., `if (el.innerText !== String(newVal))`) before applying data to DOM node attributes during iterative render loops.
+
+## 2025-03-26 - [O(N²) array lookups in Theatre Log Rendering]
+**Learning:** Found O(N²) array lookup pattern when mapping chat actors inside `.on('value')` Firebase real-time loops in `hoja_personaje.js`, `hoja_personaje.html`, and `pantalla_dm.html`. Inside loops formatting each chat message, it iterated over `Object.values(window.allActoresCache).find(...)` multiple times.
+**Action:** Implemented a pre-computed O(1) string lowercase key map matching mechanism outside of the message formatting loops and also wrapped the DOM append logic inside `document.createDocumentFragment()` to reduce O(N) DOM reflows to O(1).

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -12967,11 +12967,26 @@
           const logs = snap.val();
           if (logs) {
             let isFirst = true;
+
+            // Bolt ⚡: Pre-compute actors map for O(1) lookup
+            let actoresMap = null;
+            if (window.allActoresCache) {
+              actoresMap = new Map();
+              for (const actor of Object.values(window.allActoresCache)) {
+                if (actor.nombre) {
+                  actoresMap.set(actor.nombre.toLowerCase(), actor);
+                }
+              }
+            }
+
+            // Bolt ⚡: Batch DOM insertions to prevent reflows
+            const fragment = document.createDocumentFragment();
+
             for (const [key, msg] of Object.entries(logs)) {
               if (!isFirst) {
                 const divider = document.createElement("hr");
                 divider.className = "dialogue-divider";
-                scrollArea.appendChild(divider);
+                fragment.appendChild(divider);
               }
               isFirst = false;
 
@@ -12982,13 +12997,8 @@
               const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
               let dynamicIcon = null;
-              if (window.allActoresCache) {
-                const actorMatch = Object.values(window.allActoresCache).find(
-                  (actor) =>
-                    actor.nombre &&
-                    msg.nombre &&
-                    actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-                );
+              if (actoresMap && msg.nombre) {
+                const actorMatch = actoresMap.get(msg.nombre.toLowerCase());
                 if (actorMatch && actorMatch.icono) {
                   dynamicIcon = actorMatch.icono;
                 }
@@ -13009,8 +13019,9 @@
                   <p>${msg.mensaje}</p>
                 </div>
               `;
-              scrollArea.appendChild(row);
+              fragment.appendChild(row);
             }
+            scrollArea.appendChild(fragment);
 
             // Create confirm button footer if it doesn't exist
             let footer = logContainer.querySelector(".dialogue-footer");

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -1198,11 +1198,26 @@ function initializeCharacterSheet() {
 
         if (logs) {
           let isFirst = true;
+
+          // Bolt ⚡: Pre-compute actors map for O(1) lookup
+          let actoresMap = null;
+          if (window.allActoresCache) {
+            actoresMap = new Map();
+            for (const actor of Object.values(window.allActoresCache)) {
+              if (actor.nombre) {
+                actoresMap.set(actor.nombre.toLowerCase(), actor);
+              }
+            }
+          }
+
+          // Bolt ⚡: Batch DOM insertions to prevent reflows
+          const fragment = document.createDocumentFragment();
+
           for (const [key, msg] of Object.entries(logs)) {
             if (!isFirst) {
               const divider = document.createElement("hr");
               divider.className = "dialogue-divider";
-              scrollArea.appendChild(divider);
+              fragment.appendChild(divider);
             }
             isFirst = false;
 
@@ -1214,13 +1229,8 @@ function initializeCharacterSheet() {
             const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
             let dynamicIcon = null;
-            if (window.allActoresCache) {
-              const actorMatch = Object.values(window.allActoresCache).find(
-                (actor) =>
-                  actor.nombre &&
-                  msg.nombre &&
-                  actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-              );
+            if (actoresMap && msg.nombre) {
+              const actorMatch = actoresMap.get(msg.nombre.toLowerCase());
               if (actorMatch && actorMatch.icono) {
                 dynamicIcon = actorMatch.icono;
               }
@@ -1242,8 +1252,9 @@ function initializeCharacterSheet() {
                         </div>
                       `;
 
-            scrollArea.appendChild(row);
+            fragment.appendChild(row);
           }
+          scrollArea.appendChild(fragment);
           scrollArea.scrollTop = scrollArea.scrollHeight;
         }
       };

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -6960,11 +6960,26 @@
 
             if (logs) {
               let isFirst = true;
+
+              // Bolt ⚡: Pre-compute actors map for O(1) lookup
+              let actoresMap = null;
+              if (typeof dbActoresCache !== "undefined" && dbActoresCache) {
+                actoresMap = new Map();
+                for (const actor of Object.values(dbActoresCache)) {
+                  if (actor.nombre) {
+                    actoresMap.set(actor.nombre.toLowerCase(), actor);
+                  }
+                }
+              }
+
+              // Bolt ⚡: Batch DOM insertions to prevent reflows
+              const fragment = document.createDocumentFragment();
+
               for (const [key, msg] of Object.entries(logs)) {
                 if (!isFirst) {
                   const divider = document.createElement("hr");
                   divider.className = "dialogue-divider";
-                  scrollArea.appendChild(divider);
+                  fragment.appendChild(divider);
                 }
                 isFirst = false;
 
@@ -6975,13 +6990,8 @@
                 const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
                 let dynamicIcon = null;
-                if (typeof dbActoresCache !== "undefined" && dbActoresCache) {
-                  const actorMatch = Object.values(dbActoresCache).find(
-                    (actor) =>
-                      actor.nombre &&
-                      msg.nombre &&
-                      actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-                  );
+                if (actoresMap && msg.nombre) {
+                  const actorMatch = actoresMap.get(msg.nombre.toLowerCase());
                   if (actorMatch && actorMatch.icono) {
                     dynamicIcon = actorMatch.icono;
                   }
@@ -7003,8 +7013,9 @@
                     <p>${msg.mensaje}</p>
                   </div>
                 `;
-                scrollArea.appendChild(row);
+                fragment.appendChild(row);
               }
+              scrollArea.appendChild(fragment);
 
               // Create confirm button footer if it doesn't exist
               let footer = logContainer.querySelector(".dialogue-footer");


### PR DESCRIPTION
💡 What: Replaced an inner loop array scan `Object.values(window.allActoresCache).find()` with a pre-computed O(1) string lowercase `Map` lookup. Also batched all generated HTML rows into a `DocumentFragment` before appending them to the DOM.
🎯 Why: Theatre logs can get long, and recalculating the array `.find()` (O(N) operation) repeatedly inside an `Object.entries(logs)` loop leads to O(N²) scaling inside the Firebase `.on("value")` listener. Also, iteratively appending rows directly to the container caused multiple layout reflows per render. 
📊 Impact: Changing the lookup to O(1) drastically reduces JS CPU time when rendering the entire log. Grouping DOM insertions reduces the rendering engine workload from O(N) reflows down to O(1).
🔬 Measurement: Verified that visually the page renders perfectly using Playwright, confirming that both icon matching and fallback matching still work with the new Map.

---
*PR created automatically by Jules for task [17358683223959079841](https://jules.google.com/task/17358683223959079841) started by @sokcrow*