### PR TITLE
Corrige UI del teatro: placas, locación y menús

### DIFF
--- a/css/theatre-dialogue.css
+++ b/css/theatre-dialogue.css
@@ -305,6 +305,38 @@ html body.on-game-dashboard #modulo-teatro .theatre-dm-menu-toggle > img {
   margin: 0 !important;
 }
 
+/* El SVG de DM ya trae un heptágono dibujado; el botón CSS también. Ocultamos
+ * ese wrapper duplicado y usamos el mismo glyph de tres barras del jugador. */
+html body.on-game-dashboard #modulo-teatro .theatre-dm-menu-toggle > img {
+  display: none !important;
+}
+
+html body.on-game-dashboard #modulo-teatro .theatre-dm-menu-toggle::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  z-index: 2;
+  width: 24px;
+  height: 16px;
+  background: linear-gradient(
+    to bottom,
+    currentColor 0 2px,
+    transparent 2px 7px,
+    currentColor 7px 9px,
+    transparent 9px 14px,
+    currentColor 14px 16px
+  );
+  transform: translate(-50%, -50%);
+  transform-origin: center;
+  transition: transform 160ms ease;
+  pointer-events: none;
+}
+
+html body.on-game-dashboard #modulo-teatro .theatre-dm-menu[open] .theatre-dm-menu-toggle::after {
+  transform: translate(-50%, -50%) rotate(90deg);
+}
+
 @media (max-width: 700px) {
   html body.player-instance-theatre .hud-sidebar-right .hud-menu-toggle > svg,
   html body.player-instance-theatre .hud-sidebar-right #hud-menu-dropdown .hud-menu-item > svg,
@@ -317,5 +349,18 @@ html body.on-game-dashboard #modulo-teatro .theatre-dm-menu-toggle > img {
     max-width: 21px !important;
     max-height: 21px !important;
     flex-basis: 21px !important;
+  }
+
+  html body.on-game-dashboard #modulo-teatro .theatre-dm-menu-toggle::after {
+    width: 20px;
+    height: 14px;
+    background: linear-gradient(
+      to bottom,
+      currentColor 0 2px,
+      transparent 2px 6px,
+      currentColor 6px 8px,
+      transparent 8px 12px,
+      currentColor 12px 14px
+    );
   }
 }

--- a/css/theatre-dialogue.css
+++ b/css/theatre-dialogue.css
@@ -256,3 +256,66 @@
     flex-grow: 1 !important;
     pointer-events: auto !important;
 }
+
+/* ==================================================
+   CORRECCIONES COMPARTIDAS DE UI DEL TEATRO
+   ================================================== */
+
+/*
+ * theatre-hud.css fuerza display:flex !important en las placas. El motor usa
+ * display:none inline para narración/pensamiento, así que esta regla respeta
+ * explícitamente ese estado y elimina por completo name + title plates.
+ */
+html body #theatre-view-player .theatre-plates-container[style*="display: none"],
+html body.on-game-dashboard #modulo-teatro .theatre-plates-container[style*="display: none"] {
+  display: none !important;
+}
+
+/*
+ * Mantener el heptágono como contenedor y centrar el glyph real. Esto evita
+ * que Menu.svg y los iconos del HUD se estiren a 100% con aspect-ratio 16/9.
+ */
+html body.player-instance-theatre .hud-sidebar-right .hud-menu-toggle,
+html body.player-instance-theatre .hud-sidebar-right #hud-menu-dropdown .hud-menu-item,
+html body.on-game-dashboard #modulo-teatro .theatre-dm-menu-toggle {
+  padding: 0 !important;
+  line-height: 0 !important;
+}
+
+html body.player-instance-theatre .hud-sidebar-right .hud-menu-toggle::before,
+html body.player-instance-theatre .hud-sidebar-right #hud-menu-dropdown .hud-menu-item::before,
+html body.on-game-dashboard #modulo-teatro .theatre-dm-menu-toggle::before {
+  aspect-ratio: auto !important;
+}
+
+html body.player-instance-theatre .hud-sidebar-right .hud-menu-toggle > svg,
+html body.player-instance-theatre .hud-sidebar-right #hud-menu-dropdown .hud-menu-item > svg,
+html body.player-instance-theatre .hud-sidebar-right #hud-menu-dropdown .hud-menu-item > img:not(#tienda-fisica-badge),
+html body.on-game-dashboard #modulo-teatro .theatre-dm-menu-toggle > img {
+  width: 26px !important;
+  height: 26px !important;
+  min-width: 26px !important;
+  min-height: 26px !important;
+  max-width: 26px !important;
+  max-height: 26px !important;
+  flex: 0 0 26px !important;
+  object-fit: contain !important;
+  object-position: center !important;
+  aspect-ratio: 1 / 1 !important;
+  margin: 0 !important;
+}
+
+@media (max-width: 700px) {
+  html body.player-instance-theatre .hud-sidebar-right .hud-menu-toggle > svg,
+  html body.player-instance-theatre .hud-sidebar-right #hud-menu-dropdown .hud-menu-item > svg,
+  html body.player-instance-theatre .hud-sidebar-right #hud-menu-dropdown .hud-menu-item > img:not(#tienda-fisica-badge),
+  html body.on-game-dashboard #modulo-teatro .theatre-dm-menu-toggle > img {
+    width: 21px !important;
+    height: 21px !important;
+    min-width: 21px !important;
+    min-height: 21px !important;
+    max-width: 21px !important;
+    max-height: 21px !important;
+    flex-basis: 21px !important;
+  }
+}

--- a/js/instance-control.js
+++ b/js/instance-control.js
@@ -2,6 +2,7 @@
   "use strict";
 
   const INSTANCE_PATH = "campaña/estado_mundo/instancia_activa";
+  const DEFAULT_THEATRE_SCENE_PATH = "campaña/estado_mundo/escena_actual";
 
   function normalizeInstance(instance) {
     return typeof instance === "string" && instance.trim()
@@ -107,10 +108,71 @@
     console.warn("LuminousInstanceControl.bindDm is deprecated. Use bindDashboard.");
   }
 
+  function getTheatreScenePath() {
+    return global.LuminousTheatreState?.getPaths?.().scene || DEFAULT_THEATRE_SCENE_PATH;
+  }
+
+  function ensureDmLocationControl({ db, doc } = {}) {
+    const documentRef = doc || global.document;
+    if (!db || !documentRef?.body?.classList.contains("on-game-dashboard")) return null;
+
+    const locationInput = documentRef.getElementById("theatre-location-input");
+    if (!locationInput) return null;
+
+    let button = documentRef.getElementById("btn-update-theatre-location");
+    if (button) return button;
+
+    button = documentRef.createElement("button");
+    button.id = "btn-update-theatre-location";
+    button.type = "button";
+    button.className = "btn-action theatre-location-only-btn";
+    button.textContent = "ACTUALIZAR LOCALIZACIÓN";
+    button.title = "Cambia solo el cartel de localización sin hacer transición ni modificar el fondo";
+    button.style.cssText = "padding:8px;background:#1a222c;color:#a37c35;border:1px solid #a37c35;cursor:pointer;width:100%;box-sizing:border-box;";
+    locationInput.insertAdjacentElement("afterend", button);
+
+    const updateLocation = async () => {
+      const locationName = String(locationInput.value || "").trim();
+      if (!locationName) {
+        global.alert?.("Escribe una localización antes de actualizarla.");
+        return;
+      }
+
+      const previousText = button.textContent;
+      button.disabled = true;
+      button.textContent = "ACTUALIZANDO...";
+      try {
+        await db.ref(`${getTheatreScenePath()}/locacion`).set(locationName);
+        button.textContent = "LOCALIZACIÓN ACTUALIZADA";
+        global.setTimeout(() => {
+          if (button.isConnected) button.textContent = previousText;
+        }, 1200);
+      } catch (error) {
+        console.error("No se pudo actualizar la localización del Theatre:", error);
+        button.textContent = previousText;
+        global.alert?.("No se pudo actualizar la localización.");
+      } finally {
+        button.disabled = false;
+      }
+    };
+
+    button.addEventListener("click", updateLocation);
+    locationInput.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" && (event.ctrlKey || event.metaKey)) {
+        event.preventDefault();
+        updateLocation();
+      }
+    });
+
+    return button;
+  }
+
   function bindDashboard({ db, doc } = {}) {
     const documentRef = doc || global.document;
     if (!db || !documentRef) return;
     const instanceRef = db.ref(INSTANCE_PATH);
+
+    ensureDmLocationControl({ db, doc: documentRef });
 
     documentRef.querySelectorAll('input[name="instancia"]').forEach(radio => {
         radio.addEventListener('change', (evento) => {
@@ -147,6 +209,7 @@
     applyDmInstance,
     applyPlayerInstance,
     applyDashboardInstance,
+    ensureDmLocationControl,
     bindDm,
     bindDashboard,
     bindPlayer,

--- a/tests/theatre_ui_polish.spec.js
+++ b/tests/theatre_ui_polish.spec.js
@@ -1,0 +1,43 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
+const dialogueCss = read("css/theatre-dialogue.css");
+const instanceControl = read("js/instance-control.js");
+
+function block(source, start, end) {
+  const from = source.indexOf(start);
+  expect(from).toBeGreaterThanOrEqual(0);
+  const to = end ? source.indexOf(end, from) : source.length;
+  return source.slice(from, to < 0 ? source.length : to);
+}
+
+test("narración y pensamiento pueden ocultar por completo name/title plates", () => {
+  expect(dialogueCss).toContain('.theatre-plates-container[style*="display: none"]');
+  expect(dialogueCss).toMatch(/theatre-plates-container\[style\*="display: none"\][\s\S]*?display:\s*none\s*!important/);
+});
+
+test("el controlador de localización reutiliza el input y solo escribe locacion", () => {
+  const locationControl = block(instanceControl, "function ensureDmLocationControl", "function bindDashboard");
+  expect(locationControl).toContain('getElementById("theatre-location-input")');
+  expect(locationControl).toContain('button.id = "btn-update-theatre-location"');
+  expect(locationControl).toContain('db.ref(`${getTheatreScenePath()}/locacion`).set(locationName)');
+  expect(locationControl).not.toContain("changeScene");
+  expect(locationControl).not.toContain("/fondo");
+  expect(locationControl).not.toContain("dialogue");
+});
+
+test("hamburguesa del jugador usa glyphs centrados de tamaño fijo", () => {
+  expect(dialogueCss).toContain(".hud-sidebar-right .hud-menu-toggle > svg");
+  expect(dialogueCss).toContain("width: 26px !important;");
+  expect(dialogueCss).toContain("height: 26px !important;");
+  expect(dialogueCss).toContain("aspect-ratio: 1 / 1 !important;");
+});
+
+test("hamburguesa del DM evita el heptágono SVG duplicado", () => {
+  expect(dialogueCss).toMatch(/\.theatre-dm-menu-toggle > img\s*\{[\s\S]*?display:\s*none\s*!important/);
+  expect(dialogueCss).toContain(".theatre-dm-menu-toggle::after");
+  expect(dialogueCss).toContain("currentColor 7px 9px");
+  expect(dialogueCss).toContain("rotate(90deg)");
+});


### PR DESCRIPTION
## Qué cambia

- Oculta por completo `name` y `title` plates durante narración y pensamiento, respetando el `display: none` que ya publica el motor.
- Los nameplates vuelven a mostrarse automáticamente cuando entra un diálogo normal con identidad visible.
- Reutiliza `#theatre-location-input` en la hoja de DM y agrega un botón `ACTUALIZAR LOCALIZACIÓN` que solo escribe `scene/locacion`.
- El cambio de locación independiente no ejecuta transición, no cambia el fondo, no limpia diálogo y no toca actores.
- Normaliza los iconos del menú hamburguesa en jugador y DM para que no se estiren al 100% ni hereden `aspect-ratio: 16/9`.
- En DM se evita el heptágono duplicado que ya venía dibujado dentro de `Menu.svg`; el glyph de hamburguesa se dibuja centrado dentro del botón existente.
- Añade pruebas de regresión estáticas para los tres comportamientos.

## Causa raíz

1. `theatre-engine.js` ya hacía `platesContainer.style.display = "none"` para narración/pensamiento, pero `theatre-hud.css` imponía `display: flex !important`, dejando las placas colapsadas en vez de invisibles.
2. El campo de localización estaba acoplado al flujo completo de escenarios, que exige fondo + localización y llama a `changeScene()`.
3. Los iconos compartidos del hamburguesa se forzaban a `width/height: 100%` y `aspect-ratio: 16/9`; además `Menu.svg` del DM ya contiene su propio heptágono, duplicando la geometría del botón CSS.

## Validación

- Se añadió `tests/theatre_ui_polish.spec.js` para verificar:
  - ocultamiento completo de placas;
  - escritura aislada de `locacion` sin `changeScene`;
  - tamaño fijo/centrado de glyphs del jugador;
  - eliminación del heptágono SVG duplicado en DM.
- Diff limitado a `css/theatre-dialogue.css`, `js/instance-control.js` y la nueva prueba.

Dejo este PR en **draft** para revisión visual/manual antes de merge.