### PR TITLE
feat: implement Skill definition and AoE targeting mechanics

### DIFF
--- a/Battle-viewer.html
+++ b/Battle-viewer.html
@@ -259,6 +259,15 @@
         }
         const unit = combatData[data.id];
 
+        // Inicializar actionSlots de forma explicita con array si no lo tiene
+        if (!unit.slots) {
+            unit.slots = Array.from({length: unit.actionSlots || 1}).map((_, i) => ({
+                id: `${data.id}_slot_${i}`,
+                slotWeight: 1,
+                isTargetedThisRound: false
+            }));
+        }
+
         const slotsHtml = isCombatant ? Array.from({length: unit.actionSlots || 1}).map((_, i) => {
             const slotId = `${data.id}_slot_${i}`;
             return `

--- a/js/combatEngine.js
+++ b/js/combatEngine.js
@@ -1,4 +1,58 @@
 const CombatEngine = {
+// 0. Habilidades y Poder (Skills)
+    createSkill: function(config = {}) {
+        return {
+            basePower: config.basePower || 0,
+            coinPower: config.coinPower || 0,
+            coinAmount: Math.max(1, config.coinAmount || 1),
+            attackType: config.attackType || 'Slash',
+            sinAffinity: config.sinAffinity !== undefined ? config.sinAffinity : null,
+            levelModifier: config.levelModifier || 0,
+            attackWeight: config.attackWeight || 1,
+            skillAmount: config.skillAmount || 1
+        };
+    },
+
+    calculateFinalPower: function(skill, headsFlipped) {
+        return skill.basePower + (headsFlipped * skill.coinPower);
+    },
+
+    calculateAoETargets: function(skill, primaryTarget, allPossibleTargets) {
+        let targetsHit = [primaryTarget];
+        let remainingWeight = skill.attackWeight - (primaryTarget.slotWeight || 1);
+
+        if (remainingWeight <= 0) return targetsHit;
+
+        // Filter out the primary target from the possible targets
+        let remainingTargets = allPossibleTargets.filter(t => t !== primaryTarget);
+
+        // Sort targets based on priority:
+        // 1. Untargeted in current round (assuming a property 'isTargetedThisRound' exists, false if undefined)
+        // 2. Lowest HP percentage
+        remainingTargets.sort((a, b) => {
+            let aTargeted = a.isTargetedThisRound ? 1 : 0;
+            let bTargeted = b.isTargetedThisRound ? 1 : 0;
+            if (aTargeted !== bTargeted) {
+                return aTargeted - bTargeted; // 0 comes before 1
+            }
+
+            let aHpPct = (a.hp / (a.maxHp || 1));
+            let bHpPct = (b.hp / (b.maxHp || 1));
+            return aHpPct - bHpPct; // Lower HP% comes first
+        });
+
+        for (let target of remainingTargets) {
+            if (remainingWeight > 0) {
+                targetsHit.push(target);
+                remainingWeight -= (target.slotWeight || 1);
+            } else {
+                break;
+            }
+        }
+
+        return targetsHit;
+    },
+
     // 1. Stats Base y Cálculo de HP
     calculateMaxHP: function(base, hpCoef, level) {
         return Math.floor(base + (hpCoef * level));


### PR DESCRIPTION
This PR introduces the base structural definition and math calculations for combat Skills. It implements an AoE Target distribution system that prioritizes untargeted units and distributes Attack Weight by consuming each valid target's Slot Weight. Skills are kept as raw objects (via factory functions) to guarantee compatibility with Firebase. Also, slot generation logic was updated to attach the default `slotWeight` attribute.

---
*PR created automatically by Jules for task [11161173886210797461](https://jules.google.com/task/11161173886210797461) started by @sokcrow*