### PR TITLE
Hace visible y robusta la edición en Gestión de Personajes

### DIFF
--- a/css/dm-character-editor-ux.css
+++ b/css/dm-character-editor-ux.css
@@ -1,0 +1,62 @@
+/* ==================================================
+   DM CHARACTER EDITOR UX
+   Gestión de Personajes: feedback visible y foco de edición.
+   ================================================== */
+
+#dashboard-actores .actor-studio-wrapper {
+  scroll-margin-top: 18px;
+  transition: border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
+}
+
+#dashboard-actores .actor-studio-wrapper.dm-character-editor-active {
+  border-color: #c49a00;
+  background: #0d0b08;
+  box-shadow:
+    0 0 0 1px rgba(196, 154, 0, 0.28),
+    0 0 24px rgba(196, 154, 0, 0.16),
+    inset 0 0 28px rgba(196, 154, 0, 0.035);
+}
+
+#dashboard-actores .dm-character-edit-context {
+  width: 100%;
+  box-sizing: border-box;
+  margin: -4px 0 12px;
+  padding: 9px 11px;
+  overflow-wrap: anywhere;
+  color: #f2d47b;
+  background: #171109;
+  border: 1px solid #5c4925;
+  border-left: 4px solid #c49a00;
+  font-family: "Share Tech Mono", monospace;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+#dashboard-actores .actor-studio-wrapper.dm-character-editor-active .actor-studio-form > h4 {
+  color: #f2d47b !important;
+}
+
+#dashboard-actores .actor-studio-wrapper.dm-character-editor-active #btn-crear-actor {
+  background: linear-gradient(135deg, #7b5a17, #4a360d);
+  border-color: #e0b84c;
+  color: #fff6d4;
+  box-shadow: 0 0 12px rgba(196, 154, 0, 0.32);
+}
+
+#dashboard-actores .actor-studio-wrapper.dm-character-editor-active #btn-cancelar-actor {
+  border-color: #7d6a42;
+}
+
+#dashboard-actores .actor-studio-wrapper.dm-character-editor-active .actor-studio-input:focus,
+#dashboard-actores .actor-studio-wrapper.dm-character-editor-active .actor-studio-select:focus {
+  border-color: #e0b84c;
+  box-shadow: 0 0 0 2px rgba(196, 154, 0, 0.16);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #dashboard-actores .actor-studio-wrapper {
+    transition: none;
+  }
+}

--- a/js/dm-character-editor-ux.js
+++ b/js/dm-character-editor-ux.js
@@ -1,0 +1,217 @@
+(function (global) {
+  "use strict";
+
+  const doc = global.document;
+  if (!doc) return;
+
+  function normalizeTags(value) {
+    if (Array.isArray(value)) {
+      return value.map((tag) => String(tag || "").trim()).filter(Boolean);
+    }
+    if (typeof value === "string") {
+      return value.split(",").map((tag) => tag.trim()).filter(Boolean);
+    }
+    if (value && typeof value === "object") {
+      return Object.values(value)
+        .flatMap((entry) => normalizeTags(entry))
+        .filter(Boolean);
+    }
+    return [];
+  }
+
+  function expressionUrl(value) {
+    if (typeof value === "string") return value;
+    if (!value || typeof value !== "object") return "";
+    return value.sprite || value.url || value.imagen || value.image || "";
+  }
+
+  function normalizeExpressions(value) {
+    if (!value || typeof value !== "object") return {};
+    return Object.fromEntries(
+      Object.entries(value)
+        .map(([name, entry]) => [name, expressionUrl(entry)])
+        .filter(([, url]) => Boolean(url)),
+    );
+  }
+
+  function normalizeActorForEditor(actorData) {
+    const source = actorData && typeof actorData === "object" ? actorData : {};
+    return {
+      ...source,
+      etiquetas: normalizeTags(source.etiquetas),
+      expresiones: normalizeExpressions(source.expresiones),
+    };
+  }
+
+  function ensureEditContext(actorId, actorData) {
+    const wrapper = doc.querySelector("#dashboard-actores .actor-studio-wrapper");
+    const form = wrapper?.querySelector(".actor-studio-form");
+    if (!wrapper || !form) return;
+
+    const actorName = String(
+      actorData?.nombre || doc.getElementById("actor-nombre")?.value || actorId || "Actor",
+    ).trim();
+
+    wrapper.classList.add("dm-character-editor-active");
+    wrapper.dataset.editingActorId = String(actorId || "");
+
+    let context = form.querySelector(".dm-character-edit-context");
+    if (!context) {
+      context = doc.createElement("div");
+      context.className = "dm-character-edit-context";
+      const state = doc.getElementById("actor-studio-state");
+      if (state?.parentNode) state.parentNode.insertBefore(context, state.nextSibling);
+      else form.prepend(context);
+    }
+    context.textContent = `EDITANDO FUENTE · ${actorName}${actorId ? ` · ${actorId}` : ""}`;
+
+    const title = form.querySelector("h4");
+    if (title) title.textContent = "Actor Studio · Editar personaje";
+
+    const stateBanner = doc.getElementById("actor-studio-state");
+    if (stateBanner) {
+      stateBanner.className = "actor-studio-state state-editing";
+      stateBanner.textContent = "EDITANDO";
+    }
+
+    const save = doc.getElementById("btn-crear-actor");
+    if (save) save.textContent = "GUARDAR CAMBIOS";
+
+    const cancel = doc.getElementById("btn-cancelar-actor");
+    if (cancel) cancel.style.display = "block";
+
+    wrapper.scrollIntoView({ behavior: "smooth", block: "start" });
+    global.setTimeout(() => {
+      doc.getElementById("actor-nombre")?.focus({ preventScroll: true });
+    }, 260);
+  }
+
+  function clearEditContext() {
+    const wrapper = doc.querySelector("#dashboard-actores .actor-studio-wrapper");
+    wrapper?.classList.remove("dm-character-editor-active");
+    if (wrapper) delete wrapper.dataset.editingActorId;
+    wrapper?.querySelector(".dm-character-edit-context")?.remove();
+
+    const title = wrapper?.querySelector(".actor-studio-form h4");
+    if (title && !/^Crear Perfil de Escena/i.test(title.textContent || "")) {
+      title.textContent = "Actor Studio";
+    }
+  }
+
+  function populateSafeFallback(actorData) {
+    const actor = normalizeActorForEditor(actorData);
+    const set = (id, value) => {
+      const input = doc.getElementById(id);
+      if (input) input.value = value == null ? "" : String(value);
+    };
+
+    set("actor-nombre", actor.nombre || "");
+    set("actor-titulo", actor.titulo || "");
+    set("actor-color-nombre", actor.color_nombre || "#ffffff");
+    set("actor-color-titulo", actor.color_titulo || "#c49a00");
+    set("actor-escala", actor.escala ?? 1);
+    set("actor-icono", actor.icono || "");
+    set("actor-sprite", actor.sprite || "");
+    set("actor-tipo", actor.tipo || "NPC");
+    set("actor-faccion", actor.faccion || "");
+    set("actor-vinculo-jugador", actor.vinculo_jugador || "");
+    set("actor-etiquetas", actor.etiquetas.join(", "));
+    set("actor-sprite-combate", actor.sprite_combate || "");
+    set("actor-hp", actor.combat_stats?.hp ?? "");
+    set("actor-sp", actor.combat_stats?.sp ?? "");
+    set("actor-vel", actor.combat_stats?.velocidad ?? "");
+    set("actor-atk", actor.combat_stats?.atk ?? "");
+    set("actor-ac", actor.combat_stats?.ac ?? "");
+
+    const combat = doc.getElementById("actor-combatiente");
+    if (combat) combat.checked = Boolean(actor.es_combatiente);
+
+    global.togglePlayerLink?.();
+    global.toggleCombatProperties?.();
+    global.updateActorPreview?.();
+  }
+
+  function installEditorWrapper() {
+    const original = global.loadActorIntoFormInternal;
+    if (typeof original !== "function") return false;
+    if (original.__dmCharacterEditorWrapped) return true;
+
+    function wrappedLoadActorIntoForm(actorId, actorData) {
+      const normalized = normalizeActorForEditor(actorData);
+      try {
+        original.call(this, actorId, normalized);
+      } catch (error) {
+        console.error("[DM Character Editor] Error cargando actor legacy; aplicando fallback seguro.", error);
+        populateSafeFallback(normalized);
+      } finally {
+        ensureEditContext(actorId, normalized);
+      }
+    }
+
+    wrappedLoadActorIntoForm.__dmCharacterEditorWrapped = true;
+    wrappedLoadActorIntoForm.__original = original;
+    global.loadActorIntoFormInternal = wrappedLoadActorIntoForm;
+    return true;
+  }
+
+  function bindEditorReset() {
+    const cancel = doc.getElementById("btn-cancelar-actor");
+    if (cancel && cancel.dataset.dmEditorResetBound !== "true") {
+      cancel.dataset.dmEditorResetBound = "true";
+      cancel.addEventListener("click", () => global.setTimeout(clearEditContext, 0));
+    }
+
+    const save = doc.getElementById("btn-crear-actor");
+    if (save && save.dataset.dmEditorResetBound !== "true") {
+      save.dataset.dmEditorResetBound = "true";
+      save.addEventListener("click", () => {
+        global.setTimeout(() => {
+          const state = doc.getElementById("actor-studio-state")?.textContent || "";
+          if (!/EDITANDO/i.test(state)) clearEditContext();
+        }, 0);
+      });
+    }
+  }
+
+  function installStateFallback() {
+    const banner = doc.getElementById("actor-studio-state");
+    if (!banner || banner.dataset.dmEditorObserverBound === "true") return;
+    banner.dataset.dmEditorObserverBound = "true";
+
+    new MutationObserver(() => {
+      if (/EDITANDO/i.test(banner.textContent || "")) {
+        ensureEditContext(
+          doc.querySelector("#dashboard-actores .actor-studio-wrapper")?.dataset.editingActorId || "",
+          { nombre: doc.getElementById("actor-nombre")?.value || "Actor" },
+        );
+      } else if (/BORRADOR/i.test(banner.textContent || "")) {
+        clearEditContext();
+      }
+    }).observe(banner, { childList: true, characterData: true, subtree: true });
+  }
+
+  function boot() {
+    if (!doc.getElementById("dashboard-actores")) return;
+
+    bindEditorReset();
+    installStateFallback();
+
+    let attempts = 0;
+    const timer = global.setInterval(() => {
+      attempts += 1;
+      if (installEditorWrapper() || attempts >= 80) global.clearInterval(timer);
+    }, 50);
+  }
+
+  if (doc.readyState === "loading") doc.addEventListener("DOMContentLoaded", boot, { once: true });
+  else boot();
+
+  global.LuminousDmCharacterEditorUx = Object.freeze({
+    normalizeTags,
+    normalizeExpressions,
+    normalizeActorForEditor,
+    ensureEditContext,
+    clearEditContext,
+    installEditorWrapper,
+  });
+})(window);

--- a/js/dm-character-player-resolver.js
+++ b/js/dm-character-player-resolver.js
@@ -1,0 +1,196 @@
+(function (global) {
+  "use strict";
+
+  const doc = global.document;
+  if (!doc) return;
+
+  const ROOTS = ["campaña/base_datos_npcs", "campaña/actores"];
+
+  function normalizedName(value) {
+    return String(value || "").trim().toLowerCase();
+  }
+
+  function playerDisplayName(playerId, playerData) {
+    return String(
+      playerData?.characterName ||
+      playerData?.character_name ||
+      playerData?.nombre ||
+      playerId ||
+      "",
+    ).trim();
+  }
+
+  function normalizeActorForLegacyEditor(actorData) {
+    const actor = actorData && typeof actorData === "object" ? { ...actorData } : {};
+    if (!Array.isArray(actor.etiquetas)) {
+      if (typeof actor.etiquetas === "string") {
+        actor.etiquetas = actor.etiquetas.split(",").map((tag) => tag.trim()).filter(Boolean);
+      } else if (actor.etiquetas && typeof actor.etiquetas === "object") {
+        actor.etiquetas = Object.values(actor.etiquetas).map((tag) => String(tag || "").trim()).filter(Boolean);
+      } else {
+        actor.etiquetas = [];
+      }
+    }
+
+    if (actor.expresiones && typeof actor.expresiones === "object") {
+      actor.expresiones = Object.fromEntries(
+        Object.entries(actor.expresiones)
+          .map(([name, value]) => [
+            name,
+            typeof value === "string"
+              ? value
+              : value?.sprite || value?.url || value?.imagen || value?.image || "",
+          ])
+          .filter(([, url]) => Boolean(url)),
+      );
+    }
+
+    return actor;
+  }
+
+  function firebaseDb() {
+    if (!global.firebase?.database) return null;
+    try {
+      return global.firebase.database();
+    } catch (_) {
+      return null;
+    }
+  }
+
+  async function fetchActorById(db, actorId) {
+    if (!db || !actorId || actorId === "ninguno") return null;
+    for (const root of ROOTS) {
+      const snap = await db.ref(`${root}/${actorId}`).once("value");
+      if (snap.exists()) {
+        return { actorId, root, actor: normalizeActorForLegacyEditor(snap.val()) };
+      }
+    }
+    return null;
+  }
+
+  async function findPlayerRecord(db, displayName) {
+    const snap = await db.ref("campaña/jugadores").once("value");
+    const players = snap.val() || {};
+    const wanted = normalizedName(displayName);
+
+    for (const [playerId, playerData] of Object.entries(players)) {
+      if (normalizedName(playerDisplayName(playerId, playerData)) === wanted) {
+        return { playerId, playerData: playerData || {} };
+      }
+    }
+    return null;
+  }
+
+  async function findActorLinkedToPlayer(db, playerId, playerData, displayName) {
+    const acceptedLinks = new Set(
+      [playerId, playerData?.id, displayName]
+        .filter(Boolean)
+        .map((value) => normalizedName(value)),
+    );
+
+    for (const root of ROOTS) {
+      const snap = await db.ref(root).once("value");
+      const actors = snap.val() || {};
+      for (const [actorId, rawActor] of Object.entries(actors)) {
+        const actor = normalizeActorForLegacyEditor(rawActor);
+        const link = normalizedName(actor.vinculo_jugador);
+        if (link && acceptedLinks.has(link)) {
+          return { actorId, root, actor };
+        }
+      }
+    }
+    return null;
+  }
+
+  async function resolvePlayerActorFromCard(card) {
+    const db = firebaseDb();
+    if (!db || !card) return null;
+
+    const displayName = String(
+      card.querySelector("h5 span")?.textContent ||
+      card.querySelector("h5")?.childNodes?.[0]?.textContent ||
+      "",
+    ).trim();
+
+    const playerRecord = await findPlayerRecord(db, displayName);
+    if (!playerRecord) return null;
+
+    const { playerId, playerData } = playerRecord;
+    const selectedActorId = card.querySelector("select")?.value || "";
+    const candidates = [selectedActorId, playerData.actorId]
+      .filter((value, index, values) => value && value !== "ninguno" && values.indexOf(value) === index);
+
+    for (const actorId of candidates) {
+      const direct = await fetchActorById(db, actorId);
+      if (direct) return { ...direct, playerId, playerData, displayName };
+    }
+
+    const linked = await findActorLinkedToPlayer(db, playerId, playerData, displayName);
+    return linked ? { ...linked, playerId, playerData, displayName } : null;
+  }
+
+  async function openResolvedPlayerActor(button) {
+    const card = button?.closest("#grid-personajes-jugadores .cyber-card");
+    if (!card) return false;
+
+    const originalText = button.textContent;
+    button.disabled = true;
+    button.textContent = "RESOLVIENDO ACTOR...";
+
+    try {
+      const resolved = await resolvePlayerActorFromCard(card);
+      if (!resolved) {
+        global.alert?.("No se encontró una fuente de actor válida para este jugador. Revisa su Vínculo de Almas o crea un perfil de escena.");
+        return false;
+      }
+
+      const loader = global.loadActorIntoFormInternal;
+      if (typeof loader !== "function") {
+        global.alert?.("Actor Studio todavía no está disponible. Recarga la Pantalla de DM e inténtalo de nuevo.");
+        return false;
+      }
+
+      loader(resolved.actorId, resolved.actor);
+      return true;
+    } catch (error) {
+      console.error("[DM Character Resolver] No se pudo resolver el actor del jugador.", error);
+      global.alert?.("No se pudo cargar el actor del jugador. Revisa la consola del navegador para el detalle.");
+      return false;
+    } finally {
+      button.disabled = false;
+      button.textContent = originalText;
+    }
+  }
+
+  function bindPlayerEditResolver() {
+    if (doc.documentElement.dataset.dmPlayerResolverBound === "true") return;
+    doc.documentElement.dataset.dmPlayerResolverBound = "true";
+
+    doc.addEventListener("click", (event) => {
+      const button = event.target?.closest?.("#grid-personajes-jugadores .btn-action");
+      if (!button) return;
+      if (!/editar/i.test(button.textContent || "")) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+      openResolvedPlayerActor(button);
+    }, true);
+  }
+
+  function boot() {
+    if (!doc.getElementById("dashboard-actores")) return;
+    bindPlayerEditResolver();
+  }
+
+  if (doc.readyState === "loading") doc.addEventListener("DOMContentLoaded", boot, { once: true });
+  else boot();
+
+  global.LuminousDmCharacterPlayerResolver = Object.freeze({
+    fetchActorById,
+    findPlayerRecord,
+    findActorLinkedToPlayer,
+    resolvePlayerActorFromCard,
+    openResolvedPlayerActor,
+  });
+})(window);

--- a/js/utils.js
+++ b/js/utils.js
@@ -56,7 +56,6 @@ function calculateLevelData(xp) {
     const xpRequiredForNextLevel = nextLevelXP - currentLevelXP;
 
     let xpPercent = Math.floor((xpIntoLevel / xpRequiredForNextLevel) * 100);
-    // Limit to 0-100 just in case
     xpPercent = Math.max(0, Math.min(100, xpPercent));
 
     return {
@@ -66,12 +65,6 @@ function calculateLevelData(xp) {
     };
 }
 
-/**
- * Carga la capa visual del Personal Terminal solo cuando existe la hoja del jugador.
- * Se mantiene aquí porque utils.js ya forma parte del bootstrap síncrono de hoja_personaje.html.
- * @param {Document} doc
- * @returns {HTMLLinkElement|null}
- */
 function ensurePlayerTerminalStyles(doc) {
     const documentRef = doc || (typeof document !== 'undefined' ? document : null);
     if (!documentRef?.querySelector?.('.sheet-phone-wrapper')) return null;
@@ -88,11 +81,6 @@ function ensurePlayerTerminalStyles(doc) {
     return link;
 }
 
-/**
- * Carga los retoques funcionales/visuales del jugador sin tocar el HTML gigante.
- * @param {Document} doc
- * @returns {{link: HTMLLinkElement|null, script: HTMLScriptElement|null}|null}
- */
 function ensurePlayerUxPolishAssets(doc) {
     const documentRef = doc || (typeof document !== 'undefined' ? document : null);
     if (!documentRef?.querySelector?.('.sheet-phone-wrapper')) return null;
@@ -120,12 +108,6 @@ function ensurePlayerUxPolishAssets(doc) {
     return { link, script };
 }
 
-/**
- * Carga la corrección de UX del editor de Gestión de Personajes del DM.
- * pantalla_dm.html ya carga utils.js, así que evitamos modificar el HTML monolítico.
- * @param {Document} doc
- * @returns {{link: HTMLLinkElement|null, script: HTMLScriptElement|null}|null}
- */
 function ensureDmCharacterEditorAssets(doc) {
     const documentRef = doc || (typeof document !== 'undefined' ? document : null);
     if (!documentRef?.querySelector?.('#dashboard-actores')) return null;
@@ -150,7 +132,17 @@ function ensureDmCharacterEditorAssets(doc) {
         documentRef.head?.appendChild(script);
     }
 
-    return { link, script };
+    let playerResolver = documentRef.getElementById('dm-character-player-resolver-script');
+    if (!playerResolver) {
+        playerResolver = documentRef.createElement('script');
+        playerResolver.id = 'dm-character-player-resolver-script';
+        playerResolver.src = 'js/dm-character-player-resolver.js';
+        playerResolver.async = false;
+        playerResolver.dataset.ui = 'dm-character-editor-ux';
+        documentRef.head?.appendChild(playerResolver);
+    }
+
+    return { link, script, playerResolver };
 }
 
 if (typeof document !== 'undefined') {
@@ -159,7 +151,6 @@ if (typeof document !== 'undefined') {
     ensureDmCharacterEditorAssets(document);
 }
 
-// Compatibilidad para entornos de prueba (Node.js)
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
         obtenerEstacion,

--- a/js/utils.js
+++ b/js/utils.js
@@ -120,9 +120,43 @@ function ensurePlayerUxPolishAssets(doc) {
     return { link, script };
 }
 
+/**
+ * Carga la corrección de UX del editor de Gestión de Personajes del DM.
+ * pantalla_dm.html ya carga utils.js, así que evitamos modificar el HTML monolítico.
+ * @param {Document} doc
+ * @returns {{link: HTMLLinkElement|null, script: HTMLScriptElement|null}|null}
+ */
+function ensureDmCharacterEditorAssets(doc) {
+    const documentRef = doc || (typeof document !== 'undefined' ? document : null);
+    if (!documentRef?.querySelector?.('#dashboard-actores')) return null;
+
+    let link = documentRef.getElementById('dm-character-editor-ux-stylesheet');
+    if (!link) {
+        link = documentRef.createElement('link');
+        link.id = 'dm-character-editor-ux-stylesheet';
+        link.rel = 'stylesheet';
+        link.href = 'css/dm-character-editor-ux.css';
+        link.dataset.ui = 'dm-character-editor-ux';
+        documentRef.head?.appendChild(link);
+    }
+
+    let script = documentRef.getElementById('dm-character-editor-ux-script');
+    if (!script) {
+        script = documentRef.createElement('script');
+        script.id = 'dm-character-editor-ux-script';
+        script.src = 'js/dm-character-editor-ux.js';
+        script.async = false;
+        script.dataset.ui = 'dm-character-editor-ux';
+        documentRef.head?.appendChild(script);
+    }
+
+    return { link, script };
+}
+
 if (typeof document !== 'undefined') {
     ensurePlayerTerminalStyles(document);
     ensurePlayerUxPolishAssets(document);
+    ensureDmCharacterEditorAssets(document);
 }
 
 // Compatibilidad para entornos de prueba (Node.js)
@@ -131,6 +165,7 @@ if (typeof module !== 'undefined' && module.exports) {
         obtenerEstacion,
         calculateLevelData,
         ensurePlayerTerminalStyles,
-        ensurePlayerUxPolishAssets
+        ensurePlayerUxPolishAssets,
+        ensureDmCharacterEditorAssets
     };
 }

--- a/tests/dm_character_editor_ux.spec.js
+++ b/tests/dm_character_editor_ux.spec.js
@@ -1,0 +1,73 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
+const dmHtml = read("pantalla_dm.html");
+const editorUx = read("js/dm-character-editor-ux.js");
+const editorCss = read("css/dm-character-editor-ux.css");
+const utils = read("js/utils.js");
+
+test("Gestión de Personajes conserva un editor real y botones Editar", () => {
+  expect(dmHtml).toContain('id="dashboard-actores"');
+  expect(dmHtml).toContain('class="actor-studio-wrapper"');
+  expect(dmHtml).toContain('id="actor-nombre"');
+  expect(dmHtml).toContain('id="btn-crear-actor"');
+  expect(dmHtml).toContain('btnEdit.textContent = "Editar"');
+  expect(dmHtml).toContain("loadActorIntoFormInternal(actor.id, actor)");
+});
+
+test("el wrapper normaliza etiquetas legacy antes de abrir el editor", () => {
+  expect(editorUx).toContain("function normalizeTags");
+  expect(editorUx).toContain("Array.isArray(value)");
+  expect(editorUx).toContain('typeof value === "string"');
+  expect(editorUx).toContain('value.split(",")');
+  expect(editorUx).toContain("normalizeActorForEditor(actorData)");
+  expect(editorUx).toContain("etiquetas: normalizeTags(source.etiquetas)");
+});
+
+test("expresiones legacy aceptan string u objeto de sprite", () => {
+  expect(editorUx).toContain("function expressionUrl");
+  expect(editorUx).toContain("value.sprite || value.url || value.imagen || value.image");
+  expect(editorUx).toContain("function normalizeExpressions");
+});
+
+test("Editar lleva al Actor Studio y ofrece feedback inequívoco", () => {
+  expect(editorUx).toContain("function ensureEditContext");
+  expect(editorUx).toContain('wrapper.classList.add("dm-character-editor-active")');
+  expect(editorUx).toContain("EDITANDO FUENTE");
+  expect(editorUx).toContain('stateBanner.textContent = "EDITANDO"');
+  expect(editorUx).toContain('save.textContent = "GUARDAR CAMBIOS"');
+  expect(editorUx).toContain('wrapper.scrollIntoView({ behavior: "smooth", block: "start" })');
+  expect(editorUx).toContain('getElementById("actor-nombre")?.focus');
+});
+
+test("la función existente queda envuelta sin reescribir la persistencia", () => {
+  expect(editorUx).toContain("const original = global.loadActorIntoFormInternal");
+  expect(editorUx).toContain("original.call(this, actorId, normalized)");
+  expect(editorUx).toContain("global.loadActorIntoFormInternal = wrappedLoadActorIntoForm");
+  expect(editorUx).not.toContain("firebase.database");
+  expect(editorUx).not.toContain("db.ref(");
+});
+
+test("si un actor legacy falla al cargar se conserva un fallback visible", () => {
+  expect(editorUx).toContain("function populateSafeFallback");
+  expect(editorUx).toContain("aplicando fallback seguro");
+  expect(editorUx).toContain("finally");
+  expect(editorUx).toContain("ensureEditContext(actorId, normalized)");
+});
+
+test("utils carga el arreglo solo en Gestión de Personajes del DM", () => {
+  expect(utils).toContain("function ensureDmCharacterEditorAssets");
+  expect(utils).toContain("#dashboard-actores");
+  expect(utils).toContain("css/dm-character-editor-ux.css");
+  expect(utils).toContain("js/dm-character-editor-ux.js");
+  expect(utils).toContain("ensureDmCharacterEditorAssets(document)");
+});
+
+test("el modo edición tiene contraste visual propio", () => {
+  expect(editorCss).toContain(".dm-character-editor-active");
+  expect(editorCss).toContain(".dm-character-edit-context");
+  expect(editorCss).toContain("#btn-crear-actor");
+  expect(editorCss).toContain("scroll-margin-top");
+});

--- a/tests/dm_character_player_resolver.spec.js
+++ b/tests/dm_character_player_resolver.spec.js
@@ -1,0 +1,43 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
+const resolver = read("js/dm-character-player-resolver.js");
+const utils = read("js/utils.js");
+
+test("el editor de jugador no confía ciegamente en actorId stale", () => {
+  expect(resolver).toContain("async function fetchActorById");
+  expect(resolver).toContain('"campaña/base_datos_npcs"');
+  expect(resolver).toContain('"campaña/actores"');
+  expect(resolver).toContain("const candidates = [selectedActorId, playerData.actorId]");
+  expect(resolver).toContain("const direct = await fetchActorById(db, actorId)");
+  expect(resolver).toContain("findActorLinkedToPlayer");
+});
+
+test("si actorId no existe se busca por vinculo_jugador", () => {
+  expect(resolver).toContain("acceptedLinks");
+  expect(resolver).toContain("actor.vinculo_jugador");
+  expect(resolver).toContain("acceptedLinks.has(link)");
+  expect(resolver).toContain("playerId");
+  expect(resolver).toContain("displayName");
+});
+
+test("el click Editar de jugador intercepta el handler viejo", () => {
+  expect(resolver).toContain('#grid-personajes-jugadores .btn-action');
+  expect(resolver).toContain('if (!/editar/i.test(button.textContent || "")) return;');
+  expect(resolver).toContain("event.stopImmediatePropagation()");
+  expect(resolver).toContain("openResolvedPlayerActor(button)");
+});
+
+test("el actor resuelto entra al Actor Studio existente", () => {
+  expect(resolver).toContain("const loader = global.loadActorIntoFormInternal");
+  expect(resolver).toContain("loader(resolved.actorId, resolved.actor)");
+  expect(resolver).toContain("normalizeActorForLegacyEditor");
+});
+
+test("utils carga el resolver de jugadores junto al editor DM", () => {
+  expect(utils).toContain("dm-character-player-resolver-script");
+  expect(utils).toContain("js/dm-character-player-resolver.js");
+  expect(utils).toContain("playerResolver");
+});


### PR DESCRIPTION
Supersedido por #523. La investigación posterior encontró una causa más específica para jugadores como Dante: el handler prioriza un `playerData.actorId` obsoleto aunque ese ID ya no exista, por lo que nunca cae al actor válido enlazado por `vinculo_jugador`. #523 parte del `main` actual y contiene un fix mínimo centrado en esa resolución.