### PR TITLE
Fix dependency hell and race conditions in DM dashboard

### DIFF
--- a/js/on-game-dashboard.js
+++ b/js/on-game-dashboard.js
@@ -1,37 +1,60 @@
 (function () {
   "use strict";
-  const db = window.firebase.database();
-  const SCENE_ROOT = "campaña/estado_mundo/escena_actual";
-  const DIALOGUE_ROOT = "campaña/estado_mundo/dialogo_activo";
+  document.addEventListener('DOMContentLoaded', () => {
+    const db = window.firebase.database();
+    const SCENE_ROOT = "campaña/estado_mundo/escena_actual";
+    const DIALOGUE_ROOT = "campaña/estado_mundo/dialogo_activo";
 
-  window.LuminousInstanceControl.bindDashboard({ db });
+    window.LuminousInstanceControl.bindDashboard({ db });
 
-  const status = document.getElementById("connection-status");
-  db.ref(".info/connected").on("value", (snapshot) => {
-    const online = snapshot.val() === true;
-    status.textContent = online ? "● SINCRONIZADO" : "● SIN CONEXIÓN";
-    status.classList.toggle("offline", !online);
-  });
+    const status = document.getElementById("connection-status");
+    if (status) {
+      db.ref(".info/connected").on("value", (snapshot) => {
+        const online = snapshot.val() === true;
+        status.textContent = online ? "● SINCRONIZADO" : "● SIN CONEXIÓN";
+        status.classList.toggle("offline", !online);
+      });
+    } else {
+        console.warn("ADVERTENCIA: No se encontró #connection-status");
+    }
 
-  document.getElementById("btn-update-scene").addEventListener("click", () => {
-    db.ref(SCENE_ROOT).update({
-      fondo: document.getElementById("theatre-background-input").value.trim(),
-      locacion: document.getElementById("theatre-location-input").value.trim(),
-    });
-  });
+    const btnUpdateScene = document.getElementById("btn-update-scene");
+    if (btnUpdateScene) {
+      btnUpdateScene.addEventListener("click", () => {
+        const bgInput = document.getElementById("theatre-background-input");
+        const locInput = document.getElementById("theatre-location-input");
 
-  document.getElementById("btn-send-dialogue").addEventListener("click", () => {
-    const texto = document.getElementById("theatre-dialogue-input").value.trim();
-    if (!texto) return;
-    db.ref(DIALOGUE_ROOT).update({
-      mensaje: texto,
-      nombre: "NARRADOR", // Se puede expandir en el futuro
-      timestamp: window.firebase.database.ServerValue.TIMESTAMP
-    });
-    document.getElementById("theatre-dialogue-input").value = "";
-  });
+        if (bgInput && locInput) {
+            db.ref(SCENE_ROOT).update({
+              fondo: bgInput.value.trim(),
+              locacion: locInput.value.trim(),
+            });
+        }
+      });
+    }
 
-  document.getElementById("btn-trigger-combat").addEventListener("click", () => {
-    db.ref("campaña/combate").update({ estado: "COMBAT_ACTIVE", startedAt: window.firebase.database.ServerValue.TIMESTAMP });
+    const btnSendDialogue = document.getElementById("btn-send-dialogue");
+    if (btnSendDialogue) {
+      btnSendDialogue.addEventListener("click", () => {
+        const dialogueInput = document.getElementById("theatre-dialogue-input");
+        if (!dialogueInput) return;
+
+        const texto = dialogueInput.value.trim();
+        if (!texto) return;
+        db.ref(DIALOGUE_ROOT).update({
+          mensaje: texto,
+          nombre: "NARRADOR", // Se puede expandir en el futuro
+          timestamp: window.firebase.database.ServerValue.TIMESTAMP
+        });
+        dialogueInput.value = "";
+      });
+    }
+
+    const btnTriggerCombat = document.getElementById("btn-trigger-combat");
+    if (btnTriggerCombat) {
+      btnTriggerCombat.addEventListener("click", () => {
+        db.ref("campaña/combate").update({ estado: "COMBAT_ACTIVE", startedAt: window.firebase.database.ServerValue.TIMESTAMP });
+      });
+    }
   });
 })();

--- a/js/theatre-controls.js
+++ b/js/theatre-controls.js
@@ -1,107 +1,137 @@
 (function(global) {
     "use strict";
 
-    const db = global.firebase.database();
+    document.addEventListener('DOMContentLoaded', () => {
+        const db = global.firebase.database();
 
-    const NPC_ROSTER_PATH = "campaña/base_datos_npcs";
-    const THEATRE_ACTORS_PATH = "campaña/estado_mundo/escena_actual/actores";
+        const NPC_ROSTER_PATH = "campaña/actores";
+        const THEATRE_ACTORS_PATH = "campaña/estado_mundo/escena_actual/actores";
 
-    let npcDatabase = {};
-    let liveActors = {};
+        let npcDatabase = {};
+        let liveActors = {};
 
-    const selectNpcRoster = document.getElementById("select-npc-roster");
-    const liveActorsList = document.getElementById("live-actors-list");
-    const btnSpawnNpc = document.getElementById("btn-spawn-npc");
+        const selectNpcRoster = document.getElementById("select-npc-roster");
+        const liveActorsList = document.getElementById("live-actors-list");
+        const btnSpawnNpc = document.getElementById("btn-spawn-npc");
 
-    // 1. Carga del Roster (Pre-Game NPCs)
-    if (selectNpcRoster) {
-        db.ref(NPC_ROSTER_PATH).on("value", snapshot => {
-            npcDatabase = snapshot.val() || {};
-            selectNpcRoster.innerHTML = '<option value="">Selecciona un NPC...</option>';
+        function cargarRosterNPCs() {
+            const npcRef = db.ref(NPC_ROSTER_PATH);
 
-            Object.keys(npcDatabase).forEach(npcId => {
-                const npc = npcDatabase[npcId];
-                const option = document.createElement("option");
-                option.value = npcId;
-                option.textContent = npc.nombre || npcId;
-                selectNpcRoster.appendChild(option);
+            if (!selectNpcRoster) {
+                console.error("CRÍTICO: No se encontró el #select-npc-roster en el DOM.");
+                return;
+            }
+
+            npcRef.on('value', (snapshot) => {
+                selectNpcRoster.innerHTML = '<option value="">Selecciona un Actor...</option>'; // Limpiar
+                if (!snapshot.exists()) {
+                    console.warn("ADVERTENCIA: La base de datos de NPCs está vacía o la ruta es incorrecta.");
+                    return;
+                }
+
+                npcDatabase = snapshot.val() || {};
+
+                snapshot.forEach((hijo) => {
+                    const npc = hijo.val();
+                    const npcId = hijo.key;
+                    // Ajusta 'npc.nombre' a como tengas guardado el nombre en tu JSON
+                    selectNpcRoster.innerHTML += `<option value="${npcId}">${npc.nombre || 'Sin Nombre'}</option>`;
+                });
+                console.log("Roster de NPCs cargado con éxito.");
             });
-        });
-    }
+        }
 
-    // 2. El Disparo (Spawn)
-    if (btnSpawnNpc) {
-        btnSpawnNpc.addEventListener("click", () => {
-            const selectedId = selectNpcRoster.value;
-            if (!selectedId) return;
+        // 1. Carga del Roster (Pre-Game NPCs)
+        cargarRosterNPCs();
 
-            const npcData = npcDatabase[selectedId];
-            if (!npcData) return;
+        // 2. El Disparo (Spawn)
+        if (btnSpawnNpc) {
+            btnSpawnNpc.addEventListener("click", () => {
+                if (!selectNpcRoster) return;
 
-            // Generate a unique ID for this instance on stage
-            const actorInstanceId = `actor_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
+                const selectedId = selectNpcRoster.value;
+                if (!selectedId) return;
 
-            const spawnPayload = {
-                nombre: npcData.nombre || selectedId,
-                sprite: npcData.sprite || npcData.url || "",
-                x: 0,
-                y: 0,
-                escala: 1,
-                orientacion: 'normal'
-            };
+                const npcData = npcDatabase[selectedId];
+                if (!npcData) return;
 
-            db.ref(`${THEATRE_ACTORS_PATH}/${actorInstanceId}`).set(spawnPayload)
-              .catch(err => console.error("Error inyectando NPC al teatro:", err));
-        });
-    }
+                // Generate a unique ID for this instance on stage
+                const actorInstanceId = `actor_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
 
-    // 3. Manipulación en Vivo (Live Control Cards)
-    if (liveActorsList) {
-        db.ref(THEATRE_ACTORS_PATH).on("value", snapshot => {
-            liveActors = snapshot.val() || {};
-            liveActorsList.innerHTML = '';
+                const spawnPayload = {
+                    nombre: npcData.nombre || selectedId,
+                    sprite: npcData.sprite || npcData.url || "",
+                    x: 0,
+                    y: 0,
+                    escala: npcData.escala || 1,
+                    orientacion: 'normal'
+                };
 
-            Object.keys(liveActors).forEach(actorId => {
-                const actorData = liveActors[actorId];
-
-                const card = document.createElement("div");
-                card.className = "actor-control-card";
-                card.innerHTML = `
-                    <span class="actor-name">${actorData.nombre} (ID: ${actorId.split('_')[1]})</span>
-                    <div class="actor-buttons">
-                        <button class="btn-move" data-dir="left"><</button>
-                        <button class="btn-move" data-dir="right">></button>
-                        <button class="btn-flip">ESPEJO</button>
-                        <button class="btn-remove">X</button>
-                    </div>
-                `;
-
-                // Move Left
-                card.querySelector('.btn-move[data-dir="left"]').addEventListener("click", () => {
-                    const currentX = parseInt(actorData.x) || 0;
-                    db.ref(`${THEATRE_ACTORS_PATH}/${actorId}`).update({ x: currentX - 50 });
-                });
-
-                // Move Right
-                card.querySelector('.btn-move[data-dir="right"]').addEventListener("click", () => {
-                    const currentX = parseInt(actorData.x) || 0;
-                    db.ref(`${THEATRE_ACTORS_PATH}/${actorId}`).update({ x: currentX + 50 });
-                });
-
-                // Flip (Espejo)
-                card.querySelector('.btn-flip').addEventListener("click", () => {
-                    const currentOrientation = actorData.orientacion === 'flip' ? 'normal' : 'flip';
-                    db.ref(`${THEATRE_ACTORS_PATH}/${actorId}`).update({ orientacion: currentOrientation });
-                });
-
-                // Remove
-                card.querySelector('.btn-remove').addEventListener("click", () => {
-                    db.ref(`${THEATRE_ACTORS_PATH}/${actorId}`).remove();
-                });
-
-                liveActorsList.appendChild(card);
+                db.ref(`${THEATRE_ACTORS_PATH}/${actorInstanceId}`).set(spawnPayload)
+                  .catch(err => console.error("Error inyectando NPC al teatro:", err));
             });
-        });
-    }
+        }
+
+        // 3. Manipulación en Vivo (Live Control Cards)
+        if (liveActorsList) {
+            db.ref(THEATRE_ACTORS_PATH).on("value", snapshot => {
+                liveActors = snapshot.val() || {};
+                liveActorsList.innerHTML = '';
+
+                Object.keys(liveActors).forEach(actorId => {
+                    const actorData = liveActors[actorId];
+
+                    const card = document.createElement("div");
+                    card.className = "actor-control-card";
+                    card.innerHTML = `
+                        <span class="actor-name">${actorData.nombre} (ID: ${actorId.split('_')[1]})</span>
+                        <div class="actor-buttons">
+                            <button class="btn-move" data-dir="left"><</button>
+                            <button class="btn-move" data-dir="right">></button>
+                            <button class="btn-flip">ESPEJO</button>
+                            <button class="btn-remove">X</button>
+                        </div>
+                    `;
+
+                    // Move Left
+                    const btnLeft = card.querySelector('.btn-move[data-dir="left"]');
+                    if (btnLeft) {
+                        btnLeft.addEventListener("click", () => {
+                            const currentX = parseInt(actorData.x) || 0;
+                            db.ref(`${THEATRE_ACTORS_PATH}/${actorId}`).update({ x: currentX - 50 });
+                        });
+                    }
+
+                    // Move Right
+                    const btnRight = card.querySelector('.btn-move[data-dir="right"]');
+                    if (btnRight) {
+                        btnRight.addEventListener("click", () => {
+                            const currentX = parseInt(actorData.x) || 0;
+                            db.ref(`${THEATRE_ACTORS_PATH}/${actorId}`).update({ x: currentX + 50 });
+                        });
+                    }
+
+                    // Flip (Espejo)
+                    const btnFlip = card.querySelector('.btn-flip');
+                    if (btnFlip) {
+                        btnFlip.addEventListener("click", () => {
+                            const currentOrientation = actorData.orientacion === 'flip' ? 'normal' : 'flip';
+                            db.ref(`${THEATRE_ACTORS_PATH}/${actorId}`).update({ orientacion: currentOrientation });
+                        });
+                    }
+
+                    // Remove
+                    const btnRemove = card.querySelector('.btn-remove');
+                    if (btnRemove) {
+                        btnRemove.addEventListener("click", () => {
+                            db.ref(`${THEATRE_ACTORS_PATH}/${actorId}`).remove();
+                        });
+                    }
+
+                    liveActorsList.appendChild(card);
+                });
+            });
+        }
+    });
 
 })(window);


### PR DESCRIPTION
This commit resolves a "Dependency Hell" scenario introduced by migrating to a new dashboard file. It ensures the Firebase initialization runs appropriately without render blocking and implements strict containerization using DOMContentLoaded. Mandatory defensive programming has been added (null-checking all UI elements) to prevent fatal exceptions during runtime. Finally, the incorrect NPC roster path was aligned with the database structure (campaña/actores) and updated using a reliable `.on('value')` listener.

---
*PR created automatically by Jules for task [17790562778200174927](https://jules.google.com/task/17790562778200174927) started by @sokcrow*