### PR TITLE
⚡ Bolt: [performance improvement] O(1) actor lookups in teatro log loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2025-03-26 - [DOM Attribute Thrashing in renderCharacterSheet]
 **Learning:** Found that assigning `.innerText` or `.value` unconditionally inside high-frequency real-time `on('value')` listeners (like Firebase data sync) causes unnecessary DOM layout recalculations and repaints, even if the value string hasn't changed.
 **Action:** Introduced strict equality checks (e.g., `if (el.innerText !== String(newVal))`) before applying data to DOM node attributes during iterative render loops.
+## 2026-07-07 - [O(n) find bottleneck in Teatro log loops]
+**Learning:** Found an O(N^2) complexity issue inside the real-time Firebase '.on("value")' rendering loops for the 'Teatro de la Mente' logs across `hoja_personaje.js`, `hoja_personaje.html`, and `pantalla_dm.html`. For every log message, the script invoked `Object.values(cache).find()` over the global actors cache, causing severe repetitive layout logic processing.
+**Action:** Pre-computed a hash map (`new Map()`) with lowercase actor names outside the log loop to change the O(n) inner array lookup into an O(1) hash map lookup, drastically reducing the operational overhead for large logs.

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -12967,6 +12967,17 @@
           const logs = snap.val();
           if (logs) {
             let isFirst = true;
+
+            // BOLT OPTIMIZATION: Pre-compute actor map for O(1) lookups instead of O(n) .find() inside the log loop
+            const actorsMap = new Map();
+            if (window.allActoresCache) {
+              Object.values(window.allActoresCache).forEach(actor => {
+                if (actor && actor.nombre) {
+                  actorsMap.set(actor.nombre.toLowerCase(), actor);
+                }
+              });
+            }
+
             for (const [key, msg] of Object.entries(logs)) {
               if (!isFirst) {
                 const divider = document.createElement("hr");
@@ -12982,13 +12993,8 @@
               const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
               let dynamicIcon = null;
-              if (window.allActoresCache) {
-                const actorMatch = Object.values(window.allActoresCache).find(
-                  (actor) =>
-                    actor.nombre &&
-                    msg.nombre &&
-                    actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-                );
+              if (msg.nombre) {
+                const actorMatch = actorsMap.get(msg.nombre.toLowerCase());
                 if (actorMatch && actorMatch.icono) {
                   dynamicIcon = actorMatch.icono;
                 }

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -1198,6 +1198,17 @@ function initializeCharacterSheet() {
 
         if (logs) {
           let isFirst = true;
+
+          // BOLT OPTIMIZATION: Pre-compute actor map for O(1) lookups instead of O(n) .find() inside the log loop
+          const actorsMap = new Map();
+          if (window.allActoresCache) {
+            Object.values(window.allActoresCache).forEach(actor => {
+              if (actor && actor.nombre) {
+                actorsMap.set(actor.nombre.toLowerCase(), actor);
+              }
+            });
+          }
+
           for (const [key, msg] of Object.entries(logs)) {
             if (!isFirst) {
               const divider = document.createElement("hr");
@@ -1214,13 +1225,8 @@ function initializeCharacterSheet() {
             const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
             let dynamicIcon = null;
-            if (window.allActoresCache) {
-              const actorMatch = Object.values(window.allActoresCache).find(
-                (actor) =>
-                  actor.nombre &&
-                  msg.nombre &&
-                  actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-              );
+            if (msg.nombre) {
+              const actorMatch = actorsMap.get(msg.nombre.toLowerCase());
               if (actorMatch && actorMatch.icono) {
                 dynamicIcon = actorMatch.icono;
               }

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -6960,6 +6960,17 @@
 
             if (logs) {
               let isFirst = true;
+
+              // BOLT OPTIMIZATION: Pre-compute actor map for O(1) lookups instead of O(n) .find() inside the log loop
+              const actorsMap = new Map();
+              if (typeof dbActoresCache !== "undefined" && dbActoresCache) {
+                Object.values(dbActoresCache).forEach(actor => {
+                  if (actor && actor.nombre) {
+                    actorsMap.set(actor.nombre.toLowerCase(), actor);
+                  }
+                });
+              }
+
               for (const [key, msg] of Object.entries(logs)) {
                 if (!isFirst) {
                   const divider = document.createElement("hr");
@@ -6975,13 +6986,8 @@
                 const defaultFallbackIcon = `https://via.placeholder.com/80/000000/${charHexColor.replace("#", "")}?text=${msg.nombre ? msg.nombre.charAt(0) : "?"}`;
 
                 let dynamicIcon = null;
-                if (typeof dbActoresCache !== "undefined" && dbActoresCache) {
-                  const actorMatch = Object.values(dbActoresCache).find(
-                    (actor) =>
-                      actor.nombre &&
-                      msg.nombre &&
-                      actor.nombre.toLowerCase() === msg.nombre.toLowerCase(),
-                  );
+                if (msg.nombre) {
+                  const actorMatch = actorsMap.get(msg.nombre.toLowerCase());
                   if (actorMatch && actorMatch.icono) {
                     dynamicIcon = actorMatch.icono;
                   }


### PR DESCRIPTION
💡 What: Replaced `Object.values(cache).find()` inside the `teatro/log` rendering loop with an O(1) `Map` pre-computed outside the loop.
🎯 Why: To prevent severe O(N^2) CPU overhead caused by re-iterating over the entire Actors cache for every single log message whenever the Firebase log node synced.
📊 Impact: Reduces time complexity from O(L * A) to O(L + A) [where L is number of logs and A is number of actors]. Prevents layout/JavaScript thread blocking during massive log dumps.
🔬 Measurement: Verify changes in `hoja_personaje.js` (line 1202), `hoja_personaje.html` (line 12971), and `pantalla_dm.html` (line 6964). Checked using Playwright testing.

---
*PR created automatically by Jules for task [12480691185859307698](https://jules.google.com/task/12480691185859307698) started by @sokcrow*