### PR TITLE
Complete Theatre Engine contract and regressions (#511)

### DIFF
--- a/.github/workflows/theatre-issue-511.yml
+++ b/.github/workflows/theatre-issue-511.yml
@@ -1,0 +1,41 @@
+name: Theatre Engine #511
+
+on:
+  pull_request:
+    paths:
+      - "js/theatre-engine.js"
+      - "js/theatre-controls.js"
+      - "js/on-game-dashboard.js"
+      - "tests/theatre_issue_511.spec.js"
+      - ".github/workflows/theatre-issue-511.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  theatre-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Syntax check Theatre JavaScript
+        run: |
+          node --check js/theatre-engine.js
+          node --check js/theatre-controls.js
+          node --check js/on-game-dashboard.js
+          node --check tests/theatre_issue_511.spec.js
+
+      - name: Verify Issue #511 contract regressions
+        run: npx playwright test tests/theatre_issue_511.spec.js --workers=1

--- a/.github/workflows/theatre-issue-511.yml
+++ b/.github/workflows/theatre-issue-511.yml
@@ -1,4 +1,4 @@
-name: Theatre Engine #511
+name: "Theatre Engine #511"
 
 on:
   pull_request:
@@ -37,5 +37,5 @@ jobs:
           node --check js/on-game-dashboard.js
           node --check tests/theatre_issue_511.spec.js
 
-      - name: Verify Issue #511 contract regressions
+      - name: "Verify Issue #511 contract regressions"
         run: npx playwright test tests/theatre_issue_511.spec.js --workers=1

--- a/js/on-game-dashboard.js
+++ b/js/on-game-dashboard.js
@@ -1,515 +1,444 @@
 (function () {
   "use strict";
-  document.addEventListener('DOMContentLoaded', () => {
-    // 6 & 7. Autenticación y bloqueo
+
+  document.addEventListener("DOMContentLoaded", () => {
     const auth = window.firebase.auth();
     const db = window.firebase.database();
 
-        // Auth Guard
     auth.onAuthStateChanged((user) => {
       const authBlocker = document.getElementById("auth-blocker");
       if (!user) {
-          if (authBlocker) authBlocker.style.display = 'flex';
-          return;
+        if (authBlocker) authBlocker.style.display = "flex";
+        return;
       }
 
-      db.ref("campaña/config/dm_uid").once("value").then(snap => {
-          const expectedUid = snap.val() || 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1';
-          if (user.uid !== expectedUid) {
-              if (authBlocker) authBlocker.style.display = 'flex';
-              return;
-          }
-
-          if (authBlocker) authBlocker.style.display = 'none';
-          initializeDashboard(db);
-      }).catch(err => {
-          console.error("Error verificando UID:", err);
-          if (authBlocker) authBlocker.style.display = 'flex';
+      db.ref("campaña/config/dm_uid").once("value").then((snapshot) => {
+        const expectedUid = snapshot.val() || "e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1";
+        if (user.uid !== expectedUid) {
+          if (authBlocker) authBlocker.style.display = "flex";
+          return;
+        }
+        if (authBlocker) authBlocker.style.display = "none";
+        initializeDashboard(db);
+      }).catch((error) => {
+        console.error("Error verificando UID:", error);
+        if (authBlocker) authBlocker.style.display = "flex";
       });
     });
 
-    function initializeDashboard(db) {
-        const SCENE_ROOT = "campaña/estado_mundo/escena_actual";
-        const DIALOGUE_ROOT = "campaña/estado_mundo/dialogo_activo";
-        const DEFAULT_TITLE_COLOR = "#3b2918";
+    function initializeDashboard(database) {
+      const theatre = window.LuminousTheatreState;
+      if (!theatre) throw new Error("LuminousTheatreState debe cargarse antes del dashboard del DM.");
 
-        window.LuminousInstanceControl.bindDashboard({ db });
+      const paths = () => theatre.getPaths();
+      const DEFAULT_TITLE_COLOR = "#3b2918";
+      const SCENARIOS_ROOT = "campaña/escenarios";
+      let scenariosDatabase = {};
+      let isProcessingQueue = false;
+      let processorGeneration = 0;
 
-        const status = document.getElementById("connection-status");
-        if (status) {
-          db.ref(".info/connected").on("value", (snapshot) => {
-            const online = snapshot.val() === true;
-            status.textContent = online ? "● SINCRONIZADO" : "● SIN CONEXIÓN";
-            status.classList.toggle("offline", !online);
+      window.LuminousInstanceControl.bindDashboard({ db: database });
+
+      const status = document.getElementById("connection-status");
+      if (status) {
+        database.ref(".info/connected").on("value", (snapshot) => {
+          const online = snapshot.val() === true;
+          status.textContent = online ? "● SINCRONIZADO" : "● SIN CONEXIÓN";
+          status.classList.toggle("offline", !online);
+        });
+      }
+
+      // --- BIBLIOTECA DE LUGARES / ESCENARIOS ---
+      const scenarioSelect = document.getElementById("theatre-scenario-select");
+      const locationFilter = document.getElementById("theatre-scenario-location-filter");
+      const tagFilter = document.getElementById("theatre-scenario-tag-filter");
+      const scenarioNameInput = document.getElementById("theatre-scenario-name");
+      const bgInput = document.getElementById("theatre-background-input");
+      const locInput = document.getElementById("theatre-location-input");
+      const tagsInput = document.getElementById("theatre-scenario-tags");
+      const btnSaveScenario = document.getElementById("btn-save-scenario");
+      const btnUseScenario = document.getElementById("btn-use-scenario");
+      const btnDeleteScenario = document.getElementById("btn-delete-scenario");
+      const btnUpdateScene = document.getElementById("btn-update-scene");
+
+      function ensureScenarioMetadataInputs() {
+        if (!tagsInput || document.getElementById("theatre-scenario-region")) return;
+        const region = document.createElement("input");
+        region.id = "theatre-scenario-region";
+        region.type = "text";
+        region.placeholder = "Región / sección / capítulo";
+        region.style.cssText = tagsInput.style.cssText;
+
+        const category = document.createElement("input");
+        category.id = "theatre-scenario-category";
+        category.type = "text";
+        category.placeholder = "Categoría / área";
+        category.style.cssText = tagsInput.style.cssText;
+
+        tagsInput.parentElement?.insertBefore(region, tagsInput);
+        tagsInput.parentElement?.insertBefore(category, tagsInput);
+      }
+
+      ensureScenarioMetadataInputs();
+      const regionInput = () => document.getElementById("theatre-scenario-region");
+      const categoryInput = () => document.getElementById("theatre-scenario-category");
+
+      function normalizedTags() {
+        return [...new Set((tagsInput?.value || "").split(",").map((tag) => tag.trim().toLowerCase()).filter(Boolean))];
+      }
+
+      function scenarioPayload() {
+        return {
+          nombre: scenarioNameInput?.value.trim() || "",
+          fondo: bgInput?.value.trim() || "",
+          locacion: locInput?.value.trim() || "",
+          region: regionInput()?.value.trim() || "",
+          categoria: categoryInput()?.value.trim() || "",
+          sub_etiquetas: normalizedTags()
+        };
+      }
+
+      function renderScenarioSelect() {
+        if (!scenarioSelect) return;
+        const previous = scenarioSelect.value;
+        scenarioSelect.innerHTML = '<option value="">Selecciona un escenario guardado...</option>';
+        const locValue = locationFilter?.value || "";
+        const tagValue = tagFilter?.value.toLowerCase().trim() || "";
+        const locations = new Set();
+        const grouped = new Map();
+
+        for (const [scenarioId, data] of Object.entries(scenariosDatabase)) {
+          if (data.locacion) locations.add(data.locacion);
+          if (locValue && data.locacion !== locValue) continue;
+          const searchableTags = [data.region, data.categoria, ...(data.sub_etiquetas || [])].filter(Boolean).map(String);
+          if (tagValue && !searchableTags.some((tag) => tag.toLowerCase().includes(tagValue))) continue;
+          const group = data.region || data.seccion || data.capitulo || data.locacion || "Sin sección";
+          if (!grouped.has(group)) grouped.set(group, []);
+          grouped.get(group).push([scenarioId, data]);
+        }
+
+        for (const groupName of [...grouped.keys()].sort((a, b) => a.localeCompare(b))) {
+          const optgroup = document.createElement("optgroup");
+          optgroup.label = groupName;
+          for (const [scenarioId, data] of grouped.get(groupName).sort((a, b) => String(a[1].nombre || "").localeCompare(String(b[1].nombre || "")))) {
+            const option = document.createElement("option");
+            option.value = scenarioId;
+            const category = data.categoria ? ` · ${data.categoria}` : "";
+            option.textContent = `${data.locacion || "Sin loc"} · ${data.nombre || "Sin nombre"}${category}`;
+            optgroup.appendChild(option);
+          }
+          scenarioSelect.appendChild(optgroup);
+        }
+
+        if (locationFilter) {
+          const currentLocation = locationFilter.value;
+          locationFilter.innerHTML = '<option value="">Todas las localizaciones</option>';
+          for (const location of [...locations].sort((a, b) => a.localeCompare(b))) {
+            const option = document.createElement("option");
+            option.value = location;
+            option.textContent = location;
+            locationFilter.appendChild(option);
+          }
+          locationFilter.value = currentLocation;
+        }
+        if (scenariosDatabase[previous]) scenarioSelect.value = previous;
+      }
+
+      database.ref(SCENARIOS_ROOT).on("value", (snapshot) => {
+        scenariosDatabase = snapshot.val() || {};
+        renderScenarioSelect();
+      });
+      locationFilter?.addEventListener("change", renderScenarioSelect);
+      tagFilter?.addEventListener("input", renderScenarioSelect);
+
+      scenarioSelect?.addEventListener("change", (event) => {
+        const data = scenariosDatabase[event.target.value];
+        if (!data) {
+          if (scenarioNameInput) scenarioNameInput.value = "";
+          if (bgInput) bgInput.value = "";
+          if (locInput) locInput.value = "";
+          if (tagsInput) tagsInput.value = "";
+          if (regionInput()) regionInput().value = "";
+          if (categoryInput()) categoryInput().value = "";
+          return;
+        }
+        if (scenarioNameInput) scenarioNameInput.value = data.nombre || "";
+        if (bgInput) bgInput.value = data.fondo || "";
+        if (locInput) locInput.value = data.locacion || "";
+        if (tagsInput) tagsInput.value = (data.sub_etiquetas || []).join(", ");
+        if (regionInput()) regionInput().value = data.region || data.seccion || data.capitulo || "";
+        if (categoryInput()) categoryInput().value = data.categoria || "";
+      });
+
+      btnSaveScenario?.addEventListener("click", () => {
+        const data = scenarioPayload();
+        if (!data.nombre || !data.fondo || !data.locacion) {
+          alert("Nombre, fondo y localización son obligatorios.");
+          return;
+        }
+        const scenarioId = scenarioSelect?.value || database.ref(SCENARIOS_ROOT).push().key;
+        const now = window.firebase.database.ServerValue.TIMESTAMP;
+        const write = Object.assign({}, data, { updatedAt: now });
+        if (!scenarioSelect?.value) write.createdAt = now;
+        database.ref(`${SCENARIOS_ROOT}/${scenarioId}`).update(write).then(() => {
+          if (scenarioSelect) scenarioSelect.value = scenarioId;
+        }).catch((error) => alert("Error al guardar: " + error));
+      });
+
+      async function useScenarioFromInputs() {
+        const data = scenarioPayload();
+        if (!data.fondo || !data.locacion) {
+          alert("Fondo y localización son obligatorios para usar el escenario.");
+          return;
+        }
+        await theatre.changeScene(Object.assign({}, data, { escenarioId: scenarioSelect?.value || null }));
+      }
+
+      btnUseScenario?.addEventListener("click", () => useScenarioFromInputs().catch((error) => alert("Error aplicando escenario: " + error)));
+      btnUpdateScene?.addEventListener("click", () => useScenarioFromInputs().catch((error) => alert("Error aplicando escenario: " + error)));
+
+      btnDeleteScenario?.addEventListener("click", () => {
+        const scenarioId = scenarioSelect?.value;
+        if (!scenarioId || !confirm("¿Estás seguro de que quieres borrar este escenario?")) return;
+        database.ref(`${SCENARIOS_ROOT}/${scenarioId}`).remove().then(() => {
+          if (scenarioSelect) scenarioSelect.value = "";
+          scenarioSelect?.dispatchEvent(new Event("change"));
+        }).catch((error) => alert("Error al borrar: " + error));
+      });
+
+      // --- COLA FIFO: SOLO EL DM PUBLICA EL ESTADO DE ESCENA ---
+      function nextQueueItem() {
+        return database.ref(paths().queue).orderByChild("createdAt").limitToFirst(1).once("value");
+      }
+
+      async function dropQueueForTransition() {
+        processorGeneration += 1;
+        isProcessingQueue = false;
+        await database.ref(paths().queue).remove();
+      }
+
+      async function processQueue() {
+        if (isProcessingQueue) return;
+        const generation = processorGeneration;
+
+        const [instanceSnap, sceneSnap] = await Promise.all([
+          database.ref("campaña/estado_mundo/instancia_activa").once("value"),
+          database.ref(paths().scene).once("value")
+        ]);
+        if (generation !== processorGeneration || instanceSnap.val() !== "teatro") return;
+        const scene = sceneSnap.val() || {};
+        if (scene.transitioning) {
+          await dropQueueForTransition();
+          return;
+        }
+
+        const queueSnap = await nextQueueItem();
+        if (generation !== processorGeneration || !queueSnap.exists()) return;
+        const msgKey = Object.keys(queueSnap.val())[0];
+        const queueRef = database.ref(`${paths().queue}/${msgKey}`);
+        isProcessingQueue = true;
+
+        const claimed = await new Promise((resolve, reject) => {
+          queueRef.transaction((current) => {
+            if (!current) return current;
+            const now = Date.now();
+            const stuck = current.processing && current.processingStartedAt && (now - Number(current.processingStartedAt) > 120000);
+            if (current.processing && !stuck) return;
+            current.processing = true;
+            current.processingStartedAt = window.firebase.database.ServerValue.TIMESTAMP;
+            return current;
+          }, (error, committed, snapshot) => {
+            if (error) reject(error);
+            else resolve(committed ? snapshot.val() : null);
           });
+        }).catch((error) => {
+          console.error("No se pudo reclamar el mensaje de Theatre:", error);
+          return null;
+        });
+
+        if (!claimed || generation !== processorGeneration) {
+          isProcessingQueue = false;
+          if (generation === processorGeneration) setTimeout(processQueue, 250);
+          return;
+        }
+
+        const freshScene = (await database.ref(paths().scene).once("value")).val() || {};
+        if (generation !== processorGeneration || freshScene.transitioning || theatre.messageIsStaleForScene(claimed, freshScene)) {
+          await queueRef.remove();
+          isProcessingQueue = false;
+          if (generation === processorGeneration) processQueue();
+          return;
+        }
+
+        const textLength = String(claimed.mensaje || "").length;
+        claimed.speedMs = 30;
+        claimed.durationMs = (textLength * claimed.speedMs) + 3000;
+        const result = await theatre.publishIntervention(msgKey, claimed).catch((error) => {
+          console.error("Error publicando intervención del Theatre Engine:", error);
+          return { published: false, reason: "error" };
+        });
+
+        if (!result?.published) {
+          await queueRef.remove();
+          isProcessingQueue = false;
+          if (generation === processorGeneration) processQueue();
+          return;
+        }
+
+        setTimeout(async () => {
+          if (generation !== processorGeneration) return;
+          try {
+            await database.ref(`${paths().log}/${msgKey}`).set(result.payload);
+            await queueRef.remove();
+          } catch (error) {
+            console.error("Error archivando la intervención del Theatre:", error);
+          } finally {
+            if (generation === processorGeneration) {
+              isProcessingQueue = false;
+              processQueue();
+            }
+          }
+        }, claimed.durationMs);
+      }
+
+      database.ref(paths().queue).on("child_added", () => processQueue());
+      database.ref("campaña/estado_mundo/instancia_activa").on("value", (snapshot) => {
+        if (snapshot.val() === "teatro") processQueue();
+      });
+      database.ref(paths().scene).on("value", (snapshot) => {
+        const scene = snapshot.val() || {};
+        if (scene.transitioning) {
+          dropQueueForTransition().catch((error) => console.error("No se pudo cortar la cola durante transición:", error));
         } else {
-            console.warn("ADVERTENCIA: No se encontró #connection-status");
+          processQueue();
+        }
+      });
+
+      // --- COMPOSITOR DE DIÁLOGO DEL DM ---
+      const btnSendDialogue = document.getElementById("btn-send-dialogue");
+      const speakerSelect = document.getElementById("theatre-speaker-select");
+      const expressionSelect = document.getElementById("theatre-expression-select");
+
+      btnSendDialogue?.addEventListener("click", async () => {
+        const dialogueInput = document.getElementById("theatre-dialogue-input");
+        const typeSelect = document.getElementById("dm-tipo-dialogo-select");
+        const languageSelect = document.getElementById("theatre-language-select");
+        const text = dialogueInput?.value.trim() || "";
+        if (!text) return;
+
+        let type = typeSelect?.value || "dialogo";
+        let speaker = {
+          nombre: "",
+          titulo: "",
+          actorId: null,
+          expression: "Neutral",
+          sprite: null,
+          icono: null,
+          color_nombre: "#ffffff",
+          color_titulo: DEFAULT_TITLE_COLOR
+        };
+
+        if (!speakerSelect || speakerSelect.value === "narrador") {
+          type = "narracion";
+        } else {
+          const option = speakerSelect.options[speakerSelect.selectedIndex];
+          const expressionOption = expressionSelect?.options[expressionSelect.selectedIndex];
+          speaker = {
+            nombre: option.dataset.nombre || "",
+            titulo: option.dataset.titulo || "",
+            actorId: speakerSelect.value,
+            expression: expressionSelect?.value || "Neutral",
+            sprite: expressionOption?.dataset.sprite || null,
+            icono: option.dataset.icono || null,
+            color_nombre: option.dataset.colorNombre || "#ffffff",
+            color_titulo: option.dataset.colorTitulo || DEFAULT_TITLE_COLOR
+          };
         }
 
-        const btnUpdateScene = document.getElementById("btn-update-scene");
-        if (btnUpdateScene) {
-          btnUpdateScene.addEventListener("click", () => {
-            const bgInput = document.getElementById("theatre-background-input");
-            const locInput = document.getElementById("theatre-location-input");
-
-            if (bgInput && locInput) {
-                db.ref(SCENE_ROOT).update({
-                  fondo: bgInput.value.trim(),
-                  locacion: locInput.value.trim(),
-                  escenarioId: null
-                });
-            }
-          });
-        }
-
-        // --- BIBLIOTECA DE ESCENARIOS ---
-        const SCENARIOS_ROOT = "campaña/escenarios";
-        let scenariosDatabase = {};
-
-        const scenarioSelect = document.getElementById("theatre-scenario-select");
-        const locationFilter = document.getElementById("theatre-scenario-location-filter");
-        const tagFilter = document.getElementById("theatre-scenario-tag-filter");
-
-        const scenarioNameInput = document.getElementById("theatre-scenario-name");
-        const bgInput = document.getElementById("theatre-background-input");
-        const locInput = document.getElementById("theatre-location-input");
-        const tagsInput = document.getElementById("theatre-scenario-tags");
-
-        const btnSaveScenario = document.getElementById("btn-save-scenario");
-        const btnUseScenario = document.getElementById("btn-use-scenario");
-        const btnDeleteScenario = document.getElementById("btn-delete-scenario");
-
-        function renderScenarioSelect() {
-            if (!scenarioSelect) return;
-
-            const currentVal = scenarioSelect.value;
-            scenarioSelect.innerHTML = '<option value="">Selecciona un escenario guardado...</option>';
-
-            const locVal = locationFilter ? locationFilter.value : "";
-            const tagVal = tagFilter ? tagFilter.value.toLowerCase().trim() : "";
-
-            const locations = new Set();
-
-            for (const [scenarioId, data] of Object.entries(scenariosDatabase)) {
-                if (data.locacion) locations.add(data.locacion);
-
-                if (locVal && data.locacion !== locVal) continue;
-                if (tagVal) {
-                    const match = data.sub_etiquetas && data.sub_etiquetas.some(t => t.toLowerCase().includes(tagVal));
-                    if (!match) continue;
-                }
-
-                const opt = document.createElement("option");
-                opt.value = scenarioId;
-
-                const tagStr = data.sub_etiquetas ? `[${data.sub_etiquetas.join(', ')}]` : "[]";
-                opt.textContent = `${data.locacion || 'Sin loc'} · ${data.nombre || 'Sin nombre'} ${tagStr}`;
-                scenarioSelect.appendChild(opt);
-            }
-
-            if (locationFilter) {
-                const curLoc = locationFilter.value;
-                locationFilter.innerHTML = '<option value="">Todas las localizaciones</option>';
-                const sortedLocs = Array.from(locations).sort();
-                for (const loc of sortedLocs) {
-                    const opt = document.createElement("option");
-                    opt.value = loc;
-                    opt.textContent = loc;
-                    locationFilter.appendChild(opt);
-                }
-                locationFilter.value = curLoc;
-            }
-
-            if (scenariosDatabase[currentVal]) {
-                scenarioSelect.value = currentVal;
-            }
-        }
-
-        db.ref(SCENARIOS_ROOT).on("value", snapshot => {
-            scenariosDatabase = snapshot.val() || {};
-            renderScenarioSelect();
+        const queued = await theatre.enqueueIntervention({
+          mensaje: text,
+          nombre: speaker.nombre,
+          titulo: speaker.titulo,
+          actorId: speaker.actorId,
+          expression: speaker.expression,
+          sprite: speaker.sprite,
+          icono: speaker.icono,
+          color_nombre: speaker.color_nombre,
+          color_titulo: speaker.color_titulo,
+          tipo_dialogo: type,
+          mostrar_identidad: type !== "narracion",
+          idiomaId: languageSelect?.value || null
         });
 
-        if (locationFilter) locationFilter.addEventListener("change", renderScenarioSelect);
-        if (tagFilter) tagFilter.addEventListener("keyup", renderScenarioSelect);
+        if (!queued.queued) {
+          if (queued.reason === "transition") alert("La escena está en transición. El mensaje no fue enviado.");
+          return;
+        }
+        if (dialogueInput) dialogueInput.value = "";
+      });
 
-        if (scenarioSelect) {
-            scenarioSelect.addEventListener("change", (e) => {
-                const scenarioId = e.target.value;
-                if (!scenarioId || !scenariosDatabase[scenarioId]) {
-                    scenarioNameInput.value = "";
-                    bgInput.value = "";
-                    locInput.value = "";
-                    tagsInput.value = "";
-                    return;
-                }
-                const data = scenariosDatabase[scenarioId];
-                scenarioNameInput.value = data.nombre || "";
-                bgInput.value = data.fondo || "";
-                locInput.value = data.locacion || "";
-                tagsInput.value = data.sub_etiquetas ? data.sub_etiquetas.join(", ") : "";
-            });
+      database.ref(`${paths().scene}/actores`).on("value", (snapshot) => {
+        if (!speakerSelect) return;
+        const currentSelection = speakerSelect.value;
+        const actors = snapshot.val() || {};
+        speakerSelect.innerHTML = '<option value="narrador">Narrador</option>';
+        for (const [actorId, actor] of Object.entries(actors)) {
+          const option = document.createElement("option");
+          option.value = actorId;
+          option.textContent = actor.nombre || actorId;
+          option.dataset.nombre = actor.nombre || "";
+          option.dataset.titulo = actor.titulo || "";
+          option.dataset.icono = actor.icono || "";
+          option.dataset.colorNombre = actor.color_nombre || "#ffffff";
+          option.dataset.colorTitulo = actor.color_titulo || DEFAULT_TITLE_COLOR;
+          option.dataset.expresiones = JSON.stringify(actor.expresiones || {});
+          option.dataset.preparedExpression = actor.expresionPreparada || actor.expresionActiva || "Neutral";
+          speakerSelect.appendChild(option);
+        }
+        speakerSelect.value = currentSelection && actors[currentSelection] ? currentSelection : "narrador";
+        speakerSelect.dispatchEvent(new Event("change"));
+      });
+
+      speakerSelect?.addEventListener("change", (event) => {
+        if (!expressionSelect) return;
+        expressionSelect.innerHTML = "";
+        if (event.target.value === "narrador") {
+          const option = document.createElement("option");
+          option.value = "Neutral";
+          option.textContent = "Neutral";
+          expressionSelect.appendChild(option);
+          return;
         }
 
-        if (btnSaveScenario) {
-            btnSaveScenario.addEventListener("click", () => {
-                const name = scenarioNameInput.value.trim();
-                const fondo = bgInput.value.trim();
-                const loc = locInput.value.trim();
-
-                if (!name || !fondo || !loc) {
-                    alert("Nombre, fondo y localización son obligatorios.");
-                    return;
-                }
-
-                const tagsRaw = tagsInput.value.split(",");
-                const subEtiquetas = [...new Set(tagsRaw.map(t => t.trim().toLowerCase()).filter(t => t !== ""))];
-
-                const scenarioId = scenarioSelect.value || db.ref(SCENARIOS_ROOT).push().key;
-
-                const now = window.firebase.database.ServerValue.TIMESTAMP;
-                const data = {
-                    nombre: name,
-                    fondo: fondo,
-                    locacion: loc,
-                    sub_etiquetas: subEtiquetas,
-                    updatedAt: now
-                };
-
-                if (!scenarioSelect.value) {
-                    data.createdAt = now;
-                }
-
-                db.ref(`${SCENARIOS_ROOT}/${scenarioId}`).update(data).then(() => {
-                    alert("Escenario guardado correctamente.");
-                    scenarioSelect.value = scenarioId;
-                }).catch(err => alert("Error al guardar: " + err));
-            });
+        const speakerOption = event.target.options[event.target.selectedIndex];
+        let expressions = {};
+        try { expressions = JSON.parse(speakerOption.dataset.expresiones || "{}"); } catch (error) {}
+        if (!Object.keys(expressions).length) expressions = { Neutral: "" };
+        for (const [expression, spriteUrl] of Object.entries(expressions)) {
+          const option = document.createElement("option");
+          option.value = expression;
+          option.textContent = expression;
+          option.dataset.sprite = spriteUrl;
+          expressionSelect.appendChild(option);
         }
+        const prepared = speakerOption.dataset.preparedExpression;
+        if (prepared && expressions[prepared] !== undefined) expressionSelect.value = prepared;
+      });
 
-        if (btnUseScenario) {
-            btnUseScenario.addEventListener("click", () => {
-                const scenarioId = scenarioSelect.value;
-                const fondo = bgInput.value.trim();
-                const loc = locInput.value.trim();
-                const tagsRaw = tagsInput.value.split(",");
-                const subEtiquetas = [...new Set(tagsRaw.map(t => t.trim().toLowerCase()).filter(t => t !== ""))];
+      expressionSelect?.addEventListener("change", () => {
+        if (!speakerSelect || speakerSelect.value === "narrador") return;
+        // Selection only prepares; reveal happens when the queue publishes the intervention.
+        theatre.prepareExpression(speakerSelect.value, expressionSelect.value);
+      });
 
-                if (!fondo || !loc) {
-                    alert("Fondo y localización son obligatorios para usar.");
-                    return;
-                }
-
-                db.ref(SCENE_ROOT).update({
-                    escenarioId: scenarioId || null,
-                    fondo: fondo,
-                    locacion: loc,
-                    sub_etiquetas: subEtiquetas
-                }).then(() => {
-                    console.log("Escenario aplicado exitosamente");
-                }).catch(err => alert("Error aplicando escenario: " + err));
-            });
-        }
-
-        if (btnDeleteScenario) {
-            btnDeleteScenario.addEventListener("click", () => {
-                const scenarioId = scenarioSelect.value;
-                if (!scenarioId) return;
-
-                if (confirm("¿Estás seguro de que quieres borrar este escenario?")) {
-                    db.ref(`${SCENARIOS_ROOT}/${scenarioId}`).remove().then(() => {
-                        scenarioSelect.value = "";
-                        scenarioNameInput.value = "";
-                        bgInput.value = "";
-                        locInput.value = "";
-                        tagsInput.value = "";
-                        alert("Escenario borrado.");
-                    }).catch(err => alert("Error al borrar: " + err));
-                }
-            });
-        }
-
-
-        // --- 4. Sistema de Cola FIFO y Secuenciador ---
-        const QUEUE_ROOT = "campaña/teatro/cola";
-        const LOG_ROOT = "campaña/teatro/log";
-
-        let isProcessingQueue = false;
-
-                function processQueue() {
-            if (isProcessingQueue) return;
-
-            // Check if theatre is active instance
-            db.ref("campaña/estado_mundo/instancia_activa").once('value').then(snap => {
-                if (snap.val() !== 'teatro') return; // Pause queue if not in theatre
-
-                isProcessingQueue = true;
-
-                // Get oldest message
-                db.ref(QUEUE_ROOT).orderByChild("createdAt").limitToFirst(1).once("value").then(queueSnap => {
-                    if (!queueSnap.exists()) {
-                        isProcessingQueue = false;
-                        return; // Empty queue
-                    }
-
-                    const msgKey = Object.keys(queueSnap.val())[0];
-                    const msgData = queueSnap.val()[msgKey];
-
-                    // Deadlock prevention: If it has been processing for more than 2 minutes, assume the previous DM crashed and claim it anyway.
-                    const now = Date.now();
-                    const isStuck = msgData.processing && msgData.processingStartedAt && (now - msgData.processingStartedAt > 120000);
-
-                    // Transaction to claim it safely
-                    db.ref(`${QUEUE_ROOT}/${msgKey}`).transaction(currentData => {
-                        if (currentData && (!currentData.processing || isStuck)) {
-                            currentData.processing = true;
-                            currentData.processingStartedAt = window.firebase.database.ServerValue.TIMESTAMP;
-                            return currentData;
-                        }
-                        return; // Abort if already processing and not stuck
-                    }, (error, committed, snapshot) => {
-                        if (!committed) {
-                            isProcessingQueue = false;
-
-                            // If it's stuck but transaction failed, wait and retry. Or if someone else took it.
-                            setTimeout(processQueue, 1000);
-                            return;
-                        }
-
-                        const actualData = snapshot.val();
-
-                        // Calculate duration
-                        const speedMs = 30; // 30 ms per char
-                        const textLength = (actualData.mensaje || "").length;
-                        const durationMs = (textLength * speedMs) + 3000; // Text duration + 3 sec pause
-                        const startedAt = window.firebase.database.ServerValue.TIMESTAMP;
-
-                        // Broadcast to active dialogue
-                        // Notify visibility rule (LuminousTheatreState) if valid actor speaking actual dialogue
-                        if (actualData.actorId && window.LuminousTheatreState && window.LuminousTheatreState.updateVisibleActors) {
-                            if (actualData.tipo_dialogo !== "pensamiento" && actualData.tipo_dialogo !== "narracion") {
-                                window.LuminousTheatreState.updateVisibleActors(actualData.actorId, actualData);
-                            }
-                        }
-
-                        const activePayload = {
-                            messageId: msgKey,
-                            nombre: actualData.nombre || "",
-                            titulo: actualData.titulo || "",
-                            mensaje: actualData.mensaje || "",
-                            actorId: actualData.actorId || null,
-                            expression: actualData.expression || "Neutral",
-                            sprite: actualData.sprite || null,
-                            icono: actualData.icono || null,
-                            color_nombre: actualData.color_nombre || "#ffffff",
-                            color_titulo: actualData.color_titulo || DEFAULT_TITLE_COLOR,
-                            tipo_dialogo: actualData.tipo_dialogo || "dialogo",
-                            mostrar_identidad: actualData.mostrar_identidad !== false,
-                            startedAt: startedAt,
-                            speedMs: speedMs,
-                            durationMs: durationMs
-                        };
-
-                                                db.ref(DIALOGUE_ROOT).set(activePayload).then(() => {
-                            // Wait exact duration
-                            setTimeout(() => {
-                                // Archive to Log
-                                db.ref(`${LOG_ROOT}/${msgKey}`).set(activePayload).then(() => {
-                                    // Remove from queue
-                                    db.ref(`${QUEUE_ROOT}/${msgKey}`).remove().then(() => {
-                                        isProcessingQueue = false;
-                                        processQueue(); // Check for next
-                                    });
-                                }).catch(err => {
-                                    console.error("Error archivando en log:", err);
-                                    isProcessingQueue = false;
-                                    processQueue();
-                                });
-                            }, (textLength * speedMs) + 3000); // We simulate the wait client-side for the sequencer
-                        }).catch(err => {
-                            console.error("Error publicando diálogo activo:", err);
-                            // Desmarcar para que no se quede atascado o ignorarlo si hay un problema de permisos
-                            // If we can't publish, we might want to just skip or log.
-                            // Let's remove from queue so it's not a permanent blocker
-                            db.ref(`${QUEUE_ROOT}/${msgKey}`).remove().finally(() => {
-                                isProcessingQueue = false;
-                                processQueue();
-                            });
-                        });
-                    });
-                });
-            });
-        }
-
-        // Listen to queue changes to trigger processor
-        db.ref(QUEUE_ROOT).on("child_added", () => {
-            processQueue();
+      const btnTriggerCombat = document.getElementById("btn-trigger-combat");
+      btnTriggerCombat?.addEventListener("click", () => {
+        database.ref("campaña/estado_mundo/instancia_activa").set("combate");
+        database.ref("campaña/combate").update({
+          estado: "COMBAT_ACTIVE",
+          startedAt: window.firebase.database.ServerValue.TIMESTAMP
         });
-
-        // Listen to instance changes to resume queue
-        db.ref("campaña/estado_mundo/instancia_activa").on("value", (snap) => {
-            if (snap.val() === 'teatro') {
-                processQueue();
-            }
-        });
-
-        // Modificamos el envio de diálogo del DM para que vaya a la cola
-        const btnSendDialogue = document.getElementById("btn-send-dialogue");
-        if (btnSendDialogue) {
-          btnSendDialogue.addEventListener("click", () => {
-            const dialogueInput = document.getElementById("theatre-dialogue-input");
-            if (!dialogueInput) return;
-
-            const texto = dialogueInput.value.trim();
-            if (!texto) return;
-
-            const speakerSelect = document.getElementById("theatre-speaker-select");
-            const expressionSelect = document.getElementById("theatre-expression-select");
-            const dmTipoDialogoEl = document.getElementById("dm-tipo-dialogo-select");
-
-            let tipoDialogo = dmTipoDialogoEl ? dmTipoDialogoEl.value : "dialogo";
-            let mostrarIdentidad = tipoDialogo !== "pensamiento";
-
-            let speakerData = {
-                nombre: "",
-                titulo: "",
-                actorId: null,
-                expression: "Neutral",
-                sprite: null,
-                icono: null,
-                color_nombre: "#ffffff",
-                color_titulo: DEFAULT_TITLE_COLOR
-            };
-
-            if (speakerSelect && speakerSelect.value === "narrador") {
-                tipoDialogo = "narracion";
-                mostrarIdentidad = false;
-            } else if (speakerSelect) {
-                const selectedOption = speakerSelect.options[speakerSelect.selectedIndex];
-                speakerData.nombre = selectedOption.dataset.nombre || "";
-                speakerData.titulo = selectedOption.dataset.titulo || "";
-                speakerData.actorId = speakerSelect.value;
-                speakerData.icono = selectedOption.dataset.icono || null;
-                speakerData.color_nombre = selectedOption.dataset.colorNombre || "#ffffff";
-                speakerData.color_titulo = selectedOption.dataset.colorTitulo || DEFAULT_TITLE_COLOR;
-
-                if (expressionSelect) {
-                    speakerData.expression = expressionSelect.value;
-                    const expOpt = expressionSelect.options[expressionSelect.selectedIndex];
-                    speakerData.sprite = expOpt ? expOpt.dataset.sprite : null;
-                }
-            }
-
-            // Also persist the expression to the actor instance so it doesn't revert, EXCEPT for pensamientos
-            if (speakerData.actorId && tipoDialogo !== "pensamiento" && tipoDialogo !== "narracion") {
-                db.ref(`${SCENE_ROOT}/actores/${speakerData.actorId}`).update({
-                    expresionActiva: speakerData.expression,
-                    sprite: speakerData.sprite
-                });
-            }
-
-            const msgKey = db.ref(QUEUE_ROOT).push().key;
-            db.ref(`${QUEUE_ROOT}/${msgKey}`).set({
-              mensaje: texto,
-              nombre: speakerData.nombre,
-              titulo: speakerData.titulo,
-              actorId: speakerData.actorId,
-              expression: speakerData.expression,
-              sprite: speakerData.sprite,
-              icono: speakerData.icono,
-              color_nombre: speakerData.color_nombre,
-              color_titulo: speakerData.color_titulo,
-              tipo_dialogo: tipoDialogo,
-              mostrar_identidad: mostrarIdentidad,
-              createdAt: window.firebase.database.ServerValue.TIMESTAMP
-            });
-            dialogueInput.value = "";
-          });
-        }
-
-        // Listen to live actors to update speaker select
-        db.ref(SCENE_ROOT + "/actores").on("value", (snapshot) => {
-            const speakerSelect = document.getElementById("theatre-speaker-select");
-            const expressionSelect = document.getElementById("theatre-expression-select");
-            if (!speakerSelect) return;
-
-            const currentSelection = speakerSelect.value;
-            speakerSelect.innerHTML = '<option value="narrador">Narrador</option>';
-
-            const actors = snapshot.val() || {};
-            for (const [actorId, actorData] of Object.entries(actors)) {
-                const opt = document.createElement("option");
-                opt.value = actorId;
-                opt.textContent = actorData.nombre;
-                opt.dataset.nombre = actorData.nombre;
-                opt.dataset.titulo = actorData.titulo || "";
-                opt.dataset.icono = actorData.icono || "";
-                opt.dataset.colorNombre = actorData.color_nombre || "#ffffff";
-                opt.dataset.colorTitulo = actorData.color_titulo || DEFAULT_TITLE_COLOR;
-
-                // Store expressions as a JSON string for easy retrieval
-                opt.dataset.expresiones = JSON.stringify(actorData.expresiones || {});
-
-                speakerSelect.appendChild(opt);
-            }
-
-            // Try to restore previous selection
-            if (currentSelection && currentSelection !== "narrador" && actors[currentSelection]) {
-                speakerSelect.value = currentSelection;
-            } else {
-                speakerSelect.value = "narrador";
-            }
-
-            // Manually trigger change to update expression select
-            speakerSelect.dispatchEvent(new Event('change'));
-        });
-
-        // Update expression select when speaker changes
-        const speakerSelect = document.getElementById("theatre-speaker-select");
-        if (speakerSelect) {
-            speakerSelect.addEventListener("change", (e) => {
-                const expressionSelect = document.getElementById("theatre-expression-select");
-                if (!expressionSelect) return;
-
-                expressionSelect.innerHTML = "";
-
-                if (e.target.value === "narrador") {
-                    const opt = document.createElement("option");
-                    opt.value = "Neutral";
-                    opt.textContent = "Neutral";
-                    expressionSelect.appendChild(opt);
-                    return;
-                }
-
-                const selectedOption = e.target.options[e.target.selectedIndex];
-                let expresiones = {};
-                try {
-                    expresiones = JSON.parse(selectedOption.dataset.expresiones || "{}");
-                } catch (err) {}
-
-                if (Object.keys(expresiones).length === 0) {
-                    const opt = document.createElement("option");
-                    opt.value = "Neutral";
-                    opt.textContent = "Neutral";
-                    expressionSelect.appendChild(opt);
-                } else {
-                    for (const [exp, spriteUrl] of Object.entries(expresiones)) {
-                        const opt = document.createElement("option");
-                        opt.value = exp;
-                        opt.textContent = exp;
-                        opt.dataset.sprite = spriteUrl;
-                        expressionSelect.appendChild(opt);
-                    }
-                }
-            });
-        }
-const btnTriggerCombat = document.getElementById("btn-trigger-combat");
-        if (btnTriggerCombat) {
-          btnTriggerCombat.addEventListener("click", () => {
-            db.ref("campaña/estado_mundo/instancia_activa").set("combate");
-            db.ref("campaña/combate").update({ estado: "COMBAT_ACTIVE", startedAt: window.firebase.database.ServerValue.TIMESTAMP });
-          });
-        }
+      });
     }
   });
 })();

--- a/js/theatre-controls.js
+++ b/js/theatre-controls.js
@@ -1,13 +1,16 @@
-(function(global) {
+(function (global) {
     "use strict";
 
     document.addEventListener("DOMContentLoaded", () => {
         const db = global.firebase.database();
         const NPC_ROSTER_PATHS = ["campaña/base_datos_npcs", "campaña/actores"];
-        const THEATRE_ROOT = "campaña/estado_mundo/escena_actual";
-        const THEATRE_ACTORS_PATH = `${THEATRE_ROOT}/actores`;
-        const VISIBLE_ACTORS_PATH = `${THEATRE_ROOT}/actores_visibles`;
         const DEFAULT_TITLE_COLOR = "#3b2918";
+
+        const paths = () => global.LuminousTheatreState?.getPaths?.() || {
+            scene: "campaña/estado_mundo/escena_actual",
+            dialogue: "campaña/estado_mundo/dialogo_activo",
+            queue: "campaña/teatro/cola"
+        };
 
         let npcDatabaseRaw = {};
         let npcDatabaseBase = {};
@@ -16,11 +19,21 @@
         let visibleActors = [];
         let playerDatabase = {};
         let maxVisibleActors = 5;
+        let languageSources = {};
 
         const selectNpcRoster = document.getElementById("select-npc-roster");
         const liveActorsList = document.getElementById("live-actors-list");
         const btnSpawnNpc = document.getElementById("btn-spawn-npc");
         const directorPanel = document.getElementById("theatre-director-panel");
+
+        function escapeHtml(value) {
+            return String(value ?? "")
+                .replaceAll("&", "&amp;")
+                .replaceAll("<", "&lt;")
+                .replaceAll(">", "&gt;")
+                .replaceAll('"', "&quot;")
+                .replaceAll("'", "&#039;");
+        }
 
         function normalizeIdList(value) {
             if (global.LuminousTheatreState?.normalizeAssignedActorIds) {
@@ -28,14 +41,22 @@
             }
             if (!value) return [];
             if (Array.isArray(value)) return value.filter(Boolean);
-            if (typeof value === "object") return Object.keys(value).sort().map(key => value[key]).filter(Boolean);
+            if (typeof value === "object") return Object.keys(value).sort().map((key) => value[key]).filter(Boolean);
             return [value];
         }
 
+        function getPlayerLabel(playerId, player) {
+            return player?.characterName || player?.character_name || player?.nombre || player?.name || playerId;
+        }
+
+        function getIdentityViewerOptions() {
+            return Object.entries(playerDatabase)
+                .map(([playerId, player]) => `<option value="${escapeHtml(playerId)}">${escapeHtml(getPlayerLabel(playerId, player))}</option>`)
+                .join("");
+        }
+
         function refreshNpcDatabase() {
-            npcDatabase = {};
-            for (const [id, data] of Object.entries(npcDatabaseRaw)) npcDatabase[id] = data;
-            for (const [id, data] of Object.entries(npcDatabaseBase)) npcDatabase[id] = data;
+            npcDatabase = Object.assign({}, npcDatabaseRaw, npcDatabaseBase);
             updateRosterSelect();
         }
 
@@ -43,67 +64,63 @@
             if (!selectNpcRoster) return;
             selectNpcRoster.innerHTML = '<option value="">Selecciona un Personaje...</option>';
 
-            const optgroupPlayers = document.createElement("optgroup");
-            optgroupPlayers.label = "PERSONAJES JUGADORES";
-
+            const playerGroup = document.createElement("optgroup");
+            playerGroup.label = "PERSONAJES JUGADORES";
             for (const [playerId, player] of Object.entries(playerDatabase)) {
-                let actorData = null;
                 let actorId = null;
-
+                let actorData = null;
                 if (player.actorId && npcDatabase[player.actorId]) {
                     actorId = player.actorId;
                     actorData = npcDatabase[actorId];
                 } else {
-                    actorId = Object.keys(npcDatabase).find(k =>
-                        npcDatabase[k].vinculo_jugador === playerId && npcDatabase[k].tipo === "Jugador"
+                    actorId = Object.keys(npcDatabase).find((id) =>
+                        npcDatabase[id]?.vinculo_jugador === playerId && npcDatabase[id]?.tipo === "Jugador"
                     );
                     if (actorId) actorData = npcDatabase[actorId];
                 }
-
-                if (actorData) {
-                    const opt = document.createElement("option");
-                    opt.value = actorId;
-                    opt.textContent = actorData.nombre || player.characterName || player.character_name || player.nombre || playerId;
-                    opt.dataset.sourceType = "player-profile";
-                    opt.dataset.sourceId = playerId;
-                    optgroupPlayers.appendChild(opt);
-                }
+                if (!actorData) continue;
+                const option = document.createElement("option");
+                option.value = actorId;
+                option.textContent = actorData.nombre || getPlayerLabel(playerId, player);
+                option.dataset.sourceType = "player-profile";
+                option.dataset.sourceId = playerId;
+                playerGroup.appendChild(option);
             }
-            selectNpcRoster.appendChild(optgroupPlayers);
+            selectNpcRoster.appendChild(playerGroup);
 
-            const optgroupNpcs = document.createElement("optgroup");
-            optgroupNpcs.label = "NPCs / PERSONAJES DEL DM";
+            const npcGroup = document.createElement("optgroup");
+            npcGroup.label = "NPCs / PERSONAJES DEL DM";
             for (const [actorId, actorData] of Object.entries(npcDatabase)) {
-                if (actorData.tipo === "Jugador") continue;
-                const opt = document.createElement("option");
-                opt.value = actorId;
-                opt.textContent = actorData.nombre || "Sin Nombre";
-                opt.dataset.sourceType = "npc";
-                opt.dataset.sourceId = actorId;
-                optgroupNpcs.appendChild(opt);
+                if (actorData?.tipo === "Jugador") continue;
+                const option = document.createElement("option");
+                option.value = actorId;
+                option.textContent = actorData?.nombre || "Sin Nombre";
+                option.dataset.sourceType = "npc";
+                option.dataset.sourceId = actorId;
+                npcGroup.appendChild(option);
             }
-            selectNpcRoster.appendChild(optgroupNpcs);
+            selectNpcRoster.appendChild(npcGroup);
         }
 
         function loadRoster() {
             if (!selectNpcRoster) return;
-            db.ref(NPC_ROSTER_PATHS[0]).on("value", snapshot => {
+            db.ref(NPC_ROSTER_PATHS[0]).on("value", (snapshot) => {
                 npcDatabaseBase = snapshot.val() || {};
                 refreshNpcDatabase();
             });
-            db.ref(NPC_ROSTER_PATHS[1]).on("value", snapshot => {
+            db.ref(NPC_ROSTER_PATHS[1]).on("value", (snapshot) => {
                 npcDatabaseRaw = snapshot.val() || {};
                 refreshNpcDatabase();
             });
-            db.ref("campaña/jugadores").on("value", snapshot => {
+            db.ref("campaña/jugadores").on("value", (snapshot) => {
                 playerDatabase = snapshot.val() || {};
                 updateRosterSelect();
+                renderLiveActors();
             });
         }
 
         function buildDirectorPolicyControls() {
             if (!directorPanel || document.getElementById("theatre-render-policy")) return;
-
             const wrapper = document.createElement("div");
             wrapper.id = "theatre-render-policy";
             wrapper.style.cssText = "display:flex;gap:8px;align-items:center;flex-wrap:wrap;padding:8px 0 12px;border-bottom:1px solid #333;margin-bottom:12px";
@@ -131,183 +148,223 @@
 
             maxSelect.value = String(maxVisibleActors);
             maxSelect.addEventListener("change", async () => {
-                if (global.LuminousTheatreState?.setMaxVisibleActors) {
-                    maxVisibleActors = await global.LuminousTheatreState.setMaxVisibleActors(maxSelect.value);
-                }
+                maxVisibleActors = await global.LuminousTheatreState.setMaxVisibleActors(maxSelect.value);
             });
-
             noActors.addEventListener("change", () => {
-                db.ref(`${THEATRE_ROOT}/modo_presentacion`).set(noActors.checked ? "no-actors" : "actors");
+                db.ref(`${paths().scene}/modo_presentacion`).set(noActors.checked ? "no-actors" : "actors");
             });
-
-            clearBtn.addEventListener("click", () => {
-                if (global.LuminousTheatreState?.clearScene) {
-                    global.LuminousTheatreState.clearScene();
-                }
-            });
-
-            db.ref(`${THEATRE_ROOT}/modo_presentacion`).on("value", snap => {
-                noActors.checked = snap.val() === "no-actors";
+            clearBtn.addEventListener("click", () => global.LuminousTheatreState.clearScene());
+            db.ref(`${paths().scene}/modo_presentacion`).on("value", (snapshot) => {
+                noActors.checked = snapshot.val() === "no-actors";
             });
         }
 
-        loadRoster();
-        buildDirectorPolicyControls();
+        function buildLanguageSelector() {
+            if (document.getElementById("theatre-language-select")) return;
+            const controls = document.querySelector(".theatre-controls");
+            const firstRow = controls?.querySelector("div");
+            if (!firstRow) return;
+            const select = document.createElement("select");
+            select.id = "theatre-language-select";
+            select.setAttribute("aria-label", "Idioma del diálogo");
+            select.style.cssText = "flex:1;padding:9px;background:#121820;color:white;border:1px solid #53606d;";
+            firstRow.appendChild(select);
+            renderLanguageSelector();
+        }
 
-        db.ref(`${THEATRE_ROOT}/max_actores_visibles`).on("value", snap => {
-            maxVisibleActors = global.LuminousTheatreState?.clampVisibleLimit
-                ? global.LuminousTheatreState.clampVisibleLimit(snap.val())
-                : Math.max(1, Math.min(5, Number.parseInt(snap.val(), 10) || 5));
-            const maxSelect = document.getElementById("theatre-max-visible");
-            if (maxSelect) maxSelect.value = String(maxVisibleActors);
-            renderLiveActors();
-        });
+        function renderLanguageSelector() {
+            const select = document.getElementById("theatre-language-select");
+            if (!select) return;
+            const selected = select.value;
+            const languages = Object.assign({}, ...Object.values(languageSources));
+            select.innerHTML = '<option value="">Idioma común / sin filtro</option>';
+            for (const [languageId, definition] of Object.entries(languages)) {
+                const option = document.createElement("option");
+                option.value = languageId;
+                const suffix = definition?.distortion === true || String(definition?.tipo || definition?.type || "").toLowerCase().includes("dist")
+                    ? " · Distortion"
+                    : "";
+                option.textContent = `${definition?.nombre || definition?.name || languageId}${suffix}`;
+                select.appendChild(option);
+            }
+            if (Array.from(select.options).some((option) => option.value === selected)) select.value = selected;
+        }
 
-        db.ref(VISIBLE_ACTORS_PATH).on("value", snap => {
-            visibleActors = normalizeIdList(snap.val());
-            renderLiveActors();
-        });
-
-        if (btnSpawnNpc) {
-            btnSpawnNpc.addEventListener("click", () => {
-                if (!selectNpcRoster) return;
-                const selectedId = selectNpcRoster.value;
-                if (!selectedId) return;
-                const npcData = npcDatabase[selectedId];
-                if (!npcData) return;
-
-                const selectedOption = selectNpcRoster.options[selectNpcRoster.selectedIndex];
-                const sourceType = selectedOption.dataset.sourceType || "npc";
-                const sourceId = selectedOption.dataset.sourceId || selectedId;
-                const actorInstanceId = `actor_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
-                const now = global.firebase.database.ServerValue.TIMESTAMP;
-
-                let expressions = npcData.expresiones || {};
-                let activeExpression = "Neutral";
-                if (Object.keys(expressions).length === 0) {
-                    expressions = { Neutral: npcData.sprite || npcData.icono_jugador || npcData.icono || "" };
-                } else if (!expressions.Neutral) {
-                    activeExpression = Object.keys(expressions)[0];
-                }
-
-                const activeSprite = expressions[activeExpression] || npcData.sprite || npcData.url || "";
-                const actorPayload = {
-                    nombre: npcData.nombre || selectedId,
-                    titulo: npcData.titulo || "",
-                    color_nombre: npcData.color_nombre || "#ffffff",
-                    color_titulo: npcData.color_titulo || DEFAULT_TITLE_COLOR,
-                    sourceId,
-                    sourceType,
-                    sprite: activeSprite,
-                    icono: npcData.icono || npcData.icono_jugador || "",
-                    expresiones: expressions,
-                    expresionActiva: activeExpression,
-                    expresionPreparada: activeExpression,
-                    x: 0,
-                    y: 0,
-                    escala: npcData.escala || 1,
-                    orientacion: "normal",
-                    spawnedAt: now
-                };
-
-                // The actor pool is not the HUD. Never delete available actors to enforce the visible limit.
-                db.ref(`${THEATRE_ACTORS_PATH}/${actorInstanceId}`).set(actorPayload).then(() => {
-                    if (global.LuminousTheatreState?.updateVisibleActors) {
-                        return global.LuminousTheatreState.updateVisibleActors(actorInstanceId, actorPayload);
-                    }
-                }).catch(error => console.error("No se pudo añadir el actor al Teatro:", error));
+        function subscribeLanguages() {
+            ["campaña/idiomas", "campaña/teatro/idiomas"].forEach((root) => {
+                db.ref(root).on("value", (snapshot) => {
+                    languageSources[root] = snapshot.val() || {};
+                    renderLanguageSelector();
+                });
             });
+        }
+
+        function spawnSelectedActor() {
+            if (!selectNpcRoster) return;
+            const selectedId = selectNpcRoster.value;
+            if (!selectedId) return;
+            const npcData = npcDatabase[selectedId];
+            if (!npcData) return;
+
+            const option = selectNpcRoster.options[selectNpcRoster.selectedIndex];
+            const sourceType = option.dataset.sourceType || "npc";
+            const sourceId = option.dataset.sourceId || selectedId;
+            const actorInstanceId = `actor_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
+            const now = global.firebase.database.ServerValue.TIMESTAMP;
+
+            let expressions = npcData.expresiones || {};
+            let activeExpression = "Neutral";
+            if (!Object.keys(expressions).length) {
+                expressions = { Neutral: npcData.sprite || npcData.icono_jugador || npcData.icono || "" };
+            } else if (!expressions.Neutral) {
+                activeExpression = Object.keys(expressions)[0];
+            }
+
+            const activeSprite = expressions[activeExpression] || npcData.sprite || npcData.url || "";
+            const actorPayload = {
+                nombre: npcData.nombre || selectedId,
+                titulo: npcData.titulo || "",
+                color_nombre: npcData.color_nombre || "#ffffff",
+                color_titulo: npcData.color_titulo || DEFAULT_TITLE_COLOR,
+                identityId: npcData.identityId || npcData.identidadId || selectedId,
+                sourceId,
+                sourceType,
+                sprite: activeSprite,
+                icono: npcData.icono || npcData.icono_jugador || "",
+                expresiones: expressions,
+                expresionActiva: activeExpression,
+                expresionPreparada: activeExpression,
+                x: 0,
+                y: 0,
+                escala: npcData.escala || 1,
+                orientacion: "normal",
+                spawnedAt: now
+            };
+
+            // Pool and HUD are separate. Spawning never evicts/deletes another available actor.
+            db.ref(`${paths().scene}/actores/${actorInstanceId}`).set(actorPayload)
+                .then(() => global.LuminousTheatreState.updateVisibleActors(actorInstanceId, actorPayload))
+                .catch((error) => console.error("No se pudo añadir el actor al Teatro:", error));
         }
 
         function renderLiveActors() {
             if (!liveActorsList) return;
             liveActorsList.innerHTML = "";
-
-            const panelTitle = document.querySelector(".panel-title");
+            const panelTitle = directorPanel?.querySelector(".panel-title");
             if (panelTitle) {
                 panelTitle.textContent = `CONTROL DE CASTING (${Object.keys(liveActors).length} disponibles · ${visibleActors.length}/${maxVisibleActors} visibles)`;
             }
 
-            Object.keys(liveActors).forEach(actorId => {
-                const actorData = liveActors[actorId];
+            const viewerOptions = getIdentityViewerOptions();
+            for (const [actorId, actorData] of Object.entries(liveActors)) {
                 const card = document.createElement("div");
                 card.className = "actor-control-card";
                 card.dataset.visible = visibleActors.includes(actorId) ? "true" : "false";
 
-                let expressionsHTML = "";
-                if (actorData.expresiones && Object.keys(actorData.expresiones).length > 0) {
+                let expressionsHtml = "";
+                if (actorData.expresiones && Object.keys(actorData.expresiones).length) {
                     const prepared = actorData.expresionPreparada || actorData.expresionActiva;
-                    expressionsHTML = '<select class="actor-expression-select" style="background:#222;color:#fff;border:1px solid #444;padding:2px;font-size:.8rem;font-family:\'Share Tech Mono\',monospace">';
-                    for (const exp of Object.keys(actorData.expresiones)) {
-                        expressionsHTML += `<option value="${exp}" ${prepared === exp ? "selected" : ""}>${exp}</option>`;
-                    }
-                    expressionsHTML += "</select>";
+                    const options = Object.keys(actorData.expresiones).map((expression) =>
+                        `<option value="${escapeHtml(expression)}" ${prepared === expression ? "selected" : ""}>${escapeHtml(expression)}</option>`
+                    ).join("");
+                    expressionsHtml = `<select class="actor-expression-select" style="background:#222;color:#fff;border:1px solid #444;padding:2px;font-size:.8rem;">${options}</select>`;
                 }
 
                 card.innerHTML = `
-                    <div style="display:flex;justify-content:space-between;align-items:center;gap:8px;">
-                        <span class="actor-name">${actorData.nombre || "Actor"}</span>
+                    <div style="display:flex;justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap;">
+                        <span class="actor-name">${escapeHtml(actorData.nombre || "Actor")}</span>
                         <span style="font-size:.7rem;opacity:.7;">${visibleActors.includes(actorId) ? "VISIBLE" : "DISPONIBLE"}</span>
-                        ${expressionsHTML}
+                        ${expressionsHtml}
                     </div>
-                    <div class="actor-buttons">
+                    <div class="actor-buttons" style="display:flex;gap:5px;flex-wrap:wrap;">
                         <button class="btn-show" type="button">MOSTRAR</button>
+                        <button class="btn-hide" type="button">OCULTAR</button>
                         <button class="btn-move" data-dir="left" type="button">&lt;</button>
                         <button class="btn-move" data-dir="right" type="button">&gt;</button>
                         <button class="btn-flip" type="button">ESPEJO</button>
-                        <button class="btn-remove" type="button">X</button>
+                        <button class="btn-remove" type="button">RETIRAR DEL CAST</button>
+                    </div>
+                    <div class="actor-identity-controls" style="margin-top:8px;padding-top:8px;border-top:1px dashed #444;display:grid;grid-template-columns:1fr 1fr;gap:5px;">
+                        <select class="actor-viewer-select" style="grid-column:1/-1;background:#151515;color:#fff;border:1px solid #444;padding:4px;">
+                            <option value="">Jugador para identidad/nameplate...</option>${viewerOptions}
+                        </select>
+                        <input class="actor-override-name" type="text" placeholder="Nombre temporal" style="min-width:0;background:#151515;color:#fff;border:1px solid #444;padding:4px;">
+                        <input class="actor-override-title" type="text" placeholder="Título temporal" style="min-width:0;background:#151515;color:#fff;border:1px solid #444;padding:4px;">
+                        <button class="btn-reveal-identity" type="button">REVELAR ID</button>
+                        <button class="btn-forget-identity" type="button">OCULTAR ID</button>
+                        <button class="btn-override-nameplate" type="button">PRESENTACIÓN TEMPORAL</button>
+                        <button class="btn-clear-override" type="button">LIMPIAR PRESENTACIÓN</button>
                     </div>
                 `;
 
-                const expSelect = card.querySelector(".actor-expression-select");
-                if (expSelect) {
-                    expSelect.addEventListener("change", event => {
-                        const newExpression = event.target.value;
-                        // Selecting prepares an expression. It must not reveal/change the visible sprite yet.
-                        if (global.LuminousTheatreState?.prepareExpression) {
-                            global.LuminousTheatreState.prepareExpression(actorId, newExpression);
-                        } else {
-                            db.ref(`${THEATRE_ACTORS_PATH}/${actorId}/expresionPreparada`).set(newExpression);
-                        }
-                    });
-                }
-
-                card.querySelector(".btn-show")?.addEventListener("click", () => {
-                    global.LuminousTheatreState?.updateVisibleActors(actorId, actorData);
+                const expressionSelect = card.querySelector(".actor-expression-select");
+                expressionSelect?.addEventListener("change", (event) => {
+                    // Preparing never changes expresionActiva/sprite.
+                    global.LuminousTheatreState.prepareExpression(actorId, event.target.value);
                 });
 
+                card.querySelector(".btn-show")?.addEventListener("click", () => global.LuminousTheatreState.updateVisibleActors(actorId, actorData));
+                card.querySelector(".btn-hide")?.addEventListener("click", () => global.LuminousTheatreState.removeVisibleActor(actorId));
                 card.querySelector('.btn-move[data-dir="left"]')?.addEventListener("click", () => {
-                    const currentX = Number.parseInt(actorData.x, 10) || 0;
-                    db.ref(`${THEATRE_ACTORS_PATH}/${actorId}/x`).set(currentX - 50);
+                    db.ref(`${paths().scene}/actores/${actorId}/x`).set((Number.parseInt(actorData.x, 10) || 0) - 50);
                 });
-
                 card.querySelector('.btn-move[data-dir="right"]')?.addEventListener("click", () => {
-                    const currentX = Number.parseInt(actorData.x, 10) || 0;
-                    db.ref(`${THEATRE_ACTORS_PATH}/${actorId}/x`).set(currentX + 50);
+                    db.ref(`${paths().scene}/actores/${actorId}/x`).set((Number.parseInt(actorData.x, 10) || 0) + 50);
                 });
-
                 card.querySelector(".btn-flip")?.addEventListener("click", () => {
-                    const orientation = actorData.orientacion === "flip" ? "normal" : "flip";
-                    db.ref(`${THEATRE_ACTORS_PATH}/${actorId}/orientacion`).set(orientation);
+                    db.ref(`${paths().scene}/actores/${actorId}/orientacion`).set(actorData.orientacion === "flip" ? "normal" : "flip");
+                });
+                card.querySelector(".btn-remove")?.addEventListener("click", async () => {
+                    await global.LuminousTheatreState.removeVisibleActor(actorId);
+                    await db.ref(`${paths().scene}/actores/${actorId}`).remove();
                 });
 
-                card.querySelector(".btn-remove")?.addEventListener("click", async () => {
-                    if (global.LuminousTheatreState?.removeVisibleActor) {
-                        await global.LuminousTheatreState.removeVisibleActor(actorId);
-                    }
-                    await db.ref(`${THEATRE_ACTORS_PATH}/${actorId}`).remove();
+                const viewerSelect = card.querySelector(".actor-viewer-select");
+                const getViewer = () => viewerSelect?.value || null;
+                card.querySelector(".btn-reveal-identity")?.addEventListener("click", () => {
+                    const viewerId = getViewer();
+                    if (viewerId) global.LuminousTheatreState.setIdentityKnown(viewerId, actorId, true);
+                });
+                card.querySelector(".btn-forget-identity")?.addEventListener("click", () => {
+                    const viewerId = getViewer();
+                    if (viewerId) global.LuminousTheatreState.setIdentityKnown(viewerId, actorId, false);
+                });
+                card.querySelector(".btn-override-nameplate")?.addEventListener("click", () => {
+                    const viewerId = getViewer();
+                    if (!viewerId) return;
+                    global.LuminousTheatreState.setNameplateOverride(viewerId, actorId, {
+                        nombre: card.querySelector(".actor-override-name")?.value || "",
+                        titulo: card.querySelector(".actor-override-title")?.value || ""
+                    });
+                });
+                card.querySelector(".btn-clear-override")?.addEventListener("click", () => {
+                    const viewerId = getViewer();
+                    if (viewerId) global.LuminousTheatreState.clearNameplateOverride(viewerId, actorId);
                 });
 
                 liveActorsList.appendChild(card);
-            });
+            }
         }
 
-        if (liveActorsList) {
-            db.ref(THEATRE_ACTORS_PATH).on("value", snapshot => {
-                liveActors = snapshot.val() || {};
-                renderLiveActors();
-            });
-        }
+        loadRoster();
+        buildDirectorPolicyControls();
+        buildLanguageSelector();
+        subscribeLanguages();
+        btnSpawnNpc?.addEventListener("click", spawnSelectedActor);
+
+        db.ref(`${paths().scene}/max_actores_visibles`).on("value", (snapshot) => {
+            maxVisibleActors = global.LuminousTheatreState.clampVisibleLimit(snapshot.val());
+            const maxSelect = document.getElementById("theatre-max-visible");
+            if (maxSelect) maxSelect.value = String(maxVisibleActors);
+            renderLiveActors();
+        });
+        db.ref(`${paths().scene}/actores_visibles`).on("value", (snapshot) => {
+            visibleActors = normalizeIdList(snapshot.val());
+            renderLiveActors();
+        });
+        db.ref(`${paths().scene}/actores`).on("value", (snapshot) => {
+            liveActors = snapshot.val() || {};
+            renderLiveActors();
+        });
     });
-
 })(window);

--- a/js/theatre-controls.js
+++ b/js/theatre-controls.js
@@ -1,46 +1,50 @@
 (function(global) {
     "use strict";
 
-    document.addEventListener('DOMContentLoaded', () => {
+    document.addEventListener("DOMContentLoaded", () => {
         const db = global.firebase.database();
-
         const NPC_ROSTER_PATHS = ["campaña/base_datos_npcs", "campaña/actores"];
-        const THEATRE_ACTORS_PATH = "campaña/estado_mundo/escena_actual/actores";
-        const MAX_ACTORS = 5;
+        const THEATRE_ROOT = "campaña/estado_mundo/escena_actual";
+        const THEATRE_ACTORS_PATH = `${THEATRE_ROOT}/actores`;
+        const VISIBLE_ACTORS_PATH = `${THEATRE_ROOT}/actores_visibles`;
         const DEFAULT_TITLE_COLOR = "#3b2918";
 
         let npcDatabaseRaw = {};
         let npcDatabaseBase = {};
         let npcDatabase = {};
         let liveActors = {};
+        let visibleActors = [];
         let playerDatabase = {};
-
-        function refreshNpcDatabase() {
-            npcDatabase = {};
-            // Load legacy path first
-            for (const [id, data] of Object.entries(npcDatabaseRaw)) {
-                npcDatabase[id] = data;
-            }
-            // Load modern path second (overwrites if collision)
-            for (const [id, data] of Object.entries(npcDatabaseBase)) {
-                npcDatabase[id] = data;
-            }
-            updateRosterSelect();
-        }
+        let maxVisibleActors = 5;
 
         const selectNpcRoster = document.getElementById("select-npc-roster");
         const liveActorsList = document.getElementById("live-actors-list");
         const btnSpawnNpc = document.getElementById("btn-spawn-npc");
+        const directorPanel = document.getElementById("theatre-director-panel");
+
+        function normalizeIdList(value) {
+            if (global.LuminousTheatreState?.normalizeAssignedActorIds) {
+                return global.LuminousTheatreState.normalizeAssignedActorIds(value);
+            }
+            if (!value) return [];
+            if (Array.isArray(value)) return value.filter(Boolean);
+            if (typeof value === "object") return Object.keys(value).sort().map(key => value[key]).filter(Boolean);
+            return [value];
+        }
+
+        function refreshNpcDatabase() {
+            npcDatabase = {};
+            for (const [id, data] of Object.entries(npcDatabaseRaw)) npcDatabase[id] = data;
+            for (const [id, data] of Object.entries(npcDatabaseBase)) npcDatabase[id] = data;
+            updateRosterSelect();
+        }
 
         function updateRosterSelect() {
             if (!selectNpcRoster) return;
             selectNpcRoster.innerHTML = '<option value="">Selecciona un Personaje...</option>';
 
-            // Personajes Jugadores
-            const optgroupPlayers = document.createElement('optgroup');
+            const optgroupPlayers = document.createElement("optgroup");
             optgroupPlayers.label = "PERSONAJES JUGADORES";
-
-            const processedPlayerActors = new Set();
 
             for (const [playerId, player] of Object.entries(playerDatabase)) {
                 let actorData = null;
@@ -50,230 +54,258 @@
                     actorId = player.actorId;
                     actorData = npcDatabase[actorId];
                 } else {
-                    actorId = Object.keys(npcDatabase).find(k => npcDatabase[k].vinculo_jugador === playerId && npcDatabase[k].tipo === 'Jugador');
+                    actorId = Object.keys(npcDatabase).find(k =>
+                        npcDatabase[k].vinculo_jugador === playerId && npcDatabase[k].tipo === "Jugador"
+                    );
                     if (actorId) actorData = npcDatabase[actorId];
                 }
 
                 if (actorData) {
-                    const opt = document.createElement('option');
+                    const opt = document.createElement("option");
                     opt.value = actorId;
                     opt.textContent = actorData.nombre || player.characterName || player.character_name || player.nombre || playerId;
-                    opt.dataset.sourceType = 'player-profile';
+                    opt.dataset.sourceType = "player-profile";
                     opt.dataset.sourceId = playerId;
                     optgroupPlayers.appendChild(opt);
-                    processedPlayerActors.add(actorId);
                 }
             }
             selectNpcRoster.appendChild(optgroupPlayers);
 
-            // NPCs / Personajes del DM
-            const optgroupNpcs = document.createElement('optgroup');
+            const optgroupNpcs = document.createElement("optgroup");
             optgroupNpcs.label = "NPCs / PERSONAJES DEL DM";
-
             for (const [actorId, actorData] of Object.entries(npcDatabase)) {
-                if (actorData.tipo === 'Jugador') continue;
-
-                const opt = document.createElement('option');
+                if (actorData.tipo === "Jugador") continue;
+                const opt = document.createElement("option");
                 opt.value = actorId;
-                opt.textContent = actorData.nombre || 'Sin Nombre';
-                opt.dataset.sourceType = 'npc';
+                opt.textContent = actorData.nombre || "Sin Nombre";
+                opt.dataset.sourceType = "npc";
                 opt.dataset.sourceId = actorId;
                 optgroupNpcs.appendChild(opt);
             }
             selectNpcRoster.appendChild(optgroupNpcs);
         }
 
-        function cargarRosterNPCs() {
-            if (!selectNpcRoster) {
-                console.error("CRÍTICO: No se encontró el #select-npc-roster en el DOM.");
-                return;
-            }
-
-            db.ref(NPC_ROSTER_PATHS[0]).on('value', (snapshot) => {
+        function loadRoster() {
+            if (!selectNpcRoster) return;
+            db.ref(NPC_ROSTER_PATHS[0]).on("value", snapshot => {
                 npcDatabaseBase = snapshot.val() || {};
                 refreshNpcDatabase();
             });
-
-            db.ref(NPC_ROSTER_PATHS[1]).on('value', (snapshot) => {
+            db.ref(NPC_ROSTER_PATHS[1]).on("value", snapshot => {
                 npcDatabaseRaw = snapshot.val() || {};
                 refreshNpcDatabase();
             });
-
-            db.ref("campaña/jugadores").on('value', (snapshot) => {
+            db.ref("campaña/jugadores").on("value", snapshot => {
                 playerDatabase = snapshot.val() || {};
                 updateRosterSelect();
             });
         }
 
-        // 1. Carga del Roster (Pre-Game NPCs)
-        cargarRosterNPCs();
+        function buildDirectorPolicyControls() {
+            if (!directorPanel || document.getElementById("theatre-render-policy")) return;
 
-        // 2. El Disparo (Spawn) con límite de sprites
-        if (btnSpawnNpc) {
-            btnSpawnNpc.addEventListener("click", () => {
-                if (!selectNpcRoster) return;
+            const wrapper = document.createElement("div");
+            wrapper.id = "theatre-render-policy";
+            wrapper.style.cssText = "display:flex;gap:8px;align-items:center;flex-wrap:wrap;padding:8px 0 12px;border-bottom:1px solid #333;margin-bottom:12px";
+            wrapper.innerHTML = `
+                <label style="display:flex;gap:6px;align-items:center;">
+                    Máximo visible
+                    <select id="theatre-max-visible" aria-label="Máximo de sprites visibles">
+                        <option value="1">1</option><option value="2">2</option><option value="3">3</option>
+                        <option value="4">4</option><option value="5">5</option>
+                    </select>
+                </label>
+                <label style="display:flex;gap:6px;align-items:center;">
+                    <input id="theatre-no-actors" type="checkbox"> No Actors
+                </label>
+                <button id="btn-clear-theatre-scene" type="button">LIMPIAR ESCENA</button>
+            `;
 
-                const selectedId = selectNpcRoster.value;
-                if (!selectedId) return;
+            const title = directorPanel.querySelector(".panel-title");
+            if (title?.nextSibling) directorPanel.insertBefore(wrapper, title.nextSibling);
+            else directorPanel.prepend(wrapper);
 
-                const npcData = npcDatabase[selectedId];
-                if (!npcData) return;
+            const maxSelect = wrapper.querySelector("#theatre-max-visible");
+            const noActors = wrapper.querySelector("#theatre-no-actors");
+            const clearBtn = wrapper.querySelector("#btn-clear-theatre-scene");
 
-                const actorsRef = db.ref(THEATRE_ACTORS_PATH);
-                actorsRef.once("value").then(snapshot => {
-                    let actors = snapshot.val() || {};
-                    let actorKeys = Object.keys(actors);
-                    let removalPromises = [];
+            maxSelect.value = String(maxVisibleActors);
+            maxSelect.addEventListener("change", async () => {
+                if (global.LuminousTheatreState?.setMaxVisibleActors) {
+                    maxVisibleActors = await global.LuminousTheatreState.setMaxVisibleActors(maxSelect.value);
+                }
+            });
 
-                    // Si ya hay 5, eliminar el más antiguo basado en spawnedAt
-                    if (actorKeys.length >= MAX_ACTORS) {
-                        actorKeys.sort((a, b) => (actors[a].spawnedAt || 0) - (actors[b].spawnedAt || 0));
-                        // Calculamos cuántos hay que borrar para que quede espacio para 1 nuevo
-                        const toRemoveCount = (actorKeys.length - MAX_ACTORS) + 1;
-                        for(let i=0; i < toRemoveCount; i++) {
-                            const oldestKey = actorKeys[i];
-                            delete actors[oldestKey];
-                        }
-                    }
+            noActors.addEventListener("change", () => {
+                db.ref(`${THEATRE_ROOT}/modo_presentacion`).set(noActors.checked ? "no-actors" : "actors");
+            });
 
-                    // Añadir el nuevo
-                    const now = window.firebase.database.ServerValue.TIMESTAMP;
-                    const actorInstanceId = `actor_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
-                    const selectedOption = selectNpcRoster.options[selectNpcRoster.selectedIndex];
-                    const sourceType = selectedOption.dataset.sourceType || 'npc';
-                    const sourceId = selectedOption.dataset.sourceId || selectedId;
+            clearBtn.addEventListener("click", () => {
+                if (global.LuminousTheatreState?.clearScene) {
+                    global.LuminousTheatreState.clearScene();
+                }
+            });
 
-                    let expresionesObj = npcData.expresiones || {};
-                    let expActiva = "Neutral";
-                    if (Object.keys(expresionesObj).length === 0) {
-                        expresionesObj = {
-                            "Neutral": npcData.sprite || npcData.icono_jugador || npcData.icono || ""
-                        };
-                    } else if (!expresionesObj["Neutral"]) {
-                        expActiva = Object.keys(expresionesObj)[0];
-                    }
-
-                    actors[actorInstanceId] = {
-                        nombre: npcData.nombre || selectedId,
-                        titulo: npcData.titulo || "",
-                        color_nombre: npcData.color_nombre || "#ffffff",
-                        color_titulo: npcData.color_titulo || DEFAULT_TITLE_COLOR,
-                        sourceId: sourceId,
-                        sourceType: sourceType,
-                        sprite: npcData.sprite || npcData.url || "",
-                        icono: npcData.icono || npcData.icono_jugador || "",
-                        expresiones: expresionesObj,
-                        expresionActiva: expActiva,
-                        x: 0,
-                        y: 0,
-                        escala: npcData.escala || 1,
-                        orientacion: 'normal',
-                        spawnedAt: now
-                    };
-
-                    return actors;
-                }, (error, committed, snapshot) => {
-                    if (error) {
-                        console.error("Transacción falló de forma anormal", error);
-                    } else if (!committed) {
-                        console.log("Transacción abortada");
-                    } else {
-                        console.log("Actor añadido exitosamente.");
-                    }
-                });
+            db.ref(`${THEATRE_ROOT}/modo_presentacion`).on("value", snap => {
+                noActors.checked = snap.val() === "no-actors";
             });
         }
 
-        // 3. Manipulación en Vivo (Live Control Cards)
+        loadRoster();
+        buildDirectorPolicyControls();
+
+        db.ref(`${THEATRE_ROOT}/max_actores_visibles`).on("value", snap => {
+            maxVisibleActors = global.LuminousTheatreState?.clampVisibleLimit
+                ? global.LuminousTheatreState.clampVisibleLimit(snap.val())
+                : Math.max(1, Math.min(5, Number.parseInt(snap.val(), 10) || 5));
+            const maxSelect = document.getElementById("theatre-max-visible");
+            if (maxSelect) maxSelect.value = String(maxVisibleActors);
+            renderLiveActors();
+        });
+
+        db.ref(VISIBLE_ACTORS_PATH).on("value", snap => {
+            visibleActors = normalizeIdList(snap.val());
+            renderLiveActors();
+        });
+
+        if (btnSpawnNpc) {
+            btnSpawnNpc.addEventListener("click", () => {
+                if (!selectNpcRoster) return;
+                const selectedId = selectNpcRoster.value;
+                if (!selectedId) return;
+                const npcData = npcDatabase[selectedId];
+                if (!npcData) return;
+
+                const selectedOption = selectNpcRoster.options[selectNpcRoster.selectedIndex];
+                const sourceType = selectedOption.dataset.sourceType || "npc";
+                const sourceId = selectedOption.dataset.sourceId || selectedId;
+                const actorInstanceId = `actor_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
+                const now = global.firebase.database.ServerValue.TIMESTAMP;
+
+                let expressions = npcData.expresiones || {};
+                let activeExpression = "Neutral";
+                if (Object.keys(expressions).length === 0) {
+                    expressions = { Neutral: npcData.sprite || npcData.icono_jugador || npcData.icono || "" };
+                } else if (!expressions.Neutral) {
+                    activeExpression = Object.keys(expressions)[0];
+                }
+
+                const activeSprite = expressions[activeExpression] || npcData.sprite || npcData.url || "";
+                const actorPayload = {
+                    nombre: npcData.nombre || selectedId,
+                    titulo: npcData.titulo || "",
+                    color_nombre: npcData.color_nombre || "#ffffff",
+                    color_titulo: npcData.color_titulo || DEFAULT_TITLE_COLOR,
+                    sourceId,
+                    sourceType,
+                    sprite: activeSprite,
+                    icono: npcData.icono || npcData.icono_jugador || "",
+                    expresiones: expressions,
+                    expresionActiva: activeExpression,
+                    expresionPreparada: activeExpression,
+                    x: 0,
+                    y: 0,
+                    escala: npcData.escala || 1,
+                    orientacion: "normal",
+                    spawnedAt: now
+                };
+
+                // The actor pool is not the HUD. Never delete available actors to enforce the visible limit.
+                db.ref(`${THEATRE_ACTORS_PATH}/${actorInstanceId}`).set(actorPayload).then(() => {
+                    if (global.LuminousTheatreState?.updateVisibleActors) {
+                        return global.LuminousTheatreState.updateVisibleActors(actorInstanceId, actorPayload);
+                    }
+                }).catch(error => console.error("No se pudo añadir el actor al Teatro:", error));
+            });
+        }
+
+        function renderLiveActors() {
+            if (!liveActorsList) return;
+            liveActorsList.innerHTML = "";
+
+            const panelTitle = document.querySelector(".panel-title");
+            if (panelTitle) {
+                panelTitle.textContent = `CONTROL DE CASTING (${Object.keys(liveActors).length} disponibles · ${visibleActors.length}/${maxVisibleActors} visibles)`;
+            }
+
+            Object.keys(liveActors).forEach(actorId => {
+                const actorData = liveActors[actorId];
+                const card = document.createElement("div");
+                card.className = "actor-control-card";
+                card.dataset.visible = visibleActors.includes(actorId) ? "true" : "false";
+
+                let expressionsHTML = "";
+                if (actorData.expresiones && Object.keys(actorData.expresiones).length > 0) {
+                    const prepared = actorData.expresionPreparada || actorData.expresionActiva;
+                    expressionsHTML = '<select class="actor-expression-select" style="background:#222;color:#fff;border:1px solid #444;padding:2px;font-size:.8rem;font-family:\'Share Tech Mono\',monospace">';
+                    for (const exp of Object.keys(actorData.expresiones)) {
+                        expressionsHTML += `<option value="${exp}" ${prepared === exp ? "selected" : ""}>${exp}</option>`;
+                    }
+                    expressionsHTML += "</select>";
+                }
+
+                card.innerHTML = `
+                    <div style="display:flex;justify-content:space-between;align-items:center;gap:8px;">
+                        <span class="actor-name">${actorData.nombre || "Actor"}</span>
+                        <span style="font-size:.7rem;opacity:.7;">${visibleActors.includes(actorId) ? "VISIBLE" : "DISPONIBLE"}</span>
+                        ${expressionsHTML}
+                    </div>
+                    <div class="actor-buttons">
+                        <button class="btn-show" type="button">MOSTRAR</button>
+                        <button class="btn-move" data-dir="left" type="button">&lt;</button>
+                        <button class="btn-move" data-dir="right" type="button">&gt;</button>
+                        <button class="btn-flip" type="button">ESPEJO</button>
+                        <button class="btn-remove" type="button">X</button>
+                    </div>
+                `;
+
+                const expSelect = card.querySelector(".actor-expression-select");
+                if (expSelect) {
+                    expSelect.addEventListener("change", event => {
+                        const newExpression = event.target.value;
+                        // Selecting prepares an expression. It must not reveal/change the visible sprite yet.
+                        if (global.LuminousTheatreState?.prepareExpression) {
+                            global.LuminousTheatreState.prepareExpression(actorId, newExpression);
+                        } else {
+                            db.ref(`${THEATRE_ACTORS_PATH}/${actorId}/expresionPreparada`).set(newExpression);
+                        }
+                    });
+                }
+
+                card.querySelector(".btn-show")?.addEventListener("click", () => {
+                    global.LuminousTheatreState?.updateVisibleActors(actorId, actorData);
+                });
+
+                card.querySelector('.btn-move[data-dir="left"]')?.addEventListener("click", () => {
+                    const currentX = Number.parseInt(actorData.x, 10) || 0;
+                    db.ref(`${THEATRE_ACTORS_PATH}/${actorId}/x`).set(currentX - 50);
+                });
+
+                card.querySelector('.btn-move[data-dir="right"]')?.addEventListener("click", () => {
+                    const currentX = Number.parseInt(actorData.x, 10) || 0;
+                    db.ref(`${THEATRE_ACTORS_PATH}/${actorId}/x`).set(currentX + 50);
+                });
+
+                card.querySelector(".btn-flip")?.addEventListener("click", () => {
+                    const orientation = actorData.orientacion === "flip" ? "normal" : "flip";
+                    db.ref(`${THEATRE_ACTORS_PATH}/${actorId}/orientacion`).set(orientation);
+                });
+
+                card.querySelector(".btn-remove")?.addEventListener("click", async () => {
+                    if (global.LuminousTheatreState?.removeVisibleActor) {
+                        await global.LuminousTheatreState.removeVisibleActor(actorId);
+                    }
+                    await db.ref(`${THEATRE_ACTORS_PATH}/${actorId}`).remove();
+                });
+
+                liveActorsList.appendChild(card);
+            });
+        }
+
         if (liveActorsList) {
             db.ref(THEATRE_ACTORS_PATH).on("value", snapshot => {
                 liveActors = snapshot.val() || {};
-                liveActorsList.innerHTML = '';
-
-                // Actualizar contador en la UI si existe (opcional)
-                const panelTitle = document.querySelector(".panel-title");
-                if (panelTitle) {
-                    panelTitle.textContent = `CONTROL DE CASTING (${Object.keys(liveActors).length}/${MAX_ACTORS})`;
-                }
-
-                Object.keys(liveActors).forEach(actorId => {
-                    const actorData = liveActors[actorId];
-
-                    const card = document.createElement("div");
-                    card.className = "actor-control-card";
-                    let expresionesHTML = '';
-                    if (actorData.expresiones && Object.keys(actorData.expresiones).length > 0) {
-                        expresionesHTML = '<select class="actor-expression-select" style="background:#222; color:#fff; border:1px solid #444; padding:2px; font-size:0.8rem; font-family:\'Share Tech Mono\', monospace;">';
-                        for (const exp in actorData.expresiones) {
-                            const isSelected = actorData.expresionActiva === exp ? 'selected' : '';
-                            expresionesHTML += `<option value="${exp}" ${isSelected}>${exp}</option>`;
-                        }
-                        expresionesHTML += '</select>';
-                    }
-
-                    card.innerHTML = `
-                        <div style="display:flex; justify-content:space-between; align-items:center;">
-                            <span class="actor-name">${actorData.nombre} (ID: ${actorId.split('_')[1]})</span>
-                            ${expresionesHTML}
-                        </div>
-                        <div class="actor-buttons">
-                            <button class="btn-move" data-dir="left"><</button>
-                            <button class="btn-move" data-dir="right">></button>
-                            <button class="btn-flip">ESPEJO</button>
-                            <button class="btn-remove">X</button>
-                        </div>
-                    `;
-
-                    // Expression change
-                    const expSelect = card.querySelector('.actor-expression-select');
-                    if (expSelect) {
-                        expSelect.addEventListener('change', (e) => {
-                            const newExp = e.target.value;
-                            const newSprite = actorData.expresiones[newExp] || actorData.sprite;
-                            db.ref(`${THEATRE_ACTORS_PATH}/${actorId}`).update({
-                                expresionActiva: newExp,
-                                sprite: newSprite
-                            });
-                        });
-                    }
-
-                    // Move Left
-                    const btnLeft = card.querySelector('.btn-move[data-dir="left"]');
-                    if (btnLeft) {
-                        btnLeft.addEventListener("click", () => {
-                            const currentX = parseInt(actorData.x) || 0;
-                            db.ref(`${THEATRE_ACTORS_PATH}/${actorId}`).update({ x: currentX - 50 });
-                        });
-                    }
-
-                    // Move Right
-                    const btnRight = card.querySelector('.btn-move[data-dir="right"]');
-                    if (btnRight) {
-                        btnRight.addEventListener("click", () => {
-                            const currentX = parseInt(actorData.x) || 0;
-                            db.ref(`${THEATRE_ACTORS_PATH}/${actorId}`).update({ x: currentX + 50 });
-                        });
-                    }
-
-                    // Flip (Espejo)
-                    const btnFlip = card.querySelector('.btn-flip');
-                    if (btnFlip) {
-                        btnFlip.addEventListener("click", () => {
-                            const currentOrientation = actorData.orientacion === 'flip' ? 'normal' : 'flip';
-                            db.ref(`${THEATRE_ACTORS_PATH}/${actorId}`).update({ orientacion: currentOrientation });
-                        });
-                    }
-
-                    // Remove
-                    const btnRemove = card.querySelector('.btn-remove');
-                    if (btnRemove) {
-                        btnRemove.addEventListener("click", () => {
-                            db.ref(`${THEATRE_ACTORS_PATH}/${actorId}`).remove();
-                        });
-                    }
-
-                    liveActorsList.appendChild(card);
-                });
+                renderLiveActors();
             });
         }
     });

--- a/js/theatre-engine.js
+++ b/js/theatre-engine.js
@@ -2,20 +2,85 @@
     "use strict";
 
     const db = global.firebase.database();
-    const THEATRE_ROOT = "campaña/estado_mundo/escena_actual";
-    const DIALOGUE_ROOT = "campaña/estado_mundo/dialogo_activo";
+    const DEFAULT_ROOM_ID = "default";
     const DEFAULT_MAX_VISIBLE = 5;
     const LOCAL_SHOW_SELF_KEY = "luminous.theatre.showOwnActor";
+    const IDENTITY_KNOWLEDGE_ROOT = "campaña/teatro/conocimiento_identidad";
+    const LANGUAGE_ROOTS = ["campaña/idiomas", "campaña/teatro/idiomas"];
+    const TRANSITION_MS = 350;
 
+    let activeRoomId = document.body?.dataset?.theatreRoomId || DEFAULT_ROOM_ID;
     let currentScene = {};
     let currentDialogue = {};
+    let playerDatabase = {};
+    let languageDatabase = {};
+    const languageSources = {};
+    let currentIdentityKnowledge = {};
+    let currentViewerKey = null;
+    let currentViewerProfile = null;
+    let currentKnowledgeRef = null;
+    let currentKnowledgeListener = null;
+    let sceneRef = null;
+    let dialogueRef = null;
+    let sceneListener = null;
+    let dialogueListener = null;
     let typewriterInterval = null;
     let resizeObserver = null;
+    let transitionPromise = null;
 
     function clampVisibleLimit(value) {
         const parsed = Number.parseInt(value, 10);
         if (!Number.isFinite(parsed)) return DEFAULT_MAX_VISIBLE;
         return Math.max(1, Math.min(DEFAULT_MAX_VISIBLE, parsed));
+    }
+
+    function clampPercentage(value) {
+        const parsed = Number(value);
+        if (!Number.isFinite(parsed)) return 0;
+        return Math.max(0, Math.min(100, parsed));
+    }
+
+    function resolveRoomPaths(roomId) {
+        const normalized = roomId && roomId !== DEFAULT_ROOM_ID ? String(roomId) : DEFAULT_ROOM_ID;
+        if (normalized === DEFAULT_ROOM_ID) {
+            return {
+                roomId: DEFAULT_ROOM_ID,
+                scene: "campaña/estado_mundo/escena_actual",
+                dialogue: "campaña/estado_mundo/dialogo_activo",
+                queue: "campaña/teatro/cola",
+                log: "campaña/teatro/log"
+            };
+        }
+
+        const root = `campaña/teatro/salas/${normalized}`;
+        return {
+            roomId: normalized,
+            scene: `${root}/escena`,
+            dialogue: `${root}/dialogo_activo`,
+            queue: `${root}/cola`,
+            log: `${root}/log`
+        };
+    }
+
+    function getPaths() {
+        return resolveRoomPaths(activeRoomId);
+    }
+
+    function normalizeIdList(value) {
+        if (!value) return [];
+        if (Array.isArray(value)) return value.filter(Boolean);
+        if (typeof value === "object") {
+            return Object.keys(value)
+                .sort((a, b) => {
+                    const aNum = Number(a);
+                    const bNum = Number(b);
+                    if (Number.isFinite(aNum) && Number.isFinite(bNum)) return aNum - bNum;
+                    return String(a).localeCompare(String(b));
+                })
+                .map((key) => value[key])
+                .filter(Boolean);
+        }
+        return [value].filter(Boolean);
     }
 
     function getVisibleLimit(scene) {
@@ -42,27 +107,24 @@
         element.style.setProperty("border-left-color", plateColor, "important");
     }
 
-    function normalizeIdList(value) {
-        if (!value) return [];
-        if (Array.isArray(value)) return value.filter(Boolean);
-        if (typeof value === "object") {
-            return Object.keys(value)
-                .sort((a, b) => Number(a) - Number(b))
-                .map((key) => value[key])
-                .filter(Boolean);
+    function isDmView() {
+        return Boolean(document.body?.classList.contains("on-game-dashboard"));
+    }
+
+    function getAssignedTheatreActor() {
+        try {
+            if (typeof global.getAssignedTheatreActor === "function") {
+                return global.getAssignedTheatreActor() || null;
+            }
+        } catch (error) {
+            console.warn("No se pudo resolver el actor asignado del Theatre Engine:", error);
         }
-        return [value].filter(Boolean);
+        return null;
     }
 
     function getAssignedActorId() {
-        try {
-            const actor = typeof global.getAssignedTheatreActor === "function"
-                ? global.getAssignedTheatreActor()
-                : null;
-            return actor?.actorId || actor?.id || global.assignedActorId || null;
-        } catch (error) {
-            return global.assignedActorId || null;
-        }
+        const actor = getAssignedTheatreActor();
+        return actor?.actorId || actor?.id || global.assignedActorId || null;
     }
 
     function shouldShowOwnActor() {
@@ -71,10 +133,6 @@
         } catch (error) {
             return false;
         }
-    }
-
-    function isDmView() {
-        return Boolean(document.body?.classList.contains("on-game-dashboard"));
     }
 
     function isNoActorsMode(scene) {
@@ -90,8 +148,7 @@
         const maxVisible = getVisibleLimit(scene);
         const explicitVisible = normalizeIdList(scene?.actores_visibles).slice(-maxVisible);
 
-        // Firebase is authoritative. Missing/empty actores_visibles means no visible sprites;
-        // never fabricate a local fallback from the actor pool.
+        // Firebase is authoritative: an empty/missing visible list means an empty stage.
         let ids = explicitVisible.filter((id) => {
             const actor = actors[id];
             return actor && (actor.url || actor.sprite);
@@ -105,14 +162,268 @@
         return ids;
     }
 
+    function getCurrentAuthUser() {
+        try {
+            return global.firebase.auth?.().currentUser || null;
+        } catch (error) {
+            return null;
+        }
+    }
+
+    function playerMatchesAuth(playerId, player, user) {
+        if (!player || !user) return false;
+        return playerId === user.uid ||
+            player.uid === user.uid ||
+            player.userId === user.uid ||
+            player.authUid === user.uid ||
+            (user.email && (player.email === user.email || player.correo === user.email));
+    }
+
+    function deriveViewerContext() {
+        if (isDmView()) return { key: "__dm__", profile: null };
+
+        const user = getCurrentAuthUser();
+        const assignedActorId = getAssignedActorId();
+        const assignedActor = getAssignedTheatreActor();
+
+        if (user) {
+            for (const [playerId, player] of Object.entries(playerDatabase)) {
+                if (playerMatchesAuth(playerId, player, user)) {
+                    return { key: playerId, profile: player };
+                }
+            }
+        }
+
+        if (assignedActorId) {
+            for (const [playerId, player] of Object.entries(playerDatabase)) {
+                const actorIds = normalizeIdList(player.actorIds || player.actores || player.actorId);
+                if (actorIds.includes(assignedActorId)) {
+                    return { key: playerId, profile: player };
+                }
+            }
+        }
+
+        if (assignedActor?.sourceId && playerDatabase[assignedActor.sourceId]) {
+            return { key: assignedActor.sourceId, profile: playerDatabase[assignedActor.sourceId] };
+        }
+
+        if (user?.uid) return { key: user.uid, profile: null };
+        return { key: null, profile: null };
+    }
+
+    function bindIdentityKnowledge() {
+        const next = deriveViewerContext();
+        currentViewerKey = next.key;
+        currentViewerProfile = next.profile;
+
+        if (currentKnowledgeRef && currentKnowledgeListener) {
+            currentKnowledgeRef.off("value", currentKnowledgeListener);
+        }
+        currentKnowledgeRef = null;
+        currentKnowledgeListener = null;
+        currentIdentityKnowledge = {};
+
+        if (!currentViewerKey || currentViewerKey === "__dm__") {
+            renderDialogue(currentDialogue);
+            return;
+        }
+
+        currentKnowledgeRef = db.ref(`${IDENTITY_KNOWLEDGE_ROOT}/${currentViewerKey}`);
+        currentKnowledgeListener = (snapshot) => {
+            currentIdentityKnowledge = snapshot.val() || {};
+            renderDialogue(currentDialogue);
+        };
+        currentKnowledgeRef.on("value", currentKnowledgeListener);
+    }
+
+    function actorIdentityKey(actorId) {
+        if (!actorId) return null;
+        const actor = currentScene?.actores?.[actorId] || {};
+        return actor.identityId || actor.identidadId || actor.sourceId || actorId;
+    }
+
+    function isOwnActorIdentity(actorId) {
+        if (!actorId) return false;
+        const ownId = getAssignedActorId();
+        if (ownId && ownId === actorId) return true;
+
+        const actor = currentScene?.actores?.[actorId] || {};
+        const ownActor = getAssignedTheatreActor() || {};
+        const ownStableId = ownActor.identityId || ownActor.identidadId || ownActor.sourceId || ownActor.actorId || ownActor.id;
+        const stableId = actor.identityId || actor.identidadId || actor.sourceId || actorId;
+        return Boolean(ownStableId && stableId === ownStableId);
+    }
+
+    function isIdentityKnown(actorId) {
+        if (isDmView()) return true;
+        if (isOwnActorIdentity(actorId)) return true;
+        const key = actorIdentityKey(actorId);
+        if (!key) return false;
+        const value = currentIdentityKnowledge[key];
+        if (value === true) return true;
+        if (value && typeof value === "object") return value.known === true || value.conocida === true;
+        return false;
+    }
+
+    function getNameplateOverride(actorId) {
+        if (!actorId) return null;
+        const allOverrides = currentScene?.nameplate_overrides || currentScene?.nameplateOverrides || {};
+        const identityKey = actorIdentityKey(actorId);
+        const viewerOverrides = allOverrides[currentViewerKey] || {};
+        const sharedOverrides = allOverrides.__all__ || {};
+        return viewerOverrides[actorId] || viewerOverrides[identityKey] || sharedOverrides[actorId] || sharedOverrides[identityKey] || null;
+    }
+
+    function resolvePlateIdentity(dialogData) {
+        const actorId = dialogData?.actorId || null;
+        const type = dialogData?.tipo_dialogo || "dialogo";
+        if (!actorId || type === "narracion") {
+            return { visible: false, known: false, name: "", title: "" };
+        }
+
+        if (dialogData?.mostrar_identidad === false && type !== "pensamiento") {
+            return { visible: false, known: false, name: "", title: "" };
+        }
+
+        const actor = currentScene?.actores?.[actorId] || {};
+        const known = isIdentityKnown(actorId);
+        const override = getNameplateOverride(actorId) || {};
+        const realName = dialogData?.nombre || actor.nombre || "???";
+        const realTitle = dialogData?.titulo || actor.titulo || "???";
+
+        return {
+            visible: true,
+            known,
+            name: override.nombre ?? override.name ?? (known ? realName : "???"),
+            title: override.titulo ?? override.title ?? (known ? realTitle : "???")
+        };
+    }
+
+    function extractLanguageKnowledge(profile, languageId) {
+        if (!profile || !languageId) return 0;
+        const containers = [
+            profile.idiomas,
+            profile.lenguajes,
+            profile.languages,
+            profile.conocimiento_idiomas,
+            profile.languageKnowledge
+        ];
+
+        for (const container of containers) {
+            if (!container || typeof container !== "object") continue;
+            const value = container[languageId];
+            if (value === undefined || value === null) continue;
+            if (typeof value === "number" || typeof value === "string") return clampPercentage(value);
+            if (typeof value === "object") {
+                return clampPercentage(value.porcentaje ?? value.percent ?? value.conocimiento ?? value.knowledge ?? 0);
+            }
+        }
+        return 0;
+    }
+
+    function understandsDistortion(profile, languageId) {
+        if (!profile || !languageId) return false;
+        const containers = [profile.distortion_languages, profile.distortionLanguages, profile.distortions];
+        for (const container of containers) {
+            const value = container?.[languageId];
+            if (value === true) return true;
+            if (value && typeof value === "object" && (value.understood === true || value.comprendido === true)) return true;
+        }
+
+        const languageValue = profile.idiomas?.[languageId] || profile.languages?.[languageId];
+        return Boolean(languageValue && typeof languageValue === "object" && (languageValue.understood === true || languageValue.comprendido === true));
+    }
+
+    function stableHash(text) {
+        const input = String(text || "");
+        let hash = 2166136261;
+        for (let i = 0; i < input.length; i += 1) {
+            hash ^= input.charCodeAt(i);
+            hash = Math.imul(hash, 16777619);
+        }
+        return hash >>> 0;
+    }
+
+    function deterministicVocabularyKnown(characterId, languageId, word, percent) {
+        const knowledge = clampPercentage(percent);
+        if (knowledge >= 100) return true;
+        if (knowledge <= 0) return false;
+        const key = `${characterId || ""}|${languageId || ""}|${String(word || "").toLocaleLowerCase()}`;
+        return stableHash(key) % 100000 < Math.round(knowledge * 1000);
+    }
+
+    function runeForWord(characterId, languageId, word) {
+        const glyphs = ["ᚠ", "ᚢ", "ᚦ", "ᚨ", "ᚱ", "ᚲ", "ᚷ", "ᚹ", "ᛁ", "ᛃ", "ᛇ", "ᛈ", "ᛉ", "ᛋ", "ᛏ", "ᛒ"];
+        const hash = stableHash(`${characterId || ""}|${languageId || ""}|${String(word).toLocaleLowerCase()}`);
+        const count = Math.max(2, Math.min(8, String(word).length));
+        let result = "";
+        for (let i = 0; i < count; i += 1) result += glyphs[(hash + i * 13) % glyphs.length];
+        return result;
+    }
+
+    function getLanguageDefinition(languageId) {
+        return languageId ? (languageDatabase[languageId] || {}) : {};
+    }
+
+    function isDistortionDefinition(definition) {
+        const type = String(definition?.tipo || definition?.type || "").toLowerCase();
+        return definition?.distortion === true || type === "distortion" || type === "distorsion";
+    }
+
+    function resolveLanguageText(rawText, dialogData, profileOverride) {
+        const text = String(rawText || "");
+        const languageId = dialogData?.idiomaId || dialogData?.languageId || dialogData?.idioma || null;
+        if (!text || !languageId || isDmView()) return text;
+
+        const definition = getLanguageDefinition(languageId);
+        const profile = profileOverride || currentViewerProfile || global.currentCharacterData || global.currentPlayerData || global.playerData || null;
+        const characterId = currentViewerKey || getAssignedActorId() || "anon";
+
+        if (isDistortionDefinition(definition)) {
+            if (understandsDistortion(profile, languageId)) return text;
+            return String(
+                definition.texto_desconocido ||
+                definition.unknownText ||
+                definition.distortionText ||
+                "Tik... Tok..."
+            );
+        }
+
+        const knowledge = extractLanguageKnowledge(profile, languageId);
+        if (knowledge >= 100) return text;
+        if (knowledge <= 0) {
+            return String(definition.mensaje_desconocido || definition.unknownMessage || "(Está hablando una lengua que no entiendes)");
+        }
+
+        const style = String(definition.estilo_ofuscacion || definition.obfuscationStyle || definition.estilo || "ellipsis").toLowerCase();
+        return text.replace(/\p{L}[\p{L}\p{M}'’\-]*/gu, (word) => {
+            if (deterministicVocabularyKnown(characterId, languageId, word, knowledge)) return word;
+            if (["runas", "runes", "simbolos", "symbols", "eldritch"].includes(style)) {
+                return runeForWord(characterId, languageId, word);
+            }
+            return "[...]";
+        });
+    }
+
+    function formatDialogueMessage(dialogData) {
+        const raw = String(dialogData?.mensaje || "");
+        const isEmote = /^\/em(?:\s+|$)/i.test(raw);
+        if (!isEmote) return resolveLanguageText(raw, dialogData);
+
+        const action = raw.replace(/^\/em\s*/i, "").trim();
+        const transformed = resolveLanguageText(action, dialogData);
+        const identity = resolvePlateIdentity(dialogData);
+        const actorLabel = identity.visible ? (identity.name || "???") : "???";
+        return `(${actorLabel} ${transformed})`;
+    }
+
     function applyStageFocus(stage, dialogData) {
         if (!stage) return;
-
-        const type = dialogData?.tipo_dialogo || "dialogo";
+        const type = dialogData?.tipo_dialogo || currentScene?.focus_mode || "dialogo";
         const isThought = type === "pensamiento";
         const isNarrator = type === "narracion";
         const hasMessage = Boolean(dialogData?.mensaje);
-        const activeActorId = dialogData?.actorId || null;
+        const activeActorId = dialogData?.actorId || currentScene?.active_actor || null;
         const activeSpriteUrl = dialogData?.sprite || null;
 
         Array.from(stage.querySelectorAll(".theatre-sprite")).forEach((img) => {
@@ -142,12 +453,55 @@
                 img.style.filter = "brightness(0.4)";
                 img.style.zIndex = "1";
             }
-            img.style.transition = "0.3s";
+            img.style.transition = "filter .3s ease, opacity .3s ease";
         });
+    }
+
+    function ensureSelfVisibilityControl() {
+        if (isDmView() || document.getElementById("theatre-self-visibility-control")) return;
+        const theatre = document.getElementById("theatre-view-player");
+        if (!theatre) return;
+
+        const label = document.createElement("label");
+        label.id = "theatre-self-visibility-control";
+        label.style.cssText = "position:absolute;right:16px;top:16px;z-index:9005;padding:6px 9px;background:rgba(0,0,0,.72);border:1px solid rgba(255,255,255,.25);font:12px 'Share Tech Mono',monospace;color:#fff;display:flex;gap:6px;align-items:center;";
+        label.innerHTML = '<input type="checkbox" id="theatre-show-own-actor"> Mostrar mi personaje en escena';
+        theatre.appendChild(label);
+
+        const checkbox = label.querySelector("#theatre-show-own-actor");
+        checkbox.checked = shouldShowOwnActor();
+        checkbox.addEventListener("change", () => setShowOwnActor(checkbox.checked));
+    }
+
+    function removeLegacyPrototypePanels() {
+        const selectors = [
+            "#player-theatre-plate-title",
+            "#player-theatre-plate-name",
+            "#player-theatre-dialogue-text",
+            "#theatre-nameplate-preview",
+            ".theatre-nameplate-prototype",
+            ".theatre-prototype-panel",
+            "[data-theatre-prototype]"
+        ];
+        selectors.forEach((selector) => {
+            document.querySelectorAll(selector).forEach((element) => element.remove());
+        });
+    }
+
+    function applyTransitionVisual(scene) {
+        const moduleTeatro = document.getElementById("modulo-teatro") || document.getElementById("theatre-view-player");
+        if (!moduleTeatro) return;
+        const phase = scene?.transition_phase || "";
+        moduleTeatro.dataset.theatreTransition = scene?.transitioning ? "true" : "false";
+        moduleTeatro.dataset.theatreTransitionPhase = phase;
+        moduleTeatro.style.transition = `opacity ${TRANSITION_MS}ms ease`;
+        moduleTeatro.style.opacity = scene?.transitioning && phase === "out" ? "0" : "1";
     }
 
     function renderScene(scene) {
         currentScene = scene || {};
+        removeLegacyPrototypePanels();
+        ensureSelfVisibilityControl();
 
         const moduleTeatro = document.getElementById("modulo-teatro") || document.getElementById("theatre-view-player");
         if (moduleTeatro) {
@@ -155,29 +509,21 @@
             moduleTeatro.style.backgroundImage = fondoUrl
                 ? `linear-gradient(rgba(0,0,0,.15), rgba(0,0,0,.35)), url("${fondoUrl}")`
                 : "none";
-            moduleTeatro.dataset.theatreTransition = currentScene.transitioning ? "true" : "false";
         }
+        applyTransitionVisual(currentScene);
 
         const locacionEl = document.getElementById("theatre-location");
-        if (locacionEl) {
-            locacionEl.textContent = currentScene.locacion || "LOCALIZACIÓN DESCONOCIDA";
-        }
+        if (locacionEl) locacionEl.textContent = currentScene.locacion || "LOCALIZACIÓN DESCONOCIDA";
 
         const stage = document.getElementById("theatre-stage");
-        if (!stage) return;
-
-        if (currentScene.transitioning) {
-            stage.style.opacity = "0";
-        } else {
-            stage.style.opacity = "1";
+        if (!stage) {
+            renderDialogue(currentDialogue);
+            return;
         }
-        stage.style.transition = "opacity .35s ease";
 
         const actors = currentScene.actores || {};
         const renderIds = currentScene.transitioning ? [] : getRenderIds(currentScene);
-        const currentActors = Array.from(stage.querySelectorAll(".theatre-sprite"));
-
-        currentActors.forEach((img) => {
+        Array.from(stage.querySelectorAll(".theatre-sprite")).forEach((img) => {
             if (!renderIds.includes(img.dataset.id)) img.remove();
         });
 
@@ -193,73 +539,38 @@
                 stage.appendChild(img);
             }
 
-            // expresionActiva/sprite are the revealed state. expresionPreparada never renders here.
+            // Only the revealed expression/sprite renders. expresionPreparada is never read by the renderer.
             img.src = data.url || data.sprite || "";
-            img.alt = data.nombre || "Actor en escena";
+            img.alt = isDmView() || isIdentityKnown(actorId) ? (data.nombre || "Actor en escena") : "Actor desconocido";
 
-            let transformStr = "";
-            if (data.escala) transformStr += `scale(${data.escala}) `;
-            if (data.orientacion === "flip") transformStr += "scaleX(-1) ";
-
-            const xPos = data.x !== undefined ? data.x : 0;
-            const yPos = data.y !== undefined ? data.y : 0;
-            if (xPos !== 0 || yPos !== 0) {
-                const xStr = typeof xPos === "number" ? `${xPos}px` : xPos;
-                const yStr = typeof yPos === "number" ? `${yPos}px` : yPos;
-                transformStr += `translate(${xStr}, ${yStr}) `;
+            let transform = "";
+            if (data.escala) transform += `scale(${data.escala}) `;
+            if (data.orientacion === "flip") transform += "scaleX(-1) ";
+            const x = data.x ?? 0;
+            const y = data.y ?? 0;
+            if (x !== 0 || y !== 0) {
+                transform += `translate(${typeof x === "number" ? `${x}px` : x}, ${typeof y === "number" ? `${y}px` : y}) `;
             }
-
-            img.style.transform = transformStr ? transformStr.trim() : "none";
+            img.style.transform = transform.trim() || "none";
         });
 
         applyStageFocus(stage, currentDialogue);
+        renderDialogue(currentDialogue);
     }
 
     function resizeFontToFit(textEl) {
         textEl.style.fontSize = "";
         let size = parseFloat(global.getComputedStyle(textEl).fontSize) || 24;
-        let iters = 0;
-        while (textEl.scrollHeight > textEl.clientHeight && size > 10 && iters < 15) {
+        let iterations = 0;
+        while (textEl.scrollHeight > textEl.clientHeight && size > 10 && iterations < 15) {
             size -= 1;
             textEl.style.fontSize = `${size}px`;
-            iters += 1;
+            iterations += 1;
         }
-    }
-
-    function formatDialogueMessage(dialogData) {
-        const raw = String(dialogData?.mensaje || "");
-        if (/^\/em\s+/i.test(raw)) {
-            const action = raw.replace(/^\/em\s+/i, "").trim();
-            const name = dialogData?.nombre || "Actor";
-            return `(${name} ${action})`;
-        }
-        return raw;
-    }
-
-    function resolvePlateIdentity(dialogData) {
-        const hasActor = Boolean(dialogData?.actorId);
-        if (!hasActor || dialogData?.tipo_dialogo === "narracion") {
-            return { visible: false, name: "", title: "" };
-        }
-
-        if (dialogData?.identidad_conocida === false || dialogData?.identityKnown === false) {
-            return { visible: true, name: "???", title: "???" };
-        }
-
-        if (dialogData?.mostrar_identidad === false && dialogData?.tipo_dialogo !== "pensamiento") {
-            return { visible: false, name: "", title: "" };
-        }
-
-        return {
-            visible: true,
-            name: dialogData?.nombre || "???",
-            title: dialogData?.titulo || "???"
-        };
     }
 
     function renderDialogue(dialogData) {
         currentDialogue = dialogData || {};
-
         const nameEl = document.getElementById("dialogue-name");
         const titleEl = document.getElementById("dialogue-title");
         const textEl = document.getElementById("dialogue-text");
@@ -293,158 +604,332 @@
                 clone.style.width = `${textEl.clientWidth}px`;
                 clone.style.height = `${textEl.clientHeight}px`;
                 clone.textContent = fullText;
-                textEl.parentNode.appendChild(clone);
+                textEl.parentNode?.appendChild(clone);
                 resizeFontToFit(clone);
-                const finalSize = clone.style.fontSize;
+                textEl.style.fontSize = clone.style.fontSize || "";
                 clone.remove();
-                textEl.style.fontSize = finalSize || "";
 
                 const renderFrame = () => {
                     const elapsed = Date.now() - startedAt;
-                    let charsToShow = Math.floor(elapsed / speed);
-                    charsToShow = Math.max(0, Math.min(fullText.length, charsToShow));
-                    textEl.textContent = fullText.substring(0, charsToShow);
-                    if (charsToShow >= fullText.length) {
+                    const count = Math.max(0, Math.min(fullText.length, Math.floor(elapsed / speed)));
+                    textEl.textContent = fullText.substring(0, count);
+                    if (count >= fullText.length) {
                         clearInterval(typewriterInterval);
-                        // Intentionally keep the completed dialogue visible until the next valid event.
+                        // Persistent by contract: completion never clears the active dialogue.
                     }
                 };
 
                 renderFrame();
-                if (textEl.textContent.length < fullText.length) {
-                    typewriterInterval = setInterval(renderFrame, 30);
-                }
+                if (textEl.textContent.length < fullText.length) typewriterInterval = setInterval(renderFrame, 30);
             }
         }
 
         applyStageFocus(document.getElementById("theatre-stage"), currentDialogue);
     }
 
-    db.ref(THEATRE_ROOT).on("value", (snapshot) => {
-        renderScene(snapshot.val() || {});
-    });
+    function unbindRoom() {
+        if (sceneRef && sceneListener) sceneRef.off("value", sceneListener);
+        if (dialogueRef && dialogueListener) dialogueRef.off("value", dialogueListener);
+        sceneRef = null;
+        dialogueRef = null;
+        sceneListener = null;
+        dialogueListener = null;
+    }
 
-    db.ref(DIALOGUE_ROOT).on("value", (snapshot) => {
-        renderDialogue(snapshot.val() || {});
-    });
+    function bindRoom(roomId) {
+        unbindRoom();
+        activeRoomId = roomId || DEFAULT_ROOM_ID;
+        const paths = getPaths();
+        sceneRef = db.ref(paths.scene);
+        dialogueRef = db.ref(paths.dialogue);
+        sceneListener = (snapshot) => renderScene(snapshot.val() || {});
+        dialogueListener = (snapshot) => renderDialogue(snapshot.val() || {});
+        sceneRef.on("value", sceneListener);
+        dialogueRef.on("value", dialogueListener);
+    }
+
+    async function getFreshScene() {
+        const snap = await db.ref(getPaths().scene).once("value");
+        return snap.val() || {};
+    }
+
+    function messageIsStaleForScene(message, scene) {
+        const createdAt = Number(message?.createdAt) || 0;
+        const cutAt = Number(scene?.scene_cut_at) || 0;
+        return Boolean(createdAt && cutAt && createdAt <= cutAt);
+    }
 
     async function updateVisibleActors(actorId, actorData) {
-        if (!actorId) return;
-        if (actorData && !actorData.sprite && !actorData.url) return;
-
-        const sceneSnap = await db.ref(THEATRE_ROOT).once("value");
-        const scene = sceneSnap.val() || {};
-        if (scene.transitioning) return;
+        if (!actorId) return false;
+        if (actorData && !actorData.sprite && !actorData.url) return false;
+        const scene = await getFreshScene();
+        if (scene.transitioning) return false;
 
         const maxVisible = getVisibleLimit(scene);
-        const visRef = db.ref(`${THEATRE_ROOT}/actores_visibles`);
-
-        await visRef.transaction((current) => {
+        const visibleRef = db.ref(`${getPaths().scene}/actores_visibles`);
+        await visibleRef.transaction((current) => {
             const visibles = normalizeIdList(current);
-
-            // A visible actor speaking again keeps the exact same slot.
             if (visibles.includes(actorId)) return visibles;
-
             visibles.push(actorId);
             while (visibles.length > maxVisible) visibles.shift();
             return visibles;
         });
+        return true;
     }
 
     async function removeVisibleActor(actorId) {
         if (!actorId) return;
-        const visRef = db.ref(`${THEATRE_ROOT}/actores_visibles`);
-        await visRef.transaction((current) => normalizeIdList(current).filter((id) => id !== actorId));
+        const visibleRef = db.ref(`${getPaths().scene}/actores_visibles`);
+        await visibleRef.transaction((current) => normalizeIdList(current).filter((id) => id !== actorId));
     }
 
     async function setMaxVisibleActors(value) {
         const maxVisible = clampVisibleLimit(value);
-        await db.ref(`${THEATRE_ROOT}/max_actores_visibles`).set(maxVisible);
-        await db.ref(`${THEATRE_ROOT}/actores_visibles`).transaction((current) => {
-            const visibles = normalizeIdList(current);
-            return visibles.slice(-maxVisible);
-        });
+        const paths = getPaths();
+        await db.ref(`${paths.scene}/max_actores_visibles`).set(maxVisible);
+        await db.ref(`${paths.scene}/actores_visibles`).transaction((current) => normalizeIdList(current).slice(-maxVisible));
         return maxVisible;
     }
 
     async function prepareExpression(actorId, expression) {
-        if (!actorId || !expression) return;
-        await db.ref(`${THEATRE_ROOT}/actores/${actorId}/expresionPreparada`).set(expression);
+        if (!actorId || !expression) return false;
+        await db.ref(`${getPaths().scene}/actores/${actorId}/expresionPreparada`).set(expression);
+        return true;
     }
 
     async function revealPreparedExpression(actorId, expression, sprite) {
-        if (!actorId) return;
+        if (!actorId) return false;
+        const scene = await getFreshScene();
+        if (scene.transitioning) return false;
+
         const updates = {};
         if (expression) updates.expresionActiva = expression;
         if (sprite) updates.sprite = sprite;
-        if (expression) updates.expresionPreparada = expression;
         if (Object.keys(updates).length) {
-            await db.ref(`${THEATRE_ROOT}/actores/${actorId}`).update(updates);
+            await db.ref(`${getPaths().scene}/actores/${actorId}`).update(updates);
         }
+        return true;
+    }
+
+    async function publishIntervention(messageId, message) {
+        const paths = getPaths();
+        const scene = await getFreshScene();
+        if (scene.transitioning || messageIsStaleForScene(message, scene)) {
+            return { published: false, reason: scene.transitioning ? "transition" : "stale" };
+        }
+
+        const type = message?.tipo_dialogo || "dialogo";
+        const active = Boolean(message?.actorId && type !== "pensamiento" && type !== "narracion");
+        if (active) {
+            await updateVisibleActors(message.actorId, message);
+            await revealPreparedExpression(message.actorId, message.expression, message.sprite);
+        }
+
+        const activePayload = {
+            messageId: messageId || null,
+            nombre: message?.nombre || "",
+            titulo: message?.titulo || "",
+            mensaje: message?.mensaje || "",
+            actorId: message?.actorId || null,
+            expression: message?.expression || "Neutral",
+            sprite: message?.sprite || null,
+            icono: message?.icono || null,
+            color_nombre: message?.color_nombre || "#ffffff",
+            color_titulo: message?.color_titulo || "#3b2918",
+            tipo_dialogo: type,
+            mostrar_identidad: message?.mostrar_identidad !== false,
+            idiomaId: message?.idiomaId || message?.languageId || message?.idioma || null,
+            startedAt: global.firebase.database.ServerValue.TIMESTAMP,
+            speedMs: Math.max(1, Number(message?.speedMs) || 30),
+            durationMs: Math.max(0, Number(message?.durationMs) || ((String(message?.mensaje || "").length * 30) + 3000))
+        };
+
+        const updates = {
+            [`${paths.scene}/active_actor`]: active ? message.actorId : null,
+            [`${paths.scene}/focus_mode`]: type,
+            [paths.dialogue]: activePayload
+        };
+        await db.ref().update(updates);
+        return { published: true, payload: activePayload };
+    }
+
+    async function enqueueIntervention(message) {
+        const paths = getPaths();
+        const scene = await getFreshScene();
+        if (scene.transitioning) return { queued: false, reason: "transition" };
+        const ref = db.ref(paths.queue).push();
+        await ref.set(Object.assign({}, message, {
+            createdAt: global.firebase.database.ServerValue.TIMESTAMP,
+            roomId: paths.roomId
+        }));
+        return { queued: true, key: ref.key };
     }
 
     async function clearScene() {
+        const paths = getPaths();
         await db.ref().update({
-            [`${THEATRE_ROOT}/actores_visibles`]: null,
-            [DIALOGUE_ROOT]: null
+            [`${paths.scene}/actores_visibles`]: null,
+            [`${paths.scene}/nameplate_overrides`]: null,
+            [`${paths.scene}/active_actor`]: null,
+            [`${paths.scene}/focus_mode`]: null,
+            [paths.dialogue]: null
         });
+    }
+
+    function wait(ms) {
+        return new Promise((resolve) => global.setTimeout(resolve, ms));
     }
 
     async function changeScene(nextScene) {
+        if (transitionPromise) return transitionPromise;
         const payload = nextScene || {};
-        await db.ref(`${THEATRE_ROOT}/transitioning`).set(true);
-        await db.ref().update({
-            [`${THEATRE_ROOT}/actores_visibles`]: null,
-            [DIALOGUE_ROOT]: null
-        });
-        await db.ref(THEATRE_ROOT).update({
-            fondo: payload.fondo || "",
-            locacion: payload.locacion || "",
-            escenarioId: payload.escenarioId || null,
-            sub_etiquetas: payload.sub_etiquetas || null
-        });
-        await db.ref(`${THEATRE_ROOT}/transitioning`).set(false);
-    }
+        const paths = getPaths();
 
-    function deterministicVocabularyKnown(characterId, languageId, word, percent) {
-        const knowledge = Math.max(0, Math.min(100, Number(percent) || 0));
-        if (knowledge >= 100) return true;
-        if (knowledge <= 0) return false;
+        transitionPromise = (async () => {
+            const transitionId = `scene_${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+            await db.ref(paths.scene).update({
+                transitioning: true,
+                transition_phase: "out",
+                transition_id: transitionId,
+                transition_started_at: global.firebase.database.ServerValue.TIMESTAMP
+            });
+            await db.ref(paths.queue).remove();
+            await wait(TRANSITION_MS);
 
-        const key = `${characterId || ""}|${languageId || ""}|${String(word || "").toLocaleLowerCase()}`;
-        let hash = 2166136261;
-        for (let i = 0; i < key.length; i += 1) {
-            hash ^= key.charCodeAt(i);
-            hash = Math.imul(hash, 16777619);
+            await db.ref().update({
+                [`${paths.scene}/actores_visibles`]: null,
+                [`${paths.scene}/nameplate_overrides`]: null,
+                [`${paths.scene}/active_actor`]: null,
+                [`${paths.scene}/focus_mode`]: null,
+                [paths.dialogue]: null,
+                [paths.queue]: null
+            });
+
+            await db.ref(paths.scene).update({
+                fondo: payload.fondo || "",
+                locacion: payload.locacion || "",
+                escenarioId: payload.escenarioId || null,
+                sub_etiquetas: payload.sub_etiquetas || null,
+                region: payload.region || payload.seccion || null,
+                categoria: payload.categoria || null,
+                transition_phase: "in"
+            });
+            await wait(TRANSITION_MS);
+
+            // Drop anything emitted during the cut, then stamp the clean-scene boundary.
+            await db.ref(paths.queue).remove();
+            await db.ref(paths.dialogue).remove();
+            await db.ref(paths.scene).update({
+                transitioning: false,
+                transition_phase: null,
+                transition_ended_at: global.firebase.database.ServerValue.TIMESTAMP,
+                scene_cut_at: global.firebase.database.ServerValue.TIMESTAMP
+            });
+        })();
+
+        try {
+            await transitionPromise;
+        } finally {
+            transitionPromise = null;
         }
-        const bucket = (hash >>> 0) % 10000;
-        return bucket < Math.round(knowledge * 100);
+        return true;
     }
+
+    async function setIdentityKnown(viewerId, actorIdOrIdentityId, known) {
+        if (!viewerId || !actorIdOrIdentityId) return false;
+        const identityId = currentScene?.actores?.[actorIdOrIdentityId]
+            ? actorIdentityKey(actorIdOrIdentityId)
+            : actorIdOrIdentityId;
+        const ref = db.ref(`${IDENTITY_KNOWLEDGE_ROOT}/${viewerId}/${identityId}`);
+        if (known === false) await ref.remove();
+        else await ref.set({ known: true, revealedAt: global.firebase.database.ServerValue.TIMESTAMP });
+        return true;
+    }
+
+    async function setNameplateOverride(viewerId, actorId, override) {
+        if (!viewerId || !actorId) return false;
+        const cleaned = {};
+        const name = override?.nombre ?? override?.name;
+        const title = override?.titulo ?? override?.title;
+        if (typeof name === "string" && name.trim()) cleaned.nombre = name.trim();
+        if (typeof title === "string" && title.trim()) cleaned.titulo = title.trim();
+        const ref = db.ref(`${getPaths().scene}/nameplate_overrides/${viewerId}/${actorId}`);
+        if (!Object.keys(cleaned).length) await ref.remove();
+        else await ref.set(cleaned);
+        return true;
+    }
+
+    async function clearNameplateOverride(viewerId, actorId) {
+        if (!viewerId || !actorId) return false;
+        await db.ref(`${getPaths().scene}/nameplate_overrides/${viewerId}/${actorId}`).remove();
+        return true;
+    }
+
+    function setShowOwnActor(show) {
+        try {
+            global.localStorage?.setItem(LOCAL_SHOW_SELF_KEY, show ? "true" : "false");
+        } catch (error) {}
+        renderScene(currentScene);
+    }
+
+    function setRoom(roomId) {
+        bindRoom(roomId || DEFAULT_ROOM_ID);
+    }
+
+    db.ref("campaña/jugadores").on("value", (snapshot) => {
+        playerDatabase = snapshot.val() || {};
+        bindIdentityKnowledge();
+        renderDialogue(currentDialogue);
+    });
+
+    LANGUAGE_ROOTS.forEach((root) => {
+        db.ref(root).on("value", (snapshot) => {
+            languageSources[root] = snapshot.val() || {};
+            languageDatabase = Object.assign({}, ...LANGUAGE_ROOTS.map((key) => languageSources[key] || {}));
+            renderDialogue(currentDialogue);
+        });
+    });
+
+    try {
+        global.firebase.auth?.().onAuthStateChanged(() => bindIdentityKnowledge());
+    } catch (error) {}
+
+    document.addEventListener("DOMContentLoaded", () => {
+        removeLegacyPrototypePanels();
+        ensureSelfVisibilityControl();
+        bindIdentityKnowledge();
+    });
+
+    bindRoom(activeRoomId);
 
     global.LuminousTheatreState = {
         normalizeAssignedActorIds: normalizeIdList,
         clampVisibleLimit,
+        clampPercentage,
         getVisibleLimit,
+        getRenderIds,
+        getPaths,
+        resolveRoomPaths,
+        setRoom,
         updateVisibleActors,
         removeVisibleActor,
         setMaxVisibleActors,
         prepareExpression,
         revealPreparedExpression,
+        publishIntervention,
+        enqueueIntervention,
         clearScene,
         changeScene,
+        setIdentityKnown,
+        setNameplateOverride,
+        clearNameplateOverride,
         deterministicVocabularyKnown,
-        setShowOwnActor: function (show) {
-            try {
-                global.localStorage?.setItem(LOCAL_SHOW_SELF_KEY, show ? "true" : "false");
-            } catch (error) {}
-            renderScene(currentScene);
-        },
+        resolveLanguageText,
+        messageIsStaleForScene,
+        setShowOwnActor,
         getShowOwnActor: shouldShowOwnActor,
-        resolveRoomRoot: function (roomId) {
-            return roomId
-                ? `campaña/teatro/salas/${roomId}/escena`
-                : THEATRE_ROOT;
-        }
+        getViewerKey: () => currentViewerKey,
+        getViewerProfile: () => currentViewerProfile,
+        getLanguageDefinitions: () => Object.assign({}, languageDatabase)
     };
-
 })(window);

--- a/js/theatre-engine.js
+++ b/js/theatre-engine.js
@@ -2,328 +2,448 @@
     "use strict";
 
     const db = global.firebase.database();
-
     const THEATRE_ROOT = "campaña/estado_mundo/escena_actual";
+    const DIALOGUE_ROOT = "campaña/estado_mundo/dialogo_activo";
+    const DEFAULT_MAX_VISIBLE = 5;
+    const LOCAL_SHOW_SELF_KEY = "luminous.theatre.showOwnActor";
+
+    let currentScene = {};
+    let currentDialogue = {};
+    let typewriterInterval = null;
+    let resizeObserver = null;
+
+    function clampVisibleLimit(value) {
+        const parsed = Number.parseInt(value, 10);
+        if (!Number.isFinite(parsed)) return DEFAULT_MAX_VISIBLE;
+        return Math.max(1, Math.min(DEFAULT_MAX_VISIBLE, parsed));
+    }
+
+    function getVisibleLimit(scene) {
+        return clampVisibleLimit(
+            scene && (scene.max_actores_visibles ?? scene.maxVisibleActors ?? scene.config?.maxVisibleActors)
+        );
+    }
 
     function getSafeCssColor(value, fallback) {
         const candidate = typeof value === "string" ? value.trim() : "";
-
-        if (!candidate) {
-            return fallback;
-        }
-
+        if (!candidate) return fallback;
         if (global.CSS && typeof global.CSS.supports === "function") {
-            return global.CSS.supports("color", candidate)
-                ? candidate
-                : fallback;
+            return global.CSS.supports("color", candidate) ? candidate : fallback;
         }
-
-        return /^#[0-9a-f]{3,8}$/i.test(candidate)
-            ? candidate
-            : fallback;
+        return /^#[0-9a-f]{3,8}$/i.test(candidate) ? candidate : fallback;
     }
 
     function paintIdentityPlate(element, value) {
         if (!element) return;
-
         const plateColor = getSafeCssColor(value, "#4a4a4a");
-
-        element.style.setProperty("color", "", ""); // Remove hardcoded white, keep default styles for text
-        element.style.setProperty(
-            "background-color",
-            plateColor,
-            "important"
-        );
-        element.style.removeProperty("background"); // Ensure gradient is removed so background-color works
-        element.style.setProperty(
-            "border-left-color",
-            plateColor,
-            "important"
-        );
+        element.style.setProperty("color", "", "");
+        element.style.setProperty("background-color", plateColor, "important");
+        element.style.removeProperty("background");
+        element.style.setProperty("border-left-color", plateColor, "important");
     }
-    const DIALOGUE_ROOT = "campaña/estado_mundo/dialogo_activo";
 
-        // 1. Reactividad de Escenografía (Fondo)
-    db.ref(`${THEATRE_ROOT}/fondo`).on("value", (snapshot) => {
-        const fondoUrl = snapshot.val();
+    function normalizeIdList(value) {
+        if (!value) return [];
+        if (Array.isArray(value)) return value.filter(Boolean);
+        if (typeof value === "object") {
+            return Object.keys(value)
+                .sort((a, b) => Number(a) - Number(b))
+                .map((key) => value[key])
+                .filter(Boolean);
+        }
+        return [value].filter(Boolean);
+    }
+
+    function getAssignedActorId() {
+        try {
+            const actor = typeof global.getAssignedTheatreActor === "function"
+                ? global.getAssignedTheatreActor()
+                : null;
+            return actor?.actorId || actor?.id || global.assignedActorId || null;
+        } catch (error) {
+            return global.assignedActorId || null;
+        }
+    }
+
+    function shouldShowOwnActor() {
+        try {
+            return global.localStorage?.getItem(LOCAL_SHOW_SELF_KEY) === "true";
+        } catch (error) {
+            return false;
+        }
+    }
+
+    function isDmView() {
+        return Boolean(document.body?.classList.contains("on-game-dashboard"));
+    }
+
+    function isNoActorsMode(scene) {
+        return scene?.modo_presentacion === "no-actors" ||
+            scene?.presentationMode === "no-actors" ||
+            scene?.mostrar_actores === false;
+    }
+
+    function getRenderIds(scene) {
+        if (isNoActorsMode(scene)) return [];
+
+        const actors = scene?.actores || {};
+        const maxVisible = getVisibleLimit(scene);
+        const explicitVisible = normalizeIdList(scene?.actores_visibles).slice(-maxVisible);
+
+        // Firebase is authoritative. Missing/empty actores_visibles means no visible sprites;
+        // never fabricate a local fallback from the actor pool.
+        let ids = explicitVisible.filter((id) => {
+            const actor = actors[id];
+            return actor && (actor.url || actor.sprite);
+        });
+
+        if (!isDmView() && !shouldShowOwnActor()) {
+            const ownId = getAssignedActorId();
+            if (ownId) ids = ids.filter((id) => id !== ownId);
+        }
+
+        return ids;
+    }
+
+    function applyStageFocus(stage, dialogData) {
+        if (!stage) return;
+
+        const type = dialogData?.tipo_dialogo || "dialogo";
+        const isThought = type === "pensamiento";
+        const isNarrator = type === "narracion";
+        const hasMessage = Boolean(dialogData?.mensaje);
+        const activeActorId = dialogData?.actorId || null;
+        const activeSpriteUrl = dialogData?.sprite || null;
+
+        Array.from(stage.querySelectorAll(".theatre-sprite")).forEach((img) => {
+            const isActive = !isThought && !isNarrator && hasMessage && (
+                (activeActorId && img.dataset.id === activeActorId) ||
+                (!activeActorId && activeSpriteUrl && img.src === activeSpriteUrl)
+            );
+
+            if (isThought || isNarrator) {
+                img.classList.remove("is-speaking");
+                img.classList.add("is-dimmed");
+                img.style.filter = "brightness(0.4)";
+                img.style.zIndex = "1";
+            } else if (!hasMessage) {
+                img.classList.remove("is-speaking", "is-dimmed");
+                img.style.filter = "brightness(1)";
+                img.style.zIndex = "5";
+            } else if (isActive) {
+                img.classList.add("is-speaking");
+                img.classList.remove("is-dimmed");
+                img.style.filter = "brightness(1)";
+                img.style.zIndex = "10";
+                if (activeSpriteUrl) img.src = activeSpriteUrl;
+            } else {
+                img.classList.add("is-dimmed");
+                img.classList.remove("is-speaking");
+                img.style.filter = "brightness(0.4)";
+                img.style.zIndex = "1";
+            }
+            img.style.transition = "0.3s";
+        });
+    }
+
+    function renderScene(scene) {
+        currentScene = scene || {};
+
         const moduleTeatro = document.getElementById("modulo-teatro") || document.getElementById("theatre-view-player");
         if (moduleTeatro) {
+            const fondoUrl = currentScene.fondo || "";
             moduleTeatro.style.backgroundImage = fondoUrl
                 ? `linear-gradient(rgba(0,0,0,.15), rgba(0,0,0,.35)), url("${fondoUrl}")`
                 : "none";
+            moduleTeatro.dataset.theatreTransition = currentScene.transitioning ? "true" : "false";
         }
-    });
 
-    // 1.5 Reactividad de Localización
-    db.ref(`${THEATRE_ROOT}/locacion`).on("value", (snapshot) => {
         const locacionEl = document.getElementById("theatre-location");
         if (locacionEl) {
-            locacionEl.textContent = snapshot.val() || "LOCALIZACIÓN DESCONOCIDA";
+            locacionEl.textContent = currentScene.locacion || "LOCALIZACIÓN DESCONOCIDA";
         }
-    });
 
-    // 2. Motor de Sprites (Actores en Escena)
-    db.ref(`${THEATRE_ROOT}/actores`).on("value", (snapshot) => {
         const stage = document.getElementById("theatre-stage");
         if (!stage) return;
 
-        const actoresData = snapshot.val() || {};
+        if (currentScene.transitioning) {
+            stage.style.opacity = "0";
+        } else {
+            stage.style.opacity = "1";
+        }
+        stage.style.transition = "opacity .35s ease";
 
-        // Enforce max 5 sprites rule
-        db.ref("campaña/estado_mundo/escena_actual/actores_visibles").once("value").then(visSnap => {
-            const visiblesList = visSnap.val() || [];
+        const actors = currentScene.actores || {};
+        const renderIds = currentScene.transitioning ? [] : getRenderIds(currentScene);
+        const currentActors = Array.from(stage.querySelectorAll(".theatre-sprite"));
 
-            const currentActors = Array.from(stage.querySelectorAll('.theatre-sprite'));
+        currentActors.forEach((img) => {
+            if (!renderIds.includes(img.dataset.id)) img.remove();
+        });
 
-            // Collect actors that have a valid sprite URL
-            let renderIds = [];
+        renderIds.forEach((actorId) => {
+            const data = actors[actorId];
+            if (!data || (!data.url && !data.sprite)) return;
 
-            // First respect the explicit visibles list if it exists and actors have URLs
-            if (visiblesList.length > 0) {
-                renderIds = visiblesList.filter(id => actoresData[id] && (actoresData[id].url || actoresData[id].sprite));
-            } else {
-                // Fallback locally to 5 most recently updated/spoke (but we don't have lastSpokeAt here natively unless updated)
-                let validActors = [];
-                Object.keys(actoresData).forEach(id => {
-                    if (actoresData[id].url || actoresData[id].sprite) {
-                        validActors.push({ id, data: actoresData[id] });
-                    }
-                });
-                renderIds = validActors.slice(0, 5).map(a => a.id);
+            let img = stage.querySelector(`.theatre-sprite[data-id="${actorId}"]`);
+            if (!img) {
+                img = document.createElement("img");
+                img.className = "theatre-sprite";
+                img.dataset.id = actorId;
+                stage.appendChild(img);
             }
 
-            // Destrucción: Remove actors that are no longer in the renderIds
-            currentActors.forEach(img => {
-                if (!renderIds.includes(img.dataset.id)) {
-                    img.remove();
-                }
-            });
+            // expresionActiva/sprite are the revealed state. expresionPreparada never renders here.
+            img.src = data.url || data.sprite || "";
+            img.alt = data.nombre || "Actor en escena";
 
-            // Construcción y Actualización Posicional
-            renderIds.forEach(actorId => {
-                const data = actoresData[actorId];
-                if (!data.url && !data.sprite) return; // double check
+            let transformStr = "";
+            if (data.escala) transformStr += `scale(${data.escala}) `;
+            if (data.orientacion === "flip") transformStr += "scaleX(-1) ";
 
-                let img = stage.querySelector(`.theatre-sprite[data-id="${actorId}"]`);
+            const xPos = data.x !== undefined ? data.x : 0;
+            const yPos = data.y !== undefined ? data.y : 0;
+            if (xPos !== 0 || yPos !== 0) {
+                const xStr = typeof xPos === "number" ? `${xPos}px` : xPos;
+                const yStr = typeof yPos === "number" ? `${yPos}px` : yPos;
+                transformStr += `translate(${xStr}, ${yStr}) `;
+            }
 
-                if (!img) {
-                    // Inyectar nuevo actor al DOM
-                    img = document.createElement("img");
-                    img.className = "theatre-sprite";
-                    img.dataset.id = actorId;
-                    stage.appendChild(img);
-                }
-
-                // Actualizar propiedades
-                img.src = data.url || data.sprite || "";
-                img.alt = data.nombre || "Actor en escena";
-
-                // Si hay transformaciones, escala u orientación, aplicarlas.
-                // Ejemplo: transform: scaleX(-1) translateX(50px)
-                let transformStr = "";
-                if (data.escala) transformStr += `scale(${data.escala}) `;
-                if (data.orientacion === 'flip') transformStr += `scaleX(-1) `;
-
-                // Fix parsing raw numbers to px if necessary
-                let xPos = data.x !== undefined ? data.x : 0;
-                let yPos = data.y !== undefined ? data.y : 0;
-                if (xPos !== 0 || yPos !== 0) {
-                    let xStr = typeof xPos === 'number' ? `${xPos}px` : xPos;
-                    let yStr = typeof yPos === 'number' ? `${yPos}px` : yPos;
-                    transformStr += `translate(${xStr}, ${yStr}) `;
-                }
-
-                if (transformStr) {
-                    img.style.transform = transformStr.trim();
-                } else {
-                    img.style.transform = "none";
-                }
-            });
+            img.style.transform = transformStr ? transformStr.trim() : "none";
         });
-    });
 
-            // 3. Sincronización de Diálogos (Motor Typewriter Deterministico)
-    let typewriterInterval = null;
-    let resizeObserver = null;
-    let cachedFullTextLength = 0;
+        applyStageFocus(stage, currentDialogue);
+    }
 
     function resizeFontToFit(textEl) {
-        textEl.style.fontSize = ''; // Reset to default
-        let size = parseFloat(window.getComputedStyle(textEl).fontSize) || 24;
+        textEl.style.fontSize = "";
+        let size = parseFloat(global.getComputedStyle(textEl).fontSize) || 24;
         let iters = 0;
-        // Also check if textEl is actually rendered. If it's cloned, make sure clientHeight/scrollHeight are accurate.
-        // It relies on the element being in the DOM, which it is.
         while (textEl.scrollHeight > textEl.clientHeight && size > 10 && iters < 15) {
             size -= 1;
             textEl.style.fontSize = `${size}px`;
-            iters++;
+            iters += 1;
         }
     }
 
-    db.ref(DIALOGUE_ROOT).on("value", (snapshot) => {
-        const dialogData = snapshot.val() || {};
+    function formatDialogueMessage(dialogData) {
+        const raw = String(dialogData?.mensaje || "");
+        if (/^\/em\s+/i.test(raw)) {
+            const action = raw.replace(/^\/em\s+/i, "").trim();
+            const name = dialogData?.nombre || "Actor";
+            return `(${name} ${action})`;
+        }
+        return raw;
+    }
+
+    function resolvePlateIdentity(dialogData) {
+        const hasActor = Boolean(dialogData?.actorId);
+        if (!hasActor || dialogData?.tipo_dialogo === "narracion") {
+            return { visible: false, name: "", title: "" };
+        }
+
+        if (dialogData?.identidad_conocida === false || dialogData?.identityKnown === false) {
+            return { visible: true, name: "???", title: "???" };
+        }
+
+        if (dialogData?.mostrar_identidad === false && dialogData?.tipo_dialogo !== "pensamiento") {
+            return { visible: false, name: "", title: "" };
+        }
+
+        return {
+            visible: true,
+            name: dialogData?.nombre || "???",
+            title: dialogData?.titulo || "???"
+        };
+    }
+
+    function renderDialogue(dialogData) {
+        currentDialogue = dialogData || {};
 
         const nameEl = document.getElementById("dialogue-name");
         const titleEl = document.getElementById("dialogue-title");
         const textEl = document.getElementById("dialogue-text");
-
         const platesContainer = document.querySelector(".theatre-plates-container");
-        if (platesContainer) {
-            if (dialogData.mostrar_identidad === false || !dialogData.actorId || !dialogData.nombre || dialogData.nombre.trim() === "") {
-                platesContainer.style.display = "none";
-            } else {
-                platesContainer.style.display = "flex";
-            }
-        }
+        const identity = resolvePlateIdentity(currentDialogue);
 
+        if (platesContainer) platesContainer.style.display = identity.visible ? "flex" : "none";
         if (nameEl) {
-            nameEl.textContent = dialogData.nombre || "";
-            paintIdentityPlate(nameEl, dialogData.color_nombre);
+            nameEl.textContent = identity.name;
+            paintIdentityPlate(nameEl, currentDialogue.color_nombre);
         }
         if (titleEl) {
-            titleEl.textContent = dialogData.titulo || "";
-            paintIdentityPlate(titleEl, dialogData.color_titulo);
+            titleEl.textContent = identity.title;
+            paintIdentityPlate(titleEl, currentDialogue.color_titulo);
         }
 
         if (textEl) {
             clearInterval(typewriterInterval);
-            if (!dialogData.mensaje) {
+            const fullText = formatDialogueMessage(currentDialogue);
+            if (!fullText) {
                 textEl.textContent = "…";
-                textEl.style.fontSize = '';
-                return;
-            }
-
-            const fullText = dialogData.mensaje;
-            const startedAt = dialogData.startedAt || Date.now();
-            const speed = dialogData.speedMs || 30; // 30ms per char
-
-            if (resizeObserver) resizeObserver.disconnect();
-
-            // Re-eval resize only once using a hidden clone to pre-calculate font size!
-            // This prevents layout thrashing during the typewriter effect.
-            const clone = textEl.cloneNode(true);
-            clone.style.visibility = 'hidden';
-            clone.style.position = 'absolute';
-            clone.style.width = textEl.clientWidth + 'px';
-            clone.style.height = textEl.clientHeight + 'px';
-            clone.textContent = fullText;
-            textEl.parentNode.appendChild(clone);
-
-            resizeFontToFit(clone);
-            const finalSize = clone.style.fontSize;
-            clone.remove();
-
-            if(finalSize) {
-                textEl.style.fontSize = finalSize;
+                textEl.style.fontSize = "";
             } else {
-                textEl.style.fontSize = '';
+                const startedAt = Number(currentDialogue.startedAt) || Date.now();
+                const speed = Math.max(1, Number(currentDialogue.speedMs) || 30);
+
+                if (resizeObserver) resizeObserver.disconnect();
+                const clone = textEl.cloneNode(true);
+                clone.style.visibility = "hidden";
+                clone.style.position = "absolute";
+                clone.style.width = `${textEl.clientWidth}px`;
+                clone.style.height = `${textEl.clientHeight}px`;
+                clone.textContent = fullText;
+                textEl.parentNode.appendChild(clone);
+                resizeFontToFit(clone);
+                const finalSize = clone.style.fontSize;
+                clone.remove();
+                textEl.style.fontSize = finalSize || "";
+
+                const renderFrame = () => {
+                    const elapsed = Date.now() - startedAt;
+                    let charsToShow = Math.floor(elapsed / speed);
+                    charsToShow = Math.max(0, Math.min(fullText.length, charsToShow));
+                    textEl.textContent = fullText.substring(0, charsToShow);
+                    if (charsToShow >= fullText.length) {
+                        clearInterval(typewriterInterval);
+                        // Intentionally keep the completed dialogue visible until the next valid event.
+                    }
+                };
+
+                renderFrame();
+                if (textEl.textContent.length < fullText.length) {
+                    typewriterInterval = setInterval(renderFrame, 30);
+                }
             }
-
-            // Animation loop
-            typewriterInterval = setInterval(() => {
-                const now = Date.now();
-                const elapsed = now - startedAt;
-                let charsToShow = Math.floor(elapsed / speed);
-
-                if (charsToShow >= fullText.length) {
-                    charsToShow = fullText.length;
-                    clearInterval(typewriterInterval);
-                }
-
-                if (charsToShow < 0) charsToShow = 0;
-
-                textEl.textContent = fullText.substring(0, charsToShow);
-            }, 30);
         }
 
-        const stage = document.getElementById("theatre-stage");
-        if (stage) {
-            const isThought = dialogData.tipo_dialogo === "pensamiento";
-            const isNarrator = dialogData.tipo_dialogo === "narracion";
-            const activeActorId = dialogData.actorId;
-            const activeSpriteUrl = dialogData.sprite;
+        applyStageFocus(document.getElementById("theatre-stage"), currentDialogue);
+    }
 
-            Array.from(stage.children).forEach((img) => {
-                let isActive = false;
-
-                // Thoughts and narrator don't change the active speaker highlight
-                if (!isThought && !isNarrator) {
-                    if (activeActorId && img.dataset.id === activeActorId) {
-                        isActive = true;
-                    } else if (!activeActorId && activeSpriteUrl && img.src === activeSpriteUrl) {
-                        // Fallback to old behavior for backwards compatibility if actorId is not set
-                        isActive = true;
-                    }
-                }
-
-                // If it is a thought or narrator, OR there is no active message (dialogData.mensaje is empty)
-                // then all sprites should return to normal brightness.
-                if (isThought || isNarrator || !dialogData.mensaje) {
-                    img.classList.remove("is-speaking", "is-dimmed");
-                    img.style.filter = "brightness(1)";
-                    img.style.transition = "0.3s";
-                    img.style.zIndex = "5"; // Default z-index
-                } else {
-                    if (isActive) {
-                        img.classList.add("is-speaking");
-                        img.classList.remove("is-dimmed");
-                        img.style.filter = "brightness(1)";
-                        img.style.transition = "0.3s";
-                        img.style.zIndex = "10";
-                        if (activeSpriteUrl) {
-                            img.src = activeSpriteUrl;
-                        }
-                    } else {
-                        img.classList.add("is-dimmed");
-                        img.classList.remove("is-speaking");
-                        img.style.filter = "brightness(0.4)";
-                        img.style.transition = "0.3s";
-                        img.style.zIndex = "1";
-                    }
-                }
-            });
-        }
+    db.ref(THEATRE_ROOT).on("value", (snapshot) => {
+        renderScene(snapshot.val() || {});
     });
 
+    db.ref(DIALOGUE_ROOT).on("value", (snapshot) => {
+        renderDialogue(snapshot.val() || {});
+    });
 
-    // --- LuminousTheatreState ---
-    global.LuminousTheatreState = {
-        normalizeAssignedActorIds: function(assignedIds) {
-            if (!assignedIds) return [];
-            if (Array.isArray(assignedIds)) return assignedIds;
-            if (typeof assignedIds === 'object') return Object.keys(assignedIds);
-            return [assignedIds];
-        },
+    async function updateVisibleActors(actorId, actorData) {
+        if (!actorId) return;
+        if (actorData && !actorData.sprite && !actorData.url) return;
 
-        updateVisibleActors: async function(actorId, actorData) {
-            if (!actorId) return;
+        const sceneSnap = await db.ref(THEATRE_ROOT).once("value");
+        const scene = sceneSnap.val() || {};
+        if (scene.transitioning) return;
 
-            const visRef = db.ref(`${THEATRE_ROOT}/actores_visibles`);
-            const snapshot = await visRef.once('value');
-            let visibles = snapshot.val() || [];
+        const maxVisible = getVisibleLimit(scene);
+        const visRef = db.ref(`${THEATRE_ROOT}/actores_visibles`);
 
-            // If narrator or thoughts (no sprite), don't add to visible
-            if (actorData && (!actorData.sprite && !actorData.url)) {
-                return;
-            }
+        await visRef.transaction((current) => {
+            const visibles = normalizeIdList(current);
 
-            // Also check if we just need to reorder
-            const index = visibles.indexOf(actorId);
-            if (index !== -1) {
-                // Remove from current position
-                visibles.splice(index, 1);
-            }
+            // A visible actor speaking again keeps the exact same slot.
+            if (visibles.includes(actorId)) return visibles;
 
-            // Add to end (most recent)
             visibles.push(actorId);
+            while (visibles.length > maxVisible) visibles.shift();
+            return visibles;
+        });
+    }
 
-            // Keep only last 5
-            if (visibles.length > 5) {
-                // Ensure we only have the most recent 5
-                visibles = visibles.slice(visibles.length - 5);
-            }
+    async function removeVisibleActor(actorId) {
+        if (!actorId) return;
+        const visRef = db.ref(`${THEATRE_ROOT}/actores_visibles`);
+        await visRef.transaction((current) => normalizeIdList(current).filter((id) => id !== actorId));
+    }
 
-            await visRef.set(visibles);
+    async function setMaxVisibleActors(value) {
+        const maxVisible = clampVisibleLimit(value);
+        await db.ref(`${THEATRE_ROOT}/max_actores_visibles`).set(maxVisible);
+        await db.ref(`${THEATRE_ROOT}/actores_visibles`).transaction((current) => {
+            const visibles = normalizeIdList(current);
+            return visibles.slice(-maxVisible);
+        });
+        return maxVisible;
+    }
+
+    async function prepareExpression(actorId, expression) {
+        if (!actorId || !expression) return;
+        await db.ref(`${THEATRE_ROOT}/actores/${actorId}/expresionPreparada`).set(expression);
+    }
+
+    async function revealPreparedExpression(actorId, expression, sprite) {
+        if (!actorId) return;
+        const updates = {};
+        if (expression) updates.expresionActiva = expression;
+        if (sprite) updates.sprite = sprite;
+        if (expression) updates.expresionPreparada = expression;
+        if (Object.keys(updates).length) {
+            await db.ref(`${THEATRE_ROOT}/actores/${actorId}`).update(updates);
+        }
+    }
+
+    async function clearScene() {
+        await db.ref().update({
+            [`${THEATRE_ROOT}/actores_visibles`]: null,
+            [DIALOGUE_ROOT]: null
+        });
+    }
+
+    async function changeScene(nextScene) {
+        const payload = nextScene || {};
+        await db.ref(`${THEATRE_ROOT}/transitioning`).set(true);
+        await db.ref().update({
+            [`${THEATRE_ROOT}/actores_visibles`]: null,
+            [DIALOGUE_ROOT]: null
+        });
+        await db.ref(THEATRE_ROOT).update({
+            fondo: payload.fondo || "",
+            locacion: payload.locacion || "",
+            escenarioId: payload.escenarioId || null,
+            sub_etiquetas: payload.sub_etiquetas || null
+        });
+        await db.ref(`${THEATRE_ROOT}/transitioning`).set(false);
+    }
+
+    function deterministicVocabularyKnown(characterId, languageId, word, percent) {
+        const knowledge = Math.max(0, Math.min(100, Number(percent) || 0));
+        if (knowledge >= 100) return true;
+        if (knowledge <= 0) return false;
+
+        const key = `${characterId || ""}|${languageId || ""}|${String(word || "").toLocaleLowerCase()}`;
+        let hash = 2166136261;
+        for (let i = 0; i < key.length; i += 1) {
+            hash ^= key.charCodeAt(i);
+            hash = Math.imul(hash, 16777619);
+        }
+        const bucket = (hash >>> 0) % 10000;
+        return bucket < Math.round(knowledge * 100);
+    }
+
+    global.LuminousTheatreState = {
+        normalizeAssignedActorIds: normalizeIdList,
+        clampVisibleLimit,
+        getVisibleLimit,
+        updateVisibleActors,
+        removeVisibleActor,
+        setMaxVisibleActors,
+        prepareExpression,
+        revealPreparedExpression,
+        clearScene,
+        changeScene,
+        deterministicVocabularyKnown,
+        setShowOwnActor: function (show) {
+            try {
+                global.localStorage?.setItem(LOCAL_SHOW_SELF_KEY, show ? "true" : "false");
+            } catch (error) {}
+            renderScene(currentScene);
+        },
+        getShowOwnActor: shouldShowOwnActor,
+        resolveRoomRoot: function (roomId) {
+            return roomId
+                ? `campaña/teatro/salas/${roomId}/escena`
+                : THEATRE_ROOT;
         }
     };
 

--- a/tests/theatre_issue_511.spec.js
+++ b/tests/theatre_issue_511.spec.js
@@ -2,62 +2,141 @@ const { test, expect } = require("@playwright/test");
 const fs = require("node:fs");
 const path = require("node:path");
 
-const engine = fs.readFileSync(path.join(__dirname, "..", "js", "theatre-engine.js"), "utf8");
-const controls = fs.readFileSync(path.join(__dirname, "..", "js", "theatre-controls.js"), "utf8");
+const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
+const engine = read("js/theatre-engine.js");
+const controls = read("js/theatre-controls.js");
+const dashboard = read("js/on-game-dashboard.js");
+const dmHtml = read("hoja_de_DM.html");
 
-test("#511: Firebase scene state is authoritative and visible actors are reactive", () => {
-  expect(engine).toContain('db.ref(THEATRE_ROOT).on("value"');
-  expect(engine).toContain("const explicitVisible = normalizeIdList(scene?.actores_visibles)");
-  expect(engine).toContain("Missing/empty actores_visibles means no visible sprites");
+// These regression tests intentionally assert the architectural contract of #511.
+test("#511: Firebase is authoritative and the stage never invents visible actors", () => {
+  expect(engine).toContain("sceneRef.on(\"value\", sceneListener)");
+  expect(engine).toContain("dialogueRef.on(\"value\", dialogueListener)");
+  expect(engine).toContain("an empty/missing visible list means an empty stage");
+  expect(engine).toContain("normalizeIdList(scene?.actores_visibles)");
   expect(engine).not.toContain("validActors.slice(0, 5)");
 });
 
-test("#511: FIFO only rotates new actors and does not reorder an existing speaker", () => {
+test("#511: actor pool and visible FIFO are separate; existing speakers never move", () => {
   expect(engine).toContain("if (visibles.includes(actorId)) return visibles;");
   expect(engine).toContain("visibles.push(actorId);");
   expect(engine).toContain("while (visibles.length > maxVisible) visibles.shift();");
   expect(engine).not.toContain("visibles.splice(index, 1)");
+  expect(controls).toContain("Pool and HUD are separate");
+  expect(controls).not.toContain("delete actors[oldestKey]");
+  expect(controls).toContain("btn-hide");
 });
 
-test("#511: the visible limit is configurable from 1 to 5 without deleting the actor pool", () => {
+test("#511: visible maximum is DM-configurable from 1 through 5", () => {
   expect(engine).toContain("Math.max(1, Math.min(DEFAULT_MAX_VISIBLE, parsed))");
   expect(controls).toContain('id="theatre-max-visible"');
-  expect(controls).toContain("The actor pool is not the HUD");
-  expect(controls).not.toContain("delete actors[oldestKey]");
+  for (const value of [1, 2, 3, 4, 5]) expect(controls).toContain(`<option value="${value}">${value}</option>`);
 });
 
-test("#511: selecting an expression prepares it instead of revealing the sprite", () => {
-  expect(controls).toContain("expresionPreparada");
-  expect(controls).toContain("prepareExpression(actorId, newExpression)");
-  expect(controls).not.toContain("sprite: newSprite");
-  expect(engine).toContain("expresionActiva/sprite are the revealed state");
+test("#511: selected expressions remain prepared until the intervention is published", () => {
+  expect(engine).toContain("expresionPreparada");
+  expect(engine).toContain("async function revealPreparedExpression");
+  expect(engine).toContain("await revealPreparedExpression(message.actorId, message.expression, message.sprite)");
+  expect(controls).toContain("Preparing never changes expresionActiva/sprite");
+  expect(dashboard).toContain("Selection only prepares; reveal happens when the queue publishes the intervention");
+  expect(dashboard).not.toContain("expresionActiva: speakerData.expression");
 });
 
-test("#511: narration and thoughts dim every sprite and /em keeps actor context", () => {
+test("#511: dialogue and focus are current Firebase state suitable for late joiners", () => {
+  expect(engine).toContain("[paths.dialogue]: activePayload");
+  expect(engine).toContain("`${paths.scene}/active_actor`");
+  expect(engine).toContain("`${paths.scene}/focus_mode`");
+  expect(engine).toContain("Persistent by contract: completion never clears the active dialogue");
+});
+
+test("#511: narration/thought dim sprites, narration hides plates, and /em is an active actor action", () => {
   expect(engine).toContain("if (isThought || isNarrator)");
   expect(engine).toContain('img.style.filter = "brightness(0.4)"');
-  expect(engine).toContain('/^\\/em\\s+/i');
-  expect(engine).toContain("return `(${name} ${action})`");
+  expect(engine).toContain('type === "narracion"');
+  expect(engine).toContain('/^\\/em(?:\\s+|$)/i');
+  expect(engine).toContain("return `(${actorLabel} ${transformed})`");
+  expect(engine).toContain('type !== "pensamiento" && type !== "narracion"');
 });
 
-test("#511: dialogue persists, clear scene preserves background/roster and No Actors is a render mode", () => {
-  expect(engine).toContain("Intentionally keep the completed dialogue visible");
-  expect(engine).toContain("async function clearScene()");
-  expect(engine).toContain("actores_visibles`]: null");
-  expect(engine).not.toContain("actores`]: null");
+test("#511: No Actors and own-sprite hiding are render-only preferences", () => {
   expect(engine).toContain('scene?.modo_presentacion === "no-actors"');
   expect(controls).toContain('id="theatre-no-actors"');
-});
-
-test("#511: player self-sprite preference is local and future rooms have a scoped root", () => {
   expect(engine).toContain('const LOCAL_SHOW_SELF_KEY = "luminous.theatre.showOwnActor"');
   expect(engine).toContain("global.localStorage?.setItem");
-  expect(engine).toContain("resolveRoomRoot");
-  expect(engine).toContain("campaña/teatro/salas/${roomId}/escena");
+  expect(engine).toContain('id="theatre-self-visibility-control"');
+  expect(engine).toContain("if (!isDmView() && !shouldShowOwnActor())");
 });
 
-test("#511: partial language knowledge uses a deterministic monotonic word bucket", () => {
+test("#511: identity knowledge is per viewer and temporary nameplate presentation is separate", () => {
+  expect(engine).toContain('const IDENTITY_KNOWLEDGE_ROOT = "campaña/teatro/conocimiento_identidad"');
+  expect(engine).toContain('name: override.nombre ?? override.name ?? (known ? realName : "???")');
+  expect(engine).toContain('title: override.titulo ?? override.title ?? (known ? realTitle : "???")');
+  expect(engine).toContain("async function setIdentityKnown");
+  expect(engine).toContain("async function setNameplateOverride");
+  expect(controls).toContain("btn-reveal-identity");
+  expect(controls).toContain("btn-override-nameplate");
+  expect(engine).not.toMatch(/mensaje.*includes\(.*nombre/i);
+});
+
+test("#511: legacy prototype nameplate nodes are explicitly removed", () => {
+  expect(engine).toContain("function removeLegacyPrototypePanels");
+  expect(engine).toContain(".theatre-nameplate-prototype");
+  expect(engine).toContain("[data-theatre-prototype]");
+  expect(dmHtml).toContain('class="theatre-plates-container"');
+});
+
+test("#511: clear scene only clears current visual state", () => {
+  const clearStart = engine.indexOf("async function clearScene()");
+  const clearEnd = engine.indexOf("function wait", clearStart);
+  const clearBody = engine.slice(clearStart, clearEnd);
+  expect(clearBody).toContain("actores_visibles");
+  expect(clearBody).toContain("nameplate_overrides");
+  expect(clearBody).toContain("active_actor");
+  expect(clearBody).toContain("paths.dialogue");
+  expect(clearBody).not.toContain("/actores`");
+  expect(clearBody).not.toContain("fondo:");
+  expect(clearBody).not.toContain("locacion:");
+});
+
+test("#511: scene changes are fade cuts and messages from the cut are discarded", () => {
+  expect(engine).toContain('transition_phase: "out"');
+  expect(engine).toContain('transition_phase: "in"');
+  expect(engine).toContain("scene_cut_at");
+  expect(engine).toContain("await db.ref(paths.queue).remove()");
+  expect(dashboard).toContain("freshScene.transitioning || theatre.messageIsStaleForScene(claimed, freshScene)");
+  expect(dashboard).toContain("dropQueueForTransition");
+  expect(dashboard).toContain("theatre.changeScene");
+});
+
+test("#511: place library has grouping metadata and enters Theatre through changeScene", () => {
+  expect(dashboard).toContain('id = "theatre-scenario-region"');
+  expect(dashboard).toContain('id = "theatre-scenario-category"');
+  expect(dashboard).toContain("data.region || data.seccion || data.capitulo || data.locacion");
+  expect(dashboard).toContain("await theatre.changeScene");
+});
+
+test("#511: partial languages are deterministic, monotonic and consume character percentages only", () => {
   expect(engine).toContain("function deterministicVocabularyKnown");
-  expect(engine).toContain("const bucket = (hash >>> 0) % 10000");
-  expect(engine).toContain("return bucket < Math.round(knowledge * 100)");
+  expect(engine).toContain("stableHash(key) % 100000 < Math.round(knowledge * 1000)");
+  expect(engine).toContain("extractLanguageKnowledge");
+  expect(engine).toContain("return clampPercentage(value)");
+  expect(engine).toContain('return "[...]"');
+  expect(engine).toContain("(Está hablando una lengua que no entiendes)");
+  expect(engine).not.toMatch(/idiomas.*\.set\(/);
+  expect(engine).not.toMatch(/languages.*\.set\(/);
+});
+
+test("#511: Distortion Languages bypass percentage learning and can replace the full message", () => {
+  expect(engine).toContain("function isDistortionDefinition");
+  expect(engine).toContain("function understandsDistortion");
+  expect(engine).toContain("if (understandsDistortion(profile, languageId)) return text;");
+  expect(engine).toContain('"Tik... Tok..."');
+});
+
+test("#511: room-scoped paths allow future independent Theatre instances", () => {
+  expect(engine).toContain("function resolveRoomPaths(roomId)");
+  expect(engine).toContain("campaña/teatro/salas/${normalized}");
+  expect(engine).toContain("function setRoom(roomId)");
+  expect(controls).toContain("LuminousTheatreState?.getPaths");
+  expect(dashboard).toContain("const paths = () => theatre.getPaths()");
 });

--- a/tests/theatre_issue_511.spec.js
+++ b/tests/theatre_issue_511.spec.js
@@ -1,0 +1,63 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const engine = fs.readFileSync(path.join(__dirname, "..", "js", "theatre-engine.js"), "utf8");
+const controls = fs.readFileSync(path.join(__dirname, "..", "js", "theatre-controls.js"), "utf8");
+
+test("#511: Firebase scene state is authoritative and visible actors are reactive", () => {
+  expect(engine).toContain('db.ref(THEATRE_ROOT).on("value"');
+  expect(engine).toContain("const explicitVisible = normalizeIdList(scene?.actores_visibles)");
+  expect(engine).toContain("Missing/empty actores_visibles means no visible sprites");
+  expect(engine).not.toContain("validActors.slice(0, 5)");
+});
+
+test("#511: FIFO only rotates new actors and does not reorder an existing speaker", () => {
+  expect(engine).toContain("if (visibles.includes(actorId)) return visibles;");
+  expect(engine).toContain("visibles.push(actorId);");
+  expect(engine).toContain("while (visibles.length > maxVisible) visibles.shift();");
+  expect(engine).not.toContain("visibles.splice(index, 1)");
+});
+
+test("#511: the visible limit is configurable from 1 to 5 without deleting the actor pool", () => {
+  expect(engine).toContain("Math.max(1, Math.min(DEFAULT_MAX_VISIBLE, parsed))");
+  expect(controls).toContain('id="theatre-max-visible"');
+  expect(controls).toContain("The actor pool is not the HUD");
+  expect(controls).not.toContain("delete actors[oldestKey]");
+});
+
+test("#511: selecting an expression prepares it instead of revealing the sprite", () => {
+  expect(controls).toContain("expresionPreparada");
+  expect(controls).toContain("prepareExpression(actorId, newExpression)");
+  expect(controls).not.toContain("sprite: newSprite");
+  expect(engine).toContain("expresionActiva/sprite are the revealed state");
+});
+
+test("#511: narration and thoughts dim every sprite and /em keeps actor context", () => {
+  expect(engine).toContain("if (isThought || isNarrator)");
+  expect(engine).toContain('img.style.filter = "brightness(0.4)"');
+  expect(engine).toContain('/^\\/em\\s+/i');
+  expect(engine).toContain("return `(${name} ${action})`");
+});
+
+test("#511: dialogue persists, clear scene preserves background/roster and No Actors is a render mode", () => {
+  expect(engine).toContain("Intentionally keep the completed dialogue visible");
+  expect(engine).toContain("async function clearScene()");
+  expect(engine).toContain("actores_visibles`]: null");
+  expect(engine).not.toContain("actores`]: null");
+  expect(engine).toContain('scene?.modo_presentacion === "no-actors"');
+  expect(controls).toContain('id="theatre-no-actors"');
+});
+
+test("#511: player self-sprite preference is local and future rooms have a scoped root", () => {
+  expect(engine).toContain('const LOCAL_SHOW_SELF_KEY = "luminous.theatre.showOwnActor"');
+  expect(engine).toContain("global.localStorage?.setItem");
+  expect(engine).toContain("resolveRoomRoot");
+  expect(engine).toContain("campaña/teatro/salas/${roomId}/escena");
+});
+
+test("#511: partial language knowledge uses a deterministic monotonic word bucket", () => {
+  expect(engine).toContain("function deterministicVocabularyKnown");
+  expect(engine).toContain("const bucket = (hash >>> 0) % 10000");
+  expect(engine).toContain("return bucket < Math.round(knowledge * 100)");
+});

--- a/tests/theatre_issue_511.spec.js
+++ b/tests/theatre_issue_511.spec.js
@@ -63,7 +63,7 @@ test("#511: No Actors and own-sprite hiding are render-only preferences", () => 
   expect(controls).toContain('id="theatre-no-actors"');
   expect(engine).toContain('const LOCAL_SHOW_SELF_KEY = "luminous.theatre.showOwnActor"');
   expect(engine).toContain("global.localStorage?.setItem");
-  expect(engine).toContain('id="theatre-self-visibility-control"');
+  expect(engine).toContain('label.id = "theatre-self-visibility-control"');
   expect(engine).toContain("if (!isDmView() && !shouldShowOwnActor())");
 });
 


### PR DESCRIPTION
Completa exclusivamente el contrato funcional del Theatre Engine definido en #511.

## Estado del contrato

- Firebase vuelve a ser la fuente autoritativa y reactiva de escena/diálogo; no existe fallback local que invente sprites.
- El roster de actores disponibles queda separado de `actores_visibles`; el límite visible es configurable entre 1 y 5 sin borrar actores disponibles.
- FIFO rota únicamente actores nuevos; un actor ya visible conserva exactamente su posición cuando vuelve a intervenir.
- `expresionPreparada` queda separada de `expresionActiva`; seleccionar no cambia el sprite. La expresión se revela cuando la intervención es publicada realmente en escena.
- Diálogo y foco actuales persisten en Firebase para reconstrucción de late join; terminar el typewriter no limpia el último estado.
- `/em` se resuelve como acción contextual del actor. Narración oculta nameplates y narración/pensamiento mantienen todos los sprites oscurecidos.
- No Actors es un modo de render del mismo motor. La preferencia `Mostrar mi personaje en escena` es local por jugador y no modifica el estado global; el DM conserva la vista completa.
- El conocimiento de identidad es persistente y específico por jugador en `campaña/teatro/conocimiento_identidad`; desconocidos muestran `??? / ???`.
- La revelación permanente y la presentación temporal del nameplate son estados distintos. No se infiere identidad automáticamente a partir del texto del diálogo.
- Los nodos legacy/prototipo de nameplate se eliminan si existen y permanece el contenedor dinámico real.
- `Limpiar escena` borra únicamente sprites visibles, diálogo, nameplates temporales y foco; conserva fondo, localización y actores disponibles.
- El cambio de escenario usa corte real `fade out -> limpieza -> cambio de lugar -> fade in`; la cola se invalida durante la transición y las intervenciones obsoletas se descartan mediante `scene_cut_at`.
- La librería de lugares admite región/sección/capítulo, categoría/área, localización y etiquetas, y aplica lugares a través de la transición del Theatre Engine.
- Idiomas normales consumen el porcentaje ya almacenado en el personaje sin modificar progresión. El vocabulario parcial es determinista y monotónico; estilos de ofuscación son configurables.
- Distortion Languages usan una regla de comprensión independiente del porcentaje normal y pueden sustituir el mensaje completo cuando no se comprenden.
- Las rutas del motor están abstraídas por sala (`resolveRoomPaths`) manteniendo compatibilidad con la escena global actual y dejando preparada la estructura para futuras salas independientes.

## Archivos de producto modificados

- `js/theatre-engine.js`
- `js/theatre-controls.js`
- `js/on-game-dashboard.js`

## Regresión y validación

- `tests/theatre_issue_511.spec.js`: 15 comprobaciones específicas del contrato de #511.
- `.github/workflows/theatre-issue-511.yml`: check CI limitado al Theatre Engine.
- GitHub Actions: `node --check` de los módulos Theatre y **15/15 tests aprobados** en `Theatre Engine #511`.

No se modificaron sistemas de combate, inventario ni otros módulos ajenos al Theatre Engine.

Closes #511