### PR TITLE
Hotfix: evita loop del editor D&D en DM

### DIFF
--- a/js/dm-player-dnd-studio-hotfix.js
+++ b/js/dm-player-dnd-studio-hotfix.js
@@ -1,0 +1,29 @@
+(function (global) {
+  "use strict";
+
+  if (!global?.Node || global.LuminousDmPlayerDndObserverHotfix) return;
+
+  const descriptor = Object.getOwnPropertyDescriptor(global.Node.prototype, "textContent");
+  if (!descriptor?.get || !descriptor?.set) return;
+
+  Object.defineProperty(global.Node.prototype, "textContent", {
+    configurable: descriptor.configurable,
+    enumerable: descriptor.enumerable,
+    get: descriptor.get,
+    set(value) {
+      const nextValue = value == null ? "" : String(value);
+      const isDndLegacyButton =
+        this?.nodeType === 1 &&
+        this?.matches?.("#grid-jugadores .btn-open-modal") &&
+        this?.dataset?.dndStudioProxy === "true";
+
+      if (isDndLegacyButton && descriptor.get.call(this) === nextValue) {
+        return;
+      }
+
+      descriptor.set.call(this, value);
+    },
+  });
+
+  global.LuminousDmPlayerDndObserverHotfix = true;
+})(window);

--- a/js/utils.js
+++ b/js/utils.js
@@ -108,8 +108,9 @@ function ensureDmPlayerDndStudioAssets(doc) {
     const documentRef = doc || (typeof document !== 'undefined' ? document : null);
     if (!documentRef?.querySelector?.('#dashboard-jugadores')) return null;
     const link = ensureStyleAsset(documentRef, 'dm-player-dnd-studio-stylesheet', 'css/dm-player-dnd-studio.css', { ui: 'dm-player-dnd-studio' });
+    const guard = ensureScriptAsset(documentRef, 'dm-player-dnd-studio-hotfix-script', 'js/dm-player-dnd-studio-hotfix.js', { ui: 'dm-player-dnd-hotfix' });
     const script = ensureScriptAsset(documentRef, 'dm-player-dnd-studio-script', 'js/dm-player-dnd-studio.js', { ui: 'dm-player-dnd-studio' });
-    return { link, script };
+    return { link, guard, script };
 }
 
 function ensurePlayerTheatreLanguagePolicy(doc) {


### PR DESCRIPTION
## Problema

Después de mergear #530, la página de DM puede congelarse/crashear al cargar Gestión de Jugadores.

La causa es un ciclo de mutaciones en `#grid-jugadores`: el `MutationObserver` del takeover D&D reescribe `button.textContent` y esa misma escritura vuelve a disparar el observer de forma repetida.

## Hotfix

- Añade un guard previo específico para `#grid-jugadores .btn-open-modal`.
- Si el botón ya contiene exactamente el texto D&D objetivo, la reasignación idéntica de `textContent` se ignora y no genera otra mutación.
- El guard se carga antes de `dm-player-dnd-studio.js` desde `js/utils.js`.
- No se desactiva ni revierte el editor D&D, XP, Skills, Stats ni Coin Engine.

## Alcance

Solo 2 archivos respecto a `main`:
- `js/dm-player-dnd-studio-hotfix.js`
- `js/utils.js`

La rama está 0 commits detrás de `main`.