### PR TITLE
feat: Update Skill Builder with new effects and UI improvements

### DIFF
--- a/dm-combat-creator.html
+++ b/dm-combat-creator.html
@@ -311,8 +311,11 @@
         </div> <!-- End module-units -->
 
         <div id="module-skills" style="display: none;">
+
+        <button id="btn-start-skill-builder" style="width: 100%; padding: 15px; margin-bottom: 15px; background: #c49a00; color: #000; border: none; font-weight: bold; font-family: 'Bebas Neue', cursive; font-size: 20px; cursor: pointer;">[ INICIAR NUEVO CONSTRUCTOR DE SKILL ]</button>
+
         <!-- Constructor de Skills -->
-        <fieldset id="skill-builder-container" style="border: 1px solid #444; margin-bottom: 15px; padding: 10px;">
+        <fieldset id="skill-builder-container" style="border: 1px solid #444; margin-bottom: 15px; padding: 10px; display: none;">
             <legend>Constructor de Skills</legend>
 
             <div style="display:flex; gap: 5px; margin-bottom: 5px;">
@@ -321,13 +324,25 @@
             </div>
 
             <div style="display:flex; gap: 5px; margin-bottom: 5px;">
-                <label style="flex: 1;">Base Power: <input type="number" id="sb-base" value="4" style="width: 100%; background: #222; color: white; border: 1px solid #555;"></label>
-                <label style="flex: 1;">Coin Power: <input type="number" id="sb-coin-power" value="4" style="width: 100%; background: #222; color: white; border: 1px solid #555;"></label>
+                <label style="flex: 1;">
+                    Base Power: <input type="number" id="sb-base" value="4" style="width: 100%; background: #222; color: white; border: 1px solid #555;">
+                    <small style="color: #888; font-size: 10px; display: block; margin-top: 2px;">El poder base (mínimo) del ataque.</small>
+                </label>
+                <label style="flex: 1;">
+                    Coin Power: <input type="number" id="sb-coin-power" value="4" style="width: 100%; background: #222; color: white; border: 1px solid #555;">
+                    <small style="color: #888; font-size: 10px; display: block; margin-top: 2px;">El poder adicional que otorga cada moneda (cara).</small>
+                </label>
             </div>
 
             <div style="display:flex; gap: 5px; margin-bottom: 10px;">
-                <label style="flex: 1;">Coin Count: <input type="number" id="sb-coin-count" value="1" min="1" max="5" style="width: 100%; background: #222; color: white; border: 1px solid #555;"></label>
-                <label style="flex: 1;">Weight: <input type="number" id="sb-weight" value="1" min="1" style="width: 100%; background: #222; color: white; border: 1px solid #555;"></label>
+                <label style="flex: 1;">
+                    Coin Count: <input type="number" id="sb-coin-count" value="1" min="1" max="5" style="width: 100%; background: #222; color: white; border: 1px solid #555;">
+                    <small style="color: #888; font-size: 10px; display: block; margin-top: 2px;">Número de monedas (golpes/caras) del ataque.</small>
+                </label>
+                <label style="flex: 1;">
+                    Weight: <input type="number" id="sb-weight" value="1" min="1" style="width: 100%; background: #222; color: white; border: 1px solid #555;">
+                    <small style="color: #888; font-size: 10px; display: block; margin-top: 2px;">A cuántos objetivos golpea (1 es single-target).</small>
+                </label>
             </div>
 
             <!-- Deckbuilding & Equipment -->
@@ -712,6 +727,10 @@
                 document.getElementById('sb-coin-power').value = '4';
                 document.getElementById('sb-coin-count').value = '1';
                 document.getElementById('sb-coin-count').dispatchEvent(new Event('input'));
+
+                // Hide builder and show start button again
+                container.style.display = 'none';
+                document.getElementById('btn-start-skill-builder').style.display = 'block';
             });
         }
 
@@ -844,7 +863,7 @@
         function createEffectEditorHtml(isCoinEffect) {
             const triggers = isCoinEffect
                 ? `<option value="[On Hit]">[On Hit]</option><option value="[Heads]">[Heads]</option><option value="[Tails]">[Tails]</option>`
-                : `<option value="[On Use]">[On Use]</option><option value="[On Clash Win]">[On Clash Win]</option><option value="[On Clash Lose]">[On Clash Lose]</option>`;
+                : `<option value="[On Use]">[On Use]</option><option value="[Before Clash]">[Before Clash]</option><option value="[On Clash Win]">[On Clash Win]</option><option value="[On Clash Lose]">[On Clash Lose]</option>`;
 
             return `
                 <div class="effect-row" style="display:flex; gap: 5px; margin-bottom: 5px; background: #222; padding: 5px; border: 1px solid #444;">
@@ -992,6 +1011,11 @@
             // Trigger initial generation
             document.getElementById('sb-coin-count').dispatchEvent(new Event('input'));
 
+            document.getElementById('btn-start-skill-builder').addEventListener('click', () => {
+                const container = document.getElementById('skill-builder-container');
+                container.style.display = 'block';
+                document.getElementById('btn-start-skill-builder').style.display = 'none';
+            });
         }
 
         function switchTab(tabName) {

--- a/js/combatEngine.js
+++ b/js/combatEngine.js
@@ -498,6 +498,8 @@ const CombatEngine = {
         // [Clash Start]
         this.triggerEvent('[Clash Start]', contextA, [unitB]);
         this.triggerEvent('[Clash Start]', contextB, [unitA]);
+        this.triggerEvent('[Before Clash]', contextA, [unitB]);
+        this.triggerEvent('[Before Clash]', contextB, [unitA]);
 
 
         let round = 1;

--- a/js/statusManager.js
+++ b/js/statusManager.js
@@ -64,6 +64,24 @@ const STATUS_REGISTRY = {
         description: "Resource used by certain skills for additional effects."
     },
 
+    // --- INSTANT EFFECTS (HP/SP Recovery & Damage) ---
+    'heal_hp': {
+        name: 'Heal HP', type: 'positive', mode: 'single',
+        description: "Instantly restores HP based on the effect's Potency/Count."
+    },
+    'take_hp_dmg': {
+        name: 'Take HP DMG', type: 'negative', mode: 'single',
+        description: "Instantly takes HP Damage based on the effect's Potency/Count."
+    },
+    'heal_sp': {
+        name: 'Heal SP', type: 'positive', mode: 'single',
+        description: "Instantly restores SP (Sanity) based on the effect's Potency/Count."
+    },
+    'lose_sp': {
+        name: 'Lose SP', type: 'negative', mode: 'single',
+        description: "Instantly loses SP (Sanity) based on the effect's Potency/Count."
+    },
+
     // --- GENERIC BUFFS (Other Buffs) ---
     'power_up': {
         name: 'Power Up', type: 'positive', mode: 'single',
@@ -453,10 +471,6 @@ const StatusManager = {
         }
     }
 };
-
-if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { STATUS_REGISTRY, StatusManager };
-}
 
 if (typeof window !== 'undefined') {
     window.STATUS_REGISTRY = STATUS_REGISTRY;


### PR DESCRIPTION
Implement user requests for the Skill Builder:
- Add a button to show the builder interface, keeping it hidden by default.
- Add explanatory tooltips to the main stat fields.
- Add a `[Before Clash]` effect trigger.
- Support HP and SP modification through instant effects in `STATUS_REGISTRY`.
- Fix module export behavior in `statusManager.js` to run in vanilla JS correctly.

---
*PR created automatically by Jules for task [1850791076749781176](https://jules.google.com/task/1850791076749781176) started by @sokcrow*