### PR TITLE
Adapta Stats al mock HUD D&D

### DIFF
--- a/css/player-stats-ability-bar.css
+++ b/css/player-stats-ability-bar.css
@@ -1,90 +1,119 @@
-/* PLAYER STATS / D&D */
-body:not(.on-game-dashboard) #stats-modal #stats-container{display:flex;flex-direction:column;gap:14px}
-body:not(.on-game-dashboard) #stats-modal .player-ability-console{width:100%;min-width:0;color:var(--player-ux-text,#e3decf);background:linear-gradient(180deg,rgba(185,138,50,.06),transparent 34%),#0d100d;border:1px solid #3b4036;border-top:2px solid var(--player-ux-brass,#b98a32);box-shadow:inset 0 0 28px rgba(0,0,0,.45);font-family:"Share Tech Mono",monospace}
-body:not(.on-game-dashboard) #stats-modal .player-ability-heading{display:flex;align-items:end;justify-content:space-between;gap:14px;padding:12px 14px 9px;border-bottom:1px solid #34382f}
-body:not(.on-game-dashboard) #stats-modal .player-ability-heading h3{margin:2px 0 0!important;padding:0!important;color:#f1e3c5!important;border:0!important;font-size:17px!important;letter-spacing:.08em}
-body:not(.on-game-dashboard) #stats-modal .player-ability-kicker,body:not(.on-game-dashboard) #stats-modal .player-ability-engine{color:#9b927f;font-size:9px;letter-spacing:.13em}
-body:not(.on-game-dashboard) #stats-modal .player-ability-engine{color:var(--player-ux-brass-light,#d8b65d);text-align:right}
+/* PLAYER STATS / D&D MOCK HUD */
+body:not(.on-game-dashboard) #stats-modal .hud-modal-content{width:min(96vw,1600px)!important;max-width:1600px!important;height:min(91vh,920px)!important;max-height:91vh!important;padding:0!important;overflow:hidden!important;border:2px solid rgba(153,124,74,.58)!important;border-radius:0!important;background:#050505!important;box-shadow:inset 0 0 40px rgba(0,0,0,.82),0 18px 60px rgba(0,0,0,.9)!important}
+body:not(.on-game-dashboard) #stats-modal .hud-modal-body{width:100%;height:100%;min-height:0;padding:0!important;overflow:hidden!important}
+body:not(.on-game-dashboard) #stats-modal #stats-container{position:relative!important;width:100%;height:100%;min-height:0;display:block!important;padding:0!important;margin:0!important;overflow:hidden}
+body:not(.on-game-dashboard) #stats-modal .hud-modal-close{position:absolute!important;z-index:120!important;left:26px!important;right:auto!important;top:20px!important;width:62px!important;height:62px!important;display:grid!important;place-items:center!important;padding:0!important;border:3px solid #a99672!important;border-radius:9px!important;background:linear-gradient(145deg,#2c2a27,#080808)!important;color:#e4dac5!important;font:32px/1 Georgia,"Times New Roman",serif!important;box-shadow:0 0 0 2px #080808,inset 0 0 12px #000,0 5px 10px rgba(0,0,0,.8)!important;cursor:pointer;transition:.15s}
+body:not(.on-game-dashboard) #stats-modal .hud-modal-close:hover{border-color:#e7aa37!important;color:#ffc94c!important;transform:translateX(5px)}
+body:not(.on-game-dashboard) #stats-modal .player-ability-console{position:relative;width:100%;height:100%;min-width:0;min-height:0;color:#ddd;background:#111;border:0;box-shadow:none;overflow:hidden;font-family:Arial,Helvetica,sans-serif}
+body:not(.on-game-dashboard) #stats-modal .player-stats-screen-border{position:absolute;inset:7px;z-index:100;pointer-events:none;border:2px solid rgba(153,124,74,.5);box-shadow:inset 0 0 40px rgba(0,0,0,.8),0 0 20px rgba(0,0,0,.9)}
+body:not(.on-game-dashboard) #stats-modal .player-stats-frame{width:100%;height:100%;min-height:0;display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1fr);overflow:hidden;background:#111}
 
-body:not(.on-game-dashboard) #stats-modal .player-combat-level-strip{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));border-bottom:1px solid #3b4036;background:#090b09}
-body:not(.on-game-dashboard) #stats-modal .player-level-card{position:relative;display:grid;grid-template-columns:auto 1fr;grid-template-rows:auto auto;gap:2px 8px;align-items:center;min-height:58px;padding:9px 12px;border-right:1px solid #2c3029}
-body:not(.on-game-dashboard) #stats-modal .player-level-card:last-child{border-right:0}
-body:not(.on-game-dashboard) #stats-modal .player-level-card>span:not(.player-level-icon){color:#777c70;font-size:8px;letter-spacing:.09em}
-body:not(.on-game-dashboard) #stats-modal .player-level-card>strong{grid-row:1/3;grid-column:2;justify-self:end;color:#ead9b8;font-size:21px}
-body:not(.on-game-dashboard) #stats-modal .player-level-card>small{color:#6f7369;font-size:7px}
-body:not(.on-game-dashboard) #stats-modal .player-level-card--proficiency>strong{color:var(--player-ux-brass-light,#d8b65d)}
-body:not(.on-game-dashboard) #stats-modal .player-level-icon{grid-row:1/3;width:23px;height:23px;color:#b98a32}
-body:not(.on-game-dashboard) #stats-modal .player-level-icon svg{width:100%;height:100%;fill:none;stroke:currentColor;stroke-width:1.7;stroke-linecap:round;stroke-linejoin:round}
+/* left character art */
+body:not(.on-game-dashboard) #stats-modal .player-stats-character-panel{position:relative;min-width:0;min-height:0;overflow:hidden;background:#080808}
+body:not(.on-game-dashboard) #stats-modal .player-stats-character-panel::after{content:"";position:absolute;inset:0;z-index:2;pointer-events:none;background:radial-gradient(ellipse at 45% 42%,transparent 20%,rgba(0,0,0,.12) 50%,rgba(0,0,0,.82) 100%),linear-gradient(90deg,rgba(0,0,0,.03) 0%,rgba(0,0,0,.03) 55%,rgba(0,0,0,.88) 100%),linear-gradient(0deg,rgba(0,0,0,.9) 0%,transparent 47%)}
+body:not(.on-game-dashboard) #stats-modal .player-stats-character-image,body:not(.on-game-dashboard) #stats-modal .player-stats-character-image img{position:absolute;inset:0;width:100%;height:100%}
+body:not(.on-game-dashboard) #stats-modal .player-stats-character-image img{object-fit:cover;object-position:center;filter:contrast(1.08) saturate(.95)}
+body:not(.on-game-dashboard) #stats-modal .player-stats-character-image img[hidden]{display:none!important}
+body:not(.on-game-dashboard) #stats-modal .player-stats-art-empty{position:absolute;inset:0;display:grid;place-content:center;gap:10px;text-align:center;background:radial-gradient(circle at 50% 42%,rgba(176,137,67,.11),transparent 34%),linear-gradient(135deg,#111,#050505);color:#6f675a;letter-spacing:.1em}
+body:not(.on-game-dashboard) #stats-modal .player-stats-art-empty[hidden]{display:none!important}
+body:not(.on-game-dashboard) #stats-modal .player-stats-art-empty strong{color:#b9a47f;font:700 22px Georgia,"Times New Roman",serif;letter-spacing:.14em}
+body:not(.on-game-dashboard) #stats-modal .player-stats-art-empty span{max-width:260px;font-size:11px;line-height:1.5}
+body:not(.on-game-dashboard) #stats-modal .player-stats-bottom-info{position:absolute;z-index:20;left:54px;right:34px;bottom:40px;display:flex;align-items:flex-end;gap:38px}
+body:not(.on-game-dashboard) #stats-modal .player-info-block{position:relative;min-width:135px;padding-top:28px}
+body:not(.on-game-dashboard) #stats-modal .player-info-label{position:absolute;left:0;top:0;height:27px;padding:4px 14px;border-left:3px solid #b98a3c;background:rgba(38,34,28,.95);color:#d5c19d;font-size:15px;font-weight:700;text-transform:uppercase}
+body:not(.on-game-dashboard) #stats-modal .player-info-value{min-height:46px;display:flex;align-items:center;gap:10px;color:#eee;font:700 28px Georgia,"Times New Roman",serif}
+body:not(.on-game-dashboard) #stats-modal .player-info-value svg{width:30px;height:30px;fill:#f06d5e;stroke:#f06d5e}
+body:not(.on-game-dashboard) #stats-modal .player-info-value small{color:#9b9387;font-size:15px;font-weight:400}
+body:not(.on-game-dashboard) #stats-modal .player-info-resistances{flex:1;min-width:0}
+body:not(.on-game-dashboard) #stats-modal .player-resistance-list{min-height:46px;display:flex;align-items:center;flex-wrap:wrap;gap:14px 22px}
+body:not(.on-game-dashboard) #stats-modal .player-resistance-item{display:flex;align-items:center;gap:7px;color:#c8c0b3;font-size:15px;font-weight:700}
+body:not(.on-game-dashboard) #stats-modal .player-resistance-item b{color:#e1b463;font:700 19px Georgia,"Times New Roman",serif}
+body:not(.on-game-dashboard) #stats-modal .player-resistance-item small{color:#81786b;font-size:9px;letter-spacing:.12em}
+body:not(.on-game-dashboard) #stats-modal .player-resistance-pending{color:#77726a;font-size:10px;letter-spacing:.08em}
+body:not(.on-game-dashboard) #stats-modal .player-combat-icon{width:25px;height:25px;color:#d89c53}
+body:not(.on-game-dashboard) #stats-modal .player-combat-icon svg{width:100%;height:100%;fill:none;stroke:currentColor;stroke-width:1.7;stroke-linecap:round;stroke-linejoin:round}
 
-body:not(.on-game-dashboard) #stats-modal .player-ability-bar{display:grid;grid-template-columns:repeat(6,minmax(0,1fr));min-width:0;border-bottom:1px solid #3b4036}
-body:not(.on-game-dashboard) #stats-modal .player-ability{position:relative;display:grid;grid-template-rows:auto auto auto;place-items:center;min-width:0;min-height:88px;margin:0;padding:10px 5px 8px;color:#aaa99e;background:#111410;border:0;border-right:1px solid #2c3029;border-radius:0;cursor:pointer;font:inherit}
+/* right information panel */
+body:not(.on-game-dashboard) #stats-modal .player-stats-information-panel{position:relative;min-width:0;min-height:0;display:flex;flex-direction:column;padding:20px 44px 28px 30px;overflow:hidden;background:radial-gradient(ellipse at 50% 12%,rgba(102,79,42,.25),transparent 45%),linear-gradient(180deg,#1b1815,#12110f);border-left:2px solid #473a2a}
+body:not(.on-game-dashboard) #stats-modal .player-stats-top-decoration{position:absolute;right:34px;top:2px;color:#f0a918;font-size:24px;letter-spacing:4px}
+body:not(.on-game-dashboard) #stats-modal .player-stats-season{position:absolute;right:8px;top:12px;color:#4f999b;writing-mode:vertical-rl;font-size:12px;font-weight:700;letter-spacing:1px}
+body:not(.on-game-dashboard) #stats-modal .player-stats-header{flex:0 0 145px;min-height:0}
+body:not(.on-game-dashboard) #stats-modal .player-character-name{height:66px;display:flex;align-items:center;gap:14px;padding-right:90px;border-bottom:2px solid #5b4730;color:#e7d5b3;font:700 clamp(18px,1.5vw,27px) Georgia,"Times New Roman",serif}
+body:not(.on-game-dashboard) #stats-modal .player-character-name>span{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+body:not(.on-game-dashboard) #stats-modal .player-character-icon{position:relative;width:54px;height:54px;flex:0 0 54px;display:grid;place-items:center;overflow:hidden;border:3px solid #d5ac63;border-radius:50%;background:radial-gradient(circle at 40% 35%,#eee,#777 35%,#1a1a1a 75%);color:#333;font:24px Georgia,serif}
+body:not(.on-game-dashboard) #stats-modal .player-character-icon img{width:100%;height:100%;object-fit:cover}
+body:not(.on-game-dashboard) #stats-modal .player-character-icon img[hidden],body:not(.on-game-dashboard) #stats-modal .player-character-icon [hidden]{display:none!important}
+body:not(.on-game-dashboard) #stats-modal .player-level-section{height:79px;display:grid;grid-template-columns:minmax(120px,1.25fr) repeat(3,minmax(88px,.8fr));align-items:center;gap:12px}
+body:not(.on-game-dashboard) #stats-modal .player-level-text{display:flex;align-items:baseline;gap:6px;color:#b7a98e;font-size:19px}
+body:not(.on-game-dashboard) #stats-modal .player-level-text strong{color:#f2e5c7;font:700 38px Georgia,"Times New Roman",serif}
+body:not(.on-game-dashboard) #stats-modal .player-level-text small{color:#8f8574;font-size:11px}
+body:not(.on-game-dashboard) #stats-modal .player-mock-metric{height:47px;display:grid;grid-template-columns:auto 1fr;grid-template-rows:1fr auto;align-items:center;gap:0 7px;padding:5px 9px;border:2px solid #51483c;background:linear-gradient(180deg,#39342d,#171613);color:#d0c1a7}
+body:not(.on-game-dashboard) #stats-modal .player-mock-metric strong{justify-self:end;color:#ffb629;font:700 22px Georgia,"Times New Roman",serif}
+body:not(.on-game-dashboard) #stats-modal .player-mock-metric small{justify-self:end;color:#867866;font-size:8px;letter-spacing:.14em}
+body:not(.on-game-dashboard) #stats-modal .player-mock-metric--prof{display:flex;justify-content:center;gap:9px;color:#ffb629;font-weight:700}
+body:not(.on-game-dashboard) #stats-modal .player-mock-metric--prof span{color:#c5b597;font-size:10px}
+body:not(.on-game-dashboard) #stats-modal .player-metric-icon{grid-row:1/3;width:23px;height:23px;color:#d89c53}
+body:not(.on-game-dashboard) #stats-modal .player-metric-icon svg{width:100%;height:100%;fill:none;stroke:currentColor;stroke-width:1.7;stroke-linecap:round;stroke-linejoin:round}
+body:not(.on-game-dashboard) #stats-modal .player-stats-tabline{flex:0 0 48px;display:flex;align-items:center;justify-content:space-between;gap:14px;margin-bottom:12px;border-bottom:1px solid #4b3a27}
+body:not(.on-game-dashboard) #stats-modal .player-stats-tab{position:relative;min-width:128px;height:42px;display:grid;place-items:center;border:2px solid #f2a716;background:linear-gradient(180deg,#25211c,#11100e);color:#fff;font:700 18px Georgia,"Times New Roman",serif;box-shadow:inset 0 0 17px rgba(255,155,0,.15),0 0 9px rgba(255,155,0,.25)}
+body:not(.on-game-dashboard) #stats-modal .player-stats-tab::after{content:"";position:absolute;left:50%;bottom:-10px;transform:translateX(-50%);border-left:8px solid transparent;border-right:8px solid transparent;border-top:9px solid #f2a716}
+body:not(.on-game-dashboard) #stats-modal .player-stats-engine{color:#8c806e;font-size:10px;font-weight:700;letter-spacing:.1em}
+body:not(.on-game-dashboard) #stats-modal .player-stats-engine b{color:#d89c53}
+
+/* ability bar */
+body:not(.on-game-dashboard) #stats-modal .player-ability-bar{flex:0 0 98px;width:100%;display:grid;grid-template-columns:repeat(6,minmax(0,1fr));border:3px solid #3d3124;background:linear-gradient(180deg,#080807,#12100e);box-shadow:inset 0 0 20px #000;overflow:hidden}
+body:not(.on-game-dashboard) #stats-modal .player-ability{position:relative;min-width:0;height:100%;margin:0;padding:8px 4px;display:flex;flex-direction:column;justify-content:center;align-items:center;gap:7px;border:0;border-right:2px solid #493927;border-radius:0;background:linear-gradient(180deg,#11100e 0%,#0b0a09 55%,#080807 100%);color:#c9bda9;cursor:pointer;transition:.15s}
 body:not(.on-game-dashboard) #stats-modal .player-ability:last-child{border-right:0}
-body:not(.on-game-dashboard) #stats-modal .player-ability::after{content:"";position:absolute;right:14%;bottom:0;left:14%;height:2px;background:transparent}
-body:not(.on-game-dashboard) #stats-modal .player-ability:hover,body:not(.on-game-dashboard) #stats-modal .player-ability:focus-visible{color:#eee3cc;background:#171a15;outline:none}
-body:not(.on-game-dashboard) #stats-modal .player-ability.active{color:#fff2cf;background:linear-gradient(180deg,rgba(185,138,50,.13),rgba(123,32,37,.06)),#171a15;box-shadow:inset 0 0 18px rgba(185,138,50,.08)}
-body:not(.on-game-dashboard) #stats-modal .player-ability.active::after{background:var(--player-ux-brass-light,#d8b65d);box-shadow:0 0 8px rgba(216,182,93,.45)}
-body:not(.on-game-dashboard) #stats-modal .player-ability-name{font-size:18px;font-weight:800;line-height:1;letter-spacing:.08em}
-body:not(.on-game-dashboard) #stats-modal .player-ability-score{color:var(--player-ux-brass-light,#d8b65d);font-size:20px;font-weight:800;line-height:1.05}
-body:not(.on-game-dashboard) #stats-modal .player-ability-subtitle{max-width:100%;overflow:hidden;color:#777c70;font-size:8px;line-height:1.1;text-overflow:ellipsis;white-space:nowrap}
+body:not(.on-game-dashboard) #stats-modal .player-ability-name{color:#c9bda9;font:700 clamp(21px,1.65vw,30px)/1 Georgia,"Times New Roman",serif;letter-spacing:.09em;text-shadow:2px 2px 4px #000;transition:.15s}
+body:not(.on-game-dashboard) #stats-modal .player-ability-subtitle{max-width:95%;overflow:hidden;color:#70675b;font-size:9px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;text-overflow:ellipsis;white-space:nowrap;transition:.15s}
+body:not(.on-game-dashboard) #stats-modal .player-ability:hover,body:not(.on-game-dashboard) #stats-modal .player-ability:focus-visible{outline:0;background:radial-gradient(ellipse at center,rgba(124,84,24,.23),transparent 70%),linear-gradient(180deg,#19150f,#0b0a09)}
+body:not(.on-game-dashboard) #stats-modal .player-ability.active{background:radial-gradient(ellipse at center,rgba(255,172,0,.38),rgba(151,91,0,.22) 45%,rgba(30,23,10,.15) 70%,#0c0a07 100%);box-shadow:inset 0 0 30px rgba(255,159,0,.35),inset 0 -5px 15px rgba(255,155,0,.18)}
+body:not(.on-game-dashboard) #stats-modal .player-ability.active .player-ability-name{color:#ffb51d;text-shadow:0 0 7px rgba(255,159,0,.75),2px 2px 4px #000}
+body:not(.on-game-dashboard) #stats-modal .player-ability.active .player-ability-subtitle{color:#d99725}
+body:not(.on-game-dashboard) #stats-modal .player-ability::after{content:"";position:absolute;left:50%;bottom:0;transform:translateX(-50%);width:60%;height:3px;background:transparent}
+body:not(.on-game-dashboard) #stats-modal .player-ability.active::after{background:#f1a91d;box-shadow:0 0 8px rgba(255,160,0,.8)}
 
-/* proficiency: vacío / medio / lleno / expertise con doble anillo */
-body:not(.on-game-dashboard) #stats-modal .player-prof-indicator{position:absolute;top:7px;right:7px;width:10px;height:10px;border:1px solid #787d71;border-radius:50%;background:transparent;box-sizing:border-box}
-body:not(.on-game-dashboard) #stats-modal .player-prof-indicator[data-prof-state="none"]{background:transparent}
-body:not(.on-game-dashboard) #stats-modal .player-prof-indicator[data-prof-state="half"]{border-color:#bfa155;background:linear-gradient(90deg,#d8b65d 0 50%,transparent 50% 100%)}
-body:not(.on-game-dashboard) #stats-modal .player-prof-indicator[data-prof-state="proficient"]{border-color:#d8b65d;background:#d8b65d;box-shadow:0 0 5px rgba(216,182,93,.28)}
-body:not(.on-game-dashboard) #stats-modal .player-prof-indicator[data-prof-state="expertise"]{border-color:#f0d98d;background:#d8b65d;box-shadow:0 0 0 2px #111410,0 0 0 3px #d8b65d,0 0 7px rgba(216,182,93,.35)}
-body:not(.on-game-dashboard) #stats-modal .player-prof-indicator--large{position:relative;inset:auto;display:inline-block;flex:0 0 auto;width:14px;height:14px}
+/* proficiency symbols */
+body:not(.on-game-dashboard) #stats-modal .player-prof-indicator,body:not(.on-game-dashboard) #stats-modal .skill-proficiency{width:16px;height:16px;flex:0 0 16px;display:inline-block;border:2px solid #6b5b45;border-radius:50%;background:#0b0a09;box-sizing:border-box}
+body:not(.on-game-dashboard) #stats-modal .player-prof-indicator{position:absolute;top:8px;right:8px;width:12px;height:12px;border-width:1.5px}
+body:not(.on-game-dashboard) #stats-modal [data-prof-state="none"]{background:#0b0a09}
+body:not(.on-game-dashboard) #stats-modal [data-prof-state="half"]{border-color:#d0a34e;background:linear-gradient(90deg,#e3a52a 0 50%,#0b0a09 50% 100%)}
+body:not(.on-game-dashboard) #stats-modal [data-prof-state="proficient"]{border-color:#f6c25a;background:#e3a52a;box-shadow:0 0 7px rgba(235,165,42,.5)}
+body:not(.on-game-dashboard) #stats-modal [data-prof-state="expertise"]{border-color:#ffe1a0;background:#e3a52a;box-shadow:0 0 0 2px #12100e,0 0 0 4px #e3a52a,0 0 9px rgba(235,165,42,.55)}
 
-body:not(.on-game-dashboard) #stats-modal .player-ability-detail{display:grid;grid-template-columns:minmax(280px,1fr) minmax(230px,.72fr);min-width:0}
-body:not(.on-game-dashboard) #stats-modal .player-ability-primary{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:14px;align-items:center;padding:18px;border-right:1px solid #34382f}
-body:not(.on-game-dashboard) #stats-modal .player-ability-detail-code{display:block;color:#f2dec0;font-size:34px;font-weight:900;line-height:.95;letter-spacing:.07em}
-body:not(.on-game-dashboard) #stats-modal .player-ability-detail-name{display:block;margin-top:5px;color:#858a7e;font-size:11px;letter-spacing:.08em}
-body:not(.on-game-dashboard) #stats-modal .player-ability-prof-detail{display:flex;align-items:center;gap:8px;margin-top:13px;color:#aaa58f;font-size:9px}
-body:not(.on-game-dashboard) #stats-modal .player-ability-prof-detail strong{color:#d8b65d}
-body:not(.on-game-dashboard) #stats-modal .player-ability-numbers{display:grid;grid-template-columns:repeat(3,auto);gap:7px}
-body:not(.on-game-dashboard) #stats-modal .player-ability-numbers>div{display:grid;place-items:center;min-width:58px;min-height:60px;padding:6px;background:#0a0c0a;border:1px solid #3a3f36}
-body:not(.on-game-dashboard) #stats-modal .player-ability-number-label{color:#777c70;font-size:7px;letter-spacing:.1em}
-body:not(.on-game-dashboard) #stats-modal .player-ability-numbers strong{color:var(--player-ux-brass-light,#d8b65d);font-size:20px}
+/* stat detail */
+body:not(.on-game-dashboard) #stats-modal .player-stat-content{flex:1 1 auto;min-height:0;margin-top:14px;display:flex;flex-direction:column;overflow:hidden;border:2px solid #382d22;background:linear-gradient(180deg,rgba(20,17,14,.96),rgba(10,9,8,.98));box-shadow:inset 0 0 25px #000}
+body:not(.on-game-dashboard) #stats-modal .player-stat-header{flex:0 0 145px;display:grid;grid-template-columns:minmax(0,1fr) minmax(145px,190px) minmax(145px,190px);align-items:center;padding:16px 22px;border-bottom:1px solid #493a28}
+body:not(.on-game-dashboard) #stats-modal .player-stat-title{min-width:0;display:flex;flex-direction:column;gap:7px}
+body:not(.on-game-dashboard) #stats-modal .player-stat-title>span{min-width:0;overflow:hidden;color:#e9d7b4;font:700 clamp(24px,2.1vw,35px) Georgia,"Times New Roman",serif;letter-spacing:.06em;text-shadow:2px 2px 3px #000;text-overflow:ellipsis;white-space:nowrap}
+body:not(.on-game-dashboard) #stats-modal .player-stat-title small{color:#9f927d;font-size:14px;letter-spacing:.12em;text-transform:uppercase}
+body:not(.on-game-dashboard) #stats-modal .player-stat-main{height:112px;display:grid!important;place-items:center;align-content:center;gap:1px;margin:0!important;padding:0!important;border:0!important;border-left:1px solid #4b3b29!important;border-right:1px solid #4b3b29!important;border-radius:0!important;background:transparent!important;color:inherit!important;cursor:pointer;box-shadow:none!important;text-transform:none!important}
+body:not(.on-game-dashboard) #stats-modal .player-stat-main:hover{background:radial-gradient(circle,rgba(205,144,39,.11),transparent 70%)!important}
+body:not(.on-game-dashboard) #stats-modal .player-stat-score-label,body:not(.on-game-dashboard) #stats-modal .player-save-label{color:#8c806e;font:700 11px Arial,Helvetica,sans-serif;letter-spacing:.12em}
+body:not(.on-game-dashboard) #stats-modal .player-stat-score{color:#f0dfbd;font:700 49px/1 Georgia,"Times New Roman",serif}
+body:not(.on-game-dashboard) #stats-modal .player-stat-modifier{color:#e9a82c;font:700 19px Arial,Helvetica,sans-serif}
+body:not(.on-game-dashboard) #stats-modal .player-stat-main small{margin-top:2px;color:#665d50;font:700 7px Arial,Helvetica,sans-serif;letter-spacing:.13em}
+body:not(.on-game-dashboard) #stats-modal .player-stat-save{min-width:0;display:grid;place-items:center;align-content:center;gap:5px;text-align:center}
+body:not(.on-game-dashboard) #stats-modal .player-save-line{display:flex;align-items:center;justify-content:center;gap:12px}
+body:not(.on-game-dashboard) #stats-modal .player-save-prof{width:14px;height:14px;flex-basis:14px}
+body:not(.on-game-dashboard) #stats-modal .player-save-value{color:#ffbc36;font:700 36px Georgia,"Times New Roman",serif}
+body:not(.on-game-dashboard) #stats-modal .player-stat-save small{max-width:100%;overflow:hidden;color:#8d806d;font-size:9px;text-overflow:ellipsis;white-space:nowrap}
+body:not(.on-game-dashboard) #stats-modal .player-stat-save em{color:#6f665b;font-size:8px;font-style:normal;letter-spacing:.08em}
+body:not(.on-game-dashboard) #stats-modal .player-stat-save em span{color:#d49b38}
+body:not(.on-game-dashboard) #stats-modal .player-stats-divider{flex:0 0 44px;display:flex;align-items:center;justify-content:space-between;gap:14px;padding:0 26px;border-bottom:1px solid #493a28;color:#d6b77b}
+body:not(.on-game-dashboard) #stats-modal .player-stats-divider>span{font:700 15px Georgia,"Times New Roman",serif;letter-spacing:.17em}
+body:not(.on-game-dashboard) #stats-modal .player-stats-divider small{color:#6f6659;font-size:8px;letter-spacing:.04em;text-align:right}
+body:not(.on-game-dashboard) #stats-modal .player-skill-list{flex:1 1 auto;min-height:0;display:grid;grid-template-columns:repeat(2,minmax(0,1fr));grid-auto-rows:minmax(64px,1fr);column-gap:30px;padding:10px 26px 6px;overflow:auto;scrollbar-width:thin;scrollbar-color:#5a4530 #13110f}
+body:not(.on-game-dashboard) #stats-modal .dnd-skill{min-width:0;display:grid;grid-template-columns:34px minmax(0,1fr) 58px;align-items:center;border-bottom:1px solid rgba(80,66,48,.55);color:#c8bdac}
+body:not(.on-game-dashboard) #stats-modal .dnd-skill-name{min-width:0;overflow:hidden;color:#ddd1bf;font:700 clamp(15px,1.25vw,19px) Georgia,"Times New Roman",serif;text-overflow:ellipsis;white-space:nowrap}
+body:not(.on-game-dashboard) #stats-modal .dnd-skill-name span{display:block;margin-top:3px;overflow:hidden;color:#756b5e;font:700 9px Arial,Helvetica,sans-serif;letter-spacing:.08em;text-overflow:ellipsis;white-space:nowrap}
+body:not(.on-game-dashboard) #stats-modal .dnd-skill-value{text-align:right;color:#e4a62c;font:700 22px Georgia,"Times New Roman",serif}
+body:not(.on-game-dashboard) #stats-modal .dnd-skill--empty{grid-column:1/-1}
+body:not(.on-game-dashboard) #stats-modal .player-prof-legend{flex:0 0 34px;display:flex;align-items:center;justify-content:center;flex-wrap:wrap;gap:8px 18px;padding:4px 16px 7px;color:#736a5f;font-size:8px;border-top:1px solid rgba(73,58,40,.6)}
+body:not(.on-game-dashboard) #stats-modal .player-prof-legend span{display:flex;align-items:center;gap:7px}
+body:not(.on-game-dashboard) #stats-modal .player-prof-legend .skill-proficiency{width:10px;height:10px;flex-basis:10px;border-width:1px}
 
-body:not(.on-game-dashboard) #stats-modal .player-ability-art{position:relative;min-height:160px;overflow:hidden;background:radial-gradient(circle at center,rgba(185,138,50,.09),transparent 64%),#090b09}
-body:not(.on-game-dashboard) #stats-modal .player-ability-art img{width:100%;height:100%;min-height:160px;max-height:235px;object-fit:contain;object-position:center;display:block}
-body:not(.on-game-dashboard) #stats-modal .player-ability-art img[hidden]{display:none!important}
-body:not(.on-game-dashboard) #stats-modal .player-ability-art-empty{position:absolute;inset:0;display:grid;place-content:center;gap:5px;text-align:center;color:#756f62;border-left:1px solid #34382f}
-body:not(.on-game-dashboard) #stats-modal .player-ability-art-empty span{font-size:12px;letter-spacing:.14em;color:#95886f}
-body:not(.on-game-dashboard) #stats-modal .player-ability-art-empty small{max-width:180px;font-size:8px;line-height:1.35}
-
-body:not(.on-game-dashboard) #stats-modal .player-ability-mechanics{grid-column:1/-1;display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:8px;padding:12px 18px;border-top:1px solid #34382f;background:#0c0e0c}
-body:not(.on-game-dashboard) #stats-modal .player-ability-mechanics>div{display:flex;flex-direction:column;justify-content:center;min-height:52px;padding:7px 9px;background:#111410;border-left:2px solid #373b33}
-body:not(.on-game-dashboard) #stats-modal .player-ability-mechanics span{color:#7e8377;font-size:8px;letter-spacing:.08em}
-body:not(.on-game-dashboard) #stats-modal .player-ability-mechanics strong{margin-top:4px;color:#e8dcc5;font-size:14px}
-body:not(.on-game-dashboard) #stats-modal .player-ability-mechanics small{margin-top:3px;color:#8b7b5d;font-size:7px}
-body:not(.on-game-dashboard) #stats-modal .player-proficiency-legend{grid-column:1/-1;display:flex;flex-wrap:wrap;gap:8px 20px;padding:8px 18px;border-top:1px dashed #30342c;color:#777c70;font-size:8px}
-body:not(.on-game-dashboard) #stats-modal .player-proficiency-legend>span{display:flex;align-items:center;gap:7px}
-body:not(.on-game-dashboard) #stats-modal .player-proficiency-legend .player-prof-indicator{position:relative;inset:auto;display:inline-block}
-
-body:not(.on-game-dashboard) #stats-modal .player-ability-roll-row{grid-column:1/-1;display:grid;grid-template-columns:minmax(90px,.55fr) minmax(170px,1.2fr) auto;gap:12px;align-items:center;padding:12px 18px;background:#090b09;border-top:1px solid #34382f}
-body:not(.on-game-dashboard) #stats-modal .player-ability-roll-row .sheet-skill-name{color:#d9c8a9;font-size:11px;letter-spacing:.08em}
-body:not(.on-game-dashboard) #stats-modal .player-ability-roll-copy{display:flex;flex-direction:column;min-width:0}
-body:not(.on-game-dashboard) #stats-modal .player-ability-roll-copy strong{color:var(--player-ux-brass-light,#d8b65d);font-size:11px}
-body:not(.on-game-dashboard) #stats-modal .player-ability-roll-copy small{margin-top:2px;color:#777c70;font-size:8px}
-body:not(.on-game-dashboard) #stats-modal .player-ability-roll{min-width:150px;min-height:36px;padding:7px 12px!important;color:#f3e4c6!important;background:#201b12!important;border:1px solid #7e6432!important;border-radius:0!important;cursor:pointer;font:800 10px/1 "Share Tech Mono",monospace!important;letter-spacing:.08em}
-body:not(.on-game-dashboard) #stats-modal .player-ability-roll:hover{background:#302718!important;border-color:var(--player-ux-brass-light,#d8b65d)!important}
-
-@media (max-width:800px){
- body:not(.on-game-dashboard) #stats-modal .player-combat-level-strip{grid-template-columns:repeat(2,minmax(0,1fr))}
- body:not(.on-game-dashboard) #stats-modal .player-level-card:nth-child(2){border-right:0}
- body:not(.on-game-dashboard) #stats-modal .player-ability-bar{grid-template-columns:repeat(3,minmax(0,1fr))}
- body:not(.on-game-dashboard) #stats-modal .player-ability:nth-child(3){border-right:0}
- body:not(.on-game-dashboard) #stats-modal .player-ability-detail{grid-template-columns:1fr}
- body:not(.on-game-dashboard) #stats-modal .player-ability-primary{border-right:0;border-bottom:1px solid #34382f}
- body:not(.on-game-dashboard) #stats-modal .player-ability-art{min-height:135px;border-top:0}
- body:not(.on-game-dashboard) #stats-modal .player-ability-art-empty{border-left:0}
- body:not(.on-game-dashboard) #stats-modal .player-ability-mechanics{grid-template-columns:repeat(2,minmax(0,1fr))}
- body:not(.on-game-dashboard) #stats-modal .player-ability-roll-row{grid-template-columns:1fr}
- body:not(.on-game-dashboard) #stats-modal .player-ability-roll{width:100%;min-width:0}
-}
-@media (max-width:440px){
- body:not(.on-game-dashboard) #stats-modal .player-ability-heading{align-items:start;flex-direction:column}
- body:not(.on-game-dashboard) #stats-modal .player-ability-primary{grid-template-columns:1fr}
- body:not(.on-game-dashboard) #stats-modal .player-ability-numbers{justify-content:start;grid-template-columns:repeat(3,minmax(58px,1fr))}
-}
+@media (max-width:1180px){body:not(.on-game-dashboard) #stats-modal .hud-modal-content{width:98vw!important;height:94vh!important;max-height:94vh!important}body:not(.on-game-dashboard) #stats-modal .player-stats-frame{grid-template-columns:minmax(0,.82fr) minmax(0,1.18fr)}body:not(.on-game-dashboard) #stats-modal .player-stats-information-panel{padding-left:22px;padding-right:34px}body:not(.on-game-dashboard) #stats-modal .player-stats-bottom-info{left:34px;right:24px;gap:22px}body:not(.on-game-dashboard) #stats-modal .player-level-section{gap:8px;grid-template-columns:minmax(100px,1.15fr) repeat(3,minmax(76px,.8fr))}}
+@media (max-width:860px){body:not(.on-game-dashboard) #stats-modal .hud-modal-content{width:100vw!important;height:100dvh!important;max-height:100dvh!important;border:0!important}body:not(.on-game-dashboard) #stats-modal .hud-modal-body{overflow-y:auto!important}body:not(.on-game-dashboard) #stats-modal #stats-container,body:not(.on-game-dashboard) #stats-modal .player-ability-console{height:auto;min-height:100dvh;overflow:visible}body:not(.on-game-dashboard) #stats-modal .player-stats-frame{display:block;height:auto;overflow:visible}body:not(.on-game-dashboard) #stats-modal .player-stats-character-panel{height:38dvh;min-height:300px}body:not(.on-game-dashboard) #stats-modal .player-stats-bottom-info{left:24px;right:20px;bottom:20px}body:not(.on-game-dashboard) #stats-modal .player-stats-information-panel{min-height:760px;padding:18px 24px 24px;border-left:0;border-top:2px solid #473a2a}body:not(.on-game-dashboard) #stats-modal .player-stats-screen-border{display:none}body:not(.on-game-dashboard) #stats-modal .hud-modal-close{position:fixed!important;left:14px!important;top:14px!important;width:48px!important;height:48px!important;font-size:26px!important}body:not(.on-game-dashboard) #stats-modal .player-ability-bar{grid-template-columns:repeat(3,minmax(0,1fr));flex-basis:174px}body:not(.on-game-dashboard) #stats-modal .player-ability{min-height:87px}body:not(.on-game-dashboard) #stats-modal .player-stat-header{grid-template-columns:minmax(0,1fr) 135px 135px}}
+@media (max-width:560px){body:not(.on-game-dashboard) #stats-modal .player-stats-character-panel{height:34dvh;min-height:260px}body:not(.on-game-dashboard) #stats-modal .player-stats-bottom-info{left:18px;right:15px;gap:14px}body:not(.on-game-dashboard) #stats-modal .player-resistance-pending{display:none}body:not(.on-game-dashboard) #stats-modal .player-stats-information-panel{min-height:820px;padding:16px}body:not(.on-game-dashboard) #stats-modal .player-level-section{grid-template-columns:repeat(2,minmax(0,1fr));height:126px;gap:7px;padding:8px 0}body:not(.on-game-dashboard) #stats-modal .player-stats-header{flex-basis:192px}body:not(.on-game-dashboard) #stats-modal .player-stat-header{flex-basis:auto;grid-template-columns:1fr 1fr;gap:12px;padding:14px}body:not(.on-game-dashboard) #stats-modal .player-stat-title{grid-column:1/-1;padding-bottom:10px;border-bottom:1px solid #493a28}body:not(.on-game-dashboard) #stats-modal .player-skill-list{grid-template-columns:1fr;padding-inline:16px}body:not(.on-game-dashboard) #stats-modal .player-stats-divider small{display:none}body:not(.on-game-dashboard) #stats-modal .player-prof-legend{min-height:58px}}
+@media (prefers-reduced-motion:reduce){body:not(.on-game-dashboard) #stats-modal .player-ability,body:not(.on-game-dashboard) #stats-modal .hud-modal-close{transition:none!important}}

--- a/js/player-stats-ability-bar.js
+++ b/js/player-stats-ability-bar.js
@@ -5,12 +5,48 @@
   if (!doc) return;
 
   const ABILITIES = Object.freeze([
-    { id: "str", key: "fuerza", code: "STR", name: "Strength" },
-    { id: "dex", key: "destreza", code: "DEX", name: "Dexterity" },
-    { id: "con", key: "constitucion", code: "CON", name: "Constitution" },
-    { id: "int", key: "inteligencia", code: "INT", name: "Intelligence" },
-    { id: "wis", key: "sabiduria", code: "WIS", name: "Wisdom" },
-    { id: "cha", key: "carisma", code: "CHA", name: "Charisma" },
+    {
+      id: "str", key: "fuerza", code: "STR", name: "STRENGTH", spanish: "Fuerza",
+      skills: [{ id: "athletics", name: "Athletics", spanish: "Atletismo" }],
+    },
+    {
+      id: "dex", key: "destreza", code: "DEX", name: "DEXTERITY", spanish: "Destreza",
+      skills: [
+        { id: "acrobatics", name: "Acrobatics", spanish: "Acrobacias" },
+        { id: "sleight_of_hand", name: "Sleight of Hand", spanish: "Juego de Manos" },
+        { id: "stealth", name: "Stealth", spanish: "Sigilo" },
+      ],
+    },
+    { id: "con", key: "constitucion", code: "CON", name: "CONSTITUTION", spanish: "Constitución", skills: [] },
+    {
+      id: "int", key: "inteligencia", code: "INT", name: "INTELLIGENCE", spanish: "Inteligencia",
+      skills: [
+        { id: "arcana", name: "Arcana", spanish: "Arcanos" },
+        { id: "history", name: "History", spanish: "Historia" },
+        { id: "investigation", name: "Investigation", spanish: "Investigación" },
+        { id: "nature", name: "Nature", spanish: "Naturaleza" },
+        { id: "religion", name: "Religion", spanish: "Religión" },
+      ],
+    },
+    {
+      id: "wis", key: "sabiduria", code: "WIS", name: "WISDOM", spanish: "Sabiduría",
+      skills: [
+        { id: "animal_handling", name: "Animal Handling", spanish: "Trato con Animales" },
+        { id: "insight", name: "Insight", spanish: "Perspicacia" },
+        { id: "medicine", name: "Medicine", spanish: "Medicina" },
+        { id: "perception", name: "Perception", spanish: "Percepción" },
+        { id: "survival", name: "Survival", spanish: "Supervivencia" },
+      ],
+    },
+    {
+      id: "cha", key: "carisma", code: "CHA", name: "CHARISMA", spanish: "Carisma",
+      skills: [
+        { id: "deception", name: "Deception", spanish: "Engaño" },
+        { id: "intimidation", name: "Intimidation", spanish: "Intimidación" },
+        { id: "performance", name: "Performance", spanish: "Interpretación" },
+        { id: "persuasion", name: "Persuasion", spanish: "Persuasión" },
+      ],
+    },
   ]);
 
   const PROFICIENCY_STATES = Object.freeze({
@@ -23,6 +59,7 @@
   const rollAdjustment = { bonus: 0, ignoreNextMutation: false, observer: null, resultNode: null };
   const SWORD_ICON = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14.5 4.5 19.5 2l-2.5 5-7.7 7.7-2-2z"/><path d="m8.4 13.6 2 2-4.7 4.7-2-2zM5 15l4 4M15.5 3.8l4.7 4.7"/></svg>';
   const SHIELD_ICON = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2.5 19 5v5.8c0 4.4-2.3 8-7 10.7-4.7-2.7-7-6.3-7-10.7V5z"/><path d="M12 5.5v12"/></svg>';
+  const HEART_ICON = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 20.3 4.7 13C1.9 10.2 2.3 5.7 5.6 3.9c2.2-1.2 4.8-.6 6.4 1.2 1.6-1.8 4.2-2.4 6.4-1.2 3.3 1.8 3.7 6.3.9 9.1z"/></svg>';
 
   const playerData = () => global.datosJugador || {};
   const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
@@ -41,6 +78,12 @@
   function abilityProficiencyState(ability, data = playerData()) {
     const map = data?.abilityProficiency || data?.abilityProficiencies || {};
     return normalizeProficiencyState(map?.[ability.id] ?? map?.[ability.key]);
+  }
+
+  function skillProficiencyState(skill, data = playerData()) {
+    const map = data?.skillProficiency || data?.skillProficiencies || data?.dndSkillProficiency || {};
+    const nested = data?.dndSkills?.[skill.id];
+    return normalizeProficiencyState(map?.[skill.id] ?? nested?.proficiency ?? nested?.proficiencyState);
   }
 
   function proficiencyContribution(level, state) {
@@ -72,6 +115,10 @@
   }
 
   const playerSheetArt = (data = playerData()) => String(data?.sheetArt || data?.playerSheetArt || "").trim();
+  const playerIcon = (data = playerData()) => String(data?.icono_jugador || data?.icono || data?.perfil?.icono || "").trim();
+  const playerName = (data = playerData()) => String(data?.characterName || data?.character_name || data?.nombre || data?.name || "PLAYER").trim();
+  const currentHp = (data = playerData()) => Math.trunc(numberOr(data?.combatStats?.hp_actual ?? data?.hp_actual ?? data?.hp, 0));
+  const maxHp = (data = playerData()) => Math.trunc(numberOr(data?.combatStats?.hp_max ?? data?.hp_max, currentHp(data)));
 
   function selectedAbility(panel) {
     const id = panel?.dataset?.activeStat || ABILITIES[0].id;
@@ -87,8 +134,15 @@
     return { score, modifier, state, proficiency, proficiencyValue, base: modifier + proficiencyValue };
   }
 
-  function setText(panel, selector, value) {
-    const node = panel.querySelector(selector);
+  function skillValue(skill, ability, data = playerData()) {
+    const stored = data?.dndSkills?.[skill.id]?.value;
+    if (Number.isFinite(Number(stored))) return Number(stored);
+    const state = skillProficiencyState(skill, data);
+    return abilityModifier(abilityScore(ability, data)) + proficiencyContribution(currentLevel(data), state);
+  }
+
+  function setText(root, selector, value) {
+    const node = root?.querySelector?.(selector);
     if (node && node.textContent !== String(value)) node.textContent = String(value);
   }
 
@@ -109,66 +163,115 @@
     image.onerror = () => { image.hidden = true; fallback.hidden = false; };
   }
 
-  function syncCombatLevels(panel, data) {
+  function syncCharacterIcon(panel, data) {
+    const image = panel.querySelector("[data-player-character-icon]");
+    const fallback = panel.querySelector("[data-player-character-icon-empty]");
+    if (!image || !fallback) return;
+    const icon = playerIcon(data);
+    if (!icon) {
+      image.hidden = true;
+      image.removeAttribute("src");
+      fallback.hidden = false;
+      return;
+    }
+    if (image.getAttribute("src") !== icon) image.src = icon;
+    image.hidden = false;
+    fallback.hidden = true;
+    image.onerror = () => { image.hidden = true; fallback.hidden = false; };
+  }
+
+  function syncOverview(panel, data) {
     const level = currentLevel(data);
     const proficiency = proficiencyBonus(level);
     const offensive = combatLevelBreakdown("offensive", data);
     const defensive = combatLevelBreakdown("defensive", data);
+    setText(panel, "[data-player-name]", playerName(data));
     setText(panel, "[data-player-level]", level);
     setText(panel, "[data-player-proficiency]", formatModifier(proficiency));
     setText(panel, "[data-player-offensive-level]", offensive.total);
     setText(panel, "[data-player-defensive-level]", defensive.total);
-    const offensiveCard = panel.querySelector("[data-combat-level='offensive']");
-    const defensiveCard = panel.querySelector("[data-combat-level='defensive']");
-    if (offensiveCard) offensiveCard.title = `Nivel ${level} + Clase ${formatModifier(offensive.classModifier)} + DM ${formatModifier(offensive.dmModifier)} + Items ${formatModifier(offensive.itemModifier)}`;
-    if (defensiveCard) defensiveCard.title = `Nivel ${level} + Clase ${formatModifier(defensive.classModifier)} + DM ${formatModifier(defensive.dmModifier)} + Items ${formatModifier(defensive.itemModifier)}`;
+    setText(panel, "[data-player-hp-current]", currentHp(data));
+    setText(panel, "[data-player-hp-max]", maxHp(data));
+    setText(panel, "[data-player-xp-progress]", `${Math.max(0, Math.min(100, Math.trunc(numberOr(data?.xpPercent, 0))))}%`);
+    setText(panel, "[data-player-heads-chance]", `${headsChance(data)}%`);
+    syncArt(panel, data);
+    syncCharacterIcon(panel, data);
+
+    const offensiveNode = panel.querySelector("[data-combat-level='offensive']");
+    const defensiveNode = panel.querySelector("[data-combat-level='defensive']");
+    if (offensiveNode) offensiveNode.title = `Nivel ${level} + Clase ${formatModifier(offensive.classModifier)} + DM ${formatModifier(offensive.dmModifier)} + Items ${formatModifier(offensive.itemModifier)}`;
+    if (defensiveNode) defensiveNode.title = `Nivel ${level} + Clase ${formatModifier(defensive.classModifier)} + DM ${formatModifier(defensive.dmModifier)} + Items ${formatModifier(defensive.itemModifier)}`;
+  }
+
+  function renderSkills(panel, ability, data) {
+    const list = panel.querySelector("[data-player-skill-list]");
+    if (!list) return;
+    list.replaceChildren();
+
+    if (!ability.skills.length) {
+      const empty = doc.createElement("div");
+      empty.className = "dnd-skill dnd-skill--empty";
+      empty.innerHTML = '<span class="skill-proficiency" data-prof-state="none"></span><div class="dnd-skill-name">No Skills<span>No associated skills</span></div><div class="dnd-skill-value">—</div>';
+      list.appendChild(empty);
+      return;
+    }
+
+    ability.skills.forEach((skill) => {
+      const state = skillProficiencyState(skill, data);
+      const definition = PROFICIENCY_STATES[state];
+      const row = doc.createElement("div");
+      row.className = "dnd-skill";
+      row.dataset.profState = state;
+      row.title = `${definition.label} · ${formatModifier(proficiencyContribution(currentLevel(data), state))}`;
+      row.innerHTML = `
+        <span class="skill-proficiency" data-prof-state="${state}" aria-label="${definition.label}"></span>
+        <div class="dnd-skill-name">${skill.name}<span>${skill.spanish}</span></div>
+        <div class="dnd-skill-value">${formatModifier(skillValue(skill, ability, data))}</div>`;
+      list.appendChild(row);
+    });
   }
 
   function syncPanel() {
     const panel = doc.querySelector("#stats-modal .player-ability-console");
     if (!panel) return false;
     const data = playerData();
-    syncCombatLevels(panel, data);
-    syncArt(panel, data);
+    syncOverview(panel, data);
 
     ABILITIES.forEach((ability) => {
-      const math = abilityRollMath(ability, data);
+      const state = abilityProficiencyState(ability, data);
       const button = panel.querySelector(`.player-ability[data-stat="${ability.id}"]`);
       if (!button) return;
-      setText(button, ".player-ability-score", math.score);
       const indicator = button.querySelector(".player-prof-indicator");
       if (indicator) {
-        indicator.dataset.profState = math.state;
-        indicator.title = `${PROFICIENCY_STATES[math.state].label}: ${formatModifier(math.proficiencyValue)}`;
-        indicator.setAttribute("aria-label", indicator.title);
+        indicator.dataset.profState = state;
+        indicator.title = PROFICIENCY_STATES[state].label;
+        indicator.setAttribute("aria-label", PROFICIENCY_STATES[state].label);
       }
     });
 
     const ability = selectedAbility(panel);
     const math = abilityRollMath(ability, data);
-    const sp = currentSp(data);
     const stateDefinition = PROFICIENCY_STATES[math.state];
-    setText(panel, "[data-ability-detail-code]", ability.code);
-    setText(panel, "[data-ability-detail-name]", ability.name);
-    setText(panel, "[data-ability-detail-score]", math.score);
-    setText(panel, "[data-ability-detail-mod]", formatModifier(math.modifier));
-    setText(panel, "[data-ability-detail-prof-label]", stateDefinition.label);
-    setText(panel, "[data-ability-detail-prof-value]", formatModifier(math.proficiencyValue));
-    setText(panel, "[data-ability-roll-base]", formatModifier(math.base));
-    setText(panel, "[data-ability-heads-chance]", `${headsChance(data)}%`);
-    setText(panel, "[data-ability-heads-formula]", `50 + ${sp} SP`);
+    const saveValue = math.modifier + math.proficiencyValue;
 
-    const detailIndicator = panel.querySelector("[data-ability-detail-prof-icon]");
-    if (detailIndicator) detailIndicator.dataset.profState = math.state;
-    const rollRow = panel.querySelector(".player-ability-roll-row");
-    const rollLabel = rollRow?.querySelector(".sheet-skill-name");
-    const rollButton = rollRow?.querySelector(".sheet-roll-skill-btn");
-    if (rollLabel) rollLabel.textContent = ability.name;
+    setText(panel, "[data-stat-full-name]", ability.name);
+    setText(panel, "[data-stat-spanish]", ability.spanish);
+    setText(panel, "[data-stat-score]", math.score);
+    setText(panel, "[data-stat-modifier]", formatModifier(math.modifier));
+    setText(panel, "[data-stat-save]", formatModifier(saveValue));
+    setText(panel, "[data-stat-save-state]", stateDefinition.label);
+    setText(panel, "[data-stat-prof-value]", formatModifier(math.proficiencyValue));
+
+    const saveIndicator = panel.querySelector("[data-stat-save-prof]");
+    if (saveIndicator) saveIndicator.dataset.profState = math.state;
+
+    const rollButton = panel.querySelector(".player-stat-roll");
     if (rollButton) {
       rollButton.name = `act_roll_skill_${ability.key}`;
       rollButton.dataset.stat = ability.id;
       rollButton.dataset.proficiencyContribution = String(math.proficiencyValue);
       rollButton.setAttribute("aria-label", `Tirar ${ability.name}: MOD ${formatModifier(math.modifier)} + ${stateDefinition.label} ${formatModifier(math.proficiencyValue)}, cinco monedas`);
+      rollButton.title = `Tirar ${ability.name} · MOD ${formatModifier(math.modifier)} + PROF ${formatModifier(math.proficiencyValue)} · 5 coins · ${headsChance(data)} cara`;
     }
 
     panel.querySelectorAll(".player-ability").forEach((button) => {
@@ -177,6 +280,8 @@
       button.setAttribute("aria-selected", active ? "true" : "false");
       button.tabIndex = active ? 0 : -1;
     });
+
+    renderSkills(panel, ability, data);
     return true;
   }
 
@@ -199,26 +304,89 @@
     let panel = statsContainer.querySelector(":scope > .player-ability-console");
     if (!panel) {
       panel = doc.createElement("section");
-      panel.className = "player-ability-console";
+      panel.className = "player-ability-console player-stats-mock-hud";
       panel.dataset.activeStat = ABILITIES[0].id;
       panel.setAttribute("aria-label", "D&D player stats");
       panel.innerHTML = `
-        <div class="player-ability-heading"><div><span class="player-ability-kicker">D&D ATTRIBUTE MATRIX</span><h3>PLAYER STATS</h3></div><span class="player-ability-engine">COIN ENGINE / 5 COINS</span></div>
-        <div class="player-combat-level-strip" aria-label="Nivel y niveles de combate">
-          <div class="player-level-card"><span>LEVEL</span><strong data-player-level>1</strong></div>
-          <div class="player-level-card player-level-card--proficiency"><span>PROFICIENCY</span><strong data-player-proficiency>+1</strong><small>ceil(Level / 20)</small></div>
-          <div class="player-level-card player-level-card--combat" data-combat-level="offensive"><span class="player-level-icon">${SWORD_ICON}</span><span>OFFENSIVE LEVEL</span><strong data-player-offensive-level>1</strong></div>
-          <div class="player-level-card player-level-card--combat" data-combat-level="defensive"><span class="player-level-icon">${SHIELD_ICON}</span><span>DEFENSIVE LEVEL</span><strong data-player-defensive-level>1</strong></div>
-        </div>
-        <div class="player-ability-bar" role="tablist" aria-label="D&D abilities">
-          ${ABILITIES.map((ability, index) => `<button type="button" class="player-ability${index === 0 ? " active" : ""}" data-stat="${ability.id}" role="tab" aria-selected="${index === 0 ? "true" : "false"}" tabindex="${index === 0 ? "0" : "-1"}"><span class="player-prof-indicator" data-prof-state="none" aria-hidden="false"></span><span class="player-ability-name">${ability.code}</span><span class="player-ability-score">10</span><span class="player-ability-subtitle">${ability.name}</span></button>`).join("")}
-        </div>
-        <div class="player-ability-detail">
-          <div class="player-ability-primary"><div class="player-ability-identity"><span class="player-ability-detail-code" data-ability-detail-code>STR</span><span class="player-ability-detail-name" data-ability-detail-name>Strength</span><div class="player-ability-prof-detail"><span class="player-prof-indicator player-prof-indicator--large" data-ability-detail-prof-icon data-prof-state="none"></span><span data-ability-detail-prof-label>Not Proficient</span><strong data-ability-detail-prof-value>+0</strong></div></div><div class="player-ability-numbers"><div><span class="player-ability-number-label">SCORE</span><strong data-ability-detail-score>10</strong></div><div><span class="player-ability-number-label">MOD</span><strong data-ability-detail-mod>+0</strong></div><div><span class="player-ability-number-label">ROLL BASE</span><strong data-ability-roll-base>+0</strong></div></div></div>
-          <div class="player-ability-art" aria-label="Assigned player art"><img data-player-sheet-art alt="Player art assigned by the DM" hidden><div data-player-sheet-art-empty class="player-ability-art-empty"><span>PLAYER ART</span><small>Asignada por el DM en Gestión de Jugadores</small></div></div>
-          <div class="player-ability-mechanics" aria-label="Reglas de tirada"><div><span>BASE</span><strong>MOD + PROF</strong></div><div><span>CADA CARA</span><strong>+4</strong></div><div><span>P(CARA)</span><strong data-ability-heads-chance>50%</strong><small data-ability-heads-formula>50 + 0 SP</small></div><div><span>MONEDAS</span><strong>5</strong></div></div>
-          <div class="player-proficiency-legend" aria-label="Estados de proficiency">${Object.entries(PROFICIENCY_STATES).map(([state, definition]) => `<span><i class="player-prof-indicator" data-prof-state="${state}"></i>${definition.label}</span>`).join("")}</div>
-          <div class="player-ability-roll-row sheet-skill-row"><span class="sheet-skill-name">Strength</span><div class="player-ability-roll-copy"><strong>MOD + PROF + (4 × CARAS)</strong><small>Prof = Proficiency × estado. Cada cara usa (50 + SP)%.</small></div><button type="action" name="act_roll_skill_fuerza" class="sheet-roll-skill-btn player-ability-roll">TIRAR ABILITY</button></div>
+        <div class="player-stats-screen-border" aria-hidden="true"></div>
+        <div class="player-stats-frame">
+          <section class="player-stats-character-panel" aria-label="Player art">
+            <div class="player-stats-character-image">
+              <img data-player-sheet-art alt="Player art assigned by the DM" hidden>
+              <div class="player-stats-art-empty" data-player-sheet-art-empty>
+                <strong>PLAYER ART</strong>
+                <span>Asignada por el DM en Gestión de Jugadores</span>
+              </div>
+            </div>
+            <div class="player-stats-bottom-info">
+              <div class="player-info-block">
+                <div class="player-info-label">Status</div>
+                <div class="player-info-value player-info-hp">${HEART_ICON}<span data-player-hp-current>0</span><small>/ <span data-player-hp-max>0</span></small></div>
+              </div>
+              <div class="player-info-block player-info-resistances">
+                <div class="player-info-label">Resistances</div>
+                <div class="player-resistance-list">
+                  <div class="player-resistance-item" data-combat-level="offensive"><span class="player-combat-icon">${SWORD_ICON}</span><b data-player-offensive-level>1</b><small>OFF</small></div>
+                  <div class="player-resistance-item" data-combat-level="defensive"><span class="player-combat-icon">${SHIELD_ICON}</span><b data-player-defensive-level>1</b><small>DEF</small></div>
+                  <div class="player-resistance-item player-resistance-pending">EQUIPMENT · PENDING</div>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section class="player-stats-information-panel">
+            <div class="player-stats-top-decoration" aria-hidden="true">◇◇◇</div>
+            <div class="player-stats-season">D&amp;D · STATS</div>
+
+            <header class="player-stats-header">
+              <div class="player-character-name">
+                <div class="player-character-icon">
+                  <img data-player-character-icon alt="Character icon" hidden>
+                  <span data-player-character-icon-empty>◈</span>
+                </div>
+                <span data-player-name>PLAYER</span>
+              </div>
+              <div class="player-level-section">
+                <div class="player-level-text"><span>LV</span><strong data-player-level>1</strong><small data-player-xp-progress>0%</small></div>
+                <div class="player-mock-metric player-mock-metric--prof"><span>PROF</span><strong data-player-proficiency>+1</strong></div>
+                <div class="player-mock-metric" data-combat-level="offensive"><span class="player-metric-icon">${SWORD_ICON}</span><strong data-player-offensive-level>1</strong><small>OFF</small></div>
+                <div class="player-mock-metric" data-combat-level="defensive"><span class="player-metric-icon">${SHIELD_ICON}</span><strong data-player-defensive-level>1</strong><small>DEF</small></div>
+              </div>
+            </header>
+
+            <div class="player-stats-tabline">
+              <span class="player-stats-tab active">Stats</span>
+              <span class="player-stats-engine">5 COINS · <b data-player-heads-chance>50%</b> HEADS</span>
+            </div>
+
+            <div class="player-ability-bar" role="tablist" aria-label="D&D abilities">
+              ${ABILITIES.map((ability, index) => `<button type="button" class="player-ability${index === 0 ? " active" : ""}" data-stat="${ability.id}" role="tab" aria-selected="${index === 0 ? "true" : "false"}" tabindex="${index === 0 ? "0" : "-1"}"><span class="player-prof-indicator" data-prof-state="none"></span><span class="player-ability-name">${ability.code}</span><span class="player-ability-subtitle">${ability.name.charAt(0) + ability.name.slice(1).toLowerCase()}</span></button>`).join("")}
+            </div>
+
+            <div class="player-stat-content">
+              <div class="player-stat-header">
+                <div class="player-stat-title"><span data-stat-full-name>STRENGTH</span><small data-stat-spanish>Fuerza</small></div>
+                <button type="action" name="act_roll_skill_fuerza" class="sheet-roll-skill-btn player-stat-main player-stat-roll">
+                  <span class="player-stat-score-label">SCORE</span>
+                  <strong class="player-stat-score" data-stat-score>10</strong>
+                  <span class="player-stat-modifier" data-stat-modifier>+0</span>
+                  <small>CLICK TO ROLL</small>
+                </button>
+                <div class="player-stat-save">
+                  <div class="player-save-label">SAVING THROW</div>
+                  <div class="player-save-line"><span class="skill-proficiency player-save-prof" data-stat-save-prof data-prof-state="none"></span><strong class="player-save-value" data-stat-save>+0</strong></div>
+                  <small data-stat-save-state>Not Proficient</small>
+                  <em>PROF <span data-stat-prof-value>+0</span></em>
+                </div>
+              </div>
+
+              <div class="player-stats-divider"><span>SKILLS</span><small>Skill proficiency is read from player D&amp;D data when available.</small></div>
+              <div class="player-skill-list" data-player-skill-list></div>
+              <div class="player-prof-legend" aria-label="Proficiency states">
+                ${Object.entries(PROFICIENCY_STATES).map(([state, definition]) => `<span><i class="skill-proficiency" data-prof-state="${state}"></i>${definition.label}</span>`).join("")}
+              </div>
+            </div>
+          </section>
         </div>`;
       statsContainer.prepend(panel);
 
@@ -236,11 +404,13 @@
           activate(panel, ABILITIES[next].id, true);
         });
       });
-      panel.querySelector(".player-ability-roll")?.addEventListener("click", (event) => {
+
+      panel.querySelector(".player-stat-roll")?.addEventListener("click", (event) => {
         rollAdjustment.bonus = Number.parseInt(event.currentTarget.dataset.proficiencyContribution, 10) || 0;
         rollAdjustment.ignoreNextMutation = false;
       });
     }
+
     syncPanel();
     return true;
   }
@@ -259,7 +429,10 @@
       resultNode.textContent = String(raw + rollAdjustment.bonus);
     });
     rollAdjustment.observer.observe(resultNode, { childList: true, characterData: true, subtree: true });
-    doc.getElementById("coin-toss-close-btn")?.addEventListener("click", () => { rollAdjustment.bonus = 0; rollAdjustment.ignoreNextMutation = false; });
+    doc.getElementById("coin-toss-close-btn")?.addEventListener("click", () => {
+      rollAdjustment.bonus = 0;
+      rollAdjustment.ignoreNextMutation = false;
+    });
     return true;
   }
 
@@ -272,5 +445,17 @@
   if (doc.readyState === "loading") doc.addEventListener("DOMContentLoaded", boot, { once: true });
   else boot();
 
-  global.LuminousPlayerStats = Object.freeze({ ABILITIES, PROFICIENCY_STATES, abilityModifier, proficiencyBonus, proficiencyContribution, combatLevelBreakdown, headsChance, buildPanel, syncPanel });
+  global.LuminousPlayerStats = Object.freeze({
+    ABILITIES,
+    PROFICIENCY_STATES,
+    abilityModifier,
+    proficiencyBonus,
+    proficiencyContribution,
+    combatLevelBreakdown,
+    skillProficiencyState,
+    skillValue,
+    headsChance,
+    buildPanel,
+    syncPanel,
+  });
 })(window);

--- a/tests/player_stats_ability_bar.spec.js
+++ b/tests/player_stats_ability_bar.spec.js
@@ -11,27 +11,31 @@ const dmPage = read("pantalla_dm.html");
 const dmDnd = read("js/dm-player-dnd-studio.js");
 const dmDndCss = read("css/dm-player-dnd-studio.css");
 
-test("Stats usa STR DEX CON INT WIS CHA y elimina el bloque CUERPO MENTE ALMA", () => {
-  for (const code of ["STR", "DEX", "CON", "INT", "WIS", "CHA"]) expect(statsUi).toContain(`code: "${code}"`);
-  expect(statsUi).toContain('class="player-ability-bar"');
+test("Stats adopta el mock HUD de dos paneles sin CUERPO MENTE ALMA", () => {
+  expect(statsUi).toContain('class="player-stats-frame"');
+  expect(statsUi).toContain('class="player-stats-character-panel"');
+  expect(statsUi).toContain('class="player-stats-information-panel"');
+  expect(statsUi).toContain('class="player-stat-content"');
+  expect(statsUi).toContain('class="player-skill-list"');
+  expect(statsCss).toContain("grid-template-columns:minmax(0,1fr) minmax(0,1fr)");
+  expect(statsCss).toContain("radial-gradient(ellipse at 50% 12%");
   expect(statsUi).toContain("function removeLegacyStats(statsContainer)");
   expect(statsUi).toContain('statsContainer.querySelectorAll(":scope > .sheet-attributes-grid, :scope > .player-secondary-stats")');
-  expect(statsUi).toContain("node.remove()");
   expect(statsUi).not.toContain("HABILIDADES / ATRIBUTOS SECUNDARIOS");
-  expect(statsCss).toContain("grid-template-columns:repeat(6,minmax(0,1fr))");
 });
 
-test("Proficiency es ceil(Level / 20) y se muestra junto a Level", () => {
+test("la barra conserva STR DEX CON INT WIS CHA con selector activo", () => {
+  for (const code of ["STR", "DEX", "CON", "INT", "WIS", "CHA"]) expect(statsUi).toContain(`code: "${code}"`);
+  expect(statsUi).toContain('class="player-ability-bar"');
+  expect(statsUi).toContain('data-stat="${ability.id}"');
+  expect(statsUi).toContain("panel.dataset.activeStat = abilityId");
+  expect(statsCss).toContain("grid-template-columns:repeat(6,minmax(0,1fr))");
+  expect(statsCss).toContain("rgba(255,172,0,.38)");
+});
+
+test("Proficiency sigue siendo ceil(Level / 20) con los cuatro estados", () => {
   expect(statsUi).toContain("Math.ceil(numericLevel / 20)");
   expect(dmDnd).toContain("Math.ceil(Math.max(0, numberOr(level, 0)) / 20)");
-  expect(statsUi).toContain("ceil(Level / 20)");
-  expect(statsUi).toContain("data-player-level");
-  expect(statsUi).toContain("data-player-proficiency");
-  expect(dmDnd).toContain('id="dm-player-dnd-level"');
-  expect(dmDnd).toContain('id="dm-player-dnd-prof"');
-});
-
-test("Abilities soporta Not Half Proficient y Expertise con las reglas acordadas", () => {
   expect(statsUi).toContain('none: Object.freeze({ label: "Not Proficient", multiplier: 0 })');
   expect(statsUi).toContain('half: Object.freeze({ label: "Half Proficient", multiplier: 0.5 })');
   expect(statsUi).toContain('proficient: Object.freeze({ label: "Proficient", multiplier: 1 })');
@@ -40,40 +44,61 @@ test("Abilities soporta Not Half Proficient y Expertise con las reglas acordadas
   expect(statsCss).toContain('[data-prof-state="half"]');
   expect(statsCss).toContain('[data-prof-state="proficient"]');
   expect(statsCss).toContain('[data-prof-state="expertise"]');
-  expect(statsCss).toContain("box-shadow:");
+  expect(statsCss).toContain("0 0 0 4px #e3a52a");
 });
 
-test("la tirada conserva el Coin Engine y suma Proficiency al MOD antes de las monedas", () => {
-  expect(statsUi).toContain('class="sheet-roll-skill-btn player-ability-roll"');
+test("Saving Throw usa MOD más la proficiency del atributo", () => {
+  expect(statsUi).toContain("const saveValue = math.modifier + math.proficiencyValue");
+  expect(statsUi).toContain("data-stat-save");
+  expect(statsUi).toContain("data-stat-save-prof");
+  expect(statsUi).toContain("data-stat-save-state");
+  expect(statsUi).toContain("data-stat-prof-value");
+});
+
+test("el panel usa la lista estándar de skills D&D asociada a cada atributo", () => {
+  for (const skill of [
+    "Athletics", "Acrobatics", "Sleight of Hand", "Stealth", "Arcana", "History",
+    "Investigation", "Nature", "Religion", "Animal Handling", "Insight", "Medicine",
+    "Perception", "Survival", "Deception", "Intimidation", "Performance", "Persuasion",
+  ]) expect(statsUi).toContain(`name: "${skill}"`);
+  expect(statsUi).toContain("function skillProficiencyState(skill, data = playerData())");
+  expect(statsUi).toContain("data?.skillProficiency || data?.skillProficiencies || data?.dndSkillProficiency");
+  expect(statsUi).toContain("abilityModifier(abilityScore(ability, data)) + proficiencyContribution");
+  expect(statsUi).toContain("No associated skills");
+});
+
+test("el score del mock sigue tirando con el Coin Engine existente", () => {
+  expect(statsUi).toContain('class="sheet-roll-skill-btn player-stat-main player-stat-roll"');
   expect(statsUi).toContain("rollButton.name = `act_roll_skill_${ability.key}`");
-  expect(statsUi).toContain("base: modifier + proficiencyValue");
-  expect(statsUi).toContain("MOD + PROF + (4 × CARAS)");
+  expect(statsUi).toContain("dataset.proficiencyContribution");
   expect(statsUi).toContain('doc.getElementById("roll-total-score")');
   expect(statsUi).toContain("raw + rollAdjustment.bonus");
   expect(playerEngine).toContain('["fuerza", "destreza", "constitucion", "inteligencia", "sabiduria", "carisma"]');
   expect(playerEngine).toContain("baseVal = Math.floor((rawVal - 10) / 2);");
-  expect(playerEngine).toContain("let probHeads = 50 + sp;");
   expect(playerEngine).toContain("const totalCoins = 5;");
   expect(playerEngine).toContain("currentTotal += 4;");
 });
 
-test("Stats muestra art asignada por DM y Offensive / Defensive Level", () => {
+test("el mock usa art, icono, HP, Level, Proficiency y Offensive/Defensive reales", () => {
   expect(statsUi).toContain("data-player-sheet-art");
-  expect(statsUi).toContain("Asignada por el DM en Gestión de Jugadores");
-  expect(statsUi).toContain("OFFENSIVE LEVEL");
-  expect(statsUi).toContain("DEFENSIVE LEVEL");
+  expect(statsUi).toContain("data-player-character-icon");
+  expect(statsUi).toContain("data-player-hp-current");
+  expect(statsUi).toContain("data-player-hp-max");
+  expect(statsUi).toContain("data-player-level");
+  expect(statsUi).toContain("data-player-proficiency");
+  expect(statsUi).toContain("data-player-offensive-level");
+  expect(statsUi).toContain("data-player-defensive-level");
   expect(statsUi).toContain("SWORD_ICON");
   expect(statsUi).toContain("SHIELD_ICON");
+  expect(statsUi).toContain("EQUIPMENT · PENDING");
   expect(statsUi).toContain("level + classModifier + dmModifier + itemModifier");
 });
 
-test("Gestión de Jugadores es el lugar que edita scores proficiency art y modificadores DM", () => {
+test("Gestión de Jugadores sigue editando el modelo D&D que consume el mock", () => {
   expect(dmPage).toContain('data-tab="dashboard-jugadores"');
   expect(dmPage).toContain('id="dashboard-jugadores"');
-  expect(dmPage).toContain("Gestión de Jugadores");
   expect(dmDnd).toContain('const PLAYERS_ROOT = "campaña/jugadores"');
   expect(dmDnd).toContain('field("dashboard-jugadores")');
-  expect(dmDnd).toContain('field("grid-jugadores")');
   for (const id of ["str", "dex", "con", "int", "wis", "cha"]) {
     expect(dmDnd).toContain(`dm-player-stat-${id}`);
     expect(dmDnd).toContain(`dm-player-prof-${id}`);
@@ -83,18 +108,10 @@ test("Gestión de Jugadores es el lugar que edita scores proficiency art y modif
   expect(dmDnd).toContain("updates.sheetArt");
   expect(dmDnd).toContain('updates["combatLevels/offensive/dmModifier"]');
   expect(dmDnd).toContain('updates["combatLevels/defensive/dmModifier"]');
+  expect(dmDndCss).toContain("#dm-player-dnd-studio");
 });
 
-test("Clase e Items quedan como fuentes separadas y Resistencias reservadas para Equipamiento", () => {
-  expect(dmDnd).toContain("classModifier");
-  expect(dmDnd).toContain("itemModifier");
-  expect(dmDnd).toContain("equipmentModifiers");
-  expect(dmDnd).toContain("classModifiers");
-  expect(dmDnd).toContain("RESISTENCIAS:");
-  expect(dmDnd).toContain("reservadas para Equipamiento");
-});
-
-test("utils carga los dos módulos solo en sus superficies correspondientes", () => {
+test("utils carga el mock solo en la hoja de jugador y el editor solo en Gestión de Jugadores", () => {
   expect(utils).toContain("function ensurePlayerStatsAbilityBarAssets");
   expect(utils).toContain("css/player-stats-ability-bar.css");
   expect(utils).toContain("js/player-stats-ability-bar.js");
@@ -102,14 +119,15 @@ test("utils carga los dos módulos solo en sus superficies correspondientes", ()
   expect(utils).toContain("#dashboard-jugadores");
   expect(utils).toContain("css/dm-player-dnd-studio.css");
   expect(utils).toContain("js/dm-player-dnd-studio.js");
-  expect(dmDndCss).toContain("#dm-player-dnd-studio");
 });
 
-test("la barra soporta teclado y layouts móviles", () => {
+test("el mock conserva teclado y una adaptación móvil funcional", () => {
   expect(statsUi).toContain('event.key === "ArrowRight"');
   expect(statsUi).toContain('event.key === "ArrowLeft"');
   expect(statsUi).toContain('event.key === "Home"');
   expect(statsUi).toContain('event.key === "End"');
-  expect(statsCss).toContain("@media (max-width:800px)");
+  expect(statsCss).toContain("@media (max-width:860px)");
   expect(statsCss).toContain("grid-template-columns:repeat(3,minmax(0,1fr))");
+  expect(statsCss).toContain("@media (max-width:560px)");
+  expect(statsCss).toContain("grid-template-columns:1fr");
 });


### PR DESCRIPTION
## Qué cambia

Este PR toma el mock visual entregado para **Stats** y lo integra sobre el sistema D&D que ya quedó en `main` tras el PR #528.

### Layout

- Convierte el modal de Stats en un HUD de dos paneles inspirado directamente en el mock:
  - art grande del jugador a la izquierda;
  - información D&D a la derecha;
  - marco, degradados, tipografía serif y acentos dorados del mock;
  - barra horizontal `STR / DEX / CON / INT / WIS / CHA`;
  - panel de detalle con Score, Modifier, Saving Throw y Skills.
- El botón de cerrar adopta el lenguaje visual del menú lateral del mock sin añadir botones muertos.
- En móvil el layout se apila y la barra de atributos pasa a 3 columnas.

### Datos reales, no valores del ejemplo

El HUD se alimenta de `datosJugador`:

- nombre e icono del personaje;
- Player Art asignado por el DM;
- HP actual / máximo;
- Level y progreso XP;
- Proficiency (`ceil(Level / 20)`);
- Offensive Level;
- Defensive Level;
- SP para mostrar la probabilidad actual de cara del Coin Engine.

Las resistencias no reciben números falsos: el área queda marcada como `EQUIPMENT · PENDING` hasta que Equipamiento sea su fuente real.

### Abilities y Proficiency

Se conservan los cuatro estados definidos en el sistema:

- Not Proficient: `Proficiency × 0`
- Half Proficient: `floor(Proficiency × 0.5)`
- Proficient: `Proficiency × 1`
- Expertise: `Proficiency × 2`

Se representan con círculo vacío, medio lleno, lleno y doble anillo.

El `Saving Throw` mostrado para el atributo seleccionado es:

`Ability Modifier + Ability Proficiency Contribution`

### Skills D&D

El detalle incluye las skills estándar asociadas a cada ability (Athletics, Acrobatics, Stealth, Arcana, Perception, Persuasion, etc.).

El renderer ya acepta proficiency específica de skill desde `skillProficiency`, `skillProficiencies`, `dndSkillProficiency` o `dndSkills[skill].proficiency` cuando esa información exista. Si no existe todavía, la skill se muestra como Not Proficient y su valor parte del modificador del atributo.

### Coin Engine

No se crea un motor nuevo. El bloque central de `SCORE` funciona como botón de tirada y continúa usando `act_roll_skill_<ability>` y el Coin Engine existente.

La contribución de Proficiency se suma al resultado como ya hacía la integración anterior; se mantienen las 5 monedas y el `+4` por cara.

### Alcance

Solo modifica:

- `js/player-stats-ability-bar.js`
- `css/player-stats-ability-bar.css`
- `tests/player_stats_ability_bar.spec.js`

No modifica Gestión de Jugadores, Theatre, Combate ni el motor base de tiradas.

## Validación

- `node --check` correcto para el JS del HUD.
- `node --check` correcto para la spec actualizada.
- Rama basada directamente en el `main` actual: 1 commit, 0 commits detrás.
