### PR TITLE
feat(dashboard): decouple theatre rendering and fix DM instance reactivity

### DIFF
--- a/css/on-game-dashboard.css
+++ b/css/on-game-dashboard.css
@@ -23,9 +23,25 @@ body { margin: 0; overflow: hidden; background: #020304; color: #e8edf2; }
 }
 #modulo-standby { align-items: center; justify-content: center; background: #000; }
 .standby-text { color: #24272a; letter-spacing: .45em; font-size: clamp(1.5rem, 4vw, 4rem); }
-#modulo-teatro { flex-direction: column; background-position: center; background-size: cover; }
-#theatre-stage { flex: 1; display: flex; align-items: flex-end; justify-content: center; gap: 1vw; overflow: hidden; }
-.theatre-sprite { max-height: 72vh; max-width: 30vw; object-fit: contain; filter: drop-shadow(0 0 12px #000); }
+#modulo-teatro { flex-direction: row; }
+.stage-view-wrapper { flex: 1; display: flex; flex-direction: column; background-position: center; background-size: cover; overflow: hidden; }
+#theatre-stage { flex: 1; display: flex; align-items: flex-end; justify-content: center; gap: 1vw; overflow: hidden; aspect-ratio: 16 / 9; max-height: 100%; margin: 0 auto; }
+.theatre-sprite { max-height: 72vh; max-width: 30vw; object-fit: contain; filter: drop-shadow(0 0 12px #000); transform-origin: bottom center; }
+
+.director-controls { width: 350px; background: #0a0a0a; border-left: 2px solid #a37c35; display: flex; flex-direction: column; padding: 15px; overflow-y: auto; }
+.panel-title { color: #a37c35; font-size: 1.2rem; text-align: center; margin: 0 0 15px 0; border-bottom: 1px solid #333; padding-bottom: 10px; }
+.npc-spawner-section { display: flex; flex-direction: column; gap: 10px; margin-bottom: 20px; }
+.strict-dropdown { padding: 8px; background: #121820; color: white; border: 1px solid #53606d; font-family: "Share Tech Mono", monospace; }
+.btn-action { padding: 10px; background: #8a1c1c; color: white; border: 1px solid #ff6575; cursor: pointer; font-family: "Share Tech Mono", monospace; font-weight: bold; }
+.btn-action:hover { background: #a62323; }
+.active-actors-list { display: flex; flex-direction: column; gap: 10px; }
+.actor-control-card { background: #121212; border: 1px solid #444; padding: 10px; display: flex; flex-direction: column; gap: 8px; }
+.actor-name { color: #d1d1d1; font-size: 0.9rem; font-weight: bold; }
+.actor-buttons { display: flex; gap: 5px; }
+.actor-buttons button { flex: 1; padding: 5px; background: #222; color: #a37c35; border: 1px solid #a37c35; cursor: pointer; font-family: "Share Tech Mono", monospace; font-size: 0.8rem; }
+.actor-buttons button:hover { background: #333; }
+.actor-buttons .btn-remove { background: #3a0c0c; color: #ff6575; border-color: #ff6575; }
+.actor-buttons .btn-remove:hover { background: #5c1414; }
 .dialogue-panel { padding: 18px 5vw; min-height: 130px; background: rgba(0,0,0,.88); border-top: 2px solid #c49a00; }
 .dialogue-name { color: #c49a00; font-size: 1.25rem; }
 .theatre-controls { display: grid; grid-template-columns: 1fr 1fr auto; gap: 8px; padding: 12px; background: #090c10; }

--- a/css/on-game-dashboard.css
+++ b/css/on-game-dashboard.css
@@ -7,9 +7,20 @@ body { margin: 0; overflow: hidden; background: #020304; color: #e8edf2; }
 .instance-toggles label:has(input:checked) { color: #050505; background: #c49a00; border-color: #ffe084; }
 .connection-status { color: #7aff9b; font-size: .8rem; }
 .connection-status.offline { color: #ff6575; }
-.game-module { position: fixed; inset: 64px 0 0; background: #050608; }
-.game-module.hidden { display: none; }
-.game-module.active-module { display: flex; }
+.game-module {
+    display: none; /* Oculto por defecto */
+    position: fixed;
+    inset: 64px 0 0;
+    background: #050608;
+    width: 100%;
+    height: calc(100vh - 64px);
+}
+.game-module.active-module {
+    display: flex; /* flex, para maquetar dentro (ya estaba) */
+}
+.hidden {
+    display: none !important;
+}
 #modulo-standby { align-items: center; justify-content: center; background: #000; }
 .standby-text { color: #24272a; letter-spacing: .45em; font-size: clamp(1.5rem, 4vw, 4rem); }
 #modulo-teatro { flex-direction: column; background-position: center; background-size: cover; }

--- a/hoja_de_DM.html
+++ b/hoja_de_DM.html
@@ -51,6 +51,7 @@
     firebase.initializeApp({apiKey:"AIzaSyAIVIuKgXUsdrb9Mmss9PH7R3FpWAMG2hU",authDomain:"luminous-system.firebaseapp.com",databaseURL:"https://luminous-system-default-rtdb.firebaseio.com",projectId:"luminous-system",storageBucket:"luminous-system.firebasestorage.app",messagingSenderId:"330473029689",appId:"1:330473029689:web:44a05e870d493a3b294de8"});
   </script>
   <script src="js/instance-control.js"></script>
+  <script src="js/theatre-engine.js"></script>
   <script src="js/on-game-dashboard.js"></script>
 </body>
 </html>

--- a/hoja_de_DM.html
+++ b/hoja_de_DM.html
@@ -23,18 +23,41 @@
       <h1 class="standby-text">SISTEMA EN ESPERA</h1>
     </section>
     <section id="modulo-teatro" class="game-module hidden" aria-hidden="true">
-      <header class="dialogue-panel"><strong id="theatre-location">LOCALIZACIÓN DESCONOCIDA</strong></header>
-      <div id="theatre-stage" aria-label="Escenario del teatro"></div>
-      <div class="dialogue-panel">
-        <span id="dialogue-name" class="dialogue-name">NARRADOR</span> <small id="dialogue-title"></small>
-        <p id="dialogue-text">…</p>
+      <div class="stage-view-wrapper">
+        <header class="dialogue-panel"><strong id="theatre-location">LOCALIZACIÓN DESCONOCIDA</strong></header>
+        <div id="theatre-stage" class="stage-view" aria-label="Escenario del teatro">
+          <!-- Aquí el motor inyecta los fondos y sprites reactivos -->
+        </div>
+        <div class="dialogue-panel">
+          <span id="dialogue-name" class="dialogue-name">NARRADOR</span> <small id="dialogue-title"></small>
+          <p id="dialogue-text">…</p>
+        </div>
+        <div class="theatre-controls">
+          <input id="theatre-background-input" type="url" placeholder="URL del fondo">
+          <input id="theatre-location-input" type="text" placeholder="Localización">
+          <button id="btn-update-scene" type="button">ACTUALIZAR ESCENA</button>
+          <textarea id="theatre-dialogue-input" placeholder="Diálogo en vivo"></textarea>
+          <button id="btn-send-dialogue" type="button">ENVIAR DIÁLOGO</button>
+        </div>
       </div>
-      <div class="theatre-controls">
-        <input id="theatre-background-input" type="url" placeholder="URL del fondo">
-        <input id="theatre-location-input" type="text" placeholder="Localización">
-        <button id="btn-update-scene" type="button">ACTUALIZAR ESCENA</button>
-        <textarea id="theatre-dialogue-input" placeholder="Diálogo en vivo"></textarea>
-        <button id="btn-send-dialogue" type="button">ENVIAR DIÁLOGO</button>
+
+      <!-- El Panel de Control (Solo para el DM) -->
+      <div id="theatre-director-panel" class="director-controls">
+          <h3 class="panel-title">CONTROL DE CASTING</h3>
+
+          <!-- Buscador e Inyector de NPCs desde la Base de Datos -->
+          <div class="npc-spawner-section">
+              <select id="select-npc-roster" class="strict-dropdown">
+                  <option value="">Cargando NPCs disponibles...</option>
+                  <!-- JS poblará esto leyendo de base_datos_npcs -->
+              </select>
+              <button id="btn-spawn-npc" class="btn-action">INYECTAR A ESCENA</button>
+          </div>
+
+          <!-- Lista de Actores Actualmente en el Escenario -->
+          <div class="active-actors-list" id="live-actors-list">
+              <!-- Tarjetas de control dinámicas por cada actor en escena -->
+          </div>
       </div>
     </section>
     <section id="modulo-combate" class="game-module hidden" aria-hidden="true">
@@ -52,6 +75,7 @@
   </script>
   <script src="js/instance-control.js"></script>
   <script src="js/theatre-engine.js"></script>
+  <script src="js/theatre-controls.js"></script>
   <script src="js/on-game-dashboard.js"></script>
 </body>
 </html>

--- a/js/instance-control.js
+++ b/js/instance-control.js
@@ -38,23 +38,33 @@
 
   function applyDashboardInstance(instance, doc) {
     const documentRef = doc || global.document;
-    const activeInstance = normalizeInstance(instance);
-    const moduleIds = {
-      ninguno: "modulo-standby",
-      teatro: "modulo-teatro",
-      combate: "modulo-combate",
-    };
-    const targetId = moduleIds[activeInstance] || moduleIds.ninguno;
+    const activeInstance = instance || 'ninguno'; // Fallback a pantalla negra
 
-    documentRef.querySelectorAll(".game-module").forEach((module) => {
-      const active = module.id === targetId;
-      module.classList.toggle("active-module", active);
-      module.classList.toggle("hidden", !active);
-      module.setAttribute("aria-hidden", active ? "false" : "true");
+    // A. Sincronizar la UI de Control (Radio Buttons)
+    const radioBtn = documentRef.querySelector(`input[name="instancia"][value="${activeInstance}"]`);
+    if (radioBtn) radioBtn.checked = true;
+
+    // B. Purga Visual (Ocultar todos los módulos)
+    documentRef.querySelectorAll('.game-module').forEach((modulo) => {
+      modulo.classList.remove('active-module');
+      modulo.classList.add('hidden');
     });
-    documentRef.querySelectorAll('input[name="instancia"]').forEach((radio) => {
-      radio.checked = radio.value === activeInstance;
-    });
+
+    // C. Despliegue Dinámico del Módulo Activo
+    let activeModuleId = 'modulo-standby'; // Default
+
+    if (activeInstance === 'teatro') {
+        activeModuleId = 'modulo-teatro';
+    } else if (activeInstance === 'combate') {
+        activeModuleId = 'modulo-combate';
+    }
+
+    const activeModule = documentRef.getElementById(activeModuleId);
+    if (activeModule) {
+        activeModule.classList.remove('hidden');
+        activeModule.classList.add('active-module');
+    }
+
     return activeInstance;
   }
 
@@ -138,21 +148,29 @@
     if (!db || !documentRef) return;
     const instanceRef = db.ref(INSTANCE_PATH);
 
-    documentRef.querySelectorAll('input[name="instancia"]').forEach((radio) => {
-      radio.addEventListener("change", () => {
-        if (!radio.checked) return;
-        const next = normalizeInstance(radio.value);
-        const updates = { [INSTANCE_PATH]: next };
-        if (next === "combate") {
-          updates["campaña/combate/estado"] = "PRE_COMBAT_PLANNING";
-          updates["campaña/combate/planningStartedAt"] = global.firebase.database.ServerValue.TIMESTAMP;
-          updates["campaña/combate/planningDuration"] = 60;
-        }
-        db.ref().update(updates);
-      });
+    // 2. EMISOR DE ESTADO (Control del DM)
+    documentRef.querySelectorAll('input[name="instancia"]').forEach(radio => {
+        radio.addEventListener('change', (evento) => {
+            const nuevaInstancia = evento.target.value;
+            // Sobrescribe el nodo maestro en Firebase
+            instanceRef.set(nuevaInstancia).catch(error => {
+                console.error("Error al transicionar instancia de juego:", error);
+            });
+
+            // Logica adicional que había (opcional mantener, pero user pidió snippet específico para instancia)
+            if (nuevaInstancia === "combate") {
+                const updates = {};
+                updates["campaña/combate/estado"] = "PRE_COMBAT_PLANNING";
+                updates["campaña/combate/planningStartedAt"] = global.firebase.database.ServerValue.TIMESTAMP;
+                updates["campaña/combate/planningDuration"] = 60;
+                db.ref().update(updates);
+            }
+        });
     });
-    instanceRef.on("value", (snapshot) => {
-      applyDashboardInstance(snapshot.val(), documentRef);
+
+    // 1. LISTENER DE RECEPCIÓN
+    instanceRef.on('value', (snapshot) => {
+        applyDashboardInstance(snapshot.val(), documentRef);
     });
   }
 

--- a/js/on-game-dashboard.js
+++ b/js/on-game-dashboard.js
@@ -1,7 +1,8 @@
 (function () {
   "use strict";
   const db = window.firebase.database();
-  const theatreRef = db.ref("campaña/teatro");
+  const SCENE_ROOT = "campaña/estado_mundo/escena_actual";
+  const DIALOGUE_ROOT = "campaña/estado_mundo/dialogo_activo";
 
   window.LuminousInstanceControl.bindDashboard({ db });
 
@@ -12,50 +13,24 @@
     status.classList.toggle("offline", !online);
   });
 
-  function renderScene(state) {
-    state = state || {};
-    const module = document.getElementById("modulo-teatro");
-    module.style.backgroundImage = state.fondo ? `linear-gradient(rgba(0,0,0,.15), rgba(0,0,0,.35)), url("${state.fondo}")` : "none";
-    document.getElementById("theatre-location").textContent = state.locacion || "LOCALIZACIÓN DESCONOCIDA";
-    document.getElementById("dialogue-name").textContent = state.nombre || "NARRADOR";
-    document.getElementById("dialogue-title").textContent = state.titulo || "";
-    document.getElementById("dialogue-text").textContent = state.mensaje || "…";
-    const stage = document.getElementById("theatre-stage");
-    stage.replaceChildren();
-    const sprites = state.sprites || (state.sprite ? [{
-      url: state.sprite,
-      nombre: state.nombre,
-    }] : []);
-    Object.values(sprites).forEach((sprite) => {
-      const img = document.createElement("img");
-      img.className = "theatre-sprite";
-      img.src = sprite.url || sprite.sprite || "";
-      img.alt = sprite.nombre || "Actor en escena";
-      if (img.src) stage.appendChild(img);
-    });
-  }
-
-  theatreRef.child("estado_actual").on("value", (snapshot) => renderScene(snapshot.val()));
-  theatreRef.child("locacion").on("value", (snapshot) => {
-    document.getElementById("theatre-location").textContent = snapshot.val() || "LOCALIZACIÓN DESCONOCIDA";
-  });
-  theatreRef.child("fondo").on("value", (snapshot) => {
-    const value = snapshot.val();
-    if (value) document.getElementById("modulo-teatro").style.backgroundImage = `url("${value}")`;
-  });
-
   document.getElementById("btn-update-scene").addEventListener("click", () => {
-    theatreRef.update({
+    db.ref(SCENE_ROOT).update({
       fondo: document.getElementById("theatre-background-input").value.trim(),
       locacion: document.getElementById("theatre-location-input").value.trim(),
     });
   });
+
   document.getElementById("btn-send-dialogue").addEventListener("click", () => {
     const texto = document.getElementById("theatre-dialogue-input").value.trim();
     if (!texto) return;
-    theatreRef.child("estado_actual").update({ mensaje: texto, timestamp: window.firebase.database.ServerValue.TIMESTAMP });
+    db.ref(DIALOGUE_ROOT).update({
+      mensaje: texto,
+      nombre: "NARRADOR", // Se puede expandir en el futuro
+      timestamp: window.firebase.database.ServerValue.TIMESTAMP
+    });
     document.getElementById("theatre-dialogue-input").value = "";
   });
+
   document.getElementById("btn-trigger-combat").addEventListener("click", () => {
     db.ref("campaña/combate").update({ estado: "COMBAT_ACTIVE", startedAt: window.firebase.database.ServerValue.TIMESTAMP });
   });

--- a/js/theatre-controls.js
+++ b/js/theatre-controls.js
@@ -1,0 +1,107 @@
+(function(global) {
+    "use strict";
+
+    const db = global.firebase.database();
+
+    const NPC_ROSTER_PATH = "campaña/base_datos_npcs";
+    const THEATRE_ACTORS_PATH = "campaña/estado_mundo/escena_actual/actores";
+
+    let npcDatabase = {};
+    let liveActors = {};
+
+    const selectNpcRoster = document.getElementById("select-npc-roster");
+    const liveActorsList = document.getElementById("live-actors-list");
+    const btnSpawnNpc = document.getElementById("btn-spawn-npc");
+
+    // 1. Carga del Roster (Pre-Game NPCs)
+    if (selectNpcRoster) {
+        db.ref(NPC_ROSTER_PATH).on("value", snapshot => {
+            npcDatabase = snapshot.val() || {};
+            selectNpcRoster.innerHTML = '<option value="">Selecciona un NPC...</option>';
+
+            Object.keys(npcDatabase).forEach(npcId => {
+                const npc = npcDatabase[npcId];
+                const option = document.createElement("option");
+                option.value = npcId;
+                option.textContent = npc.nombre || npcId;
+                selectNpcRoster.appendChild(option);
+            });
+        });
+    }
+
+    // 2. El Disparo (Spawn)
+    if (btnSpawnNpc) {
+        btnSpawnNpc.addEventListener("click", () => {
+            const selectedId = selectNpcRoster.value;
+            if (!selectedId) return;
+
+            const npcData = npcDatabase[selectedId];
+            if (!npcData) return;
+
+            // Generate a unique ID for this instance on stage
+            const actorInstanceId = `actor_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
+
+            const spawnPayload = {
+                nombre: npcData.nombre || selectedId,
+                sprite: npcData.sprite || npcData.url || "",
+                x: 0,
+                y: 0,
+                escala: 1,
+                orientacion: 'normal'
+            };
+
+            db.ref(`${THEATRE_ACTORS_PATH}/${actorInstanceId}`).set(spawnPayload)
+              .catch(err => console.error("Error inyectando NPC al teatro:", err));
+        });
+    }
+
+    // 3. Manipulación en Vivo (Live Control Cards)
+    if (liveActorsList) {
+        db.ref(THEATRE_ACTORS_PATH).on("value", snapshot => {
+            liveActors = snapshot.val() || {};
+            liveActorsList.innerHTML = '';
+
+            Object.keys(liveActors).forEach(actorId => {
+                const actorData = liveActors[actorId];
+
+                const card = document.createElement("div");
+                card.className = "actor-control-card";
+                card.innerHTML = `
+                    <span class="actor-name">${actorData.nombre} (ID: ${actorId.split('_')[1]})</span>
+                    <div class="actor-buttons">
+                        <button class="btn-move" data-dir="left"><</button>
+                        <button class="btn-move" data-dir="right">></button>
+                        <button class="btn-flip">ESPEJO</button>
+                        <button class="btn-remove">X</button>
+                    </div>
+                `;
+
+                // Move Left
+                card.querySelector('.btn-move[data-dir="left"]').addEventListener("click", () => {
+                    const currentX = parseInt(actorData.x) || 0;
+                    db.ref(`${THEATRE_ACTORS_PATH}/${actorId}`).update({ x: currentX - 50 });
+                });
+
+                // Move Right
+                card.querySelector('.btn-move[data-dir="right"]').addEventListener("click", () => {
+                    const currentX = parseInt(actorData.x) || 0;
+                    db.ref(`${THEATRE_ACTORS_PATH}/${actorId}`).update({ x: currentX + 50 });
+                });
+
+                // Flip (Espejo)
+                card.querySelector('.btn-flip').addEventListener("click", () => {
+                    const currentOrientation = actorData.orientacion === 'flip' ? 'normal' : 'flip';
+                    db.ref(`${THEATRE_ACTORS_PATH}/${actorId}`).update({ orientacion: currentOrientation });
+                });
+
+                // Remove
+                card.querySelector('.btn-remove').addEventListener("click", () => {
+                    db.ref(`${THEATRE_ACTORS_PATH}/${actorId}`).remove();
+                });
+
+                liveActorsList.appendChild(card);
+            });
+        });
+    }
+
+})(window);

--- a/js/theatre-engine.js
+++ b/js/theatre-engine.js
@@ -1,0 +1,92 @@
+(function (global) {
+    "use strict";
+
+    const db = global.firebase.database();
+
+    const THEATRE_ROOT = "campaña/estado_mundo/escena_actual";
+    const DIALOGUE_ROOT = "campaña/estado_mundo/dialogo_activo";
+
+    // 1. Reactividad de Escenografía (Fondo)
+    db.ref(`${THEATRE_ROOT}/fondo`).on("value", (snapshot) => {
+        const fondoUrl = snapshot.val();
+        const moduleTeatro = document.getElementById("modulo-teatro");
+        if (moduleTeatro) {
+            moduleTeatro.style.backgroundImage = fondoUrl
+                ? `linear-gradient(rgba(0,0,0,.15), rgba(0,0,0,.35)), url("${fondoUrl}")`
+                : "none";
+        }
+    });
+
+    db.ref(`${THEATRE_ROOT}/locacion`).on("value", (snapshot) => {
+        const locacion = snapshot.val();
+        const locationEl = document.getElementById("theatre-location");
+        if (locationEl) {
+            locationEl.textContent = locacion || "LOCALIZACIÓN DESCONOCIDA";
+        }
+    });
+
+    // 2. Motor de Sprites (Actores en Escena)
+    db.ref(`${THEATRE_ROOT}/actores`).on("value", (snapshot) => {
+        const stage = document.getElementById("theatre-stage");
+        if (!stage) return;
+
+        const actoresData = snapshot.val() || {};
+
+        // Track current actors in DOM by data-id
+        const currentActors = Array.from(stage.querySelectorAll('.theatre-sprite'));
+        const currentActorIds = currentActors.map(img => img.dataset.id);
+        const newActorIds = Object.keys(actoresData);
+
+        // Destrucción: Remove actors that are no longer in the JSON
+        currentActors.forEach(img => {
+            if (!newActorIds.includes(img.dataset.id)) {
+                img.remove();
+            }
+        });
+
+        // Construcción y Actualización Posicional
+        newActorIds.forEach(actorId => {
+            const data = actoresData[actorId];
+            let img = stage.querySelector(`.theatre-sprite[data-id="${actorId}"]`);
+
+            if (!img) {
+                // Inyectar nuevo actor al DOM
+                img = document.createElement("img");
+                img.className = "theatre-sprite";
+                img.dataset.id = actorId;
+                stage.appendChild(img);
+            }
+
+            // Actualizar propiedades
+            img.src = data.url || data.sprite || "";
+            img.alt = data.nombre || "Actor en escena";
+
+            // Si hay transformaciones, escala u orientación, aplicarlas.
+            // Ejemplo: transform: scaleX(-1) translateX(50px)
+            let transformStr = "";
+            if (data.escala) transformStr += `scale(${data.escala}) `;
+            if (data.orientacion === 'flip') transformStr += `scaleX(-1) `;
+            if (data.x || data.y) transformStr += `translate(${data.x || '0px'}, ${data.y || '0px'}) `;
+
+            if (transformStr) {
+                img.style.transform = transformStr.trim();
+            } else {
+                img.style.transform = "none";
+            }
+        });
+    });
+
+    // 3. Sincronización de Diálogos y Logs (Caja Visual Novel)
+    db.ref(DIALOGUE_ROOT).on("value", (snapshot) => {
+        const dialogData = snapshot.val() || {};
+
+        const nameEl = document.getElementById("dialogue-name");
+        const titleEl = document.getElementById("dialogue-title");
+        const textEl = document.getElementById("dialogue-text");
+
+        if (nameEl) nameEl.textContent = dialogData.nombre || "NARRADOR";
+        if (titleEl) titleEl.textContent = dialogData.titulo || "";
+        if (textEl) textEl.textContent = dialogData.mensaje || "…";
+    });
+
+})(window);

--- a/js/theatre-engine.js
+++ b/js/theatre-engine.js
@@ -66,7 +66,15 @@
             let transformStr = "";
             if (data.escala) transformStr += `scale(${data.escala}) `;
             if (data.orientacion === 'flip') transformStr += `scaleX(-1) `;
-            if (data.x || data.y) transformStr += `translate(${data.x || '0px'}, ${data.y || '0px'}) `;
+
+            // Fix parsing raw numbers to px if necessary
+            let xPos = data.x !== undefined ? data.x : 0;
+            let yPos = data.y !== undefined ? data.y : 0;
+            if (xPos !== 0 || yPos !== 0) {
+                let xStr = typeof xPos === 'number' ? `${xPos}px` : xPos;
+                let yStr = typeof yPos === 'number' ? `${yPos}px` : yPos;
+                transformStr += `translate(${xStr}, ${yStr}) `;
+            }
 
             if (transformStr) {
                 img.style.transform = transformStr.trim();

--- a/server.log
+++ b/server.log
@@ -1,0 +1,13 @@
+127.0.0.1 - - [13/Aug/2026 19:24:04] "GET /hoja_de_DM.html HTTP/1.1" 200 -
+127.0.0.1 - - [13/Aug/2026 19:24:04] "GET /css/on-game-dashboard.css HTTP/1.1" 200 -
+127.0.0.1 - - [13/Aug/2026 19:24:04] "GET /js/instance-control.js HTTP/1.1" 200 -
+127.0.0.1 - - [13/Aug/2026 19:24:04] "GET /js/on-game-dashboard.js HTTP/1.1" 200 -
+127.0.0.1 - - [13/Aug/2026 19:24:04] "GET /Battle-viewer.html HTTP/1.1" 200 -
+127.0.0.1 - - [13/Aug/2026 19:24:04] "GET /js/combatEngine.js HTTP/1.1" 200 -
+127.0.0.1 - - [13/Aug/2026 19:42:29] "GET /hoja_de_DM.html HTTP/1.1" 200 -
+127.0.0.1 - - [13/Aug/2026 19:42:29] "GET /css/on-game-dashboard.css HTTP/1.1" 200 -
+127.0.0.1 - - [13/Aug/2026 19:42:29] "GET /js/instance-control.js HTTP/1.1" 200 -
+127.0.0.1 - - [13/Aug/2026 19:42:29] "GET /js/theatre-engine.js HTTP/1.1" 200 -
+127.0.0.1 - - [13/Aug/2026 19:42:29] "GET /js/on-game-dashboard.js HTTP/1.1" 200 -
+127.0.0.1 - - [13/Aug/2026 19:42:29] "GET /Battle-viewer.html HTTP/1.1" 200 -
+127.0.0.1 - - [13/Aug/2026 19:42:29] "GET /js/combatEngine.js HTTP/1.1" 200 -

--- a/server.log
+++ b/server.log
@@ -11,3 +11,11 @@
 127.0.0.1 - - [13/Aug/2026 19:42:29] "GET /js/on-game-dashboard.js HTTP/1.1" 200 -
 127.0.0.1 - - [13/Aug/2026 19:42:29] "GET /Battle-viewer.html HTTP/1.1" 200 -
 127.0.0.1 - - [13/Aug/2026 19:42:29] "GET /js/combatEngine.js HTTP/1.1" 200 -
+127.0.0.1 - - [13/Aug/2026 20:01:09] "GET /hoja_de_DM.html HTTP/1.1" 200 -
+127.0.0.1 - - [13/Aug/2026 20:01:09] "GET /css/on-game-dashboard.css HTTP/1.1" 200 -
+127.0.0.1 - - [13/Aug/2026 20:01:09] "GET /js/on-game-dashboard.js HTTP/1.1" 200 -
+127.0.0.1 - - [13/Aug/2026 20:01:09] "GET /js/theatre-controls.js HTTP/1.1" 200 -
+127.0.0.1 - - [13/Aug/2026 20:01:09] "GET /js/instance-control.js HTTP/1.1" 200 -
+127.0.0.1 - - [13/Aug/2026 20:01:09] "GET /js/theatre-engine.js HTTP/1.1" 200 -
+127.0.0.1 - - [13/Aug/2026 20:01:09] "GET /Battle-viewer.html HTTP/1.1" 200 -
+127.0.0.1 - - [13/Aug/2026 20:01:09] "GET /js/combatEngine.js HTTP/1.1" 200 -


### PR DESCRIPTION
Isolates the theatre engine in the DM dashboard into `theatre-engine.js` to correctly manage sprites, background, and dialogue reactivity via Firebase `campaña/estado_mundo/` nodes. Fixes module visibility via `on-game-dashboard.css` and links instance switching using bidirectional controls in `instance-control.js`.

---
*PR created automatically by Jules for task [17271323979917915221](https://jules.google.com/task/17271323979917915221) started by @sokcrow*