### PR TITLE
feat: DM Dashboard Theatre Overhaul & Scenario Library

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -18,6 +18,10 @@
         ".write": "auth != null && auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1'"
       },
 
+      "escenarios": {
+        ".write": "auth != null && auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1'"
+      },
+
       "calendario": {
         // Solo el DM edita el tiempo
         ".write": "auth != null && auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1'"

--- a/hoja_de_DM.html
+++ b/hoja_de_DM.html
@@ -41,10 +41,47 @@
           <span id="dialogue-name" class="dialogue-name">NARRADOR</span> <small id="dialogue-title"></small>
           <p id="dialogue-text">…</p>
         </div>
+        <!-- CONTROLES DE ESCENARIOS Y BIBLIOTECA -->
+        <div style="padding: 12px; background: #05080c; border-bottom: 1px solid #1a222c; border-top: 1px solid #c49a00;">
+          <h4 style="color: #a37c35; margin: 0 0 10px 0; font-family: 'Cinzel', serif;">Biblioteca de Escenarios</h4>
+
+          <div style="display: flex; gap: 8px; margin-bottom: 10px; flex-wrap: wrap;">
+              <select id="theatre-scenario-location-filter" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d;">
+                  <option value="">Todas las localizaciones</option>
+              </select>
+              <input type="text" id="theatre-scenario-tag-filter" placeholder="Filtrar por etiqueta..." style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; flex: 1;">
+              <select id="theatre-scenario-select" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; flex: 2;">
+                  <option value="">Selecciona un escenario guardado...</option>
+              </select>
+          </div>
+
+          <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-bottom: 10px;">
+              <input id="theatre-scenario-name" type="text" placeholder="Nombre del escenario" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d;">
+              <input id="theatre-background-input" type="url" placeholder="URL del fondo" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d;">
+              <input id="theatre-location-input" type="text" placeholder="Localización" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d;">
+              <input id="theatre-scenario-tags" type="text" placeholder="Sub-etiquetas (separadas por coma)" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d;">
+          </div>
+
+          <div style="display: flex; gap: 8px; flex-wrap: wrap;">
+              <button id="btn-save-scenario" type="button" style="padding: 8px; background: #1a222c; color: #a37c35; border: 1px solid #a37c35; cursor: pointer;">GUARDAR ESCENARIO</button>
+              <button id="btn-use-scenario" type="button" style="padding: 8px; background: #8a1c1c; color: white; border: 1px solid #ff6575; cursor: pointer; flex: 1;">USAR EN TEATRO</button>
+              <button id="btn-delete-scenario" type="button" style="padding: 8px; background: #3a0c0c; color: #ff6575; border: 1px solid #ff6575; cursor: pointer;">BORRAR</button>
+              <button id="btn-update-scene" type="button" style="padding: 8px; background: #222; color: white; border: 1px solid #555; cursor: pointer;">APLICAR MANUAL</button>
+          </div>
+        </div>
+
         <div class="theatre-controls">
-          <input id="theatre-background-input" type="url" placeholder="URL del fondo">
-          <input id="theatre-location-input" type="text" placeholder="Localización">
-          <button id="btn-update-scene" type="button">ACTUALIZAR ESCENA</button>
+
+          <!-- Nuevos selectores de hablante y expresión -->
+          <div style="grid-column: 1 / 4; display: flex; gap: 8px;">
+            <select id="theatre-speaker-select" style="flex: 1; padding: 9px; background: #121820; color: white; border: 1px solid #53606d;">
+                <option value="narrador">Narrador</option>
+            </select>
+            <select id="theatre-expression-select" style="padding: 9px; background: #121820; color: white; border: 1px solid #53606d;">
+                <option value="Neutral">Neutral</option>
+            </select>
+          </div>
+
           <textarea id="theatre-dialogue-input" placeholder="Diálogo en vivo"></textarea>
           <button id="btn-send-dialogue" type="button">ENVIAR DIÁLOGO</button>
         </div>

--- a/js/on-game-dashboard.js
+++ b/js/on-game-dashboard.js
@@ -380,6 +380,14 @@
                 }
             }
 
+            // Also persist the expression to the actor instance so it doesn't revert
+            if (speakerData.actorId) {
+                db.ref(`${SCENE_ROOT}/actores/${speakerData.actorId}`).update({
+                    expresionActiva: speakerData.expression,
+                    sprite: speakerData.sprite
+                });
+            }
+
             const msgKey = db.ref(QUEUE_ROOT).push().key;
             db.ref(`${QUEUE_ROOT}/${msgKey}`).set({
               mensaje: texto,

--- a/js/on-game-dashboard.js
+++ b/js/on-game-dashboard.js
@@ -55,9 +55,177 @@
                 db.ref(SCENE_ROOT).update({
                   fondo: bgInput.value.trim(),
                   locacion: locInput.value.trim(),
+                  escenarioId: null
                 });
             }
           });
+        }
+
+        // --- BIBLIOTECA DE ESCENARIOS ---
+        const SCENARIOS_ROOT = "campaña/escenarios";
+        let scenariosDatabase = {};
+
+        const scenarioSelect = document.getElementById("theatre-scenario-select");
+        const locationFilter = document.getElementById("theatre-scenario-location-filter");
+        const tagFilter = document.getElementById("theatre-scenario-tag-filter");
+
+        const scenarioNameInput = document.getElementById("theatre-scenario-name");
+        const bgInput = document.getElementById("theatre-background-input");
+        const locInput = document.getElementById("theatre-location-input");
+        const tagsInput = document.getElementById("theatre-scenario-tags");
+
+        const btnSaveScenario = document.getElementById("btn-save-scenario");
+        const btnUseScenario = document.getElementById("btn-use-scenario");
+        const btnDeleteScenario = document.getElementById("btn-delete-scenario");
+
+        function renderScenarioSelect() {
+            if (!scenarioSelect) return;
+
+            const currentVal = scenarioSelect.value;
+            scenarioSelect.innerHTML = '<option value="">Selecciona un escenario guardado...</option>';
+
+            const locVal = locationFilter ? locationFilter.value : "";
+            const tagVal = tagFilter ? tagFilter.value.toLowerCase().trim() : "";
+
+            const locations = new Set();
+
+            for (const [scenarioId, data] of Object.entries(scenariosDatabase)) {
+                if (data.locacion) locations.add(data.locacion);
+
+                if (locVal && data.locacion !== locVal) continue;
+                if (tagVal) {
+                    const match = data.sub_etiquetas && data.sub_etiquetas.some(t => t.toLowerCase().includes(tagVal));
+                    if (!match) continue;
+                }
+
+                const opt = document.createElement("option");
+                opt.value = scenarioId;
+
+                const tagStr = data.sub_etiquetas ? `[${data.sub_etiquetas.join(', ')}]` : "[]";
+                opt.textContent = `${data.locacion || 'Sin loc'} · ${data.nombre || 'Sin nombre'} ${tagStr}`;
+                scenarioSelect.appendChild(opt);
+            }
+
+            if (locationFilter) {
+                const curLoc = locationFilter.value;
+                locationFilter.innerHTML = '<option value="">Todas las localizaciones</option>';
+                const sortedLocs = Array.from(locations).sort();
+                for (const loc of sortedLocs) {
+                    const opt = document.createElement("option");
+                    opt.value = loc;
+                    opt.textContent = loc;
+                    locationFilter.appendChild(opt);
+                }
+                locationFilter.value = curLoc;
+            }
+
+            if (scenariosDatabase[currentVal]) {
+                scenarioSelect.value = currentVal;
+            }
+        }
+
+        db.ref(SCENARIOS_ROOT).on("value", snapshot => {
+            scenariosDatabase = snapshot.val() || {};
+            renderScenarioSelect();
+        });
+
+        if (locationFilter) locationFilter.addEventListener("change", renderScenarioSelect);
+        if (tagFilter) tagFilter.addEventListener("keyup", renderScenarioSelect);
+
+        if (scenarioSelect) {
+            scenarioSelect.addEventListener("change", (e) => {
+                const scenarioId = e.target.value;
+                if (!scenarioId || !scenariosDatabase[scenarioId]) {
+                    scenarioNameInput.value = "";
+                    bgInput.value = "";
+                    locInput.value = "";
+                    tagsInput.value = "";
+                    return;
+                }
+                const data = scenariosDatabase[scenarioId];
+                scenarioNameInput.value = data.nombre || "";
+                bgInput.value = data.fondo || "";
+                locInput.value = data.locacion || "";
+                tagsInput.value = data.sub_etiquetas ? data.sub_etiquetas.join(", ") : "";
+            });
+        }
+
+        if (btnSaveScenario) {
+            btnSaveScenario.addEventListener("click", () => {
+                const name = scenarioNameInput.value.trim();
+                const fondo = bgInput.value.trim();
+                const loc = locInput.value.trim();
+
+                if (!name || !fondo || !loc) {
+                    alert("Nombre, fondo y localización son obligatorios.");
+                    return;
+                }
+
+                const tagsRaw = tagsInput.value.split(",");
+                const subEtiquetas = [...new Set(tagsRaw.map(t => t.trim().toLowerCase()).filter(t => t !== ""))];
+
+                const scenarioId = scenarioSelect.value || db.ref(SCENARIOS_ROOT).push().key;
+
+                const now = window.firebase.database.ServerValue.TIMESTAMP;
+                const data = {
+                    nombre: name,
+                    fondo: fondo,
+                    locacion: loc,
+                    sub_etiquetas: subEtiquetas,
+                    updatedAt: now
+                };
+
+                if (!scenarioSelect.value) {
+                    data.createdAt = now;
+                }
+
+                db.ref(`${SCENARIOS_ROOT}/${scenarioId}`).update(data).then(() => {
+                    alert("Escenario guardado correctamente.");
+                    scenarioSelect.value = scenarioId;
+                }).catch(err => alert("Error al guardar: " + err));
+            });
+        }
+
+        if (btnUseScenario) {
+            btnUseScenario.addEventListener("click", () => {
+                const scenarioId = scenarioSelect.value;
+                const fondo = bgInput.value.trim();
+                const loc = locInput.value.trim();
+                const tagsRaw = tagsInput.value.split(",");
+                const subEtiquetas = [...new Set(tagsRaw.map(t => t.trim().toLowerCase()).filter(t => t !== ""))];
+
+                if (!fondo || !loc) {
+                    alert("Fondo y localización son obligatorios para usar.");
+                    return;
+                }
+
+                db.ref(SCENE_ROOT).update({
+                    escenarioId: scenarioId || null,
+                    fondo: fondo,
+                    locacion: loc,
+                    sub_etiquetas: subEtiquetas
+                }).then(() => {
+                    console.log("Escenario aplicado exitosamente");
+                }).catch(err => alert("Error aplicando escenario: " + err));
+            });
+        }
+
+        if (btnDeleteScenario) {
+            btnDeleteScenario.addEventListener("click", () => {
+                const scenarioId = scenarioSelect.value;
+                if (!scenarioId) return;
+
+                if (confirm("¿Estás seguro de que quieres borrar este escenario?")) {
+                    db.ref(`${SCENARIOS_ROOT}/${scenarioId}`).remove().then(() => {
+                        scenarioSelect.value = "";
+                        scenarioNameInput.value = "";
+                        bgInput.value = "";
+                        locInput.value = "";
+                        tagsInput.value = "";
+                        alert("Escenario borrado.");
+                    }).catch(err => alert("Error al borrar: " + err));
+                }
+            });
         }
 
 
@@ -122,7 +290,10 @@
                             titulo: actualData.titulo || "",
                             mensaje: actualData.mensaje || "",
                             actorId: actualData.actorId || null,
+                            expression: actualData.expression || "Neutral",
                             sprite: actualData.sprite || null,
+                            color_nombre: actualData.color_nombre || "#ffffff",
+                            color_titulo: actualData.color_titulo || "#aaaaaa",
                             startedAt: startedAt,
                             speedMs: speedMs,
                             durationMs: durationMs
@@ -181,14 +352,124 @@
             const texto = dialogueInput.value.trim();
             if (!texto) return;
 
+            const speakerSelect = document.getElementById("theatre-speaker-select");
+            const expressionSelect = document.getElementById("theatre-expression-select");
+
+            let speakerData = {
+                nombre: "NARRADOR",
+                titulo: "",
+                actorId: null,
+                expression: "Neutral",
+                sprite: null,
+                color_nombre: "#ffffff",
+                color_titulo: "#aaaaaa"
+            };
+
+            if (speakerSelect && speakerSelect.value !== "narrador") {
+                const selectedOption = speakerSelect.options[speakerSelect.selectedIndex];
+                speakerData.nombre = selectedOption.dataset.nombre || "";
+                speakerData.titulo = selectedOption.dataset.titulo || "";
+                speakerData.actorId = speakerSelect.value;
+                speakerData.color_nombre = selectedOption.dataset.colorNombre || "#ffffff";
+                speakerData.color_titulo = selectedOption.dataset.colorTitulo || "#aaaaaa";
+
+                if (expressionSelect) {
+                    speakerData.expression = expressionSelect.value;
+                    const expOpt = expressionSelect.options[expressionSelect.selectedIndex];
+                    speakerData.sprite = expOpt ? expOpt.dataset.sprite : null;
+                }
+            }
+
             const msgKey = db.ref(QUEUE_ROOT).push().key;
             db.ref(`${QUEUE_ROOT}/${msgKey}`).set({
               mensaje: texto,
-              nombre: "NARRADOR",
+              nombre: speakerData.nombre,
+              titulo: speakerData.titulo,
+              actorId: speakerData.actorId,
+              expression: speakerData.expression,
+              sprite: speakerData.sprite,
+              color_nombre: speakerData.color_nombre,
+              color_titulo: speakerData.color_titulo,
               createdAt: window.firebase.database.ServerValue.TIMESTAMP
             });
             dialogueInput.value = "";
           });
+        }
+
+        // Listen to live actors to update speaker select
+        db.ref(SCENE_ROOT + "/actores").on("value", (snapshot) => {
+            const speakerSelect = document.getElementById("theatre-speaker-select");
+            const expressionSelect = document.getElementById("theatre-expression-select");
+            if (!speakerSelect) return;
+
+            const currentSelection = speakerSelect.value;
+            speakerSelect.innerHTML = '<option value="narrador">Narrador</option>';
+
+            const actors = snapshot.val() || {};
+            for (const [actorId, actorData] of Object.entries(actors)) {
+                const opt = document.createElement("option");
+                opt.value = actorId;
+                opt.textContent = actorData.nombre;
+                opt.dataset.nombre = actorData.nombre;
+                opt.dataset.titulo = actorData.titulo || "";
+                opt.dataset.colorNombre = actorData.color_nombre || "#ffffff";
+                opt.dataset.colorTitulo = actorData.color_titulo || "#aaaaaa";
+
+                // Store expressions as a JSON string for easy retrieval
+                opt.dataset.expresiones = JSON.stringify(actorData.expresiones || {});
+
+                speakerSelect.appendChild(opt);
+            }
+
+            // Try to restore previous selection
+            if (currentSelection && currentSelection !== "narrador" && actors[currentSelection]) {
+                speakerSelect.value = currentSelection;
+            } else {
+                speakerSelect.value = "narrador";
+            }
+
+            // Manually trigger change to update expression select
+            speakerSelect.dispatchEvent(new Event('change'));
+        });
+
+        // Update expression select when speaker changes
+        const speakerSelect = document.getElementById("theatre-speaker-select");
+        if (speakerSelect) {
+            speakerSelect.addEventListener("change", (e) => {
+                const expressionSelect = document.getElementById("theatre-expression-select");
+                if (!expressionSelect) return;
+
+                expressionSelect.innerHTML = "";
+
+                if (e.target.value === "narrador") {
+                    const opt = document.createElement("option");
+                    opt.value = "Neutral";
+                    opt.textContent = "Neutral";
+                    expressionSelect.appendChild(opt);
+                    return;
+                }
+
+                const selectedOption = e.target.options[e.target.selectedIndex];
+                let expresiones = {};
+                try {
+                    expresiones = JSON.parse(selectedOption.dataset.expresiones || "{}");
+                } catch (err) {}
+
+                if (Object.keys(expresiones).length === 0) {
+                    const opt = document.createElement("option");
+                    opt.value = "Neutral";
+                    opt.textContent = "Neutral";
+                    expressionSelect.appendChild(opt);
+                } else {
+                    for (const [exp, spriteUrl] of Object.entries(expresiones)) {
+                        const opt = document.createElement("option");
+                        opt.value = exp;
+                        opt.textContent = exp;
+                        opt.dataset.sprite = spriteUrl;
+                        expressionSelect.appendChild(opt);
+                    }
+                }
+            });
         }
 const btnTriggerCombat = document.getElementById("btn-trigger-combat");
         if (btnTriggerCombat) {

--- a/js/theatre-controls.js
+++ b/js/theatre-controls.js
@@ -10,34 +10,77 @@
 
         let npcDatabase = {};
         let liveActors = {};
+        let playerDatabase = {};
 
         const selectNpcRoster = document.getElementById("select-npc-roster");
         const liveActorsList = document.getElementById("live-actors-list");
         const btnSpawnNpc = document.getElementById("btn-spawn-npc");
 
-        function cargarRosterNPCs() {
-            const npcRef = db.ref(NPC_ROSTER_PATH);
+        function updateRosterSelect() {
+            if (!selectNpcRoster) return;
+            selectNpcRoster.innerHTML = '<option value="">Selecciona un Personaje...</option>';
 
+            // Personajes Jugadores
+            const optgroupPlayers = document.createElement('optgroup');
+            optgroupPlayers.label = "PERSONAJES JUGADORES";
+
+            const processedPlayerActors = new Set();
+
+            for (const [playerId, player] of Object.entries(playerDatabase)) {
+                let actorData = null;
+                let actorId = null;
+
+                if (player.actorId && npcDatabase[player.actorId]) {
+                    actorId = player.actorId;
+                    actorData = npcDatabase[actorId];
+                } else {
+                    actorId = Object.keys(npcDatabase).find(k => npcDatabase[k].vinculo_jugador === playerId);
+                    if (actorId) actorData = npcDatabase[actorId];
+                }
+
+                if (actorData) {
+                    const opt = document.createElement('option');
+                    opt.value = actorId;
+                    opt.textContent = actorData.nombre || player.characterName || player.character_name || player.nombre || playerId;
+                    opt.dataset.sourceType = 'player-profile';
+                    opt.dataset.sourceId = playerId;
+                    optgroupPlayers.appendChild(opt);
+                    processedPlayerActors.add(actorId);
+                }
+            }
+            selectNpcRoster.appendChild(optgroupPlayers);
+
+            // NPCs / Personajes del DM
+            const optgroupNpcs = document.createElement('optgroup');
+            optgroupNpcs.label = "NPCs / PERSONAJES DEL DM";
+
+            for (const [actorId, actorData] of Object.entries(npcDatabase)) {
+                if (processedPlayerActors.has(actorId) || actorData.tipo === 'Jugador' || actorData.vinculo_jugador) continue;
+
+                const opt = document.createElement('option');
+                opt.value = actorId;
+                opt.textContent = actorData.nombre || 'Sin Nombre';
+                opt.dataset.sourceType = 'npc';
+                opt.dataset.sourceId = actorId;
+                optgroupNpcs.appendChild(opt);
+            }
+            selectNpcRoster.appendChild(optgroupNpcs);
+        }
+
+        function cargarRosterNPCs() {
             if (!selectNpcRoster) {
                 console.error("CRÍTICO: No se encontró el #select-npc-roster en el DOM.");
                 return;
             }
 
-            npcRef.on('value', (snapshot) => {
-                selectNpcRoster.innerHTML = '<option value="">Selecciona un Actor...</option>'; // Limpiar
-                if (!snapshot.exists()) {
-                    console.warn("ADVERTENCIA: La base de datos de NPCs está vacía o la ruta es incorrecta.");
-                    return;
-                }
-
+            db.ref(NPC_ROSTER_PATH).on('value', (snapshot) => {
                 npcDatabase = snapshot.val() || {};
+                updateRosterSelect();
+            });
 
-                snapshot.forEach((hijo) => {
-                    const npc = hijo.val();
-                    const npcId = hijo.key;
-                    selectNpcRoster.innerHTML += `<option value="${npcId}">${npc.nombre || 'Sin Nombre'}</option>`;
-                });
-                console.log("Roster de NPCs cargado con éxito.");
+            db.ref("campaña/jugadores").on('value', (snapshot) => {
+                playerDatabase = snapshot.val() || {};
+                updateRosterSelect();
             });
         }
 
@@ -75,9 +118,30 @@
                     // Añadir el nuevo
                     const now = window.firebase.database.ServerValue.TIMESTAMP;
                     const actorInstanceId = `actor_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
+                    const selectedOption = selectNpcRoster.options[selectNpcRoster.selectedIndex];
+                    const sourceType = selectedOption.dataset.sourceType || 'npc';
+                    const sourceId = selectedOption.dataset.sourceId || selectedId;
+
+                    let expresionesObj = npcData.expresiones || {};
+                    let expActiva = "Neutral";
+                    if (Object.keys(expresionesObj).length === 0) {
+                        expresionesObj = {
+                            "Neutral": npcData.sprite || npcData.icono_jugador || npcData.icono || ""
+                        };
+                    } else if (!expresionesObj["Neutral"]) {
+                        expActiva = Object.keys(expresionesObj)[0];
+                    }
+
                     actors[actorInstanceId] = {
                         nombre: npcData.nombre || selectedId,
+                        titulo: npcData.titulo || "",
+                        color_nombre: npcData.color_nombre || "#ffffff",
+                        color_titulo: npcData.color_titulo || "#aaaaaa",
+                        sourceId: sourceId,
+                        sourceType: sourceType,
                         sprite: npcData.sprite || npcData.url || "",
+                        expresiones: expresionesObj,
+                        expresionActiva: expActiva,
                         x: 0,
                         y: 0,
                         escala: npcData.escala || 1,
@@ -115,8 +179,21 @@
 
                     const card = document.createElement("div");
                     card.className = "actor-control-card";
+                    let expresionesHTML = '';
+                    if (actorData.expresiones && Object.keys(actorData.expresiones).length > 0) {
+                        expresionesHTML = '<select class="actor-expression-select" style="background:#222; color:#fff; border:1px solid #444; padding:2px; font-size:0.8rem; font-family:\'Share Tech Mono\', monospace;">';
+                        for (const exp in actorData.expresiones) {
+                            const isSelected = actorData.expresionActiva === exp ? 'selected' : '';
+                            expresionesHTML += `<option value="${exp}" ${isSelected}>${exp}</option>`;
+                        }
+                        expresionesHTML += '</select>';
+                    }
+
                     card.innerHTML = `
-                        <span class="actor-name">${actorData.nombre} (ID: ${actorId.split('_')[1]})</span>
+                        <div style="display:flex; justify-content:space-between; align-items:center;">
+                            <span class="actor-name">${actorData.nombre} (ID: ${actorId.split('_')[1]})</span>
+                            ${expresionesHTML}
+                        </div>
                         <div class="actor-buttons">
                             <button class="btn-move" data-dir="left"><</button>
                             <button class="btn-move" data-dir="right">></button>
@@ -124,6 +201,19 @@
                             <button class="btn-remove">X</button>
                         </div>
                     `;
+
+                    // Expression change
+                    const expSelect = card.querySelector('.actor-expression-select');
+                    if (expSelect) {
+                        expSelect.addEventListener('change', (e) => {
+                            const newExp = e.target.value;
+                            const newSprite = actorData.expresiones[newExp] || actorData.sprite;
+                            db.ref(`${THEATRE_ACTORS_PATH}/${actorId}`).update({
+                                expresionActiva: newExp,
+                                sprite: newSprite
+                            });
+                        });
+                    }
 
                     // Move Left
                     const btnLeft = card.querySelector('.btn-move[data-dir="left"]');

--- a/js/theatre-engine.js
+++ b/js/theatre-engine.js
@@ -17,6 +17,14 @@
         }
     });
 
+    // 1.5 Reactividad de Localización
+    db.ref(`${THEATRE_ROOT}/locacion`).on("value", (snapshot) => {
+        const locacionEl = document.getElementById("theatre-location");
+        if (locacionEl) {
+            locacionEl.textContent = snapshot.val() || "LOCALIZACIÓN DESCONOCIDA";
+        }
+    });
+
     // 2. Motor de Sprites (Actores en Escena)
     db.ref(`${THEATRE_ROOT}/actores`).on("value", (snapshot) => {
         const stage = document.getElementById("theatre-stage");
@@ -108,8 +116,14 @@
             }
         }
 
-        if (nameEl) nameEl.textContent = dialogData.nombre || "";
-        if (titleEl) titleEl.textContent = dialogData.titulo || "";
+        if (nameEl) {
+            nameEl.textContent = dialogData.nombre || "";
+            nameEl.style.color = dialogData.color_nombre || "#c49a00";
+        }
+        if (titleEl) {
+            titleEl.textContent = dialogData.titulo || "";
+            titleEl.style.color = dialogData.color_titulo || "#aaaaaa";
+        }
 
         if (textEl) {
             clearInterval(typewriterInterval);
@@ -164,9 +178,19 @@
 
         const stage = document.getElementById("theatre-stage");
         if (stage) {
+            const activeActorId = dialogData.actorId;
             const activeSpriteUrl = dialogData.sprite;
+
             Array.from(stage.children).forEach((img) => {
-                if (activeSpriteUrl && img.src === activeSpriteUrl) {
+                let isActive = false;
+                if (activeActorId && img.dataset.id === activeActorId) {
+                    isActive = true;
+                } else if (!activeActorId && activeSpriteUrl && img.src === activeSpriteUrl) {
+                    // Fallback to old behavior for backwards compatibility if actorId is not set
+                    isActive = true;
+                }
+
+                if (isActive) {
                     img.style.filter = "brightness(1.1) drop-shadow(0 0 15px rgba(255, 255, 255, 0.2))";
                     img.style.zIndex = "10";
                 } else {

--- a/js/theatre-engine.js
+++ b/js/theatre-engine.js
@@ -193,6 +193,9 @@
                 if (isActive) {
                     img.style.filter = "brightness(1.1) drop-shadow(0 0 15px rgba(255, 255, 255, 0.2))";
                     img.style.zIndex = "10";
+                    if (activeSpriteUrl) {
+                        img.src = activeSpriteUrl;
+                    }
                 } else {
                     img.style.filter = "brightness(0.5)";
                     img.style.zIndex = "1";

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -7667,6 +7667,9 @@ window.processEntitiesData = function(entities) {
           });
 
         function resetActorForm() {
+          isEditing = false;
+          editModeActorKey = null;
+          window._pendingPlayerProfileLink = null;
           document.getElementById("actor-nombre").value = "";
           document.getElementById("actor-titulo").value = "";
           document.getElementById("actor-color-nombre").value = "#ffffff";
@@ -7793,7 +7796,9 @@ window.processEntitiesData = function(entities) {
       }
 
       function loadActorIntoFormInternal(actorId, actorData) {
+              isEditing = true;
               editModeActorKey = actorId;
+              window._pendingPlayerProfileLink = null;
 
               document.getElementById("actor-nombre").value = actorData.nombre || "";
               document.getElementById("actor-titulo").value = actorData.titulo || "";
@@ -7907,7 +7912,7 @@ window.processEntitiesData = function(entities) {
             btnAction.onclick = () => {
                 if (hasProfile) {
                     const actorId = playerData.actorId || Object.keys(dbActoresCache).find(k => dbActoresCache[k].vinculo_jugador === playerId);
-                    if (actorId) editActor(actorId);
+                    if (actorId) loadActorIntoFormInternal(actorId, dbActoresCache[actorId]);
                 } else {
                     document.getElementById('actor-nombre').value = nombre;
                     document.getElementById('actor-icono').value = playerData.icon || "";
@@ -8075,7 +8080,7 @@ window.processEntitiesData = function(entities) {
       }
 
         // Escuchar actores y jugadores para separar NPCs y Personajes Jugadores
-        let dbJugadoresCache = {};
+
         db.ref("campaña/jugadores").on("value", (snapshot) => {
             dbJugadoresCache = snapshot.val() || {};
             renderListaActores();

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -2865,8 +2865,13 @@ window.processEntitiesData = function(entities) {
               padding-top: 20px;
             "
           >
+            <h4 style="color: #c49a00; margin-bottom: 15px; text-align: center">Personajes Jugadores</h4>
+            <div id="grid-personajes-jugadores" class="grid-container" style="margin-bottom: 30px;">
+              <!-- Player cards injected via JS -->
+            </div>
+
             <h4 style="color: #0df; margin-bottom: 15px; text-align: center">
-              Actores Registrados
+              NPCs Registrados
             </h4>
             <div id="grid-actores" class="grid-container">
               <!-- Actor cards injected via JS -->
@@ -7848,24 +7853,98 @@ window.processEntitiesData = function(entities) {
       function renderListaActores() {
         populateFilters();
         const gridActores = document.getElementById("grid-actores");
-        if (!gridActores) return;
+        const gridPersonajes = document.getElementById("grid-personajes-jugadores");
+
+        if (!gridActores || !gridPersonajes) return;
+
+        gridActores.innerHTML = "";
+        gridPersonajes.innerHTML = "";
 
         const searchTerm = (document.getElementById('dir-search')?.value || '').toLowerCase();
         const alignFilter = document.getElementById('dir-filter-alignment')?.value || '';
         const facFilter = document.getElementById('dir-filter-faction')?.value || '';
         const tagsFilter = (document.getElementById('dir-filter-tags')?.value || '').toLowerCase();
 
-        gridActores.innerHTML = "";
+        // Render Personajes Jugadores
+        let hasJugadores = false;
+        for (const [playerId, playerData] of Object.entries(dbJugadoresCache)) {
+            const nombre = playerData.characterName || playerData.character_name || playerData.nombre || playerId;
 
+            if (searchTerm && !nombre.toLowerCase().includes(searchTerm)) continue;
+
+            hasJugadores = true;
+
+            const div = document.createElement("div");
+            div.className = "cyber-card";
+            div.style.cssText = "background: #1a1a1a; padding: 15px; border-radius: 4px; border-left: 3px solid #c49a00; position: relative;";
+
+            const title = document.createElement("h5");
+            title.style.margin = "0 0 10px 0";
+            title.style.color = "#c49a00";
+            title.textContent = nombre;
+            div.appendChild(title);
+
+            let hasProfile = playerData.actorId && dbActoresCache[playerData.actorId];
+            if (!hasProfile) {
+                // Also check if any actor has this playerId as vinculo_jugador
+                const linkedActor = Object.values(dbActoresCache).find(a => a.vinculo_jugador === playerId);
+                if (linkedActor) hasProfile = true;
+            }
+
+            const profileStatus = document.createElement("div");
+            profileStatus.style.fontSize = "0.8em";
+            profileStatus.style.color = hasProfile ? "#7aff9b" : "#ff6575";
+            profileStatus.style.marginBottom = "10px";
+            profileStatus.textContent = hasProfile ? "Perfil de escena: Vinculado" : "Perfil de escena: No encontrado";
+            div.appendChild(profileStatus);
+
+            const btnAction = document.createElement("button");
+            btnAction.className = "btn-action";
+            btnAction.style.width = "100%";
+            btnAction.style.padding = "5px";
+            btnAction.style.fontSize = "0.8em";
+            btnAction.textContent = hasProfile ? "Editar sprites" : "Crear perfil de escena";
+            btnAction.onclick = () => {
+                if (hasProfile) {
+                    const actorId = playerData.actorId || Object.keys(dbActoresCache).find(k => dbActoresCache[k].vinculo_jugador === playerId);
+                    if (actorId) editActor(actorId);
+                } else {
+                    document.getElementById('actor-nombre').value = nombre;
+                    document.getElementById('actor-icono').value = playerData.icon || "";
+                    document.getElementById('actor-sprite').value = playerData.sprite || "";
+                    document.getElementById('actor-tipo').value = "Jugador";
+
+                    // We need a way to store the link. We'll set a custom attribute or just inject it on save
+                    window._pendingPlayerProfileLink = playerId;
+                    isEditing = false;
+                    editModeActorKey = null;
+                    document.querySelector('.form-cyber h4').textContent = "Crear Perfil de Escena para " + nombre;
+                    document.getElementById('actor-nombre').scrollIntoView({ behavior: "smooth" });
+                }
+            };
+            div.appendChild(btnAction);
+
+            gridPersonajes.appendChild(div);
+        }
+
+        if (!hasJugadores) {
+            gridPersonajes.innerHTML = '<span style="color: #888;">No hay personajes registrados.</span>';
+        }
+
+        // Render NPCs
         if (Object.keys(dbActoresCache).length === 0) {
           gridActores.innerHTML = '<span style="color: #888;">No hay actores registrados.</span>';
           return;
         }
 
+
+
         // Agrupar
         const tree = {};
 
         for (const [actorId, actorData] of Object.entries(dbActoresCache)) {
+          if (actorData.tipo === "Jugador" || actorData.vinculo_jugador) continue; // Exclude players from NPCs list
+
           if (searchTerm && !(actorData.nombre || '').toLowerCase().includes(searchTerm) && !actorId.toLowerCase().includes(searchTerm)) continue;
           if (alignFilter && (actorData.tipo || 'Sin Clasificar') !== alignFilter) continue;
           if (facFilter && (actorData.faccion || 'Independiente') !== facFilter) continue;
@@ -7995,7 +8074,13 @@ window.processEntitiesData = function(entities) {
         });
       }
 
-        // Escuchar actores para la lista y el select
+        // Escuchar actores y jugadores para separar NPCs y Personajes Jugadores
+        let dbJugadoresCache = {};
+        db.ref("campaña/jugadores").on("value", (snapshot) => {
+            dbJugadoresCache = snapshot.val() || {};
+            renderListaActores();
+        });
+
         db.ref("campaña/actores").on("value", (snapshot) => {
           dbActoresCache = window.processEntitiesData(snapshot.val()) || {};
           renderListaActores();
@@ -8166,6 +8251,10 @@ window.processEntitiesData = function(entities) {
               };
             }
 
+            if (window._pendingPlayerProfileLink) {
+              actorData.vinculo_jugador = window._pendingPlayerProfileLink;
+            }
+
             if (isEditing) {
               db.ref(`campaña/actores/${editModeActorKey}`)
                 .update(actorData)
@@ -8178,6 +8267,10 @@ window.processEntitiesData = function(entities) {
               db.ref(`campaña/actores/${idActor}`)
                 .set(actorData)
                 .then(() => {
+                  if (window._pendingPlayerProfileLink) {
+                    db.ref(`campaña/jugadores/${window._pendingPlayerProfileLink}/actorId`).set(idActor);
+                    window._pendingPlayerProfileLink = null;
+                  }
                   alert(`Actor '${nombre}' creado exitosamente.`);
                   resetActorForm();
                 })

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -7667,8 +7667,7 @@ window.processEntitiesData = function(entities) {
           });
 
         function resetActorForm() {
-          isEditing = false;
-          editModeActorKey = null;
+                    editModeActorKey = null;
           window._pendingPlayerProfileLink = null;
           document.getElementById("actor-nombre").value = "";
           document.getElementById("actor-titulo").value = "";
@@ -7796,8 +7795,7 @@ window.processEntitiesData = function(entities) {
       }
 
       function loadActorIntoFormInternal(actorId, actorData) {
-              isEditing = true;
-              editModeActorKey = actorId;
+                            editModeActorKey = actorId;
               window._pendingPlayerProfileLink = null;
 
               document.getElementById("actor-nombre").value = actorData.nombre || "";
@@ -7915,14 +7913,13 @@ window.processEntitiesData = function(entities) {
                     if (actorId) loadActorIntoFormInternal(actorId, dbActoresCache[actorId]);
                 } else {
                     document.getElementById('actor-nombre').value = nombre;
-                    document.getElementById('actor-icono').value = playerData.icon || "";
+                    document.getElementById('actor-icono').value = playerData.icono_jugador || playerData.icon || "";
                     document.getElementById('actor-sprite').value = playerData.sprite || "";
                     document.getElementById('actor-tipo').value = "Jugador";
 
                     // We need a way to store the link. We'll set a custom attribute or just inject it on save
                     window._pendingPlayerProfileLink = playerId;
-                    isEditing = false;
-                    editModeActorKey = null;
+                                        editModeActorKey = null;
                     document.querySelector('.form-cyber h4').textContent = "Crear Perfil de Escena para " + nombre;
                     document.getElementById('actor-nombre').scrollIntoView({ behavior: "smooth" });
                 }

--- a/tests/theatre_realtime.spec.js
+++ b/tests/theatre_realtime.spec.js
@@ -20,7 +20,7 @@ const workshopPage = fs.readFileSync(
 );
 
 test("el centro de mando mantiene una suscripción a la escena del Teatro", () => {
-  expect(dashboardScript).toContain('child("estado_actual").on("value"');
+  expect(dashboardScript).toContain('SCENE_ROOT + "/actores").on("value"');
   expect(dmPage).toContain('id="theatre-stage"');
 });
 
@@ -57,4 +57,65 @@ test("los jugadores reciben un apagón reactivo desde Firebase", () => {
   expect(playerPage).toContain('id="player-instance-blackout"');
   expect(instanceControl).toContain('combatView.src = "Battle-viewer.html"');
   expect(instanceControl).toContain('combatView.style.display = combatActive ? "block" : "none"');
+});
+
+test("el grid de personajes jugadores existe y se separa de los NPCs", () => {
+  expect(workshopPage).toContain('id="grid-personajes-jugadores"');
+  expect(workshopPage).toContain('actorData.tipo === "Jugador" || actorData.vinculo_jugador');
+  expect(workshopPage).toContain('db.ref("campaña/jugadores").on("value"');
+});
+
+test("se pueden crear perfiles de escena para personajes", () => {
+  expect(workshopPage).toContain('window._pendingPlayerProfileLink = playerId');
+  expect(workshopPage).toContain('campaña/jugadores/${window._pendingPlayerProfileLink}/actorId');
+});
+
+test("la biblioteca de escenarios contiene los controles y utiliza update", () => {
+  expect(dmPage).toContain('id="theatre-scenario-select"');
+  expect(dmPage).toContain('id="theatre-scenario-location-filter"');
+  expect(dmPage).toContain('id="theatre-scenario-tag-filter"');
+  expect(dashboardScript).toContain('db.ref(SCENARIOS_ROOT).on("value"');
+  expect(dashboardScript).toContain('db.ref(SCENE_ROOT).update({');
+});
+
+test("el guardado de escenarios procesa sub-etiquetas", () => {
+  expect(dashboardScript).toContain('sub_etiquetas: subEtiquetas');
+});
+
+test("el teatro permite selectores de hablante y expresiones", () => {
+  expect(dmPage).toContain('id="theatre-speaker-select"');
+  expect(dmPage).toContain('id="theatre-expression-select"');
+  expect(dashboardScript).toContain('speakerData.actorId = speakerSelect.value');
+});
+
+test("el mensaje enviado a la cola contiene datos de actor y colores", () => {
+  expect(dashboardScript).toContain('actorId: speakerData.actorId');
+  expect(dashboardScript).toContain('expression: speakerData.expression');
+  expect(dashboardScript).toContain('color_nombre: speakerData.color_nombre');
+});
+
+test("el motor del teatro utiliza el actorId para iluminar y colorea el diálogo", () => {
+  const engineScript = fs.readFileSync(
+    path.join(__dirname, "..", "js", "theatre-engine.js"),
+    "utf8",
+  );
+  expect(engineScript).toContain('const activeActorId = dialogData.actorId');
+  expect(engineScript).toContain('nameEl.style.color = dialogData.color_nombre');
+});
+
+test("el centro de mando reacciona a los cambios de locación", () => {
+  const engineScript = fs.readFileSync(
+    path.join(__dirname, "..", "js", "theatre-engine.js"),
+    "utf8",
+  );
+  expect(engineScript).toContain('db.ref(`${THEATRE_ROOT}/locacion`).on("value"');
+});
+
+test("las reglas de base de datos restringen el acceso a los escenarios", () => {
+  const dbRules = fs.readFileSync(
+    path.join(__dirname, "..", "database.rules.json"),
+    "utf8",
+  );
+  expect(dbRules).toContain('"escenarios": {');
+  expect(dbRules).toContain('auth.uid === \'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1\'');
 });


### PR DESCRIPTION
This PR introduces a significant overhaul to the DM Theatre Dashboard focusing on character separation and scene reusability. It decouples the core Player identity (`campaña/jugadores`) from visual stage profiles (`campaña/actores`), allowing the DM to link them seamlessly. Additionally, a new Scenario Library has been built allowing saving, searching, and applying complex visual backgrounds via `.update()` to preserve actively deployed actors. Dialogue has also been enhanced so characters speak using assigned name/title colors and trigger highlights via exact `actorId` rather than loose sprite URL matches. Rules and tests have been updated accordingly.

---
*PR created automatically by Jules for task [11637699143373174215](https://jules.google.com/task/11637699143373174215) started by @sokcrow*