### PR TITLE
feat: Skill Evolution Engine & UI Injections

### DIFF
--- a/dm-combat-creator.html
+++ b/dm-combat-creator.html
@@ -754,6 +754,55 @@
                 <div id="sb-coins-container"></div>
             </div>
 
+
+            <!-- Skill Evolution Module -->
+            <div style="border-top: 1px dashed #555; margin-top: 10px; padding-top: 10px; background: #1a0a0a; border: 1px solid #500; padding: 10px; border-radius: 4px;">
+                <h3 style="margin-top: 0; color: #ff4a22; font-family: 'Cinzel', serif; font-size: 14px;">[ MUTACIÓN DE HABILIDAD (Skill Evolution) ]</h3>
+                <label style="display:flex; justify-content: space-between; font-size: 11px; margin-bottom: 5px;">Habilitar Mutación
+                    <input type="checkbox" id="sb-evo-enable" onchange="document.getElementById('sb-evo-config').style.display = this.checked ? 'block' : 'none'">
+                </label>
+                <div id="sb-evo-config" style="display: none; border-left: 2px solid #8a0303; padding-left: 10px; margin-top: 5px;">
+                    <label style="display:flex; justify-content: space-between; font-size: 11px; margin-bottom: 5px;">Target Skill ID
+                        <select id="sb-evo-target-id" style="width: 150px; background: #000; color: #fff; border: 1px solid #444;">
+                            <option value="">-- Seleccionar --</option>
+                        </select>
+                    </label>
+                    <label style="display:flex; justify-content: space-between; font-size: 11px; margin-bottom: 5px;">Condition Target
+                        <select id="sb-evo-target" style="width: 150px; background: #000; color: #fff; border: 1px solid #444;">
+                            <option value="Self">Self</option>
+                            <option value="Target">Target</option>
+                        </select>
+                    </label>
+                    <label style="display:flex; justify-content: space-between; font-size: 11px; margin-bottom: 5px;">Condition Type
+                        <select id="sb-evo-cond-type" style="width: 150px; background: #000; color: #fff; border: 1px solid #444;">
+                            <option value="hp_percent">HP %</option>
+                            <option value="status_potency">Status Potency</option>
+                            <option value="status_count">Status Count</option>
+                        </select>
+                    </label>
+                    <label style="display:flex; justify-content: space-between; font-size: 11px; margin-bottom: 5px;">Status ID (si aplica)
+                        <input type="text" id="sb-evo-status-id" placeholder="Ej. burn" style="width: 150px; background: #000; color: #fff; border: 1px solid #444;">
+                    </label>
+                    <div style="display: flex; gap: 5px; margin-bottom: 5px;">
+                        <label style="font-size: 11px; flex: 1;">Operador
+                            <select id="sb-evo-operator" style="width: 100%; background: #000; color: #fff; border: 1px solid #444;">
+                                <option value="<"><</option>
+                                <option value="<="><=</option>
+                                <option value="=">=</option>
+                                <option value=">=">>=</option>
+                                <option value=">">></option>
+                            </select>
+                        </label>
+                        <label style="font-size: 11px; flex: 1;">Valor
+                            <input type="number" id="sb-evo-value" style="width: 100%; background: #000; color: #fff; border: 1px solid #444;">
+                        </label>
+                    </div>
+                    <label style="display:flex; justify-content: space-between; font-size: 11px; margin-top: 5px;">Evolución Permanente
+                        <input type="checkbox" id="sb-evo-permanent">
+                    </label>
+                </div>
+            </div>
+
             <div style="margin-top: 15px;">
                 <button type="button" id="save-skill-db-btn" onclick="saveSkillToDB()" style="width: 100%; padding: 8px; margin-top: 5px; background: #8a0303; color: white; border: none; cursor: pointer; font-weight: bold;">[ GUARDAR HABILIDAD EN DB ]</button>
             </div>
@@ -980,6 +1029,7 @@
             db.ref('campaña/base_datos_skills/').once('value').then(snap => {
                 allGlobalSkills = snap.val() || {};
                 renderSkillModalList('');
+                updateEvolutionDropdown();
             });
         }
 
@@ -1079,6 +1129,15 @@
                 document.getElementById('sb-coin-count').dispatchEvent(new Event('input'));
 
                 document.getElementById('sb-global-effects-container').innerHTML = '';
+                document.getElementById('sb-evo-enable').checked = false;
+                document.getElementById('sb-evo-enable').dispatchEvent(new Event('change'));
+                document.getElementById('sb-evo-target-id').value = '';
+                document.getElementById('sb-evo-target').value = 'Self';
+                document.getElementById('sb-evo-cond-type').value = 'hp_percent';
+                document.getElementById('sb-evo-status-id').value = '';
+                document.getElementById('sb-evo-operator').value = '<';
+                document.getElementById('sb-evo-value').value = '';
+                document.getElementById('sb-evo-permanent').checked = false;
 
                 // Hide builder and show start button again
                 container.style.display = 'none';
@@ -1677,10 +1736,28 @@
                 renderStatusDirectory(snap.val());
             });
 
-            db.ref('campaña/base_datos_skills/').on('value', (snap) => {
+                        db.ref('campaña/base_datos_skills/').on('value', (snap) => {
                 allGlobalSkills = snap.val() || {};
                 filterSkillDirectory();
+                updateEvolutionDropdown();
             });
+        function updateEvolutionDropdown() {
+            const select = document.getElementById('sb-evo-target-id');
+            if(!select) return;
+            const currentValue = select.value;
+            select.innerHTML = '<option value="">-- Seleccionar --</option>';
+            if(allGlobalSkills) {
+                Object.entries(allGlobalSkills).forEach(([id, skill]) => {
+                    const option = document.createElement('option');
+                    option.value = id;
+                    option.textContent = skill.name + " (" + id + ")";
+                    select.appendChild(option);
+                });
+            }
+            if(currentValue && allGlobalSkills[currentValue]) {
+                select.value = currentValue;
+            }
+        }
         }
 
         function filterSkillDirectory() {
@@ -2116,6 +2193,19 @@
                 effects: gatherEffects(document.getElementById('sb-global-effects-container')),
                 coins: []
             };
+
+            if (document.getElementById('sb-evo-enable').checked) {
+                const conditionValue = parseFloat(document.getElementById('sb-evo-value').value);
+                skillObj.evolution = {
+                    target_skill_id: document.getElementById('sb-evo-target-id').value,
+                    condition_target: document.getElementById('sb-evo-target').value,
+                    condition_type: document.getElementById('sb-evo-cond-type').value,
+                    condition_status_id: document.getElementById('sb-evo-status-id').value,
+                    condition_operator: document.getElementById('sb-evo-operator').value,
+                    condition_value: isNaN(conditionValue) ? 0 : conditionValue,
+                    is_permanent: document.getElementById('sb-evo-permanent').checked
+                };
+            }
 
             if (isDefense) {
                 skillObj.defenseSubtype = document.getElementById('sb-defense-subtype').value;

--- a/js/combatEngine.js
+++ b/js/combatEngine.js
@@ -24,6 +24,15 @@ const CombatEngine = {
         unit.attack_tier_2_sequence = unit.attack_tier_2_sequence || [];
         unit.attack_tier_3_sequence = unit.attack_tier_3_sequence || [];
 
+        // Initialize Original Sequences Memory (Base State Reversion)
+        if (!unit.original_sequences) {
+            unit.original_sequences = {
+                tier_1: JSON.parse(JSON.stringify(unit.attack_tier_1_sequence)),
+                tier_2: JSON.parse(JSON.stringify(unit.attack_tier_2_sequence)),
+                tier_3: JSON.parse(JSON.stringify(unit.attack_tier_3_sequence))
+            };
+        }
+
         // At runtime, default current sprite to idle
         unit.current_sprite = unit.idle_sprite;
     },
@@ -1384,6 +1393,83 @@ const CombatEngine = {
 
 
 
+    // Skill Evolution Mutation Scanner
+    // Skill Evolution Mutation Scanner
+    scanSkillEvolutions: function(unit, allUnits) {
+        if (!unit.original_sequences) return;
+
+        const evaluateCondition = (evolution, targetUnit) => {
+            if (!targetUnit) return false;
+            let val = 0;
+            if (evolution.condition_type === 'hp_percent') {
+                val = (targetUnit.hp / (targetUnit.maxHp || 1)) * 100;
+            } else if (evolution.condition_type === 'status_potency') {
+                const status = (targetUnit.statuses || []).find(s => s.id === evolution.condition_status_id);
+                val = status ? status.potency : 0;
+            } else if (evolution.condition_type === 'status_count') {
+                const status = (targetUnit.statuses || []).find(s => s.id === evolution.condition_status_id);
+                val = status ? status.count : 0;
+            }
+
+            const targetVal = parseFloat(evolution.condition_value) || 0;
+            switch (evolution.condition_operator) {
+                case '<': return val < targetVal;
+                case '<=': return val <= targetVal;
+                case '=': return val === targetVal;
+                case '>=': return val >= targetVal;
+                case '>': return val > targetVal;
+                default: return false;
+            }
+        };
+
+        const processSequence = (activeSeq, originalSeq) => {
+            for (let i = 0; i < activeSeq.length; i++) {
+                // Siempre partimos desde la base (la habilidad original)
+                // A menos que hayamos mutado permanentemente y sobrescrito el original
+                let currentBaseId = originalSeq[i];
+                let skill = window.SKILL_REGISTRY ? window.SKILL_REGISTRY[currentBaseId] : null;
+
+                let nextEvolvedId = currentBaseId; // The ID we will end up with
+                let depth = 0;
+
+                while (skill && skill.evolution && depth < 10) {
+                    depth++; // Max depth to prevent infinite loops
+
+                    let conditionPassed = false;
+
+                    if (skill.evolution.condition_target === 'Self') {
+                        conditionPassed = evaluateCondition(skill.evolution, unit);
+                    } else if (skill.evolution.condition_target === 'Target') {
+                        // We check if ANY enemy meets the condition
+                        const enemies = allUnits.filter(u => u.hp > 0 && u.isPlayer !== unit.isPlayer);
+                        conditionPassed = enemies.some(enemy => evaluateCondition(skill.evolution, enemy));
+                    }
+
+                    if (conditionPassed) {
+                        nextEvolvedId = skill.evolution.target_skill_id;
+
+                        // Si la mutacion es permanente, actualizamos la memoria base para que no retroceda
+                        if (skill.evolution.is_permanent) {
+                            originalSeq[i] = nextEvolvedId;
+                        }
+
+                        // Para soporte de cadena (Tier 3), obtenemos la nueva habilidad inyectada y re-evaluamos en el while
+                        skill = window.SKILL_REGISTRY ? window.SKILL_REGISTRY[nextEvolvedId] : null;
+                    } else {
+                        break; // Condition failed, stop evolving this chain
+                    }
+                }
+
+                // Aplicamos la habilidad resultante a la secuencia activa
+                activeSeq[i] = nextEvolvedId;
+            }
+        };
+
+        processSequence(unit.attack_tier_1_sequence, unit.original_sequences.tier_1);
+        processSequence(unit.attack_tier_2_sequence, unit.original_sequences.tier_2);
+        processSequence(unit.attack_tier_3_sequence, unit.original_sequences.tier_3);
+    },
+
     triggerPhase: function(phaseTag, allUnits) {
         if (!allUnits || !Array.isArray(allUnits)) return;
 
@@ -1421,6 +1507,11 @@ const CombatEngine = {
                     }
                 }
                 unit.delayed_effects = []; // Clear buffer
+            }
+
+            // Skill Evolution Dynamic Mutation (After delayed effects, before action generation)
+            if (phaseTag === '[Round Start]' && unit.hp > 0) {
+                this.scanSkillEvolutions(unit, allUnits);
             }
 
             // Unidades pueden tener efectos pasivos en root (skills pasivas, equipamiento)


### PR DESCRIPTION
This PR implements a massive architectural upgrade to the combat engine by introducing the "Skill Evolution" system. This empowers skills to dynamically mutate into other skills during the `[Round Start]` phase depending on real-time board state (HP thresholds, Status Effect potencies/counts). The engine safely uses a cloned `original_sequences` memory block to allow skills to revert/cool down on subsequent rounds if the condition is no longer met, unless explicitly flagged as permanent by the DM.

**Key changes:**
- UI: Added a dedicated Skill Evolution configuration block in the Skill Builder form (`dm-combat-creator.html`).
- Engine Initialization: Clones base sequences to `original_sequences` for safe reversion.
- Engine Logic: Evaluates conditions against Self or Target(Any Enemy) dynamically before action selection.
- Chaining Support: The logic gracefully continues to evaluate if an injected skill also possesses its own evolution condition.

---
*PR created automatically by Jules for task [8205961484961292681](https://jules.google.com/task/8205961484961292681) started by @sokcrow*