### PR TITLE
Convierte DM en control maestro y pule UX del jugador

### DIFF
--- a/css/player-ux-polish.css
+++ b/css/player-ux-polish.css
@@ -1,0 +1,289 @@
+/* ==================================================
+   PLAYER UX POLISH
+   Vínculos, directorio, log heptagonal y ajustes reales.
+   ================================================== */
+
+:root {
+  --player-ux-brass: #b98a32;
+  --player-ux-brass-light: #d8b65d;
+  --player-ux-panel: #10120f;
+  --player-ux-panel-2: #171a15;
+  --player-ux-line: #3c4037;
+  --player-ux-muted: #8d9084;
+  --player-ux-text: #e3decf;
+  --player-ux-red: #7b2025;
+}
+
+/* ---------- Personal Terminal: texto que siempre cabe ---------- */
+body:not(.on-game-dashboard) .sheet-app-grid {
+  min-width: 0 !important;
+}
+
+body:not(.on-game-dashboard) .sheet-app-btn {
+  min-width: 0 !important;
+  overflow: hidden !important;
+}
+
+body:not(.on-game-dashboard) .sheet-app-btn > span {
+  display: block !important;
+  width: 100% !important;
+  max-width: 100% !important;
+  min-width: 0 !important;
+  white-space: normal !important;
+  overflow-wrap: anywhere !important;
+  word-break: normal !important;
+  text-overflow: clip !important;
+  font-size: clamp(11px, 1.35vw, 15px) !important;
+  line-height: 1.12 !important;
+}
+
+body:not(.on-game-dashboard) .sheet-app-btn::before {
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@media (max-width: 700px) {
+  body:not(.on-game-dashboard) .sheet-app-btn {
+    min-height: 82px !important;
+    padding: 10px 9px 10px 46px !important;
+  }
+
+  body:not(.on-game-dashboard) .sheet-app-icon {
+    left: 11px !important;
+    width: 24px !important;
+    height: 24px !important;
+  }
+
+  body:not(.on-game-dashboard) .sheet-app-btn > span {
+    font-size: 12px !important;
+    letter-spacing: .035em !important;
+  }
+
+  body:not(.on-game-dashboard) .sheet-app-btn::before {
+    font-size: 7px !important;
+    letter-spacing: .06em !important;
+  }
+}
+
+/* ---------- Vínculos vs Directorio de Red ---------- */
+body:not(.on-game-dashboard) #subtab-contacts .player-network-directory-note {
+  margin: 0;
+  padding: 8px 10px;
+  color: #b7b9ad;
+  background: #0d100d;
+  border-bottom: 1px dashed #3b4036;
+  font: 10px/1.4 "Share Tech Mono", monospace;
+  letter-spacing: .035em;
+}
+
+body:not(.on-game-dashboard) #subtab-contacts .player-network-directory-note strong {
+  color: var(--player-ux-brass-light);
+  font-weight: 700;
+}
+
+/* ---------- Theatre log: retrato heptagonal ---------- */
+#theatre-view-player #theatre-log-container .character-col {
+  width: 92px !important;
+}
+
+#theatre-view-player #theatre-log-container .hex-border {
+  width: 58px !important;
+  height: 58px !important;
+  padding: 3px !important;
+  border-radius: 0 !important;
+  background: linear-gradient(145deg, #d4af55 0%, #6c4f21 48%, #271b10 100%) !important;
+  clip-path: polygon(50% 0%, 88% 17%, 100% 55%, 78% 100%, 22% 100%, 0 55%, 12% 17%) !important;
+  box-shadow: 0 5px 12px rgba(0,0,0,.35) !important;
+}
+
+#theatre-view-player #theatre-log-container .hex-portrait {
+  width: 52px !important;
+  height: 52px !important;
+  border-radius: 0 !important;
+  background: #15120e !important;
+  clip-path: polygon(50% 0%, 88% 17%, 100% 55%, 78% 100%, 22% 100%, 0 55%, 12% 17%) !important;
+}
+
+#theatre-view-player #theatre-log-container .hex-portrait img {
+  width: 100% !important;
+  height: 100% !important;
+  object-fit: cover !important;
+  object-position: center !important;
+  border-radius: 0 !important;
+}
+
+#theatre-view-player #theatre-log-container .character-name {
+  max-width: 90px;
+  overflow-wrap: anywhere;
+  text-align: center;
+  line-height: 1.05;
+}
+
+/* ---------- Ajustes del Personal Terminal ---------- */
+body:not(.on-game-dashboard) .player-settings-console {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding: 14px;
+  font-family: "Share Tech Mono", monospace;
+}
+
+body:not(.on-game-dashboard) .player-settings-section {
+  min-width: 0;
+  padding: 13px;
+  background: linear-gradient(145deg, #131611, #0b0d0b);
+  border: 1px solid #34382f;
+  border-left: 3px solid #765c2e;
+  box-shadow: inset 0 0 18px rgba(0,0,0,.38);
+}
+
+body:not(.on-game-dashboard) .player-settings-section h3 {
+  margin: 0 0 5px !important;
+  color: var(--player-ux-brass-light) !important;
+  font-size: 13px !important;
+  letter-spacing: .09em !important;
+}
+
+body:not(.on-game-dashboard) .player-settings-section > p {
+  margin: 0 0 12px;
+  color: var(--player-ux-muted);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+body:not(.on-game-dashboard) .player-setting-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  min-height: 40px;
+  padding: 8px 0;
+  border-top: 1px dashed #30342c;
+}
+
+body:not(.on-game-dashboard) .player-setting-row:first-of-type {
+  border-top: 0;
+}
+
+body:not(.on-game-dashboard) .player-setting-copy {
+  min-width: 0;
+}
+
+body:not(.on-game-dashboard) .player-setting-label {
+  display: block;
+  color: var(--player-ux-text);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .035em;
+}
+
+body:not(.on-game-dashboard) .player-setting-help {
+  display: block;
+  margin-top: 3px;
+  color: var(--player-ux-muted);
+  font-size: 9px;
+  line-height: 1.35;
+}
+
+body:not(.on-game-dashboard) .player-setting-toggle {
+  appearance: none;
+  width: 42px !important;
+  height: 22px !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  position: relative;
+  background: #222720 !important;
+  border: 1px solid #4b5145 !important;
+  border-radius: 0 !important;
+  cursor: pointer;
+}
+
+body:not(.on-game-dashboard) .player-setting-toggle::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 14px;
+  height: 14px;
+  background: #74786c;
+  transition: transform 140ms ease, background 140ms ease;
+}
+
+body:not(.on-game-dashboard) .player-setting-toggle:checked {
+  border-color: #9c7a39 !important;
+  background: #322a18 !important;
+}
+
+body:not(.on-game-dashboard) .player-setting-toggle:checked::after {
+  transform: translateX(19px);
+  background: var(--player-ux-brass-light);
+}
+
+body:not(.on-game-dashboard) .player-setting-volume-wrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+body:not(.on-game-dashboard) #player-setting-volume {
+  width: min(170px, 24vw) !important;
+  accent-color: var(--player-ux-brass);
+}
+
+body:not(.on-game-dashboard) #player-setting-volume-value {
+  min-width: 34px;
+  color: var(--player-ux-brass-light);
+  text-align: right;
+  font-size: 10px;
+}
+
+body:not(.on-game-dashboard) .player-settings-action {
+  min-height: 34px;
+  padding: 7px 10px !important;
+  color: var(--player-ux-text) !important;
+  background: #151814 !important;
+  border: 1px solid #474b41 !important;
+  cursor: pointer;
+  font: 700 10px/1.1 "Share Tech Mono", monospace !important;
+}
+
+body:not(.on-game-dashboard) .player-settings-action:hover {
+  border-color: var(--player-ux-brass) !important;
+  color: #fff4d4 !important;
+}
+
+body.player-terminal-large-text .sheet-phone-screen {
+  font-size: 1.09em !important;
+}
+
+body.player-terminal-compact .sheet-app-btn {
+  min-height: 68px !important;
+}
+
+body.player-terminal-compact .sheet-weather-widget {
+  padding-top: 8px !important;
+  padding-bottom: 8px !important;
+}
+
+body.player-reduce-motion *,
+body.player-reduce-motion *::before,
+body.player-reduce-motion *::after {
+  animation-duration: .001ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: .001ms !important;
+  scroll-behavior: auto !important;
+}
+
+@media (max-width: 700px) {
+  body:not(.on-game-dashboard) .player-settings-console {
+    grid-template-columns: 1fr;
+    gap: 9px;
+    padding: 9px;
+  }
+
+  body:not(.on-game-dashboard) #player-setting-volume {
+    width: 110px !important;
+  }
+}

--- a/css/theatre-actor-studio.css
+++ b/css/theatre-actor-studio.css
@@ -1,0 +1,220 @@
+/* ==================================================
+   THEATRE ACTOR STUDIO / DM UX
+   Distingue catálogo persistente de cast temporal.
+   ================================================== */
+
+.on-game-dashboard .npc-spawner-section {
+  padding: 10px;
+  background: #0b0e11;
+  border: 1px solid #29313a;
+  border-left: 3px solid #a37c35;
+}
+
+.on-game-dashboard .theatre-actor-source-note {
+  margin: 0;
+  color: #9ba2a8;
+  font: 10px/1.4 "Share Tech Mono", monospace;
+}
+
+.on-game-dashboard .theatre-actor-source-note strong {
+  color: #d1a84e;
+}
+
+.on-game-dashboard .theatre-actor-source-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 7px;
+}
+
+.on-game-dashboard .theatre-actor-source-actions button {
+  min-height: 34px;
+  padding: 7px 8px;
+  color: #e5e7e8;
+  background: #151a1f;
+  border: 1px solid #59616a;
+  cursor: pointer;
+  font: 700 10px/1.15 "Share Tech Mono", monospace;
+}
+
+.on-game-dashboard .theatre-actor-source-actions button:hover {
+  color: #f0c761;
+  border-color: #a37c35;
+}
+
+.on-game-dashboard #btn-spawn-npc[data-unlinked-player="true"] {
+  opacity: .45;
+  cursor: not-allowed;
+}
+
+.on-game-dashboard .actor-control-card .btn-edit-source {
+  flex-basis: 100%;
+  color: #d1a84e !important;
+  border-color: #806328 !important;
+  background: #17140d !important;
+}
+
+/* ---------- Modal de edición persistente ---------- */
+.theatre-actor-studio-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 12000;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+  background: rgba(0,0,0,.82);
+  backdrop-filter: blur(5px);
+}
+
+.theatre-actor-studio-overlay.open {
+  display: flex;
+}
+
+.theatre-actor-studio {
+  width: min(720px, 96vw);
+  max-height: min(760px, 92vh);
+  overflow: auto;
+  color: #e4e6e7;
+  background: linear-gradient(145deg, #11161b, #080b0e);
+  border: 1px solid #5c6268;
+  border-top: 3px solid #a37c35;
+  box-shadow: 0 24px 65px rgba(0,0,0,.76), inset 0 0 28px rgba(0,0,0,.46);
+  font-family: "Share Tech Mono", monospace;
+}
+
+.theatre-actor-studio__header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  align-items: flex-start;
+  padding: 14px 16px 12px;
+  background: rgba(12,15,18,.97);
+  border-bottom: 1px solid #303840;
+}
+
+.theatre-actor-studio__eyebrow {
+  display: block;
+  margin-bottom: 4px;
+  color: #8c9399;
+  font-size: 9px;
+  letter-spacing: .13em;
+}
+
+.theatre-actor-studio__title {
+  margin: 0;
+  color: #d0a94e;
+  font-size: 18px;
+  letter-spacing: .06em;
+}
+
+.theatre-actor-studio__close {
+  width: 34px;
+  height: 34px;
+  color: #ddd;
+  background: #171b1f;
+  border: 1px solid #4a5056;
+  cursor: pointer;
+}
+
+.theatre-actor-studio__body {
+  padding: 15px 16px;
+}
+
+.theatre-actor-studio__source {
+  margin: 0 0 13px;
+  padding: 9px 10px;
+  color: #b5bbc0;
+  background: #0b0e11;
+  border-left: 3px solid #76602f;
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.theatre-actor-studio__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.theatre-actor-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.theatre-actor-field--wide {
+  grid-column: 1 / -1;
+}
+
+.theatre-actor-field label {
+  color: #9fa6ac;
+  font-size: 9px;
+  letter-spacing: .07em;
+  text-transform: uppercase;
+}
+
+.theatre-actor-field input,
+.theatre-actor-field select {
+  width: 100%;
+  min-width: 0;
+  min-height: 36px;
+  padding: 7px 8px;
+  color: #fff;
+  background: #0c1014;
+  border: 1px solid #404850;
+  border-radius: 0;
+  font: 12px/1.2 "Share Tech Mono", monospace;
+}
+
+.theatre-actor-field input:focus,
+.theatre-actor-field select:focus {
+  outline: 1px solid rgba(163,124,53,.48);
+  border-color: #a37c35;
+}
+
+.theatre-actor-studio__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 13px 16px 16px;
+  border-top: 1px solid #303840;
+}
+
+.theatre-actor-studio__footer button {
+  min-height: 36px;
+  padding: 8px 13px;
+  cursor: pointer;
+  font: 700 11px/1 "Share Tech Mono", monospace;
+}
+
+.theatre-actor-studio__cancel {
+  color: #d0d4d7;
+  background: #171b1f;
+  border: 1px solid #4b5259;
+}
+
+.theatre-actor-studio__save {
+  color: #120f08;
+  background: #c19a45;
+  border: 1px solid #e2bd67;
+}
+
+.theatre-actor-studio__save:disabled {
+  opacity: .5;
+  cursor: progress;
+}
+
+@media (max-width: 620px) {
+  .on-game-dashboard .theatre-actor-source-actions,
+  .theatre-actor-studio__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .theatre-actor-field--wide {
+    grid-column: auto;
+  }
+}

--- a/css/theatre-actor-studio.css
+++ b/css/theatre-actor-studio.css
@@ -1,49 +1,340 @@
 /* ==================================================
-   THEATRE ACTOR STUDIO / DM UX
-   Distingue catálogo persistente de cast temporal.
+   THEATRE ACTOR MASTER CONTROL / DM UX
+   La Pantalla de DM administra la fuente persistente.
    ================================================== */
 
-.on-game-dashboard .npc-spawner-section {
-  padding: 10px;
-  background: #0b0e11;
-  border: 1px solid #29313a;
-  border-left: 3px solid #a37c35;
+.on-game-dashboard #theatre-actor-master-panel {
+  margin: 0 0 18px;
+  color: #dce0e2;
+  background: linear-gradient(145deg, #0d1216, #070a0d);
+  border: 1px solid #35404a;
+  border-top: 3px solid #b0873c;
+  box-shadow: inset 0 0 30px rgba(0,0,0,.42), 0 8px 22px rgba(0,0,0,.28);
+  font-family: "Share Tech Mono", monospace;
 }
 
-.on-game-dashboard .theatre-actor-source-note {
+.on-game-dashboard .theatre-master-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 13px 14px 11px;
+  background: linear-gradient(90deg, rgba(113,80,31,.17), rgba(10,14,18,.5));
+  border-bottom: 1px solid #323b43;
+}
+
+.on-game-dashboard .theatre-master-header h4 {
+  margin: 2px 0 3px !important;
+  color: #d7ad51 !important;
+  font: 700 16px/1.1 "Share Tech Mono", monospace !important;
+  letter-spacing: .06em;
+}
+
+.on-game-dashboard .theatre-master-header p {
   margin: 0;
-  color: #9ba2a8;
-  font: 10px/1.4 "Share Tech Mono", monospace;
+  max-width: 620px;
+  color: #899198;
+  font-size: 9px;
+  line-height: 1.4;
 }
 
-.on-game-dashboard .theatre-actor-source-note strong {
-  color: #d1a84e;
+.on-game-dashboard .theatre-master-eyebrow {
+  display: block;
+  color: #717a82;
+  font-size: 8px;
+  letter-spacing: .14em;
 }
 
-.on-game-dashboard .theatre-actor-source-actions {
+.on-game-dashboard .theatre-master-status {
+  flex: 0 0 auto;
+  padding: 5px 8px;
+  color: #9ca3a9;
+  background: #11171c;
+  border: 1px solid #3c464e;
+  font-size: 8px;
+  letter-spacing: .09em;
+}
+
+.on-game-dashboard .theatre-master-status[data-tone="ok"] {
+  color: #c8dcaa;
+  border-color: #536a39;
+}
+
+.on-game-dashboard .theatre-master-status[data-tone="warn"] {
+  color: #ecc76a;
+  border-color: #84672d;
+}
+
+.on-game-dashboard .theatre-master-status[data-tone="error"] {
+  color: #ff8a8a;
+  border-color: #7d3030;
+}
+
+.on-game-dashboard .theatre-master-status[data-tone="new"] {
+  color: #c6ced4;
+  border-color: #57636d;
+}
+
+.on-game-dashboard .theatre-master-layout {
+  display: grid;
+  grid-template-columns: minmax(210px, .72fr) minmax(0, 1.55fr);
+  min-height: 440px;
+}
+
+.on-game-dashboard .theatre-master-browser {
+  min-width: 0;
+  padding: 12px;
+  background: rgba(5,8,10,.66);
+  border-right: 1px solid #303941;
+}
+
+.on-game-dashboard .theatre-master-browser > label,
+.on-game-dashboard .theatre-master-field > span {
+  display: block;
+  margin-bottom: 4px;
+  color: #919aa1;
+  font-size: 8px;
+  line-height: 1.2;
+  letter-spacing: .09em;
+  text-transform: uppercase;
+}
+
+.on-game-dashboard #theatre-master-search,
+.on-game-dashboard #theatre-master-source-select,
+.on-game-dashboard .theatre-master-field input,
+.on-game-dashboard .theatre-master-field select,
+.on-game-dashboard #theatre-master-expressions {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  color: #eef0f1;
+  background: #0a0f13;
+  border: 1px solid #3d4851;
+  border-radius: 0;
+  font: 11px/1.25 "Share Tech Mono", monospace;
+}
+
+.on-game-dashboard #theatre-master-search {
+  min-height: 34px;
+  margin-bottom: 10px;
+  padding: 7px 8px;
+}
+
+.on-game-dashboard #theatre-master-source-select {
+  min-height: 270px;
+  padding: 4px;
+  outline: none;
+}
+
+.on-game-dashboard #theatre-master-source-select optgroup {
+  color: #ddb35b;
+  background: #10161a;
+  font-weight: 700;
+}
+
+.on-game-dashboard #theatre-master-source-select option {
+  padding: 5px 6px;
+  color: #d9dddf;
+  background: #0b1014;
+}
+
+.on-game-dashboard #theatre-master-source-select option:checked {
+  color: #fff0c9;
+  background: #4a3818;
+}
+
+.on-game-dashboard .theatre-master-browser-actions {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 7px;
+  gap: 6px;
+  margin-top: 8px;
 }
 
-.on-game-dashboard .theatre-actor-source-actions button {
+.on-game-dashboard .theatre-master-browser-actions button,
+.on-game-dashboard .theatre-master-actions button {
+  min-width: 0;
   min-height: 34px;
   padding: 7px 8px;
-  color: #e5e7e8;
-  background: #151a1f;
-  border: 1px solid #59616a;
+  color: #d7dcdf;
+  background: #151c21;
+  border: 1px solid #4b565e;
+  border-radius: 0;
   cursor: pointer;
-  font: 700 10px/1.15 "Share Tech Mono", monospace;
+  font: 700 9px/1.15 "Share Tech Mono", monospace;
+  letter-spacing: .025em;
 }
 
-.on-game-dashboard .theatre-actor-source-actions button:hover {
-  color: #f0c761;
+.on-game-dashboard .theatre-master-browser-actions button:hover,
+.on-game-dashboard .theatre-master-actions button:hover {
+  color: #ffe8ad;
   border-color: #a37c35;
 }
 
-.on-game-dashboard #btn-spawn-npc[data-unlinked-player="true"] {
-  opacity: .45;
+.on-game-dashboard .theatre-master-browser-actions button:disabled,
+.on-game-dashboard .theatre-master-actions button:disabled {
+  opacity: .38;
   cursor: not-allowed;
+}
+
+.on-game-dashboard .theatre-master-help {
+  margin: 9px 0 0;
+  color: #7f888f;
+  font-size: 8px;
+  line-height: 1.45;
+}
+
+.on-game-dashboard .theatre-master-help strong {
+  color: #caa553;
+}
+
+.on-game-dashboard .theatre-master-editor {
+  min-width: 0;
+  padding: 12px 14px 14px;
+}
+
+.on-game-dashboard .theatre-master-source-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  margin-bottom: 11px;
+  padding: 7px 8px;
+  color: #a7adb2;
+  background: #090d10;
+  border-left: 3px solid #87672d;
+  font-size: 8px;
+}
+
+.on-game-dashboard #theatre-master-source-kind {
+  flex: 0 0 auto;
+  color: #d2ab55;
+  font-weight: 700;
+  letter-spacing: .055em;
+}
+
+.on-game-dashboard #theatre-master-source-path {
+  min-width: 0;
+  overflow: hidden;
+  color: #858e95;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.on-game-dashboard .theatre-master-fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 9px 10px;
+}
+
+.on-game-dashboard .theatre-master-field {
+  display: block;
+  min-width: 0;
+}
+
+.on-game-dashboard .theatre-master-field--wide {
+  grid-column: 1 / -1;
+}
+
+.on-game-dashboard .theatre-master-field input,
+.on-game-dashboard .theatre-master-field select {
+  min-height: 34px;
+  padding: 7px 8px;
+}
+
+.on-game-dashboard #theatre-master-search:focus,
+.on-game-dashboard #theatre-master-source-select:focus,
+.on-game-dashboard .theatre-master-field input:focus,
+.on-game-dashboard .theatre-master-field select:focus,
+.on-game-dashboard #theatre-master-expressions:focus {
+  outline: 1px solid rgba(176,135,60,.38);
+  border-color: #a37c35;
+}
+
+.on-game-dashboard .theatre-master-advanced {
+  margin-top: 10px;
+  padding: 0;
+  background: #090d10;
+  border: 1px solid #303940;
+}
+
+.on-game-dashboard .theatre-master-advanced summary {
+  padding: 8px 9px;
+  color: #a7afb5;
+  cursor: pointer;
+  font-size: 9px;
+  letter-spacing: .06em;
+}
+
+.on-game-dashboard .theatre-master-advanced p {
+  margin: 0;
+  padding: 0 9px 7px;
+  color: #727b82;
+  font-size: 8px;
+  line-height: 1.4;
+}
+
+.on-game-dashboard #theatre-master-expressions {
+  display: block;
+  min-height: 130px;
+  padding: 8px;
+  resize: vertical;
+  border-width: 1px 0 0;
+}
+
+.on-game-dashboard .theatre-master-actions {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 7px;
+  margin-top: 11px;
+}
+
+.on-game-dashboard .theatre-master-actions .is-primary {
+  color: #171106;
+  background: #c39a45;
+  border-color: #e0ba63;
+}
+
+.on-game-dashboard .theatre-master-actions .is-danger {
+  color: #ffb3b3;
+  background: #271012;
+  border-color: #6f3034;
+}
+
+.on-game-dashboard .theatre-master-feedback {
+  min-height: 16px;
+  margin: 8px 0 0;
+  color: #879097;
+  font-size: 8px;
+  line-height: 1.35;
+}
+
+.on-game-dashboard .theatre-master-feedback[data-tone="ok"] { color: #a9c886; }
+.on-game-dashboard .theatre-master-feedback[data-tone="warn"] { color: #d7b65e; }
+.on-game-dashboard .theatre-master-feedback[data-tone="error"] { color: #e77878; }
+
+/* ---------- Cast rápido: queda explícitamente temporal ---------- */
+.on-game-dashboard .npc-spawner-section.theatre-quick-cast {
+  margin-bottom: 12px;
+  padding: 10px;
+  background: #0b0e11;
+  border: 1px solid #29313a;
+  border-left: 3px solid #59636b;
+}
+
+.on-game-dashboard .theatre-quick-cast-title {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: baseline;
+  margin: -2px 0 8px;
+  color: #949ca2;
+  font-size: 8px;
+}
+
+.on-game-dashboard .theatre-quick-cast-title strong {
+  color: #c9a24d;
+  font-size: 9px;
 }
 
 .on-game-dashboard .actor-control-card .btn-edit-source {
@@ -53,168 +344,41 @@
   background: #17140d !important;
 }
 
-/* ---------- Modal de edición persistente ---------- */
-.theatre-actor-studio-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 12000;
-  display: none;
-  align-items: center;
-  justify-content: center;
-  padding: 18px;
-  background: rgba(0,0,0,.82);
-  backdrop-filter: blur(5px);
-}
-
-.theatre-actor-studio-overlay.open {
-  display: flex;
-}
-
-.theatre-actor-studio {
-  width: min(720px, 96vw);
-  max-height: min(760px, 92vh);
-  overflow: auto;
-  color: #e4e6e7;
-  background: linear-gradient(145deg, #11161b, #080b0e);
-  border: 1px solid #5c6268;
-  border-top: 3px solid #a37c35;
-  box-shadow: 0 24px 65px rgba(0,0,0,.76), inset 0 0 28px rgba(0,0,0,.46);
-  font-family: "Share Tech Mono", monospace;
-}
-
-.theatre-actor-studio__header {
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  display: flex;
-  justify-content: space-between;
-  gap: 14px;
-  align-items: flex-start;
-  padding: 14px 16px 12px;
-  background: rgba(12,15,18,.97);
-  border-bottom: 1px solid #303840;
-}
-
-.theatre-actor-studio__eyebrow {
-  display: block;
-  margin-bottom: 4px;
-  color: #8c9399;
-  font-size: 9px;
-  letter-spacing: .13em;
-}
-
-.theatre-actor-studio__title {
-  margin: 0;
-  color: #d0a94e;
-  font-size: 18px;
-  letter-spacing: .06em;
-}
-
-.theatre-actor-studio__close {
-  width: 34px;
-  height: 34px;
-  color: #ddd;
-  background: #171b1f;
-  border: 1px solid #4a5056;
-  cursor: pointer;
-}
-
-.theatre-actor-studio__body {
-  padding: 15px 16px;
-}
-
-.theatre-actor-studio__source {
-  margin: 0 0 13px;
-  padding: 9px 10px;
-  color: #b5bbc0;
-  background: #0b0e11;
-  border-left: 3px solid #76602f;
-  font-size: 10px;
-  line-height: 1.4;
-}
-
-.theatre-actor-studio__grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
-}
-
-.theatre-actor-field {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-width: 0;
-}
-
-.theatre-actor-field--wide {
-  grid-column: 1 / -1;
-}
-
-.theatre-actor-field label {
-  color: #9fa6ac;
-  font-size: 9px;
-  letter-spacing: .07em;
-  text-transform: uppercase;
-}
-
-.theatre-actor-field input,
-.theatre-actor-field select {
-  width: 100%;
-  min-width: 0;
-  min-height: 36px;
-  padding: 7px 8px;
-  color: #fff;
-  background: #0c1014;
-  border: 1px solid #404850;
-  border-radius: 0;
-  font: 12px/1.2 "Share Tech Mono", monospace;
-}
-
-.theatre-actor-field input:focus,
-.theatre-actor-field select:focus {
-  outline: 1px solid rgba(163,124,53,.48);
-  border-color: #a37c35;
-}
-
-.theatre-actor-studio__footer {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-  padding: 13px 16px 16px;
-  border-top: 1px solid #303840;
-}
-
-.theatre-actor-studio__footer button {
-  min-height: 36px;
-  padding: 8px 13px;
-  cursor: pointer;
-  font: 700 11px/1 "Share Tech Mono", monospace;
-}
-
-.theatre-actor-studio__cancel {
-  color: #d0d4d7;
-  background: #171b1f;
-  border: 1px solid #4b5259;
-}
-
-.theatre-actor-studio__save {
-  color: #120f08;
-  background: #c19a45;
-  border: 1px solid #e2bd67;
-}
-
-.theatre-actor-studio__save:disabled {
-  opacity: .5;
-  cursor: progress;
-}
-
-@media (max-width: 620px) {
-  .on-game-dashboard .theatre-actor-source-actions,
-  .theatre-actor-studio__grid {
+@media (max-width: 900px) {
+  .on-game-dashboard .theatre-master-layout {
     grid-template-columns: 1fr;
   }
 
-  .theatre-actor-field--wide {
+  .on-game-dashboard .theatre-master-browser {
+    border-right: 0;
+    border-bottom: 1px solid #303941;
+  }
+
+  .on-game-dashboard #theatre-master-source-select {
+    min-height: 180px;
+  }
+}
+
+@media (max-width: 620px) {
+  .on-game-dashboard .theatre-master-header,
+  .on-game-dashboard .theatre-master-source-meta,
+  .on-game-dashboard .theatre-quick-cast-title {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .on-game-dashboard .theatre-master-fields,
+  .on-game-dashboard .theatre-master-browser-actions,
+  .on-game-dashboard .theatre-master-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .on-game-dashboard .theatre-master-field--wide {
     grid-column: auto;
+  }
+
+  .on-game-dashboard #theatre-master-source-path {
+    white-space: normal;
+    overflow-wrap: anywhere;
   }
 }

--- a/js/instance-control.js
+++ b/js/instance-control.js
@@ -167,11 +167,39 @@
     return button;
   }
 
+  function ensureDashboardActorStudioAssets(doc) {
+    const documentRef = doc || global.document;
+    if (!documentRef?.body?.classList.contains("on-game-dashboard")) return null;
+
+    let link = documentRef.getElementById("theatre-actor-studio-stylesheet");
+    if (!link) {
+      link = documentRef.createElement("link");
+      link.id = "theatre-actor-studio-stylesheet";
+      link.rel = "stylesheet";
+      link.href = "css/theatre-actor-studio.css";
+      link.dataset.ui = "theatre-actor-studio";
+      documentRef.head?.appendChild(link);
+    }
+
+    let script = documentRef.getElementById("theatre-actor-studio-script");
+    if (!script) {
+      script = documentRef.createElement("script");
+      script.id = "theatre-actor-studio-script";
+      script.src = "js/theatre-actor-studio.js";
+      script.async = false;
+      script.dataset.ui = "theatre-actor-studio";
+      documentRef.head?.appendChild(script);
+    }
+
+    return { link, script };
+  }
+
   function bindDashboard({ db, doc } = {}) {
     const documentRef = doc || global.document;
     if (!db || !documentRef) return;
     const instanceRef = db.ref(INSTANCE_PATH);
 
+    ensureDashboardActorStudioAssets(documentRef);
     ensureDmLocationControl({ db, doc: documentRef });
 
     documentRef.querySelectorAll('input[name="instancia"]').forEach(radio => {
@@ -210,6 +238,7 @@
     applyPlayerInstance,
     applyDashboardInstance,
     ensureDmLocationControl,
+    ensureDashboardActorStudioAssets,
     bindDm,
     bindDashboard,
     bindPlayer,

--- a/js/player-ux-polish.js
+++ b/js/player-ux-polish.js
@@ -1,0 +1,315 @@
+(function (global) {
+  "use strict";
+
+  const doc = global.document;
+  if (!doc) return;
+
+  const STORAGE = {
+    volume: "luminous.player.masterVolume",
+    reduceMotion: "luminous.player.reduceMotion",
+    largeText: "luminous.player.largeText",
+    compact: "luminous.player.compactUi",
+  };
+
+  function onReady(callback) {
+    if (doc.readyState === "loading") doc.addEventListener("DOMContentLoaded", callback, { once: true });
+    else callback();
+  }
+
+  function readStored(key, fallback) {
+    try {
+      const value = global.localStorage?.getItem(key);
+      return value == null ? fallback : value;
+    } catch (_) {
+      return fallback;
+    }
+  }
+
+  function writeStored(key, value) {
+    try {
+      global.localStorage?.setItem(key, String(value));
+    } catch (_) {}
+  }
+
+  function escapeXml(value) {
+    return String(value || "?")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;");
+  }
+
+  function initialsIcon(name) {
+    const parts = String(name || "?").trim().split(/\s+/).filter(Boolean);
+    const initials = (parts.length > 1 ? `${parts[0][0]}${parts[1][0]}` : parts[0]?.slice(0, 2) || "?").toUpperCase();
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#17130f"/><path d="M50 4 87 20 98 55 76 96 24 96 2 55 13 20Z" fill="none" stroke="#b98a32" stroke-width="5"/><text x="50" y="59" text-anchor="middle" font-family="monospace" font-size="34" font-weight="700" fill="#e6d7b8">${escapeXml(initials)}</text></svg>`;
+    return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+  }
+
+  function getActorRecords() {
+    const cache = global.allActoresCache;
+    return cache && typeof cache === "object" ? Object.values(cache) : [];
+  }
+
+  function findActorByName(name) {
+    const normalized = String(name || "").trim().toLowerCase();
+    if (!normalized) return null;
+    return getActorRecords().find((actor) =>
+      String(actor?.nombre || actor?.name || "").trim().toLowerCase() === normalized
+    ) || null;
+  }
+
+  function actorAssignedIcon(actor) {
+    if (!actor) return "";
+    return actor.icono || actor.icono_jugador || actor.icon_url || "";
+  }
+
+  function polishLogRows() {
+    const log = doc.getElementById("theatre-log-container");
+    if (!log) return;
+
+    log.querySelectorAll(".dialogue-row").forEach((row) => {
+      const img = row.querySelector(".hex-portrait img");
+      if (!img) return;
+      const displayedName = row.querySelector(".character-name")?.textContent || img.alt || "Desconocido";
+      const actor = findActorByName(displayedName);
+      const assignedIcon = actorAssignedIcon(actor);
+      const forbiddenSources = [actor?.sprite, actor?.url, actor?.avatar].filter(Boolean);
+      const current = img.getAttribute("src") || "";
+
+      if (assignedIcon) {
+        if (current !== assignedIcon) img.src = assignedIcon;
+      } else if (actor && forbiddenSources.includes(current)) {
+        img.src = initialsIcon(displayedName);
+      }
+
+      img.classList.add("theatre-log-actor-icon");
+      img.addEventListener("error", () => {
+        img.src = initialsIcon(displayedName);
+      }, { once: true });
+    });
+  }
+
+  function watchTheatreLog() {
+    const run = () => polishLogRows();
+    run();
+    const observer = new MutationObserver(run);
+    observer.observe(doc.body, { childList: true, subtree: true });
+    global.setInterval(run, 1500);
+  }
+
+  function renameRelationshipUx() {
+    const apegoButton = doc.querySelector('[name="act_hud_apego"]');
+    if (apegoButton) {
+      const label = apegoButton.querySelector("span");
+      if (label) label.textContent = "Vínculos";
+      apegoButton.title = "Vínculos y relaciones personales";
+      apegoButton.setAttribute("aria-label", "Abrir vínculos y relaciones personales");
+    }
+
+    const apegoModal = doc.getElementById("apego-modal");
+    if (apegoModal) {
+      apegoModal.querySelectorAll("h1,h2,h3,h4").forEach((heading) => {
+        if (/apego/i.test(heading.textContent || "")) heading.textContent = "VÍNCULOS / RELACIONES";
+      });
+    }
+
+    const directoryButton = doc.getElementById("btn-show-contacts");
+    if (directoryButton) {
+      directoryButton.textContent = "DIRECTORIO";
+      directoryButton.title = "Directorio de red: números y alias usados por Email/Chat";
+      directoryButton.setAttribute("aria-label", "Abrir directorio de red para mensajería");
+    }
+
+    const directory = doc.getElementById("subtab-contacts");
+    if (directory && !directory.querySelector(".player-network-directory-note")) {
+      const note = doc.createElement("p");
+      note.className = "player-network-directory-note";
+      note.innerHTML = "<strong>DIRECTORIO DE RED:</strong> guarda números y alias para comunicación. Las relaciones personales, afinidad y progreso social se administran en <strong>VÍNCULOS</strong> desde el HUD.";
+      const list = directory.querySelector("#contacts-list");
+      if (list) directory.insertBefore(note, list);
+      else directory.prepend(note);
+    }
+  }
+
+  function currentMuteState() {
+    const button = doc.getElementById("btn-toggle-mute");
+    if (!button) return false;
+    const text = button.textContent || "";
+    return text.includes("🔕") || button.getAttribute("aria-pressed") === "true" || button.dataset.muted === "true";
+  }
+
+  function applyVolume(volume) {
+    const normalized = Math.max(0, Math.min(1, Number(volume)));
+    doc.querySelectorAll("audio, video").forEach((media) => {
+      try { media.volume = normalized; } catch (_) {}
+    });
+    return normalized;
+  }
+
+  function applyBooleanSetting(inputId, storageKey, className) {
+    const input = doc.getElementById(inputId);
+    if (!input) return;
+    const enabled = readStored(storageKey, "0") === "1";
+    input.checked = enabled;
+    doc.body.classList.toggle(className, enabled);
+    input.addEventListener("change", () => {
+      doc.body.classList.toggle(className, input.checked);
+      writeStored(storageKey, input.checked ? "1" : "0");
+    });
+  }
+
+  function buildSettingsPanel() {
+    const settingsBody = doc.querySelector(".sheet-tab-settings .sheet-app-body");
+    if (!settingsBody || settingsBody.dataset.playerUxReady === "true") return;
+    settingsBody.dataset.playerUxReady = "true";
+
+    settingsBody.innerHTML = `
+      <div class="player-settings-console">
+        <section class="player-settings-section" aria-labelledby="player-settings-audio-title">
+          <h3 id="player-settings-audio-title">AUDIO / NOTIFICACIONES</h3>
+          <p>Controles locales del dispositivo del jugador.</p>
+          <label class="player-setting-row">
+            <span class="player-setting-copy">
+              <span class="player-setting-label">Silenciar alertas</span>
+              <span class="player-setting-help">Usa el mismo estado de silencio que la campana del terminal.</span>
+            </span>
+            <input id="player-setting-mute" class="player-setting-toggle" type="checkbox">
+          </label>
+          <label class="player-setting-row">
+            <span class="player-setting-copy">
+              <span class="player-setting-label">Volumen maestro local</span>
+              <span class="player-setting-help">Afecta audio y video reproducidos en este navegador.</span>
+            </span>
+            <span class="player-setting-volume-wrap">
+              <input id="player-setting-volume" type="range" min="0" max="100" step="5">
+              <output id="player-setting-volume-value">100%</output>
+            </span>
+          </label>
+        </section>
+
+        <section class="player-settings-section" aria-labelledby="player-settings-interface-title">
+          <h3 id="player-settings-interface-title">INTERFAZ</h3>
+          <p>Preferencias de lectura y densidad guardadas solo en este dispositivo.</p>
+          <label class="player-setting-row">
+            <span class="player-setting-copy">
+              <span class="player-setting-label">Reducir movimiento</span>
+              <span class="player-setting-help">Minimiza transiciones y animaciones decorativas.</span>
+            </span>
+            <input id="player-setting-reduce-motion" class="player-setting-toggle" type="checkbox">
+          </label>
+          <label class="player-setting-row">
+            <span class="player-setting-copy">
+              <span class="player-setting-label">Texto grande</span>
+              <span class="player-setting-help">Aumenta la escala de lectura del Personal Terminal.</span>
+            </span>
+            <input id="player-setting-large-text" class="player-setting-toggle" type="checkbox">
+          </label>
+          <label class="player-setting-row">
+            <span class="player-setting-copy">
+              <span class="player-setting-label">Interfaz compacta</span>
+              <span class="player-setting-help">Reduce altura de módulos para ver más contenido.</span>
+            </span>
+            <input id="player-setting-compact" class="player-setting-toggle" type="checkbox">
+          </label>
+        </section>
+
+        <section class="player-settings-section" aria-labelledby="player-settings-network-title">
+          <h3 id="player-settings-network-title">COMUNICACIÓN</h3>
+          <p>El Directorio de Red y Vínculos son sistemas diferentes.</p>
+          <div class="player-setting-row">
+            <span class="player-setting-copy">
+              <span class="player-setting-label">Directorio de Red</span>
+              <span class="player-setting-help">Números y alias para Email/Chat. No modifica relaciones.</span>
+            </span>
+          </div>
+          <div class="player-setting-row">
+            <span class="player-setting-copy">
+              <span class="player-setting-label">Vínculos</span>
+              <span class="player-setting-help">Afinidad, relaciones y progreso social. Se abre desde el HUD superior.</span>
+            </span>
+          </div>
+        </section>
+
+        <section class="player-settings-section" aria-labelledby="player-settings-reset-title">
+          <h3 id="player-settings-reset-title">DISPOSITIVO</h3>
+          <p>Restablece solo preferencias visuales y de audio locales.</p>
+          <button id="player-settings-reset" class="player-settings-action" type="button">RESTABLECER PREFERENCIAS</button>
+        </section>
+      </div>
+    `;
+
+    const volume = doc.getElementById("player-setting-volume");
+    const volumeOutput = doc.getElementById("player-setting-volume-value");
+    const storedVolume = Math.round(Number(readStored(STORAGE.volume, "1")) * 100);
+    volume.value = String(Number.isFinite(storedVolume) ? Math.max(0, Math.min(100, storedVolume)) : 100);
+    volumeOutput.value = `${volume.value}%`;
+    applyVolume(Number(volume.value) / 100);
+    volume.addEventListener("input", () => {
+      const normalized = applyVolume(Number(volume.value) / 100);
+      volumeOutput.value = `${Math.round(normalized * 100)}%`;
+      writeStored(STORAGE.volume, normalized);
+    });
+
+    const muteSetting = doc.getElementById("player-setting-mute");
+    const muteButton = doc.getElementById("btn-toggle-mute");
+    const syncMute = () => { if (muteSetting) muteSetting.checked = currentMuteState(); };
+    syncMute();
+    muteSetting?.addEventListener("change", () => {
+      if (!muteButton) return;
+      if (muteSetting.checked !== currentMuteState()) muteButton.click();
+      global.setTimeout(syncMute, 0);
+    });
+    if (muteButton) new MutationObserver(syncMute).observe(muteButton, { childList: true, characterData: true, subtree: true, attributes: true });
+
+    applyBooleanSetting("player-setting-reduce-motion", STORAGE.reduceMotion, "player-reduce-motion");
+    applyBooleanSetting("player-setting-large-text", STORAGE.largeText, "player-terminal-large-text");
+    applyBooleanSetting("player-setting-compact", STORAGE.compact, "player-terminal-compact");
+
+    doc.getElementById("player-settings-reset")?.addEventListener("click", () => {
+      Object.values(STORAGE).forEach((key) => {
+        try { global.localStorage?.removeItem(key); } catch (_) {}
+      });
+      doc.body.classList.remove("player-reduce-motion", "player-terminal-large-text", "player-terminal-compact");
+      if (volume) volume.value = "100";
+      if (volumeOutput) volumeOutput.value = "100%";
+      applyVolume(1);
+      ["player-setting-reduce-motion", "player-setting-large-text", "player-setting-compact"].forEach((id) => {
+        const input = doc.getElementById(id);
+        if (input) input.checked = false;
+      });
+    });
+  }
+
+  function bindMediaVolume() {
+    doc.addEventListener("play", (event) => {
+      const target = event.target;
+      if (!(target instanceof global.HTMLMediaElement)) return;
+      const volume = Number(readStored(STORAGE.volume, "1"));
+      try { target.volume = Math.max(0, Math.min(1, volume)); } catch (_) {}
+    }, true);
+  }
+
+  function boot() {
+    renameRelationshipUx();
+    buildSettingsPanel();
+    bindMediaVolume();
+    watchTheatreLog();
+
+    const domObserver = new MutationObserver(() => {
+      renameRelationshipUx();
+      buildSettingsPanel();
+    });
+    domObserver.observe(doc.body, { childList: true, subtree: true });
+  }
+
+  onReady(boot);
+
+  global.LuminousPlayerUxPolish = Object.freeze({
+    initialsIcon,
+    actorAssignedIcon,
+    polishLogRows,
+    renameRelationshipUx,
+    buildSettingsPanel,
+  });
+})(window);

--- a/js/player-ux-polish.js
+++ b/js/player-ux-polish.js
@@ -11,57 +11,40 @@
     compact: "luminous.player.compactUi",
   };
 
-  function onReady(callback) {
-    if (doc.readyState === "loading") doc.addEventListener("DOMContentLoaded", callback, { once: true });
-    else callback();
-  }
-
-  function readStored(key, fallback) {
+  const readStored = (key, fallback) => {
     try {
       const value = global.localStorage?.getItem(key);
       return value == null ? fallback : value;
-    } catch (_) {
-      return fallback;
-    }
-  }
+    } catch (_) { return fallback; }
+  };
 
-  function writeStored(key, value) {
-    try {
-      global.localStorage?.setItem(key, String(value));
-    } catch (_) {}
-  }
-
-  function escapeXml(value) {
-    return String(value || "?")
-      .replaceAll("&", "&amp;")
-      .replaceAll("<", "&lt;")
-      .replaceAll(">", "&gt;")
-      .replaceAll('"', "&quot;");
-  }
+  const writeStored = (key, value) => {
+    try { global.localStorage?.setItem(key, String(value)); } catch (_) {}
+  };
 
   function initialsIcon(name) {
     const parts = String(name || "?").trim().split(/\s+/).filter(Boolean);
     const initials = (parts.length > 1 ? `${parts[0][0]}${parts[1][0]}` : parts[0]?.slice(0, 2) || "?").toUpperCase();
-    const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#17130f"/><path d="M50 4 87 20 98 55 76 96 24 96 2 55 13 20Z" fill="none" stroke="#b98a32" stroke-width="5"/><text x="50" y="59" text-anchor="middle" font-family="monospace" font-size="34" font-weight="700" fill="#e6d7b8">${escapeXml(initials)}</text></svg>`;
+    const safe = initials.replace(/[&<>"']/g, "");
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#17130f"/><path d="M50 4 87 20 98 55 76 96 24 96 2 55 13 20Z" fill="none" stroke="#b98a32" stroke-width="5"/><text x="50" y="59" text-anchor="middle" font-family="monospace" font-size="34" font-weight="700" fill="#e6d7b8">${safe}</text></svg>`;
     return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
   }
 
-  function getActorRecords() {
+  function actorAssignedIcon(actor) {
+    return actor?.icono || actor?.icono_jugador || actor?.icon_url || "";
+  }
+
+  function actorRecords() {
     const cache = global.allActoresCache;
     return cache && typeof cache === "object" ? Object.values(cache) : [];
   }
 
-  function findActorByName(name) {
+  function actorByName(name) {
     const normalized = String(name || "").trim().toLowerCase();
     if (!normalized) return null;
-    return getActorRecords().find((actor) =>
+    return actorRecords().find((actor) =>
       String(actor?.nombre || actor?.name || "").trim().toLowerCase() === normalized
     ) || null;
-  }
-
-  function actorAssignedIcon(actor) {
-    if (!actor) return "";
-    return actor.icono || actor.icono_jugador || actor.icon_url || "";
   }
 
   function polishLogRows() {
@@ -72,51 +55,45 @@
       const img = row.querySelector(".hex-portrait img");
       if (!img) return;
       const displayedName = row.querySelector(".character-name")?.textContent || img.alt || "Desconocido";
-      const actor = findActorByName(displayedName);
-      const assignedIcon = actorAssignedIcon(actor);
-      const forbiddenSources = [actor?.sprite, actor?.url, actor?.avatar].filter(Boolean);
+      const actor = actorByName(displayedName);
+      const assigned = actorAssignedIcon(actor);
       const current = img.getAttribute("src") || "";
+      const forbidden = [actor?.sprite, actor?.url, actor?.avatar].filter(Boolean);
 
-      if (assignedIcon) {
-        if (current !== assignedIcon) img.src = assignedIcon;
-      } else if (actor && forbiddenSources.includes(current)) {
-        img.src = initialsIcon(displayedName);
-      }
+      if (assigned && current !== assigned) img.src = assigned;
+      else if (actor && forbidden.includes(current)) img.src = initialsIcon(displayedName);
 
       img.classList.add("theatre-log-actor-icon");
-      img.addEventListener("error", () => {
-        img.src = initialsIcon(displayedName);
-      }, { once: true });
+      if (img.dataset.iconFallbackBound !== "true") {
+        img.dataset.iconFallbackBound = "true";
+        img.addEventListener("error", () => { img.src = initialsIcon(displayedName); }, { once: true });
+      }
     });
   }
 
   function watchTheatreLog() {
-    const run = () => polishLogRows();
-    run();
-    const observer = new MutationObserver(run);
-    observer.observe(doc.body, { childList: true, subtree: true });
-    global.setInterval(run, 1500);
+    polishLogRows();
+    const log = doc.getElementById("theatre-log-container");
+    if (log) new MutationObserver(polishLogRows).observe(log, { childList: true, subtree: true });
+    global.setInterval(polishLogRows, 1500);
   }
 
   function renameRelationshipUx() {
     const apegoButton = doc.querySelector('[name="act_hud_apego"]');
     if (apegoButton) {
       const label = apegoButton.querySelector("span");
-      if (label) label.textContent = "Vínculos";
+      if (label && label.textContent !== "Vínculos") label.textContent = "Vínculos";
       apegoButton.title = "Vínculos y relaciones personales";
       apegoButton.setAttribute("aria-label", "Abrir vínculos y relaciones personales");
     }
 
-    const apegoModal = doc.getElementById("apego-modal");
-    if (apegoModal) {
-      apegoModal.querySelectorAll("h1,h2,h3,h4").forEach((heading) => {
-        if (/apego/i.test(heading.textContent || "")) heading.textContent = "VÍNCULOS / RELACIONES";
-      });
-    }
+    doc.querySelectorAll("#apego-modal h1,#apego-modal h2,#apego-modal h3,#apego-modal h4").forEach((heading) => {
+      if (/apego/i.test(heading.textContent || "")) heading.textContent = "VÍNCULOS / RELACIONES";
+    });
 
     const directoryButton = doc.getElementById("btn-show-contacts");
     if (directoryButton) {
-      directoryButton.textContent = "DIRECTORIO";
+      if (directoryButton.textContent !== "DIRECTORIO") directoryButton.textContent = "DIRECTORIO";
       directoryButton.title = "Directorio de red: números y alias usados por Email/Chat";
       directoryButton.setAttribute("aria-label", "Abrir directorio de red para mensajería");
     }
@@ -125,7 +102,7 @@
     if (directory && !directory.querySelector(".player-network-directory-note")) {
       const note = doc.createElement("p");
       note.className = "player-network-directory-note";
-      note.innerHTML = "<strong>DIRECTORIO DE RED:</strong> guarda números y alias para comunicación. Las relaciones personales, afinidad y progreso social se administran en <strong>VÍNCULOS</strong> desde el HUD.";
+      note.innerHTML = "<strong>DIRECTORIO DE RED:</strong> números y alias para comunicación. La afinidad y las relaciones personales viven en <strong>VÍNCULOS</strong> desde el HUD.";
       const list = directory.querySelector("#contacts-list");
       if (list) directory.insertBefore(note, list);
       else directory.prepend(note);
@@ -134,25 +111,23 @@
 
   function currentMuteState() {
     const button = doc.getElementById("btn-toggle-mute");
-    if (!button) return false;
-    const text = button.textContent || "";
-    return text.includes("🔕") || button.getAttribute("aria-pressed") === "true" || button.dataset.muted === "true";
+    const text = button?.textContent || "";
+    return text.includes("🔕") || button?.getAttribute("aria-pressed") === "true" || button?.dataset.muted === "true";
   }
 
-  function applyVolume(volume) {
-    const normalized = Math.max(0, Math.min(1, Number(volume)));
-    doc.querySelectorAll("audio, video").forEach((media) => {
-      try { media.volume = normalized; } catch (_) {}
+  function applyVolume(value) {
+    const volume = Math.max(0, Math.min(1, Number(value)));
+    doc.querySelectorAll("audio,video").forEach((media) => {
+      try { media.volume = volume; } catch (_) {}
     });
-    return normalized;
+    return volume;
   }
 
-  function applyBooleanSetting(inputId, storageKey, className) {
-    const input = doc.getElementById(inputId);
+  function bindBooleanSetting(id, storageKey, className) {
+    const input = doc.getElementById(id);
     if (!input) return;
-    const enabled = readStored(storageKey, "0") === "1";
-    input.checked = enabled;
-    doc.body.classList.toggle(className, enabled);
+    input.checked = readStored(storageKey, "0") === "1";
+    doc.body.classList.toggle(className, input.checked);
     input.addEventListener("change", () => {
       doc.body.classList.toggle(className, input.checked);
       writeStored(storageKey, input.checked ? "1" : "0");
@@ -160,95 +135,43 @@
   }
 
   function buildSettingsPanel() {
-    const settingsBody = doc.querySelector(".sheet-tab-settings .sheet-app-body");
-    if (!settingsBody || settingsBody.dataset.playerUxReady === "true") return;
-    settingsBody.dataset.playerUxReady = "true";
-
-    settingsBody.innerHTML = `
+    const body = doc.querySelector(".sheet-tab-settings .sheet-app-body");
+    if (!body || body.dataset.playerUxReady === "true") return;
+    body.dataset.playerUxReady = "true";
+    body.innerHTML = `
       <div class="player-settings-console">
-        <section class="player-settings-section" aria-labelledby="player-settings-audio-title">
-          <h3 id="player-settings-audio-title">AUDIO / NOTIFICACIONES</h3>
-          <p>Controles locales del dispositivo del jugador.</p>
-          <label class="player-setting-row">
-            <span class="player-setting-copy">
-              <span class="player-setting-label">Silenciar alertas</span>
-              <span class="player-setting-help">Usa el mismo estado de silencio que la campana del terminal.</span>
-            </span>
-            <input id="player-setting-mute" class="player-setting-toggle" type="checkbox">
-          </label>
-          <label class="player-setting-row">
-            <span class="player-setting-copy">
-              <span class="player-setting-label">Volumen maestro local</span>
-              <span class="player-setting-help">Afecta audio y video reproducidos en este navegador.</span>
-            </span>
-            <span class="player-setting-volume-wrap">
-              <input id="player-setting-volume" type="range" min="0" max="100" step="5">
-              <output id="player-setting-volume-value">100%</output>
-            </span>
-          </label>
+        <section class="player-settings-section">
+          <h3>AUDIO / NOTIFICACIONES</h3><p>Controles locales del dispositivo.</p>
+          <label class="player-setting-row"><span class="player-setting-copy"><span class="player-setting-label">Silenciar alertas</span><span class="player-setting-help">Usa el mismo estado que la campana del terminal.</span></span><input id="player-setting-mute" class="player-setting-toggle" type="checkbox"></label>
+          <label class="player-setting-row"><span class="player-setting-copy"><span class="player-setting-label">Volumen maestro</span><span class="player-setting-help">Afecta audio/video reproducido en este navegador.</span></span><span class="player-setting-volume-wrap"><input id="player-setting-volume" type="range" min="0" max="100" step="5"><output id="player-setting-volume-value">100%</output></span></label>
         </section>
-
-        <section class="player-settings-section" aria-labelledby="player-settings-interface-title">
-          <h3 id="player-settings-interface-title">INTERFAZ</h3>
-          <p>Preferencias de lectura y densidad guardadas solo en este dispositivo.</p>
-          <label class="player-setting-row">
-            <span class="player-setting-copy">
-              <span class="player-setting-label">Reducir movimiento</span>
-              <span class="player-setting-help">Minimiza transiciones y animaciones decorativas.</span>
-            </span>
-            <input id="player-setting-reduce-motion" class="player-setting-toggle" type="checkbox">
-          </label>
-          <label class="player-setting-row">
-            <span class="player-setting-copy">
-              <span class="player-setting-label">Texto grande</span>
-              <span class="player-setting-help">Aumenta la escala de lectura del Personal Terminal.</span>
-            </span>
-            <input id="player-setting-large-text" class="player-setting-toggle" type="checkbox">
-          </label>
-          <label class="player-setting-row">
-            <span class="player-setting-copy">
-              <span class="player-setting-label">Interfaz compacta</span>
-              <span class="player-setting-help">Reduce altura de módulos para ver más contenido.</span>
-            </span>
-            <input id="player-setting-compact" class="player-setting-toggle" type="checkbox">
-          </label>
+        <section class="player-settings-section">
+          <h3>INTERFAZ</h3><p>Preferencias guardadas en este dispositivo.</p>
+          <label class="player-setting-row"><span class="player-setting-copy"><span class="player-setting-label">Reducir movimiento</span><span class="player-setting-help">Minimiza animaciones decorativas.</span></span><input id="player-setting-reduce-motion" class="player-setting-toggle" type="checkbox"></label>
+          <label class="player-setting-row"><span class="player-setting-copy"><span class="player-setting-label">Texto grande</span><span class="player-setting-help">Aumenta la escala de lectura del terminal.</span></span><input id="player-setting-large-text" class="player-setting-toggle" type="checkbox"></label>
+          <label class="player-setting-row"><span class="player-setting-copy"><span class="player-setting-label">Interfaz compacta</span><span class="player-setting-help">Reduce altura de módulos.</span></span><input id="player-setting-compact" class="player-setting-toggle" type="checkbox"></label>
         </section>
-
-        <section class="player-settings-section" aria-labelledby="player-settings-network-title">
-          <h3 id="player-settings-network-title">COMUNICACIÓN</h3>
-          <p>El Directorio de Red y Vínculos son sistemas diferentes.</p>
-          <div class="player-setting-row">
-            <span class="player-setting-copy">
-              <span class="player-setting-label">Directorio de Red</span>
-              <span class="player-setting-help">Números y alias para Email/Chat. No modifica relaciones.</span>
-            </span>
-          </div>
-          <div class="player-setting-row">
-            <span class="player-setting-copy">
-              <span class="player-setting-label">Vínculos</span>
-              <span class="player-setting-help">Afinidad, relaciones y progreso social. Se abre desde el HUD superior.</span>
-            </span>
-          </div>
+        <section class="player-settings-section">
+          <h3>COMUNICACIÓN</h3><p>Dos sistemas con responsabilidades distintas.</p>
+          <div class="player-setting-row"><span class="player-setting-copy"><span class="player-setting-label">Directorio de Red</span><span class="player-setting-help">Números y alias para Email/Chat; no modifica relaciones.</span></span></div>
+          <div class="player-setting-row"><span class="player-setting-copy"><span class="player-setting-label">Vínculos</span><span class="player-setting-help">Afinidad, relaciones y progreso social; se abre desde el HUD.</span></span></div>
         </section>
-
-        <section class="player-settings-section" aria-labelledby="player-settings-reset-title">
-          <h3 id="player-settings-reset-title">DISPOSITIVO</h3>
-          <p>Restablece solo preferencias visuales y de audio locales.</p>
+        <section class="player-settings-section">
+          <h3>DISPOSITIVO</h3><p>Restablece preferencias locales, no datos del personaje.</p>
           <button id="player-settings-reset" class="player-settings-action" type="button">RESTABLECER PREFERENCIAS</button>
         </section>
-      </div>
-    `;
+      </div>`;
 
     const volume = doc.getElementById("player-setting-volume");
-    const volumeOutput = doc.getElementById("player-setting-volume-value");
-    const storedVolume = Math.round(Number(readStored(STORAGE.volume, "1")) * 100);
-    volume.value = String(Number.isFinite(storedVolume) ? Math.max(0, Math.min(100, storedVolume)) : 100);
-    volumeOutput.value = `${volume.value}%`;
-    applyVolume(Number(volume.value) / 100);
+    const output = doc.getElementById("player-setting-volume-value");
+    const stored = Math.max(0, Math.min(1, Number(readStored(STORAGE.volume, "1")) || 0));
+    volume.value = String(Math.round(stored * 100));
+    output.value = `${volume.value}%`;
+    applyVolume(stored);
     volume.addEventListener("input", () => {
-      const normalized = applyVolume(Number(volume.value) / 100);
-      volumeOutput.value = `${Math.round(normalized * 100)}%`;
-      writeStored(STORAGE.volume, normalized);
+      const next = applyVolume(Number(volume.value) / 100);
+      output.value = `${Math.round(next * 100)}%`;
+      writeStored(STORAGE.volume, next);
     });
 
     const muteSetting = doc.getElementById("player-setting-mute");
@@ -256,37 +179,32 @@
     const syncMute = () => { if (muteSetting) muteSetting.checked = currentMuteState(); };
     syncMute();
     muteSetting?.addEventListener("change", () => {
-      if (!muteButton) return;
-      if (muteSetting.checked !== currentMuteState()) muteButton.click();
+      if (muteButton && muteSetting.checked !== currentMuteState()) muteButton.click();
       global.setTimeout(syncMute, 0);
     });
-    if (muteButton) new MutationObserver(syncMute).observe(muteButton, { childList: true, characterData: true, subtree: true, attributes: true });
+    if (muteButton) new MutationObserver(syncMute).observe(muteButton, { childList: true, subtree: true, attributes: true });
 
-    applyBooleanSetting("player-setting-reduce-motion", STORAGE.reduceMotion, "player-reduce-motion");
-    applyBooleanSetting("player-setting-large-text", STORAGE.largeText, "player-terminal-large-text");
-    applyBooleanSetting("player-setting-compact", STORAGE.compact, "player-terminal-compact");
+    bindBooleanSetting("player-setting-reduce-motion", STORAGE.reduceMotion, "player-reduce-motion");
+    bindBooleanSetting("player-setting-large-text", STORAGE.largeText, "player-terminal-large-text");
+    bindBooleanSetting("player-setting-compact", STORAGE.compact, "player-terminal-compact");
 
     doc.getElementById("player-settings-reset")?.addEventListener("click", () => {
-      Object.values(STORAGE).forEach((key) => {
-        try { global.localStorage?.removeItem(key); } catch (_) {}
-      });
+      Object.values(STORAGE).forEach((key) => { try { global.localStorage?.removeItem(key); } catch (_) {} });
       doc.body.classList.remove("player-reduce-motion", "player-terminal-large-text", "player-terminal-compact");
-      if (volume) volume.value = "100";
-      if (volumeOutput) volumeOutput.value = "100%";
-      applyVolume(1);
       ["player-setting-reduce-motion", "player-setting-large-text", "player-setting-compact"].forEach((id) => {
-        const input = doc.getElementById(id);
-        if (input) input.checked = false;
+        const input = doc.getElementById(id); if (input) input.checked = false;
       });
+      volume.value = "100";
+      output.value = "100%";
+      applyVolume(1);
     });
   }
 
   function bindMediaVolume() {
     doc.addEventListener("play", (event) => {
       const target = event.target;
-      if (!(target instanceof global.HTMLMediaElement)) return;
-      const volume = Number(readStored(STORAGE.volume, "1"));
-      try { target.volume = Math.max(0, Math.min(1, volume)); } catch (_) {}
+      if (!global.HTMLMediaElement || !(target instanceof global.HTMLMediaElement)) return;
+      try { target.volume = Math.max(0, Math.min(1, Number(readStored(STORAGE.volume, "1")))); } catch (_) {}
     }, true);
   }
 
@@ -295,21 +213,10 @@
     buildSettingsPanel();
     bindMediaVolume();
     watchTheatreLog();
-
-    const domObserver = new MutationObserver(() => {
-      renameRelationshipUx();
-      buildSettingsPanel();
-    });
-    domObserver.observe(doc.body, { childList: true, subtree: true });
   }
 
-  onReady(boot);
+  if (doc.readyState === "loading") doc.addEventListener("DOMContentLoaded", boot, { once: true });
+  else boot();
 
-  global.LuminousPlayerUxPolish = Object.freeze({
-    initialsIcon,
-    actorAssignedIcon,
-    polishLogRows,
-    renameRelationshipUx,
-    buildSettingsPanel,
-  });
+  global.LuminousPlayerUxPolish = Object.freeze({ initialsIcon, actorAssignedIcon, polishLogRows, renameRelationshipUx, buildSettingsPanel });
 })(window);

--- a/js/theatre-actor-studio.js
+++ b/js/theatre-actor-studio.js
@@ -1,0 +1,431 @@
+(function (global) {
+  "use strict";
+
+  const doc = global.document;
+  const firebase = global.firebase;
+  if (!doc || !firebase?.database) return;
+
+  const db = firebase.database();
+  const ROOTS = {
+    base: "campaña/base_datos_npcs",
+    legacy: "campaña/actores",
+    players: "campaña/jugadores",
+  };
+
+  const state = {
+    base: {},
+    legacy: {},
+    players: {},
+    refreshTimer: null,
+    editorContext: null,
+  };
+
+  function scenePath() {
+    return global.LuminousTheatreState?.getPaths?.().scene || "campaña/estado_mundo/escena_actual";
+  }
+
+  function actorPool() {
+    return Object.assign({}, state.legacy, state.base);
+  }
+
+  function playerLabel(playerId, player) {
+    return player?.characterName || player?.character_name || player?.nombre || player?.name || playerId;
+  }
+
+  function slug(value) {
+    return String(value || "actor")
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, "_")
+      .replace(/^_+|_+$/g, "") || "actor";
+  }
+
+  function persistentRecord(actorId) {
+    if (actorId && Object.prototype.hasOwnProperty.call(state.base, actorId)) {
+      return { actorId, root: ROOTS.base, data: state.base[actorId] || {} };
+    }
+    if (actorId && Object.prototype.hasOwnProperty.call(state.legacy, actorId)) {
+      return { actorId, root: ROOTS.legacy, data: state.legacy[actorId] || {} };
+    }
+    return null;
+  }
+
+  function linkedActorId(playerId, player) {
+    const pool = actorPool();
+    if (player?.actorId && pool[player.actorId]) return player.actorId;
+    return Object.keys(pool).find((actorId) => {
+      const actor = pool[actorId];
+      return actor?.vinculo_jugador === playerId && actor?.tipo === "Jugador";
+    }) || null;
+  }
+
+  function scheduleRosterRefresh() {
+    global.clearTimeout(state.refreshTimer);
+    state.refreshTimer = global.setTimeout(refreshUnlinkedPlayers, 60);
+  }
+
+  function refreshUnlinkedPlayers() {
+    const select = doc.getElementById("select-npc-roster");
+    if (!select) return;
+
+    select.querySelector('optgroup[data-actor-studio="unlinked"]')?.remove();
+    const missing = Object.entries(state.players).filter(([playerId, player]) => !linkedActorId(playerId, player));
+    if (!missing.length) {
+      syncSpawnButtonState();
+      return;
+    }
+
+    const group = doc.createElement("optgroup");
+    group.label = "JUGADORES SIN ACTOR THEATRE";
+    group.dataset.actorStudio = "unlinked";
+    missing.forEach(([playerId, player]) => {
+      const option = doc.createElement("option");
+      option.value = `__player__:${playerId}`;
+      option.textContent = `${playerLabel(playerId, player)} · CREAR ACTOR`;
+      option.dataset.sourceType = "unlinked-player";
+      option.dataset.sourceId = playerId;
+      group.appendChild(option);
+    });
+    select.appendChild(group);
+    syncSpawnButtonState();
+  }
+
+  function syncSpawnButtonState() {
+    const select = doc.getElementById("select-npc-roster");
+    const spawn = doc.getElementById("btn-spawn-npc");
+    if (!select || !spawn) return;
+    const unlinked = String(select.value || "").startsWith("__player__:");
+    spawn.dataset.unlinkedPlayer = unlinked ? "true" : "false";
+    spawn.disabled = unlinked;
+    spawn.title = unlinked
+      ? "Este jugador todavía no tiene actor Theatre. Usa EDITAR / REPARAR FUENTE para crearlo primero."
+      : "Añade una instancia temporal de este actor al cast de la escena actual.";
+  }
+
+  function createEditor() {
+    let overlay = doc.getElementById("theatre-actor-studio-overlay");
+    if (overlay) return overlay;
+
+    overlay = doc.createElement("div");
+    overlay.id = "theatre-actor-studio-overlay";
+    overlay.className = "theatre-actor-studio-overlay";
+    overlay.setAttribute("aria-hidden", "true");
+    overlay.innerHTML = `
+      <section class="theatre-actor-studio" role="dialog" aria-modal="true" aria-labelledby="theatre-actor-studio-title">
+        <header class="theatre-actor-studio__header">
+          <div>
+            <span class="theatre-actor-studio__eyebrow">ACTOR SOURCE / PERSISTENT DATABASE</span>
+            <h2 id="theatre-actor-studio-title" class="theatre-actor-studio__title">EDITAR ACTOR</h2>
+          </div>
+          <button class="theatre-actor-studio__close" type="button" aria-label="Cerrar">×</button>
+        </header>
+        <div class="theatre-actor-studio__body">
+          <p id="theatre-actor-studio-source" class="theatre-actor-studio__source"></p>
+          <div class="theatre-actor-studio__grid">
+            <div class="theatre-actor-field">
+              <label for="theatre-actor-name">Nombre</label>
+              <input id="theatre-actor-name" type="text" autocomplete="off">
+            </div>
+            <div class="theatre-actor-field">
+              <label for="theatre-actor-title">Título</label>
+              <input id="theatre-actor-title" type="text" autocomplete="off">
+            </div>
+            <div class="theatre-actor-field">
+              <label for="theatre-actor-type">Tipo</label>
+              <select id="theatre-actor-type"><option value="NPC">NPC</option><option value="Jugador">Jugador</option></select>
+            </div>
+            <div class="theatre-actor-field">
+              <label for="theatre-actor-scale">Escala</label>
+              <input id="theatre-actor-scale" type="number" min="0.25" max="3" step="0.05" value="1">
+            </div>
+            <div class="theatre-actor-field theatre-actor-field--wide">
+              <label for="theatre-actor-icon">Icono del actor · usado en log/HUD</label>
+              <input id="theatre-actor-icon" type="url" placeholder="https://... icono">
+            </div>
+            <div class="theatre-actor-field theatre-actor-field--wide">
+              <label for="theatre-actor-sprite">Sprite de escena · NO se usa como icono</label>
+              <input id="theatre-actor-sprite" type="url" placeholder="https://... sprite">
+            </div>
+            <div class="theatre-actor-field">
+              <label for="theatre-actor-name-color">Color nameplate nombre</label>
+              <input id="theatre-actor-name-color" type="text" placeholder="#4a4a4a">
+            </div>
+            <div class="theatre-actor-field">
+              <label for="theatre-actor-title-color">Color nameplate título</label>
+              <input id="theatre-actor-title-color" type="text" placeholder="#4a4a4a">
+            </div>
+          </div>
+        </div>
+        <footer class="theatre-actor-studio__footer">
+          <button class="theatre-actor-studio__cancel" type="button">CANCELAR</button>
+          <button class="theatre-actor-studio__save" type="button">GUARDAR FUENTE</button>
+        </footer>
+      </section>
+    `;
+    doc.body.appendChild(overlay);
+
+    const close = () => {
+      overlay.classList.remove("open");
+      overlay.setAttribute("aria-hidden", "true");
+      state.editorContext = null;
+    };
+    overlay.querySelector(".theatre-actor-studio__close")?.addEventListener("click", close);
+    overlay.querySelector(".theatre-actor-studio__cancel")?.addEventListener("click", close);
+    overlay.addEventListener("click", (event) => { if (event.target === overlay) close(); });
+    overlay.querySelector(".theatre-actor-studio__save")?.addEventListener("click", saveEditor);
+    return overlay;
+  }
+
+  function field(id) {
+    return doc.getElementById(id);
+  }
+
+  function openEditor(context) {
+    const overlay = createEditor();
+    state.editorContext = context;
+    const data = context.data || {};
+    const isPlayer = Boolean(context.playerId) || data.tipo === "Jugador";
+
+    field("theatre-actor-studio-title").textContent = context.mode === "new" ? "NUEVO ACTOR PERSISTENTE" : "EDITAR ACTOR PERSISTENTE";
+    field("theatre-actor-studio-source").textContent = context.mode === "new"
+      ? "Se guardará en campaña/base_datos_npcs y aparecerá en el selector del Theatre."
+      : context.unlinked
+        ? `Jugador ${context.playerId}: se creará y enlazará un actor persistente antes de poder añadirlo al cast.`
+        : `Fuente: ${context.root}/${context.actorId}. Los cambios se propagan a sus instancias actuales del cast.`;
+
+    field("theatre-actor-name").value = data.nombre || data.characterName || data.character_name || data.name || "";
+    field("theatre-actor-title").value = data.titulo || data.identity || "";
+    field("theatre-actor-type").value = isPlayer ? "Jugador" : (data.tipo || "NPC");
+    field("theatre-actor-type").disabled = Boolean(context.playerId);
+    field("theatre-actor-scale").value = String(Number(data.escala) || 1);
+    field("theatre-actor-icon").value = data.icono || data.icono_jugador || data.icon_url || "";
+    field("theatre-actor-sprite").value = data.sprite || data.url || "";
+    field("theatre-actor-name-color").value = data.color_nombre || "";
+    field("theatre-actor-title-color").value = data.color_titulo || "";
+
+    overlay.classList.add("open");
+    overlay.setAttribute("aria-hidden", "false");
+    field("theatre-actor-name").focus();
+  }
+
+  async function resolveSelectedContext() {
+    const select = doc.getElementById("select-npc-roster");
+    const option = select?.options?.[select.selectedIndex];
+    if (!select?.value || !option) return null;
+
+    if (select.value.startsWith("__player__:")) {
+      const playerId = option.dataset.sourceId || select.value.slice("__player__:".length);
+      const player = state.players[playerId] || (await db.ref(`${ROOTS.players}/${playerId}`).once("value")).val() || {};
+      return { mode: "edit", unlinked: true, playerId, data: player };
+    }
+
+    const actorId = select.value;
+    let record = persistentRecord(actorId);
+    if (!record) {
+      const [baseSnap, legacySnap] = await Promise.all([
+        db.ref(`${ROOTS.base}/${actorId}`).once("value"),
+        db.ref(`${ROOTS.legacy}/${actorId}`).once("value"),
+      ]);
+      if (baseSnap.exists()) record = { actorId, root: ROOTS.base, data: baseSnap.val() || {} };
+      else if (legacySnap.exists()) record = { actorId, root: ROOTS.legacy, data: legacySnap.val() || {} };
+    }
+    if (!record) return null;
+
+    const sourceType = option.dataset.sourceType || "npc";
+    const sourceId = option.dataset.sourceId || actorId;
+    return {
+      mode: "edit",
+      actorId,
+      root: record.root,
+      data: record.data,
+      playerId: sourceType === "player-profile" ? sourceId : (record.data?.vinculo_jugador || null),
+    };
+  }
+
+  function editorPayload(context) {
+    const payload = {
+      nombre: String(field("theatre-actor-name").value || "").trim(),
+      titulo: String(field("theatre-actor-title").value || "").trim(),
+      tipo: context.playerId ? "Jugador" : field("theatre-actor-type").value,
+      icono: String(field("theatre-actor-icon").value || "").trim(),
+      sprite: String(field("theatre-actor-sprite").value || "").trim(),
+      color_nombre: String(field("theatre-actor-name-color").value || "").trim(),
+      color_titulo: String(field("theatre-actor-title-color").value || "").trim(),
+      escala: Math.max(.25, Math.min(3, Number(field("theatre-actor-scale").value) || 1)),
+    };
+    if (context.playerId) payload.vinculo_jugador = context.playerId;
+    return payload;
+  }
+
+  async function propagateActorSource(actorId, playerId, payload) {
+    const snap = await db.ref(`${scenePath()}/actores`).once("value");
+    const live = snap.val() || {};
+    const updates = {};
+    Object.entries(live).forEach(([instanceId, actor]) => {
+      const match = actor?.identityId === actorId || actor?.sourceId === actorId || (playerId && actor?.sourceId === playerId);
+      if (!match) return;
+      ["nombre", "titulo", "tipo", "icono", "sprite", "color_nombre", "color_titulo", "escala"].forEach((key) => {
+        updates[`${scenePath()}/actores/${instanceId}/${key}`] = payload[key] ?? "";
+      });
+    });
+    if (Object.keys(updates).length) await db.ref().update(updates);
+  }
+
+  async function saveEditor() {
+    const context = state.editorContext;
+    if (!context) return;
+    const save = doc.querySelector(".theatre-actor-studio__save");
+    const payload = editorPayload(context);
+    if (!payload.nombre) {
+      global.alert?.("El actor necesita un nombre.");
+      return;
+    }
+
+    save.disabled = true;
+    const oldText = save.textContent;
+    save.textContent = "GUARDANDO...";
+    try {
+      let actorId = context.actorId;
+      let root = context.root || ROOTS.base;
+
+      if (context.mode === "new") {
+        const ref = db.ref(ROOTS.base).push();
+        actorId = ref.key;
+        root = ROOTS.base;
+        await ref.set(Object.assign({ identityId: actorId }, payload));
+      } else if (context.unlinked && context.playerId) {
+        const player = state.players[context.playerId] || {};
+        const preferred = player.actorId && !persistentRecord(player.actorId)
+          ? player.actorId
+          : `jugador_${slug(context.playerId)}`;
+        actorId = preferred;
+        root = ROOTS.base;
+        await db.ref(`${root}/${actorId}`).set(Object.assign({ identityId: actorId }, payload));
+        await db.ref(`${ROOTS.players}/${context.playerId}/actorId`).set(actorId);
+      } else {
+        await db.ref(`${root}/${actorId}`).update(payload);
+      }
+
+      await propagateActorSource(actorId, context.playerId || payload.vinculo_jugador || null, payload);
+      save.textContent = "GUARDADO";
+      global.setTimeout(() => {
+        const overlay = doc.getElementById("theatre-actor-studio-overlay");
+        overlay?.classList.remove("open");
+        overlay?.setAttribute("aria-hidden", "true");
+        state.editorContext = null;
+      }, 450);
+    } catch (error) {
+      console.error("No se pudo guardar el actor persistente:", error);
+      global.alert?.("No se pudo guardar el actor. Revisa permisos y consola.");
+      save.textContent = oldText;
+    } finally {
+      save.disabled = false;
+    }
+  }
+
+  function findUniqueActorIdByName(name) {
+    const normalized = String(name || "").trim().toLowerCase();
+    if (!normalized) return null;
+    const matches = Object.entries(actorPool()).filter(([, actor]) => String(actor?.nombre || "").trim().toLowerCase() === normalized);
+    return matches.length === 1 ? matches[0][0] : null;
+  }
+
+  function decorateLiveCards() {
+    doc.querySelectorAll("#live-actors-list .actor-control-card").forEach((card) => {
+      if (card.querySelector(".btn-edit-source")) return;
+      const actorName = card.querySelector(".actor-name")?.textContent || "";
+      const actorId = findUniqueActorIdByName(actorName);
+      if (!actorId) return;
+      const buttons = card.querySelector(".actor-buttons");
+      if (!buttons) return;
+      const button = doc.createElement("button");
+      button.type = "button";
+      button.className = "btn-edit-source";
+      button.textContent = "EDITAR ACTOR FUENTE";
+      button.addEventListener("click", () => {
+        const record = persistentRecord(actorId);
+        if (record) openEditor({ mode: "edit", actorId, root: record.root, data: record.data, playerId: record.data?.vinculo_jugador || null });
+      });
+      buttons.appendChild(button);
+    });
+  }
+
+  function mountControls() {
+    const section = doc.querySelector(".npc-spawner-section");
+    const select = doc.getElementById("select-npc-roster");
+    const spawn = doc.getElementById("btn-spawn-npc");
+    if (!section || !select || !spawn || section.dataset.actorStudioReady === "true") return;
+    section.dataset.actorStudioReady = "true";
+
+    spawn.textContent = "AÑADIR AL CAST (TEMPORAL)";
+    spawn.title = "Crea una instancia temporal en la escena actual. No crea ni modifica la ficha persistente del actor.";
+
+    const actions = doc.createElement("div");
+    actions.className = "theatre-actor-source-actions";
+    actions.innerHTML = `
+      <button id="btn-edit-actor-source" type="button">EDITAR / REPARAR FUENTE</button>
+      <button id="btn-new-persistent-actor" type="button">NUEVO ACTOR PERSISTENTE</button>
+    `;
+
+    const note = doc.createElement("p");
+    note.className = "theatre-actor-source-note";
+    note.innerHTML = "<strong>CAST TEMPORAL:</strong> vive solo en la escena actual. <strong>ACTOR PERSISTENTE:</strong> se guarda en la base del Theatre y puede editarse/reutilizarse en otras escenas.";
+    section.append(actions, note);
+
+    select.addEventListener("change", syncSpawnButtonState);
+    actions.querySelector("#btn-edit-actor-source")?.addEventListener("click", async () => {
+      const context = await resolveSelectedContext();
+      if (!context) {
+        global.alert?.("Selecciona un actor o jugador en el roster antes de editarlo.");
+        return;
+      }
+      openEditor(context);
+    });
+    actions.querySelector("#btn-new-persistent-actor")?.addEventListener("click", () => {
+      openEditor({ mode: "new", data: { tipo: "NPC", escala: 1 } });
+    });
+    syncSpawnButtonState();
+  }
+
+  function subscribe() {
+    db.ref(ROOTS.base).on("value", (snap) => {
+      state.base = snap.val() || {};
+      scheduleRosterRefresh();
+      global.setTimeout(decorateLiveCards, 80);
+    });
+    db.ref(ROOTS.legacy).on("value", (snap) => {
+      state.legacy = snap.val() || {};
+      scheduleRosterRefresh();
+      global.setTimeout(decorateLiveCards, 80);
+    });
+    db.ref(ROOTS.players).on("value", (snap) => {
+      state.players = snap.val() || {};
+      scheduleRosterRefresh();
+    });
+  }
+
+  function boot() {
+    createEditor();
+    mountControls();
+    subscribe();
+
+    const observer = new MutationObserver(() => {
+      mountControls();
+      scheduleRosterRefresh();
+      decorateLiveCards();
+    });
+    observer.observe(doc.body, { childList: true, subtree: true });
+  }
+
+  if (doc.readyState === "loading") doc.addEventListener("DOMContentLoaded", boot, { once: true });
+  else boot();
+
+  global.LuminousTheatreActorStudio = Object.freeze({
+    persistentRecord,
+    linkedActorId,
+    refreshUnlinkedPlayers,
+    resolveSelectedContext,
+    propagateActorSource,
+  });
+})(window);

--- a/js/theatre-actor-studio.js
+++ b/js/theatre-actor-studio.js
@@ -11,34 +11,15 @@
     legacy: "campaña/actores",
     players: "campaña/jugadores",
   };
+  const state = { base: {}, legacy: {}, players: {}, editorContext: null };
 
-  const state = {
-    base: {},
-    legacy: {},
-    players: {},
-    refreshTimer: null,
-    editorContext: null,
-  };
-
-  function scenePath() {
-    return global.LuminousTheatreState?.getPaths?.().scene || "campaña/estado_mundo/escena_actual";
-  }
-
-  function actorPool() {
-    return Object.assign({}, state.legacy, state.base);
-  }
-
-  function playerLabel(playerId, player) {
-    return player?.characterName || player?.character_name || player?.nombre || player?.name || playerId;
-  }
+  const scenePath = () => global.LuminousTheatreState?.getPaths?.().scene || "campaña/estado_mundo/escena_actual";
+  const actorPool = () => Object.assign({}, state.legacy, state.base);
+  const playerLabel = (id, player) => player?.characterName || player?.character_name || player?.nombre || player?.name || id;
 
   function slug(value) {
-    return String(value || "actor")
-      .normalize("NFD")
-      .replace(/[\u0300-\u036f]/g, "")
-      .toLowerCase()
-      .replace(/[^a-z0-9_-]+/g, "_")
-      .replace(/^_+|_+$/g, "") || "actor";
+    return String(value || "actor").normalize("NFD").replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase().replace(/[^a-z0-9_-]+/g, "_").replace(/^_+|_+$/g, "") || "actor";
   }
 
   function persistentRecord(actorId) {
@@ -60,35 +41,11 @@
     }) || null;
   }
 
-  function scheduleRosterRefresh() {
-    global.clearTimeout(state.refreshTimer);
-    state.refreshTimer = global.setTimeout(refreshUnlinkedPlayers, 60);
-  }
-
-  function refreshUnlinkedPlayers() {
-    const select = doc.getElementById("select-npc-roster");
-    if (!select) return;
-
-    select.querySelector('optgroup[data-actor-studio="unlinked"]')?.remove();
-    const missing = Object.entries(state.players).filter(([playerId, player]) => !linkedActorId(playerId, player));
-    if (!missing.length) {
-      syncSpawnButtonState();
-      return;
-    }
-
-    const group = doc.createElement("optgroup");
-    group.label = "JUGADORES SIN ACTOR THEATRE";
-    group.dataset.actorStudio = "unlinked";
-    missing.forEach(([playerId, player]) => {
-      const option = doc.createElement("option");
-      option.value = `__player__:${playerId}`;
-      option.textContent = `${playerLabel(playerId, player)} · CREAR ACTOR`;
-      option.dataset.sourceType = "unlinked-player";
-      option.dataset.sourceId = playerId;
-      group.appendChild(option);
-    });
-    select.appendChild(group);
-    syncSpawnButtonState();
+  function missingPlayerIds() {
+    return Object.entries(state.players)
+      .filter(([playerId, player]) => !linkedActorId(playerId, player))
+      .map(([playerId]) => playerId)
+      .sort();
   }
 
   function syncSpawnButtonState() {
@@ -99,70 +56,66 @@
     spawn.dataset.unlinkedPlayer = unlinked ? "true" : "false";
     spawn.disabled = unlinked;
     spawn.title = unlinked
-      ? "Este jugador todavía no tiene actor Theatre. Usa EDITAR / REPARAR FUENTE para crearlo primero."
-      : "Añade una instancia temporal de este actor al cast de la escena actual.";
+      ? "Crea/repara primero el actor persistente de este jugador."
+      : "Añade una instancia temporal al cast de la escena actual.";
   }
+
+  function refreshUnlinkedPlayers() {
+    const select = doc.getElementById("select-npc-roster");
+    if (!select) return;
+    const ids = missingPlayerIds();
+    const signature = ids.join("|");
+    const current = select.querySelector('optgroup[data-actor-studio="unlinked"]');
+    if (current?.dataset.signature === signature) {
+      syncSpawnButtonState();
+      return;
+    }
+    current?.remove();
+    if (!ids.length) {
+      syncSpawnButtonState();
+      return;
+    }
+
+    const group = doc.createElement("optgroup");
+    group.label = "JUGADORES SIN ACTOR THEATRE";
+    group.dataset.actorStudio = "unlinked";
+    group.dataset.signature = signature;
+    ids.forEach((playerId) => {
+      const option = doc.createElement("option");
+      option.value = `__player__:${playerId}`;
+      option.textContent = `${playerLabel(playerId, state.players[playerId])} · CREAR ACTOR`;
+      option.dataset.sourceType = "unlinked-player";
+      option.dataset.sourceId = playerId;
+      group.appendChild(option);
+    });
+    select.appendChild(group);
+    syncSpawnButtonState();
+  }
+
+  function field(id) { return doc.getElementById(id); }
 
   function createEditor() {
     let overlay = doc.getElementById("theatre-actor-studio-overlay");
     if (overlay) return overlay;
-
     overlay = doc.createElement("div");
     overlay.id = "theatre-actor-studio-overlay";
     overlay.className = "theatre-actor-studio-overlay";
     overlay.setAttribute("aria-hidden", "true");
     overlay.innerHTML = `
       <section class="theatre-actor-studio" role="dialog" aria-modal="true" aria-labelledby="theatre-actor-studio-title">
-        <header class="theatre-actor-studio__header">
-          <div>
-            <span class="theatre-actor-studio__eyebrow">ACTOR SOURCE / PERSISTENT DATABASE</span>
-            <h2 id="theatre-actor-studio-title" class="theatre-actor-studio__title">EDITAR ACTOR</h2>
-          </div>
-          <button class="theatre-actor-studio__close" type="button" aria-label="Cerrar">×</button>
-        </header>
-        <div class="theatre-actor-studio__body">
-          <p id="theatre-actor-studio-source" class="theatre-actor-studio__source"></p>
-          <div class="theatre-actor-studio__grid">
-            <div class="theatre-actor-field">
-              <label for="theatre-actor-name">Nombre</label>
-              <input id="theatre-actor-name" type="text" autocomplete="off">
-            </div>
-            <div class="theatre-actor-field">
-              <label for="theatre-actor-title">Título</label>
-              <input id="theatre-actor-title" type="text" autocomplete="off">
-            </div>
-            <div class="theatre-actor-field">
-              <label for="theatre-actor-type">Tipo</label>
-              <select id="theatre-actor-type"><option value="NPC">NPC</option><option value="Jugador">Jugador</option></select>
-            </div>
-            <div class="theatre-actor-field">
-              <label for="theatre-actor-scale">Escala</label>
-              <input id="theatre-actor-scale" type="number" min="0.25" max="3" step="0.05" value="1">
-            </div>
-            <div class="theatre-actor-field theatre-actor-field--wide">
-              <label for="theatre-actor-icon">Icono del actor · usado en log/HUD</label>
-              <input id="theatre-actor-icon" type="url" placeholder="https://... icono">
-            </div>
-            <div class="theatre-actor-field theatre-actor-field--wide">
-              <label for="theatre-actor-sprite">Sprite de escena · NO se usa como icono</label>
-              <input id="theatre-actor-sprite" type="url" placeholder="https://... sprite">
-            </div>
-            <div class="theatre-actor-field">
-              <label for="theatre-actor-name-color">Color nameplate nombre</label>
-              <input id="theatre-actor-name-color" type="text" placeholder="#4a4a4a">
-            </div>
-            <div class="theatre-actor-field">
-              <label for="theatre-actor-title-color">Color nameplate título</label>
-              <input id="theatre-actor-title-color" type="text" placeholder="#4a4a4a">
-            </div>
-          </div>
-        </div>
-        <footer class="theatre-actor-studio__footer">
-          <button class="theatre-actor-studio__cancel" type="button">CANCELAR</button>
-          <button class="theatre-actor-studio__save" type="button">GUARDAR FUENTE</button>
-        </footer>
-      </section>
-    `;
+        <header class="theatre-actor-studio__header"><div><span class="theatre-actor-studio__eyebrow">ACTOR SOURCE / PERSISTENT DATABASE</span><h2 id="theatre-actor-studio-title" class="theatre-actor-studio__title">EDITAR ACTOR</h2></div><button class="theatre-actor-studio__close" type="button" aria-label="Cerrar">×</button></header>
+        <div class="theatre-actor-studio__body"><p id="theatre-actor-studio-source" class="theatre-actor-studio__source"></p><div class="theatre-actor-studio__grid">
+          <div class="theatre-actor-field"><label for="theatre-actor-name">Nombre</label><input id="theatre-actor-name" type="text"></div>
+          <div class="theatre-actor-field"><label for="theatre-actor-title">Título</label><input id="theatre-actor-title" type="text"></div>
+          <div class="theatre-actor-field"><label for="theatre-actor-type">Tipo</label><select id="theatre-actor-type"><option value="NPC">NPC</option><option value="Jugador">Jugador</option></select></div>
+          <div class="theatre-actor-field"><label for="theatre-actor-scale">Escala</label><input id="theatre-actor-scale" type="number" min="0.25" max="3" step="0.05" value="1"></div>
+          <div class="theatre-actor-field theatre-actor-field--wide"><label for="theatre-actor-icon">Icono · log/HUD</label><input id="theatre-actor-icon" type="url" placeholder="https://... icono"></div>
+          <div class="theatre-actor-field theatre-actor-field--wide"><label for="theatre-actor-sprite">Sprite · escena</label><input id="theatre-actor-sprite" type="url" placeholder="https://... sprite"></div>
+          <div class="theatre-actor-field"><label for="theatre-actor-name-color">Color nombre</label><input id="theatre-actor-name-color" type="text" placeholder="#4a4a4a"></div>
+          <div class="theatre-actor-field"><label for="theatre-actor-title-color">Color título</label><input id="theatre-actor-title-color" type="text" placeholder="#4a4a4a"></div>
+        </div></div>
+        <footer class="theatre-actor-studio__footer"><button class="theatre-actor-studio__cancel" type="button">CANCELAR</button><button class="theatre-actor-studio__save" type="button">GUARDAR FUENTE</button></footer>
+      </section>`;
     doc.body.appendChild(overlay);
 
     const close = () => {
@@ -177,23 +130,17 @@
     return overlay;
   }
 
-  function field(id) {
-    return doc.getElementById(id);
-  }
-
   function openEditor(context) {
     const overlay = createEditor();
     state.editorContext = context;
     const data = context.data || {};
     const isPlayer = Boolean(context.playerId) || data.tipo === "Jugador";
-
     field("theatre-actor-studio-title").textContent = context.mode === "new" ? "NUEVO ACTOR PERSISTENTE" : "EDITAR ACTOR PERSISTENTE";
     field("theatre-actor-studio-source").textContent = context.mode === "new"
-      ? "Se guardará en campaña/base_datos_npcs y aparecerá en el selector del Theatre."
+      ? "Se guardará en campaña/base_datos_npcs y quedará reutilizable entre escenas."
       : context.unlinked
-        ? `Jugador ${context.playerId}: se creará y enlazará un actor persistente antes de poder añadirlo al cast.`
-        : `Fuente: ${context.root}/${context.actorId}. Los cambios se propagan a sus instancias actuales del cast.`;
-
+        ? `Jugador ${context.playerId}: se creará y enlazará su actor Theatre persistente.`
+        : `Fuente: ${context.root}/${context.actorId}. El cast actual se sincronizará al guardar.`;
     field("theatre-actor-name").value = data.nombre || data.characterName || data.character_name || data.name || "";
     field("theatre-actor-title").value = data.titulo || data.identity || "";
     field("theatre-actor-type").value = isPlayer ? "Jugador" : (data.tipo || "NPC");
@@ -203,7 +150,6 @@
     field("theatre-actor-sprite").value = data.sprite || data.url || "";
     field("theatre-actor-name-color").value = data.color_nombre || "";
     field("theatre-actor-title-color").value = data.color_titulo || "";
-
     overlay.classList.add("open");
     overlay.setAttribute("aria-hidden", "false");
     field("theatre-actor-name").focus();
@@ -213,34 +159,16 @@
     const select = doc.getElementById("select-npc-roster");
     const option = select?.options?.[select.selectedIndex];
     if (!select?.value || !option) return null;
-
     if (select.value.startsWith("__player__:")) {
       const playerId = option.dataset.sourceId || select.value.slice("__player__:".length);
       const player = state.players[playerId] || (await db.ref(`${ROOTS.players}/${playerId}`).once("value")).val() || {};
       return { mode: "edit", unlinked: true, playerId, data: player };
     }
-
-    const actorId = select.value;
-    let record = persistentRecord(actorId);
-    if (!record) {
-      const [baseSnap, legacySnap] = await Promise.all([
-        db.ref(`${ROOTS.base}/${actorId}`).once("value"),
-        db.ref(`${ROOTS.legacy}/${actorId}`).once("value"),
-      ]);
-      if (baseSnap.exists()) record = { actorId, root: ROOTS.base, data: baseSnap.val() || {} };
-      else if (legacySnap.exists()) record = { actorId, root: ROOTS.legacy, data: legacySnap.val() || {} };
-    }
+    const record = persistentRecord(select.value);
     if (!record) return null;
-
     const sourceType = option.dataset.sourceType || "npc";
-    const sourceId = option.dataset.sourceId || actorId;
-    return {
-      mode: "edit",
-      actorId,
-      root: record.root,
-      data: record.data,
-      playerId: sourceType === "player-profile" ? sourceId : (record.data?.vinculo_jugador || null),
-    };
+    const sourceId = option.dataset.sourceId || record.actorId;
+    return { mode: "edit", actorId: record.actorId, root: record.root, data: record.data, playerId: sourceType === "player-profile" ? sourceId : (record.data?.vinculo_jugador || null) };
   }
 
   function editorPayload(context) {
@@ -259,8 +187,7 @@
   }
 
   async function propagateActorSource(actorId, playerId, payload) {
-    const snap = await db.ref(`${scenePath()}/actores`).once("value");
-    const live = snap.val() || {};
+    const live = (await db.ref(`${scenePath()}/actores`).once("value")).val() || {};
     const updates = {};
     Object.entries(live).forEach(([instanceId, actor]) => {
       const match = actor?.identityId === actorId || actor?.sourceId === actorId || (playerId && actor?.sourceId === playerId);
@@ -277,51 +204,38 @@
     if (!context) return;
     const save = doc.querySelector(".theatre-actor-studio__save");
     const payload = editorPayload(context);
-    if (!payload.nombre) {
-      global.alert?.("El actor necesita un nombre.");
-      return;
-    }
-
+    if (!payload.nombre) return global.alert?.("El actor necesita un nombre.");
     save.disabled = true;
-    const oldText = save.textContent;
     save.textContent = "GUARDANDO...";
     try {
       let actorId = context.actorId;
       let root = context.root || ROOTS.base;
-
       if (context.mode === "new") {
         const ref = db.ref(ROOTS.base).push();
         actorId = ref.key;
-        root = ROOTS.base;
         await ref.set(Object.assign({ identityId: actorId }, payload));
       } else if (context.unlinked && context.playerId) {
         const player = state.players[context.playerId] || {};
-        const preferred = player.actorId && !persistentRecord(player.actorId)
-          ? player.actorId
-          : `jugador_${slug(context.playerId)}`;
-        actorId = preferred;
+        actorId = player.actorId && !persistentRecord(player.actorId) ? player.actorId : `jugador_${slug(context.playerId)}`;
         root = ROOTS.base;
         await db.ref(`${root}/${actorId}`).set(Object.assign({ identityId: actorId }, payload));
         await db.ref(`${ROOTS.players}/${context.playerId}/actorId`).set(actorId);
       } else {
         await db.ref(`${root}/${actorId}`).update(payload);
       }
-
-      await propagateActorSource(actorId, context.playerId || payload.vinculo_jugador || null, payload);
+      await propagateActorSource(actorId, context.playerId || null, payload);
       save.textContent = "GUARDADO";
       global.setTimeout(() => {
         const overlay = doc.getElementById("theatre-actor-studio-overlay");
         overlay?.classList.remove("open");
         overlay?.setAttribute("aria-hidden", "true");
         state.editorContext = null;
-      }, 450);
+      }, 350);
     } catch (error) {
       console.error("No se pudo guardar el actor persistente:", error);
       global.alert?.("No se pudo guardar el actor. Revisa permisos y consola.");
-      save.textContent = oldText;
-    } finally {
-      save.disabled = false;
-    }
+      save.textContent = "GUARDAR FUENTE";
+    } finally { save.disabled = false; }
   }
 
   function findUniqueActorIdByName(name) {
@@ -334,18 +248,17 @@
   function decorateLiveCards() {
     doc.querySelectorAll("#live-actors-list .actor-control-card").forEach((card) => {
       if (card.querySelector(".btn-edit-source")) return;
-      const actorName = card.querySelector(".actor-name")?.textContent || "";
-      const actorId = findUniqueActorIdByName(actorName);
-      if (!actorId) return;
+      const actorId = findUniqueActorIdByName(card.querySelector(".actor-name")?.textContent || "");
+      const record = persistentRecord(actorId);
       const buttons = card.querySelector(".actor-buttons");
-      if (!buttons) return;
+      if (!record || !buttons) return;
       const button = doc.createElement("button");
       button.type = "button";
       button.className = "btn-edit-source";
       button.textContent = "EDITAR ACTOR FUENTE";
       button.addEventListener("click", () => {
-        const record = persistentRecord(actorId);
-        if (record) openEditor({ mode: "edit", actorId, root: record.root, data: record.data, playerId: record.data?.vinculo_jugador || null });
+        const fresh = persistentRecord(actorId) || record;
+        openEditor({ mode: "edit", actorId, root: fresh.root, data: fresh.data, playerId: fresh.data?.vinculo_jugador || null });
       });
       buttons.appendChild(button);
     });
@@ -357,75 +270,45 @@
     const spawn = doc.getElementById("btn-spawn-npc");
     if (!section || !select || !spawn || section.dataset.actorStudioReady === "true") return;
     section.dataset.actorStudioReady = "true";
-
     spawn.textContent = "AÑADIR AL CAST (TEMPORAL)";
-    spawn.title = "Crea una instancia temporal en la escena actual. No crea ni modifica la ficha persistente del actor.";
+    spawn.title = "Solo crea una instancia en la escena actual; no crea una fuente persistente.";
 
     const actions = doc.createElement("div");
     actions.className = "theatre-actor-source-actions";
-    actions.innerHTML = `
-      <button id="btn-edit-actor-source" type="button">EDITAR / REPARAR FUENTE</button>
-      <button id="btn-new-persistent-actor" type="button">NUEVO ACTOR PERSISTENTE</button>
-    `;
-
+    actions.innerHTML = '<button id="btn-edit-actor-source" type="button">EDITAR / REPARAR FUENTE</button><button id="btn-new-persistent-actor" type="button">NUEVO ACTOR PERSISTENTE</button>';
     const note = doc.createElement("p");
     note.className = "theatre-actor-source-note";
-    note.innerHTML = "<strong>CAST TEMPORAL:</strong> vive solo en la escena actual. <strong>ACTOR PERSISTENTE:</strong> se guarda en la base del Theatre y puede editarse/reutilizarse en otras escenas.";
+    note.innerHTML = "<strong>CAST TEMPORAL:</strong> solo escena actual. <strong>ACTOR PERSISTENTE:</strong> queda en la base y se reutiliza entre escenas.";
     section.append(actions, note);
 
     select.addEventListener("change", syncSpawnButtonState);
     actions.querySelector("#btn-edit-actor-source")?.addEventListener("click", async () => {
       const context = await resolveSelectedContext();
-      if (!context) {
-        global.alert?.("Selecciona un actor o jugador en el roster antes de editarlo.");
-        return;
-      }
-      openEditor(context);
+      if (context) openEditor(context);
+      else global.alert?.("Selecciona un actor o jugador antes de editarlo.");
     });
-    actions.querySelector("#btn-new-persistent-actor")?.addEventListener("click", () => {
-      openEditor({ mode: "new", data: { tipo: "NPC", escala: 1 } });
-    });
+    actions.querySelector("#btn-new-persistent-actor")?.addEventListener("click", () => openEditor({ mode: "new", data: { tipo: "NPC", escala: 1 } }));
     syncSpawnButtonState();
+
+    new MutationObserver(refreshUnlinkedPlayers).observe(select, { childList: true, subtree: true });
+    const liveList = doc.getElementById("live-actors-list");
+    if (liveList) new MutationObserver(decorateLiveCards).observe(liveList, { childList: true, subtree: true });
   }
 
   function subscribe() {
-    db.ref(ROOTS.base).on("value", (snap) => {
-      state.base = snap.val() || {};
-      scheduleRosterRefresh();
-      global.setTimeout(decorateLiveCards, 80);
-    });
-    db.ref(ROOTS.legacy).on("value", (snap) => {
-      state.legacy = snap.val() || {};
-      scheduleRosterRefresh();
-      global.setTimeout(decorateLiveCards, 80);
-    });
-    db.ref(ROOTS.players).on("value", (snap) => {
-      state.players = snap.val() || {};
-      scheduleRosterRefresh();
-    });
+    db.ref(ROOTS.base).on("value", (snap) => { state.base = snap.val() || {}; refreshUnlinkedPlayers(); decorateLiveCards(); });
+    db.ref(ROOTS.legacy).on("value", (snap) => { state.legacy = snap.val() || {}; refreshUnlinkedPlayers(); decorateLiveCards(); });
+    db.ref(ROOTS.players).on("value", (snap) => { state.players = snap.val() || {}; refreshUnlinkedPlayers(); });
   }
 
   function boot() {
     createEditor();
     mountControls();
     subscribe();
-
-    const observer = new MutationObserver(() => {
-      mountControls();
-      scheduleRosterRefresh();
-      decorateLiveCards();
-    });
-    observer.observe(doc.body, { childList: true, subtree: true });
   }
 
   if (doc.readyState === "loading") doc.addEventListener("DOMContentLoaded", boot, { once: true });
   else boot();
 
-  global.LuminousTheatreActorStudio = Object.freeze({
-    persistentRecord,
-    linkedActorId,
-    refreshUnlinkedPlayers,
-    resolveSelectedContext,
-    propagateActorSource,
-  });
+  global.LuminousTheatreActorStudio = Object.freeze({ persistentRecord, linkedActorId, refreshUnlinkedPlayers, resolveSelectedContext, propagateActorSource });
 })(window);

--- a/js/theatre-actor-studio.js
+++ b/js/theatre-actor-studio.js
@@ -11,15 +11,27 @@
     legacy: "campaña/actores",
     players: "campaña/jugadores",
   };
-  const state = { base: {}, legacy: {}, players: {}, editorContext: null };
+
+  const state = {
+    base: {},
+    legacy: {},
+    players: {},
+    context: null,
+    filter: "",
+  };
 
   const scenePath = () => global.LuminousTheatreState?.getPaths?.().scene || "campaña/estado_mundo/escena_actual";
   const actorPool = () => Object.assign({}, state.legacy, state.base);
+  const field = (id) => doc.getElementById(id);
   const playerLabel = (id, player) => player?.characterName || player?.character_name || player?.nombre || player?.name || id;
 
   function slug(value) {
-    return String(value || "actor").normalize("NFD").replace(/[\u0300-\u036f]/g, "")
-      .toLowerCase().replace(/[^a-z0-9_-]+/g, "_").replace(/^_+|_+$/g, "") || "actor";
+    return String(value || "actor")
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, "_")
+      .replace(/^_+|_+$/g, "") || "actor";
   }
 
   function persistentRecord(actorId) {
@@ -41,149 +53,357 @@
     }) || null;
   }
 
-  function missingPlayerIds() {
-    return Object.entries(state.players)
-      .filter(([playerId, player]) => !linkedActorId(playerId, player))
-      .map(([playerId]) => playerId)
-      .sort();
+  function actorLinkedPlayerId(actorId, actor) {
+    if (actor?.vinculo_jugador && state.players[actor.vinculo_jugador]) return actor.vinculo_jugador;
+    return Object.keys(state.players).find((playerId) => state.players[playerId]?.actorId === actorId) || null;
   }
 
-  function syncSpawnButtonState() {
-    const select = doc.getElementById("select-npc-roster");
-    const spawn = doc.getElementById("btn-spawn-npc");
-    if (!select || !spawn) return;
-    const unlinked = String(select.value || "").startsWith("__player__:");
-    spawn.dataset.unlinkedPlayer = unlinked ? "true" : "false";
-    spawn.disabled = unlinked;
-    spawn.title = unlinked
-      ? "Crea/repara primero el actor persistente de este jugador."
-      : "Añade una instancia temporal al cast de la escena actual.";
+  function expressionSprite(value) {
+    if (typeof value === "string") return value;
+    return value?.sprite || value?.url || value?.imagen || "";
   }
 
-  function refreshUnlinkedPlayers() {
-    const select = doc.getElementById("select-npc-roster");
-    if (!select) return;
-    const ids = missingPlayerIds();
-    const signature = ids.join("|");
-    const current = select.querySelector('optgroup[data-actor-studio="unlinked"]');
-    if (current?.dataset.signature === signature) {
-      syncSpawnButtonState();
-      return;
-    }
-    current?.remove();
-    if (!ids.length) {
-      syncSpawnButtonState();
-      return;
-    }
+  function sourceLabel(root) {
+    if (root === ROOTS.base) return "BASE PRINCIPAL";
+    if (root === ROOTS.legacy) return "BASE LEGACY";
+    return "NUEVO REGISTRO";
+  }
 
-    const group = doc.createElement("optgroup");
-    group.label = "JUGADORES SIN ACTOR THEATRE";
-    group.dataset.actorStudio = "unlinked";
-    group.dataset.signature = signature;
-    ids.forEach((playerId) => {
-      const option = doc.createElement("option");
-      option.value = `__player__:${playerId}`;
-      option.textContent = `${playerLabel(playerId, state.players[playerId])} · CREAR ACTOR`;
-      option.dataset.sourceType = "unlinked-player";
-      option.dataset.sourceId = playerId;
-      group.appendChild(option);
+  function mountMasterPanel() {
+    const director = doc.getElementById("theatre-director-panel");
+    const quickCast = doc.querySelector(".npc-spawner-section");
+    if (!director || !quickCast || doc.getElementById("theatre-actor-master-panel")) return;
+
+    const panel = doc.createElement("section");
+    panel.id = "theatre-actor-master-panel";
+    panel.className = "theatre-actor-master-panel";
+    panel.innerHTML = `
+      <header class="theatre-master-header">
+        <div>
+          <span class="theatre-master-eyebrow">MASTER DATABASE / DM AUTHORITY</span>
+          <h4>CONTROL MAESTRO DE ACTORES</h4>
+          <p>Administra la fuente persistente. El cast de escena es temporal y se controla por separado.</p>
+        </div>
+        <span id="theatre-master-status" class="theatre-master-status">SIN SELECCIÓN</span>
+      </header>
+
+      <div class="theatre-master-layout">
+        <aside class="theatre-master-browser">
+          <label for="theatre-master-search">BUSCAR</label>
+          <input id="theatre-master-search" type="search" placeholder="Jugador, NPC, actorId..." autocomplete="off">
+          <label for="theatre-master-source-select">FUENTES PERSISTENTES / JUGADORES</label>
+          <select id="theatre-master-source-select" size="11" aria-label="Fuentes persistentes de actores"></select>
+          <div class="theatre-master-browser-actions">
+            <button id="theatre-master-new-npc" type="button">+ NUEVO NPC</button>
+            <button id="theatre-master-reload" type="button">RECARGAR LISTA</button>
+          </div>
+          <p class="theatre-master-help"><strong>JUGADORES:</strong> siempre aparecen aquí. Si uno no tiene actor Theatre, selecciónalo y guarda para crearlo/repararlo.</p>
+        </aside>
+
+        <div class="theatre-master-editor">
+          <div class="theatre-master-source-meta">
+            <span id="theatre-master-source-kind">NUEVO REGISTRO</span>
+            <code id="theatre-master-source-path">campaña/base_datos_npcs</code>
+          </div>
+
+          <div class="theatre-master-fields">
+            <label class="theatre-master-field">
+              <span>Nombre</span>
+              <input id="theatre-master-name" type="text" autocomplete="off">
+            </label>
+            <label class="theatre-master-field">
+              <span>Título</span>
+              <input id="theatre-master-title" type="text" autocomplete="off">
+            </label>
+            <label class="theatre-master-field">
+              <span>Tipo</span>
+              <select id="theatre-master-type"><option value="NPC">NPC</option><option value="Jugador">Jugador</option></select>
+            </label>
+            <label class="theatre-master-field">
+              <span>Jugador vinculado</span>
+              <select id="theatre-master-player-link"><option value="">— Sin vínculo —</option></select>
+            </label>
+            <label class="theatre-master-field">
+              <span>Escala</span>
+              <input id="theatre-master-scale" type="number" min="0.25" max="3" step="0.05" value="1">
+            </label>
+            <label class="theatre-master-field">
+              <span>Color nombre</span>
+              <input id="theatre-master-name-color" type="text" placeholder="#4a4a4a">
+            </label>
+            <label class="theatre-master-field">
+              <span>Color título</span>
+              <input id="theatre-master-title-color" type="text" placeholder="#4a4a4a">
+            </label>
+            <label class="theatre-master-field theatre-master-field--wide">
+              <span>Icono · log / HUD</span>
+              <input id="theatre-master-icon" type="url" placeholder="https://... icono">
+            </label>
+            <label class="theatre-master-field theatre-master-field--wide">
+              <span>Sprite base · escena</span>
+              <input id="theatre-master-sprite" type="url" placeholder="https://... sprite">
+            </label>
+          </div>
+
+          <details class="theatre-master-advanced">
+            <summary>EXPRESIONES / AVANZADO</summary>
+            <p>Mapa JSON de expresiones. Se conserva como parte de la fuente persistente.</p>
+            <textarea id="theatre-master-expressions" spellcheck="false" placeholder='{"Neutral":"https://...","Enojado":"https://..."}'></textarea>
+          </details>
+
+          <div class="theatre-master-actions">
+            <button id="theatre-master-save" type="button" class="is-primary">GUARDAR EN BASE</button>
+            <button id="theatre-master-add-cast" type="button">AÑADIR AL CAST</button>
+            <button id="theatre-master-delete" type="button" class="is-danger">ELIMINAR ACTOR</button>
+            <button id="theatre-master-clear" type="button">LIMPIAR / NUEVO</button>
+          </div>
+          <p id="theatre-master-feedback" class="theatre-master-feedback" aria-live="polite"></p>
+        </div>
+      </div>
+    `;
+
+    director.insertBefore(panel, quickCast);
+    quickCast.classList.add("theatre-quick-cast");
+    const quickTitle = doc.createElement("div");
+    quickTitle.className = "theatre-quick-cast-title";
+    quickTitle.innerHTML = "<strong>CAST RÁPIDO DE ESCENA</strong><span>Instancias temporales; no modifica la base maestra.</span>";
+    quickCast.prepend(quickTitle);
+
+    bindMasterPanel();
+    renderPlayerLinkOptions();
+    renderSourceList();
+    beginNewActor();
+  }
+
+  function bindMasterPanel() {
+    field("theatre-master-search")?.addEventListener("input", (event) => {
+      state.filter = String(event.target.value || "").trim().toLowerCase();
+      renderSourceList();
     });
-    select.appendChild(group);
-    syncSpawnButtonState();
+
+    field("theatre-master-source-select")?.addEventListener("change", () => {
+      loadSelection(field("theatre-master-source-select").value);
+    });
+
+    field("theatre-master-new-npc")?.addEventListener("click", beginNewActor);
+    field("theatre-master-clear")?.addEventListener("click", beginNewActor);
+    field("theatre-master-reload")?.addEventListener("click", () => {
+      renderPlayerLinkOptions();
+      renderSourceList();
+      feedback("Lista reconstruida desde Firebase.", "ok");
+    });
+    field("theatre-master-save")?.addEventListener("click", saveCurrentActor);
+    field("theatre-master-delete")?.addEventListener("click", deleteCurrentActor);
+    field("theatre-master-add-cast")?.addEventListener("click", addCurrentActorToCast);
+    field("theatre-master-player-link")?.addEventListener("change", (event) => {
+      if (event.target.value) field("theatre-master-type").value = "Jugador";
+    });
   }
 
-  function field(id) { return doc.getElementById(id); }
-
-  function createEditor() {
-    let overlay = doc.getElementById("theatre-actor-studio-overlay");
-    if (overlay) return overlay;
-    overlay = doc.createElement("div");
-    overlay.id = "theatre-actor-studio-overlay";
-    overlay.className = "theatre-actor-studio-overlay";
-    overlay.setAttribute("aria-hidden", "true");
-    overlay.innerHTML = `
-      <section class="theatre-actor-studio" role="dialog" aria-modal="true" aria-labelledby="theatre-actor-studio-title">
-        <header class="theatre-actor-studio__header"><div><span class="theatre-actor-studio__eyebrow">ACTOR SOURCE / PERSISTENT DATABASE</span><h2 id="theatre-actor-studio-title" class="theatre-actor-studio__title">EDITAR ACTOR</h2></div><button class="theatre-actor-studio__close" type="button" aria-label="Cerrar">×</button></header>
-        <div class="theatre-actor-studio__body"><p id="theatre-actor-studio-source" class="theatre-actor-studio__source"></p><div class="theatre-actor-studio__grid">
-          <div class="theatre-actor-field"><label for="theatre-actor-name">Nombre</label><input id="theatre-actor-name" type="text"></div>
-          <div class="theatre-actor-field"><label for="theatre-actor-title">Título</label><input id="theatre-actor-title" type="text"></div>
-          <div class="theatre-actor-field"><label for="theatre-actor-type">Tipo</label><select id="theatre-actor-type"><option value="NPC">NPC</option><option value="Jugador">Jugador</option></select></div>
-          <div class="theatre-actor-field"><label for="theatre-actor-scale">Escala</label><input id="theatre-actor-scale" type="number" min="0.25" max="3" step="0.05" value="1"></div>
-          <div class="theatre-actor-field theatre-actor-field--wide"><label for="theatre-actor-icon">Icono · log/HUD</label><input id="theatre-actor-icon" type="url" placeholder="https://... icono"></div>
-          <div class="theatre-actor-field theatre-actor-field--wide"><label for="theatre-actor-sprite">Sprite · escena</label><input id="theatre-actor-sprite" type="url" placeholder="https://... sprite"></div>
-          <div class="theatre-actor-field"><label for="theatre-actor-name-color">Color nombre</label><input id="theatre-actor-name-color" type="text" placeholder="#4a4a4a"></div>
-          <div class="theatre-actor-field"><label for="theatre-actor-title-color">Color título</label><input id="theatre-actor-title-color" type="text" placeholder="#4a4a4a"></div>
-        </div></div>
-        <footer class="theatre-actor-studio__footer"><button class="theatre-actor-studio__cancel" type="button">CANCELAR</button><button class="theatre-actor-studio__save" type="button">GUARDAR FUENTE</button></footer>
-      </section>`;
-    doc.body.appendChild(overlay);
-
-    const close = () => {
-      overlay.classList.remove("open");
-      overlay.setAttribute("aria-hidden", "true");
-      state.editorContext = null;
-    };
-    overlay.querySelector(".theatre-actor-studio__close")?.addEventListener("click", close);
-    overlay.querySelector(".theatre-actor-studio__cancel")?.addEventListener("click", close);
-    overlay.addEventListener("click", (event) => { if (event.target === overlay) close(); });
-    overlay.querySelector(".theatre-actor-studio__save")?.addEventListener("click", saveEditor);
-    return overlay;
+  function renderPlayerLinkOptions() {
+    const select = field("theatre-master-player-link");
+    if (!select) return;
+    const previous = select.value;
+    select.innerHTML = '<option value="">— Sin vínculo —</option>';
+    Object.entries(state.players)
+      .sort((a, b) => playerLabel(a[0], a[1]).localeCompare(playerLabel(b[0], b[1])))
+      .forEach(([playerId, player]) => {
+        const option = doc.createElement("option");
+        option.value = playerId;
+        option.textContent = playerLabel(playerId, player);
+        select.appendChild(option);
+      });
+    if (previous && state.players[previous]) select.value = previous;
   }
 
-  function openEditor(context) {
-    const overlay = createEditor();
-    state.editorContext = context;
-    const data = context.data || {};
-    const isPlayer = Boolean(context.playerId) || data.tipo === "Jugador";
-    field("theatre-actor-studio-title").textContent = context.mode === "new" ? "NUEVO ACTOR PERSISTENTE" : "EDITAR ACTOR PERSISTENTE";
-    field("theatre-actor-studio-source").textContent = context.mode === "new"
-      ? "Se guardará en campaña/base_datos_npcs y quedará reutilizable entre escenas."
-      : context.unlinked
-        ? `Jugador ${context.playerId}: se creará y enlazará su actor Theatre persistente.`
-        : `Fuente: ${context.root}/${context.actorId}. El cast actual se sincronizará al guardar.`;
-    field("theatre-actor-name").value = data.nombre || data.characterName || data.character_name || data.name || "";
-    field("theatre-actor-title").value = data.titulo || data.identity || "";
-    field("theatre-actor-type").value = isPlayer ? "Jugador" : (data.tipo || "NPC");
-    field("theatre-actor-type").disabled = Boolean(context.playerId);
-    field("theatre-actor-scale").value = String(Number(data.escala) || 1);
-    field("theatre-actor-icon").value = data.icono || data.icono_jugador || data.icon_url || "";
-    field("theatre-actor-sprite").value = data.sprite || data.url || "";
-    field("theatre-actor-name-color").value = data.color_nombre || "";
-    field("theatre-actor-title-color").value = data.color_titulo || "";
-    overlay.classList.add("open");
-    overlay.setAttribute("aria-hidden", "false");
-    field("theatre-actor-name").focus();
+  function renderSourceList() {
+    const select = field("theatre-master-source-select");
+    if (!select) return;
+    const previous = select.value;
+    select.innerHTML = "";
+    const filter = state.filter;
+
+    const playerGroup = doc.createElement("optgroup");
+    playerGroup.label = "JUGADORES";
+    Object.entries(state.players)
+      .sort((a, b) => playerLabel(a[0], a[1]).localeCompare(playerLabel(b[0], b[1])))
+      .forEach(([playerId, player]) => {
+        const actorId = linkedActorId(playerId, player);
+        const actor = actorId ? persistentRecord(actorId)?.data : null;
+        const label = `${playerLabel(playerId, player)} ${actorId ? `· ${actor?.nombre || actorId}` : "· SIN ACTOR THEATRE"}`;
+        if (filter && !`${label} ${playerId} ${actorId || ""}`.toLowerCase().includes(filter)) return;
+        const option = doc.createElement("option");
+        option.value = `player:${playerId}`;
+        option.textContent = label;
+        option.dataset.missingActor = actorId ? "false" : "true";
+        playerGroup.appendChild(option);
+      });
+    if (playerGroup.children.length) select.appendChild(playerGroup);
+
+    const linked = new Set(Object.keys(state.players).map((playerId) => linkedActorId(playerId, state.players[playerId])).filter(Boolean));
+    const actorGroup = doc.createElement("optgroup");
+    actorGroup.label = "NPCs / ACTORES SIN JUGADOR";
+    Object.entries(actorPool())
+      .filter(([actorId]) => !linked.has(actorId))
+      .sort((a, b) => String(a[1]?.nombre || a[0]).localeCompare(String(b[1]?.nombre || b[0])))
+      .forEach(([actorId, actor]) => {
+        const record = persistentRecord(actorId);
+        const label = `${actor?.tipo === "Jugador" ? "[PJ]" : "[NPC]"} ${actor?.nombre || actorId} · ${sourceLabel(record?.root)}`;
+        if (filter && !`${label} ${actorId} ${actor?.titulo || ""}`.toLowerCase().includes(filter)) return;
+        const option = doc.createElement("option");
+        option.value = `actor:${actorId}`;
+        option.textContent = label;
+        actorGroup.appendChild(option);
+      });
+    if (actorGroup.children.length) select.appendChild(actorGroup);
+
+    if (Array.from(select.options).some((option) => option.value === previous)) select.value = previous;
   }
 
-  async function resolveSelectedContext() {
-    const select = doc.getElementById("select-npc-roster");
-    const option = select?.options?.[select.selectedIndex];
-    if (!select?.value || !option) return null;
-    if (select.value.startsWith("__player__:")) {
-      const playerId = option.dataset.sourceId || select.value.slice("__player__:".length);
-      const player = state.players[playerId] || (await db.ref(`${ROOTS.players}/${playerId}`).once("value")).val() || {};
-      return { mode: "edit", unlinked: true, playerId, data: player };
+  function beginNewActor() {
+    state.context = { mode: "new", root: ROOTS.base, actorId: null, playerId: null, data: {} };
+    const sourceSelect = field("theatre-master-source-select");
+    if (sourceSelect) sourceSelect.selectedIndex = -1;
+    setEditorValues({ tipo: "NPC", escala: 1, expresiones: {} }, "");
+    setSourceMeta("NUEVO ACTOR PERSISTENTE", ROOTS.base);
+    setStatus("NUEVO", "new");
+    feedback("Completa los datos y pulsa GUARDAR EN BASE.");
+    field("theatre-master-delete").disabled = true;
+    field("theatre-master-add-cast").disabled = true;
+  }
+
+  function loadSelection(value) {
+    if (!value) return beginNewActor();
+    if (value.startsWith("player:")) {
+      const playerId = value.slice("player:".length);
+      const player = state.players[playerId] || {};
+      const actorId = linkedActorId(playerId, player);
+      const record = persistentRecord(actorId);
+      if (record) {
+        state.context = { mode: "edit", actorId, root: record.root, playerId, data: record.data };
+        setEditorValues(record.data, playerId);
+        setSourceMeta(`JUGADOR · ${playerLabel(playerId, player)}`, `${record.root}/${actorId}`);
+        setStatus("PERSISTENTE", "ok");
+        field("theatre-master-delete").disabled = false;
+        field("theatre-master-add-cast").disabled = false;
+        feedback("Editando la fuente persistente vinculada a este jugador.");
+      } else {
+        state.context = { mode: "repair-player", actorId: null, root: ROOTS.base, playerId, data: player };
+        setEditorValues({
+          nombre: playerLabel(playerId, player),
+          titulo: player?.titulo || player?.identity || "",
+          tipo: "Jugador",
+          escala: 1,
+          icono: player?.icono || player?.icono_jugador || player?.icon_url || "",
+          sprite: player?.sprite || "",
+          expresiones: {},
+        }, playerId);
+        setSourceMeta("JUGADOR SIN ACTOR THEATRE", `${ROOTS.players}/${playerId}`);
+        setStatus("REPARAR", "warn");
+        field("theatre-master-delete").disabled = true;
+        field("theatre-master-add-cast").disabled = true;
+        feedback("Este jugador no tiene fuente Theatre. GUARDAR EN BASE la crea y enlaza.", "warn");
+      }
+      return;
     }
-    const record = persistentRecord(select.value);
-    if (!record) return null;
-    const sourceType = option.dataset.sourceType || "npc";
-    const sourceId = option.dataset.sourceId || record.actorId;
-    return { mode: "edit", actorId: record.actorId, root: record.root, data: record.data, playerId: sourceType === "player-profile" ? sourceId : (record.data?.vinculo_jugador || null) };
+
+    if (value.startsWith("actor:")) {
+      const actorId = value.slice("actor:".length);
+      const record = persistentRecord(actorId);
+      if (!record) {
+        feedback("La fuente seleccionada ya no existe.", "error");
+        renderSourceList();
+        return;
+      }
+      const playerId = actorLinkedPlayerId(actorId, record.data);
+      state.context = { mode: "edit", actorId, root: record.root, playerId, data: record.data };
+      setEditorValues(record.data, playerId || "");
+      setSourceMeta(record.data?.tipo === "Jugador" ? "ACTOR DE JUGADOR" : "NPC / ACTOR", `${record.root}/${actorId}`);
+      setStatus("PERSISTENTE", "ok");
+      field("theatre-master-delete").disabled = false;
+      field("theatre-master-add-cast").disabled = false;
+      feedback("Fuente persistente lista para edición.");
+    }
   }
 
-  function editorPayload(context) {
+  function setEditorValues(data, playerId) {
+    field("theatre-master-name").value = data?.nombre || data?.characterName || data?.character_name || data?.name || "";
+    field("theatre-master-title").value = data?.titulo || data?.identity || "";
+    field("theatre-master-type").value = playerId ? "Jugador" : (data?.tipo || "NPC");
+    field("theatre-master-player-link").value = playerId || "";
+    field("theatre-master-scale").value = String(Number(data?.escala) || 1);
+    field("theatre-master-name-color").value = data?.color_nombre || "";
+    field("theatre-master-title-color").value = data?.color_titulo || "";
+    field("theatre-master-icon").value = data?.icono || data?.icono_jugador || data?.icon_url || "";
+    field("theatre-master-sprite").value = data?.sprite || data?.url || "";
+    field("theatre-master-expressions").value = Object.keys(data?.expresiones || {}).length
+      ? JSON.stringify(data.expresiones, null, 2)
+      : "";
+  }
+
+  function setSourceMeta(kind, path) {
+    field("theatre-master-source-kind").textContent = kind;
+    field("theatre-master-source-path").textContent = path;
+  }
+
+  function setStatus(text, tone) {
+    const status = field("theatre-master-status");
+    if (!status) return;
+    status.textContent = text;
+    status.dataset.tone = tone || "";
+  }
+
+  function feedback(text, tone) {
+    const node = field("theatre-master-feedback");
+    if (!node) return;
+    node.textContent = text || "";
+    node.dataset.tone = tone || "";
+  }
+
+  function parseExpressions() {
+    const raw = String(field("theatre-master-expressions")?.value || "").trim();
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") throw new Error("EXPRESIONES_NOT_OBJECT");
+    return parsed;
+  }
+
+  function buildPayload() {
+    const linkedPlayer = field("theatre-master-player-link").value || "";
+    let expressions;
+    try {
+      expressions = parseExpressions();
+    } catch (_) {
+      global.alert?.("Expresiones debe ser un objeto JSON válido.");
+      return null;
+    }
+
     const payload = {
-      nombre: String(field("theatre-actor-name").value || "").trim(),
-      titulo: String(field("theatre-actor-title").value || "").trim(),
-      tipo: context.playerId ? "Jugador" : field("theatre-actor-type").value,
-      icono: String(field("theatre-actor-icon").value || "").trim(),
-      sprite: String(field("theatre-actor-sprite").value || "").trim(),
-      color_nombre: String(field("theatre-actor-name-color").value || "").trim(),
-      color_titulo: String(field("theatre-actor-title-color").value || "").trim(),
-      escala: Math.max(.25, Math.min(3, Number(field("theatre-actor-scale").value) || 1)),
+      nombre: String(field("theatre-master-name").value || "").trim(),
+      titulo: String(field("theatre-master-title").value || "").trim(),
+      tipo: linkedPlayer ? "Jugador" : field("theatre-master-type").value,
+      vinculo_jugador: linkedPlayer || null,
+      escala: Math.max(.25, Math.min(3, Number(field("theatre-master-scale").value) || 1)),
+      color_nombre: String(field("theatre-master-name-color").value || "").trim(),
+      color_titulo: String(field("theatre-master-title-color").value || "").trim(),
+      icono: String(field("theatre-master-icon").value || "").trim(),
+      sprite: String(field("theatre-master-sprite").value || "").trim(),
+      expresiones: expressions,
     };
-    if (context.playerId) payload.vinculo_jugador = context.playerId;
+    if (!payload.nombre) {
+      global.alert?.("El actor necesita un nombre.");
+      return null;
+    }
     return payload;
+  }
+
+  async function syncPlayerLink(actorId, oldPlayerId, newPlayerId) {
+    const updates = {};
+    if (oldPlayerId && oldPlayerId !== newPlayerId && state.players[oldPlayerId]?.actorId === actorId) {
+      updates[`${ROOTS.players}/${oldPlayerId}/actorId`] = null;
+    }
+    if (newPlayerId) updates[`${ROOTS.players}/${newPlayerId}/actorId`] = actorId;
+    if (Object.keys(updates).length) await db.ref().update(updates);
   }
 
   async function propagateActorSource(actorId, playerId, payload) {
@@ -192,123 +412,227 @@
     Object.entries(live).forEach(([instanceId, actor]) => {
       const match = actor?.identityId === actorId || actor?.sourceId === actorId || (playerId && actor?.sourceId === playerId);
       if (!match) return;
-      ["nombre", "titulo", "tipo", "icono", "sprite", "color_nombre", "color_titulo", "escala"].forEach((key) => {
-        updates[`${scenePath()}/actores/${instanceId}/${key}`] = payload[key] ?? "";
+      ["nombre", "titulo", "tipo", "icono", "sprite", "color_nombre", "color_titulo", "escala", "expresiones"].forEach((key) => {
+        updates[`${scenePath()}/actores/${instanceId}/${key}`] = payload[key] ?? null;
       });
     });
     if (Object.keys(updates).length) await db.ref().update(updates);
   }
 
-  async function saveEditor() {
-    const context = state.editorContext;
-    if (!context) return;
-    const save = doc.querySelector(".theatre-actor-studio__save");
-    const payload = editorPayload(context);
-    if (!payload.nombre) return global.alert?.("El actor necesita un nombre.");
+  async function saveCurrentActor() {
+    const context = state.context || { mode: "new", root: ROOTS.base };
+    const payload = buildPayload();
+    if (!payload) return;
+    const save = field("theatre-master-save");
+    const oldPlayerId = context.playerId || context.data?.vinculo_jugador || "";
+    const newPlayerId = payload.vinculo_jugador || "";
     save.disabled = true;
     save.textContent = "GUARDANDO...";
+    feedback("Escribiendo fuente persistente...", "warn");
+
     try {
       let actorId = context.actorId;
       let root = context.root || ROOTS.base;
+
       if (context.mode === "new") {
         const ref = db.ref(ROOTS.base).push();
         actorId = ref.key;
-        await ref.set(Object.assign({ identityId: actorId }, payload));
-      } else if (context.unlinked && context.playerId) {
-        const player = state.players[context.playerId] || {};
-        actorId = player.actorId && !persistentRecord(player.actorId) ? player.actorId : `jugador_${slug(context.playerId)}`;
         root = ROOTS.base;
+        await ref.set(Object.assign({ identityId: actorId }, payload));
+      } else if (context.mode === "repair-player") {
+        const preferred = state.players[context.playerId]?.actorId || `jugador_${slug(context.playerId)}`;
+        actorId = persistentRecord(preferred) ? db.ref(ROOTS.base).push().key : preferred;
+        root = ROOTS.base;
+        payload.tipo = "Jugador";
+        payload.vinculo_jugador = context.playerId;
         await db.ref(`${root}/${actorId}`).set(Object.assign({ identityId: actorId }, payload));
-        await db.ref(`${ROOTS.players}/${context.playerId}/actorId`).set(actorId);
       } else {
         await db.ref(`${root}/${actorId}`).update(payload);
       }
-      await propagateActorSource(actorId, context.playerId || null, payload);
-      save.textContent = "GUARDADO";
-      global.setTimeout(() => {
-        const overlay = doc.getElementById("theatre-actor-studio-overlay");
-        overlay?.classList.remove("open");
-        overlay?.setAttribute("aria-hidden", "true");
-        state.editorContext = null;
-      }, 350);
+
+      await syncPlayerLink(actorId, oldPlayerId, payload.vinculo_jugador || "");
+      await propagateActorSource(actorId, payload.vinculo_jugador || oldPlayerId || null, payload);
+
+      state.context = { mode: "edit", actorId, root, playerId: payload.vinculo_jugador || null, data: payload };
+      setSourceMeta(payload.tipo === "Jugador" ? "ACTOR DE JUGADOR" : "NPC / ACTOR", `${root}/${actorId}`);
+      setStatus("GUARDADO", "ok");
+      field("theatre-master-delete").disabled = false;
+      field("theatre-master-add-cast").disabled = false;
+      feedback("Fuente persistente guardada. Las instancias actuales del cast fueron sincronizadas.", "ok");
+      renderSourceList();
+      selectContextInBrowser(actorId, payload.vinculo_jugador || "");
     } catch (error) {
       console.error("No se pudo guardar el actor persistente:", error);
-      global.alert?.("No se pudo guardar el actor. Revisa permisos y consola.");
-      save.textContent = "GUARDAR FUENTE";
-    } finally { save.disabled = false; }
+      setStatus("ERROR", "error");
+      feedback("No se pudo guardar. Revisa permisos/Firebase y consola.", "error");
+      global.alert?.("No se pudo guardar el actor persistente.");
+    } finally {
+      save.disabled = false;
+      save.textContent = "GUARDAR EN BASE";
+    }
   }
 
-  function findUniqueActorIdByName(name) {
-    const normalized = String(name || "").trim().toLowerCase();
-    if (!normalized) return null;
-    const matches = Object.entries(actorPool()).filter(([, actor]) => String(actor?.nombre || "").trim().toLowerCase() === normalized);
-    return matches.length === 1 ? matches[0][0] : null;
+  function selectContextInBrowser(actorId, playerId) {
+    const select = field("theatre-master-source-select");
+    if (!select) return;
+    const preferred = playerId ? `player:${playerId}` : `actor:${actorId}`;
+    if (Array.from(select.options).some((option) => option.value === preferred)) select.value = preferred;
   }
 
-  function decorateLiveCards() {
+  async function addCurrentActorToCast() {
+    const context = state.context;
+    if (!context?.actorId) {
+      global.alert?.("Guarda primero el actor en la base maestra.");
+      return;
+    }
+    const record = persistentRecord(context.actorId) || { data: context.data || {} };
+    const actor = record.data || {};
+    const playerId = actorLinkedPlayerId(context.actorId, actor) || context.playerId || null;
+    const instanceId = `actor_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
+    const expressions = actor.expresiones || {};
+    const firstExpression = Object.keys(expressions)[0] || "";
+    const baseSprite = actor.sprite || actor.url || expressionSprite(expressions[firstExpression]) || "";
+
+    const payload = {
+      nombre: actor.nombre || context.actorId,
+      titulo: actor.titulo || "",
+      tipo: actor.tipo || (playerId ? "Jugador" : "NPC"),
+      color_nombre: actor.color_nombre || "",
+      color_titulo: actor.color_titulo || "",
+      identityId: actor.identityId || context.actorId,
+      sourceId: playerId || context.actorId,
+      sourceType: playerId ? "player-profile" : "npc",
+      sprite: baseSprite,
+      icono: actor.icono || actor.icono_jugador || actor.icon_url || "",
+      expresiones: expressions,
+      x: 0,
+      y: 0,
+      escala: Number(actor.escala) || 1,
+      orientacion: "normal",
+      spawnedAt: global.firebase.database.ServerValue.TIMESTAMP,
+    };
+
+    try {
+      await db.ref(`${scenePath()}/actores/${instanceId}`).set(payload);
+      feedback(`${payload.nombre} añadido al cast temporal de la escena.`, "ok");
+    } catch (error) {
+      console.error("No se pudo añadir actor al cast:", error);
+      feedback("No se pudo añadir al cast.", "error");
+    }
+  }
+
+  async function deleteCurrentActor() {
+    const context = state.context;
+    if (!context?.actorId || !context.root) return;
+    const record = persistentRecord(context.actorId) || { data: context.data || {} };
+    const actor = record.data || {};
+    const name = actor.nombre || context.actorId;
+    const linkedPlayer = actorLinkedPlayerId(context.actorId, actor) || context.playerId || null;
+    if (!global.confirm?.(`Eliminar permanentemente el actor "${name}" de la base maestra?\n\nTambién se retirarán sus instancias de la escena actual. El jugador, si existe, NO se elimina; quedará sin actor Theatre.`)) return;
+
+    const button = field("theatre-master-delete");
+    button.disabled = true;
+    feedback("Eliminando fuente persistente...", "warn");
+    try {
+      const live = (await db.ref(`${scenePath()}/actores`).once("value")).val() || {};
+      const instanceIds = Object.entries(live)
+        .filter(([, liveActor]) => liveActor?.identityId === context.actorId || liveActor?.sourceId === context.actorId || (linkedPlayer && liveActor?.sourceId === linkedPlayer))
+        .map(([instanceId]) => instanceId);
+
+      for (const instanceId of instanceIds) {
+        if (global.LuminousTheatreState?.removeVisibleActor) {
+          await global.LuminousTheatreState.removeVisibleActor(instanceId).catch(() => {});
+        }
+        await db.ref(`${scenePath()}/actores/${instanceId}`).remove();
+      }
+
+      await db.ref(`${context.root}/${context.actorId}`).remove();
+      if (linkedPlayer && state.players[linkedPlayer]?.actorId === context.actorId) {
+        await db.ref(`${ROOTS.players}/${linkedPlayer}/actorId`).remove();
+      }
+
+      setStatus("ELIMINADO", "warn");
+      feedback(`Actor ${name} eliminado.`, "ok");
+      beginNewActor();
+    } catch (error) {
+      console.error("No se pudo eliminar el actor:", error);
+      feedback("No se pudo eliminar el actor.", "error");
+      button.disabled = false;
+    }
+  }
+
+  function decorateQuickCast() {
+    const spawn = doc.getElementById("btn-spawn-npc");
+    if (spawn) {
+      spawn.textContent = "AÑADIR AL CAST (TEMPORAL)";
+      spawn.title = "Crea una instancia temporal de la selección en la escena actual.";
+    }
+
     doc.querySelectorAll("#live-actors-list .actor-control-card").forEach((card) => {
       if (card.querySelector(".btn-edit-source")) return;
-      const actorId = findUniqueActorIdByName(card.querySelector(".actor-name")?.textContent || "");
-      const record = persistentRecord(actorId);
+      const actorName = String(card.querySelector(".actor-name")?.textContent || "").trim().toLowerCase();
+      const matches = Object.entries(actorPool()).filter(([, actor]) => String(actor?.nombre || "").trim().toLowerCase() === actorName);
+      if (matches.length !== 1) return;
+      const actorId = matches[0][0];
       const buttons = card.querySelector(".actor-buttons");
-      if (!record || !buttons) return;
-      const button = doc.createElement("button");
-      button.type = "button";
-      button.className = "btn-edit-source";
-      button.textContent = "EDITAR ACTOR FUENTE";
-      button.addEventListener("click", () => {
-        const fresh = persistentRecord(actorId) || record;
-        openEditor({ mode: "edit", actorId, root: fresh.root, data: fresh.data, playerId: fresh.data?.vinculo_jugador || null });
+      if (!buttons) return;
+      const edit = doc.createElement("button");
+      edit.type = "button";
+      edit.className = "btn-edit-source";
+      edit.textContent = "ABRIR EN CONTROL MAESTRO";
+      edit.addEventListener("click", () => {
+        const record = persistentRecord(actorId);
+        if (!record) return;
+        const playerId = actorLinkedPlayerId(actorId, record.data);
+        const sourceSelect = field("theatre-master-source-select");
+        const value = playerId ? `player:${playerId}` : `actor:${actorId}`;
+        if (sourceSelect && Array.from(sourceSelect.options).some((option) => option.value === value)) {
+          sourceSelect.value = value;
+          loadSelection(value);
+          field("theatre-actor-master-panel")?.scrollIntoView?.({ behavior: "smooth", block: "start" });
+        }
       });
-      buttons.appendChild(button);
+      buttons.appendChild(edit);
     });
-  }
-
-  function mountControls() {
-    const section = doc.querySelector(".npc-spawner-section");
-    const select = doc.getElementById("select-npc-roster");
-    const spawn = doc.getElementById("btn-spawn-npc");
-    if (!section || !select || !spawn || section.dataset.actorStudioReady === "true") return;
-    section.dataset.actorStudioReady = "true";
-    spawn.textContent = "AÑADIR AL CAST (TEMPORAL)";
-    spawn.title = "Solo crea una instancia en la escena actual; no crea una fuente persistente.";
-
-    const actions = doc.createElement("div");
-    actions.className = "theatre-actor-source-actions";
-    actions.innerHTML = '<button id="btn-edit-actor-source" type="button">EDITAR / REPARAR FUENTE</button><button id="btn-new-persistent-actor" type="button">NUEVO ACTOR PERSISTENTE</button>';
-    const note = doc.createElement("p");
-    note.className = "theatre-actor-source-note";
-    note.innerHTML = "<strong>CAST TEMPORAL:</strong> solo escena actual. <strong>ACTOR PERSISTENTE:</strong> queda en la base y se reutiliza entre escenas.";
-    section.append(actions, note);
-
-    select.addEventListener("change", syncSpawnButtonState);
-    actions.querySelector("#btn-edit-actor-source")?.addEventListener("click", async () => {
-      const context = await resolveSelectedContext();
-      if (context) openEditor(context);
-      else global.alert?.("Selecciona un actor o jugador antes de editarlo.");
-    });
-    actions.querySelector("#btn-new-persistent-actor")?.addEventListener("click", () => openEditor({ mode: "new", data: { tipo: "NPC", escala: 1 } }));
-    syncSpawnButtonState();
-
-    new MutationObserver(refreshUnlinkedPlayers).observe(select, { childList: true, subtree: true });
-    const liveList = doc.getElementById("live-actors-list");
-    if (liveList) new MutationObserver(decorateLiveCards).observe(liveList, { childList: true, subtree: true });
   }
 
   function subscribe() {
-    db.ref(ROOTS.base).on("value", (snap) => { state.base = snap.val() || {}; refreshUnlinkedPlayers(); decorateLiveCards(); });
-    db.ref(ROOTS.legacy).on("value", (snap) => { state.legacy = snap.val() || {}; refreshUnlinkedPlayers(); decorateLiveCards(); });
-    db.ref(ROOTS.players).on("value", (snap) => { state.players = snap.val() || {}; refreshUnlinkedPlayers(); });
+    db.ref(ROOTS.base).on("value", (snap) => {
+      state.base = snap.val() || {};
+      renderSourceList();
+      decorateQuickCast();
+    });
+    db.ref(ROOTS.legacy).on("value", (snap) => {
+      state.legacy = snap.val() || {};
+      renderSourceList();
+      decorateQuickCast();
+    });
+    db.ref(ROOTS.players).on("value", (snap) => {
+      state.players = snap.val() || {};
+      renderPlayerLinkOptions();
+      renderSourceList();
+    });
+
+    const liveList = doc.getElementById("live-actors-list");
+    if (liveList) new MutationObserver(decorateQuickCast).observe(liveList, { childList: true, subtree: true });
   }
 
   function boot() {
-    createEditor();
-    mountControls();
+    mountMasterPanel();
+    decorateQuickCast();
     subscribe();
   }
 
   if (doc.readyState === "loading") doc.addEventListener("DOMContentLoaded", boot, { once: true });
   else boot();
 
-  global.LuminousTheatreActorStudio = Object.freeze({ persistentRecord, linkedActorId, refreshUnlinkedPlayers, resolveSelectedContext, propagateActorSource });
+  global.LuminousTheatreActorStudio = Object.freeze({
+    persistentRecord,
+    linkedActorId,
+    actorLinkedPlayerId,
+    renderSourceList,
+    loadSelection,
+    propagateActorSource,
+    addCurrentActorToCast,
+  });
 })(window);

--- a/js/utils.js
+++ b/js/utils.js
@@ -88,11 +88,49 @@ function ensurePlayerTerminalStyles(doc) {
     return link;
 }
 
+/**
+ * Carga los retoques funcionales/visuales del jugador sin tocar el HTML gigante.
+ * @param {Document} doc
+ * @returns {{link: HTMLLinkElement|null, script: HTMLScriptElement|null}|null}
+ */
+function ensurePlayerUxPolishAssets(doc) {
+    const documentRef = doc || (typeof document !== 'undefined' ? document : null);
+    if (!documentRef?.querySelector?.('.sheet-phone-wrapper')) return null;
+
+    let link = documentRef.getElementById('player-ux-polish-stylesheet');
+    if (!link) {
+        link = documentRef.createElement('link');
+        link.id = 'player-ux-polish-stylesheet';
+        link.rel = 'stylesheet';
+        link.href = 'css/player-ux-polish.css';
+        link.dataset.ui = 'player-ux-polish';
+        documentRef.head?.appendChild(link);
+    }
+
+    let script = documentRef.getElementById('player-ux-polish-script');
+    if (!script) {
+        script = documentRef.createElement('script');
+        script.id = 'player-ux-polish-script';
+        script.src = 'js/player-ux-polish.js';
+        script.async = false;
+        script.dataset.ui = 'player-ux-polish';
+        documentRef.head?.appendChild(script);
+    }
+
+    return { link, script };
+}
+
 if (typeof document !== 'undefined') {
     ensurePlayerTerminalStyles(document);
+    ensurePlayerUxPolishAssets(document);
 }
 
 // Compatibilidad para entornos de prueba (Node.js)
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { obtenerEstacion, calculateLevelData, ensurePlayerTerminalStyles };
+    module.exports = {
+        obtenerEstacion,
+        calculateLevelData,
+        ensurePlayerTerminalStyles,
+        ensurePlayerUxPolishAssets
+    };
 }

--- a/tests/player_dm_ux_polish.spec.js
+++ b/tests/player_dm_ux_polish.spec.js
@@ -1,0 +1,138 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
+const playerUx = read("js/player-ux-polish.js");
+const playerUxCss = read("css/player-ux-polish.css");
+const actorStudio = read("js/theatre-actor-studio.js");
+const actorStudioCss = read("css/theatre-actor-studio.css");
+const utils = read("js/utils.js");
+const instanceControl = read("js/instance-control.js");
+const theatreControls = read("js/theatre-controls.js");
+const playerHtml = read("hoja_personaje.html");
+
+function block(source, start, end) {
+  const from = source.indexOf(start);
+  expect(from).toBeGreaterThanOrEqual(0);
+  const to = end ? source.indexOf(end, from) : source.length;
+  return source.slice(from, to < 0 ? source.length : to);
+}
+
+test("Vínculos y Directorio de Red quedan diferenciados", () => {
+  expect(playerHtml).toContain('name="act_hud_apego"');
+  expect(playerHtml).toContain('id="btn-show-contacts"');
+  expect(playerHtml).toContain('id="new-contact-number"');
+  expect(playerHtml).toContain('id="new-contact-alias"');
+  expect(playerUx).toContain('label.textContent = "Vínculos"');
+  expect(playerUx).toContain('directoryButton.textContent = "DIRECTORIO"');
+  expect(playerUx).toContain("números y alias para comunicación");
+  expect(playerUx).toContain("afinidad y las relaciones personales");
+});
+
+test("el log usa icono asignado y nunca el sprite como fuente preferida", () => {
+  const iconResolver = block(playerUx, "function actorAssignedIcon", "function actorRecords");
+  expect(iconResolver).toContain("actor?.icono");
+  expect(iconResolver).toContain("actor?.icono_jugador");
+  expect(iconResolver).toContain("actor?.icon_url");
+  expect(iconResolver).not.toContain("sprite");
+  expect(iconResolver).not.toContain("avatar");
+
+  const logPolish = block(playerUx, "function polishLogRows", "function watchTheatreLog");
+  expect(logPolish).toContain("actor?.sprite");
+  expect(logPolish).toContain("actor?.url");
+  expect(logPolish).toContain("actor?.avatar");
+  expect(logPolish).toContain("initialsIcon(displayedName)");
+});
+
+test("el retrato del log es un heptágono y no un círculo", () => {
+  expect(playerUxCss).toContain("clip-path: polygon(50% 0%, 88% 17%, 100% 55%, 78% 100%, 22% 100%, 0 55%, 12% 17%)");
+  const border = block(playerUxCss, "#theatre-view-player #theatre-log-container .hex-border", "#theatre-view-player #theatre-log-container .hex-portrait");
+  expect(border).toContain("border-radius: 0 !important");
+  expect(border).not.toContain("border-radius: 50%");
+});
+
+test("los textos de módulos del celular pueden envolver sin salirse", () => {
+  expect(playerUxCss).toContain("overflow-wrap: anywhere !important");
+  expect(playerUxCss).toContain("white-space: normal !important");
+  expect(playerUxCss).toContain("min-width: 0 !important");
+  expect(playerUxCss).toContain("@media (max-width: 700px)");
+});
+
+test("Ajustes ofrece controles útiles y locales", () => {
+  for (const id of [
+    "player-setting-mute",
+    "player-setting-volume",
+    "player-setting-reduce-motion",
+    "player-setting-large-text",
+    "player-setting-compact",
+    "player-settings-reset",
+  ]) {
+    expect(playerUx).toContain(id);
+  }
+  expect(playerUx).toContain("luminous.player.masterVolume");
+  expect(playerUx).toContain("luminous.player.reduceMotion");
+  expect(playerUx).toContain("luminous.player.largeText");
+  expect(playerUx).toContain("luminous.player.compactUi");
+  expect(playerUx).toContain('getElementById("btn-toggle-mute")');
+});
+
+test("utils carga los retoques del jugador de forma idempotente", () => {
+  expect(utils).toContain("function ensurePlayerUxPolishAssets");
+  expect(utils).toContain("player-ux-polish-stylesheet");
+  expect(utils).toContain("css/player-ux-polish.css");
+  expect(utils).toContain("player-ux-polish-script");
+  expect(utils).toContain("js/player-ux-polish.js");
+});
+
+test("el DM diferencia cast temporal de actor persistente", () => {
+  const existingSpawn = block(theatreControls, "function spawnSelectedActor", "function renderLiveActors");
+  expect(existingSpawn).toContain('db.ref(`${paths().scene}/actores/${actorInstanceId}`).set(actorPayload)');
+
+  expect(actorStudio).toContain('spawn.textContent = "AÑADIR AL CAST (TEMPORAL)"');
+  expect(actorStudio).toContain("EDITAR / REPARAR FUENTE");
+  expect(actorStudio).toContain("NUEVO ACTOR PERSISTENTE");
+  expect(actorStudio).toContain('base: "campaña/base_datos_npcs"');
+  expect(actorStudio).toContain('legacy: "campaña/actores"');
+});
+
+test("jugadores sin actor pueden repararse y quedan enlazados", () => {
+  expect(actorStudio).toContain("JUGADORES SIN ACTOR THEATRE");
+  expect(actorStudio).toContain('option.value = `__player__:${playerId}`');
+  expect(actorStudio).toContain('await db.ref(`${ROOTS.players}/${context.playerId}/actorId`).set(actorId)');
+  expect(actorStudio).toContain('await db.ref(`${root}/${actorId}`).set(Object.assign({ identityId: actorId }, payload))');
+});
+
+test("editar una fuente actualiza instancias del cast sin crear copias nuevas", () => {
+  const propagate = block(actorStudio, "async function propagateActorSource", "async function saveEditor");
+  expect(propagate).toContain('db.ref(`${scenePath()}/actores`).once("value")');
+  expect(propagate).toContain("db.ref().update(updates)");
+  expect(propagate).not.toContain("push()");
+
+  const save = block(actorStudio, "async function saveEditor", "function findUniqueActorIdByName");
+  expect(save).toContain('db.ref(`${root}/${actorId}`).update(payload)');
+  expect(save).toContain("propagateActorSource");
+});
+
+test("Actor Studio separa icono de sprite", () => {
+  expect(actorStudio).toContain("Icono · log/HUD");
+  expect(actorStudio).toContain("Sprite · escena");
+  const payload = block(actorStudio, "function editorPayload", "async function propagateActorSource");
+  expect(payload).toContain("icono:");
+  expect(payload).toContain("sprite:");
+  expect(actorStudioCss).toContain("THEATRE ACTOR STUDIO / DM UX");
+});
+
+test("instance-control carga Actor Studio solo en dashboard DM", () => {
+  expect(instanceControl).toContain("function ensureDashboardActorStudioAssets");
+  expect(instanceControl).toContain("css/theatre-actor-studio.css");
+  expect(instanceControl).toContain("js/theatre-actor-studio.js");
+  expect(instanceControl).toContain('body?.classList.contains("on-game-dashboard")');
+});
+
+test("los observers quedan acotados y no vigilan todo el body del Actor Studio", () => {
+  expect(actorStudio).not.toContain("observer.observe(doc.body");
+  expect(actorStudio).toContain("observe(select, { childList: true, subtree: true })");
+  expect(actorStudio).toContain("observe(liveList, { childList: true, subtree: true })");
+  expect(playerUx).not.toContain("observe(doc.body");
+});

--- a/tests/player_dm_ux_polish.spec.js
+++ b/tests/player_dm_ux_polish.spec.js
@@ -85,54 +85,100 @@ test("utils carga los retoques del jugador de forma idempotente", () => {
   expect(utils).toContain("js/player-ux-polish.js");
 });
 
-test("el DM diferencia cast temporal de actor persistente", () => {
-  const existingSpawn = block(theatreControls, "function spawnSelectedActor", "function renderLiveActors");
-  expect(existingSpawn).toContain('db.ref(`${paths().scene}/actores/${actorInstanceId}`).set(actorPayload)');
+test("la Pantalla de DM monta un Control Maestro visible y no un modal auxiliar", () => {
+  expect(actorStudio).toContain('panel.id = "theatre-actor-master-panel"');
+  expect(actorStudio).toContain("CONTROL MAESTRO DE ACTORES");
+  expect(actorStudio).toContain("MASTER DATABASE / DM AUTHORITY");
+  expect(actorStudio).toContain('director.insertBefore(panel, quickCast)');
+  expect(actorStudio).not.toContain("theatre-actor-studio-overlay");
+  expect(actorStudioCss).toContain("THEATRE ACTOR MASTER CONTROL / DM UX");
+  expect(actorStudioCss).toContain("#theatre-actor-master-panel");
+});
 
-  expect(actorStudio).toContain('spawn.textContent = "AÑADIR AL CAST (TEMPORAL)"');
-  expect(actorStudio).toContain("EDITAR / REPARAR FUENTE");
-  expect(actorStudio).toContain("NUEVO ACTOR PERSISTENTE");
+test("el DM lista siempre jugadores y fuentes persistentes aunque no estén en escena", () => {
+  expect(actorStudio).toContain('playerGroup.label = "JUGADORES"');
+  expect(actorStudio).toContain("SIN ACTOR THEATRE");
+  expect(actorStudio).toContain('actorGroup.label = "NPCs / ACTORES SIN JUGADOR"');
   expect(actorStudio).toContain('base: "campaña/base_datos_npcs"');
   expect(actorStudio).toContain('legacy: "campaña/actores"');
+  expect(actorStudio).toContain('players: "campaña/jugadores"');
 });
 
-test("jugadores sin actor pueden repararse y quedan enlazados", () => {
-  expect(actorStudio).toContain("JUGADORES SIN ACTOR THEATRE");
-  expect(actorStudio).toContain('option.value = `__player__:${playerId}`');
-  expect(actorStudio).toContain('await db.ref(`${ROOTS.players}/${context.playerId}/actorId`).set(actorId)');
-  expect(actorStudio).toContain('await db.ref(`${root}/${actorId}`).set(Object.assign({ identityId: actorId }, payload))');
+test("el formulario maestro edita identidad visual, vínculo y expresiones", () => {
+  for (const id of [
+    "theatre-master-name",
+    "theatre-master-title",
+    "theatre-master-type",
+    "theatre-master-player-link",
+    "theatre-master-scale",
+    "theatre-master-name-color",
+    "theatre-master-title-color",
+    "theatre-master-icon",
+    "theatre-master-sprite",
+    "theatre-master-expressions",
+  ]) {
+    expect(actorStudio).toContain(id);
+  }
+  expect(actorStudio).toContain("Icono · log / HUD");
+  expect(actorStudio).toContain("Sprite base · escena");
+  expect(actorStudio).toContain("EXPRESIONES / AVANZADO");
 });
 
-test("editar una fuente actualiza instancias del cast sin crear copias nuevas", () => {
-  const propagate = block(actorStudio, "async function propagateActorSource", "async function saveEditor");
+test("crear o reparar jugador escribe fuente persistente y actorId del jugador", () => {
+  const save = block(actorStudio, "async function saveCurrentActor", "function selectContextInBrowser");
+  expect(save).toContain('db.ref(ROOTS.base).push()');
+  expect(save).toContain('context.mode === "repair-player"');
+  expect(save).toContain("identityId: actorId");
+  expect(actorStudio).toContain('updates[`${ROOTS.players}/${newPlayerId}/actorId`] = actorId');
+});
+
+test("guardar actor existente modifica su fuente y propaga al cast sin duplicarlo", () => {
+  const save = block(actorStudio, "async function saveCurrentActor", "function selectContextInBrowser");
+  expect(save).toContain('db.ref(`${root}/${actorId}`).update(payload)');
+  expect(save).toContain("propagateActorSource");
+
+  const propagate = block(actorStudio, "async function propagateActorSource", "async function saveCurrentActor");
   expect(propagate).toContain('db.ref(`${scenePath()}/actores`).once("value")');
   expect(propagate).toContain("db.ref().update(updates)");
   expect(propagate).not.toContain("push()");
-
-  const save = block(actorStudio, "async function saveEditor", "function findUniqueActorIdByName");
-  expect(save).toContain('db.ref(`${root}/${actorId}`).update(payload)');
-  expect(save).toContain("propagateActorSource");
 });
 
-test("Actor Studio separa icono de sprite", () => {
-  expect(actorStudio).toContain("Icono · log/HUD");
-  expect(actorStudio).toContain("Sprite · escena");
-  const payload = block(actorStudio, "function editorPayload", "async function propagateActorSource");
+test("el DM diferencia de forma explícita base maestra y cast temporal", () => {
+  const existingSpawn = block(theatreControls, "function spawnSelectedActor", "function renderLiveActors");
+  expect(existingSpawn).toContain('db.ref(`${paths().scene}/actores/${actorInstanceId}`).set(actorPayload)');
+  expect(actorStudio).toContain("AÑADIR AL CAST (TEMPORAL)");
+  expect(actorStudio).toContain("CAST RÁPIDO DE ESCENA");
+  expect(actorStudio).toContain("Instancias temporales; no modifica la base maestra.");
+  expect(actorStudio).toContain("async function addCurrentActorToCast");
+  expect(actorStudio).toContain('db.ref(`${scenePath()}/actores/${instanceId}`).set(payload)');
+});
+
+test("el Control Maestro puede eliminar una fuente sin borrar al jugador", () => {
+  const deletion = block(actorStudio, "async function deleteCurrentActor", "function decorateQuickCast");
+  expect(deletion).toContain('db.ref(`${context.root}/${context.actorId}`).remove()');
+  expect(deletion).toContain('db.ref(`${ROOTS.players}/${linkedPlayer}/actorId`).remove()');
+  expect(deletion).toContain('db.ref(`${scenePath()}/actores/${instanceId}`).remove()');
+  expect(deletion).toContain("El jugador, si existe, NO se elimina");
+});
+
+test("Actor Master separa icono de sprite en datos y cast", () => {
+  const payload = block(actorStudio, "function buildPayload", "async function syncPlayerLink");
   expect(payload).toContain("icono:");
   expect(payload).toContain("sprite:");
-  expect(actorStudioCss).toContain("THEATRE ACTOR STUDIO / DM UX");
+  const cast = block(actorStudio, "async function addCurrentActorToCast", "async function deleteCurrentActor");
+  expect(cast).toContain("icono: actor.icono");
+  expect(cast).toContain("sprite: baseSprite");
 });
 
-test("instance-control carga Actor Studio solo en dashboard DM", () => {
+test("instance-control carga Master Control solo en dashboard DM", () => {
   expect(instanceControl).toContain("function ensureDashboardActorStudioAssets");
   expect(instanceControl).toContain("css/theatre-actor-studio.css");
   expect(instanceControl).toContain("js/theatre-actor-studio.js");
   expect(instanceControl).toContain('body?.classList.contains("on-game-dashboard")');
 });
 
-test("los observers quedan acotados y no vigilan todo el body del Actor Studio", () => {
+test("los observers quedan acotados", () => {
   expect(actorStudio).not.toContain("observer.observe(doc.body");
-  expect(actorStudio).toContain("observe(select, { childList: true, subtree: true })");
   expect(actorStudio).toContain("observe(liveList, { childList: true, subtree: true })");
   expect(playerUx).not.toContain("observe(doc.body");
 });


### PR DESCRIPTION
## Qué cambia

### Jugador
- **Vínculos** queda como el motor social/relacional del HUD.
- **Directorio** dentro de Mail queda como libreta de números/alias para Email/Chat.
- El log del Theatre usa retratos heptagonales y prioriza `icono`, `icono_jugador` o `icon_url`, nunca el sprite.
- Se corrige overflow de labels del Personal Terminal.
- Ajustes ofrece controles útiles de silencio, volumen local, reducir movimiento, texto grande, interfaz compacta y reset local.

### DM — Control Maestro de Actores
La Pantalla de DM pasa a ser la autoridad de edición del Theatre, no solo un spawner de escena.

- Añade un **CONTROL MAESTRO DE ACTORES** visible dentro de `#theatre-director-panel`.
- A la izquierda lista siempre:
  - todos los jugadores;
  - jugadores sin actor Theatre;
  - NPCs/actores persistentes que no estén vinculados a un jugador.
- A la derecha permite editar directamente:
  - nombre;
  - título;
  - tipo;
  - vínculo jugador ↔ actor;
  - escala;
  - colores de nameplate;
  - icono de log/HUD;
  - sprite base de escena;
  - expresiones en bloque avanzado.
- **GUARDAR EN BASE** crea o actualiza la fuente persistente.
- Un jugador sin actor puede repararse desde el mismo panel; se crea su actor persistente y se escribe `campaña/jugadores/{playerId}/actorId`.
- **ELIMINAR ACTOR** borra la fuente y retira sus instancias de la escena actual, pero nunca elimina al jugador; el jugador queda simplemente sin actor Theatre.
- **AÑADIR AL CAST** crea una instancia temporal de la fuente seleccionada en la escena actual.
- El casting rápido existente se mantiene debajo y queda rotulado explícitamente como temporal.
- Las tarjetas de actores vivos pueden abrir su fuente en el Control Maestro.
- Guardar una fuente existente sincroniza sus campos visuales y expresiones a las instancias actuales del cast sin crear duplicados.

## Modelo de datos

- Fuente principal nueva: `campaña/base_datos_npcs`.
- Fuentes legacy existentes: `campaña/actores` se siguen pudiendo editar en su ubicación actual.
- Jugadores: `campaña/jugadores`.
- Cast temporal: `campaña/estado_mundo/escena_actual/actores` (o la ruta de sala resuelta por Theatre State).

Esto deja clara la separación:

**Base maestra = persistente y editable desde DM.**  
**Cast = instancia temporal de la escena.**

## Validación

Se actualiza `tests/player_dm_ux_polish.spec.js` para cubrir:
- Control Maestro visible en DM;
- jugadores y NPCs editables aunque no estén en escena;
- reparación de jugadores sin actor;
- creación/edición persistente;
- propagación al cast sin duplicar;
- eliminación de actor sin borrar jugador;
- separación icono/sprite;
- cast temporal vs base maestra;
- Vínculos/Directorio, log heptagonal y Ajustes del jugador.

GitHub no reporta Actions ni status checks para el head actual, por lo que este PR permanece en **draft** para revisión funcional/manual antes de merge.