### PR TITLE
Rediseño de la hoja de DM con interfaz industrial estilo Luminous/Limbus

### DIFF
--- a/css/on-game-dashboard.css
+++ b/css/on-game-dashboard.css
@@ -1,75 +1,304 @@
-@font-face { font-family: "Bebas Kai"; src: url("../Fonts/BebasKai.ttf") format("truetype"); font-display: swap; }
-:root { color-scheme: dark; font-family: "Share Tech Mono", monospace; --ivory: #ded9c9; --paper: #aaa797; --ink: #090a09; --blood: #9f1e1e; --blood-bright: #d2382f; --acid: #d0b53c; --line: rgba(222,217,201,.24); }
+@font-face {
+  font-family: "Bebas Kai";
+  src: url("../Fonts/BebasKai.ttf") format("truetype");
+  font-display: swap;
+}
+
+:root {
+  color-scheme: dark;
+  font-family: "Share Tech Mono", monospace;
+  --panel: #0d0e0c;
+  --panel-raised: #161714;
+  --ivory: #ded9c9;
+  --muted: #777970;
+  --blood: #9f1e1e;
+  --blood-bright: #d2382f;
+  --line: #3b3c36;
+}
+
 * { box-sizing: border-box; }
-body { margin: 0; overflow: hidden; background: #070807; color: var(--ivory); }
-body::after { content: ""; position: fixed; inset: 0; z-index: 100; pointer-events: none; opacity: .17; background: repeating-linear-gradient(0deg, transparent 0 3px, #000 4px), radial-gradient(circle at 50% 50%, transparent 55%, #000 120%); mix-blend-mode: multiply; }
+
+body {
+  margin: 0;
+  overflow: hidden;
+  background: #070807;
+  color: var(--ivory);
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  pointer-events: none;
+  opacity: .15;
+  background:
+    repeating-linear-gradient(0deg, transparent 0 3px, #000 4px),
+    radial-gradient(circle, transparent 55%, #000 120%);
+  mix-blend-mode: multiply;
+}
+
 button, input, textarea { font: inherit; }
-.master-control-bar { position: fixed; inset: 0 0 auto; z-index: 50; height: 82px; padding: 0 28px; display: grid; grid-template-columns: 270px 1fr 180px; align-items: stretch; background: #0c0d0c; border-bottom: 2px solid var(--blood); box-shadow: 0 8px 35px #000; }
-.master-control-bar::before { content: ""; position: absolute; left: 0; bottom: -7px; width: 34%; height: 5px; background: var(--blood); clip-path: polygon(0 0, 100% 0, 98% 100%, 0 100%); }
-.brand-lockup { display: flex; align-items: center; gap: 13px; }
-.brand-mark { display: grid; place-items: center; width: 43px; height: 43px; color: var(--ivory); border: 2px solid var(--ivory); font-family: "Bebas Kai"; font-size: 1.65rem; transform: rotate(45deg); }
-.brand-mark::first-letter { transform: rotate(-45deg); }
-.brand-lockup div { display: flex; flex-direction: column; }
-.brand-lockup strong { font: 1.55rem/1 "Bebas Kai", sans-serif; letter-spacing: .18em; }
-.brand-lockup small, .system-readout small { color: #777970; font-size: .61rem; letter-spacing: .13em; margin-top: 5px; }
-.instance-toggles { display: flex; justify-content: center; align-items: stretch; }
-.instance-toggles label { position: relative; min-width: 150px; display: flex; align-items: center; justify-content: center; gap: 9px; padding: 0 20px; border-left: 1px solid #272926; cursor: pointer; color: #85877f; letter-spacing: .06em; transition: .18s ease; }
-.instance-toggles label:last-child { border-right: 1px solid #272926; }
-.instance-toggles label:hover { color: var(--ivory); background: #151715; }
+
+.master-control-bar {
+  position: fixed;
+  inset: 0 0 auto;
+  z-index: 50;
+  min-height: 72px;
+  padding: 10px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  background: rgba(10, 11, 9, .98);
+  border-bottom: 2px solid var(--blood);
+  box-shadow: 0 8px 30px #000;
+}
+
+.master-control-bar::before {
+  content: "DIRECTOR CONTROL // INSTANCE SELECT";
+  position: absolute;
+  left: 24px;
+  bottom: -17px;
+  padding: 2px 16px 2px 8px;
+  color: #c4bfae;
+  background: var(--blood);
+  clip-path: polygon(0 0, 100% 0, 91% 100%, 0 100%);
+  font-size: .56rem;
+  letter-spacing: .13em;
+}
+
+.instance-toggles {
+  display: flex;
+  gap: 6px;
+}
+
+.instance-toggles label {
+  position: relative;
+  min-width: 155px;
+  padding: 12px 16px 12px 40px;
+  overflow: hidden;
+  color: #999b92;
+  background: var(--panel-raised);
+  border: 1px solid var(--line);
+  cursor: pointer;
+  letter-spacing: .06em;
+  transition: color .18s, background .18s, border-color .18s;
+}
+
+.instance-toggles label::before {
+  content: "00";
+  position: absolute;
+  left: 12px;
+  color: var(--blood-bright);
+  font-size: .65rem;
+}
+
+.instance-toggles label:nth-child(2)::before { content: "01"; }
+.instance-toggles label:nth-child(3)::before { content: "02"; }
+.instance-toggles label:hover { color: #fff; border-color: #76786f; }
 .instance-toggles input { position: absolute; opacity: 0; }
-.instance-toggles label:has(input:checked) { color: #fff; background: linear-gradient(135deg, #681313, var(--blood)); }
-.instance-toggles label:has(input:checked)::after { content: ""; position: absolute; inset: auto 14px 8px; height: 2px; background: #f0c7a6; }
-.mode-index { color: var(--blood-bright); font-size: .7rem; }
-.instance-toggles label:has(input:checked) .mode-index { color: #fff1cd; }
-.system-readout { display: flex; flex-direction: column; justify-content: center; align-items: flex-end; }
-.connection-status { color: #92b978; font-size: .76rem; letter-spacing: .08em; margin-top: 5px; }
-.connection-status.offline { color: #d7524c; }
-.game-module { position: fixed; inset: 82px 0 0; background: #090a09; }
+
+.instance-toggles label:has(input:checked) {
+  color: #fff4dc;
+  background: linear-gradient(135deg, #651313, var(--blood));
+  border-color: #d04a3d;
+  box-shadow: inset 0 -3px #e7c99e;
+}
+
+.instance-toggles label:has(input:focus-visible) { outline: 2px solid #fff; outline-offset: 2px; }
+
+.connection-status {
+  min-width: 150px;
+  color: #9ab985;
+  font-size: .72rem;
+  letter-spacing: .08em;
+  text-align: right;
+}
+
+.connection-status::before {
+  content: "NETWORK STATUS";
+  display: block;
+  margin-bottom: 5px;
+  color: var(--muted);
+  font-size: .56rem;
+}
+
+.connection-status.offline { color: #df5b52; }
+
+.game-module {
+  position: fixed;
+  inset: 72px 0 0;
+  background: #090a09;
+}
+
 .game-module.hidden { display: none; }
 .game-module.active-module { display: flex; }
-#modulo-standby { flex-direction: column; align-items: center; justify-content: center; isolation: isolate; background: radial-gradient(circle at 50% 48%, #292b27 0, #111210 32%, #070807 68%); }
-#modulo-standby::before { content: ""; position: absolute; inset: 0; z-index: -1; opacity: .24; background: linear-gradient(115deg, transparent 0 18%, var(--line) 18.1% 18.25%, transparent 18.4% 72%, var(--line) 72.1% 72.25%, transparent 72.4%), repeating-linear-gradient(90deg, transparent 0 119px, rgba(255,255,255,.035) 120px); }
-.standby-emblem { position: absolute; width: min(44vw, 500px); aspect-ratio: 1; display: grid; place-items: center; border: 1px solid rgba(213,209,192,.13); border-radius: 50%; animation: system-pulse 4s ease-in-out infinite; }
-.standby-emblem::before, .standby-emblem::after { content: ""; position: absolute; inset: 10%; border: 3px solid rgba(159,30,30,.28); transform: rotate(45deg); }
-.standby-emblem::after { inset: 22%; border-width: 1px; transform: rotate(0); }
-.standby-emblem span { color: rgba(222,217,201,.05); font: 17rem "Bebas Kai"; }
-.eyebrow { z-index: 1; margin: 0 0 12px; color: var(--blood-bright); font-size: .72rem; letter-spacing: .35em; }
-.standby-text { z-index: 1; margin: 0; color: var(--ivory); font: clamp(4rem, 9vw, 8.3rem)/.76 "Bebas Kai", sans-serif; text-align: center; letter-spacing: .05em; text-shadow: 7px 7px 0 #000; }
-.standby-text span { color: transparent; -webkit-text-stroke: 1px #77786f; }
-.standby-hint { z-index: 1; margin-top: 35px; padding: 9px 18px; color: #85877e; border-left: 2px solid var(--blood); border-right: 2px solid var(--blood); font-size: .72rem; letter-spacing: .16em; }
-.standby-code { position: absolute; bottom: 22px; left: 28px; color: #4b4d47; font-size: .65rem; letter-spacing: .12em; }
-@keyframes system-pulse { 50% { opacity: .55; transform: scale(1.025) rotate(1deg); } }
-#modulo-teatro { flex-direction: column; background-position: center; background-size: cover; }
-#modulo-teatro::after { content: ""; position: absolute; inset: 0; pointer-events: none; background: linear-gradient(90deg, rgba(0,0,0,.75), transparent 18% 82%, rgba(0,0,0,.75)); }
-.scene-header, .combat-header { z-index: 2; height: 54px; padding: 9px 28px; display: flex; align-items: center; justify-content: space-between; background: linear-gradient(90deg, rgba(8,9,8,.95), rgba(8,9,8,.55)); border-bottom: 1px solid var(--blood); }
-.scene-header div { display: flex; flex-direction: column; }
-.scene-header small, .combat-header small, #combat-log-and-controls small { color: var(--blood-bright); font-size: .6rem; letter-spacing: .17em; }
-.scene-header strong { font: 1.25rem "Bebas Kai"; letter-spacing: .16em; }
-.scene-header > span { color: #9ead8c; font-size: .68rem; }
-#theatre-stage { position: relative; z-index: 1; flex: 1; display: flex; align-items: flex-end; justify-content: center; gap: 1vw; overflow: hidden; }
-.theatre-sprite { max-height: 68vh; max-width: 30vw; object-fit: contain; filter: drop-shadow(0 0 12px #000); }
-.theatre-bottom { z-index: 3; display: grid; grid-template-columns: 1fr minmax(390px, 34vw); min-height: 196px; border-top: 2px solid var(--blood); }
-.dialogue-panel { padding: 24px 5vw; background: rgba(7,8,7,.93); }
-.speaker-line { display: flex; align-items: baseline; gap: 12px; }
-.dialogue-name { color: #f0e2bd; font: 1.7rem "Bebas Kai"; letter-spacing: .12em; }
-.speaker-line small { color: var(--blood-bright); }
-.dialogue-panel p { max-width: 850px; color: #bab9b0; line-height: 1.5; }
-.theatre-controls { display: grid; grid-template-columns: 1fr 1fr; gap: 7px; padding: 14px; background: #111210; border-left: 1px solid #3d3e39; }
-.control-heading { grid-column: 1 / -1; display: flex; justify-content: space-between; color: var(--ivory); font-size: .75rem; letter-spacing: .1em; }
-.control-heading small { color: #676962; }
-.theatre-controls input, .theatre-controls textarea { min-width: 0; padding: 9px 11px; outline: 0; background: #080908; color: white; border: 1px solid #393b36; }
-.theatre-controls input:focus, .theatre-controls textarea:focus { border-color: var(--acid); }
-.theatre-controls textarea { grid-column: 1 / -1; resize: none; }
-.theatre-controls button, #btn-trigger-combat { padding: 9px 13px; display: flex; justify-content: space-between; background: #ded9c9; color: #111; border: 0; cursor: pointer; font-weight: bold; }
-#btn-send-dialogue { background: var(--blood); color: #fff; }
+
+#modulo-standby {
+  align-items: center;
+  justify-content: center;
+  isolation: isolate;
+  background:
+    linear-gradient(115deg, transparent 18%, rgba(222, 217, 201, .06) 18.1% 18.25%, transparent 18.4% 72%, rgba(222, 217, 201, .06) 72.1% 72.25%, transparent 72.4%),
+    radial-gradient(circle, #292b27 0, #111210 34%, #070807 70%);
+}
+
+#modulo-standby::before {
+  content: "01";
+  position: absolute;
+  z-index: -1;
+  display: grid;
+  place-items: center;
+  width: min(48vw, 500px);
+  aspect-ratio: 1;
+  color: rgba(222, 217, 201, .04);
+  border: 2px solid rgba(159, 30, 30, .32);
+  outline: 1px solid rgba(222, 217, 201, .13);
+  outline-offset: 45px;
+  font: 17rem "Bebas Kai", sans-serif;
+  transform: rotate(45deg);
+}
+
+.standby-text {
+  margin: 0;
+  color: var(--ivory);
+  font: clamp(3.7rem, 8vw, 8rem)/1 "Bebas Kai", sans-serif;
+  letter-spacing: .08em;
+  text-shadow: 7px 7px #000;
+}
+
+.standby-text::before {
+  content: "DIRECTOR AUTHORITY // IDLE";
+  display: block;
+  margin-bottom: 10px;
+  color: var(--blood-bright);
+  font: .7rem "Share Tech Mono", monospace;
+  letter-spacing: .3em;
+  text-align: center;
+  text-shadow: none;
+}
+
+#modulo-teatro {
+  flex-direction: column;
+  background-position: center;
+  background-size: cover;
+}
+
+#theatre-stage {
+  flex: 1;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 1vw;
+  min-height: 0;
+  overflow: hidden;
+  background: linear-gradient(90deg, rgba(0, 0, 0, .6), transparent 20% 80%, rgba(0, 0, 0, .6));
+}
+
+.theatre-sprite {
+  max-height: 72vh;
+  max-width: 30vw;
+  object-fit: contain;
+  filter: drop-shadow(0 0 12px #000);
+}
+
+.dialogue-panel {
+  position: relative;
+  z-index: 2;
+  min-height: 112px;
+  padding: 18px 5vw;
+  background: rgba(8, 9, 8, .94);
+  border-top: 2px solid var(--blood);
+}
+
+#modulo-teatro > .dialogue-panel:first-child {
+  min-height: auto;
+  padding-block: 12px;
+  border-top: 0;
+  border-bottom: 1px solid var(--blood);
+  font-family: "Bebas Kai", sans-serif;
+  letter-spacing: .14em;
+}
+
+.dialogue-name {
+  color: #f0e2bd;
+  font: 1.55rem "Bebas Kai", sans-serif;
+  letter-spacing: .12em;
+}
+
+.dialogue-panel p { color: #bab9b0; line-height: 1.45; }
+
+.theatre-controls {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 7px;
+  padding: 12px;
+  background: var(--panel);
+  border-top: 1px solid var(--line);
+}
+
+.theatre-controls input,
+.theatre-controls textarea,
+.theatre-controls button {
+  min-width: 0;
+  padding: 10px 12px;
+  color: white;
+  background: #080908;
+  border: 1px solid var(--line);
+  outline: 0;
+}
+
+.theatre-controls input:focus,
+.theatre-controls textarea:focus { border-color: #c6aa3d; }
+.theatre-controls textarea { grid-column: 1 / 3; resize: none; }
+
+.theatre-controls button {
+  color: #fff;
+  background: var(--blood);
+  border-color: #ce493e;
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.theatre-controls button:hover, #btn-trigger-combat:hover { background: #bd2923; }
+
 #modulo-combate { flex-direction: column; }
-.combat-header { height: 46px; }
-.combat-header > span { font: 1.25rem "Bebas Kai"; letter-spacing: .15em; }
 #combat-grid { flex: 1; min-height: 0; padding: 8px; background: #050605; }
-#combat-grid iframe { width: 100%; height: 100%; border: 1px solid #343630; }
-#combat-log-and-controls { min-height: 72px; padding: 10px 22px; display: flex; align-items: center; justify-content: space-between; background: #10110f; border-top: 2px solid var(--blood); }
-#combat-log-and-controls div { display: flex; flex-direction: column; gap: 5px; }
-#btn-trigger-combat { min-width: 270px; background: var(--blood); color: #fff; }
-@media (max-width: 900px) { .master-control-bar { height: 116px; padding: 0 12px; grid-template-columns: 1fr auto; grid-template-rows: 58px 58px; } .brand-lockup { grid-column: 1; } .system-readout { grid-column: 2; grid-row: 1; } .instance-toggles { grid-column: 1 / -1; grid-row: 2; } .instance-toggles label { flex: 1; min-width: 0; padding: 0 8px; font-size: .68rem; } .game-module { inset-block-start: 116px; } .theatre-bottom { grid-template-columns: 1fr; max-height: 48vh; overflow: auto; } .dialogue-panel { min-height: 130px; } .theatre-controls { border-left: 0; border-top: 1px solid #3d3e39; } }
-@media (max-width: 560px) { .brand-lockup small { display: none; } .standby-hint { max-width: 85vw; text-align: center; } .scene-header { padding-inline: 14px; } #combat-log-and-controls { gap: 10px; } #btn-trigger-combat { min-width: 150px; } }
-@media (prefers-reduced-motion: reduce) { .standby-emblem { animation: none; } }
+#combat-grid iframe { width: 100%; height: 100%; border: 1px solid var(--line); }
+
+#combat-log-and-controls {
+  min-height: 64px;
+  padding: 9px 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--panel);
+  border-top: 2px solid var(--blood);
+}
+
+#btn-trigger-combat {
+  padding: 11px 18px;
+  color: #fff;
+  background: var(--blood);
+  border: 1px solid #df5046;
+  cursor: pointer;
+}
+
+@media (max-width: 850px) {
+  .master-control-bar { min-height: 108px; align-items: flex-start; padding: 10px 12px; }
+  .instance-toggles { flex-wrap: wrap; }
+  .instance-toggles label { min-width: 125px; padding: 9px 8px 9px 32px; font-size: .68rem; }
+  .game-module { inset-block-start: 108px; }
+  .connection-status { min-width: 115px; }
+  .theatre-controls { grid-template-columns: 1fr; }
+  .theatre-controls textarea { grid-column: auto; }
+}
+
+@media (max-width: 560px) {
+  .master-control-bar { gap: 8px; }
+  .connection-status { position: absolute; top: 8px; right: 12px; }
+  .instance-toggles { padding-top: 34px; }
+  .standby-text { max-width: 90vw; text-align: center; }
+  #combat-log-and-controls { gap: 10px; font-size: .68rem; }
+}

--- a/css/on-game-dashboard.css
+++ b/css/on-game-dashboard.css
@@ -1,28 +1,75 @@
-:root { color-scheme: dark; font-family: "Share Tech Mono", monospace; }
+@font-face { font-family: "Bebas Kai"; src: url("../Fonts/BebasKai.ttf") format("truetype"); font-display: swap; }
+:root { color-scheme: dark; font-family: "Share Tech Mono", monospace; --ivory: #ded9c9; --paper: #aaa797; --ink: #090a09; --blood: #9f1e1e; --blood-bright: #d2382f; --acid: #d0b53c; --line: rgba(222,217,201,.24); }
 * { box-sizing: border-box; }
-body { margin: 0; overflow: hidden; background: #020304; color: #e8edf2; }
-.master-control-bar { position: fixed; inset: 0 0 auto; z-index: 50; min-height: 64px; padding: 12px 24px; display: flex; align-items: center; justify-content: space-between; background: rgba(5, 8, 12, .96); border-bottom: 1px solid #c49a00; box-shadow: 0 4px 20px #000; }
-.instance-toggles { display: flex; gap: 12px; }
-.instance-toggles label { padding: 9px 14px; border: 1px solid #46505a; cursor: pointer; letter-spacing: .05em; }
-.instance-toggles label:has(input:checked) { color: #050505; background: #c49a00; border-color: #ffe084; }
-.connection-status { color: #7aff9b; font-size: .8rem; }
-.connection-status.offline { color: #ff6575; }
-.game-module { position: fixed; inset: 64px 0 0; background: #050608; }
+body { margin: 0; overflow: hidden; background: #070807; color: var(--ivory); }
+body::after { content: ""; position: fixed; inset: 0; z-index: 100; pointer-events: none; opacity: .17; background: repeating-linear-gradient(0deg, transparent 0 3px, #000 4px), radial-gradient(circle at 50% 50%, transparent 55%, #000 120%); mix-blend-mode: multiply; }
+button, input, textarea { font: inherit; }
+.master-control-bar { position: fixed; inset: 0 0 auto; z-index: 50; height: 82px; padding: 0 28px; display: grid; grid-template-columns: 270px 1fr 180px; align-items: stretch; background: #0c0d0c; border-bottom: 2px solid var(--blood); box-shadow: 0 8px 35px #000; }
+.master-control-bar::before { content: ""; position: absolute; left: 0; bottom: -7px; width: 34%; height: 5px; background: var(--blood); clip-path: polygon(0 0, 100% 0, 98% 100%, 0 100%); }
+.brand-lockup { display: flex; align-items: center; gap: 13px; }
+.brand-mark { display: grid; place-items: center; width: 43px; height: 43px; color: var(--ivory); border: 2px solid var(--ivory); font-family: "Bebas Kai"; font-size: 1.65rem; transform: rotate(45deg); }
+.brand-mark::first-letter { transform: rotate(-45deg); }
+.brand-lockup div { display: flex; flex-direction: column; }
+.brand-lockup strong { font: 1.55rem/1 "Bebas Kai", sans-serif; letter-spacing: .18em; }
+.brand-lockup small, .system-readout small { color: #777970; font-size: .61rem; letter-spacing: .13em; margin-top: 5px; }
+.instance-toggles { display: flex; justify-content: center; align-items: stretch; }
+.instance-toggles label { position: relative; min-width: 150px; display: flex; align-items: center; justify-content: center; gap: 9px; padding: 0 20px; border-left: 1px solid #272926; cursor: pointer; color: #85877f; letter-spacing: .06em; transition: .18s ease; }
+.instance-toggles label:last-child { border-right: 1px solid #272926; }
+.instance-toggles label:hover { color: var(--ivory); background: #151715; }
+.instance-toggles input { position: absolute; opacity: 0; }
+.instance-toggles label:has(input:checked) { color: #fff; background: linear-gradient(135deg, #681313, var(--blood)); }
+.instance-toggles label:has(input:checked)::after { content: ""; position: absolute; inset: auto 14px 8px; height: 2px; background: #f0c7a6; }
+.mode-index { color: var(--blood-bright); font-size: .7rem; }
+.instance-toggles label:has(input:checked) .mode-index { color: #fff1cd; }
+.system-readout { display: flex; flex-direction: column; justify-content: center; align-items: flex-end; }
+.connection-status { color: #92b978; font-size: .76rem; letter-spacing: .08em; margin-top: 5px; }
+.connection-status.offline { color: #d7524c; }
+.game-module { position: fixed; inset: 82px 0 0; background: #090a09; }
 .game-module.hidden { display: none; }
 .game-module.active-module { display: flex; }
-#modulo-standby { align-items: center; justify-content: center; background: #000; }
-.standby-text { color: #24272a; letter-spacing: .45em; font-size: clamp(1.5rem, 4vw, 4rem); }
+#modulo-standby { flex-direction: column; align-items: center; justify-content: center; isolation: isolate; background: radial-gradient(circle at 50% 48%, #292b27 0, #111210 32%, #070807 68%); }
+#modulo-standby::before { content: ""; position: absolute; inset: 0; z-index: -1; opacity: .24; background: linear-gradient(115deg, transparent 0 18%, var(--line) 18.1% 18.25%, transparent 18.4% 72%, var(--line) 72.1% 72.25%, transparent 72.4%), repeating-linear-gradient(90deg, transparent 0 119px, rgba(255,255,255,.035) 120px); }
+.standby-emblem { position: absolute; width: min(44vw, 500px); aspect-ratio: 1; display: grid; place-items: center; border: 1px solid rgba(213,209,192,.13); border-radius: 50%; animation: system-pulse 4s ease-in-out infinite; }
+.standby-emblem::before, .standby-emblem::after { content: ""; position: absolute; inset: 10%; border: 3px solid rgba(159,30,30,.28); transform: rotate(45deg); }
+.standby-emblem::after { inset: 22%; border-width: 1px; transform: rotate(0); }
+.standby-emblem span { color: rgba(222,217,201,.05); font: 17rem "Bebas Kai"; }
+.eyebrow { z-index: 1; margin: 0 0 12px; color: var(--blood-bright); font-size: .72rem; letter-spacing: .35em; }
+.standby-text { z-index: 1; margin: 0; color: var(--ivory); font: clamp(4rem, 9vw, 8.3rem)/.76 "Bebas Kai", sans-serif; text-align: center; letter-spacing: .05em; text-shadow: 7px 7px 0 #000; }
+.standby-text span { color: transparent; -webkit-text-stroke: 1px #77786f; }
+.standby-hint { z-index: 1; margin-top: 35px; padding: 9px 18px; color: #85877e; border-left: 2px solid var(--blood); border-right: 2px solid var(--blood); font-size: .72rem; letter-spacing: .16em; }
+.standby-code { position: absolute; bottom: 22px; left: 28px; color: #4b4d47; font-size: .65rem; letter-spacing: .12em; }
+@keyframes system-pulse { 50% { opacity: .55; transform: scale(1.025) rotate(1deg); } }
 #modulo-teatro { flex-direction: column; background-position: center; background-size: cover; }
-#theatre-stage { flex: 1; display: flex; align-items: flex-end; justify-content: center; gap: 1vw; overflow: hidden; }
-.theatre-sprite { max-height: 72vh; max-width: 30vw; object-fit: contain; filter: drop-shadow(0 0 12px #000); }
-.dialogue-panel { padding: 18px 5vw; min-height: 130px; background: rgba(0,0,0,.88); border-top: 2px solid #c49a00; }
-.dialogue-name { color: #c49a00; font-size: 1.25rem; }
-.theatre-controls { display: grid; grid-template-columns: 1fr 1fr auto; gap: 8px; padding: 12px; background: #090c10; }
-.theatre-controls input, .theatre-controls textarea, .theatre-controls button { padding: 9px; background: #121820; color: white; border: 1px solid #53606d; }
-.theatre-controls textarea { grid-column: 1 / 3; resize: none; }
+#modulo-teatro::after { content: ""; position: absolute; inset: 0; pointer-events: none; background: linear-gradient(90deg, rgba(0,0,0,.75), transparent 18% 82%, rgba(0,0,0,.75)); }
+.scene-header, .combat-header { z-index: 2; height: 54px; padding: 9px 28px; display: flex; align-items: center; justify-content: space-between; background: linear-gradient(90deg, rgba(8,9,8,.95), rgba(8,9,8,.55)); border-bottom: 1px solid var(--blood); }
+.scene-header div { display: flex; flex-direction: column; }
+.scene-header small, .combat-header small, #combat-log-and-controls small { color: var(--blood-bright); font-size: .6rem; letter-spacing: .17em; }
+.scene-header strong { font: 1.25rem "Bebas Kai"; letter-spacing: .16em; }
+.scene-header > span { color: #9ead8c; font-size: .68rem; }
+#theatre-stage { position: relative; z-index: 1; flex: 1; display: flex; align-items: flex-end; justify-content: center; gap: 1vw; overflow: hidden; }
+.theatre-sprite { max-height: 68vh; max-width: 30vw; object-fit: contain; filter: drop-shadow(0 0 12px #000); }
+.theatre-bottom { z-index: 3; display: grid; grid-template-columns: 1fr minmax(390px, 34vw); min-height: 196px; border-top: 2px solid var(--blood); }
+.dialogue-panel { padding: 24px 5vw; background: rgba(7,8,7,.93); }
+.speaker-line { display: flex; align-items: baseline; gap: 12px; }
+.dialogue-name { color: #f0e2bd; font: 1.7rem "Bebas Kai"; letter-spacing: .12em; }
+.speaker-line small { color: var(--blood-bright); }
+.dialogue-panel p { max-width: 850px; color: #bab9b0; line-height: 1.5; }
+.theatre-controls { display: grid; grid-template-columns: 1fr 1fr; gap: 7px; padding: 14px; background: #111210; border-left: 1px solid #3d3e39; }
+.control-heading { grid-column: 1 / -1; display: flex; justify-content: space-between; color: var(--ivory); font-size: .75rem; letter-spacing: .1em; }
+.control-heading small { color: #676962; }
+.theatre-controls input, .theatre-controls textarea { min-width: 0; padding: 9px 11px; outline: 0; background: #080908; color: white; border: 1px solid #393b36; }
+.theatre-controls input:focus, .theatre-controls textarea:focus { border-color: var(--acid); }
+.theatre-controls textarea { grid-column: 1 / -1; resize: none; }
+.theatre-controls button, #btn-trigger-combat { padding: 9px 13px; display: flex; justify-content: space-between; background: #ded9c9; color: #111; border: 0; cursor: pointer; font-weight: bold; }
+#btn-send-dialogue { background: var(--blood); color: #fff; }
 #modulo-combate { flex-direction: column; }
-#combat-grid { flex: 1; }
-#combat-grid iframe { width: 100%; height: 100%; border: 0; }
-#combat-log-and-controls { padding: 8px 18px; display: flex; justify-content: space-between; background: #090c10; border-top: 1px solid #c49a00; }
-#btn-trigger-combat { padding: 10px 18px; background: #8b111d; color: #fff; border: 1px solid #ff6575; }
-@media (max-width: 850px) { .master-control-bar { align-items: flex-start; } .instance-toggles { flex-wrap: wrap; } .instance-toggles label { font-size: .7rem; } .theatre-controls { grid-template-columns: 1fr; } .theatre-controls textarea { grid-column: auto; } }
+.combat-header { height: 46px; }
+.combat-header > span { font: 1.25rem "Bebas Kai"; letter-spacing: .15em; }
+#combat-grid { flex: 1; min-height: 0; padding: 8px; background: #050605; }
+#combat-grid iframe { width: 100%; height: 100%; border: 1px solid #343630; }
+#combat-log-and-controls { min-height: 72px; padding: 10px 22px; display: flex; align-items: center; justify-content: space-between; background: #10110f; border-top: 2px solid var(--blood); }
+#combat-log-and-controls div { display: flex; flex-direction: column; gap: 5px; }
+#btn-trigger-combat { min-width: 270px; background: var(--blood); color: #fff; }
+@media (max-width: 900px) { .master-control-bar { height: 116px; padding: 0 12px; grid-template-columns: 1fr auto; grid-template-rows: 58px 58px; } .brand-lockup { grid-column: 1; } .system-readout { grid-column: 2; grid-row: 1; } .instance-toggles { grid-column: 1 / -1; grid-row: 2; } .instance-toggles label { flex: 1; min-width: 0; padding: 0 8px; font-size: .68rem; } .game-module { inset-block-start: 116px; } .theatre-bottom { grid-template-columns: 1fr; max-height: 48vh; overflow: auto; } .dialogue-panel { min-height: 130px; } .theatre-controls { border-left: 0; border-top: 1px solid #3d3e39; } }
+@media (max-width: 560px) { .brand-lockup small { display: none; } .standby-hint { max-width: 85vw; text-align: center; } .scene-header { padding-inline: 14px; } #combat-log-and-controls { gap: 10px; } #btn-trigger-combat { min-width: 150px; } }
+@media (prefers-reduced-motion: reduce) { .standby-emblem { animation: none; } }

--- a/hoja_de_DM.html
+++ b/hoja_de_DM.html
@@ -10,38 +10,59 @@
 </head>
 <body class="on-game-dashboard">
   <nav class="master-control-bar" aria-label="Control de instancia">
-    <div class="instance-toggles">
-      <label><input type="radio" name="instancia" value="ninguno"> PANTALLA NEGRA</label>
-      <label><input type="radio" name="instancia" value="teatro"> TEATRO / LORE</label>
-      <label><input type="radio" name="instancia" value="combate"> COMBATE TÁCTICO</label>
+    <div class="brand-lockup" aria-label="Luminous director console">
+      <span class="brand-mark" aria-hidden="true">L</span>
+      <div>
+        <strong>LUMINOUS</strong>
+        <small>DIRECTOR CONTROL // 01</small>
+      </div>
     </div>
-    <span id="connection-status" class="connection-status offline">● CONECTANDO</span>
+    <div class="instance-toggles">
+      <label><input type="radio" name="instancia" value="ninguno"><span class="mode-index">00</span> APAGADO</label>
+      <label><input type="radio" name="instancia" value="teatro"><span class="mode-index">01</span> TEATRO / LORE</label>
+      <label><input type="radio" name="instancia" value="combate"><span class="mode-index">02</span> COMBATE</label>
+    </div>
+    <div class="system-readout">
+      <small>NETWORK STATUS</small>
+      <span id="connection-status" class="connection-status offline">● CONECTANDO</span>
+    </div>
   </nav>
 
   <main>
     <section id="modulo-standby" class="game-module active-module" aria-hidden="false">
-      <h1 class="standby-text">SISTEMA EN ESPERA</h1>
+      <div class="standby-emblem" aria-hidden="true"><span>01</span></div>
+      <p class="eyebrow">DIRECTOR AUTHORITY // IDLE</p>
+      <h1 class="standby-text">SISTEMA<br><span>EN ESPERA</span></h1>
+      <p class="standby-hint">SELECCIONA UNA INSTANCIA PARA INICIAR LA TRANSMISIÓN</p>
+      <div class="standby-code">LUM-OS&nbsp;&nbsp;|&nbsp;&nbsp;SECTOR 12&nbsp;&nbsp;|&nbsp;&nbsp;LINK READY</div>
     </section>
     <section id="modulo-teatro" class="game-module hidden" aria-hidden="true">
-      <header class="dialogue-panel"><strong id="theatre-location">LOCALIZACIÓN DESCONOCIDA</strong></header>
+      <header class="scene-header">
+        <div><small>ESCENA ACTIVA</small><strong id="theatre-location">LOCALIZACIÓN DESCONOCIDA</strong></div>
+        <span>LIVE // 01</span>
+      </header>
       <div id="theatre-stage" aria-label="Escenario del teatro"></div>
-      <div class="dialogue-panel">
-        <span id="dialogue-name" class="dialogue-name">NARRADOR</span> <small id="dialogue-title"></small>
-        <p id="dialogue-text">…</p>
-      </div>
-      <div class="theatre-controls">
-        <input id="theatre-background-input" type="url" placeholder="URL del fondo">
-        <input id="theatre-location-input" type="text" placeholder="Localización">
-        <button id="btn-update-scene" type="button">ACTUALIZAR ESCENA</button>
-        <textarea id="theatre-dialogue-input" placeholder="Diálogo en vivo"></textarea>
-        <button id="btn-send-dialogue" type="button">ENVIAR DIÁLOGO</button>
+      <div class="theatre-bottom">
+        <div class="dialogue-panel">
+          <div class="speaker-line"><span id="dialogue-name" class="dialogue-name">NARRADOR</span><small id="dialogue-title"></small></div>
+          <p id="dialogue-text">…</p>
+        </div>
+        <div class="theatre-controls">
+          <div class="control-heading"><span>SCENE COMMAND</span><small>EDIT CHANNEL</small></div>
+          <input id="theatre-background-input" type="url" placeholder="URL // FONDO DE ESCENA">
+          <input id="theatre-location-input" type="text" placeholder="DESIGNACIÓN // LOCALIZACIÓN">
+          <button id="btn-update-scene" type="button">APLICAR ESCENA <span>↗</span></button>
+          <textarea id="theatre-dialogue-input" placeholder="INTRODUCIR DIÁLOGO EN VIVO..."></textarea>
+          <button id="btn-send-dialogue" type="button">TRANSMITIR <span>▶</span></button>
+        </div>
       </div>
     </section>
     <section id="modulo-combate" class="game-module hidden" aria-hidden="true">
+      <div class="combat-header"><span>ENCOUNTER CONTROL</span><small>TACTICAL FEED // LIVE</small></div>
       <div id="combat-grid"><iframe src="Battle-viewer.html" title="Cuadrícula de combate táctica"></iframe></div>
       <div id="combat-log-and-controls">
-        <span>FASE INICIAL: 60 s · PRE_COMBAT_PLANNING</span>
-        <button id="btn-trigger-combat" type="button">INICIAR COMBATE (Fin de Planeación)</button>
+        <div><small>ESTADO DE OPERACIÓN</small><span>FASE INICIAL: 60 s · PRE_COMBAT_PLANNING</span></div>
+        <button id="btn-trigger-combat" type="button">INICIAR COMBATE <span>▶</span></button>
       </div>
     </section>
   </main>

--- a/hoja_de_DM.html
+++ b/hoja_de_DM.html
@@ -10,59 +10,38 @@
 </head>
 <body class="on-game-dashboard">
   <nav class="master-control-bar" aria-label="Control de instancia">
-    <div class="brand-lockup" aria-label="Luminous director console">
-      <span class="brand-mark" aria-hidden="true">L</span>
-      <div>
-        <strong>LUMINOUS</strong>
-        <small>DIRECTOR CONTROL // 01</small>
-      </div>
-    </div>
     <div class="instance-toggles">
-      <label><input type="radio" name="instancia" value="ninguno"><span class="mode-index">00</span> APAGADO</label>
-      <label><input type="radio" name="instancia" value="teatro"><span class="mode-index">01</span> TEATRO / LORE</label>
-      <label><input type="radio" name="instancia" value="combate"><span class="mode-index">02</span> COMBATE</label>
+      <label><input type="radio" name="instancia" value="ninguno"> PANTALLA NEGRA</label>
+      <label><input type="radio" name="instancia" value="teatro"> TEATRO / LORE</label>
+      <label><input type="radio" name="instancia" value="combate"> COMBATE TÁCTICO</label>
     </div>
-    <div class="system-readout">
-      <small>NETWORK STATUS</small>
-      <span id="connection-status" class="connection-status offline">● CONECTANDO</span>
-    </div>
+    <span id="connection-status" class="connection-status offline">● CONECTANDO</span>
   </nav>
 
   <main>
     <section id="modulo-standby" class="game-module active-module" aria-hidden="false">
-      <div class="standby-emblem" aria-hidden="true"><span>01</span></div>
-      <p class="eyebrow">DIRECTOR AUTHORITY // IDLE</p>
-      <h1 class="standby-text">SISTEMA<br><span>EN ESPERA</span></h1>
-      <p class="standby-hint">SELECCIONA UNA INSTANCIA PARA INICIAR LA TRANSMISIÓN</p>
-      <div class="standby-code">LUM-OS&nbsp;&nbsp;|&nbsp;&nbsp;SECTOR 12&nbsp;&nbsp;|&nbsp;&nbsp;LINK READY</div>
+      <h1 class="standby-text">SISTEMA EN ESPERA</h1>
     </section>
     <section id="modulo-teatro" class="game-module hidden" aria-hidden="true">
-      <header class="scene-header">
-        <div><small>ESCENA ACTIVA</small><strong id="theatre-location">LOCALIZACIÓN DESCONOCIDA</strong></div>
-        <span>LIVE // 01</span>
-      </header>
+      <header class="dialogue-panel"><strong id="theatre-location">LOCALIZACIÓN DESCONOCIDA</strong></header>
       <div id="theatre-stage" aria-label="Escenario del teatro"></div>
-      <div class="theatre-bottom">
-        <div class="dialogue-panel">
-          <div class="speaker-line"><span id="dialogue-name" class="dialogue-name">NARRADOR</span><small id="dialogue-title"></small></div>
-          <p id="dialogue-text">…</p>
-        </div>
-        <div class="theatre-controls">
-          <div class="control-heading"><span>SCENE COMMAND</span><small>EDIT CHANNEL</small></div>
-          <input id="theatre-background-input" type="url" placeholder="URL // FONDO DE ESCENA">
-          <input id="theatre-location-input" type="text" placeholder="DESIGNACIÓN // LOCALIZACIÓN">
-          <button id="btn-update-scene" type="button">APLICAR ESCENA <span>↗</span></button>
-          <textarea id="theatre-dialogue-input" placeholder="INTRODUCIR DIÁLOGO EN VIVO..."></textarea>
-          <button id="btn-send-dialogue" type="button">TRANSMITIR <span>▶</span></button>
-        </div>
+      <div class="dialogue-panel">
+        <span id="dialogue-name" class="dialogue-name">NARRADOR</span> <small id="dialogue-title"></small>
+        <p id="dialogue-text">…</p>
+      </div>
+      <div class="theatre-controls">
+        <input id="theatre-background-input" type="url" placeholder="URL del fondo">
+        <input id="theatre-location-input" type="text" placeholder="Localización">
+        <button id="btn-update-scene" type="button">ACTUALIZAR ESCENA</button>
+        <textarea id="theatre-dialogue-input" placeholder="Diálogo en vivo"></textarea>
+        <button id="btn-send-dialogue" type="button">ENVIAR DIÁLOGO</button>
       </div>
     </section>
     <section id="modulo-combate" class="game-module hidden" aria-hidden="true">
-      <div class="combat-header"><span>ENCOUNTER CONTROL</span><small>TACTICAL FEED // LIVE</small></div>
       <div id="combat-grid"><iframe src="Battle-viewer.html" title="Cuadrícula de combate táctica"></iframe></div>
       <div id="combat-log-and-controls">
-        <div><small>ESTADO DE OPERACIÓN</small><span>FASE INICIAL: 60 s · PRE_COMBAT_PLANNING</span></div>
-        <button id="btn-trigger-combat" type="button">INICIAR COMBATE <span>▶</span></button>
+        <span>FASE INICIAL: 60 s · PRE_COMBAT_PLANNING</span>
+        <button id="btn-trigger-combat" type="button">INICIAR COMBATE (Fin de Planeación)</button>
       </div>
     </section>
   </main>


### PR DESCRIPTION
### Motivation

- Actualizar visualmente la hoja de DM hacia una estética industrial inspirada en Limbus Company para mejorar legibilidad, jerarquía visual y presencia de la consola de dirección. 
- Unificar el panel superior y los modos (Apagado / Teatro / Combate) con indicadores claros y una lectura de estado de red dedicada.
- Reorganizar los controles de Teatro y Combate para facilitar la operación en directo desde la interfaz del DM.

### Description

- Reescrito `hoja_de_DM.html` para añadir un "brand lockup" LUMINOUS, indicadores numerados de modo, lectura de estado de red y una pantalla de espera con emblema y mensajes de estado; además se reestructuró la sección Teatro en `theatre-stage` + `theatre-bottom` (diálogo y controles) y se añadió una cabecera táctica para Combate.  
- Reemplazado `css/on-game-dashboard.css` por una versión nueva que introduce `@font-face` para Bebas Kai, variables de color (rojos carmesí, tonos oscuros), textura de fondo, emblema animado, layout de barra de mando en grid, estilos para escenas/diálogo/controles y reglas responsive y `prefers-reduced-motion`.  
- Se mantuvo la lógica JS existente; los cambios son puramente de marcado y estilo para la UX visual.  
- Cambios registrados en repositorio con el mensaje de commit "Redesign DM dashboard with industrial command UI".

### Testing

- Se validó el HTML con un `HTMLParser` script y la comprobación `git diff --check`, ambos devolvieron OK sin errores de sintaxis.  
- Ejecutado `npx playwright test` sobre la suite local de pruebas, resultado: 6 tests pasaron y 2 fallaron debido a la imposibilidad de lanzar Chromium porque los navegadores de Playwright no están instalados en el entorno.  
- Intento de instalar navegadores con `npx playwright install` falló por error de descarga (HTTP 403), por lo que las pruebas en navegador sin headless local no pudieron completarse y la captura con Playwright falló por ausencia del ejecutable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7e18b4fb4483239386b72439ef9447)