### PR TITLE
Sincroniza control reactivo de instancias de juego

### DIFF
--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -6894,6 +6894,20 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
 
 
 /* --- THEATRE VIEW (PLAYER) --- */
+#player-instance-blackout {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 2147483647;
+    background: #000;
+    pointer-events: all;
+}
+
+#player-instance-blackout.active,
+body.instance-blackout #player-instance-blackout {
+    display: block !important;
+}
+
 #theatre-view-player {
     position: fixed;
     top: 0; left: 0;

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -297,6 +297,7 @@
     </style>
   </head>
   <body>
+    <div id="player-instance-blackout" aria-hidden="true"></div>
     <div id="system-loading-overlay">
       <img
         src="https://limbuscompany.wiki.gg/images/thumb/DanteStar.png/1024px-DanteStar.png?e52927"
@@ -13105,15 +13106,22 @@
       // Listen to global instance state (Teatro, Mapa, Combate)
       db.ref("campaña/estado_mundo/instancia_activa").on("value", (snap) => {
         const activeInstance = snap.val() || "ninguno";
+        const theatreActive = activeInstance === "teatro";
+        const blackoutActive = activeInstance === "ninguno";
 
-        // Vista local del Teatro
+        // Apply the Firebase event directly to the root DOM in the same tick.
+        document.body.classList.toggle("instance-theatre", theatreActive);
+        document.body.classList.toggle("instance-blackout", blackoutActive);
+        const blackout = document.getElementById("player-instance-blackout");
+        if (blackout) {
+          blackout.classList.toggle("active", blackoutActive);
+          blackout.setAttribute("aria-hidden", String(!blackoutActive));
+        }
+
         const theatreView = document.getElementById("theatre-view-player");
         if (theatreView) {
-          if (activeInstance === "teatro") {
-            theatreView.classList.add("theatre-active");
-          } else {
-            theatreView.classList.remove("theatre-active");
-          }
+          theatreView.classList.toggle("theatre-active", theatreActive);
+          theatreView.style.display = theatreActive ? "flex" : "none";
         }
 
         // Futuro: Agregar aquí la lógica para mostrar Mapas o Combates cuando existan

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -1650,10 +1650,7 @@
       <button class="dm-tab-btn" data-tab="tab-acceso">
         Control de Acceso
       </button>
-      <button class="dm-tab-btn btn-modo-director" id="btn-modo-director">
-        VISUALIZADOR DE JUEGO
-        <span id="dm-theatre-live-badge" class="theatre-live-badge" aria-live="polite"></span>
-      </button>
+      <span id="dm-theatre-live-badge" class="theatre-live-badge" aria-live="polite"></span>
     </div>
 
     <div
@@ -5176,8 +5173,6 @@ window.processEntitiesData = function(entities) {
         // --- LÓGICA DE TABS VISUALIZADOR DE JUEGO ---
         document.querySelectorAll(".dm-tab-btn").forEach((btn) => {
           btn.addEventListener("click", () => {
-            if (btn.id === "btn-modo-director") return;
-
             // Remove active class from all buttons and panes
             document
               .querySelectorAll(".dm-tab-btn")
@@ -5204,29 +5199,6 @@ window.processEntitiesData = function(entities) {
 
           });
         });
-
-        document
-          .getElementById("btn-modo-director")
-          .addEventListener("click", () => {
-            // Evaluamos la instancia global activa antes de abrir
-            db.ref("campaña/estado_mundo/instancia_activa").once("value").then((snap) => {
-              const activeInstance = snap.val() || "ninguno";
-
-              if (activeInstance === "teatro") {
-                document.querySelector(".dm-tabs-nav").style.display = "none";
-                document.querySelector(".dm-tabs-content").style.display = "none";
-                const theatreView = document.getElementById("theatre-view-dm");
-                if (theatreView) {
-                  theatreView.style.display = "flex";
-                }
-              } else if (activeInstance === "ninguno") {
-                alert("No hay ninguna instancia en transmisión (PANTALLA NEGRA).");
-              } else {
-                alert("La instancia activa ('" + activeInstance + "') no tiene un visualizador disponible localmente todavía.");
-              }
-            });
-          });
-
 
         // --- COMUNICACIONES DM ---
         let currentDmChatId = null;
@@ -8568,10 +8540,8 @@ window.processEntitiesData = function(entities) {
         document
           .getElementById("btn-exit-theatre")
           .addEventListener("click", () => {
-            document.getElementById("theatre-view-dm").style.display = "none";
-            document.querySelector(".dm-tabs-nav").style.display = "flex";
-            document.querySelector(".dm-tabs-content").style.display = "flex";
-            // db.ref("campaña/teatro").update({ activo: false }); // Desacoplado localmente
+            applyDmInstance("ninguno");
+            db.ref("campaña/estado_mundo/instancia_activa").set("ninguno");
           });
 
 
@@ -8579,10 +8549,28 @@ window.processEntitiesData = function(entities) {
 
         // --- CONTROL DE INSTANCIAS (GLOBAL) ---
         const instanceRadios = document.querySelectorAll('.instance-radio');
+
+        function applyDmInstance(instance) {
+          const activeInstance = instance || "ninguno";
+          const theatreActive = activeInstance === "teatro";
+          const tabsNav = document.querySelector(".dm-tabs-nav");
+          const tabsContent = document.querySelector(".dm-tabs-content");
+          const theatreView = document.getElementById("theatre-view-dm");
+
+          if (tabsNav) tabsNav.style.display = theatreActive ? "none" : "flex";
+          if (tabsContent) tabsContent.style.display = theatreActive ? "none" : "flex";
+          if (theatreView) {
+            theatreView.style.display = theatreActive ? "flex" : "none";
+            theatreView.classList.toggle("theatre-active", theatreActive);
+          }
+        }
+
         instanceRadios.forEach(radio => {
           radio.addEventListener('change', (e) => {
             if (e.target.checked) {
               const selectedInstance = e.target.value;
+              // The local transition never waits for the network round trip.
+              applyDmInstance(selectedInstance);
               db.ref("campaña/estado_mundo/instancia_activa").set(selectedInstance);
             }
           });
@@ -8595,6 +8583,9 @@ window.processEntitiesData = function(entities) {
           if (targetRadio) {
             targetRadio.checked = true;
           }
+          // This listener is also the strict initializer: the first Firebase
+          // value overrides the default HTML state as soon as it arrives.
+          applyDmInstance(val);
         });
 
         // (Original code below)

--- a/tests/theatre_realtime.spec.js
+++ b/tests/theatre_realtime.spec.js
@@ -27,3 +27,31 @@ test("un control opcional de recetas no interrumpe la inicialización del Teatro
     'document.getElementById("btn-crear-receta").addEventListener',
   );
 });
+
+test("la instancia del DM aplica la vista reactiva sin botón intermedio", () => {
+  expect(dmPage).toContain("function applyDmInstance(instance)");
+  expect(dmPage).toContain("applyDmInstance(selectedInstance)");
+  expect(dmPage).toContain("applyDmInstance(val)");
+  expect(dmPage).not.toContain('id="btn-modo-director"');
+});
+
+test("el teatro del DM conserva un listener persistente para la escena activa", () => {
+  expect(dmPage).toContain(
+    'db.ref("campaña/teatro/estado_actual").on("value"',
+  );
+  expect(dmPage).toContain('id="theatre-stage-container"');
+});
+
+test("los jugadores reciben un apagón reactivo desde Firebase", () => {
+  const playerPage = fs.readFileSync(
+    path.join(__dirname, "..", "hoja_personaje.html"),
+    "utf8",
+  );
+  expect(playerPage).toContain('id="player-instance-blackout"');
+  expect(playerPage).toContain(
+    'document.body.classList.toggle("instance-blackout", blackoutActive)',
+  );
+  expect(playerPage).toContain(
+    'theatreView.style.display = theatreActive ? "flex" : "none"',
+  );
+});


### PR DESCRIPTION
### Motivation

- Resolver la desincronización entre la UI del DM y los clientes que provocaba transiciones manuales, estados por defecto inconsistentes en la inicialización y retrasos en la propagación de cambios de instancia.
- Forzar la aplicación inmediata del estado persistido `campaña/estado_mundo/instancia_activa` para que la vista del teatro y el apagón táctico se apliquen sin intervención manual.
- Asegurar listeners persistentes en tiempo real para la escena activa para refrescar sprites, fondos y texto en cuanto Firebase emite cambios.

### Description

- Se elimina el botón intermedio `btn-modo-director` y su lógica asociada, manteniendo únicamente el indicador `dm-theatre-live-badge` para estado de conexión; la transición ahora es automática desde la selección de radio en el DM (`pantalla_dm.html`).
- Se introduce `applyDmInstance(instance)` en `pantalla_dm.html` y se invoca de forma inmediata al cambiar el radio para ocultar/mostrar `.dm-tabs-nav`, `.dm-tabs-content` y `#theatre-view-dm` sin esperar la ronda de red.
- El botón de salida del teatro en el DM ahora llama a `applyDmInstance("ninguno")` y escribe `campaña/estado_mundo/instancia_activa = "ninguno"` en Firebase para mantener sincronía global.
- En el cliente jugador (`hoja_personaje.html`) se añadió un overlay `#player-instance-blackout`, CSS asociado y la lógica del listener de `campaña/estado_mundo/instancia_activa` para forzar el apagón (`instance-blackout`) y mostrar/ocultar `#theatre-view-player` en el mismo evento emitido por Firebase.
- Se preservan y confirman listeners persistentes `on("value")` sobre `campaña/teatro/estado_actual` y demás rutas relevantes en DM y clientes para garantizar actualización reactiva de escenas, placas y sprites.
- Se añadieron pruebas de regresión en `tests/theatre_realtime.spec.js` que cubren la ausencia del botón intermedio, la aplicación inmediata de la instancia, la existencia de listeners persistentes y el overlay de apagón en jugadores.

### Testing

- `npx playwright test tests/theatre_realtime.spec.js --reporter=line` se ejecutó contra el archivo modificado y todas las pruebas del fichero pasaron (6 passed).
- Se intentó ejecutar la suite completa `npx playwright test tests --reporter=line`, donde 6 pruebas pasaron y 2 fallaron porque Playwright no pudo lanzar navegadores locales ya que `npx playwright install chromium` falló por una descarga bloqueada con HTTP 403 en este entorno.
- `git diff --check` no reportó problemas en los cambios aplicados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7dfe1225dc83239d99f819334c2067)