### PR TITLE
Fix data blindness via legacy fallback injections

### DIFF
--- a/Battle-viewer.html
+++ b/Battle-viewer.html
@@ -337,8 +337,8 @@
         unit.attack_tier_2_sequence = unit.attack_tier_2_sequence || [];
         unit.attack_tier_3_sequence = unit.attack_tier_3_sequence || [];
 
-        if (window.CombatEngine && window.CombatEngine.initializeUnitAnimations) {
-            window.CombatEngine.initializeUnitAnimations(unit);
+        if (window.CombatEngine && window.CombatEngine.initializeUnitData) {
+            window.CombatEngine.initializeUnitData(unit);
         }
 
         // Inicializar actionSlots de forma explicita con array si no lo tiene

--- a/dm-combat-creator.html
+++ b/dm-combat-creator.html
@@ -916,6 +916,24 @@
 
 
     <script>
+
+        // FALLBACK FUNCTIONS TO PREVENT DATA BLINDNESS
+        window.applySkillFallbacks = function(skill) {
+            if (!skill || typeof skill !== 'object') return skill;
+            if (!('evolution_chain' in skill)) skill.evolution_chain = null;
+            if (!skill.effects) skill.effects = [];
+            // Any other fallback for skill maxCap or global modifiers
+            return skill;
+        };
+
+        window.processSkillsData = function(skills) {
+            if (!skills) return skills;
+            for (let key in skills) {
+                skills[key] = window.applySkillFallbacks(skills[key]);
+            }
+            return skills;
+        };
+
         const firebaseConfig = {
             apiKey: "AIzaSyAIVIuKgXUsdrb9Mmss9PH7R3FpWAMG2hU",
             authDomain: "luminous-system.firebaseapp.com",
@@ -1027,7 +1045,7 @@
 
         function loadSkillsIntoModal() {
             db.ref('campaña/base_datos_skills/').once('value').then(snap => {
-                allGlobalSkills = snap.val() || {};
+                allGlobalSkills = window.processSkillsData(snap.val()) || {};
                 renderSkillModalList('');
                 updateEvolutionDropdown();
             });
@@ -1737,7 +1755,7 @@
             });
 
                         db.ref('campaña/base_datos_skills/').on('value', (snap) => {
-                allGlobalSkills = snap.val() || {};
+                allGlobalSkills = window.processSkillsData(snap.val()) || {};
                 filterSkillDirectory();
                 updateEvolutionDropdown();
             });

--- a/dm-item-creator.html
+++ b/dm-item-creator.html
@@ -823,6 +823,24 @@
 
         // On Load
         document.addEventListener('DOMContentLoaded', () => {
+        // FALLBACK FUNCTIONS TO PREVENT DATA BLINDNESS
+        window.applyItemFallbacks = function(item) {
+            if (!item || typeof item !== 'object') return item;
+            item.price = item.price !== undefined ? item.price : 0;
+            item.max_stash = item.max_stash !== undefined ? item.max_stash : 99;
+            item.max_inventory = item.max_inventory !== undefined ? item.max_inventory : 99;
+            if (!('evolution_chain' in item)) item.evolution_chain = null;
+            return item;
+        };
+
+        window.processItemsData = function(items) {
+            if (!items) return items;
+            for (let key in items) {
+                items[key] = window.applyItemFallbacks(items[key]);
+            }
+            return items;
+        };
+
             fetchFirebaseDropdowns();
             listenToDatabase();
             // Iniciar con 2 ingredientes por defecto en el panel de recetas
@@ -863,14 +881,14 @@
         function listenToDatabase() {
             // Listen to Items
             db.ref('campaña/base_datos_items').on('value', snap => {
-                dbItems = snap.val() || {};
+                dbItems = window.processItemsData(snap.val()) || {};
                 updateSynthesisResultOptions();
                 renderDirectory();
             });
 
             // Listen to Augmentations
             db.ref('campaña/base_datos_aumentos').on('value', snap => {
-                dbAugmentations = snap.val() || {};
+                dbAugmentations = window.processItemsData(snap.val()) || {};
                 renderDirectory();
             });
 

--- a/js/combatEngine.js
+++ b/js/combatEngine.js
@@ -8,6 +8,16 @@ const CombatEngine = {
 // 0. Habilidades y Poder (Skills)
     // 0.5 Helper D&D
     // 0.4 Initialization Helpers
+        initializeUnitData: function(unit) {
+        if (!unit) return;
+        if (unit.took_damage_this_turn === undefined) unit.took_damage_this_turn = false;
+        if (unit.took_damage_last_turn === undefined) unit.took_damage_last_turn = false;
+        if (!unit.delayed_effects) unit.delayed_effects = [];
+        if (!unit.next_turn_buffer) unit.next_turn_buffer = [];
+        if (unit.damage_dealt_multiplier === undefined) unit.damage_dealt_multiplier = 1.0;
+        if (unit.damage_taken_multiplier === undefined) unit.damage_taken_multiplier = 1.0;
+        this.initializeUnitAnimations(unit);
+    },
     initializeUnitAnimations: function(unit) {
         if (!unit) return;
 

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -1549,6 +1549,44 @@
       </style>
 
       <script>
+
+// FALLBACK FUNCTIONS TO PREVENT DATA BLINDNESS
+window.applyItemFallbacks = function(item) {
+    if (!item || typeof item !== 'object') return item;
+    item.price = item.price !== undefined ? item.price : 0;
+    item.max_stash = item.max_stash !== undefined ? item.max_stash : 99;
+    item.max_inventory = item.max_inventory !== undefined ? item.max_inventory : 99;
+    if (!('evolution_chain' in item)) item.evolution_chain = null;
+    return item;
+};
+
+window.applyEntityFallbacks = function(entity) {
+    if (!entity || typeof entity !== 'object') return entity;
+    if (entity.took_damage_this_turn === undefined) entity.took_damage_this_turn = false;
+    if (entity.took_damage_last_turn === undefined) entity.took_damage_last_turn = false;
+    if (!entity.delayed_effects) entity.delayed_effects = [];
+    if (!entity.next_turn_buffer) entity.next_turn_buffer = [];
+    if (entity.damage_dealt_multiplier === undefined) entity.damage_dealt_multiplier = 1.0;
+    if (entity.damage_taken_multiplier === undefined) entity.damage_taken_multiplier = 1.0;
+    return entity;
+};
+
+window.processItemsData = function(items) {
+    if (!items) return items;
+    for (let key in items) {
+        items[key] = window.applyItemFallbacks(items[key]);
+    }
+    return items;
+};
+
+window.processEntitiesData = function(entities) {
+    if (!entities) return entities;
+    for (let key in entities) {
+        entities[key] = window.applyEntityFallbacks(entities[key]);
+    }
+    return entities;
+};
+
         function toggleWeatherManager() {
             const container = document.getElementById('weather-manager-container');
             const icon = document.getElementById('wm-toggle-icon');
@@ -4554,7 +4592,7 @@
 
         // Asegurarse de renderizar cuando la DB de jugadores cambie también
         const originalJugadoresListener = db.ref("campaña/jugadores").on("value", (snapshot) => {
-          dbJugadoresCache = snapshot.val() || {};
+          dbJugadoresCache = window.processEntitiesData(snapshot.val()) || {};
           renderActorAsignacion();
           renderRolTurns();
         });
@@ -5716,7 +5754,7 @@
 
         // Poblar checkboxes y select cuando jugadores cambian
         db.ref("campaña/jugadores/").on("value", (snapshot) => {
-            const jugadores = snapshot.val();
+          const jugadores = window.processEntitiesData(snapshot.val());
             if (contratoJugadoresCheckboxes) {
                 const checked = Array.from(contratoJugadoresCheckboxes.querySelectorAll('input:checked')).map(cb => cb.value);
                 contratoJugadoresCheckboxes.innerHTML = '';
@@ -5986,7 +6024,7 @@
 
         db.ref("campaña/jugadores/").on("value", (snapshot) => {
           bancoContainer.innerHTML = "";
-          const jugadores = snapshot.val();
+          const jugadores = window.processEntitiesData(snapshot.val());
           window.jugadoresData = jugadores; // Guarda para el modal
 
           const pendingContainer = document.getElementById(
@@ -6577,7 +6615,7 @@
 
             const stashRef = db.ref("campaña/jugadores/" + jugador + "/inventario_stash");
             stashRef.once("value", snap => {
-                const stash = snap.val() || {};
+                const stash = window.processItemsData(snap.val()) || {};
                 let foundKey = null;
                 for (const [k, v] of Object.entries(stash)) {
                     if (v.nombre === selectedItemToOtorgar.nombre && (v.tier || 'I') === (selectedItemToOtorgar.tier || 'I')) {
@@ -6618,7 +6656,7 @@
 
             const activoRef = db.ref("campaña/jugadores/" + jugador + "/inventario_activo");
             activoRef.once("value", snap => {
-                const activo = snap.val() || {};
+                const activo = window.processItemsData(snap.val()) || {};
                 let foundKey = null;
                 for (const [k, v] of Object.entries(activo)) {
                     if (v.nombre === selectedItemToOtorgar.nombre && (v.tier || 'I') === (selectedItemToOtorgar.tier || 'I')) {
@@ -6645,7 +6683,7 @@
 
         // Sincronizar cambios de jugadores en el select
         db.ref("campaña/jugadores").on("value", (snap) => {
-            dbJugadoresCache = snap.val() || {};
+          dbJugadoresCache = window.processEntitiesData(snap.val()) || {};
             window.dbJugadoresCache = dbJugadoresCache;
             updateOtorgarJugadoresSelect();
         });
@@ -6773,7 +6811,7 @@
 
         // Escuchar base_datos_items
         db.ref("campaña/base_datos_items").on("value", (snapshot) => {
-            const items = snapshot.val();
+            const items = window.processItemsData(snapshot.val());
             window.dbItemsCache = items || {};
             dbItemsCache = window.dbItemsCache; // Fallback sync
             renderGlobalItemsAndAugments();
@@ -6796,7 +6834,7 @@
 
         // Escuchar base_datos_aumentos
         db.ref("campaña/base_datos_aumentos").on("value", (snapshot) => {
-            window.dbAugmentationsCache = snapshot.val() || {};
+            window.dbAugmentationsCache = window.processItemsData(snapshot.val()) || {};
             renderGlobalItemsAndAugments();
         });
 
@@ -7020,6 +7058,13 @@
         db.ref("campaña/tiendas").on("value", (snapshot) => {
           gridTiendas.innerHTML = "";
           const tiendas = snapshot.val();
+          if (tiendas) {
+              for (let tId in tiendas) {
+                  if (tiendas[tId].items) {
+                      tiendas[tId].items = window.processItemsData(tiendas[tId].items);
+                  }
+              }
+          }
 
           const fragmentTiendas = document.createDocumentFragment();
 
@@ -8138,7 +8183,7 @@
 
         // Escuchar actores para la lista y el select
         db.ref("campaña/actores").on("value", (snapshot) => {
-          dbActoresCache = snapshot.val() || {};
+          dbActoresCache = window.processEntitiesData(snapshot.val()) || {};
           renderListaActores();
           renderActorAsignacion();
         });


### PR DESCRIPTION
Resolves the architecture red alert where legacy Items, NPCs, Players, and Skills lacking new structure parameters were failing to render or causing system collapses. Null-safety fallbacks and empty arrays are now injected in-memory upon database read.

---
*PR created automatically by Jules for task [676379131667264074](https://jules.google.com/task/676379131667264074) started by @sokcrow*