### PR TITLE
Implement Coin-Level Triggers in Combat Engine

### DIFF
--- a/dm-combat-creator.html
+++ b/dm-combat-creator.html
@@ -1491,7 +1491,7 @@
 
                 function createEffectEditorHtml(isCoinEffect) {
             const triggers = isCoinEffect
-                ? `<option value="[On Hit]">[On Hit]</option><option value="[Heads]">[Heads]</option><option value="[Tails]">[Tails]</option>`
+                ? `<option value="[On Hit]">[On Hit]</option><option value="[Heads]">[Heads]</option><option value="[Tails]">[Tails]</option><option value="[Before Attack]">[Before Attack]</option><option value="[On Unopposed Attack]">[On Unopposed Attack]</option><option value="[Attack End]">[Attack End]</option><option value="[Before Getting Hit]">[Before Getting Hit]</option><option value="[On Kill]">[On Kill]</option>`
                 : `<option value="[On Use]">[On Use]</option><option value="[Before Clash]">[Before Clash]</option><option value="[On Clash Win]">[On Clash Win]</option><option value="[On Clash Lose]">[On Clash Lose]</option>`;
 
             const statGridHtml = generateStatGridItems();

--- a/js/combatEngine.js
+++ b/js/combatEngine.js
@@ -333,10 +333,15 @@ const CombatEngine = {
         }
 
         this.triggerEvent('[Before Attack]', context, [unitDefender]);
-        this.triggerEvent('[On Unopposed Attack]', context, [unitDefender]);
 
-        let defContext = { engine: this, attacker: unitAttacker, defender: unitDefender, skill: attackSkill };
-        this.triggerEvent('[Before Getting Hit]', defContext, [unitDefender]);
+        if (!options.clashResult) {
+            this.triggerEvent('[On Unopposed Attack]', context, [unitDefender]);
+        }
+
+        if (counterSkill) {
+            let defContext = { engine: this, attacker: unitAttacker, defender: unitDefender, skill: counterSkill };
+            this.triggerEvent('[Before Getting Hit]', defContext, [unitDefender]);
+        }
 
         let activeAttackCoins = attackSkill.coins.filter(c => c.status === 'active' || c.status === 'cracked' || c.status === 'latent');
         let probAttacker = this.getCoinProbability(unitAttacker.sp || 0);
@@ -397,10 +402,15 @@ const CombatEngine = {
             let clashCount = options.clashCount || 0; // options.clashCount could be passed if from a clash, else 0
             let finalDamage = this.calculateCoinDamage(unitAttacker, unitDefender, attackSkill, attackPower, false, clashCount);
 
+            let hpBeforeHit = unitDefender.hp;
             let applyDmgResult = this.applyDamage(unitDefender, finalDamage, 'directo', false, attackSkill);
             context.damageDealt = finalDamage;
 
             this.triggerEvent('[On Hit]', context, [unitDefender]);
+
+            if (hpBeforeHit > 0 && unitDefender.hp <= 0) {
+                this.triggerEvent('[On Kill]', context, [unitDefender]);
+            }
 
             // If they just won a clash
             if (options.clashResult === 'Win') {
@@ -894,6 +904,18 @@ const CombatEngine = {
         let applicableEffects = [];
         if (context.skill.effects) {
             applicableEffects.push(...context.skill.effects.filter(e => e.tag === tag));
+        }
+
+        // For some global tags, we need to scan all active coins in the skill
+        let globalCoinTags = ['[Before Attack]', '[On Unopposed Attack]', '[Attack End]', '[Before Getting Hit]'];
+        if (globalCoinTags.includes(tag) && context.skill.coins) {
+            for (let coin of context.skill.coins) {
+                if (coin.status === 'active' || coin.status === 'cracked' || coin.status === 'latent') {
+                    if (coin.effects) {
+                        applicableEffects.push(...coin.effects.filter(e => e.tag === tag));
+                    }
+                }
+            }
         }
 
         // If context has a currentCoin, collect effects from that coin too


### PR DESCRIPTION
Added 5 new execution triggers for coin-level effects (`[Before Attack]`, `[On Unopposed Attack]`, `[Attack End]`, `[Before Getting Hit]`, `[On Kill]`). UI correctly isolates them for coin effects, and the engine correctly executes them at the specified timings.

---
*PR created automatically by Jules for task [11248544948202150604](https://jules.google.com/task/11248544948202150604) started by @sokcrow*