### PR TITLE
feat(combat): integrate status icons and paralyze mechanic

### DIFF
--- a/js/combatEngine.js
+++ b/js/combatEngine.js
@@ -252,7 +252,7 @@ const CombatEngine = {
     resolveSpell: function(spellSkill, target, targetHeadsFlipped) {
         // Genera la tirada de salvación para el objetivo
         let saveSkill = this.createSaveSkill(target, spellSkill.statUsed);
-        let savePower = this.calculateFinalPower(saveSkill, targetHeadsFlipped);
+        let savePower = this.calculateFinalPower(saveSkill, targetHeadsFlipped, target);
 
         let isSuccess = savePower >= spellSkill.saveDC;
 
@@ -274,7 +274,7 @@ const CombatEngine = {
 
         let probDefender = this.getCoinProbability(unitDefender.sp || 0);
         let guardTosses = guardSkill.coins.map(c => c.status === 'active' ? (Math.random() * 100 < probDefender) : true);
-        let guardPower = this.calculateFinalPower(guardSkill, guardTosses);
+        let guardPower = this.calculateFinalPower(guardSkill, guardTosses, unitDefender);
 
         unitDefender.shield = (unitDefender.shield || 0) + guardPower;
 
@@ -326,7 +326,7 @@ const CombatEngine = {
             this.triggerEvent('[Coin Start]', context, [unitDefender]);
 
             let attackTosses = activeAttackCoins.map(c => c.status === 'active' ? (Math.random() * 100 < probAttacker) : true);
-            let attackPower = this.calculateFinalPower(attackSkill, attackTosses);
+            let attackPower = this.calculateFinalPower(attackSkill, attackTosses, unitAttacker);
 
             // current coin toss result (it's the i-th toss basically, if we consider only active ones we need mapping, but let's assume current toss is for current coin)
             // Limbus note: toss result for current coin is attackTosses[i]
@@ -406,13 +406,13 @@ const CombatEngine = {
 
             // Roll Evade
             let evadeTosses = evadeSkill.coins.map(c => c.status === 'active' ? (Math.random() * 100 < probDefender) : true);
-            let evadePower = this.calculateFinalPower(evadeSkill, evadeTosses);
+            let evadePower = this.calculateFinalPower(evadeSkill, evadeTosses, unitDefender);
 
             // Roll Attack (only rolling the current coin + previous coins are usually evaluated as well,
             // but in Evade vs Attack, the attacker usually rolls all their remaining coins for power)
             // Limbus Rule: Attacker rolls ALL active coins for power. We will roll all active/cracked for the attacker.
             let attackTosses = activeAttackCoins.map(c => c.status === 'active' ? (Math.random() * 100 < probAttacker) : true);
-            let attackPower = this.calculateFinalPower(attackSkill, attackTosses);
+            let attackPower = this.calculateFinalPower(attackSkill, attackTosses, unitAttacker);
 
             let log = {
                 evadePower: evadePower,
@@ -530,8 +530,8 @@ const CombatEngine = {
             let tossesA = allUsableA.map(c => c.status === 'active' ? (Math.random() * 100 < probA) : true);
             let tossesB = allUsableB.map(c => c.status === 'active' ? (Math.random() * 100 < probB) : true);
 
-            let powerA = this.calculateFinalPower(skillA, tossesA);
-            let powerB = this.calculateFinalPower(skillB, tossesB);
+            let powerA = this.calculateFinalPower(skillA, tossesA, unitA);
+            let powerB = this.calculateFinalPower(skillB, tossesB, unitB);
 
             let roundWinner = powerA > powerB ? 'A' : (powerB > powerA ? 'B' : 'Tie');
 
@@ -667,9 +667,9 @@ const CombatEngine = {
         return result;
     },
 
-    resolveRollClash: function(skillA, headsA, skillB, headsB) {
-        let powerA = this.calculateFinalPower(skillA, headsA);
-        let powerB = this.calculateFinalPower(skillB, headsB);
+    resolveRollClash: function(skillA, headsA, skillB, headsB, unitA, unitB) {
+        let powerA = this.calculateFinalPower(skillA, headsA, unitA);
+        let powerB = this.calculateFinalPower(skillB, headsB, unitB);
 
         let winner = powerA > powerB ? 'A' : (powerB > powerA ? 'B' : 'Tie');
 
@@ -707,9 +707,23 @@ const CombatEngine = {
         };
     },
 
-    calculateFinalPower: function(skill, headsFlipped) {
+    calculateFinalPower: function(skill, headsFlipped, unit = null) {
         if (typeof headsFlipped === 'number') {
-            return skill.basePower + (headsFlipped * skill.coinPower);
+            // No se puede aplicar paralisis de forma secuencial en una tirada agregada sin desglose,
+            // pero para mantener consistencia matematica, si hay paralisis, anulamos X monedas simuladas.
+            let power = skill.basePower;
+            let effectiveHeads = headsFlipped;
+            if (unit && unit.statusEffects && unit.statusEffects['paralyze'] && unit.statusEffects['paralyze'].count > 0) {
+                // Simplificacion para casos donde headsFlipped es un numero entero
+                let paralyzeCount = unit.statusEffects['paralyze'].count;
+                let paralyzedCoins = Math.min(effectiveHeads, paralyzeCount);
+                effectiveHeads -= paralyzedCoins;
+                unit.statusEffects['paralyze'].count -= paralyzedCoins;
+                if (unit.statusEffects['paralyze'].count <= 0) {
+                    delete unit.statusEffects['paralyze'];
+                }
+            }
+            return power + (effectiveHeads * skill.coinPower);
         }
 
         if (Array.isArray(headsFlipped)) {
@@ -722,17 +736,34 @@ const CombatEngine = {
 
                 if (!coin) continue;
 
-                if (coin.status === 'active') {
-                    if (coinResult) {
-                        totalPower += skill.coinPower;
-                    }
+                // Determinar si la moneda salio Cara o es una moneda agrietada (cracked) que actua como Cara
+                let isHeads = false;
+                if (coin.status === 'active' && coinResult) {
+                    isHeads = true;
                 } else if (coin.status === 'cracked') {
-                    // Cracked coins have a fixed base power of 1 or -1 before external modifiers
-                    // In calculateFinalPower context, the coin base is fixed and it acts as an automatic heads
-                    let crackedBasePower = skill.coinPower < 0 ? -1 : 1;
-                    totalPower += crackedBasePower;
-                    // Any external modifiers would be applied after this function,
-                    // as calculateFinalPower only calculates the base + coin power
+                    isHeads = true;
+                }
+
+                // Intercepcion de Paralisis (Paralyze)
+                let powerModifier = 0;
+                if (coin.status === 'active') {
+                    powerModifier = skill.coinPower;
+                } else if (coin.status === 'cracked') {
+                    powerModifier = skill.coinPower < 0 ? -1 : 1;
+                }
+
+                if (isHeads) {
+                    // Si la moneda es Cara, verificar si hay Paralisis activa
+                    if (unit && unit.statusEffects && unit.statusEffects['paralyze'] && unit.statusEffects['paralyze'].count > 0) {
+                        // La Paralisis fuerza el modificador a 0
+                        powerModifier = 0;
+                        // Consumir carga de Paralisis
+                        unit.statusEffects['paralyze'].count--;
+                        if (unit.statusEffects['paralyze'].count <= 0) {
+                            delete unit.statusEffects['paralyze'];
+                        }
+                    }
+                    totalPower += powerModifier;
                 }
             }
             return totalPower;

--- a/js/statusManager.js
+++ b/js/statusManager.js
@@ -4,15 +4,15 @@ const SIN_TYPES = ['Wrath', 'Lust', 'Sloth', 'Gluttony', 'Gloom', 'Pride', 'Envy
 const STATUS_REGISTRY = {
     // --- CORE STATUSES (Efectos Clave) ---
     'burn': {
-        name: 'Burn', type: 'negative', mode: 'double',
+        name: 'Burn', type: 'negative', mode: 'double', icon: 'https://imgur.com/L4bRd44.png',
         description: "At the end of the turn, take fixed damage by the effect’s Potency, then reduce its Count by 1."
     },
     'bleed': {
-        name: 'Bleed', type: 'negative', mode: 'double',
+        name: 'Bleed', type: 'negative', mode: 'double', icon: 'https://imgur.com/mp9fbme.png',
         description: "When tossing an attack Coin, take fixed damage by the effect’s Potency. Then, reduce its Count by 1."
     },
     'tremor': {
-        name: 'Tremor', type: 'negative', mode: 'double',
+        name: 'Tremor', type: 'negative', mode: 'double', icon: 'https://imgur.com/fuDGjpn.png',
         description: "When attacked by skills that burst Tremor, raise the Stagger Threshold by the effect’s Potency. At the end of the turn, reduce the Count by 1."
     },
     'tremor_decay': {
@@ -48,19 +48,19 @@ const STATUS_REGISTRY = {
         description: "When triggering Amplitude Conversion, add the effects of the resulting Tremor type to the list of active Tremor effects under Tremor - Superposition."
     },
     'rupture': {
-        name: 'Rupture', type: 'negative', mode: 'double',
+        name: 'Rupture', type: 'negative', mode: 'double', icon: 'https://imgur.com/g5LTeDs.png',
         description: "When hit by an attack, take fixed damage by the effect’s Potency. Then, reduce its Count by 1."
     },
     'sinking': {
-        name: 'Sinking', type: 'negative', mode: 'double',
+        name: 'Sinking', type: 'negative', mode: 'double', icon: 'https://imgur.com/ZnulGzZ.png',
         description: "When hit by an attack, take fixed SP damage by the effect’s Potency. (Non-SP Units take Gloom damage instead.) Then, reduce its Count by 1."
     },
     'poise': {
-        name: 'Poise', type: 'positive', mode: 'double',
+        name: 'Poise', type: 'positive', mode: 'double', icon: 'https://imgur.com/KFEmJB5.png',
         description: "Gain a chance to deal Critical Damage on hit. Potency increases Critical Chance, Count increases Critical Damage. Count is reduced by 1 at turn end."
     },
     'charge': {
-        name: 'Charge', type: 'positive', mode: 'double', maxCount: 20,
+        name: 'Charge', type: 'positive', mode: 'double', maxCount: 20, icon: 'https://imgur.com/GzJzNPV.png',
         description: "Resource used by certain skills for additional effects."
     },
 
@@ -70,15 +70,15 @@ const STATUS_REGISTRY = {
         description: "All skills gain Final Power by the effect's Count for one turn."
     },
     'attack_power_up': {
-        name: 'Attack Power Up', type: 'positive', mode: 'single',
+        name: 'Attack Power Up', type: 'positive', mode: 'single', icon: 'https://imgur.com/JbDs4X0.png',
         description: "Attack skills gain Final Power by the effect's Count for one turn."
     },
     'defense_power_up': {
-        name: 'Defense Power Up', type: 'positive', mode: 'single',
+        name: 'Defense Power Up', type: 'positive', mode: 'single', icon: 'https://imgur.com/AkiiCza.png',
         description: "Defense skills gain Final Power by the effect's Count for one turn."
     },
     'clash_power_up': {
-        name: 'Clash Power Up', type: 'positive', mode: 'single',
+        name: 'Clash Power Up', type: 'positive', mode: 'single', icon: 'https://imgur.com/Q49TCVN.png',
         description: "Gain Clash Power by the effect's Count for one turn."
     },
     'base_power_up': {
@@ -86,23 +86,23 @@ const STATUS_REGISTRY = {
         description: "Raise the Base Power of Skills by the effect's Count."
     },
     'offense_level_up': {
-        name: 'Offense Level Up', type: 'positive', mode: 'single',
+        name: 'Offense Level Up', type: 'positive', mode: 'single', icon: 'https://imgur.com/p70Fei4.png',
         description: "Offense level increases based on the effect's Count for one turn."
     },
     'defense_level_up': {
-        name: 'Defense Level Up', type: 'positive', mode: 'single',
+        name: 'Defense Level Up', type: 'positive', mode: 'single', icon: 'https://imgur.com/C0apZVL.png',
         description: "Defense Level increases based on the effect's Count for one turn."
     },
     'damage_up': {
-        name: 'Damage Up', type: 'positive', mode: 'single', maxCount: 10,
+        name: 'Damage Up', type: 'positive', mode: 'single', maxCount: 10, icon: 'https://imgur.com/KDLYRCR.png',
         description: "Deal 10% more damage with skills based on the effect's Count for one turn. (Max 10)"
     },
     'haste': {
-        name: 'Haste', type: 'positive', mode: 'single',
+        name: 'Haste', type: 'positive', mode: 'single', icon: 'https://imgur.com/zxUsYIN.png',
         description: "Speed increases by the effect's Count for one turn."
     },
     'protection': {
-        name: 'Protection', type: 'positive', mode: 'single', maxCount: 10,
+        name: 'Protection', type: 'positive', mode: 'single', maxCount: 10, icon: 'https://imgur.com/yjPgnjd.png',
         description: "Take 10% less damage per Count from attacks for one turn. (Max 10)"
     },
     'plus_coin_boost': {
@@ -118,7 +118,7 @@ const STATUS_REGISTRY = {
         description: "Boost the damage of attacks against Weak resistances by 1% per Count for one turn."
     },
     'hp_healing_boost': {
-        name: 'HP Healing Boost', type: 'positive', mode: 'single', maxCount: 5,
+        name: 'HP Healing Boost', type: 'positive', mode: 'single', maxCount: 5, icon: 'https://imgur.com/uynjNTN.png',
         description: "Increases HP healing provided by Passive abilities, Skills, and Coin effects by 10% per Count. (Max 5)"
     },
     'ego_resource_amp': {
@@ -132,39 +132,39 @@ const STATUS_REGISTRY = {
         description: "All skills lose Final Power by the effect's Count for one turn."
     },
     'attack_power_down': {
-        name: 'Attack Power Down', type: 'negative', mode: 'single',
+        name: 'Attack Power Down', type: 'negative', mode: 'single', icon: 'https://imgur.com/g69L38F.png',
         description: "Attack skills lose Final Power by the effect's Count for one turn."
     },
     'defense_power_down': {
-        name: 'Defense Power Down', type: 'negative', mode: 'single',
+        name: 'Defense Power Down', type: 'negative', mode: 'single', icon: 'https://imgur.com/MGdXCaC.png',
         description: "Defense skills lose Final Power by the effect's Count for one turn."
     },
     'clash_power_down': {
-        name: 'Clash Power Down', type: 'negative', mode: 'single',
+        name: 'Clash Power Down', type: 'negative', mode: 'single', icon: 'https://imgur.com/TppbWXb.png',
         description: "Lose Clash Power by the effect's Count for one turn."
     },
     'offense_level_down': {
-        name: 'Offense Level Down', type: 'negative', mode: 'single',
+        name: 'Offense Level Down', type: 'negative', mode: 'single', icon: 'https://imgur.com/usBnT9m.png',
         description: "Offense level decreases based on the effect's Count for one turn."
     },
     'defense_level_down': {
-        name: 'Defense Level Down', type: 'negative', mode: 'single',
+        name: 'Defense Level Down', type: 'negative', mode: 'single', icon: 'https://imgur.com/C0apZVL.png',
         description: "Defense Level decreases based on the effect's Count for one turn."
     },
     'damage_down': {
-        name: 'Damage Down', type: 'negative', mode: 'single', maxCount: 10,
+        name: 'Damage Down', type: 'negative', mode: 'single', maxCount: 10, icon: 'https://imgur.com/bo7reA0.png',
         description: "Deal 10% less damage with skills per Count for one turn. (Max 10)"
     },
     'bind': {
-        name: 'Bind', type: 'negative', mode: 'single',
+        name: 'Bind', type: 'negative', mode: 'single', icon: 'https://imgur.com/QndWew8.png',
         description: "Speed decreases by the effect's Count for one turn."
     },
     'fragile': {
-        name: 'Fragile', type: 'negative', mode: 'single', maxCount: 10,
+        name: 'Fragile', type: 'negative', mode: 'single', maxCount: 10, icon: 'https://imgur.com/wSFboZT.png',
         description: "Take 10% more damage from skills per Count for one turn. (Max 10)"
     },
     'paralyze': {
-        name: 'Paralyze', type: 'negative', mode: 'single',
+        name: 'Paralyze', type: 'negative', mode: 'single', icon: 'https://imgur.com/9TkO8Ce.png',
         description: "Fix the Power of X Coin(s) to 0 for one turn."
     },
     'plus_coin_drop': {
@@ -176,7 +176,7 @@ const STATUS_REGISTRY = {
         description: "Raise the Power of Minus Coins by the effect's Count for one turn."
     },
     'hp_healing_down': {
-        name: 'HP Healing Down', type: 'negative', mode: 'single',
+        name: 'HP Healing Down', type: 'negative', mode: 'single', icon: 'https://imgur.com/5WYFFVt.png',
         description: "Decreases HP healing provided by Passive abilities, Skills, and Coin effects."
     },
     'poison': {


### PR DESCRIPTION
- Added visual `icon` URLs to `STATUS_REGISTRY` in `js/statusManager.js`
- Implemented 'Paralyze' mechanic in `calculateFinalPower` within `js/combatEngine.js`
- Updated all calls to `calculateFinalPower` to pass the `unit` context
- 'Paralyze' now correctly nullifies Heads (and cracked coins), intercepts Minus Coins effectively, and decrements per coin processing, auto-purging when the count hits 0.

---
*PR created automatically by Jules for task [9634851018138645325](https://jules.google.com/task/9634851018138645325) started by @sokcrow*