### PR TITLE
Hotfix: encuadre configurable y visor completo del splash art

### DIFF
--- a/css/player-splash-framing.css
+++ b/css/player-splash-framing.css
@@ -1,0 +1,66 @@
+/* PLAYER SPLASH ART FRAMING HOTFIX */
+
+/* DM framing editor */
+#dm-player-dnd-studio .dm-player-dnd-art-row.splash-framing-active{grid-template-columns:1fr}
+#dm-player-dnd-studio .dm-player-dnd-art-row.splash-framing-active .dm-player-dnd-art-preview{display:none!important}
+#dm-player-dnd-studio .dm-player-splash-framing{display:grid;grid-template-columns:minmax(250px,.8fr) minmax(300px,1.2fr);gap:16px;margin-top:10px;padding:12px;background:linear-gradient(145deg,#080a08,#0d100c);border:1px solid #3b4036;border-left:2px solid #a37c35}
+#dm-player-dnd-studio .dm-player-splash-preview-shell{display:flex;align-items:center;justify-content:center;min-width:0;padding:8px;background:#050605;border:1px solid #292d27}
+#dm-player-dnd-studio .dm-player-splash-preview{position:relative;width:min(100%,390px);aspect-ratio:7/8;overflow:hidden;background:radial-gradient(circle at 50% 42%,rgba(196,154,0,.08),transparent 38%),#030403;border:1px solid #50442e;box-shadow:inset 0 0 24px #000}
+#dm-player-dnd-studio .dm-player-splash-preview img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;transition:transform .16s ease,object-position .16s ease}
+#dm-player-dnd-studio .dm-player-splash-preview img[hidden]{display:none!important}
+#dm-player-dnd-studio .dm-player-splash-preview-empty{position:absolute;inset:0;display:grid;place-items:center;color:#68685f;font-size:9px;letter-spacing:.12em}
+#dm-player-dnd-studio .dm-player-splash-crop-label{position:absolute;z-index:3;left:9px;bottom:8px;padding:4px 7px;color:#d7bc7d;background:rgba(8,8,6,.82);border-left:2px solid #b98a3c;font-size:7px;letter-spacing:.12em}
+#dm-player-dnd-studio .dm-player-splash-controls{display:flex;flex-direction:column;gap:11px;min-width:0;padding:10px}
+#dm-player-dnd-studio .dm-player-splash-controls header{display:flex;align-items:flex-end;justify-content:space-between;gap:12px;padding-bottom:8px;border-bottom:1px solid #33382f}
+#dm-player-dnd-studio .dm-player-splash-controls header span{color:#d8c49b;font-size:10px;font-weight:800;letter-spacing:.12em}
+#dm-player-dnd-studio .dm-player-splash-controls header b{color:#d8b65d;font-size:9px;white-space:nowrap}
+#dm-player-dnd-studio .dm-player-splash-controls p{margin:0;color:#74786e;font-size:8px;line-height:1.55}
+#dm-player-dnd-studio .dm-player-splash-control-grid{display:grid;grid-template-columns:150px minmax(180px,1fr);gap:14px;align-items:center}
+#dm-player-dnd-studio .dm-player-splash-pad{display:grid;grid-template-columns:repeat(3,42px);grid-template-rows:repeat(3,38px);gap:4px;justify-content:center}
+#dm-player-dnd-studio .dm-player-splash-pad button,#dm-player-dnd-studio .dm-player-splash-zoom button,#dm-player-dnd-studio .dm-player-splash-reset{color:#e6d8b8;background:#17140e;border:1px solid #65522f;cursor:pointer;font-family:"Share Tech Mono",monospace;transition:.15s}
+#dm-player-dnd-studio .dm-player-splash-pad button:hover,#dm-player-dnd-studio .dm-player-splash-zoom button:hover,#dm-player-dnd-studio .dm-player-splash-reset:hover{color:#ffd777;border-color:#c89a3e;background:#241d12;box-shadow:0 0 10px rgba(200,154,62,.15)}
+#dm-player-dnd-studio .dm-player-splash-pad [data-splash-nudge="up"]{grid-column:2;grid-row:1}
+#dm-player-dnd-studio .dm-player-splash-pad [data-splash-nudge="left"]{grid-column:1;grid-row:2}
+#dm-player-dnd-studio .dm-player-splash-pad [data-splash-center]{grid-column:2;grid-row:2;color:#d8b65d}
+#dm-player-dnd-studio .dm-player-splash-pad [data-splash-nudge="right"]{grid-column:3;grid-row:2}
+#dm-player-dnd-studio .dm-player-splash-pad [data-splash-nudge="down"]{grid-column:2;grid-row:3}
+#dm-player-dnd-studio .dm-player-splash-zoom{display:grid;gap:8px;color:#83877b;font-size:8px;letter-spacing:.1em}
+#dm-player-dnd-studio .dm-player-splash-zoom>div{display:grid;grid-template-columns:34px 1fr 34px;gap:7px;align-items:center}
+#dm-player-dnd-studio .dm-player-splash-zoom button{height:34px;font-size:18px}
+#dm-player-dnd-studio .dm-player-splash-zoom input{min-height:24px!important;padding:0!important;accent-color:#b98a3c}
+#dm-player-dnd-studio .dm-player-splash-reset{align-self:flex-start;min-height:34px;padding:7px 10px;font-size:8px;letter-spacing:.06em}
+
+/* Player cropped view */
+body:not(.on-game-dashboard) #stats-modal .player-stats-character-image{overflow:hidden}
+body:not(.on-game-dashboard) #stats-modal .player-stats-character-image img[data-player-sheet-art]{will-change:transform;transition:transform .18s ease,object-position .18s ease}
+body:not(.on-game-dashboard) #stats-modal .player-splash-expand{position:absolute;z-index:35;top:22px;right:24px;width:48px;height:48px;display:grid;place-items:center;padding:0;color:#e7d8b8;background:rgba(12,11,9,.82);border:2px solid #8e7448;border-radius:4px;box-shadow:0 4px 14px rgba(0,0,0,.65),inset 0 0 10px rgba(196,154,0,.08);cursor:pointer;font:700 25px/1 Georgia,"Times New Roman",serif;transition:.15s}
+body:not(.on-game-dashboard) #stats-modal .player-splash-expand:hover,body:not(.on-game-dashboard) #stats-modal .player-splash-expand:focus-visible{outline:0;color:#ffd777;border-color:#e0aa43;background:#211a10;transform:scale(1.05)}
+body:not(.on-game-dashboard) #stats-modal .player-splash-expand[hidden]{display:none!important}
+
+/* Full splash lightbox */
+.player-splash-lightbox[hidden]{display:none!important}
+.player-splash-lightbox{position:fixed;inset:0;z-index:300000;display:grid;place-items:center;padding:5vh 5vw;background:rgba(0,0,0,.94);backdrop-filter:blur(8px)}
+.player-splash-lightbox-stage{position:relative;width:min(92vw,1600px);height:min(86vh,900px);display:grid;place-items:center;overflow:hidden;background:radial-gradient(circle at 50% 50%,#181510,#050505 70%);border:1px solid #695334;box-shadow:0 24px 80px #000,inset 0 0 35px rgba(196,154,0,.05)}
+.player-splash-lightbox-stage img{display:block;max-width:100%;max-height:100%;width:auto;height:auto;object-fit:contain!important;object-position:center!important;transform:none!important;filter:none!important}
+.player-splash-lightbox-close{position:fixed;z-index:2;top:22px;right:28px;width:54px;height:54px;display:grid;place-items:center;padding:0;color:#eadabd;background:#17130d;border:2px solid #9e7b3f;cursor:pointer;font:36px/1 Georgia,"Times New Roman",serif}
+.player-splash-lightbox-close:hover,.player-splash-lightbox-close:focus-visible{outline:0;color:#ffd777;border-color:#e1ae4b;background:#241b0f}
+.player-splash-lightbox-caption{position:fixed;left:50%;bottom:18px;transform:translateX(-50%);color:#9d8d71;font:700 9px Arial,sans-serif;letter-spacing:.18em}
+body.player-splash-lightbox-open{overflow:hidden!important}
+
+@media(max-width:820px){
+  #dm-player-dnd-studio .dm-player-splash-framing{grid-template-columns:1fr}
+  #dm-player-dnd-studio .dm-player-splash-preview{width:min(100%,360px);aspect-ratio:7/8}
+}
+@media(max-width:560px){
+  #dm-player-dnd-studio .dm-player-splash-control-grid{grid-template-columns:1fr}
+  #dm-player-dnd-studio .dm-player-splash-controls header{align-items:flex-start;flex-direction:column}
+  body:not(.on-game-dashboard) #stats-modal .player-splash-expand{top:16px;right:16px;width:42px;height:42px}
+}
+@media(prefers-reduced-motion:reduce){
+  #dm-player-dnd-studio .dm-player-splash-preview img,
+  #dm-player-dnd-studio .dm-player-splash-pad button,
+  #dm-player-dnd-studio .dm-player-splash-zoom button,
+  #dm-player-dnd-studio .dm-player-splash-reset,
+  body:not(.on-game-dashboard) #stats-modal .player-stats-character-image img[data-player-sheet-art],
+  body:not(.on-game-dashboard) #stats-modal .player-splash-expand{transition:none}
+}

--- a/js/player-splash-framing.js
+++ b/js/player-splash-framing.js
@@ -1,0 +1,330 @@
+(function (global) {
+  "use strict";
+
+  const doc = global.document;
+  if (!doc) return;
+
+  const PLAYERS_ROOT = "campaña/jugadores";
+  const DEFAULT_FRAME = Object.freeze({ x: 50, y: 50, zoom: 1 });
+  const state = {
+    dmMounted: false,
+    dmPlayerId: "",
+    dmFrame: { ...DEFAULT_FRAME },
+    dmLoadToken: 0,
+    playerMounted: false,
+  };
+
+  const clamp = (value, min, max) => Math.min(max, Math.max(min, Number(value)));
+  const numberOr = (value, fallback) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+  function normalizeFrame(source) {
+    const raw = source || {};
+    return {
+      x: Math.round(clamp(numberOr(raw.x, DEFAULT_FRAME.x), 0, 100)),
+      y: Math.round(clamp(numberOr(raw.y, DEFAULT_FRAME.y), 0, 100)),
+      zoom: Math.round(clamp(numberOr(raw.zoom, DEFAULT_FRAME.zoom), 1, 2.5) * 100) / 100,
+    };
+  }
+
+  function frameFromPlayer(player) {
+    return normalizeFrame(
+      player?.sheetArtFraming ||
+      player?.playerSheetArtFraming ||
+      player?.sheetArtCrop ||
+      DEFAULT_FRAME
+    );
+  }
+
+  function currentPlayerData() {
+    return global.datosJugador || {};
+  }
+
+  function playerSheetArt(data = currentPlayerData()) {
+    return String(data?.sheetArt || data?.playerSheetArt || "").trim();
+  }
+
+  function applyFrame(image, frame) {
+    if (!image) return;
+    const normalized = normalizeFrame(frame);
+    image.style.objectPosition = `${normalized.x}% ${normalized.y}%`;
+    image.style.transformOrigin = `${normalized.x}% ${normalized.y}%`;
+    image.style.transform = `scale(${normalized.zoom})`;
+  }
+
+  function markDmDirty() {
+    const feedback = doc.getElementById("dm-player-dnd-feedback");
+    if (feedback && !/GUARDANDO|GUARDADOS|ERROR/.test(feedback.textContent || "")) {
+      feedback.textContent = "CAMBIOS SIN GUARDAR";
+    }
+  }
+
+  function dmArtUrl() {
+    return String(doc.getElementById("dm-player-dnd-art")?.value || "").trim();
+  }
+
+  function syncDmPreview() {
+    const image = doc.querySelector("[data-dm-splash-framing-preview]");
+    const empty = doc.querySelector("[data-dm-splash-framing-empty]");
+    const copy = doc.querySelector("[data-dm-splash-framing-copy]");
+    const zoom = doc.querySelector("[data-dm-splash-zoom]");
+    if (!image || !empty || !copy) return;
+
+    const art = dmArtUrl();
+    if (art) {
+      if (image.getAttribute("src") !== art) image.src = art;
+      image.hidden = false;
+      empty.hidden = true;
+      image.onerror = () => {
+        image.hidden = true;
+        empty.hidden = false;
+      };
+    } else {
+      image.hidden = true;
+      image.removeAttribute("src");
+      empty.hidden = false;
+    }
+
+    applyFrame(image, state.dmFrame);
+    copy.textContent = `X ${state.dmFrame.x}% · Y ${state.dmFrame.y}% · ZOOM ${Math.round(state.dmFrame.zoom * 100)}%`;
+    if (zoom && doc.activeElement !== zoom) zoom.value = String(state.dmFrame.zoom);
+  }
+
+  function setDmFrame(next, dirty = true) {
+    state.dmFrame = normalizeFrame({ ...state.dmFrame, ...next });
+    syncDmPreview();
+    if (dirty) markDmDirty();
+  }
+
+  function nudgeDmFrame(direction) {
+    const step = 5;
+    if (direction === "up") setDmFrame({ y: state.dmFrame.y - step });
+    if (direction === "down") setDmFrame({ y: state.dmFrame.y + step });
+    if (direction === "left") setDmFrame({ x: state.dmFrame.x - step });
+    if (direction === "right") setDmFrame({ x: state.dmFrame.x + step });
+  }
+
+  function resetDmFrame() {
+    state.dmFrame = { ...DEFAULT_FRAME };
+    syncDmPreview();
+    markDmDirty();
+  }
+
+  async function loadDmFrame(playerId) {
+    const token = ++state.dmLoadToken;
+    state.dmPlayerId = playerId || "";
+    if (!playerId || !global.firebase?.database) {
+      state.dmFrame = { ...DEFAULT_FRAME };
+      syncDmPreview();
+      return;
+    }
+
+    try {
+      const snapshot = await global.firebase.database().ref(`${PLAYERS_ROOT}/${playerId}`).once("value");
+      if (token !== state.dmLoadToken) return;
+      const player = snapshot.val() || {};
+      state.dmFrame = frameFromPlayer(player);
+      syncDmPreview();
+    } catch (error) {
+      console.warn("No se pudo cargar el encuadre del splash art:", error);
+      state.dmFrame = { ...DEFAULT_FRAME };
+      syncDmPreview();
+    }
+  }
+
+  async function saveDmFrame() {
+    const playerId = String(doc.getElementById("dm-player-dnd-select")?.value || "");
+    if (!playerId || !global.firebase?.database) return false;
+    const frame = normalizeFrame(state.dmFrame);
+    try {
+      await global.firebase.database().ref(`${PLAYERS_ROOT}/${playerId}`).update({
+        "sheetArtFraming/x": frame.x,
+        "sheetArtFraming/y": frame.y,
+        "sheetArtFraming/zoom": frame.zoom,
+      });
+      return true;
+    } catch (error) {
+      console.error("No se pudo guardar el encuadre del splash art:", error);
+      return false;
+    }
+  }
+
+  function mountDmControls() {
+    if (state.dmMounted && doc.querySelector(".dm-player-splash-framing")) return true;
+    const editor = doc.getElementById("dm-player-dnd-editor");
+    const artRow = editor?.querySelector?.(".dm-player-dnd-art-row");
+    const artInput = doc.getElementById("dm-player-dnd-art");
+    if (!editor || !artRow || !artInput) return false;
+
+    artRow.classList.add("splash-framing-active");
+
+    const framing = doc.createElement("section");
+    framing.className = "dm-player-splash-framing";
+    framing.innerHTML = `
+      <div class="dm-player-splash-preview-shell">
+        <div class="dm-player-splash-preview" aria-label="Vista del recorte que verá el jugador">
+          <img data-dm-splash-framing-preview alt="Previsualización del encuadre del splash art" hidden>
+          <div class="dm-player-splash-preview-empty" data-dm-splash-framing-empty>SIN SPLASH ART</div>
+          <span class="dm-player-splash-crop-label">PLAYER VIEW · CROP</span>
+        </div>
+      </div>
+      <div class="dm-player-splash-controls">
+        <header><span>SPLASH ART · ENCUADRE</span><b data-dm-splash-framing-copy>X 50% · Y 50% · ZOOM 100%</b></header>
+        <p>Mueve la ventana del splash sin modificar la imagen original. El botón ⛶ del jugador muestra el arte completo.</p>
+        <div class="dm-player-splash-control-grid">
+          <div class="dm-player-splash-pad" aria-label="Mover encuadre">
+            <button type="button" data-splash-nudge="up" aria-label="Mover arriba">↑</button>
+            <button type="button" data-splash-nudge="left" aria-label="Mover izquierda">←</button>
+            <button type="button" data-splash-center aria-label="Centrar encuadre">●</button>
+            <button type="button" data-splash-nudge="right" aria-label="Mover derecha">→</button>
+            <button type="button" data-splash-nudge="down" aria-label="Mover abajo">↓</button>
+          </div>
+          <label class="dm-player-splash-zoom">
+            <span>ZOOM</span>
+            <div><button type="button" data-splash-zoom-step="-0.05" aria-label="Alejar">−</button><input data-dm-splash-zoom type="range" min="1" max="2.5" step="0.05" value="1"><button type="button" data-splash-zoom-step="0.05" aria-label="Acercar">+</button></div>
+          </label>
+        </div>
+        <button type="button" class="dm-player-splash-reset" data-splash-reset>RESTABLECER · 50 / 50 / 100%</button>
+      </div>`;
+
+    artRow.insertAdjacentElement("afterend", framing);
+
+    framing.querySelectorAll("[data-splash-nudge]").forEach((button) => {
+      button.addEventListener("click", () => nudgeDmFrame(button.dataset.splashNudge));
+    });
+    framing.querySelector("[data-splash-center]")?.addEventListener("click", () => {
+      setDmFrame({ x: 50, y: 50 });
+    });
+    framing.querySelector("[data-splash-reset]")?.addEventListener("click", resetDmFrame);
+    framing.querySelectorAll("[data-splash-zoom-step]").forEach((button) => {
+      button.addEventListener("click", () => {
+        setDmFrame({ zoom: state.dmFrame.zoom + numberOr(button.dataset.splashZoomStep, 0) });
+      });
+    });
+    framing.querySelector("[data-dm-splash-zoom]")?.addEventListener("input", (event) => {
+      setDmFrame({ zoom: numberOr(event.target.value, 1) });
+    });
+    artInput.addEventListener("input", syncDmPreview);
+
+    const select = doc.getElementById("dm-player-dnd-select");
+    select?.addEventListener("change", () => loadDmFrame(select.value));
+    doc.getElementById("dm-player-dnd-save")?.addEventListener("click", () => {
+      void saveDmFrame();
+    });
+
+    state.dmMounted = true;
+    state.dmPlayerId = String(select?.value || "");
+    void loadDmFrame(state.dmPlayerId);
+    syncDmPreview();
+    return true;
+  }
+
+  function ensureLightbox() {
+    let overlay = doc.getElementById("player-splash-lightbox");
+    if (overlay) return overlay;
+
+    overlay = doc.createElement("div");
+    overlay.id = "player-splash-lightbox";
+    overlay.className = "player-splash-lightbox";
+    overlay.hidden = true;
+    overlay.setAttribute("role", "dialog");
+    overlay.setAttribute("aria-modal", "true");
+    overlay.setAttribute("aria-label", "Splash art completo");
+    overlay.innerHTML = `
+      <button type="button" class="player-splash-lightbox-close" data-player-splash-close aria-label="Cerrar splash art">×</button>
+      <div class="player-splash-lightbox-stage">
+        <img data-player-splash-full alt="Splash art completo del jugador">
+      </div>
+      <span class="player-splash-lightbox-caption">SPLASH ART · FULL VIEW</span>`;
+
+    doc.body.appendChild(overlay);
+    overlay.addEventListener("click", (event) => {
+      if (event.target === overlay || event.target.closest?.("[data-player-splash-close]")) closeLightbox();
+    });
+    doc.addEventListener("keydown", (event) => {
+      if (event.key === "Escape" && !overlay.hidden) closeLightbox();
+    });
+    return overlay;
+  }
+
+  function openLightbox() {
+    const art = playerSheetArt();
+    if (!art) return;
+    const overlay = ensureLightbox();
+    const image = overlay.querySelector("[data-player-splash-full]");
+    if (image) image.src = art;
+    overlay.hidden = false;
+    doc.body.classList.add("player-splash-lightbox-open");
+    overlay.querySelector("[data-player-splash-close]")?.focus?.();
+  }
+
+  function closeLightbox() {
+    const overlay = doc.getElementById("player-splash-lightbox");
+    if (!overlay) return;
+    overlay.hidden = true;
+    doc.body.classList.remove("player-splash-lightbox-open");
+  }
+
+  function syncPlayerFrame() {
+    const panel = doc.querySelector("#stats-modal .player-ability-console");
+    if (!panel) return false;
+    const image = panel.querySelector("[data-player-sheet-art]");
+    if (!image) return false;
+
+    const data = currentPlayerData();
+    const frame = frameFromPlayer(data);
+    applyFrame(image, frame);
+
+    let expand = panel.querySelector("[data-player-splash-expand]");
+    if (!expand) {
+      const artPanel = panel.querySelector(".player-stats-character-panel");
+      if (!artPanel) return false;
+      expand = doc.createElement("button");
+      expand.type = "button";
+      expand.className = "player-splash-expand";
+      expand.dataset.playerSplashExpand = "true";
+      expand.setAttribute("aria-label", "Ver splash art completo");
+      expand.title = "Ver splash art completo";
+      expand.textContent = "⛶";
+      expand.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        openLightbox();
+      });
+      artPanel.appendChild(expand);
+    }
+
+    expand.hidden = !playerSheetArt(data);
+    return true;
+  }
+
+  function boot() {
+    const tick = () => {
+      if (doc.getElementById("dashboard-jugadores")) {
+        mountDmControls();
+        const selected = String(doc.getElementById("dm-player-dnd-select")?.value || "");
+        if (selected !== state.dmPlayerId) void loadDmFrame(selected);
+        if (state.dmMounted) syncDmPreview();
+      }
+
+      if (doc.querySelector(".sheet-phone-wrapper")) {
+        state.playerMounted = syncPlayerFrame() || state.playerMounted;
+      }
+    };
+
+    tick();
+    global.setInterval(tick, 500);
+  }
+
+  if (doc.readyState === "loading") doc.addEventListener("DOMContentLoaded", boot, { once: true });
+  else boot();
+
+  global.LuminousPlayerSplashFraming = Object.freeze({
+    DEFAULT_FRAME,
+    normalizeFrame,
+    frameFromPlayer,
+    applyFrame,
+    openLightbox,
+    closeLightbox,
+    syncPlayerFrame,
+  });
+})(window);

--- a/js/utils.js
+++ b/js/utils.js
@@ -113,6 +113,16 @@ function ensureDmPlayerDndStudioAssets(doc) {
     return { link, guard, script };
 }
 
+function ensurePlayerSplashFramingAssets(doc) {
+    const documentRef = doc || (typeof document !== 'undefined' ? document : null);
+    const isPlayer = documentRef?.querySelector?.('.sheet-phone-wrapper');
+    const isDm = documentRef?.querySelector?.('#dashboard-jugadores');
+    if (!isPlayer && !isDm) return null;
+    const link = ensureStyleAsset(documentRef, 'player-splash-framing-stylesheet', 'css/player-splash-framing.css', { ui: 'player-splash-framing' });
+    const script = ensureScriptAsset(documentRef, 'player-splash-framing-script', 'js/player-splash-framing.js', { ui: 'player-splash-framing' });
+    return { link, script };
+}
+
 function ensurePlayerTheatreLanguagePolicy(doc) {
     const documentRef = doc || (typeof document !== 'undefined' ? document : null);
     if (!documentRef?.querySelector?.('.sheet-phone-wrapper')) return null;
@@ -190,6 +200,7 @@ if (typeof document !== 'undefined') {
     ensurePlayerUxPolishAssets(document);
     ensurePlayerStatsAbilityBarAssets(document);
     ensureDmPlayerDndStudioAssets(document);
+    ensurePlayerSplashFramingAssets(document);
     ensurePlayerTheatreLanguagePolicy(document);
     ensureDmCharacterManagerAssets(document);
 }
@@ -203,6 +214,7 @@ if (typeof module !== 'undefined' && module.exports) {
         ensurePlayerUxPolishAssets,
         ensurePlayerStatsAbilityBarAssets,
         ensureDmPlayerDndStudioAssets,
+        ensurePlayerSplashFramingAssets,
         ensurePlayerTheatreLanguagePolicy,
         ensureDmCharacterManagerAssets
     };


### PR DESCRIPTION
## Qué añade

Este hotfix mantiene el tamaño actual del splash art en el HUD, pero permite al DM decidir qué parte de la imagen 16:9 queda visible normalmente.

### Gestión de Jugadores

- Control de encuadre del splash por jugador.
- Flechas para mover el foco X/Y en pasos de 5%.
- Botón central para recentrar.
- Zoom entre 100% y 250%.
- Botones - / + y slider de zoom.
- Vista previa inmediata con una proporción similar al viewport real del HUD.
- Botón para restaurar 50% / 50% / 100%.
- Persistencia en `sheetArtFraming/x`, `sheetArtFraming/y` y `sheetArtFraming/zoom`.

### HUD del jugador

- Se aplica el encuadre configurado por el DM al splash actual.
- Se añade botón `⛶` sobre el splash.
- Al pulsarlo se abre el splash completo, sin crop ni zoom, usando `object-fit: contain`.
- El visor puede cerrarse con `×`, clic fuera o `Esc`.

## Alcance

Solo 3 archivos respecto a `main`:
- `js/player-splash-framing.js`
- `css/player-splash-framing.css`
- `js/utils.js`

No modifica Coin Engine, Stats, Skills ni cálculos de combate.