### PR TITLE
Fix: guard optional recipe button to avoid aborting DM theatre initialization

### DIFF
--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -6773,7 +6773,10 @@ window.processEntitiesData = function(entities) {
             db.ref("campaña/estado_mundo/mesa_crafteo_activa").set(e.target.checked);
         });
 
-        document.getElementById("btn-crear-receta").addEventListener("click", () => {
+        // El editor de recetas ahora vive en la herramienta standalone. En esta
+        // pantalla el botón puede no existir; no debemos abortar el inicializador
+        // completo del DM (incluido el Teatro) por ese control opcional.
+        document.getElementById("btn-crear-receta")?.addEventListener("click", () => {
             const itemResultado = document.getElementById("receta-item-resultado").value.trim();
             const ingredientesStr = document.getElementById("receta-ingredientes").value.trim();
             const dificultad = parseInt(document.getElementById("receta-dificultad").value) || 0;

--- a/tests/theatre_realtime.spec.js
+++ b/tests/theatre_realtime.spec.js
@@ -18,3 +18,12 @@ test("el panel DM distingue una cola vacía de una desconexión", () => {
   expect(dmPage).toContain('updateTheatreLiveBadge(queueItems.length, false)');
   expect(dmPage).toContain("Sin conexión en tiempo real con el Teatro");
 });
+
+test("un control opcional de recetas no interrumpe la inicialización del Teatro", () => {
+  expect(dmPage).toContain(
+    'document.getElementById("btn-crear-receta")?.addEventListener',
+  );
+  expect(dmPage).not.toContain(
+    'document.getElementById("btn-crear-receta").addEventListener',
+  );
+});


### PR DESCRIPTION
### Motivation
- Evitar que la ausencia del botón de editor de recetas bloquee la inicialización completa del panel del DM, lo que interrumpía controles y suscripciones en tiempo real del Teatro.

### Description
- Trato el manejador de `btn-crear-receta` como opcional usando `document.getElementById("btn-crear-receta")?.addEventListener(...)` en `pantalla_dm.html` para no lanzar si el botón no existe.
- Añadí una prueba de regresión en `tests/theatre_realtime.spec.js` que verifica que el código use la versión opcional (`?.addEventListener`) y no la versión que falla (`.addEventListener`).

### Testing
- Ejecuté `npx playwright test tests/theatre_realtime.spec.js --reporter=list` y las 3 pruebas del archivo pasaron satisfactoriamente.
- Verifiqué la sintaxis JavaScript embebida con `node --check` sobre los scripts extraídos y no se reportaron errores.
- Intenté ejecutar la instalación de navegadores para Playwright (`npx playwright install`) pero la descarga de Chromium falló con HTTP 403, por lo que no fue posible ejecutar pruebas que requieran bajar navegadores en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7df8920b2c8323b6952778f99721eb)