### PR TITLE
Fix actor directory sync order

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "description": "Test character creation.",
   "main": "hoja_personaje.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "playwright test"
   },
   "repository": {
     "type": "git",

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -3792,7 +3792,57 @@ window.processEntitiesData = function(entities) {
       function initializeDMApp() {
 
 
-        // --- INICIALIZADOR DE TELEFONOS ---
+        const ACTOR_DATABASE_PATHS = ["campaña/base_datos_npcs", "campaña/actores"];
+        let dbJugadoresCache = {};
+        let dbNpcsCache = {};
+
+        let dbActoresRawCache = {};
+        let dbActoresCache = {};
+        let actorSourcePathById = {};
+
+        function showActorDirectoryError(path, error) {
+            console.error(`Error al cargar el directorio de actores desde la ruta: ${path}`, error);
+            const errorMsg = document.createElement("div");
+            errorMsg.style.cssText = "color: #ff4444; font-size: 14px; text-align: center; margin: 10px; background: #331111; padding: 10px; border: 1px solid #ff4444;";
+            errorMsg.innerText = `Error de conexión con Firebase (${path}). Revisa la consola.`;
+
+            const header = document.getElementById("header-jugadores");
+            if (header) {
+                header.insertAdjacentElement('afterend', errorMsg.cloneNode(true));
+            }
+            const grid = document.getElementById("grid-actores");
+            if (grid) {
+                grid.parentElement.insertBefore(errorMsg.cloneNode(true), grid);
+            }
+        }
+
+        function startActorDirectorySubscriptions() {
+            db.ref("campaña/jugadores").on("value", (snapshot) => {
+                const data = snapshot.val() || {};
+                dbJugadoresCache = window.processEntitiesData ? window.processEntitiesData(data) : data;
+                window.dbJugadoresCache = dbJugadoresCache;
+                renderListaActores();
+                if (typeof updateOtorgarJugadoresSelect === "function") updateOtorgarJugadoresSelect();
+                if (typeof renderActorAsignacion === "function") renderActorAsignacion();
+            }, (error) => showActorDirectoryError("campaña/jugadores", error));
+
+            db.ref("campaña/base_datos_npcs").on("value", (snapshot) => {
+                const data = snapshot.val() || {};
+                dbNpcsCache = window.processEntitiesData ? window.processEntitiesData(data) : data;
+                refreshActorCache();
+                renderListaActores();
+            }, (error) => showActorDirectoryError("campaña/base_datos_npcs", error));
+
+            db.ref("campaña/actores").on("value", (snapshot) => {
+                const data = snapshot.val() || {};
+                dbActoresRawCache = window.processEntitiesData ? window.processEntitiesData(data) : data;
+                refreshActorCache();
+                renderListaActores();
+            }, (error) => showActorDirectoryError("campaña/actores", error));
+        }
+
+        startActorDirectorySubscriptions();
+// --- INICIALIZADOR DE TELEFONOS ---
         function initPhoneNumbers() {
           function generatePhoneNumber() {
             const prefix = Math.floor(100 + Math.random() * 900); // 3 digits
@@ -3833,7 +3883,6 @@ window.processEntitiesData = function(entities) {
             "Lluvia": ["Nublado"]
         };
 
-        let dbJugadoresCache = {};
         let currentWeather = "Soleado";
         let previousWeather = null;
 
@@ -6420,11 +6469,7 @@ window.processEntitiesData = function(entities) {
         });
 
         // Sincronizar cambios de jugadores en el select
-        db.ref("campaña/jugadores").on("value", (snap) => {
-          dbJugadoresCache = window.processEntitiesData(snap.val()) || {};
-            window.dbJugadoresCache = dbJugadoresCache;
-            updateOtorgarJugadoresSelect();
-        });
+
 
         const gridItemsGlobales = document.getElementById("grid-items-globales");
 
@@ -7541,16 +7586,6 @@ window.processEntitiesData = function(entities) {
           });
 
         // --- LÓGICA GESTIÓN DE ACTORES ---
-        const ACTOR_DATABASE_PATHS = [
-          "campaña/base_datos_npcs",
-          "campaña/actores",
-        ];
-
-        let dbNpcsCache = {};
-        let dbActoresRawCache = {};
-        let dbActoresCache = {};
-        let actorSourcePathById = {};
-
         function refreshActorCache() {
           actorSourcePathById = {};
           dbActoresCache = {};
@@ -8170,24 +8205,7 @@ window.processEntitiesData = function(entities) {
         });
       }
 
-        // Escuchar actores y jugadores para separar NPCs y Personajes Jugadores
 
-        db.ref("campaña/jugadores").on("value", (snapshot) => {
-            dbJugadoresCache = snapshot.val() || {};
-            renderListaActores();
-        });
-
-        db.ref("campaña/base_datos_npcs").on("value", (snapshot) => {
-          dbNpcsCache = window.processEntitiesData(snapshot.val()) || {};
-          refreshActorCache();
-          renderListaActores();
-        });
-
-        db.ref("campaña/actores").on("value", (snapshot) => {
-          dbActoresRawCache = window.processEntitiesData(snapshot.val()) || {};
-          refreshActorCache();
-          renderListaActores();
-        });
 
         // Escuchar jugadores para la lista (reusando el que ya existe o creando nuevo listener local aquí)
         // Ya está siendo escuchado en la línea 4347 aprox

--- a/pantalla_dm.html
+++ b/pantalla_dm.html
@@ -3802,22 +3802,31 @@ window.processEntitiesData = function(entities) {
 
         function showActorDirectoryError(path, error) {
             console.error(`Error al cargar el directorio de actores desde la ruta: ${path}`, error);
+            const errId = "err-" + path.replace(/[^a-zA-Z0-9]/g, '-');
+
+            // Si ya existe, no duplicarlo
+            if (document.getElementById(errId)) return;
+
             const errorMsg = document.createElement("div");
+            errorMsg.id = errId;
             errorMsg.style.cssText = "color: #ff4444; font-size: 14px; text-align: center; margin: 10px; background: #331111; padding: 10px; border: 1px solid #ff4444;";
             errorMsg.innerText = `Error de conexión con Firebase (${path}). Revisa la consola.`;
 
-            const header = document.getElementById("header-jugadores");
-            if (header) {
-                header.insertAdjacentElement('afterend', errorMsg.cloneNode(true));
-            }
             const grid = document.getElementById("grid-actores");
             if (grid) {
-                grid.parentElement.insertBefore(errorMsg.cloneNode(true), grid);
+                grid.parentElement.insertBefore(errorMsg, grid);
             }
+        }
+
+        function clearActorDirectoryError(path) {
+            const errId = "err-" + path.replace(/[^a-zA-Z0-9]/g, '-');
+            const el = document.getElementById(errId);
+            if (el) el.remove();
         }
 
         function startActorDirectorySubscriptions() {
             db.ref("campaña/jugadores").on("value", (snapshot) => {
+                clearActorDirectoryError("campaña/jugadores");
                 const data = snapshot.val() || {};
                 dbJugadoresCache = window.processEntitiesData ? window.processEntitiesData(data) : data;
                 window.dbJugadoresCache = dbJugadoresCache;
@@ -3827,6 +3836,7 @@ window.processEntitiesData = function(entities) {
             }, (error) => showActorDirectoryError("campaña/jugadores", error));
 
             db.ref("campaña/base_datos_npcs").on("value", (snapshot) => {
+                clearActorDirectoryError("campaña/base_datos_npcs");
                 const data = snapshot.val() || {};
                 dbNpcsCache = window.processEntitiesData ? window.processEntitiesData(data) : data;
                 refreshActorCache();
@@ -3834,6 +3844,7 @@ window.processEntitiesData = function(entities) {
             }, (error) => showActorDirectoryError("campaña/base_datos_npcs", error));
 
             db.ref("campaña/actores").on("value", (snapshot) => {
+                clearActorDirectoryError("campaña/actores");
                 const data = snapshot.val() || {};
                 dbActoresRawCache = window.processEntitiesData ? window.processEntitiesData(data) : data;
                 refreshActorCache();

--- a/tests/dm_directory_behavior.spec.js
+++ b/tests/dm_directory_behavior.spec.js
@@ -1,0 +1,141 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+test.describe('Comportamiento de Sincronización del Directorio DM', () => {
+  test.beforeEach(async ({ page }) => {
+    // Bloquear los scripts reales de firebase para inyectar nuestro mock
+    await page.route('**/*firebase*.js', route => route.fulfill({ body: '' }));
+
+    await page.addInitScript(() => {
+      // Fixture
+      const fixtureJugadores = {};
+      for (let i = 1; i <= 8; i++) {
+          fixtureJugadores[`jugador${i}`] = { characterName: `Jugador ${i}`, online: true };
+      }
+      // Enlazar al menos uno
+      fixtureJugadores['jugador1'].actorId = 'actor_jugador1';
+
+      const fixtureActores = {};
+      // 8 de tipo Jugador en la ruta heredada
+      for (let i = 1; i <= 8; i++) {
+          fixtureActores[`actor_jugador${i}`] = { nombre: `Actor Jugador ${i}`, tipo: 'Jugador', vinculo_jugador: `jugador${i}` };
+      }
+      // 10 de otro tipo (NPCs) en la ruta heredada
+      for (let i = 1; i <= 10; i++) {
+          fixtureActores[`npc_${i}`] = { nombre: `NPC Antiguo ${i}`, tipo: 'Enemigo' };
+      }
+
+      // Añadir colisión en la ruta moderna
+      const fixtureNpcs = {
+          'npc_1': { nombre: 'NPC Moderno 1', tipo: 'Aliado' } // Colisiona con npc_1 de actores
+      };
+
+      window.mockFirebaseData = {
+          'jugadores': fixtureJugadores,
+          'actores': fixtureActores,
+          'base_datos_npcs': fixtureNpcs
+      };
+
+      window.mockListeners = {};
+
+      window.firebase = {
+          initializeApp: () => {},
+          auth: () => ({
+              onAuthStateChanged: (cb) => cb({ uid: 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1' }),
+              setPersistence: () => Promise.resolve()
+          }),
+          database: () => ({
+              ServerValue: { TIMESTAMP: Date.now() },
+              ref: (dbPath) => {
+                  const cleanPath = dbPath.replace('campaña/', '');
+                  return {
+                      on: (event, cb, errCb) => {
+                          if (event === 'value' && window.mockFirebaseData[cleanPath] !== undefined) {
+                              window.mockListeners[dbPath] = { cb, errCb };
+                              // Emitir snapshot inicial simulado
+                              cb({ val: () => window.mockFirebaseData[cleanPath] });
+                          }
+                      },
+                      once: async (event, cb) => {
+                          if (cb) cb({ val: () => null });
+                          return { val: () => null };
+                      },
+                      update: async () => {},
+                      set: async () => {},
+                      remove: async () => {},
+                      push: () => ({ key: 'mock_key', set: async () => {} })
+                  };
+              }
+          })
+      };
+    });
+
+    const uri = `file://${path.resolve(__dirname, '..', 'pantalla_dm.html')}`;
+    await page.goto(uri);
+    await page.waitForTimeout(500); // Esperar procesamiento DOM inicial
+  });
+
+  test('Renderiza correctamente 8 jugadores y clasifica NPCs vs Jugadores', async ({ page }) => {
+    // 8 cards en grid-personajes-jugadores
+    const playerCards = await page.locator('#grid-personajes-jugadores .cyber-card').count();
+    expect(playerCards).toBe(8);
+
+    // 10 NPCs heredados (-1 por el overriden + 1 moderno = 10 únicos)
+    const npcCards = await page.locator('#grid-actores .character-card').count();
+    expect(npcCards).toBe(10);
+
+    // Validar colisión y prioridad: La versión moderna debe sobreescribir a la antigua
+    const firstNpcText = await page.locator('#grid-actores .character-card').nth(0).innerText();
+    expect(firstNpcText).toContain('NPC Moderno 1');
+    expect(firstNpcText).not.toContain('NPC Antiguo 1');
+  });
+
+  test('Emite un nuevo snapshot y el directorio vuelve a renderizarse sin recargar', async ({ page }) => {
+    // Enviar un nuevo snapshot con 1 NPC extra
+    await page.evaluate(() => {
+        window.mockFirebaseData['base_datos_npcs']['npc_nuevo'] = { nombre: 'NPC Totalmente Nuevo', tipo: 'Aliado' };
+        window.mockListeners['campaña/base_datos_npcs'].cb({ val: () => window.mockFirebaseData['base_datos_npcs'] });
+    });
+
+    await page.waitForTimeout(200);
+
+    const npcCards = await page.locator('#grid-actores .character-card').count();
+    expect(npcCards).toBe(11); // 10 originales + 1 nuevo
+    const textContent = await page.locator('#grid-actores').innerText();
+    expect(textContent).toContain('NPC Totalmente Nuevo');
+  });
+
+  test('Maneja base_datos_npcs nula y conserva los actores de la ruta heredada', async ({ page }) => {
+    // Emitir null en base_datos_npcs
+    await page.evaluate(() => {
+        window.mockListeners['campaña/base_datos_npcs'].cb({ val: () => null });
+    });
+
+    await page.waitForTimeout(200);
+
+    // Al ser nula, la caché moderna se limpia, pero la de actores (heredada) retiene sus 10 NPCs.
+    // La colisión se resuelve a favor del legado.
+    const npcCards = await page.locator('#grid-actores .character-card').count();
+    expect(npcCards).toBe(10);
+
+    const firstNpcText = await page.locator('#grid-actores .character-card').nth(0).innerText();
+    expect(firstNpcText).toContain('NPC Antiguo 1');
+  });
+
+  test('Callback de error muestra mensaje sin destruir los datos ya renderizados', async ({ page }) => {
+    // Emitir un error
+    await page.evaluate(() => {
+        window.mockListeners['campaña/base_datos_npcs'].errCb({ message: 'Permission Denied' });
+    });
+
+    await page.waitForTimeout(200);
+
+    // Los datos preexistentes permanecen (10 NPCs renderizados)
+    const npcCards = await page.locator('#grid-actores .character-card').count();
+    expect(npcCards).toBe(10);
+
+    // El mensaje de error aparece inyectado
+    const errorDivs = await page.locator('div', { hasText: 'Error de conexión con Firebase' }).count();
+    expect(errorDivs).toBeGreaterThan(0);
+  });
+});

--- a/tests/theatre_realtime.spec.js
+++ b/tests/theatre_realtime.spec.js
@@ -183,3 +183,53 @@ test("el escenario está aislado y el diálogo tiene una capa superior a los spr
   expect(dashboardCss).toContain('isolation: isolate;');
   expect(sheetCss).toContain('isolation: isolate;');
 });
+
+
+test("la inicialización del directorio de actores se registra de forma segura al inicio", () => {
+  const dmPageCurrent = fs.readFileSync(
+    path.join(__dirname, "..", "pantalla_dm.html"),
+    "utf8"
+  );
+  expect(dmPageCurrent).toContain("function startActorDirectorySubscriptions");
+  expect(dmPageCurrent).toContain("showActorDirectoryError");
+  expect(dmPageCurrent).toContain("campaña/base_datos_npcs");
+  expect(dmPageCurrent).toContain("campaña/actores");
+  expect(dmPageCurrent).toContain("campaña/jugadores");
+
+  // Verifica que los listeners no estén duplicados al final (se eliminó la versión antigua)
+  const matchesJugadores = [...dmPageCurrent.matchAll(/db.ref\("campaña\/jugadores"\)\.on\("value"/g)];
+  expect(matchesJugadores.length).toBeLessThanOrEqual(2); // Uno puede ser el del Roster (en otro script si estuviera) pero en dm_page ahora debe haber 1.
+});
+
+
+test("la inicialización del directorio de actores maneja los errores visualmente", () => {
+  const dmPageCurrent = fs.readFileSync(
+    path.join(__dirname, "..", "pantalla_dm.html"),
+    "utf8"
+  );
+  expect(dmPageCurrent).toContain("function showActorDirectoryError");
+  expect(dmPageCurrent).toContain("header-jugadores");
+  expect(dmPageCurrent).toContain("grid-actores");
+  expect(dmPageCurrent).toContain("errorMsg");
+});
+
+
+test("el directorio lee de las tres rutas de Firebase", () => {
+  const dmPageCurrent = fs.readFileSync(
+    path.join(__dirname, "..", "pantalla_dm.html"),
+    "utf8"
+  );
+  expect(dmPageCurrent).toContain('db.ref("campaña/jugadores").on("value"');
+  expect(dmPageCurrent).toContain('db.ref("campaña/base_datos_npcs").on("value"');
+  expect(dmPageCurrent).toContain('db.ref("campaña/actores").on("value"');
+});
+
+test("la inicialización del directorio se realiza antes que módulos opcionales", () => {
+  const dmPageCurrent = fs.readFileSync(
+    path.join(__dirname, "..", "pantalla_dm.html"),
+    "utf8"
+  );
+  const startIdx = dmPageCurrent.indexOf('startActorDirectorySubscriptions();');
+  const weatherIdx = dmPageCurrent.indexOf('let currentWeather = "Soleado";');
+  expect(startIdx).toBeLessThan(weatherIdx);
+});

--- a/tests/theatre_realtime.spec.js
+++ b/tests/theatre_realtime.spec.js
@@ -196,9 +196,15 @@ test("la inicialización del directorio de actores se registra de forma segura a
   expect(dmPageCurrent).toContain("campaña/actores");
   expect(dmPageCurrent).toContain("campaña/jugadores");
 
-  // Verifica que los listeners no estén duplicados al final (se eliminó la versión antigua)
-  const matchesJugadores = [...dmPageCurrent.matchAll(/db.ref\("campaña\/jugadores"\)\.on\("value"/g)];
-  expect(matchesJugadores.length).toBeLessThanOrEqual(2); // Uno puede ser el del Roster (en otro script si estuviera) pero en dm_page ahora debe haber 1.
+  // Verifica que cada listener del directorio aparezca exactamente una vez (con la firma exacta del directorio)
+  const matchesJugadores = [...dmPageCurrent.matchAll(/db\.ref\("campaña\/jugadores"\)\.on\("value", \(snapshot\) => \{\s*clearActorDirectoryError/g)];
+  expect(matchesJugadores.length).toBe(1);
+
+  const matchesNpcs = [...dmPageCurrent.matchAll(/db\.ref\("campaña\/base_datos_npcs"\)\.on\("value", \(snapshot\) => \{\s*clearActorDirectoryError/g)];
+  expect(matchesNpcs.length).toBe(1);
+
+  const matchesActores = [...dmPageCurrent.matchAll(/db\.ref\("campaña\/actores"\)\.on\("value", \(snapshot\) => \{\s*clearActorDirectoryError/g)];
+  expect(matchesActores.length).toBe(1);
 });
 
 


### PR DESCRIPTION
This commit fixes the fragile initialization order causing the actor directory in `pantalla_dm.html` to fail parsing and remain empty. The logic has been centralized inside `initializeDMApp` as `startActorDirectorySubscriptions` safely loading cache maps from the three database branches concurrently (`jugadores`, `base_datos_npcs` and `actores`) before passing it downstream. Error states are correctly caught and injected visually. A rigorous UI-behavioral Playwright test is included using mocked Firebase nodes.

---
*PR created automatically by Jules for task [4965012469513225130](https://jules.google.com/task/4965012469513225130) started by @sokcrow*