### PR TITLE
feat: dynamically expand STATUS_REGISTRY and adjust mode limits

### DIFF
--- a/js/statusManager.js
+++ b/js/statusManager.js
@@ -1,22 +1,95 @@
+const DAMAGE_TYPES = ['Slash', 'Pierce', 'Blunt'];
+const SIN_TYPES = ['Wrath', 'Lust', 'Sloth', 'Gluttony', 'Gloom', 'Pride', 'Envy'];
+
 const STATUS_REGISTRY = {
-    // Examples based on generic ecosystem
-    'burn': { type: 'negative', mode: 'double', basePotency: 1, baseCount: 1, maxPotency: 99, maxCount: 99 },
-    'bleed': { type: 'negative', mode: 'double', basePotency: 1, baseCount: 1, maxPotency: 99, maxCount: 99 },
-    'tremor': { type: 'negative', mode: 'double', basePotency: 1, baseCount: 1, maxPotency: 99, maxCount: 99 },
-    'rupture': { type: 'negative', mode: 'double', basePotency: 1, baseCount: 1, maxPotency: 99, maxCount: 99 },
-    'sinking': { type: 'negative', mode: 'double', basePotency: 1, baseCount: 1, maxPotency: 99, maxCount: 99 },
-    'charge': { type: 'positive', mode: 'single', baseCount: 1, maxCount: 20 },
-    'poise': { type: 'positive', mode: 'double', basePotency: 1, baseCount: 1, maxPotency: 99, maxCount: 99 },
+    // Core Statuses
+    'burn': { type: 'negative', mode: 'double', basePotency: 1, baseCount: 1, maxPotency: 99, maxCount: 99, description: "At turn end, take Burn Potency as Wrath damage and reduce Count by 1." },
+    'bleed': { type: 'negative', mode: 'double', basePotency: 1, baseCount: 1, maxPotency: 99, maxCount: 99, description: "Whenever tossing a coin for an Attack Skill, take Bleed Potency as damage and reduce Count by 1." },
+    'tremor': { type: 'negative', mode: 'double', basePotency: 1, baseCount: 1, maxPotency: 99, maxCount: 99, description: "When hit by an attack with Tremor Burst, raise Stagger Threshold by Tremor Potency. Count is reduced by 1 at turn end." },
+    'rupture': { type: 'negative', mode: 'double', basePotency: 1, baseCount: 1, maxPotency: 99, maxCount: 99, description: "When hit by an attack, take Rupture Potency as true damage and reduce Count by 1." },
+    'sinking': { type: 'negative', mode: 'double', basePotency: 1, baseCount: 1, maxPotency: 99, maxCount: 99, description: "When hit by an attack, take Sinking Potency as Gloom damage and reduce Count by 1 (or SP damage if applicable)." },
+    'poise': { type: 'positive', mode: 'double', basePotency: 1, baseCount: 1, maxPotency: 99, maxCount: 99, description: "Gain a chance to deal Critical Damage on hit. Potency increases Critical Chance, Count increases Critical Damage. Count is reduced by 1 at turn end." },
+    'charge': { type: 'positive', mode: 'double', basePotency: 1, baseCount: 1, maxPotency: 99, maxCount: 20, description: "Resource used by certain skills for additional effects." },
 
-    // Some static ones that might exist
-    'fragile': { type: 'negative', mode: 'single', baseCount: 1, maxCount: 10 },
-    'protection': { type: 'positive', mode: 'single', baseCount: 1, maxCount: 10 },
-    'damage up': { type: 'positive', mode: 'single', baseCount: 1, maxCount: 10 },
-    'damage down': { type: 'negative', mode: 'single', baseCount: 1, maxCount: 10 },
-
-    // Zero mode example
-    'marked': { type: 'negative', mode: 'zero' },
+    // Generic Modifiers
+    'damage_up': { type: 'positive', mode: 'single', maxCount: 10, description: "Deal 10% more damage per Count. (Max 10)" },
+    'damage_down': { type: 'negative', mode: 'single', maxCount: 10, description: "Deal 10% less damage per Count. (Max 10)" },
+    'fragile': { type: 'negative', mode: 'single', maxCount: 10, description: "Take 10% more damage per Count. (Max 10)" },
+    'protection': { type: 'positive', mode: 'single', maxCount: 10, description: "Take 10% less damage per Count. (Max 10)" },
+    'attack_power_up': { type: 'positive', mode: 'single', maxCount: Infinity, description: "Increases Final Power of Attack Skills by Count." },
+    'defense_power_up': { type: 'positive', mode: 'single', maxCount: Infinity, description: "Increases Final Power of Defense Skills by Count." },
+    'clash_power_up': { type: 'positive', mode: 'single', maxCount: Infinity, description: "Increases Clash Power by Count." },
+    'haste': { type: 'positive', mode: 'single', maxCount: Infinity, description: "Increases Speed by Count." },
+    'bind': { type: 'negative', mode: 'single', maxCount: Infinity, description: "Decreases Speed by Count." },
+    'offense_level_up': { type: 'positive', mode: 'single', maxCount: Infinity, description: "Increases Offense Level by Count." },
+    'offense_level_down': { type: 'negative', mode: 'single', maxCount: Infinity, description: "Decreases Offense Level by Count." },
+    'defense_level_up': { type: 'positive', mode: 'single', maxCount: Infinity, description: "Increases Defense Level by Count." },
+    'defense_level_down': { type: 'negative', mode: 'single', maxCount: Infinity, description: "Decreases Defense Level by Count." },
 };
+
+const generateElementalStatuses = () => {
+    const allTypes = [...DAMAGE_TYPES, ...SIN_TYPES];
+
+    allTypes.forEach(type => {
+        const idPrefix = type.toLowerCase();
+
+        // 1. DMG Up (Limit: 10)
+        STATUS_REGISTRY[`${idPrefix}_dmg_up`] = {
+            name: `${type} DMG Up`,
+            type: 'positive',
+            mode: 'single',
+            maxCount: 10,
+            description: `Deal 10% more damage with ${type} skills per Count for one turn. (Max 10)`
+        };
+
+        // 2. Power Up (Limit: Infinity)
+        STATUS_REGISTRY[`${idPrefix}_power_up`] = {
+            name: `${type} Power Up`,
+            type: 'positive',
+            mode: 'single',
+            maxCount: Infinity,
+            description: `${type} skills gain final Power by the effect's Count for one turn.`
+        };
+
+        // 3. Protection (Limit: 10)
+        STATUS_REGISTRY[`${idPrefix}_protection`] = {
+            name: `${type} Protection`,
+            type: 'positive',
+            mode: 'single',
+            maxCount: 10,
+            description: `Take 10% less damage from ${type} skills per Count for one turn. (Max 10)`
+        };
+
+        // 4. DMG Down (Limit: 10)
+        STATUS_REGISTRY[`${idPrefix}_dmg_down`] = {
+            name: `${type} DMG Down`,
+            type: 'negative',
+            mode: 'single',
+            maxCount: 10,
+            description: `Deal 10% less damage with ${type} skills per Count for one turn. (Max 10)`
+        };
+
+        // 5. Power Down (Limit: Infinity)
+        STATUS_REGISTRY[`${idPrefix}_power_down`] = {
+            name: `${type} Power Down`,
+            type: 'negative',
+            mode: 'single',
+            maxCount: Infinity,
+            description: `${type} skills lose final Power by the effect's Count for one turn.`
+        };
+
+        // 6. Fragility (Limit: 10)
+        STATUS_REGISTRY[`${idPrefix}_fragility`] = {
+            name: `${type} Fragility`,
+            type: 'negative',
+            mode: 'single',
+            maxCount: 10,
+            description: `Take 10% more damage from ${type} skills per Count for one turn. (Max 10)`
+        };
+    });
+};
+
+generateElementalStatuses();
 
 const StatusManager = {
     /**
@@ -119,7 +192,7 @@ const StatusManager = {
 
         // Apply max values
         if (registry.mode === 'single') {
-            const maxCount = registry.maxCount !== undefined ? registry.maxCount : 99;
+            const maxCount = registry.maxCount !== undefined ? registry.maxCount : Infinity;
             status.count = Math.min(status.count, maxCount);
         } else if (registry.mode === 'double') {
             const maxPotency = registry.maxPotency !== undefined ? registry.maxPotency : 99;


### PR DESCRIPTION
This PR expands the `STATUS_REGISTRY` in `js/statusManager.js` to establish the foundational data structure for the upcoming combat engine and DM UI integration. It implements a DRY generation factory for redundant elemental buffs/debuffs to keep the codebase clean, inserts core effects with accurate tooltip descriptions, and corrects the limit fallback mechanism for single-mode stat modifiers.

---
*PR created automatically by Jules for task [7837913784450730955](https://jules.google.com/task/7837913784450730955) started by @sokcrow*