### PR TITLE
Implement Phase 2: Deckbuilding and Action Slots

### DIFF
--- a/dm-combat-creator.html
+++ b/dm-combat-creator.html
@@ -152,6 +152,7 @@
             <div style="display:flex; gap: 5px; margin-bottom: 5px;">
                 <label style="flex: 1;">Velocidad: <input type="text" id="statSpeed" value="2-4" style="width: 100%; background: #222; color: white; border: 1px solid #555;"></label>
                 <label style="flex: 1;">Action Slots: <input type="number" id="statSlots" value="1" style="width: 100%; background: #222; color: white; border: 1px solid #555;"></label>
+                <label style="flex: 1;">Max Action Slots: <input type="number" id="statMaxSlots" value="3" style="width: 100%; background: #222; color: white; border: 1px solid #555;"></label>
             </div>
             <label style="display:none; margin-top: 5px;">Skills (JSON Array IDs):
                 <textarea id="statSkills" style="display:none; width: 100%; height: 60px; background: #222; color: white; border: 1px solid #555;">["skill_id_1"]</textarea>
@@ -175,6 +176,23 @@
             <div style="display:flex; gap: 5px; margin-bottom: 10px;">
                 <label style="flex: 1;">Coin Count: <input type="number" id="sb-coin-count" value="1" min="1" max="5" style="width: 100%; background: #222; color: white; border: 1px solid #555;"></label>
                 <label style="flex: 1;">Weight: <input type="number" id="sb-weight" value="1" min="1" style="width: 100%; background: #222; color: white; border: 1px solid #555;"></label>
+            </div>
+
+            <!-- Deckbuilding & Equipment -->
+            <div style="background: #1e1e1e; padding: 10px; margin-bottom: 10px; border: 1px solid #444; border-radius: 3px;">
+                <strong style="display:block; margin-bottom: 5px; color: #ffdd44; font-size: 13px;">Deckbuilding & Equipment</strong>
+                <div style="display:flex; gap: 5px; align-items: center;">
+                    <label style="flex: 1; font-size: 12px;">Tier (Costo):
+                        <select id="sb-tier" style="width: 100%; background: #222; color: white; border: 1px solid #555; padding: 2px;">
+                            <option value="1">Tier 1 (1 Slot)</option>
+                            <option value="2">Tier 2 (2 Slots)</option>
+                            <option value="3">Tier 3 (3 Slots)</option>
+                        </select>
+                    </label>
+                    <label style="flex: 1; display: flex; align-items: center; gap: 5px; font-size: 12px; margin-top: 15px;">
+                        <input type="checkbox" id="sb-is-item-skill"> Item Skill (Costo 0)
+                    </label>
+                </div>
             </div>
 
             <label style="display:block; margin-bottom: 10px;">Sin Type:
@@ -337,6 +355,7 @@
                 level: 1,
                 speed: "2-4",
                 actionSlots: 1,
+                maxSlotsLimit: 3,
                 skills: ["skill_id_1"]
             },
             skillsData: {
@@ -457,6 +476,8 @@
             const skillObj = {
                 id: document.getElementById('sb-id').value || "new_skill",
                 name: document.getElementById('sb-name').value || "New Skill",
+                tier: parseInt(document.getElementById('sb-tier').value) || 1,
+                isItemSkill: document.getElementById('sb-is-item-skill').checked,
                 basePower: parseInt(document.getElementById('sb-base').value) || 0,
                 coinPower: parseInt(document.getElementById('sb-coin-power').value) || 0,
                 coinAmount: parseInt(document.getElementById('sb-coin-count').value) || 1,
@@ -639,6 +660,7 @@
             bindInput('statLevel', 'mechanics.level', true);
             bindInput('statSpeed', 'mechanics.speed');
             bindInput('statSlots', 'mechanics.actionSlots', true);
+            bindInput('statMaxSlots', 'mechanics.maxSlotsLimit', true);
 
             document.getElementById('statSkills').addEventListener('input', (e) => {
                 try { currentState.mechanics.skills = JSON.parse(e.target.value); } catch(err) { /* ignore parse errors while typing */ }
@@ -716,6 +738,7 @@
             document.getElementById('statLevel').value = currentState.mechanics.level;
             document.getElementById('statSpeed').value = currentState.mechanics.speed;
             document.getElementById('statSlots').value = currentState.mechanics.actionSlots;
+            document.getElementById('statMaxSlots').value = currentState.mechanics.maxSlotsLimit !== undefined ? currentState.mechanics.maxSlotsLimit : 3;
             document.getElementById('statSkills').value = JSON.stringify(currentState.mechanics.skills);
 
             // Removed rawSkillEffects loading

--- a/js/combatEngine.js
+++ b/js/combatEngine.js
@@ -151,6 +151,8 @@ const CombatEngine = {
             levelModifier: config.levelModifier || 0,
             attackWeight: config.attackWeight || 1,
             skillAmount: config.skillAmount || 1,
+            tier: config.tier !== undefined ? config.tier : 1, // Fallback a tier 1
+            isItemSkill: config.isItemSkill || false, // Fallback a false
 
             // D&D Hybrid Additions
             type: config.type || 'Normal', // 'Normal', 'Spell', 'Roll', 'Guard', 'Evade', 'Counter', 'ClashableGuard', 'ClashableCounter'
@@ -1073,6 +1075,55 @@ const CombatEngine = {
     },
 
     // 4. Velocidad, Slots y Targeting
+
+    calculateActionSlots: function(combatants, currentRound, hasReinforcements, isPlayerFaction) {
+        let maxGlobalSlots = (isPlayerFaction && !hasReinforcements) ? 11 : 12;
+        let totalSlotsToDistribute = combatants.length + (currentRound - 1);
+
+        totalSlotsToDistribute = Math.min(totalSlotsToDistribute, maxGlobalSlots);
+
+        // Ordenar combatientes por Velocidad (de mayor a menor)
+        let sortedCombatants = combatants.sort((a, b) => b.speed - a.speed);
+
+        // Asignar 1 slot base a cada uno vivo
+        sortedCombatants.forEach(c => {
+            c.activeSlots = 1;
+            // Aseguramos que la propiedad exista, si no, asumimos 3 (minion)
+            if (c.maxSlotsLimit === undefined) {
+                c.maxSlotsLimit = 3;
+            }
+        });
+
+        let remainingSlots = totalSlotsToDistribute - sortedCombatants.length;
+
+        // Bucle para repartir los restantes al más rápido, respetando sus topes individuales
+        let i = 0;
+        let iterationsWithoutAssignment = 0; // Guard against infinite loop
+
+        while(remainingSlots > 0 && i < sortedCombatants.length) {
+            let unit = sortedCombatants[i];
+            if (unit.activeSlots < unit.maxSlotsLimit) {
+                unit.activeSlots++;
+                remainingSlots--;
+                iterationsWithoutAssignment = 0;
+            } else {
+                iterationsWithoutAssignment++;
+            }
+
+            i++; // Pasar al siguiente más rápido
+
+            // Reiniciar el loop si aún hay slots y todos los rápidos ya recibieron su ronda
+            if (i >= sortedCombatants.length && remainingSlots > 0) {
+                if (iterationsWithoutAssignment >= sortedCombatants.length) {
+                    // Everyone is at their limit, break the loop to prevent infinite loop
+                    break;
+                }
+                i = 0;
+            }
+        }
+        return sortedCombatants;
+    },
+
     autoTarget: function(attacker, skill, enemies) {
         if (!enemies || enemies.length === 0) return null;
 

--- a/js/deckEngine.js
+++ b/js/deckEngine.js
@@ -1,0 +1,87 @@
+const DeckEngine = {
+    /**
+     * Initializes a unit's deck and drawing logic.
+     * @param {Object} unit - The unit whose deck is to be initialized.
+     * @param {Array} equippedSkills - Array of skill objects equipped by the unit.
+     */
+    initDeck: function(unit, equippedSkills) {
+        // Initialize deck based on equipped skills
+        unit.deck = [];
+        equippedSkills.forEach(skill => {
+            // Default amount is 1 if not specified
+            let amount = skill.skillAmount || 1;
+            for (let i = 0; i < amount; i++) {
+                unit.deck.push(Object.assign({}, skill));
+            }
+        });
+
+        // Shuffle the deck initially
+        this.shuffleDeck(unit.deck);
+    },
+
+    /**
+     * Shuffles a deck array in place using the Fisher-Yates algorithm.
+     * @param {Array} deck - The deck array to shuffle.
+     */
+    shuffleDeck: function(deck) {
+        for (let i = deck.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [deck[i], deck[j]] = [deck[j], deck[i]];
+        }
+    },
+
+    /**
+     * Draws the hand for a given action slot.
+     * Returns 2 active skills and 1 preview skill.
+     * If the deck runs out, it needs to be reshuffled from a discard pile (to be implemented as needed).
+     * @param {Array} deck - The unit's current deck of skills.
+     * @returns {Object} An object containing the drawn skills.
+     */
+    drawHandForSlot: function(deck) {
+        // We need at least 3 skills for a full hand (2 active, 1 preview)
+        // If there are fewer than 3 skills, we will just return what we have.
+        // In a full implementation, you would move a discard pile back to the deck and reshuffle.
+
+        let hand = {
+            activeOptions: [],
+            previewOption: null
+        };
+
+        if (deck.length >= 1) {
+            hand.activeOptions.push(deck.shift());
+        }
+        if (deck.length >= 1) {
+            hand.activeOptions.push(deck.shift());
+        }
+        if (deck.length >= 1) {
+            hand.previewOption = deck.shift();
+        }
+
+        return hand;
+    },
+
+    /**
+     * Injects a defensive skill into the hand, replacing a specified active option.
+     * This bypasses the random deck draw and is triggered by a long-press in the UI.
+     * @param {Object} currentHand - The current hand object (returned by drawHandForSlot).
+     * @param {Object} defensiveSkill - The static defensive skill to inject.
+     * @param {number} indexToReplace - The index of the active option to replace (0 or 1).
+     * @returns {Object} The updated hand.
+     */
+    injectDefensiveSkill: function(currentHand, defensiveSkill, indexToReplace) {
+        if (!currentHand || !currentHand.activeOptions) return currentHand;
+
+        if (indexToReplace >= 0 && indexToReplace < currentHand.activeOptions.length) {
+            // Replace the selected slot with the defensive skill
+            currentHand.activeOptions[indexToReplace] = Object.assign({}, defensiveSkill);
+        }
+
+        return currentHand;
+    }
+};
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = DeckEngine;
+} else if (typeof window !== 'undefined') {
+    window.DeckEngine = DeckEngine;
+}


### PR DESCRIPTION
Implement Phase 2: Deckbuilding UI, Hand Logic, and Action Slot scaling.

- Added Tier (Slot Cost) and Item Skill (Free Slot) toggles to `dm-combat-creator.html`.
- Added Max Action Slots limit configuration to Entity Stats.
- Created `deckEngine.js` module to handle shuffling, drawing, and defensive skill injection.
- Implemented `calculateActionSlots` in `combatEngine.js` to distribute slots up to 12 globally, sorted by speed and bounded by max limits.
- Added backward-compatible fallbacks for skill creation.

---
*PR created automatically by Jules for task [5814423640734706180](https://jules.google.com/task/5814423640734706180) started by @sokcrow*