### PR TITLE
Refactor: Unify Theatre Dialogue UI and Layout

### DIFF
--- a/css/on-game-dashboard.css
+++ b/css/on-game-dashboard.css
@@ -24,8 +24,8 @@ body { margin: 0; overflow: hidden; background: #020304; color: #e8edf2; }
 #modulo-standby { align-items: center; justify-content: center; background: #000; }
 .standby-text { color: #24272a; letter-spacing: .45em; font-size: clamp(1.5rem, 4vw, 4rem); }
 #modulo-teatro { flex-direction: row; }
-.stage-view-wrapper { flex: 1; display: flex; flex-direction: column; background-position: center; background-size: cover; overflow: hidden; }
-#theatre-stage { flex: 1; display: flex; align-items: flex-end; justify-content: center; gap: 1vw; overflow: hidden; aspect-ratio: 16 / 9; max-height: 100%; margin: 0 auto; }
+.stage-view-wrapper { flex: 1; display: flex; flex-direction: column; background-position: center; background-size: cover; overflow: hidden; isolation: isolate; }
+#theatre-stage { flex: 1; display: flex; align-items: flex-end; justify-content: center; gap: 1vw; overflow: hidden; aspect-ratio: 16 / 9; max-height: 100%; margin: 0 auto; z-index: var(--theatre-layer-stage); }
 .theatre-sprite { max-height: 72vh; max-width: 30vw; object-fit: contain; filter: drop-shadow(0 0 12px #000); transform-origin: bottom center; }
 
 .director-controls { width: 350px; background: #0a0a0a; border-left: 2px solid #a37c35; display: flex; flex-direction: column; padding: 15px; overflow-y: auto; }

--- a/css/theatre-dialogue.css
+++ b/css/theatre-dialogue.css
@@ -1,0 +1,255 @@
+:root {
+  --theatre-layer-stage: 10;
+  --theatre-layer-dialogue: 8500;
+}
+
+@font-face {
+  font-family: "BebasKai";
+  src: url("../Fonts/BebasKai.otf") format("opentype");
+}
+
+/* --- THEATRE OF THE MIND STYLES --- */
+      .theatre-location {
+        position: absolute;
+        top: 50px;
+        left: 40px;
+        background: linear-gradient(to bottom, #111, #050505);
+        border: none;
+        border-top: 3px solid #d4af37;
+        border-bottom: 3px solid #d4af37;
+        border-radius: 0;
+        padding: 12px 30px;
+        color: #f5f5dc;
+        font-size: 24px;
+        font-family: "BebasKai", impact, sans-serif;
+        letter-spacing: 1px;
+        text-transform: uppercase;
+        font-weight: bold;
+        box-shadow: 5px 5px 15px rgba(0, 0, 0, 0.8);
+        z-index: 2010;
+        letter-spacing: 1px;
+        -webkit-text-stroke: 2px black;
+        paint-order: stroke fill;
+        text-shadow: 1px 1px 2px black;
+        transform: rotate(-15deg);
+        transform-origin: top left;
+      }
+
+      .theatre-location::before {
+        content: "";
+        position: absolute;
+        top: -50px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 8px;
+        height: 50px;
+        background: #d4af37;
+        box-shadow:
+          inset 2px 0 0 rgba(255, 255, 255, 0.4),
+          inset -2px 0 0 rgba(0, 0, 0, 0.4);
+        z-index: -1;
+      }
+
+      .theatre-location::after {
+        content: "";
+        position: absolute;
+        top: -6px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 14px;
+        height: 14px;
+        background: #555;
+        border: 2px solid #d4af37;
+        border-radius: 50%;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.8);
+        z-index: 2;
+      }
+
+      .theatre-location span {
+        display: inline-block;
+        transform: none;
+      }
+
+      .theatre-dialogue-wrapper {
+        width: 95%;
+        max-width: 1400px;
+        filter: drop-shadow(0px 5px 5px rgba(0, 0, 0, 0.8));
+        pointer-events: none; /* Let clicks pass through empty areas */
+      }
+
+      .theatre-dialogue-wrapper > * {
+        pointer-events: auto; /* Enable clicks on actual content like plates and text */
+      }
+
+      .theatre-plates-container {
+        position: absolute;
+        top: -65px; /* LOWERED: from -100px to -65px to sink it more into the dialogue box */
+        left: 20px;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0px;
+        filter: drop-shadow(0px 5px 5px rgba(0, 0, 0, 0.8));
+        padding-left: 20px;
+        z-index: 15;
+        transform: rotate(-15deg); /* strictly 15 degrees */
+        transform-origin: bottom left;
+      }
+
+      .theatre-plates-container::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 5px;
+        bottom: -15px;
+        width: 14px;
+        background: linear-gradient(to right, #444, #222);
+        border: 2px solid #111;
+        border-radius: 4px;
+        box-shadow: 2px 0 5px rgba(0, 0, 0, 0.8);
+        z-index: 3;
+      }
+
+      .theatre-plates-container::after {
+        content: "";
+        position: absolute;
+        left: 3px;
+        top: 15px;
+        width: 8px;
+        height: 8px;
+        background: #d4af37;
+        border-radius: 50%;
+        box-shadow:
+          0 40px 0 #d4af37,
+          0 70px 0 #d4af37;
+        z-index: 4;
+      }
+
+      .theatre-plate-title {
+        background: linear-gradient(90deg, #5c3a21 0%, #3a2210 100%);
+        color: #d69c52;
+        border: none;
+        border-left: 4px solid #d4af37;
+        padding: 2px 40px 2px 20px;
+        font-family: "BebasKai", impact, sans-serif;
+        letter-spacing: 1px;
+        text-transform: uppercase;
+        font-weight: bold;
+        font-size: 16px;
+        box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.8);
+        margin-left: 5px;
+        text-transform: uppercase;
+        letter-spacing: -0.5px;
+        position: relative;
+        border-radius: 0;
+        z-index: 1;
+      }
+
+      .theatre-plate-title span {
+        display: inline-block;
+      }
+
+      .theatre-plate-name {
+        background: #416268;
+        color: #ffffff;
+        border: none;
+        border-left: 6px solid #1a1a1a;
+        padding: 4px 60px 4px 30px;
+        font-family: "BebasKai", impact, sans-serif;
+        letter-spacing: 1px;
+        text-transform: uppercase;
+        font-weight: 900;
+        font-size: 32px;
+        -webkit-text-stroke: 2px black;
+        paint-order: stroke fill;
+        text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8);
+        box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.8);
+        position: relative;
+        z-index: 2;
+        margin-top: -3px;
+        border-radius: 0;
+      }
+
+      .theatre-plate-name span {
+        display: inline-block;
+      }
+
+      .theatre-dialogue-text {
+        position: relative;
+        border: none;
+        border-radius: 0;
+        padding: 50px 70px 40px 70px;
+        min-height: 180px;
+        color: #fffacd; /* Amarillo pálido (LemonChiffon) */
+        font-size: 1.1rem;
+        line-height: 1.6;
+        font-family: "Roboto", sans-serif;
+        box-shadow: none;
+        text-shadow: none;
+        z-index: 10;
+        white-space: pre-wrap;
+        word-wrap: break-word;
+        overflow-wrap: break-word;
+      }
+
+      .theatre-dialogue-text::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: repeating-linear-gradient(
+          0deg,
+          rgba(0, 0, 0, 0.8),
+          rgba(0, 0, 0, 0.8) 2px,
+          rgba(0, 0, 0, 0.9) 2px,
+          rgba(0, 0, 0, 0.9) 4px
+        );
+        backdrop-filter: blur(2px);
+        -webkit-mask-image: linear-gradient(
+          to right,
+          transparent 0%,
+          black 20%,
+          black 80%,
+          transparent 100%
+        );
+        mask-image: linear-gradient(
+          to right,
+          transparent 0%,
+          black 20%,
+          black 80%,
+          transparent 100%
+        );
+        z-index: -1;
+      }
+
+.on-game-dashboard .theatre-dialogue-wrapper {
+  width: calc(100vw - 350px) !important;
+}
+
+/* Limitar el wrapper para que no invada toda la pantalla baja */
+.theatre-dialogue-wrapper {
+    display: flex !important;
+    flex-direction: column !important;
+    justify-content: flex-end !important;
+    z-index: var(--theatre-layer-dialogue) !important;
+}
+
+/* Aislar la zona donde se escribe para que SIEMPRE esté por encima y clickeable */
+.theatre-controls {
+    position: relative !important;
+    z-index: 9999 !important; /* Máxima prioridad sobre cualquier imagen o wrapper */
+    background-color: #050505 !important; /* Fondo negro sólido para no mezclarse con el fondo */
+    padding: 15px !important;
+    border-top: 2px solid var(--border-accent, #c49a00) !important;
+    pointer-events: auto !important;
+    display: flex !important;
+    gap: 10px !important;
+}
+
+/* Asegurar que el input específico tome el espacio y sea clickeable */
+.theatre-controls input[type="text"] {
+    flex-grow: 1 !important;
+    pointer-events: auto !important;
+}

--- a/hoja_de_DM.html
+++ b/hoja_de_DM.html
@@ -5,8 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Centro de Mando - ON GAME</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Share+Tech+Mono&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/on-game-dashboard.css">
+  <link rel="stylesheet" href="css/theatre-dialogue.css">
 </head>
 <body class="on-game-dashboard">
     <nav class="master-control-bar" aria-label="Control de instancia">
@@ -33,57 +34,28 @@
     </section>
     <section id="modulo-teatro" class="game-module hidden" aria-hidden="true">
       <div class="stage-view-wrapper">
-        <header class="dialogue-panel"><strong id="theatre-location">LOCALIZACIÓN DESCONOCIDA</strong></header>
+        <!-- Location Sign -->
+        <div class="theatre-location">
+          <span id="theatre-location">LOCALIZACIÓN DESCONOCIDA</span>
+        </div>
         <div id="theatre-stage" class="stage-view" aria-label="Escenario del teatro">
           <!-- Aquí el motor inyecta los fondos y sprites reactivos -->
         </div>
-        <div class="dialogue-panel">
-          <span id="dialogue-name" class="dialogue-name">NARRADOR</span> <small id="dialogue-title"></small>
-          <p id="dialogue-text">…</p>
-        </div>
-        <!-- CONTROLES DE ESCENARIOS Y BIBLIOTECA -->
-        <div style="padding: 12px; background: #05080c; border-bottom: 1px solid #1a222c; border-top: 1px solid #c49a00;">
-          <h4 style="color: #a37c35; margin: 0 0 10px 0; font-family: 'Cinzel', serif;">Biblioteca de Escenarios</h4>
-
-          <div style="display: flex; gap: 8px; margin-bottom: 10px; flex-wrap: wrap;">
-              <select id="theatre-scenario-location-filter" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d;">
-                  <option value="">Todas las localizaciones</option>
-              </select>
-              <input type="text" id="theatre-scenario-tag-filter" placeholder="Filtrar por etiqueta..." style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; flex: 1;">
-              <select id="theatre-scenario-select" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; flex: 2;">
-                  <option value="">Selecciona un escenario guardado...</option>
-              </select>
+        <!-- Dialogue Box Area (Visual) -->
+        <div class="theatre-dialogue-wrapper">
+          <!-- Plates -->
+          <div class="theatre-plates-container">
+            <div id="dialogue-title" class="theatre-plate-title">
+              <span>Title</span>
+            </div>
+            <div id="dialogue-name" class="theatre-plate-name">
+              <span>Name</span>
+            </div>
           </div>
-
-          <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-bottom: 10px;">
-              <input id="theatre-scenario-name" type="text" placeholder="Nombre del escenario" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d;">
-              <input id="theatre-background-input" type="url" placeholder="URL del fondo" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d;">
-              <input id="theatre-location-input" type="text" placeholder="Localización" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d;">
-              <input id="theatre-scenario-tags" type="text" placeholder="Sub-etiquetas (separadas por coma)" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d;">
+          <!-- Main Text Box -->
+          <div id="dialogue-text" class="theatre-dialogue-text">
+            …
           </div>
-
-          <div style="display: flex; gap: 8px; flex-wrap: wrap;">
-              <button id="btn-save-scenario" type="button" style="padding: 8px; background: #1a222c; color: #a37c35; border: 1px solid #a37c35; cursor: pointer;">GUARDAR ESCENARIO</button>
-              <button id="btn-use-scenario" type="button" style="padding: 8px; background: #8a1c1c; color: white; border: 1px solid #ff6575; cursor: pointer; flex: 1;">USAR EN TEATRO</button>
-              <button id="btn-delete-scenario" type="button" style="padding: 8px; background: #3a0c0c; color: #ff6575; border: 1px solid #ff6575; cursor: pointer;">BORRAR</button>
-              <button id="btn-update-scene" type="button" style="padding: 8px; background: #222; color: white; border: 1px solid #555; cursor: pointer;">APLICAR MANUAL</button>
-          </div>
-        </div>
-
-        <div class="theatre-controls">
-
-          <!-- Nuevos selectores de hablante y expresión -->
-          <div style="grid-column: 1 / 4; display: flex; gap: 8px;">
-            <select id="theatre-speaker-select" style="flex: 1; padding: 9px; background: #121820; color: white; border: 1px solid #53606d;">
-                <option value="narrador">Narrador</option>
-            </select>
-            <select id="theatre-expression-select" style="padding: 9px; background: #121820; color: white; border: 1px solid #53606d;">
-                <option value="Neutral">Neutral</option>
-            </select>
-          </div>
-
-          <textarea id="theatre-dialogue-input" placeholder="Diálogo en vivo"></textarea>
-          <button id="btn-send-dialogue" type="button">ENVIAR DIÁLOGO</button>
         </div>
       </div>
 
@@ -101,8 +73,53 @@
           </div>
 
           <!-- Lista de Actores Actualmente en el Escenario -->
-          <div class="active-actors-list" id="live-actors-list">
+          <div class="active-actors-list" id="live-actors-list" style="margin-bottom: 20px;">
               <!-- Tarjetas de control dinámicas por cada actor en escena -->
+          </div>
+
+          <!-- CONTROLES DE ESCENARIOS Y BIBLIOTECA -->
+          <div style="padding: 12px; background: #05080c; border-bottom: 1px solid #1a222c; border-top: 1px solid #c49a00; margin-bottom: 20px;">
+            <h4 style="color: #a37c35; margin: 0 0 10px 0; font-family: 'Cinzel', serif;">Biblioteca de Escenarios</h4>
+
+            <div style="display: flex; gap: 8px; margin-bottom: 10px; flex-wrap: wrap;">
+                <select id="theatre-scenario-location-filter" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d;">
+                    <option value="">Todas las localizaciones</option>
+                </select>
+                <input type="text" id="theatre-scenario-tag-filter" placeholder="Filtrar por etiqueta..." style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; flex: 1;">
+                <select id="theatre-scenario-select" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; flex: 2;">
+                    <option value="">Selecciona un escenario guardado...</option>
+                </select>
+            </div>
+
+            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-bottom: 10px;">
+                <input id="theatre-scenario-name" type="text" placeholder="Nombre del escenario" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d;">
+                <input id="theatre-background-input" type="url" placeholder="URL del fondo" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d;">
+                <input id="theatre-location-input" type="text" placeholder="Localización" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d;">
+                <input id="theatre-scenario-tags" type="text" placeholder="Sub-etiquetas (separadas por coma)" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d;">
+            </div>
+
+            <div style="display: flex; gap: 8px; flex-wrap: wrap;">
+                <button id="btn-save-scenario" type="button" style="padding: 8px; background: #1a222c; color: #a37c35; border: 1px solid #a37c35; cursor: pointer;">GUARDAR ESCENARIO</button>
+                <button id="btn-use-scenario" type="button" style="padding: 8px; background: #8a1c1c; color: white; border: 1px solid #ff6575; cursor: pointer; flex: 1;">USAR EN TEATRO</button>
+                <button id="btn-delete-scenario" type="button" style="padding: 8px; background: #3a0c0c; color: #ff6575; border: 1px solid #ff6575; cursor: pointer;">BORRAR</button>
+                <button id="btn-update-scene" type="button" style="padding: 8px; background: #222; color: white; border: 1px solid #555; cursor: pointer;">APLICAR MANUAL</button>
+            </div>
+          </div>
+
+          <div class="theatre-controls" style="display: flex; flex-direction: column; gap: 10px;">
+            <h4 style="color: #a37c35; margin: 0; font-family: 'Cinzel', serif;">Compositor de Diálogo</h4>
+            <!-- Nuevos selectores de hablante y expresión -->
+            <div style="display: flex; gap: 8px;">
+              <select id="theatre-speaker-select" style="flex: 1; padding: 9px; background: #121820; color: white; border: 1px solid #53606d;">
+                  <option value="narrador">Narrador</option>
+              </select>
+              <select id="theatre-expression-select" style="flex: 1; padding: 9px; background: #121820; color: white; border: 1px solid #53606d;">
+                  <option value="Neutral">Neutral</option>
+              </select>
+            </div>
+
+            <textarea id="theatre-dialogue-input" placeholder="Diálogo en vivo" style="min-height: 80px;"></textarea>
+            <button id="btn-send-dialogue" type="button">ENVIAR DIÁLOGO</button>
           </div>
       </div>
     </section>

--- a/hoja_de_DM.html
+++ b/hoja_de_DM.html
@@ -82,20 +82,20 @@
             <h4 style="color: #a37c35; margin: 0 0 10px 0; font-family: 'Cinzel', serif;">Biblioteca de Escenarios</h4>
 
             <div style="display: flex; gap: 8px; margin-bottom: 10px; flex-wrap: wrap;">
-                <select id="theatre-scenario-location-filter" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d;">
+                <select id="theatre-scenario-location-filter" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; flex: 1; max-width: 100%; box-sizing: border-box;">
                     <option value="">Todas las localizaciones</option>
                 </select>
-                <input type="text" id="theatre-scenario-tag-filter" placeholder="Filtrar por etiqueta..." style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; flex: 1;">
-                <select id="theatre-scenario-select" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; flex: 2;">
+                <input type="text" id="theatre-scenario-tag-filter" placeholder="Filtrar por etiqueta..." style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; flex: 1; max-width: 100%; box-sizing: border-box;">
+                <select id="theatre-scenario-select" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; flex: 1 1 100%; max-width: 100%; box-sizing: border-box;">
                     <option value="">Selecciona un escenario guardado...</option>
                 </select>
             </div>
 
-            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-bottom: 10px;">
-                <input id="theatre-scenario-name" type="text" placeholder="Nombre del escenario" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d;">
-                <input id="theatre-background-input" type="url" placeholder="URL del fondo" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d;">
-                <input id="theatre-location-input" type="text" placeholder="Localización" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d;">
-                <input id="theatre-scenario-tags" type="text" placeholder="Sub-etiquetas (separadas por coma)" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d;">
+            <div style="display: grid; grid-template-columns: 1fr; gap: 8px; margin-bottom: 10px;">
+                <input id="theatre-scenario-name" type="text" placeholder="Nombre del escenario" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; width: 100%; box-sizing: border-box;">
+                <input id="theatre-background-input" type="url" placeholder="URL del fondo" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; width: 100%; box-sizing: border-box;">
+                <input id="theatre-location-input" type="text" placeholder="Localización" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; width: 100%; box-sizing: border-box;">
+                <input id="theatre-scenario-tags" type="text" placeholder="Sub-etiquetas (separadas por coma)" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; width: 100%; box-sizing: border-box;">
             </div>
 
             <div style="display: flex; gap: 8px; flex-wrap: wrap;">

--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -5518,7 +5518,6 @@ input[name="attr_tab"][value="shop"] ~ .sheet-phone-screen .sheet-tab-shop {
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    isolation: isolate;
 }
 
 .shop-modal-body {

--- a/hoja_personaje.css
+++ b/hoja_personaje.css
@@ -5518,6 +5518,7 @@ input[name="attr_tab"][value="shop"] ~ .sheet-phone-screen .sheet-tab-shop {
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    isolation: isolate;
 }
 
 .shop-modal-body {
@@ -6937,6 +6938,7 @@ input.sheet-state-hud-modal[value="apego"] ~ .modal-apego {
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    isolation: isolate;
 }
 
 #theatre-view-player.theatre-active {

--- a/hoja_personaje.html
+++ b/hoja_personaje.html
@@ -6,6 +6,7 @@
     <title>Hoja de Personaje - Luminous</title>
 
     <link rel="stylesheet" href="hoja_personaje.css" />
+    <link rel="stylesheet" href="css/theatre-dialogue.css" />
 
     <style>
       #system-loading-overlay {
@@ -79,221 +80,6 @@
         src: url("Fonts/BebasKai.otf") format("opentype");
       }
 
-      /* --- THEATRE OF THE MIND STYLES --- */
-      .theatre-location {
-        position: absolute;
-        top: 50px;
-        left: 40px;
-        background: linear-gradient(to bottom, #111, #050505);
-        border: none;
-        border-top: 3px solid #d4af37;
-        border-bottom: 3px solid #d4af37;
-        border-radius: 0;
-        padding: 12px 30px;
-        color: #f5f5dc;
-        font-size: 24px;
-        font-family: "BebasKai", impact, sans-serif;
-        letter-spacing: 1px;
-        text-transform: uppercase;
-        font-weight: bold;
-        box-shadow: 5px 5px 15px rgba(0, 0, 0, 0.8);
-        z-index: 2010;
-        letter-spacing: 1px;
-        -webkit-text-stroke: 2px black;
-        paint-order: stroke fill;
-        text-shadow: 1px 1px 2px black;
-        transform: rotate(-15deg);
-        transform-origin: top left;
-      }
-
-      .theatre-location::before {
-        content: "";
-        position: absolute;
-        top: -50px;
-        left: 50%;
-        transform: translateX(-50%);
-        width: 8px;
-        height: 50px;
-        background: #d4af37;
-        box-shadow:
-          inset 2px 0 0 rgba(255, 255, 255, 0.4),
-          inset -2px 0 0 rgba(0, 0, 0, 0.4);
-        z-index: -1;
-      }
-
-      .theatre-location::after {
-        content: "";
-        position: absolute;
-        top: -6px;
-        left: 50%;
-        transform: translateX(-50%);
-        width: 14px;
-        height: 14px;
-        background: #555;
-        border: 2px solid #d4af37;
-        border-radius: 50%;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.8);
-        z-index: 2;
-      }
-
-      .theatre-location span {
-        display: inline-block;
-        transform: none;
-      }
-
-      .theatre-dialogue-wrapper {
-        width: 95%;
-        max-width: 1400px;
-        filter: drop-shadow(0px 5px 5px rgba(0, 0, 0, 0.8));
-        pointer-events: none; /* Let clicks pass through empty areas */
-      }
-
-      .theatre-dialogue-wrapper > * {
-        pointer-events: auto; /* Enable clicks on actual content like plates and text */
-      }
-
-      .theatre-plates-container {
-        position: absolute;
-        top: -65px; /* LOWERED: from -100px to -65px to sink it more into the dialogue box */
-        left: 20px;
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 0px;
-        filter: drop-shadow(0px 5px 5px rgba(0, 0, 0, 0.8));
-        padding-left: 20px;
-        z-index: 15;
-        transform: rotate(-15deg); /* strictly 15 degrees */
-        transform-origin: bottom left;
-      }
-
-      .theatre-plates-container::before {
-        content: "";
-        position: absolute;
-        left: 0;
-        top: 5px;
-        bottom: -15px;
-        width: 14px;
-        background: linear-gradient(to right, #444, #222);
-        border: 2px solid #111;
-        border-radius: 4px;
-        box-shadow: 2px 0 5px rgba(0, 0, 0, 0.8);
-        z-index: 3;
-      }
-
-      .theatre-plates-container::after {
-        content: "";
-        position: absolute;
-        left: 3px;
-        top: 15px;
-        width: 8px;
-        height: 8px;
-        background: #d4af37;
-        border-radius: 50%;
-        box-shadow:
-          0 40px 0 #d4af37,
-          0 70px 0 #d4af37;
-        z-index: 4;
-      }
-
-      .theatre-plate-title {
-        background: linear-gradient(90deg, #5c3a21 0%, #3a2210 100%);
-        color: #d69c52;
-        border: none;
-        border-left: 4px solid #d4af37;
-        padding: 2px 40px 2px 20px;
-        font-family: "BebasKai", impact, sans-serif;
-        letter-spacing: 1px;
-        text-transform: uppercase;
-        font-weight: bold;
-        font-size: 16px;
-        box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.8);
-        margin-left: 5px;
-        text-transform: uppercase;
-        letter-spacing: -0.5px;
-        position: relative;
-        border-radius: 0;
-        z-index: 1;
-      }
-
-      .theatre-plate-title span {
-        display: inline-block;
-      }
-
-      .theatre-plate-name {
-        background: #416268;
-        color: #ffffff;
-        border: none;
-        border-left: 6px solid #1a1a1a;
-        padding: 4px 60px 4px 30px;
-        font-family: "BebasKai", impact, sans-serif;
-        letter-spacing: 1px;
-        text-transform: uppercase;
-        font-weight: 900;
-        font-size: 32px;
-        -webkit-text-stroke: 2px black;
-        paint-order: stroke fill;
-        text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8);
-        box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.8);
-        position: relative;
-        z-index: 2;
-        margin-top: -3px;
-        border-radius: 0;
-      }
-
-      .theatre-plate-name span {
-        display: inline-block;
-      }
-
-      .theatre-dialogue-text {
-        position: relative;
-        border: none;
-        border-radius: 0;
-        padding: 50px 70px 40px 70px;
-        min-height: 180px;
-        color: #fffacd; /* Amarillo pálido (LemonChiffon) */
-        font-size: 1.1rem;
-        line-height: 1.6;
-        font-family: "Roboto", sans-serif;
-        box-shadow: none;
-        text-shadow: none;
-        z-index: 10;
-        white-space: pre-wrap;
-        word-wrap: break-word;
-        overflow-wrap: break-word;
-      }
-
-      .theatre-dialogue-text::before {
-        content: "";
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: repeating-linear-gradient(
-          0deg,
-          rgba(0, 0, 0, 0.8),
-          rgba(0, 0, 0, 0.8) 2px,
-          rgba(0, 0, 0, 0.9) 2px,
-          rgba(0, 0, 0, 0.9) 4px
-        );
-        backdrop-filter: blur(2px);
-        -webkit-mask-image: linear-gradient(
-          to right,
-          transparent 0%,
-          black 20%,
-          black 80%,
-          transparent 100%
-        );
-        mask-image: linear-gradient(
-          to right,
-          transparent 0%,
-          black 20%,
-          black 80%,
-          transparent 100%
-        );
-        z-index: -1;
-      }
     </style>
   </head>
   <body>
@@ -12641,7 +12427,7 @@
     </div>
 
     <!-- VISTA DEL TEATRO (MODO JUGADOR) -->
-    <div id="theatre-view-player" style="display: none">
+    <div id="theatre-view-player" style="display: none; isolation: isolate;">
       <!-- Location Sign -->
       <div class="theatre-location">
         <span id="theatre-location">Unknown Location</span>
@@ -12665,6 +12451,7 @@
           justify-content: center;
           gap: 0;
           position: relative;
+          z-index: var(--theatre-layer-stage);
         "
       >
         <!-- Sprites will be injected here -->
@@ -13758,31 +13545,6 @@
 
 /* ==================== HOTFIXES ==================== */
 
-/* Limitar el wrapper para que no invada toda la pantalla baja */
-.theatre-dialogue-wrapper {
-    display: flex !important;
-    flex-direction: column !important;
-    justify-content: flex-end !important;
-    z-index: 8500 !important;
-}
-
-/* Aislar la zona donde se escribe para que SIEMPRE esté por encima y clickeable */
-.theatre-controls {
-    position: relative !important;
-    z-index: 9999 !important; /* Máxima prioridad sobre cualquier imagen o wrapper */
-    background-color: #050505 !important; /* Fondo negro sólido para no mezclarse con el fondo */
-    padding: 15px !important;
-    border-top: 2px solid var(--border-accent, #c49a00) !important;
-    pointer-events: auto !important;
-    display: flex !important;
-    gap: 10px !important;
-}
-
-/* Asegurar que el input específico tome el espacio y sea clickeable */
-.theatre-controls input[type="text"] {
-    flex-grow: 1 !important;
-    pointer-events: auto !important;
-}
 
 #theatre-dialogue-history {
     flex-grow: 1 !important;

--- a/tests/theatre_realtime.spec.js
+++ b/tests/theatre_realtime.spec.js
@@ -119,3 +119,56 @@ test("las reglas de base de datos restringen el acceso a los escenarios", () => 
   expect(dbRules).toContain('"escenarios": {');
   expect(dbRules).toContain('auth.uid === \'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1\'');
 });
+
+test("jugador y DM comparten el mismo componente de diálogo sin estilos genéricos", () => {
+  const playerPage = fs.readFileSync(
+    path.join(__dirname, "..", "hoja_personaje.html"),
+    "utf8",
+  );
+  const dmPageCurrent = fs.readFileSync(
+    path.join(__dirname, "..", "hoja_de_DM.html"),
+    "utf8",
+  );
+
+  // Ambos cargan el CSS compartido
+  expect(playerPage).toContain('css/theatre-dialogue.css');
+  expect(dmPageCurrent).toContain('css/theatre-dialogue.css');
+
+  // Ambos usan las clases estructurales compartidas
+  expect(dmPageCurrent).toContain('class="theatre-dialogue-wrapper"');
+  expect(dmPageCurrent).toContain('class="theatre-plates-container"');
+
+  // El DM ya no usa la clase genérica
+  expect(dmPageCurrent).not.toContain('class="dialogue-panel"');
+});
+
+test("el escenario está aislado y el diálogo tiene una capa superior a los sprites", () => {
+  const dmPageCurrent = fs.readFileSync(
+    path.join(__dirname, "..", "hoja_de_DM.html"),
+    "utf8",
+  );
+  const playerPage = fs.readFileSync(
+    path.join(__dirname, "..", "hoja_personaje.html"),
+    "utf8",
+  );
+  const sharedCss = fs.readFileSync(
+    path.join(__dirname, "..", "css", "theatre-dialogue.css"),
+    "utf8",
+  );
+  const dashboardCss = fs.readFileSync(
+    path.join(__dirname, "..", "css", "on-game-dashboard.css"),
+    "utf8",
+  );
+  const sheetCss = fs.readFileSync(
+    path.join(__dirname, "..", "hoja_personaje.css"),
+    "utf8",
+  );
+
+  // Comprobar variables de capa en CSS
+  expect(sharedCss).toContain('--theatre-layer-stage: 10;');
+  expect(sharedCss).toContain('--theatre-layer-dialogue: 8500;');
+
+  // Comprobar isolation isolate
+  expect(dashboardCss).toContain('isolation: isolate;');
+  expect(sheetCss).toContain('isolation: isolate;');
+});


### PR DESCRIPTION
Unifies the "Theatre of the Mind" dialogue box across player and DM views.
- Creates `css/theatre-dialogue.css` to store the shared visual rules.
- Upgrades `hoja_de_DM.html`'s dialogue panel structure to match the player's.
- Moves DM interaction controls out of the visual scene into the sidebar.
- Fixes layering issues via CSS `isolation: isolate` and strict Z-index variables.
- Expands Playwright regression tests.

---
*PR created automatically by Jules for task [13312349487591313830](https://jules.google.com/task/13312349487591313830) started by @sokcrow*