### PR TITLE
Rework Immobilized status lifecycle and combat restrictions

### DIFF
--- a/Battle-viewer.html
+++ b/Battle-viewer.html
@@ -569,6 +569,9 @@
         const allySlots = document.querySelectorAll('.action-slot-wrapper[data-faction="ally"]');
         if (allySlots.length === 0) return;
         enemySlots.forEach(eSlot => {
+            const baseId = eSlot.id.split('_slot_')[0];
+            if (combatData[baseId] && combatData[baseId].isImmobilized) return;
+
             const randomAlly = allySlots[Math.floor(Math.random() * allySlots.length)];
             slotTargets[eSlot.id] = randomAlly.id;
         });
@@ -583,6 +586,9 @@
         let availableEnemies = [...enemySlotsNodes];
 
         allySlotsNodes.forEach(ally => {
+            const baseId = ally.id.split('_slot_')[0];
+            if (combatData[baseId] && combatData[baseId].isImmobilized) return;
+
             let allyId = ally.id; let targetId = null;
             let directAttacker = enemySlotsNodes.find(e => slotTargets[e.id] === allyId);
             if (directAttacker) { targetId = directAttacker.id; } 
@@ -682,6 +688,11 @@
         function handleDragStart(e) {
             const slot = e.target.closest('.action-slot-wrapper');
             if (slot && slot.dataset.faction === 'ally') {
+                const baseId = slot.id.split('_slot_')[0];
+                if (combatData[baseId] && combatData[baseId].isImmobilized) {
+                    addLogEntry(`[ INMOVILIZADO ] - ${combatData[baseId].name} no puede asignar objetivos.`, 'interrupt');
+                    return;
+                }
                 isDragging = true; dragStartSlotId = slot.id;
                 const coords = getPointerCoords(e); dragCurrentX = coords.x; dragCurrentY = coords.y;
             }
@@ -794,6 +805,11 @@
 
             const attackerUnit = combatData[attackerBaseId];
             const targetUnit = combatData[targetBaseId];
+
+            if (attackerUnit.isImmobilized) {
+                addLogEntry(`[ INMOVILIZADO ] - ${attackerUnit.name} no puede actuar este turno.`, 'interrupt');
+                continue;
+            }
 
             addLogEntry(`${attackerUnit.name} se mueve hacia ${targetUnit.name}...`);
 

--- a/js/combatEngine.js
+++ b/js/combatEngine.js
@@ -1541,6 +1541,11 @@ const CombatEngine = {
         if (!allUnits || !Array.isArray(allUnits)) return;
 
         for (let unit of allUnits) {
+            // Evaluacion de inmovilizacion (al inicio del round)
+            if (phaseTag === '[Round Start]') {
+                unit.isImmobilized = unit.statusEffects && unit.statusEffects['immobilized'] && unit.statusEffects['immobilized'].count > 0;
+            }
+
             // Historial de combate y transicion de daño
             if (phaseTag === '[Round End]' || phaseTag === '[Round Start]') {
                 unit.consumable_used_this_turn = false; // Reset strict consumable limiter per turn!


### PR DESCRIPTION
This PR correctly refactors the "Immobilized" status logic to adhere to the design spec:
- Evaluates `isImmobilized` via the status presence at `[Round Start]`.
- Keeps the unit's action slots targetable by enemies (allowing unopposed attacks).
- Prevents the unit from assigning targets or acting in the combat loop.
- Blocks UI drag-and-drop actions for immobilized allies in `Battle-viewer.html`.
- Allows the native `statusManager.js` to correctly decay the `total_loss` status naturally at round end.

---
*PR created automatically by Jules for task [655889268545742604](https://jules.google.com/task/655889268545742604) started by @sokcrow*