### PR TITLE
Fix DM UI Tabs Navigation and Overlay Block

### DIFF
--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -1077,6 +1077,7 @@
         width: 100vw;
         height: 100vh;
         z-index: 10000;
+        pointer-events: none;
         background-color: #0b0a0a;
         display: flex;
         align-items: center;
@@ -4659,7 +4660,10 @@
               .forEach((b) => b.classList.remove("active"));
             document
               .querySelectorAll(".dm-tab-pane")
-              .forEach((p) => p.classList.remove("active"));
+              .forEach((p) => {
+                  p.classList.remove("active");
+                  p.style.display = ""; // Fix the inline display styles issue
+              });
 
             // Add active class to clicked button and target pane
             btn.classList.add("active");
@@ -4670,15 +4674,10 @@
             }
             if (targetPane) {
                 targetPane.classList.add("active");
-                targetPane.style.display = "flex";
+                targetPane.style.display = ""; // Let CSS handle flex
             }
 
-            // hide other panes specifically to be safe
-            document.querySelectorAll(".dm-tab-pane").forEach((p) => {
-                if(p !== targetPane) {
-                    p.style.display = "none";
-                }
-            });
+
           });
         });
 


### PR DESCRIPTION
This change fixes a bug where users on the DM screen were unable to navigate through the UI tabs (such as clicking the 'Clima' or 'Combate' tab), getting stuck on the default 'Tiempo' tab. It also ensures the system loading overlay cannot accidentally block the user's cursor interactions if Firebase takes too long to load or fails.

---
*PR created automatically by Jules for task [10895954081962267745](https://jules.google.com/task/10895954081962267745) started by @sokcrow*