### PR TITLE
Modernizar menú lateral HUD de la hoja de personaje

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -6366,6 +6366,124 @@ input[name="attr_tab"][value="shop"] ~ .sheet-phone-screen .sheet-tab-shop {
 /* --- TACTICAL HUD LEFT --- */
 /* hud-sidebar-left purged */
 
+/* --- CHARACTER SHEET COMMAND RAIL --- */
+.hud-sidebar-right {
+    position: fixed;
+    top: clamp(14px, 3vh, 32px);
+    right: clamp(10px, 2vw, 28px);
+    z-index: 9000;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 8px;
+    font-family: "BebasKai", "Share Tech Mono", sans-serif;
+}
+
+.hud-menu-toggle {
+    width: 52px;
+    height: 48px;
+    display: grid;
+    place-items: center;
+    color: #e9d9a6;
+    background: linear-gradient(145deg, #282722 0%, #11110f 72%);
+    border: 1px solid #9f8744;
+    border-right: 4px solid #8e241d;
+    clip-path: polygon(9px 0, 100% 0, 100% calc(100% - 9px), calc(100% - 9px) 100%, 0 100%, 0 9px);
+    cursor: pointer;
+    box-shadow: 0 5px 16px #000b, inset 0 0 0 1px #fff08;
+    transition: width .2s ease, color .2s ease, background .2s ease;
+}
+
+.hud-menu-toggle:hover,
+.hud-menu-toggle:focus-visible {
+    color: #fff4c9;
+    background: linear-gradient(145deg, #3b3830, #181713);
+    outline: 1px solid #d9bd6b;
+    outline-offset: 2px;
+}
+
+.hud-menu-toggle svg { transition: transform .25s ease; }
+.hud-sidebar-right.is-open .hud-menu-toggle svg { transform: rotate(90deg); }
+
+.hud-menu-dropdown {
+    width: 174px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 9px 8px 11px;
+    background: linear-gradient(100deg, rgba(18,18,16,.96), rgba(5,5,5,.96));
+    border: 1px solid #655b3d;
+    border-top: 3px solid #8e241d;
+    clip-path: polygon(12px 0, 100% 0, 100% calc(100% - 12px), calc(100% - 12px) 100%, 0 100%, 0 12px);
+    box-shadow: -8px 12px 28px #000c;
+    transform: translateX(calc(100% + 35px));
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: transform .25s cubic-bezier(.2,.8,.2,1), opacity .2s, visibility .2s;
+}
+
+.hud-sidebar-right.is-open .hud-menu-dropdown {
+    transform: translateX(0);
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+}
+
+.hud-menu-item {
+    position: relative;
+    min-height: 44px;
+    display: grid;
+    grid-template-columns: 30px 1fr;
+    align-items: center;
+    gap: 9px;
+    padding: 5px 12px 5px 9px;
+    color: #cfc8b4;
+    background: linear-gradient(90deg, #292824 0%, #171715 75%);
+    border: 0;
+    border-left: 3px solid #635b47;
+    text-align: left;
+    text-transform: uppercase;
+    letter-spacing: 1.2px;
+    cursor: pointer;
+    overflow: hidden;
+    transition: color .15s, border-color .15s, transform .15s, background .15s;
+}
+
+.hud-menu-item::after {
+    content: "";
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    width: 24px;
+    height: 2px;
+    background: #8e241d;
+}
+
+.hud-menu-item svg { width: 22px; height: 22px; color: #af9a61; }
+.hud-menu-item span { font-size: 16px; line-height: 1; }
+.hud-menu-item:hover,
+.hud-menu-item:focus-visible {
+    color: #fff5d1;
+    border-left-color: #c22e25;
+    background: linear-gradient(90deg, #403b30, #211e19);
+    transform: translateX(-5px);
+    outline: none;
+}
+.hud-menu-item:hover svg,
+.hud-menu-item:focus-visible svg { color: #ead27f; }
+
+@media (max-width: 700px), (max-height: 620px) {
+    .hud-menu-dropdown { width: 154px; gap: 2px; padding: 7px; }
+    .hud-menu-item { min-height: 38px; grid-template-columns: 25px 1fr; }
+    .hud-menu-item span { font-size: 14px; }
+    .hud-menu-item svg { width: 19px; height: 19px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .hud-menu-dropdown, .hud-menu-toggle svg, .hud-menu-item { transition: none; }
+}
+
 .btn-hud {
     background: #111;
     color: var(--cyan-tech);

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -7447,77 +7447,84 @@
 
 
 
-      <!-- Tactical HUD Right (Heptagonal Menu) -->
-      <div class="hud-sidebar-right" style="position: absolute; top: 20px; right: 20px; z-index: 9000; display: flex; flex-direction: column; align-items: flex-end; gap: 10px;">
-        <button id="btn-toggle-hud-menu" type="button" class="btn-hud heptagon-btn" style="background: var(--bg-card, #000); border: 2px solid var(--cyan-tech, #0df); color: var(--cyan-tech, #0df); width: 50px; height: 50px; cursor: pointer; clip-path: polygon(50% 0%, 90% 20%, 100% 60%, 75% 100%, 25% 100%, 0% 60%, 10% 20%); display: flex; justify-content: center; align-items: center;" title="Menu">
+      <!-- Tactical HUD Right -->
+      <nav class="hud-sidebar-right is-open" aria-label="Accesos de la hoja de personaje">
+        <button id="btn-toggle-hud-menu" type="button" class="hud-menu-toggle" title="Ocultar menú" aria-label="Ocultar menú de personaje" aria-expanded="true" aria-controls="hud-menu-dropdown">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square" stroke-linejoin="miter">
             <line x1="3" y1="12" x2="21" y2="12"></line>
             <line x1="3" y1="6" x2="21" y2="6"></line>
             <line x1="3" y1="18" x2="21" y2="18"></line>
           </svg>
         </button>
-        <div id="hud-menu-dropdown" style="display: none; flex-direction: column; gap: 10px; background: #000; border: 1px solid var(--cyan-tech, #0df); padding: 10px; box-shadow: 0 0 10px rgba(0,221,255,0.2);">
+        <div id="hud-menu-dropdown" class="hud-menu-dropdown">
 
 
           <!-- HP (Vitales) -->
-          <button id="btn-toggle-hud" class="btn-hud heptagon-btn" title="Alternar HUD de Combate" style="background: var(--bg-card, #111); width: 40px; height: 40px; border: none; cursor: pointer; clip-path: polygon(50% 0%, 90% 20%, 100% 60%, 75% 100%, 25% 100%, 0% 60%, 10% 20%); display: flex; justify-content: center; align-items: center; background-color: var(--cyan-tech, #0df); color: #000;">
+          <button id="btn-toggle-hud" class="hud-menu-item" title="Alternar HUD de combate">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square">
               <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
             </svg>
+            <span>Vitales</span>
           </button>
 
           <!-- Stats -->
-          <button type="action" name="act_hud_stats" class="btn-hud heptagon-btn" title="Stats" style="background: var(--bg-card, #111); width: 40px; height: 40px; border: none; cursor: pointer; clip-path: polygon(50% 0%, 90% 20%, 100% 60%, 75% 100%, 25% 100%, 0% 60%, 10% 20%); display: flex; justify-content: center; align-items: center; background-color: var(--cyan-tech, #0df); color: #000;">
+          <button type="action" name="act_hud_stats" class="hud-menu-item" title="Atributos">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square">
               <rect x="18" y="3" width="4" height="18"></rect>
               <rect x="10" y="8" width="4" height="13"></rect>
               <rect x="2" y="13" width="4" height="8"></rect>
             </svg>
+            <span>Atributos</span>
           </button>
 
           <!-- Perks -->
-          <button type="action" name="act_hud_perks" class="btn-hud heptagon-btn" title="Perks" style="background: var(--bg-card, #111); width: 40px; height: 40px; border: none; cursor: pointer; clip-path: polygon(50% 0%, 90% 20%, 100% 60%, 75% 100%, 25% 100%, 0% 60%, 10% 20%); display: flex; justify-content: center; align-items: center; background-color: var(--cyan-tech, #0df); color: #000;">
+          <button type="action" name="act_hud_perks" class="hud-menu-item" title="Ventajas">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square">
               <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon>
             </svg>
+            <span>Ventajas</span>
           </button>
 
           <!-- Skills -->
-          <button type="action" name="act_hud_skills" class="btn-hud heptagon-btn" title="Skills" style="background: var(--bg-card, #111); width: 40px; height: 40px; border: none; cursor: pointer; clip-path: polygon(50% 0%, 90% 20%, 100% 60%, 75% 100%, 25% 100%, 0% 60%, 10% 20%); display: flex; justify-content: center; align-items: center; background-color: var(--cyan-tech, #0df); color: #000;">
+          <button type="action" name="act_hud_skills" class="hud-menu-item" title="Habilidades">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square">
               <path d="M14.5 17.5L3 6V3h3l11.5 11.5"></path>
               <path d="M13 19l6-6"></path>
               <path d="M16 16l4 4"></path>
               <path d="M19 21l2-2"></path>
             </svg>
+            <span>Habilidades</span>
           </button>
 
           <!-- Apego (Hablar) -->
-          <button type="action" name="act_hud_apego" class="btn-hud heptagon-btn" title="Hablar / Apego" style="background: var(--bg-card, #111); width: 40px; height: 40px; border: none; cursor: pointer; clip-path: polygon(50% 0%, 90% 20%, 100% 60%, 75% 100%, 25% 100%, 0% 60%, 10% 20%); display: flex; justify-content: center; align-items: center; background-color: var(--cyan-tech, #0df); color: #000;">
+          <button type="action" name="act_hud_apego" class="hud-menu-item" title="Apego">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square">
               <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
             </svg>
+            <span>Apego</span>
           </button>
 
           <!-- Phone (Celular) -->
-          <button type="action" name="act_tab_home" id="btn-toggle-phone" class="btn-hud heptagon-btn" title="Phone" style="background: var(--bg-card, #111); width: 40px; height: 40px; border: none; cursor: pointer; clip-path: polygon(50% 0%, 90% 20%, 100% 60%, 75% 100%, 25% 100%, 0% 60%, 10% 20%); display: flex; justify-content: center; align-items: center; background-color: var(--cyan-tech, #0df); color: #000;">
+          <button type="action" name="act_tab_home" id="btn-toggle-phone" class="hud-menu-item" title="Terminal">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square">
               <rect x="5" y="2" width="14" height="20" rx="2" ry="2"></rect>
               <line x1="12" y1="18" x2="12.01" y2="18"></line>
             </svg>
+            <span>Terminal</span>
           </button>
 
           <!-- Inventory -->
-          <button type="action" name="act_tab_inventory" class="btn-hud heptagon-btn btn-global-inventory" title="Inventory" style="background: var(--bg-card, #111); width: 40px; height: 40px; border: none; cursor: pointer; clip-path: polygon(50% 0%, 90% 20%, 100% 60%, 75% 100%, 25% 100%, 0% 60%, 10% 20%); display: flex; justify-content: center; align-items: center; background-color: var(--cyan-tech, #0df); color: #000;">
+          <button type="action" name="act_tab_inventory" class="hud-menu-item btn-global-inventory" title="Inventario">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square">
               <path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"></path>
               <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
               <line x1="12" y1="22.08" x2="12" y2="12"></line>
             </svg>
+            <span>Inventario</span>
           </button>
 
         </div>
-      </div>
+      </nav>
 
 
       <input

--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -3949,9 +3949,13 @@ function initializeCharacterSheet() {
     document.addEventListener("click", (e) => {
       const btnMenu = e.target.closest("#btn-toggle-hud-menu");
       if (btnMenu) {
+        const sidebar = btnMenu.closest(".hud-sidebar-right");
         const dropdown = document.getElementById("hud-menu-dropdown");
-        if (dropdown) {
-          dropdown.style.display = dropdown.style.display === "none" || dropdown.style.display === "" ? "flex" : "none";
+        if (dropdown && sidebar) {
+          const isOpen = sidebar.classList.toggle("is-open");
+          btnMenu.setAttribute("aria-expanded", String(isOpen));
+          btnMenu.setAttribute("aria-label", isOpen ? "Ocultar menú de personaje" : "Mostrar menú de personaje");
+          btnMenu.title = isOpen ? "Ocultar menú" : "Mostrar menú";
         }
       }
     });


### PR DESCRIPTION
### Motivation
- Actualizar la barra de comandos lateral de la hoja de personaje con una estética más moderna y compacta inspirada en Limbus Company. 
- Mejorar la usabilidad y accesibilidad del control desplegable añadiendo etiquetas visibles, estados ARIA y mejor comportamiento en pantallas pequeñas.

### Description
- Reemplacé el bloque original del HUD por un elemento semántico `<nav class="hud-sidebar-right">` y un botón de control `#btn-toggle-hud-menu` con atributos `aria-*` para describir y controlar el estado del menú. (HTML changes)
- Sustituí botones circulares por elementos con la nueva clase `.hud-menu-item` y añadí texto en español para los siete accesos: Vitales, Atributos, Ventajas, Habilidades, Apego, Terminal e Inventario. (HTML changes)
- Añadí un conjunto completo de estilos CSS para `.hud-sidebar-right`, `.hud-menu-toggle`, `.hud-menu-dropdown` y `.hud-menu-item` con animación de apertura, variantes responsivas y soporte para `prefers-reduced-motion`. (CSS changes)
- Cambié la lógica del toggle en `hoja_personaje.js` para alternar la clase `is-open` en el contenedor, sincronizar `aria-expanded`/`aria-label` y controlar la visualización del desplegable desde el DOM en vez de manipular estilos en linea. (JS change)

### Testing
- `node --check hoja_personaje.js` — passed. 
- `git diff --check` — pasó sin errores detectados por el chequeo automático.
- Script programático de verificación del marcado (`python3` assertion) que comprueba la presencia de `hud-sidebar-right is-open`, siete elementos con `class="hud-menu-item"` y `aria-expanded="true"` — pasó.
- Intento de generar captura de pantalla con Playwright/Chromium falló por limitación del entorno al descargar navegadores (CDN devolvió HTTP 403), por lo que no se generó la imagen visual.  
- Intento automatizado de invocar la herramienta `make_pr`/MCP en el entorno falló por ausencia de algunos paquetes/servicios en el contenedor (error de inicialización de MCP), por lo que la creación remota del PR no se completó en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7df6f31f5c8323b95a1c3cc91b291d)