### PR TITLE
feat: implement dynamic crit rate and strict damage/power up tagging architecture

### DIFF
--- a/dm-combat-creator.html
+++ b/dm-combat-creator.html
@@ -1035,6 +1035,35 @@
                         </label>
                     </div>
 
+                    <div class="sb-row">
+                        <label class="sb-block-label">Damage Type Tag (Damage/Power Up):
+                            <select id="sb-status-damage-type">
+                                <option value="">(None)</option>
+                                <option value="Blunt">Blunt</option>
+                                <option value="Pierce">Pierce</option>
+                                <option value="Slash">Slash</option>
+                            </select>
+                        </label>
+                        <label class="sb-block-label">Sin Affinity Tag (Damage/Power Up):
+                            <select id="sb-status-sin-affinity">
+                                <option value="">(None)</option>
+                                <option value="Wrath">Wrath</option>
+                                <option value="Lust">Lust</option>
+                                <option value="Sloth">Sloth</option>
+                                <option value="Gluttony">Gluttony</option>
+                                <option value="Gloom">Gloom</option>
+                                <option value="Pride">Pride</option>
+                                <option value="Envy">Envy</option>
+                            </select>
+                        </label>
+                    </div>
+
+                    <div class="sb-row">
+                        <label class="sb-block-label">Crit Vulnerability per Count:
+                            <input type="number" step="0.01" id="sb-status-crit-vuln" placeholder="0.0">
+                        </label>
+                    </div>
+
                     <label class="sb-block-label">URL del Asset Visual (Ícono): <input type="text" id="sb-status-icon"></label>
 
                     <fieldset id="sb-rules-container" style="margin-top: 10px; border: 1px solid #b8943b;">
@@ -3054,6 +3083,10 @@
             document.getElementById('sb-status-mode').value = status.mode || 'single';
             document.getElementById('sb-status-tag').value = status.type || status.tag || 'neutral';
 
+            document.getElementById('sb-status-damage-type').value = status.damage_type_tag || '';
+            document.getElementById('sb-status-sin-affinity').value = status.sin_affinity_tag || '';
+            document.getElementById('sb-status-crit-vuln').value = status.crit_vulnerability_per_count !== undefined ? status.crit_vulnerability_per_count : '';
+
             const iconInput = document.getElementById('sb-status-icon');
             iconInput.value = status.icon || '';
 
@@ -3113,6 +3146,9 @@
                 icon: document.getElementById('sb-status-icon').value.trim(),
                 mode: document.getElementById('sb-status-mode').value,
                 type: document.getElementById('sb-status-tag').value,
+                damage_type_tag: document.getElementById('sb-status-damage-type').value || null,
+                sin_affinity_tag: document.getElementById('sb-status-sin-affinity').value || null,
+                crit_vulnerability_per_count: parseFloat(document.getElementById('sb-status-crit-vuln').value) || null,
                 rules: rules,
                 // Nullify legacy fields
                 trigger: null,

--- a/dm-combat-creator.html
+++ b/dm-combat-creator.html
@@ -1036,7 +1036,7 @@
                     </div>
 
                     <div class="sb-row">
-                        <label class="sb-block-label">Damage Type Tag (Damage/Power Up):
+                        <label class="sb-block-label">Damage Type Tag (Damage/Power/Protection/Fragility):
                             <select id="sb-status-damage-type">
                                 <option value="">(None)</option>
                                 <option value="Blunt">Blunt</option>
@@ -1044,7 +1044,7 @@
                                 <option value="Slash">Slash</option>
                             </select>
                         </label>
-                        <label class="sb-block-label">Sin Affinity Tag (Damage/Power Up):
+                        <label class="sb-block-label">Sin Affinity Tag (Damage/Power/Protection/Fragility):
                             <select id="sb-status-sin-affinity">
                                 <option value="">(None)</option>
                                 <option value="Wrath">Wrath</option>

--- a/js/combatEngine.js
+++ b/js/combatEngine.js
@@ -430,12 +430,35 @@ const CombatEngine = {
             // Apply damage physically to process HP and Stagger states
             let clashCount = options.clashCount || 0; // options.clashCount could be passed if from a clash, else 0
 
-            let isCritical = false;
-            if (unitAttacker.statusEffects && unitAttacker.statusEffects['poise'] > 0) {
-                // Future poise integration can override this logic.
-                // Assuming it's calculated elsewhere or we hook into it.
-                // We'll leave it as false unless overridden, but the code structure handles it.
+            // 1. Modulo de Tasa Critica (Crit Rate & Poise)
+            let baseCritRate = 0.05;
+            let poiseBonus = 0;
+
+            // Poise del atacante
+            if (unitAttacker.statusEffects && unitAttacker.statusEffects['poise']) {
+                let p_count = typeof unitAttacker.statusEffects['poise'] === 'object' ? (unitAttacker.statusEffects['poise'].count || 1) : unitAttacker.statusEffects['poise'];
+                poiseBonus = p_count * 0.05;
             }
+
+            // Vulnerabilidad Critica del Defensor
+            let critVulnerabilityBonus = 0;
+            if (unitDefender.statusEffects) {
+                let activeStatuses = Object.keys(unitDefender.statusEffects);
+                for (let statusId of activeStatuses) {
+                    let statusConfig = null;
+                    if (typeof window !== 'undefined' && window.STATUS_REGISTRY) statusConfig = window.STATUS_REGISTRY[statusId];
+                    if (!statusConfig && typeof STATUS_REGISTRY !== 'undefined') statusConfig = STATUS_REGISTRY[statusId];
+
+                    if (statusConfig && statusConfig.crit_vulnerability_per_count) {
+                        let statusInstance = unitDefender.statusEffects[statusId];
+                        let count = typeof statusInstance === 'object' ? (statusInstance.count || 1) : (typeof statusInstance === 'number' ? statusInstance : 1);
+                        critVulnerabilityBonus += (statusConfig.crit_vulnerability_per_count * count);
+                    }
+                }
+            }
+
+            let finalCritRate = baseCritRate + poiseBonus + critVulnerabilityBonus;
+            let isCritical = Math.random() < finalCritRate;
 
             let finalDamage = this.calculateCoinDamage(unitAttacker, unitDefender, attackSkill, attackPower, isCritical, clashCount, context);
 
@@ -726,8 +749,8 @@ const CombatEngine = {
             let powerA = this.calculateFinalPower(skillA, tossesA, unitA);
             let powerB = this.calculateFinalPower(skillB, tossesB, unitB);
 
-            if (!skillA.isDefense) powerA += (this.applyPassiveModifiers(unitA).clash_power || 0);
-            if (!skillB.isDefense) powerB += (this.applyPassiveModifiers(unitB).clash_power || 0);
+            if (!skillA.isDefense) powerA += (this.applyPassiveModifiers(unitA, { skill: skillA }).clash_power || 0);
+            if (!skillB.isDefense) powerB += (this.applyPassiveModifiers(unitB, { skill: skillB }).clash_power || 0);
 
             let roundWinner = powerA > powerB ? 'A' : (powerB > powerA ? 'B' : 'Tie');
 
@@ -919,7 +942,7 @@ const CombatEngine = {
             }
         }
 
-        let passiveMods = unit ? this.applyPassiveModifiers(unit) : {};
+        let passiveMods = unit ? this.applyPassiveModifiers(unit, { skill: skill }) : {};
         let finalActualBasePower = basePowerOverride !== null ? basePowerOverride : skill.basePower;
         let finalActualCoinPower = coinPowerOverride !== null ? coinPowerOverride : skill.coinPower;
         let finalPowerBonus = 0;
@@ -1220,7 +1243,7 @@ const CombatEngine = {
 
 
 
-    applyPassiveModifiers: function(unit) {
+    applyPassiveModifiers: function(unit, contextOptions = null) {
         if (!unit || !unit.statusEffects) return {};
 
         let modifiers = {
@@ -1256,6 +1279,24 @@ const CombatEngine = {
 
             for (let rule of statusConfig.rules) {
                 if (rule.trigger !== 'passive') continue;
+
+                // 2 & 3. Segregacion de etiquetas de Damage y Power Up
+                if (contextOptions && contextOptions.skill) {
+                    let skill = contextOptions.skill;
+
+                    if (statusConfig.damage_type_tag) {
+                        let skillDamageType = skill.damageType || skill.type;
+                        if (skillDamageType !== statusConfig.damage_type_tag) {
+                            continue; // Validacion falla, ignorar regla
+                        }
+                    }
+                    if (statusConfig.sin_affinity_tag) {
+                        let skillAffinity = skill.affinity;
+                        if (skillAffinity !== statusConfig.sin_affinity_tag) {
+                            continue; // Validacion falla, ignorar regla
+                        }
+                    }
+                }
 
                 let potency = typeof statusInstance === 'object' ? (statusInstance.potency || 1) : 1;
                 let count = typeof statusInstance === 'object' ? (statusInstance.count || 1) : (typeof statusInstance === 'number' ? statusInstance : 1);
@@ -1631,8 +1672,8 @@ const CombatEngine = {
     // Nueva función para calcular el daño por moneda con modificadores planos
         calculateCoinDamage: function(attacker, defender, skill, coinFinalPower, isCritical, clashCount, context = null) {
         // Passive modifiers
-        let attackerMods = this.applyPassiveModifiers(attacker);
-        let defenderMods = this.applyPassiveModifiers(defender);
+        let attackerMods = this.applyPassiveModifiers(attacker, { skill: skill });
+        let defenderMods = this.applyPassiveModifiers(defender, { skill: skill });
         let dmgDealtMultiplierMod = attackerMods.damage_dealt_multiplier || 0;
         let dmgTakenMultiplierMod = defenderMods.damage_taken_multiplier || 0;
 

--- a/js/statusManager.js
+++ b/js/statusManager.js
@@ -183,10 +183,14 @@ const generateElementalStatuses = () => {
     allTypes.forEach(type => {
         const idPrefix = type.toLowerCase();
 
+        const isSinType = SIN_TYPES.includes(type);
+        const tagKey = isSinType ? 'sin_affinity_tag' : 'damage_type_tag';
+
         STATUS_REGISTRY[`${idPrefix}_dmg_up`] = {
             name: `${type} DMG Up`,
             type: 'positive',
             mode: 'single',
+            [tagKey]: type,
             rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'damage_dealt_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
             maxCount: 10,
             description: `Deal 10% more damage with ${type} skills per Count for one turn. (Max 10)`
@@ -196,6 +200,7 @@ const generateElementalStatuses = () => {
             name: `${type} Power Up`,
             type: 'positive',
             mode: 'single',
+            [tagKey]: type,
             rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'final_power', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
             description: `${type} skills gain final Power by the effect's Count for one turn.`
         };
@@ -213,6 +218,7 @@ const generateElementalStatuses = () => {
             name: `${type} DMG Down`,
             type: 'negative',
             mode: 'single',
+            [tagKey]: type,
             rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'sub', aff_input: 1, affectation: 'damage_dealt_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
             maxCount: 10,
             description: `Deal 10% less damage with ${type} skills per Count for one turn. (Max 10)`
@@ -222,6 +228,7 @@ const generateElementalStatuses = () => {
             name: `${type} Power Down`,
             type: 'negative',
             mode: 'single',
+            [tagKey]: type,
             rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'sub', aff_input: 1, affectation: 'final_power', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
             description: `${type} skills lose final Power by the effect's Count for one turn.`
         };

--- a/js/statusManager.js
+++ b/js/statusManager.js
@@ -209,6 +209,7 @@ const generateElementalStatuses = () => {
             name: `${type} Protection`,
             type: 'positive',
             mode: 'single',
+            [tagKey]: type,
             rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'damage_taken_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
             maxCount: 10,
             description: `Take 10% less damage from ${type} skills per Count for one turn. (Max 10)`
@@ -237,6 +238,7 @@ const generateElementalStatuses = () => {
             name: `${type} Fragility`,
             type: 'negative',
             mode: 'single',
+            [tagKey]: type,
             rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'sub', aff_input: 1, affectation: 'damage_taken_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
             maxCount: 10,
             description: `Take 10% more damage from ${type} skills per Count for one turn. (Max 10)`


### PR DESCRIPTION
This PR completes the required architectural restructuring of the combat engine to resolve mathematical bleeding across damage up modifiers and implements the new Poise and Critical Rate evaluation engine.

### Core Changes:
- **Crit Rate & Poise Module:** The engine now evaluates an actual probability calculation immediately before coin damage resolution, driven by a 5% baseline, +5% per count of Poise on the attacker, and an open hook `crit_vulnerability_per_count` for defensive vulnerabilities on the target.
- **Strict Architecture for Modifiers:** The abstract `applyPassiveModifiers` now accepts `{ skill: ... }` context. If a status configures `damage_type_tag` or `sin_affinity_tag`, the rule is strictly evaluated and bypassed if the skill does not mathematically match the requested affinity. 
- **Power Up Specifics:** Now natively segregated. Because `applyPassiveModifiers` acts dynamically, 'Power Ups' tied to an affinity/damage type affect Clash and Base combat correctly without spilling over to unrelated skills.
- **Status Builder UI Expansion:** Dropdowns and inputs were added to `dm-combat-creator.html` to allow Dungeon Masters to assign damage type tags, sin tags, and crit vulnerability vectors cleanly. Hardcoded fallback statuses in `statusManager.js` were updated to self-declare these properties dynamically at initialization.

All local UI Playwright tests pass cleanly.

---
*PR created automatically by Jules for task [4997415817188646484](https://jules.google.com/task/4997415817188646484) started by @sokcrow*