### PR TITLE
Add Combat Animation Sprite Slots and Backend Schema

### DIFF
--- a/Battle-viewer.html
+++ b/Battle-viewer.html
@@ -332,6 +332,15 @@
         }
         const unit = combatData[data.id];
 
+        // Inicializar secuencias de ataque ocultas en backend
+        unit.attack_tier_1_sequence = unit.attack_tier_1_sequence || [];
+        unit.attack_tier_2_sequence = unit.attack_tier_2_sequence || [];
+        unit.attack_tier_3_sequence = unit.attack_tier_3_sequence || [];
+
+        if (window.CombatEngine && window.CombatEngine.initializeUnitAnimations) {
+            window.CombatEngine.initializeUnitAnimations(unit);
+        }
+
         // Inicializar actionSlots de forma explicita con array si no lo tiene
         if (!unit.slots) {
             unit.slots = Array.from({length: unit.actionSlots || 1}).map((_, i) => ({
@@ -409,7 +418,7 @@
                 ` : ''}
                 
                 <div class="sprite-anchor" id="anchor-${data.id}" style="bottom: ${unit.spriteY || 0}px; margin-left: ${unit.spriteX || 0}px; transform: scale(${unit.scale || 1});">
-                    <img src="${data.img}" class="sprite-img" onerror="this.src='https://via.placeholder.com/200x200/500/fff?text=Error'">
+                    <img src="${unit.current_sprite || data.img}" class="sprite-img" onerror="this.src='https://via.placeholder.com/200x200/500/fff?text=Error'">
                 </div>
 
                 <div class="floating-hp-group">

--- a/dm-combat-creator.html
+++ b/dm-combat-creator.html
@@ -335,6 +335,24 @@
             <label style="display:block; margin-bottom: 5px;">URL de Sprite:
                 <input type="text" id="spriteUrl" style="width: 100%; background: #222; color: white; border: 1px solid #555;">
             </label>
+            <label style="display:block; margin-bottom: 5px;">Idle Sprite:
+                <input type="text" id="idle_sprite" style="width: 100%; background: #222; color: white; border: 1px solid #555;">
+            </label>
+            <label style="display:block; margin-bottom: 5px;">Moving Sprite:
+                <input type="text" id="moving_sprite" style="width: 100%; background: #222; color: white; border: 1px solid #555;">
+            </label>
+            <label style="display:block; margin-bottom: 5px;">Guard Sprite:
+                <input type="text" id="guard_sprite" style="width: 100%; background: #222; color: white; border: 1px solid #555;">
+            </label>
+            <label style="display:block; margin-bottom: 5px;">Evade Sprite:
+                <input type="text" id="evade_sprite" style="width: 100%; background: #222; color: white; border: 1px solid #555;">
+            </label>
+            <label style="display:block; margin-bottom: 5px;">Hurt Sprite:
+                <input type="text" id="hurt_sprite" style="width: 100%; background: #222; color: white; border: 1px solid #555;">
+            </label>
+            <label style="display:block; margin-bottom: 5px;">Dead Sprite:
+                <input type="text" id="dead_sprite" style="width: 100%; background: #222; color: white; border: 1px solid #555;">
+            </label>
             <label style="display:flex; justify-content: space-between; margin-bottom: 5px;">Focused Encounter:
                 <input type="checkbox" id="isFocusedToggle">
             </label>
@@ -1052,7 +1070,10 @@
                         linkedPlayerUID: document.getElementById('metaLinkedNpc').value,
                         tags: document.getElementById('metaTags').value.split(',').map(s => s.trim()),
                         visual: currentState.visual,
-                        action_slots: unitActionSlots
+                        action_slots: unitActionSlots,
+                        attack_tier_1_sequence: [],
+                        attack_tier_2_sequence: [],
+                        attack_tier_3_sequence: []
                     };
 
                     if (!isPlayer) {
@@ -1350,6 +1371,12 @@
         let currentState = {
             visual: {
                 spriteUrl: "",
+                idle_sprite: "",
+                moving_sprite: "",
+                guard_sprite: "",
+                evade_sprite: "",
+                hurt_sprite: "",
+                dead_sprite: "",
                 scale: 1.0,
                 spriteX: 0,
                 spriteY: 0,
@@ -1962,6 +1989,12 @@
             };
 
             bindInput('spriteUrl', 'visual.spriteUrl');
+            bindInput('idle_sprite', 'visual.idle_sprite');
+            bindInput('moving_sprite', 'visual.moving_sprite');
+            bindInput('guard_sprite', 'visual.guard_sprite');
+            bindInput('evade_sprite', 'visual.evade_sprite');
+            bindInput('hurt_sprite', 'visual.hurt_sprite');
+            bindInput('dead_sprite', 'visual.dead_sprite');
             bindInput('isFocusedToggle', 'visual.isFocused');
             bindInput('scaleSlider', 'visual.scale', true);
             bindInput('spriteXSlider', 'visual.spriteX', true);
@@ -2034,6 +2067,12 @@
 
             // Update UI inputs
             if (document.getElementById('spriteUrl')) document.getElementById('spriteUrl').value = currentState.visual.spriteUrl || '';
+            if (document.getElementById('idle_sprite')) document.getElementById('idle_sprite').value = currentState.visual.idle_sprite || '';
+            if (document.getElementById('moving_sprite')) document.getElementById('moving_sprite').value = currentState.visual.moving_sprite || '';
+            if (document.getElementById('guard_sprite')) document.getElementById('guard_sprite').value = currentState.visual.guard_sprite || '';
+            if (document.getElementById('evade_sprite')) document.getElementById('evade_sprite').value = currentState.visual.evade_sprite || '';
+            if (document.getElementById('hurt_sprite')) document.getElementById('hurt_sprite').value = currentState.visual.hurt_sprite || '';
+            if (document.getElementById('dead_sprite')) document.getElementById('dead_sprite').value = currentState.visual.dead_sprite || '';
             if (document.getElementById('isFocusedToggle')) document.getElementById('isFocusedToggle').checked = currentState.visual.isFocused || false;
 
             if (document.getElementById('scaleSlider')) document.getElementById('scaleSlider').value = currentState.visual.scale;

--- a/js/combatEngine.js
+++ b/js/combatEngine.js
@@ -7,6 +7,27 @@ const RESONANCE_BONUS = {
 const CombatEngine = {
 // 0. Habilidades y Poder (Skills)
     // 0.5 Helper D&D
+    // 0.4 Initialization Helpers
+    initializeUnitAnimations: function(unit) {
+        if (!unit) return;
+
+        // Ensure visual animation state variables exist
+        unit.idle_sprite = unit.idle_sprite || unit.img || '';
+        unit.moving_sprite = unit.moving_sprite || '';
+        unit.guard_sprite = unit.guard_sprite || '';
+        unit.evade_sprite = unit.evade_sprite || '';
+        unit.hurt_sprite = unit.hurt_sprite || '';
+        unit.dead_sprite = unit.dead_sprite || '';
+
+        // Ensure attack sequence architecture arrays exist
+        unit.attack_tier_1_sequence = unit.attack_tier_1_sequence || [];
+        unit.attack_tier_2_sequence = unit.attack_tier_2_sequence || [];
+        unit.attack_tier_3_sequence = unit.attack_tier_3_sequence || [];
+
+        // At runtime, default current sprite to idle
+        unit.current_sprite = unit.idle_sprite;
+    },
+
     calculateResonance: function(actionQueue) {
         if (!actionQueue || actionQueue.length === 0) return;
 
@@ -268,6 +289,9 @@ const CombatEngine = {
     },
 
     resolveGuard: function(unitDefender, guardSkill) {
+        if (unitDefender && unitDefender.guard_sprite) {
+            unitDefender.current_sprite = unitDefender.guard_sprite;
+        }
         if (!guardSkill.coins) {
             guardSkill.coins = Array.from({length: guardSkill.coinAmount}, () => ({ type: guardSkill.coinType || 'standard', status: 'active' }));
         }
@@ -409,6 +433,9 @@ const CombatEngine = {
     },
 
     resolveEvade: function(unitDefender, evadeSkill, unitAttacker, attackSkill) {
+        if (unitDefender && unitDefender.evade_sprite) {
+            unitDefender.current_sprite = unitDefender.evade_sprite;
+        }
         let result = {
             evadeLogs: [],
             evadeDestroyed: false,
@@ -857,6 +884,10 @@ const CombatEngine = {
 
 // 0.8 Event-Driven System (Hooks)
     triggerEvent: function(tag, context, targetsHit = []) {
+        if (context && context.unitAttacker && context.unitAttacker.moving_sprite && (tag === '[On Attack]' || tag === '[Clash Start]')) {
+            context.unitAttacker.current_sprite = context.unitAttacker.moving_sprite;
+        }
+
         if (!context || !context.skill) return;
 
         // Collect all effects that match the tag from the skill root
@@ -893,6 +924,10 @@ const CombatEngine = {
         if (!allUnits || !Array.isArray(allUnits)) return;
 
         for (let unit of allUnits) {
+            // Restore idle sprite on certain phases if not dead
+            if (unit.hp > 0 && unit.idle_sprite && (phaseTag === '[Phase Start]' || phaseTag === '[Round Start]')) {
+                unit.current_sprite = unit.idle_sprite;
+            }
             // Unidades pueden tener efectos pasivos en root (skills pasivas, equipamiento)
             // que queremos disparar aquí. Asumimos que unit.passives es un arreglo de habilidades/efectos.
             if (!unit.passives) continue;
@@ -1057,6 +1092,11 @@ const CombatEngine = {
 
     // 2. Sistema de Escudos (Shield) y Daño (Aplicación)
     applyDamage: function(unit, damage, tipoDaño = 'directo', isCritical = false, skillUsed = null) {
+        if (unit.hurt_sprite) {
+            unit.current_sprite = unit.hurt_sprite;
+            // Un motor real de animaciones regresaría esto a idle con un timeout o trigger,
+            // pero por ahora el modelo dicta mapear la lógica base
+        }
         // Híbrido D&D: Si la habilidad es Spell o Roll, no se aplica daño automático.
         if (skillUsed && (skillUsed.type === 'Spell' || skillUsed.type === 'Roll' || skillUsed.type === 'Save')) {
             return { hp: unit.hp, shield: unit.shield, message: 'Daño automático omitido por tipo de habilidad (Spell/Roll).' };
@@ -1115,6 +1155,10 @@ const CombatEngine = {
     },
 
     checkStagger: function(unit) {
+        if (unit.hp <= 0 && unit.dead_sprite) {
+            unit.current_sprite = unit.dead_sprite;
+        }
+
         if (!unit.staggerThresholds || unit.staggerThresholds.length === 0) return;
         if (!unit.maxHp || unit.maxHp <= 0) return;
 


### PR DESCRIPTION
This implements the UI and structural foundation required for the combat animation engine, injecting new fields exclusively into the Combat Creator. It establishes logical mapping for the unit's active sprite based on battle events, preserving strict boundaries between Theatre (Narrative) and Combat (Gameplay) modules.

---
*PR created automatically by Jules for task [9046423842621540551](https://jules.google.com/task/9046423842621540551) started by @sokcrow*