### PR TITLE
feat: add Crit DMG Up status effect

### DIFF
--- a/dm-combat-creator.html
+++ b/dm-combat-creator.html
@@ -3050,6 +3050,7 @@
                     <option value="final_power">Final Power</option>
                     <option value="damage_dealt_multiplier">Damage Dealt Multiplier (x0.1)</option>
                     <option value="damage_taken_multiplier">Damage Taken Multiplier (x0.1)</option>
+                    <option value="crit_damage_multiplier">Crit Damage Multiplier (x0.1)</option>
                     <option value="healing_multiplier">Healing Multiplier</option>
                     <option value="speed">Speed</option>
                     <option value="resource">Resource</option>

--- a/js/combatEngine.js
+++ b/js/combatEngine.js
@@ -1258,7 +1258,8 @@ const CombatEngine = {
             defensive_level: 0,
             speed: 0,
             resource: 0,
-            coin_power: 0
+            coin_power: 0,
+            crit_damage_multiplier: 0
         };
 
         const activeStatuses = Object.keys(unit.statusEffects);
@@ -1698,7 +1699,8 @@ const CombatEngine = {
         let levelMod = (offLevel - defLevel) / (Math.abs(offLevel - defLevel) + 25);
 
         // 3. Modificadores por Crítico y Choque
-        let critMod = isCritical ? 0.2 : 0;
+        let critDmgUpMod = attackerMods.crit_damage_multiplier || 0;
+        let critMod = isCritical ? 0.2 + (critDmgUpMod * 0.1) : 0;
         let cCount = clashCount || 0;
         let clashMod = 0;
         if (cCount >= 1) {

--- a/js/statusManager.js
+++ b/js/statusManager.js
@@ -28,6 +28,11 @@ const STATUS_REGISTRY = {
         rules: [{trigger: 'on_crit', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'sub_count_1'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'sub_count_1'}],
         description: "All skills gain Final Power by the effect's Count for one turn."
     },
+    'crit_dmg_up': {
+        name: 'Crit DMG Up', type: 'positive', mode: 'single', icon: 'https://limbuscompany.wiki.gg/images/Crit_DMG_Up.png?fd7a3d=&format=original',
+        rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'crit_damage_multiplier', decay: 'none'}, {trigger: 'on_round_end', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 0, affectation: '', decay: 'total_loss'}],
+        description: "Critical attacks deal 10% more damage per Count for one turn."
+    },
     'attack_power_up': {
         name: 'Attack Power Up', type: 'positive', mode: 'single', icon: 'https://imgur.com/JbDs4X0.png',
         trigger: 'on_round_end', rules: [{trigger: 'passive', cond_input: 1, cond_type: 'count', operation: 'add', aff_input: 1, affectation: 'final_power', decay: 'total_loss'}],


### PR DESCRIPTION
Adds the new 'Crit DMG Up' status effect and backend modifier integration to scale critical hits by 10% per count of the effect.

---
*PR created automatically by Jules for task [16836224469724680676](https://jules.google.com/task/16836224469724680676) started by @sokcrow*