### PR TITLE
feat: Add critical hit damage scaling to applyDamage in combatEngine

### DIFF
--- a/js/combatEngine.js
+++ b/js/combatEngine.js
@@ -43,8 +43,8 @@ const CombatEngine = {
     },
 
     // 2. Sistema de Escudos (Shield) y Daño (Aplicación)
-    applyDamage: function(unit, damage, tipoDaño = 'directo') {
-        let remainingDamage = damage;
+    applyDamage: function(unit, damage, tipoDaño = 'directo', isCritical = false) {
+        let remainingDamage = isCritical ? damage * 1.5 : damage;
 
         if (unit.shield && unit.shield > 0) {
             if (unit.shield >= remainingDamage) {


### PR DESCRIPTION
This pull request introduces critical hit functionality into the combat engine's damage resolution step. By passing `isCritical = true` to `applyDamage`, the engine will now scale the incoming damage (which already factors in resistances and levels) by a factor of 1.5 before it reduces the target's shield and hit points.

---
*PR created automatically by Jules for task [10559523617791440605](https://jules.google.com/task/10559523617791440605) started by @sokcrow*