### PR TITLE
Fix JS crash on weather tab and fix empty clock bug

### DIFF
--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -1317,7 +1317,7 @@
           </div>
 
         </div>
-
+        </div>
       <!-- TAB: CLIMA -->
       <div id="tab-clima" class="dm-tab-pane">
         <div class="panel-cyber" style="margin-top: 20px; display: flex; flex-direction: row; gap: 20px; flex-wrap: wrap; align-items: flex-start; justify-content: center;">
@@ -3898,6 +3898,7 @@
             "Lluvia": ["Nublado"]
         };
 
+        let dbJugadoresCache = {};
         let currentWeather = "Soleado";
         let previousWeather = null;
 
@@ -4102,7 +4103,7 @@
                     updateTimeDisplay();
                 } else {
                     // Fallback a los nodos antiguos si el timestamp no existe aún
-                    db.ref("campaña/estado_mundo").once("value", oldSnap => {
+                    db.ref("campaña/calendario").once("value", oldSnap => {
                         const data = oldSnap.val();
                         if (data) {
                             currentWorldDate = new Date();
@@ -4112,12 +4113,12 @@
 
                             // Parsear "HH:MM" de "campaña/hora_actual"
                             db.ref("campaña/hora_actual").once("value", timeSnap => {
-                                const timeStr = timeSnap.val() || "08:00";
+                                const timeStr = timeSnap.val() || "00:00";
                                 const parts = timeStr.split(":");
-                                currentWorldDate.setHours(parseInt(parts[0]) || 8);
+                                currentWorldDate.setHours(parseInt(parts[0]) || 0);
                                 currentWorldDate.setMinutes(parseInt(parts[1]) || 0);
                                 currentWorldDate.setSeconds(0);
-                                currentWorldTimeSynced = true;
+                                currentWorldTimeSynced = true; // Desbloquea los botones
                                 updateTimeDisplay();
                             });
                             currentWeather = data.clima || "Soleado";
@@ -4138,10 +4139,14 @@
             const mm = String(currentWorldDate.getMonth() + 1).padStart(2, '0');
             const yyyy = currentWorldDate.getFullYear();
 
-            const hh = String(currentWorldDate.getHours()).padStart(2, '0');
+            let hours = currentWorldDate.getHours();
             const mins = String(currentWorldDate.getMinutes()).padStart(2, '0');
+            const ampm = hours >= 12 ? 'PM' : 'AM';
+            hours = hours % 12;
+            hours = hours ? hours : 12; // la hora '0' debería ser '12'
+            const hh = String(hours).padStart(2, '0');
 
-            display.innerText = `📅 ${dd}/${mm}/${yyyy} | ⏱️ ${hh}:${mins}`;
+            display.innerText = `${dd}/${mm}/${yyyy} - ${hh}:${mins} ${ampm}`;
         }
 
         window.advanceTime = function(minutes) {
@@ -5119,17 +5124,6 @@
               estadoActual.dia = data.dia || 1;
               estadoActual.mes = data.mes || 1;
               estadoActual.clima = data.clima || "Despejado";
-
-              // Actualizar UI
-              document.getElementById("lbl-auto-fecha").innerText =
-                `Año ${estadoActual.año} / Mes ${estadoActual.mes} / Día ${estadoActual.dia}`;
-              document.getElementById("lbl-auto-clima").innerText =
-                estadoActual.clima;
-
-              document.getElementById("debug-año").value = estadoActual.año;
-              document.getElementById("debug-dia").value = estadoActual.dia;
-              document.getElementById("debug-mes").value = estadoActual.mes;
-              document.getElementById("debug-clima").value = estadoActual.clima;
 
               // Inyectar/actualizar radial de clima
               if (typeof renderClimaRadial === "function") {
@@ -7476,14 +7470,8 @@
           renderActorAsignacion();
         });
 
-        let dbJugadoresCache = {};
-
         // Escuchar jugadores para la lista (reusando el que ya existe o creando nuevo listener local aquí)
-        db.ref("campaña/jugadores").on("value", (snapshot) => {
-          dbJugadoresCache = snapshot.val() || {};
-          renderActorAsignacion();
-        });
-
+        // Ya está siendo escuchado en la línea 4347 aprox
         function renderActorAsignacion() {
           const container = document.getElementById("actor-asignacion-lista");
           if (!container) return;


### PR DESCRIPTION
* Fixed the JS crash preventing tabs like "Clima" from rendering correctly due to obsolete DOM references.
* Fixed the syncWorldTime fallback to correctly pull date from `campaña/calendario`.
* Updated the digital clock display to correctly format times in 12-hour format with AM/PM.

---
*PR created automatically by Jules for task [1689263896191278308](https://jules.google.com/task/1689263896191278308) started by @sokcrow*