### PR TITLE
Limita el teatro a un viewport 16:9 responsivo

### DIFF
--- a/css/theatre-dialogue.css
+++ b/css/theatre-dialogue.css
@@ -337,6 +337,44 @@ html body.on-game-dashboard #modulo-teatro .theatre-dm-menu[open] .theatre-dm-me
   transform: translate(-50%, -50%) rotate(90deg);
 }
 
+/*
+ * El teatro es una superficie 16:9, no un fondo infinito. Se calculan ancho y
+ * alto máximos que caben en la ventana; si una dimensión es menor, ambas se
+ * reducen proporcionalmente y el resto queda como letterbox fuera del teatro.
+ */
+html body.player-instance-theatre #theatre-view-player {
+  box-sizing: border-box !important;
+  width: min(100vw, 177.7778vh) !important;
+  height: min(100vh, 56.25vw) !important;
+  max-width: 100vw !important;
+  max-height: 100vh !important;
+  aspect-ratio: 16 / 9 !important;
+  inset: 0 !important;
+  margin: auto !important;
+  background-color: #000 !important;
+  background-size: cover !important;
+  background-position: center center !important;
+  background-repeat: no-repeat !important;
+}
+
+/* En DM reservamos los 64px de la barra maestra y centramos el viewport 16:9
+ * dentro del área restante. El panel de director sigue viviendo dentro de esa
+ * misma superficie, así que escenario, diálogo y controles comparten límites. */
+html body.on-game-dashboard #modulo-teatro.game-module {
+  box-sizing: border-box !important;
+  width: min(100vw, calc(177.7778vh - 113.7778px)) !important;
+  height: min(calc(100vh - 64px), 56.25vw) !important;
+  max-width: 100vw !important;
+  max-height: calc(100vh - 64px) !important;
+  aspect-ratio: 16 / 9 !important;
+  inset: 64px 0 0 !important;
+  margin: auto !important;
+  background-color: #000 !important;
+  background-size: cover !important;
+  background-position: center center !important;
+  background-repeat: no-repeat !important;
+}
+
 @media (max-width: 700px) {
   html body.player-instance-theatre .hud-sidebar-right .hud-menu-toggle > svg,
   html body.player-instance-theatre .hud-sidebar-right #hud-menu-dropdown .hud-menu-item > svg,

--- a/tests/theatre_ui_polish.spec.js
+++ b/tests/theatre_ui_polish.spec.js
@@ -41,3 +41,28 @@ test("hamburguesa del DM evita el heptágono SVG duplicado", () => {
   expect(dialogueCss).toContain("currentColor 7px 9px");
   expect(dialogueCss).toContain("rotate(90deg)");
 });
+
+test("viewport del teatro conserva 16:9 y nunca repite el fondo", () => {
+  const playerViewport = block(
+    dialogueCss,
+    "html body.player-instance-theatre #theatre-view-player {",
+    "/* En DM reservamos los 64px"
+  );
+  expect(playerViewport).toContain("width: min(100vw, 177.7778vh) !important;");
+  expect(playerViewport).toContain("height: min(100vh, 56.25vw) !important;");
+  expect(playerViewport).toContain("aspect-ratio: 16 / 9 !important;");
+  expect(playerViewport).toContain("background-size: cover !important;");
+  expect(playerViewport).toContain("background-repeat: no-repeat !important;");
+
+  const dmViewport = block(
+    dialogueCss,
+    "html body.on-game-dashboard #modulo-teatro.game-module {",
+    "@media (max-width: 700px)"
+  );
+  expect(dmViewport).toContain("width: min(100vw, calc(177.7778vh - 113.7778px)) !important;");
+  expect(dmViewport).toContain("height: min(calc(100vh - 64px), 56.25vw) !important;");
+  expect(dmViewport).toContain("aspect-ratio: 16 / 9 !important;");
+  expect(dmViewport).toContain("inset: 64px 0 0 !important;");
+  expect(dmViewport).toContain("background-size: cover !important;");
+  expect(dmViewport).toContain("background-repeat: no-repeat !important;");
+});


### PR DESCRIPTION
## Qué cambia

- Limita la superficie del Teatro del jugador a un viewport máximo 16:9 centrado.
- Limita la superficie del Teatro en la hoja de DM a 16:9 dentro del espacio disponible debajo de la barra maestra.
- Si la ventana es más pequeña o tiene otra proporción, el viewport se reduce proporcionalmente sin deformarse.
- El fondo usa `background-size: cover`, `background-position: center` y `background-repeat: no-repeat`, evitando el mosaico/repetición infinita cuando sobra espacio.
- Añade regresión estática para verificar dimensiones 16:9 y fondo no repetido.

## Causa raíz

El render del Teatro podía ocupar toda la superficie disponible aunque esta fuera más ancha/alta que 16:9. Como el fondo se aplicaba al contenedor sin una regla explícita de `background-repeat: no-repeat`, una imagen podía repetirse para cubrir el espacio excedente.

## Validación

- Se añadieron asserts a `tests/theatre_ui_polish.spec.js` para el viewport del jugador y del DM.
- El cambio parte del `main` actual, después del merge de #516, y queda limitado a CSS + regresión.

Dejo este PR en **draft** para revisión visual/manual antes de merge.