### PR TITLE
Math Engine Refactor: Separate damage_dealt and damage_taken multipliers

### DIFF
--- a/dm-combat-creator.html
+++ b/dm-combat-creator.html
@@ -2500,7 +2500,8 @@
                     <option value="coin_power">Coin Power</option>
                     <option value="base_power">Base Power</option>
                     <option value="final_power">Final Power</option>
-                    <option value="damage_multiplier">Damage Multiplier (x0.1)</option>
+                    <option value="damage_dealt_multiplier">Damage Dealt Multiplier (x0.1)</option>
+                    <option value="damage_taken_multiplier">Damage Taken Multiplier (x0.1)</option>
                     <option value="healing_multiplier">Healing Multiplier</option>
                     <option value="speed">Speed</option>
                     <option value="resource">Resource</option>

--- a/fix_registry_again.js
+++ b/fix_registry_again.js
@@ -56,7 +56,7 @@ content = content.replace(
 // Elemental Up
 content = content.replace(
     /name: `\$\{type\} DMG Up`,.*?rules: \[.*?\]/s,
-    "name: `${type} DMG Up`,\n            type: 'positive',\n            mode: 'single',\n            rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'damage_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}]"
+    "name: `${type} DMG Up`,\n            type: 'positive',\n            mode: 'single',\n            rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'damage_dealt_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}]"
 );
 content = content.replace(
     /name: `\$\{type\} Power Up`,.*?rules: \[.*?\]/s,
@@ -64,13 +64,13 @@ content = content.replace(
 );
 content = content.replace(
     /name: `\$\{type\} Protection`,.*?rules: \[.*?\]/s,
-    "name: `${type} Protection`,\n            type: 'positive',\n            mode: 'single',\n            rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'damage_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}]"
+    "name: `${type} Protection`,\n            type: 'positive',\n            mode: 'single',\n            rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'damage_taken_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}]"
 );
 
 // Elemental Down
 content = content.replace(
     /name: `\$\{type\} DMG Down`,.*?rules: \[.*?\]/s,
-    "name: `${type} DMG Down`,\n            type: 'negative',\n            mode: 'single',\n            rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'sub', aff_input: 1, affectation: 'damage_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}]"
+    "name: `${type} DMG Down`,\n            type: 'negative',\n            mode: 'single',\n            rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'sub', aff_input: 1, affectation: 'damage_dealt_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}]"
 );
 content = content.replace(
     /name: `\$\{type\} Power Down`,.*?rules: \[.*?\]/s,
@@ -78,14 +78,14 @@ content = content.replace(
 );
 content = content.replace(
     /name: `\$\{type\} Fragility`,.*?rules: \[.*?\]/s,
-    "name: `${type} Fragility`,\n            type: 'negative',\n            mode: 'single',\n            rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'sub', aff_input: 1, affectation: 'damage_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}]"
+    "name: `${type} Fragility`,\n            type: 'negative',\n            mode: 'single',\n            rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'sub', aff_input: 1, affectation: 'damage_taken_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}]"
 );
 
 
 // Generic buffs
 content = content.replace(
     /name: 'Damage Up',.*?\],/s,
-    "name: 'Damage Up', type: 'positive', mode: 'single', maxCount: 10, icon: 'https://imgur.com/KDLYRCR.png',\n        rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'damage_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],"
+    "name: 'Damage Up', type: 'positive', mode: 'single', maxCount: 10, icon: 'https://imgur.com/KDLYRCR.png',\n        rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'damage_dealt_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],"
 );
 content = content.replace(
     /name: 'Haste',.*?\],/s,
@@ -93,7 +93,7 @@ content = content.replace(
 );
 content = content.replace(
     /name: 'Protection',.*?\],/s,
-    "name: 'Protection', type: 'positive', mode: 'single', maxCount: 10, icon: 'https://imgur.com/yjPgnjd.png',\n        rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'damage_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],"
+    "name: 'Protection', type: 'positive', mode: 'single', maxCount: 10, icon: 'https://imgur.com/yjPgnjd.png',\n        rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'damage_taken_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],"
 );
 content = content.replace(
     /name: 'Plus Coin Boost',.*?\],/s,
@@ -105,7 +105,7 @@ content = content.replace(
 );
 content = content.replace(
     /name: 'Weak-resist DMG Boost',.*?\],/s,
-    "name: 'Weak-resist DMG Boost', type: 'positive', mode: 'single',\n        rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'damage_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],"
+    "name: 'Weak-resist DMG Boost', type: 'positive', mode: 'single',\n        rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'damage_dealt_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],"
 );
 content = content.replace(
     /name: 'HP Healing Boost',.*?\],/s,
@@ -143,7 +143,7 @@ content = content.replace(
 );
 content = content.replace(
     /name: 'Damage Down',.*?\],/s,
-    "name: 'Damage Down', type: 'negative', mode: 'single', maxCount: 10, icon: 'https://imgur.com/bo7reA0.png',\n        rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'sub', aff_input: 1, affectation: 'damage_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],"
+    "name: 'Damage Down', type: 'negative', mode: 'single', maxCount: 10, icon: 'https://imgur.com/bo7reA0.png',\n        rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'sub', aff_input: 1, affectation: 'damage_dealt_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],"
 );
 content = content.replace(
     /name: 'Bind',.*?\],/s,
@@ -151,7 +151,7 @@ content = content.replace(
 );
 content = content.replace(
     /name: 'Fragile',.*?\],/s,
-    "name: 'Fragile', type: 'negative', mode: 'single', maxCount: 10, icon: 'https://imgur.com/wSFboZT.png',\n        rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'sub', aff_input: 1, affectation: 'damage_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],"
+    "name: 'Fragile', type: 'negative', mode: 'single', maxCount: 10, icon: 'https://imgur.com/wSFboZT.png',\n        rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'sub', aff_input: 1, affectation: 'damage_taken_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],"
 );
 content = content.replace(
     /name: 'Paralyze',.*?\],/s,
@@ -182,7 +182,7 @@ let engine = fs.readFileSync('js/combatEngine.js', 'utf8');
 // I have done this above. We just need to make sure the engine handles empty affectations correctly.
 engine = engine.replace(
     /if \(affectation\) \{.*?\}\n\s*\}/s,
-    "if (affectation && affectation !== '') {\n                    if (affectation === 'hp') {\n                        finalDmg = effectValue;\n                        if (rule.operation === 'sub') {\n                            this.applyDamage(unit, finalDmg, 'efecto_estado');\n                        } else if (rule.operation === 'add') {\n                            unit.hp = Math.min(unit.hp + finalDmg, unit.maxHp || unit.hp);\n                        } else if (rule.operation === 'set') {\n                            unit.hp = Math.min(finalDmg, unit.maxHp || unit.hp);\n                        }\n                    } else if (affectation === 'sp') {\n                        if (rule.operation === 'sub') {\n                            unit.sp = this.limitSP((unit.sp || 0) - effectValue);\n                        } else if (rule.operation === 'add') {\n                            unit.sp = this.limitSP((unit.sp || 0) + effectValue);\n                        } else if (rule.operation === 'set') {\n                            unit.sp = this.limitSP(effectValue);\n                        }\n                    } else if (affectation === 'stagger_threshold') {\n                         if (rule.operation === 'add') {\n                             this.modifyNextStaggerThreshold(unit, effectValue);\n                         } else if (rule.operation === 'sub') {\n                             this.modifyNextStaggerThreshold(unit, -effectValue);\n                         }\n                    } else if (affectation === 'damage_multiplier' || affectation === 'healing_multiplier' || affectation === 'speed' || affectation === 'resource' || affectation === 'defensive_level' || affectation === 'offensive_level' || affectation === 'clash_power' || affectation === 'coin_power' || affectation === 'base_power' || affectation === 'final_power') {\n                        if (context && typeof context === 'object') {\n                            if (!context.modifiers) context.modifiers = {};\n                            if (!context.modifiers[affectation]) context.modifiers[affectation] = 0;\n                            \n                            if (rule.operation === 'add') context.modifiers[affectation] += effectValue;\n                            if (rule.operation === 'sub') context.modifiers[affectation] -= effectValue;\n                            if (rule.operation === 'mult') context.modifiers[affectation] *= effectValue;\n                            if (rule.operation === 'div' && effectValue !== 0) context.modifiers[affectation] /= effectValue;\n                            if (rule.operation === 'set') context.modifiers[affectation] = effectValue;\n                        }\n                    }\n                }"
+    "if (affectation && affectation !== '') {\n                    let actualAffectation = affectation === 'damage_multiplier' ? 'damage_dealt_multiplier' : affectation;\n                    if (actualAffectation === 'hp') {\n                        finalDmg = effectValue;\n                        if (rule.operation === 'sub') {\n                            this.applyDamage(unit, finalDmg, 'efecto_estado');\n                        } else if (rule.operation === 'add') {\n                            unit.hp = Math.min(unit.hp + finalDmg, unit.maxHp || unit.hp);\n                        } else if (rule.operation === 'set') {\n                            unit.hp = Math.min(finalDmg, unit.maxHp || unit.hp);\n                        }\n                    } else if (actualAffectation === 'sp') {\n                        if (rule.operation === 'sub') {\n                            unit.sp = this.limitSP((unit.sp || 0) - effectValue);\n                        } else if (rule.operation === 'add') {\n                            unit.sp = this.limitSP((unit.sp || 0) + effectValue);\n                        } else if (rule.operation === 'set') {\n                            unit.sp = this.limitSP(effectValue);\n                        }\n                    } else if (actualAffectation === 'stagger_threshold') {\n                         if (rule.operation === 'add') {\n                             this.modifyNextStaggerThreshold(unit, effectValue);\n                         } else if (rule.operation === 'sub') {\n                             this.modifyNextStaggerThreshold(unit, -effectValue);\n                         }\n                    } else if (actualAffectation === 'damage_dealt_multiplier' || actualAffectation === 'damage_taken_multiplier' || actualAffectation === 'healing_multiplier' || actualAffectation === 'speed' || actualAffectation === 'resource' || actualAffectation === 'defensive_level' || actualAffectation === 'offensive_level' || actualAffectation === 'clash_power' || actualAffectation === 'coin_power' || actualAffectation === 'base_power' || actualAffectation === 'final_power') {\n                        if (context && typeof context === 'object') {\n                            if (!context.modifiers) context.modifiers = {};\n                            if (!context.modifiers[actualAffectation]) context.modifiers[actualAffectation] = 0;\n                            \n                            if (rule.operation === 'add') context.modifiers[actualAffectation] += effectValue;\n                            if (rule.operation === 'sub') context.modifiers[actualAffectation] -= effectValue;\n                            if (rule.operation === 'mult') context.modifiers[actualAffectation] *= effectValue;\n                            if (rule.operation === 'div' && effectValue !== 0) context.modifiers[actualAffectation] /= effectValue;\n                            if (rule.operation === 'set') context.modifiers[actualAffectation] = effectValue;\n                        }\n                    }\n                }"
 );
 
 fs.writeFileSync('js/combatEngine.js', engine, 'utf8');

--- a/js/combatEngine.js
+++ b/js/combatEngine.js
@@ -1138,7 +1138,8 @@ const CombatEngine = {
         if (!unit || !unit.statusEffects) return {};
 
         let modifiers = {
-            damage_multiplier: 0,
+            damage_dealt_multiplier: 0,
+            damage_taken_multiplier: 0,
             healing_multiplier: 0,
             final_power: 0,
             base_power: 0,
@@ -1227,7 +1228,10 @@ const CombatEngine = {
                 let affectation = rule.affectation;
 
                 if (affectation && affectation !== '') {
-                    if (affectation === 'hp') {
+                    // Legacy Fallback for older skills
+                    let actualAffectation = affectation === 'damage_multiplier' ? 'damage_dealt_multiplier' : affectation;
+
+                    if (actualAffectation === 'hp') {
                         finalDmg = effectValue;
                         if (rule.operation === 'sub') {
                             this.applyDamage(unit, finalDmg, 'efecto_estado');
@@ -1236,7 +1240,7 @@ const CombatEngine = {
                         } else if (rule.operation === 'set') {
                             unit.hp = Math.min(finalDmg, unit.maxHp || unit.hp);
                         }
-                    } else if (affectation === 'sp') {
+                    } else if (actualAffectation === 'sp') {
                         if (rule.operation === 'sub') {
                             unit.sp = this.limitSP((unit.sp || 0) - effectValue);
                         } else if (rule.operation === 'add') {
@@ -1244,22 +1248,22 @@ const CombatEngine = {
                         } else if (rule.operation === 'set') {
                             unit.sp = this.limitSP(effectValue);
                         }
-                    } else if (affectation === 'stagger_threshold') {
+                    } else if (actualAffectation === 'stagger_threshold') {
                          if (rule.operation === 'add') {
                              this.modifyNextStaggerThreshold(unit, effectValue);
                          } else if (rule.operation === 'sub') {
                              this.modifyNextStaggerThreshold(unit, -effectValue);
                          }
-                    } else if (affectation === 'damage_multiplier' || affectation === 'healing_multiplier' || affectation === 'speed' || affectation === 'resource' || affectation === 'defensive_level' || affectation === 'offensive_level' || affectation === 'clash_power' || affectation === 'coin_power' || affectation === 'base_power' || affectation === 'final_power' || affectation === 'defense_power') {
+                    } else if (actualAffectation === 'damage_dealt_multiplier' || actualAffectation === 'damage_taken_multiplier' || actualAffectation === 'healing_multiplier' || actualAffectation === 'speed' || actualAffectation === 'resource' || actualAffectation === 'defensive_level' || actualAffectation === 'offensive_level' || actualAffectation === 'clash_power' || actualAffectation === 'coin_power' || actualAffectation === 'base_power' || actualAffectation === 'final_power' || actualAffectation === 'defense_power') {
                         if (context && typeof context === 'object') {
                             if (!context.modifiers) context.modifiers = {};
-                            if (!context.modifiers[affectation]) context.modifiers[affectation] = 0;
+                            if (!context.modifiers[actualAffectation]) context.modifiers[actualAffectation] = 0;
 
-                            if (rule.operation === 'add') context.modifiers[affectation] += effectValue;
-                            if (rule.operation === 'sub') context.modifiers[affectation] -= effectValue;
-                            if (rule.operation === 'mult') context.modifiers[affectation] *= effectValue;
-                            if (rule.operation === 'div' && effectValue !== 0) context.modifiers[affectation] /= effectValue;
-                            if (rule.operation === 'set') context.modifiers[affectation] = effectValue;
+                            if (rule.operation === 'add') context.modifiers[actualAffectation] += effectValue;
+                            if (rule.operation === 'sub') context.modifiers[actualAffectation] -= effectValue;
+                            if (rule.operation === 'mult') context.modifiers[actualAffectation] *= effectValue;
+                            if (rule.operation === 'div' && effectValue !== 0) context.modifiers[actualAffectation] /= effectValue;
+                            if (rule.operation === 'set') context.modifiers[actualAffectation] = effectValue;
                         }
                     }
 
@@ -1435,8 +1439,8 @@ const CombatEngine = {
         // Passive modifiers
         let attackerMods = this.applyPassiveModifiers(attacker);
         let defenderMods = this.applyPassiveModifiers(defender);
-        let dmgMultiplierMod = attackerMods.damage_multiplier || 0;
-        let defDmgMultiplierMod = defenderMods.damage_multiplier || 0;
+        let dmgDealtMultiplierMod = attackerMods.damage_dealt_multiplier || 0;
+        let dmgTakenMultiplierMod = defenderMods.damage_taken_multiplier || 0;
 
         let staggerLevel = defender.staggerLevel || 0;
         let isStaggered = defender.isStaggered || false;
@@ -1468,29 +1472,19 @@ const CombatEngine = {
 
         let totalStaticMod = physMod + sinMod + levelMod + critMod + clashMod;
 
-        // Daño Base
-        let baseDamage = Math.floor(coinFinalPower * (1 + totalStaticMod) * (1 + (dmgMultiplierMod * 0.1)) * Math.max(0.1, (1 - (defDmgMultiplierMod * 0.1))));
+        // --- NUEVA ARQUITECTURA DE CÁLCULO DE DAÑO (La Regla del 0.1) ---
+        // Paso 1: Cálculo de poder en bruto
+        let rawDamage = coinFinalPower * (1 + totalStaticMod);
 
-        // 4. Modificadores Dinámicos (Planos)
-        let dynamicMod = 0;
+        // Paso 3: Aplicación del modificador ofensivo (Damage Dealt Multiplier del atacante)
+        let offMult = Math.max(0, 1.0 + (dmgDealtMultiplierMod * 0.1));
+        let damageWithOffensive = rawDamage * offMult;
 
-        // Efectos del defensor (Fragile, Protection, etc.)
-        if (defender.statusEffects) {
-            if (defender.statusEffects['Fragile']) dynamicMod += defender.statusEffects['Fragile'];
-            if (defender.statusEffects['Protection']) dynamicMod -= defender.statusEffects['Protection'];
-            // Asume otros estados aquí si es necesario, o usa un bucle.
-        }
+        // Paso 4: Paso Final: Aplicación del modificador defensivo (Damage Taken Multiplier del objetivo)
+        let defMult = Math.max(0, 1.0 - (dmgTakenMultiplierMod * 0.1));
+        let damageWithDefensive = damageWithOffensive * defMult;
 
-        // Efectos del atacante (Damage Up, Damage Down, etc.)
-        if (attacker.statusEffects) {
-            if (attacker.statusEffects['Damage Up']) dynamicMod += attacker.statusEffects['Damage Up'];
-            if (attacker.statusEffects['Damage Down']) dynamicMod -= attacker.statusEffects['Damage Down'];
-        }
-
-        let damageWithDynamic = baseDamage + dynamicMod;
-
-        // 5. Límite de Daño Mínimo (5% o 1) envolviendo a los Modificadores Dinámicos
-        let finalDamage = Math.max(damageWithDynamic, Math.floor(coinFinalPower * 0.05), 1);
+        let finalDamage = Math.max(Math.floor(damageWithDefensive), 0);
 
         // 6. Attack Adders (Daño Adicional Condicional)
         let attackAdders = 0;

--- a/js/statusManager.js
+++ b/js/statusManager.js
@@ -60,7 +60,7 @@ const STATUS_REGISTRY = {
     },
     'damage_up': {
         name: 'Damage Up', type: 'positive', mode: 'single', maxCount: 10, icon: 'https://imgur.com/KDLYRCR.png',
-        rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'damage_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
+        rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'damage_dealt_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
         description: "Deal 10% more damage with skills based on the effect's Count for one turn. (Max 10)"
     },
     'haste': {
@@ -70,7 +70,7 @@ const STATUS_REGISTRY = {
     },
     'protection': {
         name: 'Protection', type: 'positive', mode: 'single', maxCount: 10, icon: 'https://imgur.com/yjPgnjd.png',
-        rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'damage_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
+        rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'damage_taken_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
         description: "Take 10% less damage per Count from attacks for one turn. (Max 10)"
     },
     'plus_coin_boost': {
@@ -85,7 +85,7 @@ const STATUS_REGISTRY = {
     },
     'weak_resist_dmg_boost': {
         name: 'Weak-resist DMG Boost', type: 'positive', mode: 'single',
-        rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'damage_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
+        rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'damage_dealt_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
         description: "Boost the damage of attacks against Weak resistances by 1% per Count for one turn."
     },
     'hp_healing_boost': {
@@ -132,7 +132,7 @@ const STATUS_REGISTRY = {
     },
     'damage_down': {
         name: 'Damage Down', type: 'negative', mode: 'single', maxCount: 10, icon: 'https://imgur.com/bo7reA0.png',
-        rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'sub', aff_input: 1, affectation: 'damage_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
+        rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'sub', aff_input: 1, affectation: 'damage_dealt_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
         description: "Deal 10% less damage with skills per Count for one turn. (Max 10)"
     },
     'bind': {
@@ -142,7 +142,7 @@ const STATUS_REGISTRY = {
     },
     'fragile': {
         name: 'Fragile', type: 'negative', mode: 'single', maxCount: 10, icon: 'https://imgur.com/wSFboZT.png',
-        rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'sub', aff_input: 1, affectation: 'damage_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
+        rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'sub', aff_input: 1, affectation: 'damage_taken_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
         description: "Take 10% more damage from skills per Count for one turn. (Max 10)"
     },
     'paralyze': {
@@ -187,7 +187,7 @@ const generateElementalStatuses = () => {
             name: `${type} DMG Up`,
             type: 'positive',
             mode: 'single',
-            rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'damage_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
+            rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'damage_dealt_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
             maxCount: 10,
             description: `Deal 10% more damage with ${type} skills per Count for one turn. (Max 10)`
         };
@@ -204,7 +204,7 @@ const generateElementalStatuses = () => {
             name: `${type} Protection`,
             type: 'positive',
             mode: 'single',
-            rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'damage_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
+            rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'damage_taken_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
             maxCount: 10,
             description: `Take 10% less damage from ${type} skills per Count for one turn. (Max 10)`
         };
@@ -213,7 +213,7 @@ const generateElementalStatuses = () => {
             name: `${type} DMG Down`,
             type: 'negative',
             mode: 'single',
-            rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'sub', aff_input: 1, affectation: 'damage_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
+            rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'sub', aff_input: 1, affectation: 'damage_dealt_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
             maxCount: 10,
             description: `Deal 10% less damage with ${type} skills per Count for one turn. (Max 10)`
         };
@@ -230,7 +230,7 @@ const generateElementalStatuses = () => {
             name: `${type} Fragility`,
             type: 'negative',
             mode: 'single',
-            rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'sub', aff_input: 1, affectation: 'damage_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
+            rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'sub', aff_input: 1, affectation: 'damage_taken_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
             maxCount: 10,
             description: `Take 10% more damage from ${type} skills per Count for one turn. (Max 10)`
         };


### PR DESCRIPTION
Implemented a structural shift in the combat engine's damage math according to user specifications. Split `damage_multiplier` into `damage_dealt_multiplier` and `damage_taken_multiplier`. Adapted the calculation logic in `combatEngine.js` to strictly follow: 1) Raw Damage, 2) Resistances, 3) Offensive modifier, 4) Defensive modifier. Added a fallback to maintain compatibility with legacy JSON data, and updated `statusManager.js`, `dm-combat-creator.html`, and `fix_registry_again.js` to correctly assign statuses to their new directional multiplier. Capped damage modifiers to prevent negative values from healing the defender.

---
*PR created automatically by Jules for task [4190417536233074533](https://jules.google.com/task/4190417536233074533) started by @sokcrow*