### PR TITLE
Corrige crash al editar NPC y PJ en Character Manager

### DIFF
--- a/js/character-manager-language-ux.js
+++ b/js/character-manager-language-ux.js
@@ -8,6 +8,8 @@
   let manager = null;
   let observer = null;
   let retryTimer = null;
+  let decorateTimer = null;
+  let decorating = false;
 
   function getManager() {
     manager = manager || global.LuminousCharacterManager || null;
@@ -37,6 +39,10 @@
     nameHost.appendChild(badge);
   }
 
+  function setText(node, text) {
+    if (node && node.textContent !== text) node.textContent = text;
+  }
+
   function decorateRow(row, languageMap) {
     const languageId = row?.dataset?.languageId;
     if (!languageId) return;
@@ -55,14 +61,13 @@
     row.classList.toggle("cm-language-row--common", common);
     row.dataset.languageMeaning = common ? "default" : distortion ? "special" : "standard";
 
-    if (meter && !meter.querySelector(".cm-language-domain-label")) {
-      const caption = doc.createElement("span");
+    let caption = meter?.querySelector(".cm-language-domain-label") || null;
+    if (meter && !caption) {
+      caption = doc.createElement("span");
       caption.className = "cm-language-domain-label";
-      caption.textContent = distortion ? "HABLA" : "DOMINIO";
       meter.prepend(caption);
-    } else if (meter?.querySelector(".cm-language-domain-label")) {
-      meter.querySelector(".cm-language-domain-label").textContent = distortion ? "HABLA" : "DOMINIO";
     }
+    setText(caption, distortion ? "HABLA" : "DOMINIO");
 
     if (range) range.setAttribute("aria-label", distortion ? `Capacidad para hablar ${label}` : `Dominio de ${label}`);
     if (percent) percent.setAttribute("aria-label", distortion ? `Porcentaje para hablar ${label}` : `Porcentaje de dominio de ${label}`);
@@ -83,6 +88,9 @@
       return;
     }
 
+    if (range) range.disabled = false;
+    if (percent) percent.disabled = false;
+
     if (!distortion) {
       if (toggle) toggle.hidden = true;
       if (checkbox) checkbox.checked = false;
@@ -93,23 +101,39 @@
     if (toggle) {
       toggle.hidden = false;
       toggle.title = "DECODIFICA: entiende este idioma especial aunque su capacidad para hablarlo sea 0.";
-      if (!toggle.querySelector(".cm-distortion-copy")) {
-        const copy = doc.createElement("b");
+      let copy = toggle.querySelector(".cm-distortion-copy");
+      if (!copy) {
+        copy = doc.createElement("b");
         copy.className = "cm-distortion-copy";
-        copy.textContent = "DECODIFICA";
         toggle.appendChild(copy);
       }
+      setText(copy, "DECODIFICA");
     }
     if (checkbox) checkbox.setAttribute("aria-label", `Decodifica ${label}`);
     row.title = "HABLA controla si puede usar el idioma. DECODIFICA controla si puede entender su forma especial.";
   }
 
   function decorate() {
+    if (decorating) return false;
     const host = doc.getElementById("character-manager-languages");
     if (!host || !getManager()) return false;
-    const languageMap = definitions();
-    host.querySelectorAll(".cm-language-row").forEach((row) => decorateRow(row, languageMap));
-    return true;
+
+    decorating = true;
+    try {
+      const languageMap = definitions();
+      host.querySelectorAll(".cm-language-row").forEach((row) => decorateRow(row, languageMap));
+      return true;
+    } finally {
+      decorating = false;
+    }
+  }
+
+  function scheduleDecorate() {
+    global.clearTimeout(decorateTimer);
+    decorateTimer = global.setTimeout(() => {
+      decorateTimer = null;
+      decorate();
+    }, 0);
   }
 
   function install() {
@@ -118,10 +142,12 @@
     if (!host) return false;
     decorate();
     if (!observer) {
-      observer = new MutationObserver(() => decorate());
-      observer.observe(host, { childList: true, subtree: true });
+      observer = new MutationObserver(scheduleDecorate);
+      // Solo observamos altas/bajas de filas. Observar subtree haría que la
+      // propia decoración de labels dispare recursivamente el observer.
+      observer.observe(host, { childList: true });
     }
-    manager.subscribeLanguages?.(() => global.setTimeout(decorate, 0));
+    manager.subscribeLanguages?.(scheduleDecorate);
     return true;
   }
 

--- a/tests/player_terminal_domain_ux.spec.js
+++ b/tests/player_terminal_domain_ux.spec.js
@@ -58,3 +58,11 @@ test("el control especial solo explica decodificaciÃ³n para idiomas de distorsiÃ
   expect(languageUx).toContain('HABLA controla si puede usar el idioma');
   expect(languageUx).toContain('DECODIFICA controla si puede entender su forma especial');
 });
+
+test("editar NPC o PJ no entra en un bucle del observer de Idiomas", () => {
+  expect(languageUx).toContain('if (decorating) return false');
+  expect(languageUx).toContain('function scheduleDecorate()');
+  expect(languageUx).toContain('observer.observe(host, { childList: true });');
+  expect(languageUx).not.toContain('observer.observe(host, { childList: true, subtree: true })');
+  expect(languageUx).toContain('node.textContent !== text');
+});


### PR DESCRIPTION
## Contexto

Hotfix posterior a #526. Ese PR fue fusionado antes de que entrara esta corrección, por lo que estos dos commits quedaron fuera de `main`.

## Problema

Al seleccionar un NPC o PJ para editar, `character-manager-studio.js` reconstruye la lista de idiomas. La capa `character-manager-language-ux.js` tenía un `MutationObserver` configurado con `subtree: true` y el propio decorador modificaba nodos internos de esa lista. Eso podía realimentar el observer de forma repetitiva y congelar/crashear la UI al cargar el actor.

## Corrección

- `character-manager-language-ux.js` ahora es idempotente.
- Añade guardia de reentrada (`decorating`).
- Agrupa decoraciones mediante `scheduleDecorate()`.
- El observer escucha únicamente altas/bajas de filas en el contenedor raíz con `{ childList: true }`.
- Las etiquetas solo cambian `textContent` cuando el valor realmente es distinto.
- Al cambiar de Común a otro idioma, los controles de dominio vuelven a habilitarse correctamente.

## Regresión

`tests/player_terminal_domain_ux.spec.js` fija que:
- no se vuelva a observar `subtree` en la lista de idiomas;
- exista protección de reentrada;
- el decorador sea idempotente;
- editar NPC/PJ no vuelva a activar el ciclo de mutaciones.

## Alcance

Solo modifica:
- `js/character-manager-language-ux.js`
- `tests/player_terminal_domain_ux.spec.js`

No toca Theatre renderer, Combat Engine, Firebase paths ni persistencia de actores.