### PR TITLE
Extiende Character Manager con escala live, vínculos e idiomas

### DIFF
--- a/css/character-manager-social.css
+++ b/css/character-manager-social.css
@@ -1,0 +1,94 @@
+.character-manager-studio .cm-group-mode {
+  margin-left: auto;
+  max-width: 92px;
+  padding: 3px 5px;
+  color: #b8a270;
+  background: #0e0e0d;
+  border: 1px solid #39352c;
+  font: 9px "Share Tech Mono", monospace;
+}
+.character-manager-studio .cm-roster-group { display: grid; gap: 3px; }
+.character-manager-studio .cm-roster-group + .cm-roster-group { margin-top: 8px; }
+.character-manager-studio .cm-roster-group-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 6px;
+  color: #8f7b4e;
+  border-bottom: 1px solid #302b21;
+  font-size: 9px;
+  letter-spacing: .12em;
+}
+.character-manager-studio .cm-roster-group-heading code { color: #6d675d; }
+.character-manager-studio .cm-taxonomy-tags {
+  display: flex;
+  gap: 3px;
+  margin-top: 3px;
+  min-width: 0;
+  overflow: hidden;
+}
+.character-manager-studio .cm-taxonomy-tags > span {
+  max-width: 70px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 1px 4px;
+  border: 1px solid #353027;
+  color: #777066;
+  font-size: 8px;
+  text-transform: uppercase;
+}
+.character-manager-studio .cm-social-relations {
+  margin-top: 14px;
+  border-top: 1px solid #4a3d27;
+  background: #0a0a09;
+}
+.character-manager-studio .cm-social-relations > header {
+  min-height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 10px;
+  color: #b89a5d;
+  background: #11100d;
+  border-bottom: 1px solid #29261f;
+  font-size: 10px;
+  letter-spacing: .1em;
+}
+.character-manager-studio .cm-social-title { display: inline-flex; align-items: center; gap: 7px; }
+.character-manager-studio .cm-social-title svg {
+  width: 17px;
+  height: 17px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5;
+}
+.character-manager-studio .cm-relations-list { display: grid; }
+.character-manager-studio .cm-bond-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 1.4fr) minmax(78px, .7fr) minmax(135px, 1.2fr) minmax(105px, .8fr);
+  gap: 8px;
+  align-items: center;
+  padding: 8px 10px;
+  border-bottom: 1px solid #201e1a;
+}
+.character-manager-studio .cm-bond-row[data-saving="true"] { opacity: .55; }
+.character-manager-studio .cm-bond-player { display: grid; min-width: 0; }
+.character-manager-studio .cm-bond-player strong { color: #ded7c8; font-size: 11px; overflow: hidden; text-overflow: ellipsis; }
+.character-manager-studio .cm-bond-player code { color: #615d55; font-size: 8px; overflow: hidden; text-overflow: ellipsis; }
+.character-manager-studio .cm-bond-known-wrap { display: inline-flex; align-items: center; gap: 5px; color: #827b70; font-size: 9px; }
+.character-manager-studio .cm-bond-known-wrap input { accent-color: #a7813c; }
+.character-manager-studio .cm-bond-meter { display: grid; grid-template-columns: 1fr 34px; gap: 5px; align-items: center; }
+.character-manager-studio .cm-bond-meter input[type="range"] { accent-color: #a7813c; padding: 0; }
+.character-manager-studio .cm-bond-meter output { color: #b89a5d; font-size: 9px; text-align: right; }
+.character-manager-studio .cm-bond-state {
+  padding: 5px;
+  color: #c8c0b0;
+  background: #11110f;
+  border: 1px solid #37332b;
+  font-size: 9px;
+}
+.character-manager-studio .cm-social-empty { padding: 14px; color: #5e5a52; font-size: 9px; letter-spacing: .08em; text-align: center; }
+@media (max-width: 820px) {
+  .character-manager-studio .cm-bond-row { grid-template-columns: 1fr 1fr; }
+}

--- a/css/theatre-message-policy.css
+++ b/css/theatre-message-policy.css
@@ -1,0 +1,72 @@
+.theatre-message-policy {
+  border: 1px solid #4e4431;
+  background: linear-gradient(180deg, #0d0d0c, #080807);
+  padding: 9px;
+  display: grid;
+  gap: 8px;
+  font-family: "Share Tech Mono", monospace;
+}
+.theatre-message-policy .tmp-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: #b89a5d;
+  letter-spacing: .12em;
+  font-size: 11px;
+}
+.theatre-message-policy .tmp-head code {
+  color: #e8e1d1;
+  background: #17140e;
+  border-left: 2px solid #a7813c;
+  padding: 3px 7px;
+}
+.theatre-message-policy .tmp-grid {
+  display: grid;
+  grid-template-columns: minmax(90px, 1fr) minmax(82px, 1fr) minmax(82px, 1fr) auto;
+  gap: 7px;
+  align-items: end;
+}
+.theatre-message-policy label {
+  display: grid;
+  gap: 4px;
+  color: #817b70;
+  font-size: 9px;
+  letter-spacing: .08em;
+}
+.theatre-message-policy input,
+.theatre-message-policy select {
+  min-width: 0;
+  padding: 7px;
+  color: #e8e1d1;
+  background: #11110f;
+  border: 1px solid #38352e;
+  font: inherit;
+}
+#btn-theatre-message-next {
+  min-width: 72px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  color: #e8e1d1;
+  background: #211b10;
+  border: 1px solid #a7813c;
+  cursor: pointer;
+  font: inherit;
+}
+#btn-theatre-message-next svg {
+  width: 17px;
+  height: 17px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.7;
+  stroke-linejoin: miter;
+}
+#btn-theatre-message-next:disabled {
+  opacity: .3;
+  cursor: default;
+}
+@media (max-width: 760px) {
+  .theatre-message-policy .tmp-grid { grid-template-columns: 1fr 1fr; }
+}

--- a/hoja_de_DM.html
+++ b/hoja_de_DM.html
@@ -9,9 +9,10 @@
   <link rel="stylesheet" href="css/on-game-dashboard.css">
   <link rel="stylesheet" href="css/theatre-dialogue.css">
   <link rel="stylesheet" href="css/theatre-hud.css">
+  <link rel="stylesheet" href="css/theatre-message-policy.css">
 </head>
 <body class="on-game-dashboard">
-    <nav class="master-control-bar" aria-label="Control de instancia">
+  <nav class="master-control-bar" aria-label="Control de instancia">
     <div class="instance-toggles">
       <label><input type="radio" name="instancia" value="ninguno"> PANTALLA NEGRA</label>
       <label><input type="radio" name="instancia" value="teatro"> TEATRO / LORE</label>
@@ -24,9 +25,9 @@
   </nav>
 
   <div id="auth-blocker" style="display: none; position: fixed; inset: 0; background: #000; z-index: 99999; color: #ff0000; flex-direction: column; align-items: center; justify-content: center; font-family: 'Share Tech Mono', monospace; font-size: 2rem;">
-      <h2>ACCESO DENEGADO</h2>
-      <p>NO TIENES PERMISOS DE DIRECTOR PARA ESTA SESIÓN.</p>
-      <a href="index.html" style="color: #fff; text-decoration: underline; margin-top: 20px; font-size: 1rem;">VOLVER AL INICIO</a>
+    <h2>ACCESO DENEGADO</h2>
+    <p>NO TIENES PERMISOS DE DIRECTOR PARA ESTA SESIÓN.</p>
+    <a href="index.html" style="color: #fff; text-decoration: underline; margin-top: 20px; font-size: 1rem;">VOLVER AL INICIO</a>
   </div>
 
   <main>
@@ -35,105 +36,84 @@
     </section>
     <section id="modulo-teatro" class="game-module hidden" aria-hidden="true">
       <div class="stage-view-wrapper">
-        <!-- Location Sign -->
-        <div class="theatre-location">
-          <span id="theatre-location">LOCALIZACIÓN DESCONOCIDA</span>
-        </div>
-        <div id="theatre-stage" class="stage-view" aria-label="Escenario del teatro">
-          <!-- Aquí el motor inyecta los fondos y sprites reactivos -->
-        </div>
-        <!-- Dialogue Box Area (Visual) -->
+        <div class="theatre-location"><span id="theatre-location">LOCALIZACIÓN DESCONOCIDA</span></div>
+        <div id="theatre-stage" class="stage-view" aria-label="Escenario del teatro"></div>
         <div class="theatre-dialogue-wrapper">
-          <!-- Plates -->
           <div class="theatre-plates-container">
-            <div id="dialogue-title" class="theatre-plate-title">
-              <span>Title</span>
-            </div>
-            <div id="dialogue-name" class="theatre-plate-name">
-              <span>Name</span>
-            </div>
+            <div id="dialogue-title" class="theatre-plate-title"><span>Title</span></div>
+            <div id="dialogue-name" class="theatre-plate-name"><span>Name</span></div>
           </div>
-          <!-- Main Text Box -->
-          <div id="dialogue-text" class="theatre-dialogue-text">
-            …
-          </div>
+          <div id="dialogue-text" class="theatre-dialogue-text">…</div>
         </div>
       </div>
 
-      <!-- El Panel de Control (Solo para el DM) -->
       <details class="theatre-dm-menu">
-      <summary class="theatre-dm-menu-toggle" title="Mostrar u ocultar controles del director" aria-label="Mostrar u ocultar controles del director">
-        <img src="Assets/Images/Buttons/Menu.svg" alt="">
-      </summary>
-      <div id="theatre-director-panel" class="director-controls">
+        <summary class="theatre-dm-menu-toggle" title="Mostrar u ocultar controles del director" aria-label="Mostrar u ocultar controles del director">
+          <img src="Assets/Images/Buttons/Menu.svg" alt="">
+        </summary>
+        <div id="theatre-director-panel" class="director-controls">
           <h3 class="panel-title">CONTROL DE CASTING</h3>
 
-          <!-- Buscador e Inyector de NPCs desde la Base de Datos -->
           <div class="npc-spawner-section">
-              <select id="select-npc-roster" class="strict-dropdown">
-                  <option value="">Cargando NPCs disponibles...</option>
-                  <!-- JS poblará esto leyendo de base_datos_npcs -->
-              </select>
-              <button id="btn-spawn-npc" class="btn-action">INYECTAR A ESCENA</button>
+            <select id="select-npc-roster" class="strict-dropdown">
+              <option value="">Cargando NPCs disponibles...</option>
+            </select>
+            <button id="btn-spawn-npc" class="btn-action">INYECTAR A ESCENA</button>
           </div>
 
-          <!-- Lista de Actores Actualmente en el Escenario -->
-          <div class="active-actors-list" id="live-actors-list" style="margin-bottom: 20px;">
-              <!-- Tarjetas de control dinámicas por cada actor en escena -->
-          </div>
+          <div class="active-actors-list" id="live-actors-list" style="margin-bottom: 20px;"></div>
 
-          <!-- CONTROLES DE ESCENARIOS Y BIBLIOTECA -->
           <div style="padding: 12px; background: #05080c; border-bottom: 1px solid #1a222c; border-top: 1px solid #c49a00; margin-bottom: 20px;">
             <h4 style="color: #a37c35; margin: 0 0 10px 0; font-family: 'Cinzel', serif;">Biblioteca de Escenarios</h4>
 
             <div style="display: flex; gap: 8px; margin-bottom: 10px; flex-wrap: wrap;">
-                <select id="theatre-scenario-location-filter" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; flex: 1; max-width: 100%; box-sizing: border-box;">
-                    <option value="">Todas las localizaciones</option>
-                </select>
-                <input type="text" id="theatre-scenario-tag-filter" placeholder="Filtrar por etiqueta..." style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; flex: 1; max-width: 100%; box-sizing: border-box;">
-                <select id="theatre-scenario-select" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; flex: 1 1 100%; max-width: 100%; box-sizing: border-box;">
-                    <option value="">Selecciona un escenario guardado...</option>
-                </select>
+              <select id="theatre-scenario-location-filter" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; flex: 1; max-width: 100%; box-sizing: border-box;">
+                <option value="">Todas las localizaciones</option>
+              </select>
+              <input type="text" id="theatre-scenario-tag-filter" placeholder="Filtrar por etiqueta..." style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; flex: 1; max-width: 100%; box-sizing: border-box;">
+              <select id="theatre-scenario-select" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; flex: 1 1 100%; max-width: 100%; box-sizing: border-box;">
+                <option value="">Selecciona un escenario guardado...</option>
+              </select>
             </div>
 
             <div style="display: grid; grid-template-columns: 1fr; gap: 8px; margin-bottom: 10px;">
-                <input id="theatre-scenario-name" type="text" placeholder="Nombre del escenario" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; width: 100%; box-sizing: border-box;">
-                <input id="theatre-background-input" type="url" placeholder="URL del fondo" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; width: 100%; box-sizing: border-box;">
-                <input id="theatre-location-input" type="text" placeholder="Localización" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; width: 100%; box-sizing: border-box;">
-                <input id="theatre-scenario-tags" type="text" placeholder="Sub-etiquetas (separadas por coma)" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; width: 100%; box-sizing: border-box;">
+              <input id="theatre-scenario-name" type="text" placeholder="Nombre del escenario" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; width: 100%; box-sizing: border-box;">
+              <input id="theatre-background-input" type="url" placeholder="URL del fondo" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; width: 100%; box-sizing: border-box;">
+              <input id="theatre-location-input" type="text" placeholder="Localización" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; width: 100%; box-sizing: border-box;">
+              <input id="theatre-scenario-tags" type="text" placeholder="Sub-etiquetas (separadas por coma)" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; width: 100%; box-sizing: border-box;">
             </div>
 
             <div style="display: flex; gap: 8px; flex-wrap: wrap;">
-                <button id="btn-save-scenario" type="button" style="padding: 8px; background: #1a222c; color: #a37c35; border: 1px solid #a37c35; cursor: pointer;">GUARDAR ESCENARIO</button>
-                <button id="btn-use-scenario" type="button" style="padding: 8px; background: #8a1c1c; color: white; border: 1px solid #ff6575; cursor: pointer; flex: 1;">USAR EN TEATRO</button>
-                <button id="btn-delete-scenario" type="button" style="padding: 8px; background: #3a0c0c; color: #ff6575; border: 1px solid #ff6575; cursor: pointer;">BORRAR</button>
-                <button id="btn-update-scene" type="button" style="padding: 8px; background: #222; color: white; border: 1px solid #555; cursor: pointer;">APLICAR MANUAL</button>
+              <button id="btn-save-scenario" type="button" style="padding: 8px; background: #1a222c; color: #a37c35; border: 1px solid #a37c35; cursor: pointer;">GUARDAR ESCENARIO</button>
+              <button id="btn-use-scenario" type="button" style="padding: 8px; background: #8a1c1c; color: white; border: 1px solid #ff6575; cursor: pointer; flex: 1;">USAR EN TEATRO</button>
+              <button id="btn-delete-scenario" type="button" style="padding: 8px; background: #3a0c0c; color: #ff6575; border: 1px solid #ff6575; cursor: pointer;">BORRAR</button>
+              <button id="btn-update-scene" type="button" style="padding: 8px; background: #222; color: white; border: 1px solid #555; cursor: pointer;">APLICAR MANUAL</button>
             </div>
           </div>
 
           <div class="theatre-controls" style="display: flex; flex-direction: column; gap: 10px;">
             <h4 style="color: #a37c35; margin: 0; font-family: 'Cinzel', serif;">Compositor de Diálogo</h4>
-            <!-- Nuevos selectores de hablante y expresión -->
             <div style="display: flex; gap: 8px;">
               <select id="theatre-speaker-select" style="flex: 1; padding: 9px; background: #121820; color: white; border: 1px solid #53606d;">
-                  <option value="narrador">Narrador</option>
+                <option value="narrador">Narrador</option>
               </select>
               <select id="dm-tipo-dialogo-select" style="flex: 1; padding: 9px; background: #121820; color: white; border: 1px solid #53606d;">
-                  <option value="dialogo">Diálogo</option>
-                  <option value="narracion">Narración</option>
-                  <option value="pensamiento">Pensamiento</option>
+                <option value="dialogo">Diálogo</option>
+                <option value="narracion">Narración</option>
+                <option value="pensamiento">Pensamiento</option>
               </select>
               <select id="theatre-expression-select" style="flex: 1; padding: 9px; background: #121820; color: white; border: 1px solid #53606d;">
-                  <option value="Neutral">Neutral</option>
+                <option value="Neutral">Neutral</option>
               </select>
             </div>
 
             <textarea id="theatre-dialogue-input" placeholder="Diálogo en vivo" style="min-height: 80px;"></textarea>
             <button id="btn-send-dialogue" type="button">ENVIAR DIÁLOGO</button>
           </div>
-      </div>
+        </div>
       </details>
     </section>
+
     <section id="modulo-combate" class="game-module hidden" aria-hidden="true">
       <div id="combat-grid"><iframe src="Battle-viewer.html" title="Cuadrícula de combate táctica"></iframe></div>
       <div id="combat-log-and-controls">
@@ -142,6 +122,7 @@
       </div>
     </section>
   </main>
+
   <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-database.js"></script>
@@ -149,8 +130,13 @@
     firebase.initializeApp({apiKey:"AIzaSyAIVIuKgXUsdrb9Mmss9PH7R3FpWAMG2hU",authDomain:"luminous-system.firebaseapp.com",databaseURL:"https://luminous-system-default-rtdb.firebaseio.com",projectId:"luminous-system",storageBucket:"luminous-system.firebasestorage.app",messagingSenderId:"330473029689",appId:"1:330473029689:web:44a05e870d493a3b294de8"});
   </script>
   <script src="js/instance-control.js"></script>
+  <script src="js/language-catalog-engine.js"></script>
+  <script src="js/bond-engine.js"></script>
   <script src="js/theatre-engine.js"></script>
+  <script src="js/character-manager-live-sync.js"></script>
   <script src="js/theatre-controls.js"></script>
+  <script src="js/theatre-language-policy.js"></script>
+  <script src="js/theatre-message-policy.js"></script>
   <script src="js/on-game-dashboard.js"></script>
 </body>
 </html>

--- a/js/bond-engine.js
+++ b/js/bond-engine.js
@@ -1,0 +1,117 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousBondManager) return;
+
+  const ROOT = "campaña/vinculos";
+  const IDENTITY_ROOT = "campaña/teatro/conocimiento_identidad";
+  const subscribers = new Set();
+  let db = null;
+  let cache = {};
+  let listener = null;
+  let retryTimer = null;
+
+  function getDb() {
+    try {
+      if (!global.firebase?.database || !global.firebase.apps?.length) return null;
+      return global.firebase.database();
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function clone(value) {
+    return JSON.parse(JSON.stringify(value || {}));
+  }
+
+  function normalizeBond(value = {}) {
+    const nivelRaw = Number(value.nivel ?? value.level ?? 0);
+    return {
+      conocido: Boolean(value.conocido ?? value.known ?? false),
+      nivel: Number.isFinite(nivelRaw) ? Math.max(0, Math.min(5, Math.round(nivelRaw))) : 0,
+      estado: String(value.estado || value.state || "neutral").trim().toLowerCase() || "neutral",
+      notas: String(value.notas || value.notes || "").trim(),
+    };
+  }
+
+  function emit() {
+    const snapshot = clone(cache);
+    subscribers.forEach((callback) => {
+      try { callback(snapshot); } catch (error) { console.error("Bond subscriber failed:", error); }
+    });
+  }
+
+  function init() {
+    if (db) return api;
+    db = getDb();
+    if (!db) {
+      if (!retryTimer) {
+        retryTimer = global.setTimeout(() => {
+          retryTimer = null;
+          init();
+        }, 100);
+      }
+      return api;
+    }
+
+    listener = (snapshot) => {
+      cache = snapshot.val() || {};
+      emit();
+    };
+    db.ref(ROOT).on("value", listener);
+    return api;
+  }
+
+  function getBond(playerId, actorId) {
+    return normalizeBond(cache?.[playerId]?.[actorId] || {});
+  }
+
+  function listForActor(actorId) {
+    const result = {};
+    Object.entries(cache || {}).forEach(([playerId, actors]) => {
+      if (actors?.[actorId]) result[playerId] = normalizeBond(actors[actorId]);
+    });
+    return result;
+  }
+
+  async function setBond(playerId, actorId, next) {
+    init();
+    if (!db) throw new Error("Firebase no está disponible para Vínculos.");
+    if (!playerId || !actorId) throw new Error("playerId y actorId son obligatorios.");
+    const bond = normalizeBond(next);
+    const timestamp = global.firebase.database.ServerValue.TIMESTAMP;
+    const updates = {
+      [`${ROOT}/${playerId}/${actorId}`]: { ...bond, updatedAt: timestamp },
+      [`${IDENTITY_ROOT}/${playerId}/${actorId}`]: {
+        known: bond.conocido,
+        conocida: bond.conocido,
+        bondLevel: bond.nivel,
+        estado: bond.estado,
+        updatedAt: timestamp,
+      },
+    };
+    await db.ref().update(updates);
+    return bond;
+  }
+
+  async function clearBond(playerId, actorId) {
+    init();
+    if (!db) throw new Error("Firebase no está disponible para Vínculos.");
+    await db.ref().update({
+      [`${ROOT}/${playerId}/${actorId}`]: null,
+      [`${IDENTITY_ROOT}/${playerId}/${actorId}`]: null,
+    });
+  }
+
+  function subscribe(callback, options = {}) {
+    init();
+    if (typeof callback !== "function") return () => {};
+    subscribers.add(callback);
+    if (options.immediate !== false) callback(clone(cache));
+    return () => subscribers.delete(callback);
+  }
+
+  const api = Object.freeze({ ROOT, IDENTITY_ROOT, init, getBond, listForActor, setBond, clearBond, subscribe, normalizeBond });
+  global.LuminousBondManager = api;
+  init();
+})(window);

--- a/js/bond-engine.js
+++ b/js/bond-engine.js
@@ -3,7 +3,7 @@
 
   if (global.LuminousBondManager) return;
 
-  const ROOT = "campaña/teatro/vinculos";
+  const ROOT = "campaña/estado_mundo/vinculos";
   const IDENTITY_ROOT = "campaña/teatro/conocimiento_identidad";
   const subscribers = new Set();
   let db = null;

--- a/js/bond-engine.js
+++ b/js/bond-engine.js
@@ -3,7 +3,7 @@
 
   if (global.LuminousBondManager) return;
 
-  const ROOT = "campaña/vinculos";
+  const ROOT = "campaña/teatro/vinculos";
   const IDENTITY_ROOT = "campaña/teatro/conocimiento_identidad";
   const subscribers = new Set();
   let db = null;

--- a/js/character-manager-live-sync.js
+++ b/js/character-manager-live-sync.js
@@ -1,28 +1,30 @@
 (function (global) {
   "use strict";
 
-  const manager = global.LuminousCharacterManager;
   const firebase = global.firebase;
-  if (!manager || !firebase?.database) return;
+  if (!firebase?.database) return;
+  if (global.LuminousCharacterLiveSync) return;
 
   const db = firebase.database();
   const DEFAULT_SCENE = "campaña/estado_mundo/escena_actual";
+  let manager = null;
   let scenePath = null;
   let sceneRef = null;
   let sceneListener = null;
   let currentScene = {};
   let syncing = false;
+  let installed = false;
 
   function paths() {
     return global.LuminousTheatreState?.getPaths?.() || { scene: DEFAULT_SCENE };
   }
 
   function masterIdFor(instanceId, actor) {
-    return actor?.identityId || actor?.identidadId || actor?.sourceActorId || (manager.getActor(instanceId) ? instanceId : null);
+    return actor?.identityId || actor?.identidadId || actor?.sourceActorId || (manager?.getActor?.(instanceId) ? instanceId : null);
   }
 
   async function syncMasterScaleToScene() {
-    if (syncing || !sceneRef) return;
+    if (syncing || !sceneRef || !manager) return;
     const actors = currentScene?.actores || {};
     const updates = {};
 
@@ -62,17 +64,31 @@
     sceneRef.on("value", sceneListener);
   }
 
-  manager.init({ db });
-  manager.subscribeActors(() => {
+  function install() {
+    if (installed) return true;
+    manager = global.LuminousCharacterManager;
+    if (!manager) return false;
+    installed = true;
+    manager.init({ db });
+    manager.subscribeActors(() => {
+      bindScene();
+      syncMasterScaleToScene();
+    });
     bindScene();
-    syncMasterScaleToScene();
-  });
+    return true;
+  }
 
-  bindScene();
-  global.setInterval(bindScene, 1000);
+  const bootstrapTimer = global.setInterval(() => {
+    if (install()) global.clearInterval(bootstrapTimer);
+  }, 100);
+  install();
+  global.setInterval(() => {
+    if (installed) bindScene();
+  }, 1000);
 
   global.LuminousCharacterLiveSync = Object.freeze({
     sync: syncMasterScaleToScene,
     getScenePath: () => scenePath,
+    isInstalled: () => installed,
   });
 })(window);

--- a/js/character-manager-live-sync.js
+++ b/js/character-manager-live-sync.js
@@ -1,0 +1,78 @@
+(function (global) {
+  "use strict";
+
+  const manager = global.LuminousCharacterManager;
+  const firebase = global.firebase;
+  if (!manager || !firebase?.database) return;
+
+  const db = firebase.database();
+  const DEFAULT_SCENE = "campaña/estado_mundo/escena_actual";
+  let scenePath = null;
+  let sceneRef = null;
+  let sceneListener = null;
+  let currentScene = {};
+  let syncing = false;
+
+  function paths() {
+    return global.LuminousTheatreState?.getPaths?.() || { scene: DEFAULT_SCENE };
+  }
+
+  function masterIdFor(instanceId, actor) {
+    return actor?.identityId || actor?.identidadId || actor?.sourceActorId || (manager.getActor(instanceId) ? instanceId : null);
+  }
+
+  async function syncMasterScaleToScene() {
+    if (syncing || !sceneRef) return;
+    const actors = currentScene?.actores || {};
+    const updates = {};
+
+    Object.entries(actors).forEach(([instanceId, liveActor]) => {
+      if (liveActor?.sync_master_scale === false || liveActor?.syncMasterScale === false) return;
+      const masterId = masterIdFor(instanceId, liveActor);
+      if (!masterId) return;
+      const master = manager.getActor(masterId)?.actor;
+      const masterScale = Number(master?.escala);
+      if (!Number.isFinite(masterScale) || masterScale <= 0) return;
+      const liveScale = Number(liveActor?.escala);
+      if (Number.isFinite(liveScale) && Math.abs(liveScale - masterScale) < 0.0001) return;
+      updates[`actores/${instanceId}/escala`] = masterScale;
+    });
+
+    if (!Object.keys(updates).length) return;
+    syncing = true;
+    try {
+      await sceneRef.update(updates);
+    } catch (error) {
+      console.error("Character Manager live scale sync failed:", error);
+    } finally {
+      syncing = false;
+    }
+  }
+
+  function bindScene() {
+    const nextPath = paths().scene || DEFAULT_SCENE;
+    if (sceneRef && scenePath === nextPath) return;
+    if (sceneRef && sceneListener) sceneRef.off("value", sceneListener);
+    scenePath = nextPath;
+    sceneRef = db.ref(scenePath);
+    sceneListener = (snapshot) => {
+      currentScene = snapshot.val() || {};
+      syncMasterScaleToScene();
+    };
+    sceneRef.on("value", sceneListener);
+  }
+
+  manager.init({ db });
+  manager.subscribeActors(() => {
+    bindScene();
+    syncMasterScaleToScene();
+  });
+
+  bindScene();
+  global.setInterval(bindScene, 1000);
+
+  global.LuminousCharacterLiveSync = Object.freeze({
+    sync: syncMasterScaleToScene,
+    getScenePath: () => scenePath,
+  });
+})(window);

--- a/js/character-manager-social-studio.js
+++ b/js/character-manager-social-studio.js
@@ -1,0 +1,272 @@
+(function (global) {
+  "use strict";
+
+  const manager = global.LuminousCharacterManager;
+  const bonds = global.LuminousBondManager;
+  if (!manager || !bonds) return;
+  if (global.__luminousCharacterSocialStudioInstalled) return;
+  global.__luminousCharacterSocialStudioInstalled = true;
+
+  const doc = global.document;
+  const state = { groupMode: "type", grouping: false, groupTimer: null };
+
+  function $(id) { return doc.getElementById(id); }
+
+  function normalizeTags(value) {
+    if (Array.isArray(value)) return value.map((tag) => String(tag || "").trim()).filter(Boolean);
+    if (typeof value === "string") return value.split(",").map((tag) => tag.trim()).filter(Boolean);
+    if (value && typeof value === "object") return Object.values(value).map((tag) => String(tag || "").trim()).filter(Boolean);
+    return [];
+  }
+
+  function slug(value) {
+    return String(value || "actor")
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, "_")
+      .replace(/^_+|_+$/g, "") || "actor";
+  }
+
+  function currentActorId() {
+    return doc.querySelector("#character-manager-roster .cm-roster-entry.is-selected")?.dataset?.actorId || null;
+  }
+
+  function currentRecord() {
+    const actorId = currentActorId();
+    return actorId ? manager.getActor(actorId) : null;
+  }
+
+  function groupLabel(record) {
+    const actor = record?.actor || {};
+    if (state.groupMode === "faction") return String(actor.faccion || actor.alineamiento || "SIN FACCIÓN").toUpperCase();
+    if (state.groupMode === "tag") {
+      const tags = normalizeTags(actor.etiquetas || actor.tags);
+      return String(tags[0] || "SIN ETIQUETA").toUpperCase();
+    }
+    if (record?.playerId || actor.tipo === "Jugador") return "JUGADORES";
+    return String(actor.tipo || "NPC").toUpperCase();
+  }
+
+  function decorateEntry(entry, record) {
+    entry.querySelector(".cm-taxonomy-tags")?.remove();
+    const tags = normalizeTags(record?.actor?.etiquetas || record?.actor?.tags);
+    if (!tags.length) return;
+    const host = doc.createElement("span");
+    host.className = "cm-taxonomy-tags";
+    tags.slice(0, 3).forEach((tag) => {
+      const chip = doc.createElement("span");
+      chip.textContent = tag;
+      host.appendChild(chip);
+    });
+    entry.querySelector(".cm-roster-copy")?.appendChild(host);
+  }
+
+  function applyGrouping(force = false) {
+    if (state.grouping) return;
+    const roster = $("character-manager-roster");
+    if (!roster) return;
+    const entries = Array.from(roster.querySelectorAll(".cm-roster-entry"));
+    if (!entries.length) return;
+    if (!force && !Array.from(roster.children).some((child) => child.classList?.contains("cm-roster-entry"))) return;
+
+    state.grouping = true;
+    const groups = new Map();
+    entries.forEach((entry) => {
+      const record = manager.getActor(entry.dataset.actorId);
+      if (!record) return;
+      decorateEntry(entry, record);
+      const label = groupLabel(record);
+      if (!groups.has(label)) groups.set(label, []);
+      groups.get(label).push(entry);
+    });
+
+    const fragment = doc.createDocumentFragment();
+    Array.from(groups.entries()).sort((a, b) => a[0].localeCompare(b[0])).forEach(([label, groupEntries]) => {
+      const section = doc.createElement("section");
+      section.className = "cm-roster-group";
+      const heading = doc.createElement("div");
+      heading.className = "cm-roster-group-heading";
+      heading.innerHTML = `<span></span><code></code>`;
+      heading.querySelector("span").textContent = label;
+      heading.querySelector("code").textContent = String(groupEntries.length).padStart(2, "0");
+      section.appendChild(heading);
+      groupEntries.forEach((entry) => section.appendChild(entry));
+      fragment.appendChild(section);
+    });
+
+    roster.replaceChildren(fragment);
+    state.grouping = false;
+  }
+
+  function scheduleGrouping(force = false) {
+    global.clearTimeout(state.groupTimer);
+    state.groupTimer = global.setTimeout(() => applyGrouping(force), 0);
+  }
+
+  function populateTags() {
+    const input = $("character-manager-tags");
+    if (!input) return;
+    const record = currentRecord();
+    input.value = normalizeTags(record?.actor?.etiquetas || record?.actor?.tags).join(", ");
+    input.disabled = false;
+  }
+
+  async function persistTags() {
+    const input = $("character-manager-tags");
+    const name = $("character-manager-name")?.value?.trim();
+    if (!input || !name) return;
+    const tags = normalizeTags(input.value);
+    const existingId = currentActorId();
+    const actorId = existingId || slug(name);
+    const record = manager.getActor(actorId);
+    await manager.saveActor({
+      actorId,
+      root: record?.root || manager.PATHS.actors[0],
+      actor: { etiquetas: tags, tags },
+    });
+  }
+
+  function relationIcon() {
+    return '<svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="8" cy="9" r="3"/><circle cx="17" cy="8" r="2.5"/><path d="M2.5 20c.5-4 2.3-6 5.5-6s5 2 5.5 6M13.5 19c.3-3 1.5-4.5 3.8-4.5 2.2 0 3.6 1.5 4.2 4.5"/></svg>';
+  }
+
+  async function saveRelation(row) {
+    const actorId = currentActorId();
+    const playerId = row.dataset.playerId;
+    if (!actorId || !playerId) return;
+    const known = Boolean(row.querySelector(".cm-bond-known")?.checked);
+    const level = Number(row.querySelector(".cm-bond-level")?.value) || 0;
+    const status = row.querySelector(".cm-bond-state")?.value || "neutral";
+    row.dataset.saving = "true";
+    try {
+      await bonds.setBond(playerId, actorId, { conocido: known, nivel: level, estado: status });
+    } catch (error) {
+      console.error("No se pudo guardar el vínculo social:", error);
+    } finally {
+      row.dataset.saving = "false";
+    }
+  }
+
+  function renderRelations() {
+    const host = $("character-manager-relations-list");
+    if (!host) return;
+    host.innerHTML = "";
+    const actorId = currentActorId();
+    if (!actorId) {
+      const empty = doc.createElement("div");
+      empty.className = "cm-social-empty";
+      empty.textContent = "GUARDA EL ACTOR PARA CREAR VÍNCULOS";
+      host.appendChild(empty);
+      return;
+    }
+
+    manager.listPlayers().sort((a, b) => a.label.localeCompare(b.label)).forEach(({ playerId, label }) => {
+      const bond = bonds.getBond(playerId, actorId);
+      const row = doc.createElement("div");
+      row.className = "cm-bond-row";
+      row.dataset.playerId = playerId;
+      row.innerHTML = `
+        <div class="cm-bond-player"><strong></strong><code></code></div>
+        <label class="cm-bond-known-wrap"><input class="cm-bond-known" type="checkbox"><span>CONOCE</span></label>
+        <div class="cm-bond-meter"><input class="cm-bond-level" type="range" min="0" max="5" step="1"><output></output></div>
+        <select class="cm-bond-state" aria-label="Estado del vínculo"><option value="neutral">NEUTRAL</option><option value="confianza">CONFIANZA</option><option value="aliado">ALIADO</option><option value="rival">RIVAL</option><option value="hostil">HOSTIL</option></select>
+      `;
+      row.querySelector("strong").textContent = label;
+      row.querySelector("code").textContent = playerId;
+      const known = row.querySelector(".cm-bond-known");
+      const level = row.querySelector(".cm-bond-level");
+      const output = row.querySelector("output");
+      const status = row.querySelector(".cm-bond-state");
+      known.checked = bond.conocido;
+      level.value = bond.nivel;
+      output.value = bond.nivel;
+      output.textContent = `LV ${bond.nivel}`;
+      status.value = bond.estado;
+      level.addEventListener("input", () => { output.textContent = `LV ${level.value}`; });
+      [known, status].forEach((control) => control.addEventListener("change", () => saveRelation(row)));
+      level.addEventListener("change", () => saveRelation(row));
+      host.appendChild(row);
+    });
+  }
+
+  function ensureUi() {
+    const panel = $("character-manager-studio");
+    if (!panel) return false;
+
+    const rosterHeading = panel.querySelector(".cm-roster-heading");
+    if (rosterHeading && !$("character-manager-group-mode")) {
+      const select = doc.createElement("select");
+      select.id = "character-manager-group-mode";
+      select.className = "cm-group-mode";
+      select.setAttribute("aria-label", "Agrupar roster");
+      select.innerHTML = '<option value="type">TIPO</option><option value="faction">FACCIÓN</option><option value="tag">ETIQUETA</option>';
+      select.addEventListener("change", () => {
+        state.groupMode = select.value;
+        applyGrouping(true);
+      });
+      rosterHeading.insertBefore(select, rosterHeading.lastElementChild);
+    }
+
+    const assignment = panel.querySelector('[data-module="assignment"]');
+    const grid = assignment?.querySelector(".cm-field-grid");
+    if (grid && !$("character-manager-tags")) {
+      const tagField = doc.createElement("label");
+      tagField.className = "cm-field cm-wide";
+      tagField.innerHTML = '<span>ETIQUETAS</span><input id="character-manager-tags" type="text" placeholder="aliado, corporación, contacto" autocomplete="off">';
+      grid.appendChild(tagField);
+    }
+
+    if (assignment && !$("character-manager-relations")) {
+      const relations = doc.createElement("section");
+      relations.id = "character-manager-relations";
+      relations.className = "cm-social-relations";
+      relations.innerHTML = `
+        <header><span class="cm-social-title">${relationIcon()}<b>RELACIONES</b></span><small>PLAYER / ACTOR</small></header>
+        <div id="character-manager-relations-list" class="cm-relations-list"></div>
+      `;
+      assignment.appendChild(relations);
+    }
+
+    const roster = $("character-manager-roster");
+    if (roster && !roster.dataset.socialObserver) {
+      const observer = new MutationObserver(() => {
+        if (!state.grouping) scheduleGrouping(false);
+      });
+      observer.observe(roster, { childList: true });
+      roster.dataset.socialObserver = "true";
+      roster.addEventListener("click", (event) => {
+        if (!event.target.closest(".cm-roster-entry")) return;
+        global.setTimeout(() => {
+          populateTags();
+          renderRelations();
+          scheduleGrouping(true);
+        }, 0);
+      });
+    }
+
+    $("character-manager-new")?.addEventListener("click", () => {
+      global.setTimeout(() => {
+        if ($("character-manager-tags")) $("character-manager-tags").value = "";
+        renderRelations();
+      }, 0);
+    });
+    $("character-manager-save")?.addEventListener("click", () => {
+      persistTags().then(() => scheduleGrouping(true)).catch((error) => console.error("No se pudieron guardar etiquetas:", error));
+    });
+
+    populateTags();
+    renderRelations();
+    scheduleGrouping(true);
+    return true;
+  }
+
+  manager.subscribeActors(() => {
+    if (ensureUi()) scheduleGrouping(true);
+  });
+  manager.subscribePlayers(() => renderRelations());
+  bonds.subscribe(() => renderRelations());
+
+  if (doc.readyState === "loading") doc.addEventListener("DOMContentLoaded", ensureUi, { once: true });
+  else ensureUi();
+})(window);

--- a/js/language-catalog-engine.js
+++ b/js/language-catalog-engine.js
@@ -3,7 +3,8 @@
 
   if (global.LuminousLanguageCatalog) return;
 
-  const ROOT = "campaña/idiomas";
+  const ROOT = "campaña/teatro/idiomas";
+  const READ_ROOTS = ["campaña/idiomas", ROOT];
   const DND_DEFAULTS = Object.freeze({
     common: { nombre: "Común", universal: true, sistema: "dnd", tipo: "standard", estilo_ofuscacion: "ellipsis" },
     dwarvish: { nombre: "Enano", sistema: "dnd", tipo: "standard", estilo_ofuscacion: "runes" },
@@ -32,8 +33,8 @@
   });
 
   let db = null;
+  const sourceCache = {};
   let definitions = {};
-  let listener = null;
   let seedRequested = false;
   const subscribers = new Set();
   let retryTimer = null;
@@ -51,7 +52,8 @@
     }
   }
 
-  function emit() {
+  function rebuild() {
+    definitions = Object.assign({}, ...READ_ROOTS.map((root) => sourceCache[root] || {}));
     const snapshot = clone(definitions);
     subscribers.forEach((callback) => {
       try { callback(snapshot); } catch (error) { console.error("Language catalog subscriber failed:", error); }
@@ -60,11 +62,11 @@
 
   async function ensureDefaults() {
     if (!db) return false;
-    const snapshot = await db.ref(ROOT).once("value");
-    const current = snapshot.val() || {};
+    const snapshots = await Promise.all(READ_ROOTS.map((root) => db.ref(root).once("value")));
+    const merged = Object.assign({}, ...snapshots.map((snapshot) => snapshot.val() || {}));
     const updates = {};
     Object.entries(DND_DEFAULTS).forEach(([languageId, definition]) => {
-      if (!Object.prototype.hasOwnProperty.call(current, languageId)) updates[languageId] = definition;
+      if (!Object.prototype.hasOwnProperty.call(merged, languageId)) updates[languageId] = definition;
     });
     if (Object.keys(updates).length) await db.ref(ROOT).update(updates);
     return true;
@@ -88,11 +90,12 @@
       return api;
     }
 
-    listener = (snapshot) => {
-      definitions = snapshot.val() || {};
-      emit();
-    };
-    db.ref(ROOT).on("value", listener);
+    READ_ROOTS.forEach((root) => {
+      db.ref(root).on("value", (snapshot) => {
+        sourceCache[root] = snapshot.val() || {};
+        rebuild();
+      });
+    });
     if (seedRequested) ensureDefaults().catch((error) => console.error("Language catalog seed failed:", error));
     return api;
   }
@@ -112,7 +115,7 @@
     return () => subscribers.delete(callback);
   }
 
-  const api = Object.freeze({ ROOT, DND_DEFAULTS, init, ensureDefaults, list, get, subscribe });
+  const api = Object.freeze({ ROOT, READ_ROOTS, DND_DEFAULTS, init, ensureDefaults, list, get, subscribe });
   global.LuminousLanguageCatalog = api;
 
   const isDm = Boolean(document.body?.classList.contains("on-game-dashboard") || document.getElementById("dashboard-actores"));

--- a/js/language-catalog-engine.js
+++ b/js/language-catalog-engine.js
@@ -1,0 +1,120 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousLanguageCatalog) return;
+
+  const ROOT = "campaña/idiomas";
+  const DND_DEFAULTS = Object.freeze({
+    common: { nombre: "Común", universal: true, sistema: "dnd", tipo: "standard", estilo_ofuscacion: "ellipsis" },
+    dwarvish: { nombre: "Enano", sistema: "dnd", tipo: "standard", estilo_ofuscacion: "runes" },
+    elvish: { nombre: "Élfico", sistema: "dnd", tipo: "standard", estilo_ofuscacion: "ellipsis" },
+    giant: { nombre: "Gigante", sistema: "dnd", tipo: "standard", estilo_ofuscacion: "runes" },
+    gnomish: { nombre: "Gnómico", sistema: "dnd", tipo: "standard", estilo_ofuscacion: "ellipsis" },
+    goblin: { nombre: "Goblin", sistema: "dnd", tipo: "standard", estilo_ofuscacion: "ellipsis" },
+    halfling: { nombre: "Mediano", sistema: "dnd", tipo: "standard", estilo_ofuscacion: "ellipsis" },
+    orc: { nombre: "Orco", sistema: "dnd", tipo: "standard", estilo_ofuscacion: "ellipsis" },
+    abyssal: { nombre: "Abisal", sistema: "dnd", tipo: "exotic", estilo_ofuscacion: "runes" },
+    celestial: { nombre: "Celestial", sistema: "dnd", tipo: "exotic", estilo_ofuscacion: "runes" },
+    draconic: { nombre: "Dracónico", sistema: "dnd", tipo: "exotic", estilo_ofuscacion: "runes" },
+    deep_speech: { nombre: "Habla Profunda", sistema: "dnd", tipo: "exotic", estilo_ofuscacion: "runes" },
+    infernal: { nombre: "Infernal", sistema: "dnd", tipo: "exotic", estilo_ofuscacion: "runes" },
+    primordial: { nombre: "Primordial", sistema: "dnd", tipo: "exotic", estilo_ofuscacion: "runes" },
+    sylvan: { nombre: "Silvano", sistema: "dnd", tipo: "exotic", estilo_ofuscacion: "ellipsis" },
+    undercommon: { nombre: "Infracomún", sistema: "dnd", tipo: "exotic", estilo_ofuscacion: "ellipsis" },
+    dante_clock: {
+      nombre: "Reloj de Dante",
+      sistema: "special",
+      tipo: "distortion",
+      distortion: true,
+      texto_desconocido: "Tik... Tok...",
+      estilo_ofuscacion: "ellipsis"
+    }
+  });
+
+  let db = null;
+  let definitions = {};
+  let listener = null;
+  let seedRequested = false;
+  const subscribers = new Set();
+  let retryTimer = null;
+
+  function clone(value) {
+    return JSON.parse(JSON.stringify(value || {}));
+  }
+
+  function getDb() {
+    try {
+      if (!global.firebase?.database || !global.firebase.apps?.length) return null;
+      return global.firebase.database();
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function emit() {
+    const snapshot = clone(definitions);
+    subscribers.forEach((callback) => {
+      try { callback(snapshot); } catch (error) { console.error("Language catalog subscriber failed:", error); }
+    });
+  }
+
+  async function ensureDefaults() {
+    if (!db) return false;
+    const snapshot = await db.ref(ROOT).once("value");
+    const current = snapshot.val() || {};
+    const updates = {};
+    Object.entries(DND_DEFAULTS).forEach(([languageId, definition]) => {
+      if (!Object.prototype.hasOwnProperty.call(current, languageId)) updates[languageId] = definition;
+    });
+    if (Object.keys(updates).length) await db.ref(ROOT).update(updates);
+    return true;
+  }
+
+  function init(options = {}) {
+    seedRequested = seedRequested || options.seedDefaults === true;
+    if (db) {
+      if (seedRequested) ensureDefaults().catch((error) => console.error("Language catalog seed failed:", error));
+      return api;
+    }
+
+    db = getDb();
+    if (!db) {
+      if (!retryTimer) {
+        retryTimer = global.setTimeout(() => {
+          retryTimer = null;
+          init(options);
+        }, 100);
+      }
+      return api;
+    }
+
+    listener = (snapshot) => {
+      definitions = snapshot.val() || {};
+      emit();
+    };
+    db.ref(ROOT).on("value", listener);
+    if (seedRequested) ensureDefaults().catch((error) => console.error("Language catalog seed failed:", error));
+    return api;
+  }
+
+  function list() {
+    return Object.entries(definitions).map(([languageId, definition]) => ({ languageId, definition: clone(definition) }));
+  }
+
+  function get(languageId) {
+    return definitions[languageId] ? clone(definitions[languageId]) : null;
+  }
+
+  function subscribe(callback, options = {}) {
+    if (typeof callback !== "function") return () => {};
+    subscribers.add(callback);
+    if (options.immediate !== false) callback(clone(definitions));
+    return () => subscribers.delete(callback);
+  }
+
+  const api = Object.freeze({ ROOT, DND_DEFAULTS, init, ensureDefaults, list, get, subscribe });
+  global.LuminousLanguageCatalog = api;
+
+  const isDm = Boolean(document.body?.classList.contains("on-game-dashboard") || document.getElementById("dashboard-actores"));
+  init({ seedDefaults: isDm });
+})(window);

--- a/js/theatre-language-policy.js
+++ b/js/theatre-language-policy.js
@@ -6,7 +6,6 @@
   if (!firebase?.database) return;
 
   const db = firebase.database();
-  const manager = global.LuminousCharacterManager || null;
   const theatre = global.LuminousTheatreState || null;
   const LANGUAGE_ROOTS = ["campaña/idiomas", "campaña/teatro/idiomas"];
   const QUEUE_PATH = "campaña/teatro/cola";
@@ -15,9 +14,20 @@
   let currentScene = {};
   let sceneRef = null;
   let scenePath = null;
+  let manager = global.LuminousCharacterManager || null;
+  let managerSubscribed = false;
 
   function isDmView() {
     return Boolean(document.body?.classList.contains("on-game-dashboard"));
+  }
+
+  function getManager() {
+    if (!manager) manager = global.LuminousCharacterManager || null;
+    if (manager && isDmView() && !managerSubscribed) {
+      managerSubscribed = true;
+      manager.subscribeActors?.(refreshDmSelector);
+    }
+    return manager;
   }
 
   function label(languageId, definition) {
@@ -89,12 +99,14 @@
     if (!speakerId || speakerId === "narrador") return { all: true, knowledge: {} };
     const liveActor = currentScene?.actores?.[speakerId] || {};
     const masterId = liveActor.identityId || liveActor.identidadId || liveActor.sourceActorId || speakerId;
-    if (manager?.getActor?.(masterId)) return { all: false, knowledge: manager.languageKnowledgeForActor(masterId) };
+    const characterManager = getManager();
+    if (characterManager?.getActor?.(masterId)) return { all: false, knowledge: characterManager.languageKnowledgeForActor(masterId) };
     return { all: false, knowledge: mergeKnowledge(liveActor.idiomas, liveActor.languages) };
   }
 
   function refreshDmSelector() {
     if (!isDmView()) return;
+    getManager();
     bindScene();
     const select = document.getElementById("theatre-language-select");
     if (!select) return;
@@ -174,7 +186,10 @@
 
   if (isDmView()) {
     bindScene();
-    manager?.subscribeActors?.(refreshDmSelector);
+    getManager();
+    const managerTimer = global.setInterval(() => {
+      if (getManager()) global.clearInterval(managerTimer);
+    }, 100);
     document.addEventListener("change", (event) => {
       if (event.target?.id === "theatre-speaker-select") refreshDmSelector();
     });

--- a/js/theatre-language-policy.js
+++ b/js/theatre-language-policy.js
@@ -1,0 +1,198 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousTheatreLanguagePolicy) return;
+  const firebase = global.firebase;
+  if (!firebase?.database) return;
+
+  const db = firebase.database();
+  const manager = global.LuminousCharacterManager || null;
+  const theatre = global.LuminousTheatreState || null;
+  const LANGUAGE_ROOTS = ["campaña/idiomas", "campaña/teatro/idiomas"];
+  const QUEUE_PATH = "campaña/teatro/cola";
+  const sources = {};
+  let definitions = {};
+  let currentScene = {};
+  let sceneRef = null;
+  let scenePath = null;
+
+  function isDmView() {
+    return Boolean(document.body?.classList.contains("on-game-dashboard"));
+  }
+
+  function label(languageId, definition) {
+    return String(definition?.nombre || definition?.name || definition?.label || languageId).toUpperCase();
+  }
+
+  function normalizeKnowledge(value) {
+    if (typeof value === "number" || typeof value === "string") return { porcentaje: Math.max(0, Math.min(100, Number(value) || 0)), comprendido: false };
+    if (!value || typeof value !== "object") return { porcentaje: 0, comprendido: false };
+    return {
+      porcentaje: Math.max(0, Math.min(100, Number(value.porcentaje ?? value.percent ?? value.conocimiento ?? value.knowledge ?? 0) || 0)),
+      comprendido: Boolean(value.comprendido ?? value.understood ?? value.distortionUnderstood ?? false),
+    };
+  }
+
+  function mergeKnowledge() {
+    const merged = {};
+    Array.from(arguments).forEach((container) => {
+      if (!container || typeof container !== "object") return;
+      Object.entries(container).forEach(([languageId, entry]) => { merged[languageId] = normalizeKnowledge(entry); });
+    });
+    return merged;
+  }
+
+  function commonOption() {
+    const option = document.createElement("option");
+    option.value = "";
+    option.textContent = label("common", definitions.common || { nombre: "Común" });
+    option.dataset.languageId = "common";
+    return option;
+  }
+
+  function fillSelector(select, knowledge, allowAll) {
+    if (!select) return;
+    const previous = select.value;
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(commonOption());
+    Object.entries(definitions)
+      .filter(([languageId]) => languageId !== "common")
+      .sort((a, b) => label(a[0], a[1]).localeCompare(label(b[0], b[1])))
+      .forEach(([languageId, definition]) => {
+        const known = normalizeKnowledge(knowledge?.[languageId]);
+        if (!allowAll && known.porcentaje <= 0) return;
+        const option = document.createElement("option");
+        option.value = languageId;
+        option.textContent = label(languageId, definition);
+        fragment.appendChild(option);
+      });
+    select.replaceChildren(fragment);
+    if (previous && Array.from(select.options).some((option) => option.value === previous)) select.value = previous;
+    else select.value = "";
+  }
+
+  function bindScene() {
+    if (!theatre?.getPaths) return;
+    const nextPath = theatre.getPaths().scene;
+    if (!nextPath || nextPath === scenePath) return;
+    if (sceneRef) sceneRef.off();
+    scenePath = nextPath;
+    sceneRef = db.ref(scenePath);
+    sceneRef.on("value", (snapshot) => {
+      currentScene = snapshot.val() || {};
+      refreshDmSelector();
+    });
+  }
+
+  function speakerKnowledge() {
+    const speakerId = document.getElementById("theatre-speaker-select")?.value;
+    if (!speakerId || speakerId === "narrador") return { all: true, knowledge: {} };
+    const liveActor = currentScene?.actores?.[speakerId] || {};
+    const masterId = liveActor.identityId || liveActor.identidadId || liveActor.sourceActorId || speakerId;
+    if (manager?.getActor?.(masterId)) return { all: false, knowledge: manager.languageKnowledgeForActor(masterId) };
+    return { all: false, knowledge: mergeKnowledge(liveActor.idiomas, liveActor.languages) };
+  }
+
+  function refreshDmSelector() {
+    if (!isDmView()) return;
+    bindScene();
+    const select = document.getElementById("theatre-language-select");
+    if (!select) return;
+    const source = speakerKnowledge();
+    fillSelector(select, source.knowledge, source.all);
+  }
+
+  function playerKnowledge() {
+    const player = global.datosJugador || global.currentCharacterData || global.currentPlayerData || global.playerData || {};
+    const actor = global.getAssignedTheatreActor?.() || {};
+    return mergeKnowledge(
+      actor.idiomas,
+      actor.languages,
+      player.idiomas,
+      player.lenguajes,
+      player.languages,
+      player.conocimiento_idiomas,
+      player.languageKnowledge
+    );
+  }
+
+  function ensurePlayerSelector() {
+    if (isDmView()) return null;
+    const container = document.getElementById("contenedor-selectores-emocion");
+    if (!container) return null;
+    let select = document.getElementById("player-theatre-language-select");
+    if (!select) {
+      select = document.createElement("select");
+      select.id = "player-theatre-language-select";
+      select.className = "theatre-player-composer-select";
+      select.setAttribute("aria-label", "Idioma de la intervención");
+      select.title = "Idioma";
+      const expression = document.getElementById("player-expression");
+      container.insertBefore(select, expression || null);
+    }
+    fillSelector(select, playerKnowledge(), false);
+    return select;
+  }
+
+  function patchPlayerQueueWrites() {
+    if (isDmView()) return;
+    const database = firebase.database();
+    if (database.__luminousLanguageRefPatched) return;
+    const originalRef = database.ref.bind(database);
+    database.ref = function (path) {
+      const ref = originalRef.apply(database, arguments);
+      const normalized = String(path || "").replace(/^\/+|\/+$/g, "");
+      if (normalized !== QUEUE_PATH || ref.__luminousLanguagePushPatched) return ref;
+      const originalPush = ref.push.bind(ref);
+      ref.push = function (value) {
+        const next = value && typeof value === "object" ? { ...value } : value;
+        const languageId = document.getElementById("player-theatre-language-select")?.value || "";
+        if (next && typeof next === "object") {
+          if (languageId) next.idiomaId = languageId;
+          else delete next.idiomaId;
+        }
+        return originalPush.apply(ref, [next].concat(Array.prototype.slice.call(arguments, 1)));
+      };
+      ref.__luminousLanguagePushPatched = true;
+      return ref;
+    };
+    database.__luminousLanguageRefPatched = true;
+  }
+
+  function refresh() {
+    if (isDmView()) refreshDmSelector();
+    else ensurePlayerSelector();
+  }
+
+  LANGUAGE_ROOTS.forEach((root) => {
+    db.ref(root).on("value", (snapshot) => {
+      sources[root] = snapshot.val() || {};
+      definitions = Object.assign({}, ...LANGUAGE_ROOTS.map((key) => sources[key] || {}));
+      refresh();
+    });
+  });
+
+  if (isDmView()) {
+    bindScene();
+    manager?.subscribeActors?.(refreshDmSelector);
+    document.addEventListener("change", (event) => {
+      if (event.target?.id === "theatre-speaker-select") refreshDmSelector();
+    });
+  } else {
+    patchPlayerQueueWrites();
+    document.addEventListener("click", (event) => {
+      if (event.target?.closest?.("#btn-abrir-escritura")) global.setTimeout(ensurePlayerSelector, 0);
+    }, true);
+    global.addEventListener("actoresCacheUpdated", () => global.setTimeout(ensurePlayerSelector, 0));
+    global.setInterval(ensurePlayerSelector, 1000);
+  }
+
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", refresh, { once: true });
+  else refresh();
+
+  global.LuminousTheatreLanguagePolicy = Object.freeze({
+    refresh,
+    getDefinitions: () => ({ ...definitions }),
+    getPlayerKnowledge: playerKnowledge,
+  });
+})(window);

--- a/js/theatre-message-policy.js
+++ b/js/theatre-message-policy.js
@@ -1,0 +1,127 @@
+(function (global) {
+  "use strict";
+
+  const theatre = global.LuminousTheatreState;
+  const firebase = global.firebase;
+  if (!theatre || !firebase?.database || typeof theatre.publishIntervention !== "function") return;
+  if (global.LuminousTheatreMessagePolicy) return;
+
+  const db = firebase.database();
+  const CONFIG_PATH = "campaña/config/theatre_messages";
+  const DEFAULTS = Object.freeze({ mode: "auto", speedMs: 30, holdMs: 3000 });
+  let config = { ...DEFAULTS };
+  let releaseCurrent = null;
+  let currentMessage = null;
+  const originalPublish = theatre.publishIntervention.bind(theatre);
+
+  function clamp(value, min, max, fallback) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? Math.max(min, Math.min(max, parsed)) : fallback;
+  }
+
+  function normalize(next) {
+    const mode = String(next?.mode || next?.modo || DEFAULTS.mode).toLowerCase() === "manual" ? "manual" : "auto";
+    return {
+      mode,
+      speedMs: Math.round(clamp(next?.speedMs, 1, 250, DEFAULTS.speedMs)),
+      holdMs: Math.round(clamp(next?.holdMs, 0, 30000, DEFAULTS.holdMs)),
+    };
+  }
+
+  function calculateDuration(message) {
+    return (String(message?.mensaje || "").length * config.speedMs) + config.holdMs;
+  }
+
+  function refreshUi() {
+    const mode = document.getElementById("theatre-message-policy-mode");
+    const speed = document.getElementById("theatre-message-policy-speed");
+    const hold = document.getElementById("theatre-message-policy-hold");
+    const next = document.getElementById("btn-theatre-message-next");
+    const status = document.getElementById("theatre-message-policy-status");
+    if (mode) mode.value = config.mode;
+    if (speed) speed.value = config.speedMs;
+    if (hold) hold.value = (config.holdMs / 1000).toFixed(1).replace(/\.0$/, "");
+    if (next) next.disabled = !releaseCurrent;
+    if (status) status.textContent = releaseCurrent ? "WAIT" : (config.mode === "manual" ? "MANUAL" : "AUTO");
+  }
+
+  function advance() {
+    if (!releaseCurrent) return false;
+    const release = releaseCurrent;
+    releaseCurrent = null;
+    currentMessage = null;
+    release();
+    refreshUi();
+    return true;
+  }
+
+  theatre.publishIntervention = async function (messageKey, message) {
+    if (!message || typeof message !== "object") return originalPublish(messageKey, message);
+    message.speedMs = config.speedMs;
+    message.durationMs = config.mode === "manual" ? 0 : calculateDuration(message);
+    const result = await originalPublish(messageKey, message);
+
+    if (result?.published && config.mode === "manual") {
+      currentMessage = { messageKey, message };
+      await new Promise((resolve) => {
+        releaseCurrent = resolve;
+        refreshUi();
+      });
+    }
+    return result;
+  };
+
+  function saveConfig() {
+    const mode = document.getElementById("theatre-message-policy-mode")?.value || DEFAULTS.mode;
+    const speedMs = clamp(document.getElementById("theatre-message-policy-speed")?.value, 1, 250, DEFAULTS.speedMs);
+    const holdSeconds = clamp(document.getElementById("theatre-message-policy-hold")?.value, 0, 30, DEFAULTS.holdMs / 1000);
+    return db.ref(CONFIG_PATH).set({ mode, speedMs: Math.round(speedMs), holdMs: Math.round(holdSeconds * 1000) });
+  }
+
+  function ensureUi() {
+    if (!document.body?.classList.contains("on-game-dashboard")) return;
+    const host = document.querySelector("#modulo-teatro .theatre-controls");
+    if (!host || document.getElementById("theatre-message-policy")) return;
+
+    const panel = document.createElement("section");
+    panel.id = "theatre-message-policy";
+    panel.className = "theatre-message-policy";
+    panel.innerHTML = `
+      <div class="tmp-head"><span>MESSAGE FLOW</span><code id="theatre-message-policy-status">AUTO</code></div>
+      <div class="tmp-grid">
+        <label><span>MODO</span><select id="theatre-message-policy-mode"><option value="auto">AUTO</option><option value="manual">MANUAL</option></select></label>
+        <label><span>TYPE / MS</span><input id="theatre-message-policy-speed" type="number" min="1" max="250" step="1"></label>
+        <label><span>HOLD / S</span><input id="theatre-message-policy-hold" type="number" min="0" max="30" step="0.5"></label>
+        <button id="btn-theatre-message-next" type="button" aria-label="Avanzar al siguiente mensaje" title="Avanzar al siguiente mensaje" disabled>
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 4l10 8L5 20z"/><path d="M18 5v14"/></svg>
+          <span>NEXT</span>
+        </button>
+      </div>
+    `;
+    host.insertBefore(panel, host.querySelector("textarea") || host.firstChild);
+    panel.querySelector("#btn-theatre-message-next")?.addEventListener("click", advance);
+    ["theatre-message-policy-mode", "theatre-message-policy-speed", "theatre-message-policy-hold"].forEach((id) => {
+      panel.querySelector(`#${id}`)?.addEventListener("change", saveConfig);
+    });
+    refreshUi();
+  }
+
+  db.ref(CONFIG_PATH).on("value", (snapshot) => {
+    const previousMode = config.mode;
+    config = normalize(snapshot.val() || DEFAULTS);
+    if (previousMode === "manual" && config.mode !== "manual" && releaseCurrent) advance();
+    refreshUi();
+  });
+
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", ensureUi, { once: true });
+  else ensureUi();
+
+  global.LuminousTheatreMessagePolicy = Object.freeze({
+    CONFIG_PATH,
+    defaults: DEFAULTS,
+    getConfig: () => ({ ...config }),
+    calculateDuration,
+    advance,
+    getCurrentMessage: () => currentMessage,
+  });
+})(window);

--- a/js/utils.js
+++ b/js/utils.js
@@ -38,99 +38,89 @@ function calculateLevelData(xp) {
         else break;
     }
 
-    if (currentLevel >= 100) {
-        return { level: 100, xpPercent: 100, xpMissing: 0 };
-    }
+    if (currentLevel >= 100) return { level: 100, xpPercent: 100, xpMissing: 0 };
 
     const currentLevelXP = xpTable[currentLevel];
     const nextLevelXP = xpTable[currentLevel + 1];
     const xpIntoLevel = numericXp - currentLevelXP;
     const xpRequiredForNextLevel = nextLevelXP - currentLevelXP;
-
     let xpPercent = Math.floor((xpIntoLevel / xpRequiredForNextLevel) * 100);
     xpPercent = Math.max(0, Math.min(100, xpPercent));
 
-    return {
-        level: currentLevel,
-        xpPercent: xpPercent,
-        xpMissing: nextLevelXP - numericXp
-    };
+    return { level: currentLevel, xpPercent, xpMissing: nextLevelXP - numericXp };
+}
+
+function ensureStyleAsset(documentRef, id, href, dataset) {
+    let link = documentRef.getElementById(id);
+    if (link) return link;
+    link = documentRef.createElement('link');
+    link.id = id;
+    link.rel = 'stylesheet';
+    link.href = href;
+    if (dataset) Object.assign(link.dataset, dataset);
+    documentRef.head?.appendChild(link);
+    return link;
+}
+
+function ensureScriptAsset(documentRef, id, src, dataset) {
+    let script = documentRef.getElementById(id);
+    if (script) return script;
+    script = documentRef.createElement('script');
+    script.id = id;
+    script.src = src;
+    script.async = false;
+    if (dataset) Object.assign(script.dataset, dataset);
+    documentRef.head?.appendChild(script);
+    return script;
 }
 
 function ensurePlayerTerminalStyles(doc) {
     const documentRef = doc || (typeof document !== 'undefined' ? document : null);
     if (!documentRef?.querySelector?.('.sheet-phone-wrapper')) return null;
-
-    let link = documentRef.getElementById('player-terminal-stylesheet');
-    if (link) return link;
-
-    link = documentRef.createElement('link');
-    link.id = 'player-terminal-stylesheet';
-    link.rel = 'stylesheet';
-    link.href = 'css/player-terminal.css';
-    link.dataset.ui = 'personal-terminal';
-    documentRef.head?.appendChild(link);
-    return link;
+    return ensureStyleAsset(documentRef, 'player-terminal-stylesheet', 'css/player-terminal.css', { ui: 'personal-terminal' });
 }
 
 function ensurePlayerUxPolishAssets(doc) {
     const documentRef = doc || (typeof document !== 'undefined' ? document : null);
     if (!documentRef?.querySelector?.('.sheet-phone-wrapper')) return null;
-
-    let link = documentRef.getElementById('player-ux-polish-stylesheet');
-    if (!link) {
-        link = documentRef.createElement('link');
-        link.id = 'player-ux-polish-stylesheet';
-        link.rel = 'stylesheet';
-        link.href = 'css/player-ux-polish.css';
-        link.dataset.ui = 'player-ux-polish';
-        documentRef.head?.appendChild(link);
-    }
-
-    let script = documentRef.getElementById('player-ux-polish-script');
-    if (!script) {
-        script = documentRef.createElement('script');
-        script.id = 'player-ux-polish-script';
-        script.src = 'js/player-ux-polish.js';
-        script.async = false;
-        script.dataset.ui = 'player-ux-polish';
-        documentRef.head?.appendChild(script);
-    }
-
+    const link = ensureStyleAsset(documentRef, 'player-ux-polish-stylesheet', 'css/player-ux-polish.css', { ui: 'player-ux-polish' });
+    const script = ensureScriptAsset(documentRef, 'player-ux-polish-script', 'js/player-ux-polish.js', { ui: 'player-ux-polish' });
     return { link, script };
+}
+
+function ensurePlayerTheatreLanguagePolicy(doc) {
+    const documentRef = doc || (typeof document !== 'undefined' ? document : null);
+    if (!documentRef?.querySelector?.('.sheet-phone-wrapper')) return null;
+    return ensureScriptAsset(documentRef, 'theatre-language-policy-script', 'js/theatre-language-policy.js', { engine: 'theatre-language-policy' });
 }
 
 function ensureDmCharacterManagerAssets(doc) {
     const documentRef = doc || (typeof document !== 'undefined' ? document : null);
     if (!documentRef?.querySelector?.('#dashboard-actores')) return null;
 
-    let link = documentRef.getElementById('character-manager-studio-stylesheet');
-    if (!link) {
-        link = documentRef.createElement('link');
-        link.id = 'character-manager-studio-stylesheet';
-        link.rel = 'stylesheet';
-        link.href = 'css/character-manager-studio.css';
-        link.dataset.ui = 'character-manager-studio';
-        documentRef.head?.appendChild(link);
-    }
+    const link = ensureStyleAsset(documentRef, 'character-manager-studio-stylesheet', 'css/character-manager-studio.css', { ui: 'character-manager-studio' });
+    ensureStyleAsset(documentRef, 'character-manager-social-stylesheet', 'css/character-manager-social.css', { ui: 'character-manager-social' });
 
-    const ensureTakeover = () => {
-        let takeover = documentRef.getElementById('dm-character-manager-takeover-script');
-        if (takeover) return takeover;
-        takeover = documentRef.createElement('script');
-        takeover.id = 'dm-character-manager-takeover-script';
-        takeover.src = 'js/dm-character-manager-takeover.js';
-        takeover.async = false;
-        takeover.dataset.ui = 'character-manager-takeover';
-        documentRef.head?.appendChild(takeover);
-        return takeover;
+    const ensureTakeover = () => ensureScriptAsset(documentRef, 'dm-character-manager-takeover-script', 'js/dm-character-manager-takeover.js', { ui: 'character-manager-takeover' });
+
+    const ensureExtensions = () => {
+        ensureScriptAsset(documentRef, 'language-catalog-engine-script', 'js/language-catalog-engine.js', { engine: 'language-catalog' });
+        const bond = ensureScriptAsset(documentRef, 'bond-engine-script', 'js/bond-engine.js', { engine: 'bond-manager' });
+        const ensureSocial = () => ensureScriptAsset(documentRef, 'character-manager-social-script', 'js/character-manager-social-studio.js', { ui: 'character-manager-social' });
+        if (typeof window !== 'undefined' && window.LuminousBondManager) ensureSocial();
+        else bond.addEventListener('load', ensureSocial, { once: true });
     };
 
     const ensureStudio = () => {
         let studio = documentRef.getElementById('character-manager-studio-script');
         if (studio) {
-            if (documentRef.getElementById('character-manager-studio')) ensureTakeover();
-            else studio.addEventListener('load', ensureTakeover, { once: true });
+            if (documentRef.getElementById('character-manager-studio')) {
+                ensureTakeover();
+                ensureExtensions();
+            } else {
+                studio.addEventListener('load', ensureTakeover, { once: true });
+                studio.addEventListener('load', ensureExtensions, { once: true });
+            }
             return studio;
         }
 
@@ -140,6 +130,7 @@ function ensureDmCharacterManagerAssets(doc) {
         studio.async = false;
         studio.dataset.ui = 'character-manager-studio';
         studio.addEventListener('load', ensureTakeover, { once: true });
+        studio.addEventListener('load', ensureExtensions, { once: true });
         documentRef.head?.appendChild(studio);
         return studio;
     };
@@ -165,6 +156,7 @@ function ensureDmCharacterManagerAssets(doc) {
 if (typeof document !== 'undefined') {
     ensurePlayerTerminalStyles(document);
     ensurePlayerUxPolishAssets(document);
+    ensurePlayerTheatreLanguagePolicy(document);
     ensureDmCharacterManagerAssets(document);
 }
 
@@ -174,6 +166,7 @@ if (typeof module !== 'undefined' && module.exports) {
         calculateLevelData,
         ensurePlayerTerminalStyles,
         ensurePlayerUxPolishAssets,
+        ensurePlayerTheatreLanguagePolicy,
         ensureDmCharacterManagerAssets
     };
 }

--- a/tests/character_manager_domain_extensions.spec.js
+++ b/tests/character_manager_domain_extensions.spec.js
@@ -51,7 +51,7 @@ test("etiquetas se persisten mediante Character Manager y no Firebase directo", 
 });
 
 test("Vínculos almacena conocimiento y nivel y alimenta conocimiento de identidad de Theatre", () => {
-  expect(bondEngine).toContain('campaña/teatro/vinculos');
+  expect(bondEngine).toContain('campaña/estado_mundo/vinculos');
   expect(bondEngine).toContain('campaña/teatro/conocimiento_identidad');
   expect(bondEngine).toContain("conocido");
   expect(bondEngine).toContain("nivel");

--- a/tests/character_manager_domain_extensions.spec.js
+++ b/tests/character_manager_domain_extensions.spec.js
@@ -1,0 +1,98 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
+const liveSync = read("js/character-manager-live-sync.js");
+const messagePolicy = read("js/theatre-message-policy.js");
+const languageCatalog = read("js/language-catalog-engine.js");
+const languagePolicy = read("js/theatre-language-policy.js");
+const bondEngine = read("js/bond-engine.js");
+const socialStudio = read("js/character-manager-social-studio.js");
+const socialCss = read("css/character-manager-social.css");
+const dm = read("hoja_de_DM.html");
+const utils = read("js/utils.js");
+const theatreEngine = read("js/theatre-engine.js");
+
+test("la escala maestra se propaga a instancias vivas por identityId", () => {
+  expect(liveSync).toContain("identityId");
+  expect(liveSync).toContain("sourceActorId");
+  expect(liveSync).toContain('updates[`actores/${instanceId}/escala`] = masterScale');
+  expect(liveSync).toContain("manager.subscribeActors");
+  expect(liveSync).toContain("sync_master_scale === false");
+  expect(dm).toContain('src="js/character-manager-live-sync.js"');
+});
+
+test("la política de mensajes permite timing configurable y avance manual", () => {
+  expect(messagePolicy).toContain('mode: "auto", speedMs: 30, holdMs: 3000');
+  expect(messagePolicy).toContain("calculateDuration");
+  expect(messagePolicy).toContain('config.mode === "manual"');
+  expect(messagePolicy).toContain("releaseCurrent");
+  expect(messagePolicy).toContain("btn-theatre-message-next");
+  expect(messagePolicy).toContain('campaña/config/theatre_messages');
+  expect(dm.indexOf('src="js/theatre-message-policy.js"')).toBeLessThan(dm.indexOf('src="js/on-game-dashboard.js"'));
+});
+
+test("el roster puede agrupar por tipo facción o etiqueta", () => {
+  expect(socialStudio).toContain('<option value="type">TIPO</option>');
+  expect(socialStudio).toContain('<option value="faction">FACCIÓN</option>');
+  expect(socialStudio).toContain('<option value="tag">ETIQUETA</option>');
+  expect(socialStudio).toContain("actor.faccion");
+  expect(socialStudio).toContain("actor.etiquetas");
+  expect(socialStudio).toContain("cm-taxonomy-tags");
+  expect(socialCss).toContain(".cm-roster-group");
+});
+
+test("etiquetas se persisten mediante Character Manager y no Firebase directo", () => {
+  expect(socialStudio).toContain("manager.saveActor");
+  expect(socialStudio).toContain("actor: { etiquetas: tags, tags }");
+  expect(socialStudio).not.toContain("firebase.database");
+  expect(socialStudio).not.toContain("db.ref(");
+});
+
+test("Vínculos almacena conocimiento y nivel y alimenta conocimiento de identidad de Theatre", () => {
+  expect(bondEngine).toContain('campaña/teatro/vinculos');
+  expect(bondEngine).toContain('campaña/teatro/conocimiento_identidad');
+  expect(bondEngine).toContain("conocido");
+  expect(bondEngine).toContain("nivel");
+  expect(bondEngine).toContain("bondLevel");
+  expect(socialStudio).toContain("cm-bond-known");
+  expect(socialStudio).toContain('type="range" min="0" max="5"');
+  expect(theatreEngine).toContain("isIdentityKnown");
+});
+
+test("el catálogo D&D se crea sin reemplazar idiomas existentes", () => {
+  ["common", "dwarvish", "elvish", "giant", "gnomish", "goblin", "halfling", "orc", "abyssal", "celestial", "draconic", "deep_speech", "infernal", "primordial", "sylvan", "undercommon"].forEach((id) => {
+    expect(languageCatalog).toContain(`${id}:`);
+  });
+  expect(languageCatalog).toContain("Object.prototype.hasOwnProperty.call(merged, languageId)");
+  expect(languageCatalog).toContain('const ROOT = "campaña/teatro/idiomas"');
+});
+
+test("Dante es un idioma especial de distorsión con Tik Tok para quien no comprende", () => {
+  expect(languageCatalog).toContain("dante_clock");
+  expect(languageCatalog).toContain('tipo: "distortion"');
+  expect(languageCatalog).toContain("distortion: true");
+  expect(languageCatalog).toContain('texto_desconocido: "Tik... Tok..."');
+  expect(theatreEngine).toContain("understandsDistortion(profile, languageId)");
+  expect(theatreEngine).toContain('"Tik... Tok..."');
+});
+
+test("Común es default y los selectores limitan idiomas por conocimiento del hablante", () => {
+  expect(languagePolicy).toContain('option.value = ""');
+  expect(languagePolicy).toContain('definition?.nombre');
+  expect(languagePolicy).toContain("known.porcentaje <= 0");
+  expect(languagePolicy).toContain("languageKnowledgeForActor");
+  expect(languagePolicy).toContain("player-theatre-language-select");
+  expect(languagePolicy).toContain("next.idiomaId = languageId");
+  expect(dm).toContain('src="js/theatre-language-policy.js"');
+  expect(utils).toContain("ensurePlayerTheatreLanguagePolicy");
+});
+
+test("las extensiones nuevas no usan emojis como iconografía", () => {
+  const uiCode = [messagePolicy, socialStudio, socialCss].join("\n");
+  const emojiPresentation = /\p{Extended_Pictographic}/u;
+  expect(emojiPresentation.test(uiCode)).toBe(false);
+  expect(messagePolicy).toContain("<svg");
+  expect(socialStudio).toContain("<svg");
+});


### PR DESCRIPTION
## Contexto

Este PR continúa #524 después de que el nuevo Character Manager/Studio SVG ya fue fusionado a `main`. El diff contiene únicamente la segunda capa de comportamiento solicitada para Theatre y Gestión de Personajes.

## Cambios

### Escala en tiempo real
- Añade `js/character-manager-live-sync.js`.
- Escucha cambios del actor maestro en `LuminousCharacterManager`.
- Propaga `escala` a cualquier instancia viva cuyo `identityId`/`sourceActorId` corresponda al actor maestro.
- La instancia puede optar por no seguir la escala maestra mediante `sync_master_scale: false`.

### Flujo de mensajes de Theatre
- Añade `js/theatre-message-policy.js` y su UI compacta SVG.
- Conserva por defecto el criterio existente: `30 ms` por carácter + `3 s` de permanencia.
- El DM puede cambiar `TYPE / MS` y `HOLD / S`.
- Modo `AUTO`: la cola avanza según la fórmula configurable.
- Modo `MANUAL`: el diálogo permanece hasta pulsar `NEXT` y entonces avanza la cola.
- La configuración se persiste en `campaña/config/theatre_messages`.

### Facciones, tipo y etiquetas
- Añade `js/character-manager-social-studio.js` + `css/character-manager-social.css`.
- El roster puede agruparse por `TIPO`, `FACCIÓN` o `ETIQUETA`.
- Restaura edición/persistencia de `etiquetas`/`tags` mediante `LuminousCharacterManager`, sin Firebase directo desde la UI.
- Mantiene PJ, aliados, enemigos, neutrales y NPC como clasificación funcional de `tipo`.

### Motor de Vínculos
- Añade `window.LuminousBondManager` en `js/bond-engine.js`.
- Base persistente: `campaña/estado_mundo/vinculos/{playerId}/{actorId}`. Esta rama ya está protegida por la regla DM-only existente de `estado_mundo`.
- Cada jugador puede tener respecto a un actor: `conocido`, `nivel` 0–5 y `estado` (`neutral`, `confianza`, `aliado`, `rival`, `hostil`).
- El Character Manager muestra la matriz de relaciones dentro del módulo VÍNCULO.
- Se refleja `conocido` + `bondLevel` en `campaña/teatro/conocimiento_identidad`, por lo que Theatre reutiliza su motor actual de identidad conocida.
- La asignación de control del actor a un jugador sigue siendo distinta del vínculo social.

### Catálogo de idiomas D&D
- Añade `js/language-catalog-engine.js`.
- Si faltan, crea sin sobrescribir definiciones existentes: Común, Enano, Élfico, Gigante, Gnómico, Goblin, Mediano, Orco, Abisal, Celestial, Dracónico, Habla Profunda, Infernal, Primordial, Silvano e Infracomún.
- Añade `dante_clock` como idioma especial de distorsión con `Tik... Tok...` para quien no lo comprende.
- Los defaults se almacenan en `campaña/teatro/idiomas`, rama ya utilizada por Theatre.

### Idioma al hablar
- Añade `js/theatre-language-policy.js`.
- `Común` es siempre la opción por defecto y universal.
- El DM solo puede elegir, para un actor, idiomas con `porcentaje > 0`; el Narrador conserva acceso a todo el catálogo.
- El jugador recibe un selector equivalente en Modo Actuación y solo puede elegir idiomas que conoce.
- La selección del jugador se añade al payload de la cola como `idiomaId`.
- Theatre sigue resolviendo la percepción por espectador: 100% texto completo, 0% desconocido y porcentajes intermedios con ofuscación determinista.
- Para `dante_clock`, `comprendido: true` permite ver el mensaje real. Un jugador puede comprenderlo sin poder hablarlo usando `{ porcentaje: 0, comprendido: true }`; para hablarlo necesita `porcentaje > 0`.

## Integración

`hoja_de_DM.html` carga los módulos en orden después de los motores existentes. `utils.js` carga la política de idiomas para el compositor del jugador y las extensiones sociales del Character Manager únicamente donde corresponden.

No se reescribe `theatre-engine.js` ni el procesador de cola existente; las nuevas políticas se acoplan a sus APIs/rutas actuales.

## Seguridad

- Vínculos sociales se guardan bajo `campaña/estado_mundo/vinculos`, heredando la escritura exclusiva del DM ya definida en las reglas actuales.
- El catálogo D&D se completa en la ruta de idiomas ya consumida por Theatre, sin requerir migrar actores/jugadores ni renombrar rutas existentes.

## Validación

Se añade `tests/character_manager_domain_extensions.spec.js` con contratos para:
- escala maestra -> escena viva;
- timing configurable y avance manual;
- agrupación por tipo/facción/etiqueta;
- persistencia de etiquetas sin Firebase directo en Studio;
- vínculos e integración con conocimiento de identidad;
- catálogo D&D missing-only;
- caso especial de Dante;
- Común por defecto y selectores DM/jugador;
- ausencia de emojis en las nuevas superficies de UI.

El PR permanece en draft para prueba real del flujo Theatre/Firebase antes de merge.