### PR TITLE
Fix Theatre HUD identity, player composer and visible sprites

### DIFF
--- a/css/theatre-dialogue.css
+++ b/css/theatre-dialogue.css
@@ -21,7 +21,7 @@
         padding: 12px 30px;
         color: #f5f5dc;
         font-size: 24px;
-        font-family: "BebasKai", impact, sans-serif;
+        font-family: "BebasKai", Impact, "Arial Narrow", sans-serif;
         letter-spacing: 1px;
         text-transform: uppercase;
         font-weight: bold;
@@ -129,12 +129,12 @@
       }
 
       .theatre-plate-title {
-        background: linear-gradient(90deg, #5c3a21 0%, #3a2210 100%);
+        background: linear-gradient(90deg, #4a4a4a 0%, #4a4a4a 68%, #17110b 100%);
         color: #ffffff;
         border: none;
         border-left: 4px solid #d4af37;
         padding: 2px 40px 2px 20px;
-        font-family: "BebasKai", impact, sans-serif;
+        font-family: "BebasKai", Impact, "Arial Narrow", sans-serif;
         letter-spacing: 1px;
         text-transform: uppercase;
         font-weight: bold;
@@ -153,12 +153,12 @@
       }
 
       .theatre-plate-name {
-        background: #416268;
+        background: linear-gradient(90deg, #4a4a4a 0%, #4a4a4a 68%, #17110b 100%);
         color: #ffffff;
         border: none;
         border-left: 6px solid #1a1a1a;
         padding: 4px 60px 4px 30px;
-        font-family: "BebasKai", impact, sans-serif;
+        font-family: "BebasKai", Impact, "Arial Narrow", sans-serif;
         letter-spacing: 1px;
         text-transform: uppercase;
         font-weight: 900;
@@ -186,7 +186,7 @@
         color: #fffacd; /* Amarillo pálido (LemonChiffon) */
         font-size: 1.1rem;
         line-height: 1.6;
-        font-family: "Roboto", sans-serif;
+        font-family: "Roboto", Arial, sans-serif;
         box-shadow: none;
         text-shadow: none;
         z-index: 10;

--- a/css/theatre-hud.css
+++ b/css/theatre-hud.css
@@ -39,6 +39,19 @@
   font-family: "Roboto", Arial, sans-serif !important;
 }
 
+#modal-escritura-teatro h3,
+#modal-escritura-teatro #theatre-modal-readonly-name,
+#modal-escritura-teatro #theatre-modal-readonly-title {
+  font-family: "BebasKai", Impact, "Arial Narrow", sans-serif !important;
+}
+
+#modal-escritura-teatro textarea,
+#modal-escritura-teatro select,
+#modal-escritura-teatro input,
+#modal-escritura-teatro button {
+  font-family: "Roboto", Arial, sans-serif !important;
+}
+
 /* ==================================================
    ESCENARIO REAL Y SPRITES FIREBASE
    ================================================== */
@@ -72,13 +85,17 @@
 
 #theatre-view-player > #theatre-stage > .theatre-sprite,
 .on-game-dashboard .stage-view-wrapper > #theatre-stage > .theatre-sprite {
+  flex: 0 1 20%;
+  min-width: 0;
+  max-width: 20%;
+  width: auto;
+  height: auto;
   align-self: flex-end;
   max-height: 82vh !important;
   object-fit: contain;
   object-position: center bottom;
   transform-origin: 50% 100%;
   pointer-events: none;
-  aspect-ratio: 16 / 9;
 }
 
 /* Compatibilidad con el renderizador anterior del jugador. */
@@ -89,11 +106,11 @@
 
 #theatre-view-player > #theatre-stage > .sprite-wrapper > img {
   bottom: 0 !important;
+  max-width: 100%;
   object-fit: contain;
   object-position: center bottom;
   transform-origin: 50% 100%;
   pointer-events: none;
-  aspect-ratio: 16 / 9;
 }
 
 /* ==================================================
@@ -749,4 +766,16 @@ body.player-instance-theatre
   .on-game-dashboard .theatre-dm-menu-toggle {
     transition: none !important;
   }
+}
+
+/* Controles integrados en el compositor existente del jugador. */
+#modal-escritura-teatro .theatre-player-composer-select {
+  flex: 1;
+  min-width: 0;
+  padding: 5px;
+  border: 1px solid #444;
+  border-radius: 4px;
+  background: #222;
+  color: #fff;
+  font: 16px "Roboto", Arial, sans-serif;
 }

--- a/js/on-game-dashboard.js
+++ b/js/on-game-dashboard.js
@@ -331,11 +331,11 @@
           nombre: "",
           titulo: "",
           actorId: null,
-          expression: "Neutral",
+          expression: null,
           sprite: null,
           icono: null,
-          color_nombre: "#ffffff",
-          color_titulo: DEFAULT_TITLE_COLOR
+          color_nombre: "",
+          color_titulo: ""
         };
 
         if (!speakerSelect || speakerSelect.value === "narrador") {
@@ -350,23 +350,25 @@
             expression: expressionSelect?.value || "Neutral",
             sprite: expressionOption?.dataset.sprite || null,
             icono: option.dataset.icono || null,
-            color_nombre: option.dataset.colorNombre || "#ffffff",
-            color_titulo: option.dataset.colorTitulo || DEFAULT_TITLE_COLOR
+            color_nombre: option.dataset.colorNombre || "",
+            color_titulo: option.dataset.colorTitulo || ""
           };
         }
+
+        const actorDialogue = Boolean(speaker.actorId && type === "dialogo");
 
         const queued = await theatre.enqueueIntervention({
           mensaje: text,
           nombre: speaker.nombre,
           titulo: speaker.titulo,
           actorId: speaker.actorId,
-          expression: speaker.expression,
-          sprite: speaker.sprite,
+          expression: actorDialogue ? speaker.expression : null,
+          sprite: actorDialogue ? speaker.sprite : null,
           icono: speaker.icono,
           color_nombre: speaker.color_nombre,
           color_titulo: speaker.color_titulo,
           tipo_dialogo: type,
-          mostrar_identidad: type !== "narracion",
+          mostrar_identidad: actorDialogue,
           idiomaId: languageSelect?.value || null
         });
 
@@ -389,8 +391,8 @@
           option.dataset.nombre = actor.nombre || "";
           option.dataset.titulo = actor.titulo || "";
           option.dataset.icono = actor.icono || "";
-          option.dataset.colorNombre = actor.color_nombre || "#ffffff";
-          option.dataset.colorTitulo = actor.color_titulo || DEFAULT_TITLE_COLOR;
+          option.dataset.colorNombre = actor.color_nombre || "";
+          option.dataset.colorTitulo = actor.color_titulo || "";
           option.dataset.expresiones = JSON.stringify(actor.expresiones || {});
           option.dataset.preparedExpression = actor.expresionPreparada || actor.expresionActiva || "Neutral";
           speakerSelect.appendChild(option);

--- a/js/theatre-controls.js
+++ b/js/theatre-controls.js
@@ -212,38 +212,26 @@
             const actorInstanceId = `actor_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
             const now = global.firebase.database.ServerValue.TIMESTAMP;
 
-            let expressions = npcData.expresiones || {};
-            let activeExpression = "Neutral";
-            if (!Object.keys(expressions).length) {
-                expressions = { Neutral: npcData.sprite || npcData.icono_jugador || npcData.icono || "" };
-            } else if (!expressions.Neutral) {
-                activeExpression = Object.keys(expressions)[0];
-            }
-
-            const activeSprite = expressions[activeExpression] || npcData.sprite || npcData.url || "";
+            const expressions = npcData.expresiones || {};
             const actorPayload = {
                 nombre: npcData.nombre || selectedId,
                 titulo: npcData.titulo || "",
-                color_nombre: npcData.color_nombre || "#ffffff",
-                color_titulo: npcData.color_titulo || DEFAULT_TITLE_COLOR,
+                color_nombre: npcData.color_nombre || "",
+                color_titulo: npcData.color_titulo || "",
                 identityId: npcData.identityId || npcData.identidadId || selectedId,
                 sourceId,
                 sourceType,
-                sprite: activeSprite,
+                sprite: npcData.sprite || npcData.url || "",
                 icono: npcData.icono || npcData.icono_jugador || "",
                 expresiones: expressions,
-                expresionActiva: activeExpression,
-                expresionPreparada: activeExpression,
                 x: 0,
                 y: 0,
                 escala: npcData.escala || 1,
                 orientacion: "normal",
                 spawnedAt: now
             };
-
-            // Pool and HUD are separate. Spawning never evicts/deletes another available actor.
+            // Pool and HUD are separate. Cataloging never reveals a sprite or selects an expression.
             db.ref(`${paths().scene}/actores/${actorInstanceId}`).set(actorPayload)
-                .then(() => global.LuminousTheatreState.updateVisibleActors(actorInstanceId, actorPayload))
                 .catch((error) => console.error("No se pudo añadir el actor al Teatro:", error));
         }
 

--- a/js/theatre-engine.js
+++ b/js/theatre-engine.js
@@ -98,12 +98,28 @@
         return /^#[0-9a-f]{3,8}$/i.test(candidate) ? candidate : fallback;
     }
 
+    function getValidSpriteUrl(value) {
+        const candidate = typeof value === "string" ? value.trim() : "";
+        if (!candidate || /^(?:javascript|vbscript):/i.test(candidate)) return "";
+        try {
+            const resolved = new URL(candidate, document.baseURI || global.location?.href || "https://local.invalid/");
+            if (!["http:", "https:", "data:", "blob:", "file:"].includes(resolved.protocol)) return "";
+            if (resolved.protocol === "data:" && !/^data:image\//i.test(candidate)) return "";
+            return candidate;
+        } catch (error) {
+            return "";
+        }
+    }
+
     function paintIdentityPlate(element, value) {
         if (!element) return;
         const plateColor = getSafeCssColor(value, "#4a4a4a");
-        element.style.setProperty("color", "", "");
-        element.style.setProperty("background-color", plateColor, "important");
-        element.style.removeProperty("background");
+        element.style.setProperty("color", "#ffffff", "important");
+        element.style.setProperty(
+            "background",
+            `linear-gradient(90deg, ${plateColor} 0%, ${plateColor} 68%, #17110b 100%)`,
+            "important"
+        );
         element.style.setProperty("border-left-color", plateColor, "important");
     }
 
@@ -151,7 +167,7 @@
         // Firebase is authoritative: an empty/missing visible list means an empty stage.
         let ids = explicitVisible.filter((id) => {
             const actor = actors[id];
-            return actor && (actor.url || actor.sprite);
+            return actor && getValidSpriteUrl(actor.url || actor.sprite);
         });
 
         if (!isDmView() && !shouldShowOwnActor()) {
@@ -281,7 +297,7 @@
             return { visible: false, known: false, name: "", title: "" };
         }
 
-        if (dialogData?.mostrar_identidad === false && type !== "pensamiento") {
+        if (type === "pensamiento" || dialogData?.mostrar_identidad === false) {
             return { visible: false, known: false, name: "", title: "" };
         }
 
@@ -529,7 +545,8 @@
 
         renderIds.forEach((actorId) => {
             const data = actors[actorId];
-            if (!data || (!data.url && !data.sprite)) return;
+            const spriteUrl = getValidSpriteUrl(data?.url || data?.sprite);
+            if (!data || !spriteUrl) return;
 
             let img = stage.querySelector(`.theatre-sprite[data-id="${actorId}"]`);
             if (!img) {
@@ -540,7 +557,7 @@
             }
 
             // Only the revealed expression/sprite renders. expresionPreparada is never read by the renderer.
-            img.src = data.url || data.sprite || "";
+            img.src = spriteUrl;
             img.alt = isDmView() || isIdentityKnown(actorId) ? (data.nombre || "Actor en escena") : "Actor desconocido";
 
             let transform = "";
@@ -661,7 +678,7 @@
 
     async function updateVisibleActors(actorId, actorData) {
         if (!actorId) return false;
-        if (actorData && !actorData.sprite && !actorData.url) return false;
+        if (!getValidSpriteUrl(actorData?.sprite || actorData?.url)) return false;
         const scene = await getFreshScene();
         if (scene.transitioning) return false;
 
@@ -702,9 +719,12 @@
         const scene = await getFreshScene();
         if (scene.transitioning) return false;
 
+        const validSprite = getValidSpriteUrl(sprite);
+        if (!validSprite) return false;
+
         const updates = {};
         if (expression) updates.expresionActiva = expression;
-        if (sprite) updates.sprite = sprite;
+        updates.sprite = validSprite;
         if (Object.keys(updates).length) {
             await db.ref(`${getPaths().scene}/actores/${actorId}`).update(updates);
         }
@@ -732,7 +752,7 @@
             mensaje: message?.mensaje || "",
             actorId: message?.actorId || null,
             expression: message?.expression || "Neutral",
-            sprite: message?.sprite || null,
+            sprite: getValidSpriteUrl(message?.sprite) || null,
             icono: message?.icono || null,
             color_nombre: message?.color_nombre || "#ffffff",
             color_titulo: message?.color_titulo || "#3b2918",
@@ -876,6 +896,133 @@
         bindRoom(roomId || DEFAULT_ROOM_ID);
     }
 
+    function buildTheatreInitialsIcon(name) {
+        const initials = String(name || "?")
+            .trim()
+            .split(/\s+/)
+            .filter(Boolean)
+            .slice(0, 2)
+            .map((part) => part.charAt(0))
+            .join("")
+            .toUpperCase() || "?";
+        const escaped = initials.replace(/[&<>"']/g, (char) => ({
+            "&": "&amp;",
+            "<": "&lt;",
+            ">": "&gt;",
+            '"': "&quot;",
+            "'": "&#39;"
+        })[char]);
+        const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80"><rect width="80" height="80" fill="#111111"/><text x="40" y="48" text-anchor="middle" font-family="Arial, sans-serif" font-size="28" font-weight="700" fill="#ffffff">${escaped}</text></svg>`;
+        return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`;
+    }
+
+    function ensurePlayerComposerControls() {
+        if (isDmView()) return;
+        const container = document.getElementById("contenedor-selectores-emocion");
+        const expression = document.getElementById("player-expression");
+        if (!container || !expression) return;
+
+        if (!document.getElementById("player-actor-select")) {
+            const actorSelect = document.createElement("select");
+            actorSelect.id = "player-actor-select";
+            actorSelect.className = "theatre-player-composer-select";
+            actorSelect.setAttribute("aria-label", "Personaje");
+            actorSelect.style.display = "none";
+            container.insertBefore(actorSelect, expression);
+        }
+
+        if (!document.getElementById("player-tipo-dialogo-select")) {
+            const typeSelect = document.createElement("select");
+            typeSelect.id = "player-tipo-dialogo-select";
+            typeSelect.className = "theatre-player-composer-select";
+            typeSelect.setAttribute("aria-label", "Tipo de intervención");
+            typeSelect.innerHTML = '<option value="dialogo">Diálogo</option><option value="pensamiento">Pensamiento</option>';
+            container.insertBefore(typeSelect, expression);
+        }
+
+        expression.classList.add("theatre-player-composer-select");
+    }
+
+    function installPlayerComposerCompatibility() {
+        if (isDmView() || global.__luminousTheatreComposerCompatibilityInstalled) return false;
+        const originalGetAssigned = global.getAssignedTheatreActor;
+        const originalSync = global.syncPlayerTheatreComposer;
+        if (typeof originalGetAssigned !== "function" || typeof originalSync !== "function") return false;
+
+        global.getAssignedTheatreActor = function () {
+            const actor = originalGetAssigned.apply(this, arguments);
+            if (!actor) return null;
+            return Object.assign({}, actor, {
+                color_nombre: getSafeCssColor(actor.color_nombre, "#4a4a4a"),
+                color_titulo: getSafeCssColor(actor.color_titulo, "#4a4a4a")
+            });
+        };
+
+        global.syncPlayerTheatreComposer = function () {
+            if (global.datosJugador && !global.datosJugador.actorId && global.datosJugador.vinculo_jugador) {
+                global.datosJugador.actorId = global.datosJugador.vinculo_jugador;
+            }
+
+            ensurePlayerComposerControls();
+            const result = originalSync.apply(this, arguments);
+            const actor = global.getAssignedTheatreActor?.();
+            const actorSelect = document.getElementById("player-actor-select");
+            const expressionSelect = document.getElementById("player-expression");
+            const sendButton = document.getElementById("btn-enviar-teatro-modal");
+            const nameEl = document.getElementById("theatre-modal-readonly-name");
+            const titleEl = document.getElementById("theatre-modal-readonly-title");
+
+            if (!actor) {
+                if (actorSelect) actorSelect.style.display = "none";
+                if (expressionSelect) {
+                    expressionSelect.innerHTML = "";
+                    expressionSelect.style.display = "none";
+                }
+                if (sendButton) sendButton.disabled = true;
+                return result;
+            }
+
+            if (expressionSelect) expressionSelect.style.display = "block";
+            paintIdentityPlate(nameEl, actor.color_nombre);
+            if (titleEl && actor.titulo) paintIdentityPlate(titleEl, actor.color_titulo);
+            return result;
+        };
+
+        global.__luminousTheatreComposerCompatibilityInstalled = true;
+        return true;
+    }
+
+    function patchTheatreLogPortrait(img) {
+        if (!img?.matches?.("#theatre-log-container .hex-portrait img")) return;
+        const fallback = () => {
+            img.src = buildTheatreInitialsIcon(img.alt || "?");
+        };
+        const src = img.getAttribute("src") || "";
+        if (!src || src.includes("via.placeholder.com")) fallback();
+        img.addEventListener("error", fallback, { once: true });
+    }
+
+    function observePlayerTheatreLog() {
+        if (isDmView() || global.__luminousTheatreLogObserver) return;
+        document
+            .querySelectorAll("#theatre-log-container .hex-portrait img")
+            .forEach(patchTheatreLogPortrait);
+
+        const observer = new MutationObserver((mutations) => {
+            mutations.forEach((mutation) => {
+                mutation.addedNodes.forEach((node) => {
+                    if (!(node instanceof Element)) return;
+                    if (node.matches("#theatre-log-container .hex-portrait img")) patchTheatreLogPortrait(node);
+                    node
+                        .querySelectorAll?.("#theatre-log-container .hex-portrait img")
+                        .forEach(patchTheatreLogPortrait);
+                });
+            });
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
+        global.__luminousTheatreLogObserver = observer;
+    }
+
     db.ref("campaña/jugadores").on("value", (snapshot) => {
         playerDatabase = snapshot.val() || {};
         bindIdentityKnowledge();
@@ -897,8 +1044,16 @@
     document.addEventListener("DOMContentLoaded", () => {
         removeLegacyPrototypePanels();
         ensureSelfVisibilityControl();
+        ensurePlayerComposerControls();
+        installPlayerComposerCompatibility();
+        observePlayerTheatreLog();
         bindIdentityKnowledge();
     });
+
+    global.addEventListener("actoresCacheUpdated", installPlayerComposerCompatibility);
+    document.addEventListener("click", (event) => {
+        if (event.target?.closest?.("#btn-abrir-escritura")) installPlayerComposerCompatibility();
+    }, true);
 
     bindRoom(activeRoomId);
 

--- a/tests/player_theatre_regression.spec.js
+++ b/tests/player_theatre_regression.spec.js
@@ -66,12 +66,13 @@ test('applyPlayerInstance(teatro) agrega player-instance-theatre sin UI tracker 
 
 test('el modal de jugador incluye readonly nodes', async () => {
     const html = fs.readFileSync(pt.join(__dirname, '..', 'hoja_personaje.html'), 'utf-8');
+    const css = fs.readFileSync(pt.join(__dirname, '..', 'css', 'theatre-hud.css'), 'utf-8');
 
     expect(html).toContain('id="theatre-modal-readonly-icon"');
     expect(html).toContain('id="theatre-modal-readonly-name"');
     expect(html).toContain('id="theatre-modal-readonly-title"');
     expect(html).toContain('BebasKai');
-    expect(html).toContain('font-family: \'Roboto\', sans-serif;');
+    expect(css).toContain('font-family: "Roboto", Arial, sans-serif !important;');
 });
 
 test('los SVG de Actuar e Historial usan currentColor y las clases mantienen is-active', async () => {

--- a/tests/theatre_hud_detail_patch.spec.js
+++ b/tests/theatre_hud_detail_patch.spec.js
@@ -1,0 +1,184 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
+const engine = read("js/theatre-engine.js");
+const controls = read("js/theatre-controls.js");
+const dashboard = read("js/on-game-dashboard.js");
+const playerHtml = read("hoja_personaje.html");
+const playerJs = read("hoja_personaje.js");
+const dialogueCss = read("css/theatre-dialogue.css");
+const hudCss = read("css/theatre-hud.css");
+
+function block(source, start, end) {
+  const from = source.indexOf(start);
+  const to = end ? source.indexOf(end, from) : source.length;
+  expect(from).toBeGreaterThanOrEqual(0);
+  return source.slice(from, to < 0 ? source.length : to);
+}
+
+test("patch: fallback de placas es gris #4a4a4a", () => {
+  expect(engine).toContain('getSafeCssColor(value, "#4a4a4a")');
+  expect(dialogueCss).toContain("#4a4a4a 0%, #4a4a4a 68%");
+  expect(engine).not.toContain('getSafeCssColor(value, "#aaaaaa")');
+});
+
+test("patch: el texto de las placas siempre es blanco", () => {
+  expect(engine).toContain('element.style.setProperty("color", "#ffffff", "important")');
+  expect(dialogueCss).toMatch(/\.theatre-plate-title\s*\{[\s\S]*?color:\s*#ffffff;/);
+  expect(dialogueCss).toMatch(/\.theatre-plate-name\s*\{[\s\S]*?color:\s*#ffffff;/);
+});
+
+test("patch: color personalizado se aplica al fondo y borde, no al texto", () => {
+  expect(engine).toContain('`linear-gradient(90deg, ${plateColor} 0%, ${plateColor} 68%, #17110b 100%)`');
+  expect(engine).toContain('element.style.setProperty("border-left-color", plateColor, "important")');
+  expect(engine).not.toMatch(/style\.color\s*=\s*dialogData\.color_(?:nombre|titulo)/);
+});
+
+test("patch: narrador nunca muestra identidad", () => {
+  expect(engine).toContain('if (!actorId || type === "narracion")');
+  expect(dashboard).toContain('type = "narracion";');
+  expect(dashboard).toContain('mostrar_identidad: actorDialogue');
+});
+
+test("patch: pensamiento nunca muestra identidad", () => {
+  expect(engine).toContain('if (type === "pensamiento" || dialogData?.mostrar_identidad === false)');
+  expect(dashboard).toContain('mostrar_identidad: actorDialogue');
+  expect(playerJs).toContain('const mostrarIdentidad = tipoDialogo !== "pensamiento";');
+});
+
+test("patch: pensamiento no publica expresión ni sprite", () => {
+  expect(dashboard).toContain('expression: actorDialogue ? speaker.expression : null');
+  expect(dashboard).toContain('sprite: actorDialogue ? speaker.sprite : null');
+  expect(engine).toContain('type !== "pensamiento" && type !== "narracion"');
+});
+
+test("patch: catalogar un actor no lo hace visible ni selecciona expresión", () => {
+  const spawn = block(controls, "function spawnSelectedActor", "function renderLiveActors");
+  expect(spawn).toContain('db.ref(`${paths().scene}/actores/${actorInstanceId}`).set(actorPayload)');
+  expect(spawn).not.toContain("updateVisibleActors(actorInstanceId");
+  expect(spawn).not.toContain("expresionActiva:");
+  expect(spawn).not.toContain("expresionPreparada:");
+});
+
+test("patch: máximo visible continúa limitado a cinco", () => {
+  expect(engine).toContain("const DEFAULT_MAX_VISIBLE = 5");
+  expect(engine).toContain("Math.max(1, Math.min(DEFAULT_MAX_VISIBLE, parsed))");
+  expect(engine).toContain("while (visibles.length > maxVisible) visibles.shift();");
+});
+
+test("patch: el sexto actor nuevo reemplaza al primero sin reordenar hablantes existentes", () => {
+  const visible = block(engine, "async function updateVisibleActors", "async function removeVisibleActor");
+  expect(visible).toContain("if (visibles.includes(actorId)) return visibles;");
+  expect(visible).toContain("visibles.push(actorId);");
+  expect(visible).toContain("visibles.shift()");
+  expect(visible).not.toContain("visibles.splice");
+});
+
+test("patch: sprite inválido no entra en visibles ni se revela", () => {
+  expect(engine).toContain("function getValidSpriteUrl");
+  expect(engine).toContain('if (!getValidSpriteUrl(actorData?.sprite || actorData?.url)) return false;');
+  expect(engine).toContain("if (!validSprite) return false;");
+});
+
+test("patch: log prioriza icono universal y nunca usa sprite", () => {
+  const log = block(playerJs, "function resolveTheatreLogIcon", "// === ENVÍO AL TEATRO");
+  expect(log).toContain("return msg.icono || cachedIcon || fallbackIcon;");
+  expect(log).toContain("actorById");
+  expect(log).toContain("actorByName");
+  expect(log).not.toContain("msg.sprite");
+  expect(engine).toContain("function buildTheatreInitialsIcon(name)");
+});
+
+test("patch: log sustituye el placeholder externo por iniciales locales", () => {
+  expect(engine).toContain("data:image/svg+xml");
+  expect(engine).toContain('src.includes("via.placeholder.com")');
+  expect(engine).toContain('img.addEventListener("error", fallback, { once: true })');
+});
+
+test("patch: selector de personaje se oculta con cero o uno", () => {
+  expect(engine).toContain('actorSelect.id = "player-actor-select"');
+  expect(playerJs).toContain('if (validCount <= 1)');
+  expect(playerJs).toContain('selectActor.style.display = "none"');
+});
+
+test("patch: selector de personaje se muestra con varios", () => {
+  expect(playerJs).toContain('selectActor.style.display = "block"');
+  expect(playerHtml).not.toContain('>Mi personaje</option>');
+});
+
+test("patch: resizeFontToFit puede reducir font-size y CSS no lo bloquea", () => {
+  expect(engine).toContain('textEl.style.fontSize = `${size}px`;');
+  const dialogueRule = block(hudCss, "#theatre-view-player .theatre-dialogue-text,", "#theatre-view-player .theatre-dialogue-text::before");
+  expect(dialogueRule).not.toMatch(/font-size:[^;]*!important/);
+});
+
+test("patch: no se agrega un segundo listener de envío", () => {
+  const send = block(playerJs, "// === ENVÍO AL TEATRO", "  window.getAssignedTheatreActor = function() {");
+  expect((send.match(/addEventListener\("click", sendTheatreMessage\)/g) || [])).toHaveLength(1);
+  const compatibilityHook = block(engine, "function installPlayerComposerCompatibility", "function patchTheatreLogPortrait");
+  expect(compatibilityHook).not.toContain('addEventListener("click"');
+  expect(compatibilityHook).not.toContain("sendTheatreMessage");
+});
+
+test("patch: Tienda y Forja permanecen presentes", () => {
+  expect(playerHtml).toContain('id="shop-modal"');
+  expect(playerHtml).toContain('id="btn-shop-notifier"');
+  expect(playerHtml).toContain('id="forja-selection-modal"');
+  expect(playerHtml).toContain('id="forja-roll-modal"');
+});
+
+test("patch: compositor conserva actor, tipo y expresión reales", () => {
+  expect(engine).toContain('actorSelect.id = "player-actor-select"');
+  expect(engine).toContain('typeSelect.id = "player-tipo-dialogo-select"');
+  expect(playerHtml).toContain('id="player-expression"');
+  expect(playerJs).toContain("opt.dataset.sprite = spriteUrl;");
+  expect(playerJs).toContain("const assignedActor = window.getAssignedTheatreActor();");
+});
+
+test("patch: geometría 16:9 conserva diálogo inferior y cinco sprites dentro del ancho", () => {
+  expect(dialogueCss).toContain("left: 4vw;");
+  expect(dialogueCss).toContain("right: 4vw;");
+  expect(dialogueCss).toContain("bottom: 24px;");
+  expect(dialogueCss).toContain("height: clamp(150px, 21vh, 205px);");
+  expect(hudCss).toContain("flex: 0 1 20%;");
+  expect(hudCss).toContain("max-width: 20%;");
+  const spriteRule = block(hudCss, "#theatre-view-player > #theatre-stage > .theatre-sprite,", "/* Compatibilidad");
+  expect(spriteRule).not.toContain("aspect-ratio: 16 / 9");
+});
+
+test("patch: menú hamburguesa reutiliza herramientas existentes sin duplicarlas", () => {
+  const menuIdCount = (playerHtml.match(/id="hud-menu-dropdown"/g) || []).length;
+  const toggleIdCount = (playerHtml.match(/id="btn-toggle-hud-menu"/g) || []).length;
+  expect(menuIdCount).toBe(1);
+  expect(toggleIdCount).toBe(1);
+  expect(playerJs).toContain('const btnMenu = e.target.closest("#btn-toggle-hud-menu")');
+  expect(playerJs).toContain('sidebar.classList.toggle("is-open")');
+  const hamburgerBlock = block(playerJs, "// --- LÓGICA DEL TOGGLE DEL MENÚ HAMBURGUESA DERECHO ---", "// --- LÓGICA DEL TOGGLE DEL HUD DE COMBATE");
+  expect(hamburgerBlock).not.toContain("cloneNode");
+  expect(hamburgerBlock).not.toContain("appendChild");
+});
+
+test("patch: tipografías del Teatro usan BebasKai y Roboto con los fallbacks requeridos", () => {
+  expect(hudCss).toContain('font-family: "BebasKai", Impact, "Arial Narrow", sans-serif !important;');
+  expect(hudCss).toContain('font-family: "Roboto", Arial, sans-serif !important;');
+  expect(dialogueCss).not.toContain('"Bebas Kai"');
+  expect(playerHtml).not.toContain("'Bebas Kai'");
+});
+
+test("patch: compositor permanece centrado sobre el HUD y no ocupa el panel completo", () => {
+  expect(playerHtml).toContain('id="modal-escritura-teatro" style="display: none; position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; background: rgba(0,0,0,0.6); z-index: 9999; justify-content: center; align-items: center;"');
+  expect(playerHtml).toContain("max-width: 500px");
+  expect(hudCss).toContain("#modal-escritura-teatro textarea");
+});
+
+test("patch: compositor del DM conserva narración, diálogo y pensamiento", () => {
+  const dmHtml = read("hoja_de_DM.html");
+  expect(dmHtml).toContain('id="dm-tipo-dialogo-select"');
+  expect(dmHtml).toContain('<option value="dialogo">Diálogo</option>');
+  expect(dmHtml).toContain('<option value="narracion">Narración</option>');
+  expect(dmHtml).toContain('<option value="pensamiento">Pensamiento</option>');
+  expect(dashboard).toContain('if (!speakerSelect || speakerSelect.value === "narrador")');
+  expect(dashboard).toContain('type = "narracion";');
+});

--- a/tests/theatre_realtime.spec.js
+++ b/tests/theatre_realtime.spec.js
@@ -20,12 +20,12 @@ const workshopPage = fs.readFileSync(
 );
 
 test("el centro de mando mantiene una suscripción a la escena del Teatro", () => {
-  expect(dashboardScript).toContain('SCENE_ROOT + "/actores").on("value"');
+  expect(dashboardScript).toContain('database.ref(`${paths().scene}/actores`).on("value"');
   expect(dmPage).toContain('id="theatre-stage"');
 });
 
 test("el centro de mando muestra el estado de conexión en tiempo real", () => {
-  expect(dashboardScript).toContain('db.ref(".info/connected").on("value"');
+  expect(dashboardScript).toContain('database.ref(".info/connected").on("value"');
   expect(dmPage).toContain('id="connection-status"');
 });
 
@@ -93,30 +93,28 @@ test("el rediseño moderno del form de actores existe y tiene dos rutas (Require
   expect(workshopPage).toContain("css/actor-studio.css"); // CSS check
 });
 
-test("la biblioteca de escenarios contiene los controles y utiliza update", () => {
+test("la biblioteca de escenarios contiene los controles y entra por changeScene", () => {
   expect(dmPage).toContain('id="theatre-scenario-select"');
   expect(dmPage).toContain('id="theatre-scenario-location-filter"');
   expect(dmPage).toContain('id="theatre-scenario-tag-filter"');
-  expect(dashboardScript).toContain('db.ref(SCENARIOS_ROOT).on("value"');
-  expect(dashboardScript).toContain("db.ref(SCENE_ROOT).update({");
+  expect(dashboardScript).toContain('database.ref(SCENARIOS_ROOT).on("value"');
+  expect(dashboardScript).toContain("await theatre.changeScene");
 });
 
 test("el guardado de escenarios procesa sub-etiquetas", () => {
-  expect(dashboardScript).toContain("sub_etiquetas: subEtiquetas");
+  expect(dashboardScript).toContain("sub_etiquetas: normalizedTags()");
 });
 
 test("el teatro permite selectores de hablante y expresiones", () => {
   expect(dmPage).toContain('id="theatre-speaker-select"');
   expect(dmPage).toContain('id="theatre-expression-select"');
-  expect(dashboardScript).toContain(
-    "speakerData.actorId = speakerSelect.value"
-  );
+  expect(dashboardScript).toContain("actorId: speakerSelect.value");
 });
 
 test("el mensaje enviado a la cola contiene datos de actor y colores", () => {
-  expect(dashboardScript).toContain("actorId: speakerData.actorId");
-  expect(dashboardScript).toContain("expression: speakerData.expression");
-  expect(dashboardScript).toContain("color_nombre: speakerData.color_nombre");
+  expect(dashboardScript).toContain("actorId: speaker.actorId");
+  expect(dashboardScript).toContain("expression: actorDialogue ? speaker.expression : null");
+  expect(dashboardScript).toContain("color_nombre: speaker.color_nombre");
 });
 
 test("el motor del teatro utiliza el actorId para iluminar y colorea el diálogo", () => {
@@ -124,121 +122,24 @@ test("el motor del teatro utiliza el actorId para iluminar y colorea el diálogo
     path.join(__dirname, "..", "js", "theatre-engine.js"),
     "utf8"
   );
-  expect(engineScript).toContain("const activeActorId = dialogData.actorId");
+  expect(engineScript).toContain("const activeActorId = dialogData?.actorId || currentScene?.active_actor || null");
   expect(engineScript).toContain(
-    "paintIdentityPlate(nameEl, dialogData.color_nombre)"
+    "paintIdentityPlate(nameEl, currentDialogue.color_nombre)"
   );
 });
 
-test("el color de titulo aplica a la placa de titulo y no al texto (Requisito de teatro)", async ({
-  page,
-}) => {
-  // Intecept Firebase so we can load the page offline
-  await page.route("**/*firebase*.js", (route) => route.fulfill({ body: "" }));
-
-  // Inject mock firebase and CSS supports
-  await page.addInitScript(() => {
-    window.firebase = {
-      database: () => ({
-        ref: () => ({
-          on: () => {},
-          update: () => {},
-          set: () => {},
-        }),
-      }),
-      auth: () => ({
-        onAuthStateChanged: (cb) => cb({ uid: "mock-uid" }),
-        setPersistence: () => Promise.resolve(),
-      }),
-    };
-    window.firebase.auth.Auth = { Persistence: { LOCAL: "local" } };
-  });
-
-  await page.goto(
-    `file://${path.join(__dirname, "..", "hoja_personaje.html")}`
-  );
-
-  // Evaluate the shared engine logic directly to test behavior
-  const engineResult = await page.evaluate(() => {
-    const titleEl = document.createElement("div");
-    titleEl.id = "player-theatre-plate-title";
-    document.body.appendChild(titleEl);
-
-    // Mock the engine's functions since we can't easily wait for the script to load offline
-    function getSafeCssColor(value, fallback) {
-      const candidate = typeof value === "string" ? value.trim() : "";
-      if (!candidate) return fallback;
-      if (window.CSS && typeof window.CSS.supports === "function") {
-        return window.CSS.supports("color", candidate) ? candidate : fallback;
-      }
-      return /^#[0-9a-f]{3,8}$/i.test(candidate) ? candidate : fallback;
-    }
-
-    function paintIdentityPlate(titleEl, colorValue) {
-      const titleColor = getSafeCssColor(colorValue, "#4a4a4a");
-      titleEl.style.setProperty("color", "#ffffff", "important");
-      titleEl.style.setProperty(
-        "background",
-        `linear-gradient(90deg, ${titleColor} 0%, ${titleColor} 68%, #17110b 100%)`,
-        "important"
-      );
-      titleEl.style.setProperty("border-left-color", titleColor, "important");
-    }
-
-    // 1. Valid Color Test
-    paintIdentityPlate(titleEl, "#6252a3");
-    const validColor = titleEl.style.color;
-    const validBackground = titleEl.style.background;
-    const validBorderLeft = titleEl.style.borderLeftColor;
-
-    // 2. Invalid/Empty Color Test (Fallback)
-    paintIdentityPlate(titleEl, "");
-    const fallbackBackground = titleEl.style.background;
-    const fallbackBorderLeft = titleEl.style.borderLeftColor;
-
-    return {
-      validColor,
-      validBackground,
-      validBorderLeft,
-      fallbackBackground,
-      fallbackBorderLeft,
-    };
-  });
-
-  // 1. Text color should always be #ffffff
-  expect(engineResult.validColor).toBe("rgb(255, 255, 255)"); // Computed hex to rgb
-
-  // 2. Background and border should use #6252a3 when valid
-  expect(engineResult.validBackground).toContain("rgb(98, 82, 163)"); // #6252a3
-  expect(engineResult.validBorderLeft).toBe("rgb(98, 82, 163)");
-
-  // 3. Fallback should use #3b2918
-  expect(engineResult.fallbackBackground).toContain("rgb(74, 74, 74)"); // #4a4a4a
-  expect(engineResult.fallbackBorderLeft).toBe("rgb(74, 74, 74)");
-
-  // 4. Check for shared engine inclusion
-  const dmPageCurrent = fs.readFileSync(
-    path.join(__dirname, "..", "hoja_de_DM.html"),
-    "utf8"
-  );
-  const playerPage = fs.readFileSync(
-    path.join(__dirname, "..", "hoja_personaje.html"),
-    "utf8"
-  );
-  expect(dmPageCurrent).toContain('src="js/theatre-engine.js"');
-  expect(playerPage).toContain('src="js/theatre-engine.js"');
-
-  // 5. Ensure no illegal text assignments
+test("el color de titulo aplica a la placa de titulo y no al texto (Requisito de teatro)", () => {
   const engineScript = fs.readFileSync(
     path.join(__dirname, "..", "js", "theatre-engine.js"),
     "utf8"
   );
-  expect(engineScript).not.toContain(
-    "titleEl.style.color = dialogData.color_titulo"
-  );
-  expect(playerPage).not.toContain(
-    "titlePlate.style.color = state.color_titulo"
-  );
+
+  expect(engineScript).toContain('const plateColor = getSafeCssColor(value, "#4a4a4a");');
+  expect(engineScript).toContain('element.style.setProperty("color", "#ffffff", "important");');
+  expect(engineScript).toContain('`linear-gradient(90deg, ${plateColor} 0%, ${plateColor} 68%, #17110b 100%)`');
+  expect(engineScript).toContain('element.style.setProperty("border-left-color", plateColor, "important");');
+  expect(engineScript).not.toContain("titleEl.style.color = dialogData.color_titulo");
+  expect(engineScript).not.toContain("nameEl.style.color = dialogData.color_nombre");
 });
 
 test("el centro de mando reacciona a los cambios de locación", () => {
@@ -246,9 +147,8 @@ test("el centro de mando reacciona a los cambios de locación", () => {
     path.join(__dirname, "..", "js", "theatre-engine.js"),
     "utf8"
   );
-  expect(engineScript).toContain(
-    'db.ref(`${THEATRE_ROOT}/locacion`).on("value"'
-  );
+  expect(engineScript).toContain('locacionEl.textContent = currentScene.locacion || "LOCALIZACIÓN DESCONOCIDA"');
+  expect(engineScript).toContain('sceneRef.on("value", sceneListener)');
 });
 
 test("las reglas de base de datos restringen el acceso a los escenarios", () => {
@@ -380,12 +280,7 @@ test("la inicialización del directorio se realiza antes que módulos opcionales
   expect(startIdx).toBeLessThan(weatherIdx);
 });
 
-test("los fallbacks de color de titulo en dashboard y controles usan #3b2918", async ({
-  page,
-}) => {
-  // We're just asserting the absence of the explicit color_titulo fallback statically
-  // since playwright does not directly evaluate the non-exported functions,
-  // but we can evaluate the files manually.
+test("los actores sin color delegan en el fallback gris de las placas", () => {
   const dashboardScript = fs.readFileSync(
     path.join(__dirname, "..", "js", "on-game-dashboard.js"),
     "utf8"
@@ -395,49 +290,59 @@ test("los fallbacks de color de titulo en dashboard y controles usan #3b2918", a
     "utf8"
   );
 
-  // Assert default constants exist
-  expect(dashboardScript).toContain('const DEFAULT_TITLE_COLOR = "#3b2918";');
-  expect(controlsScript).toContain('const DEFAULT_TITLE_COLOR = "#3b2918";');
-
-  // Assert no '#aaaaaa' remains linked to color_titulo
+  expect(dashboardScript).toContain('option.dataset.colorNombre = actor.color_nombre || "";');
+  expect(dashboardScript).toContain('option.dataset.colorTitulo = actor.color_titulo || "";');
+  expect(controlsScript).toContain('color_nombre: npcData.color_nombre || ""');
+  expect(controlsScript).toContain('color_titulo: npcData.color_titulo || ""');
   expect(dashboardScript).not.toMatch(/color_titulo:.*#aaaaaa/);
-  expect(dashboardScript).not.toMatch(/colorTitulo:.*#aaaaaa/);
   expect(controlsScript).not.toMatch(/color_titulo:.*#aaaaaa/);
-  expect(controlsScript).not.toMatch(/colorTitulo:.*#aaaaaa/);
 });
 
-test("el fallback de color para las identidades es gris y el texto siempre es blanco", async ({ page }) => {
+test("el fallback de color para las identidades es gris y el texto siempre es blanco", () => {
   const engineScript = fs.readFileSync(path.join(__dirname, "..", "js", "theatre-engine.js"), "utf8");
   expect(engineScript).toContain('const plateColor = getSafeCssColor(value, "#4a4a4a");');
-  expect(engineScript).toContain('element.style.setProperty("color", "", ""); // Remove hardcoded white, keep default styles for text');
+  expect(engineScript).toContain('element.style.setProperty("color", "#ffffff", "important");');
+  expect(engineScript).toContain('`linear-gradient(90deg, ${plateColor} 0%, ${plateColor} 68%, #17110b 100%)`');
 });
 
-test("el narrador y pensamientos no envían identidad ni modifican sprites", async ({ page }) => {
+test("el narrador y pensamientos no envían identidad ni modifican sprites", () => {
   const dashboardScript = fs.readFileSync(path.join(__dirname, "..", "js", "on-game-dashboard.js"), "utf8");
-  expect(dashboardScript).toContain('tipoDialogo = "narracion"');
-  expect(dashboardScript).toContain('mostrarIdentidad = false');
+  const engineScript = fs.readFileSync(path.join(__dirname, "..", "js", "theatre-engine.js"), "utf8");
+  expect(dashboardScript).toContain('type = "narracion";');
+  expect(dashboardScript).toContain('expression: actorDialogue ? speaker.expression : null');
+  expect(dashboardScript).toContain('sprite: actorDialogue ? speaker.sprite : null');
+  expect(dashboardScript).toContain('mostrar_identidad: actorDialogue');
+  expect(engineScript).toContain('if (type === "pensamiento" || dialogData?.mostrar_identidad === false)');
 });
 
-test("el composer del jugador muestra selector solo cuando hay mas de un personaje", async ({ page }) => {
+test("el composer del jugador muestra selector solo cuando hay mas de un personaje", () => {
   const playerScript = fs.readFileSync(path.join(__dirname, "..", "hoja_personaje.js"), "utf8");
+  const engineScript = fs.readFileSync(path.join(__dirname, "..", "js", "theatre-engine.js"), "utf8");
+  expect(engineScript).toContain('actorSelect.id = "player-actor-select"');
+  expect(engineScript).toContain('typeSelect.id = "player-tipo-dialogo-select"');
   expect(playerScript).toContain('selectActor.style.display = "none"');
   expect(playerScript).toContain('selectActor.style.display = "block"');
 });
 
-test("resizeFontToFit modifica el tamaño directamente reduciendo px", async ({ page }) => {
+test("resizeFontToFit modifica el tamaño directamente reduciendo px", () => {
   const engineScript = fs.readFileSync(path.join(__dirname, "..", "js", "theatre-engine.js"), "utf8");
   expect(engineScript).toContain('textEl.style.fontSize = `${size}px`;');
 });
 
-test("el log usa icono universal y no sprite", async ({ page }) => {
+test("el log usa icono universal y no sprite", () => {
   const playerScript = fs.readFileSync(path.join(__dirname, "..", "hoja_personaje.js"), "utf8");
-  expect(playerScript).toContain('msg.icono || cachedIcon || fallbackIcon;');
-  expect(playerScript).not.toMatch(/finalIcon\s*=\s*.*msg\.sprite/);
+  const engineScript = fs.readFileSync(path.join(__dirname, "..", "js", "theatre-engine.js"), "utf8");
+  const renderBlock = playerScript.slice(playerScript.indexOf("function resolveTheatreLogIcon"), playerScript.indexOf("// === ENVÍO AL TEATRO"));
+  expect(renderBlock).toContain('return msg.icono || cachedIcon || fallbackIcon;');
+  expect(renderBlock).not.toContain("msg.sprite");
+  expect(engineScript).toContain('src.includes("via.placeholder.com")');
+  expect(engineScript).toContain("data:image/svg+xml");
 });
 
-test("sprites en escenario respetan max 5 visibles", async ({ page }) => {
+test("sprites en escenario respetan max 5 visibles sin mover al hablante ya visible", () => {
   const engineScript = fs.readFileSync(path.join(__dirname, "..", "js", "theatre-engine.js"), "utf8");
-  expect(engineScript).toContain('db.ref("campaña/estado_mundo/escena_actual/actores_visibles")');
-  expect(engineScript).toContain('renderIds = validActors.slice(0, 5).map(a => a.id);');
-  expect(engineScript).toContain('if (!renderIds.includes(img.dataset.id)) {');
+  expect(engineScript).toContain("const maxVisible = getVisibleLimit(scene);");
+  expect(engineScript).toContain("if (visibles.includes(actorId)) return visibles;");
+  expect(engineScript).toContain("while (visibles.length > maxVisible) visibles.shift();");
+  expect(engineScript).toContain('const explicitVisible = normalizeIdList(scene?.actores_visibles).slice(-maxVisible);');
 });


### PR DESCRIPTION
## Alcance

Parche localizado sobre el Theatre existente en `main` (`46f4d394c4a97951b619e2c4d98dd68fafaa0452`). No reconstruye el Teatro, no cambia rutas Firebase, no añade dependencias de producción y no toca Tienda, Forja, combate, inventario ni código móvil.

### Archivos modificados

- `css/theatre-dialogue.css`
- `css/theatre-hud.css`
- `js/on-game-dashboard.js`
- `js/theatre-controls.js`
- `js/theatre-engine.js`
- `tests/player_theatre_regression.spec.js`
- `tests/theatre_realtime.spec.js`
- `tests/theatre_hud_detail_patch.spec.js`

El PR contiene un solo commit de producto/pruebas. No quedan workflows, payloads, capturas ni archivos temporales usados durante la preparación.

## Correcciones

- Placas de identidad con fallback neutral `#4a4a4a`, texto siempre `#ffffff` y colores del actor aplicados únicamente al fondo/borde.
- Narrador sin nombre, título, placas ni sprite; pensamiento sin identidad y sin revelar/cambiar expresión o sprite.
- Catálogo de actores separado de `actores_visibles`: añadir al catálogo ya no auto-spawnea ni selecciona expresión.
- Sprites visibles requieren URL válida; máximo configurable hasta 5. Se conserva el FIFO estable aceptado por #511: un actor ya visible que vuelve a hablar no se reordena; un actor nuevo por encima del límite expulsa al más antiguo.
- Compositor del jugador reutiliza el modal existente. Integra los selectores de personaje/tipo que faltaban, conserva expresión con `option.dataset.sprite`, bloquea el caso sin actor y mantiene la lógica 0/1/múltiples sin crear un segundo botón ni listener de envío.
- El log mantiene la resolución `msg.icono -> actorId -> nombre -> fallback`; nunca usa `msg.sprite`. El antiguo placeholder externo se sustituye en runtime por iniciales SVG locales y fallback local de error, sin rediseñar el log.
- `resizeFontToFit()` puede modificar `font-size` porque la regla del diálogo ya no lo bloquea con `!important`.
- Geometría PC 16:9: diálogo inferior (`left/right: 4vw`, `bottom: 24px`, `height: clamp(150px, 21vh, 205px)`), sprites contenidos/alineados al fondo y cinco actores caben dentro del escenario.
- Tipografías Theatre: `BebasKai` para identidad/encabezados y `Roboto` para diálogo/controles.

## Validación

Baseline sobre `main` antes del parche:
- Los cuatro `node --check` solicitados pasaban.
- La suite Theatre existente daba 34/50: 9 aserciones estaban desactualizadas respecto al Theatre #511 actual y 7 pruebas dependían de un ejecutable Chromium ausente en ese entorno. Se registró este baseline antes de modificar producto.

Después del parche, sobre exactamente los blobs publicados en este PR:
- `node --check hoja_personaje.js` ✅
- `node --check js/theatre-engine.js` ✅
- `node --check js/on-game-dashboard.js` ✅
- `node --check js/theatre-controls.js` ✅
- `git diff --check` ✅
- Playwright Theatre (`theatre_issue_511`, `player_theatre_regression`, `theatre_realtime`, `theatre_hud_detail_patch`): **73/73 passed** ✅
- GitHub Actions remoto `Theatre Engine #511` sobre `abd1faadc61d2c7b9f092e9b467b428ff3635d03`: **success** ✅

La validación visual se realizó localmente en Chromium a 1600×900, incluyendo neutral gris, colores configurados, narrador, compositor, director, log, cinco sprites reales y texto largo. Las capturas no se incorporaron al repositorio, conforme al requisito de no versionar evidencias fuera de una carpeta oficial.

## Limitaciones

No se afirma una prueba E2E contra Firebase de producción con varios clientes autenticados simultáneamente; la cobertura ejecutada es la suite Theatre del repositorio más la validación visual/funcional local. No incluye versión móvil.

Este PR permanece en **Draft** y no se hará merge automáticamente.