### PR TITLE
Restaurar visibilidad en tiempo real del Teatro para el DM

### DIFF
--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -1477,6 +1477,35 @@
         background: #00bfff;
         box-shadow: 0 0 25px rgba(0, 221, 255, 1);
       }
+      .btn-modo-director {
+        position: relative;
+      }
+      .theatre-live-badge {
+        display: none;
+        position: absolute;
+        top: -10px;
+        right: -10px;
+        min-width: 24px;
+        height: 24px;
+        padding: 0 6px;
+        align-items: center;
+        justify-content: center;
+        border: 2px solid #fff;
+        border-radius: 999px;
+        background: #d40000;
+        color: #fff;
+        font-size: 12px;
+        line-height: 1;
+        box-shadow: 0 0 12px rgba(255, 0, 0, 0.9);
+      }
+      .theatre-live-badge.visible {
+        display: inline-flex;
+      }
+      .theatre-live-badge.offline {
+        display: inline-flex;
+        background: #5b5b5b;
+        font-size: 9px;
+      }
 
       .dm-tab-pane {
         display: none;
@@ -1623,6 +1652,7 @@
       </button>
       <button class="dm-tab-btn btn-modo-director" id="btn-modo-director">
         VISUALIZADOR DE JUEGO
+        <span id="dm-theatre-live-badge" class="theatre-live-badge" aria-live="polite"></span>
       </button>
     </div>
 
@@ -8986,6 +9016,25 @@ window.processEntitiesData = function(entities) {
 
         let queueItems = [];
         window.queueItems = queueItems;
+        const theatreLiveBadge = document.getElementById("dm-theatre-live-badge");
+
+        function updateTheatreLiveBadge(count, connected = true) {
+          if (!theatreLiveBadge) return;
+
+          theatreLiveBadge.classList.toggle("offline", !connected);
+          theatreLiveBadge.classList.toggle("visible", !connected || count > 0);
+          theatreLiveBadge.textContent = connected ? (count > 99 ? "99+" : String(count || "")) : "OFF";
+          theatreLiveBadge.title = connected
+            ? `${count} actuación${count === 1 ? "" : "es"} pendiente${count === 1 ? "" : "s"} en el Teatro`
+            : "Sin conexión en tiempo real con el Teatro";
+        }
+
+        // Firebase puede recuperar la conexión sin recargar la página. El DM siempre
+        // debe saber si la ausencia de actividad significa una cola vacía o una caída.
+        db.ref(".info/connected").on("value", (snap) => {
+          updateTheatreLiveBadge(queueItems.length, snap.val() === true);
+        });
+
         // Listen to Queue
         db.ref("campaña/teatro/cola").on("value", (snap) => {
           const queueContainer = document.getElementById("dm-theatre-queue");
@@ -8995,6 +9044,7 @@ window.processEntitiesData = function(entities) {
           window.queueItems = queueItems;
           const cola = snap.val();
           if (!cola) {
+            updateTheatreLiveBadge(0);
             queueContainer.innerHTML =
               '<span style="color: #666; text-align: center;">La cola está vacía.</span>';
             return;
@@ -9063,6 +9113,10 @@ window.processEntitiesData = function(entities) {
             queueContainer.appendChild(itemDiv);
           }
 
+          // El aviso permanece visible en cualquier pestaña del panel DM, no solo
+          // cuando el visualizador del Teatro está abierto.
+          updateTheatreLiveBadge(queueItems.length);
+
           // Reactivar ciclo de avance continuo si estamos en dicho modo y la cola se llena
           const textBox = document.getElementById("theatre-dialogue-text");
           const isTypingText = textBox && textBox.typewriterInterval;
@@ -9075,6 +9129,9 @@ window.processEntitiesData = function(entities) {
           ) {
             iniciarAvanceContinuo(5000);
           }
+        }, (error) => {
+          console.error("No se pudo escuchar la cola del Teatro en tiempo real:", error);
+          updateTheatreLiveBadge(queueItems.length, false);
         });
 
         // Si el DM borra su texto, el modo continuo debería reactivarse (verificar la cola)

--- a/tests/theatre_realtime.spec.js
+++ b/tests/theatre_realtime.spec.js
@@ -1,0 +1,20 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const dmPage = fs.readFileSync(
+  path.join(__dirname, "..", "pantalla_dm.html"),
+  "utf8",
+);
+
+test("el panel DM mantiene una suscripción en tiempo real a la cola del Teatro", () => {
+  expect(dmPage).toContain('db.ref("campaña/teatro/cola").on("value"');
+  expect(dmPage).toContain('id="dm-theatre-live-badge"');
+  expect(dmPage).toContain("updateTheatreLiveBadge(queueItems.length)");
+});
+
+test("el panel DM distingue una cola vacía de una desconexión", () => {
+  expect(dmPage).toContain('db.ref(".info/connected").on("value"');
+  expect(dmPage).toContain('updateTheatreLiveBadge(queueItems.length, false)');
+  expect(dmPage).toContain("Sin conexión en tiempo real con el Teatro");
+});


### PR DESCRIPTION
### Motivation

- Restaurar la relación del "Teatro de la Mente" para que el DM pueda ver en tiempo real las actuaciones pendientes y distinguir una cola vacía de una pérdida de conexión.

### Description

- Añadido un indicador visual (`#dm-theatre-live-badge`) sobre el botón "VISUALIZADOR DE JUEGO" y estilos CSS para estados `visible` y `offline` en `pantalla_dm.html`. 
- Implementada la función `updateTheatreLiveBadge(count, connected)` que muestra el conteo de actuaciones pendientes y el texto `OFF` cuando no hay conexión en tiempo real. 
- Suscripción a `db.ref(".info/connected")` para detectar la conexión de Firebase y diferenciación entre cola vacía y desconexión, y actualización de la cola `campaña/teatro/cola` para invocar el indicador; además se agregó manejo de errores en la escucha de la cola. 
- Añadido test automatizado `tests/theatre_realtime.spec.js` que verifica la presencia de la suscripción a la cola, el badge y la detección de desconexión en el archivo `pantalla_dm.html`.

### Testing

- Ejecutado `npx playwright test tests/theatre_realtime.spec.js` y los 2 tests pasaron exitosamente. 
- Verificaciones de sintaxis JavaScript (`node --check` sobre los scripts extraídos / principales) se completaron sin errores en el entorno de trabajo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7df4e6a298832388efa452ac179931)