### PR TITLE
Feat: Weather Director visual con SVG, estaciones y HUD de jugador

### DIFF
--- a/Assets/Images/Weather/weather-icons.svg
+++ b/Assets/Images/Weather/weather-icons.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <style>.w{fill:none;stroke:currentColor;stroke-width:3;stroke-linecap:round;stroke-linejoin:round}</style>
+
+    <symbol id="sun" viewBox="0 0 64 64">
+      <circle class="w" cx="32" cy="32" r="11"/>
+      <path class="w" d="M32 6v8M32 50v8M6 32h8M50 32h8M13.6 13.6l5.7 5.7M44.7 44.7l5.7 5.7M50.4 13.6l-5.7 5.7M19.3 44.7l-5.7 5.7"/>
+    </symbol>
+
+    <symbol id="cloudy" viewBox="0 0 64 64">
+      <path class="w" d="M18 47h28a10 10 0 0 0 1.5-19.9A16 16 0 0 0 17 24.5 11.5 11.5 0 0 0 18 47Z"/>
+    </symbol>
+
+    <symbol id="partly-cloudy" viewBox="0 0 64 64">
+      <circle class="w" cx="23" cy="22" r="9"/>
+      <path class="w" d="M23 5v5M8 22h5M12.5 11.5l3.5 3.5M33.5 11.5 30 15"/>
+      <path class="w" d="M20 49h28a9 9 0 0 0 1.1-17.9A14 14 0 0 0 22 29a10 10 0 0 0-2 20Z"/>
+    </symbol>
+
+    <symbol id="drizzle" viewBox="0 0 64 64">
+      <path class="w" d="M16 38h31a9 9 0 0 0 .8-17.9A15 15 0 0 0 19 18.5 10.5 10.5 0 0 0 16 38Z"/>
+      <path class="w" d="M22 46v5M32 44v5M42 46v5"/>
+    </symbol>
+
+    <symbol id="rain" viewBox="0 0 64 64">
+      <path class="w" d="M16 37h31a9 9 0 0 0 .8-17.9A15 15 0 0 0 19 17.5 10.5 10.5 0 0 0 16 37Z"/>
+      <path class="w" d="m22 44-3 8M33 44l-3 8M44 44l-3 8"/>
+    </symbol>
+
+    <symbol id="storm" viewBox="0 0 64 64">
+      <path class="w" d="M16 35h31a9 9 0 0 0 .8-17.9A15 15 0 0 0 19 15.5 10.5 10.5 0 0 0 16 35Z"/>
+      <path class="w" d="M32 39h9l-7 8h6L27 59l4-9h-7Z"/>
+    </symbol>
+
+    <symbol id="fog" viewBox="0 0 64 64">
+      <path class="w" d="M17 33h30a8.5 8.5 0 0 0 .7-16.9A14 14 0 0 0 20 15a10 10 0 0 0-3 18Z"/>
+      <path class="w" d="M12 42h40M17 49h30M22 56h20"/>
+    </symbol>
+
+    <symbol id="snow" viewBox="0 0 64 64">
+      <path class="w" d="M16 35h31a9 9 0 0 0 .8-17.9A15 15 0 0 0 19 15.5 10.5 10.5 0 0 0 16 35Z"/>
+      <path class="w" d="M23 43v10M18.7 45.5l8.6 5M27.3 45.5l-8.6 5M41 43v10M36.7 45.5l8.6 5M45.3 45.5l-8.6 5"/>
+    </symbol>
+
+    <symbol id="snow-heavy" viewBox="0 0 64 64">
+      <path class="w" d="M14 32h34a9 9 0 0 0 .5-18A16 16 0 0 0 18 13 11 11 0 0 0 14 32Z"/>
+      <path class="w" d="M18 39v9M14.1 41.2l7.8 4.6M21.9 41.2l-7.8 4.6M32 38v11M27.2 40.7l9.6 5.6M36.8 40.7l-9.6 5.6M47 39v9M43.1 41.2l7.8 4.6M50.9 41.2l-7.8 4.6"/>
+    </symbol>
+
+    <symbol id="hail" viewBox="0 0 64 64">
+      <path class="w" d="M16 35h31a9 9 0 0 0 .8-17.9A15 15 0 0 0 19 15.5 10.5 10.5 0 0 0 16 35Z"/>
+      <circle class="w" cx="21" cy="47" r="2.5"/><circle class="w" cx="33" cy="44" r="2.5"/><circle class="w" cx="44" cy="49" r="2.5"/><circle class="w" cx="30" cy="55" r="2.5"/>
+    </symbol>
+
+    <symbol id="temperature" viewBox="0 0 64 64">
+      <path class="w" d="M28 12a6 6 0 0 1 12 0v27a12 12 0 1 1-12 0Z"/>
+      <path class="w" d="M34 18v27"/><circle class="w" cx="34" cy="48" r="5"/>
+    </symbol>
+
+    <symbol id="humidity" viewBox="0 0 64 64">
+      <path class="w" d="M32 7S16 27 16 39a16 16 0 0 0 32 0C48 27 32 7 32 7Z"/>
+      <path class="w" d="M24 40a9 9 0 0 0 9 9"/>
+    </symbol>
+
+    <symbol id="wind" viewBox="0 0 64 64">
+      <path class="w" d="M7 22h34c7 0 7-10 1-10-4 0-6 2-6 5M7 32h44c8 0 8 12 0 12-4 0-6-2-6-5M7 42h25"/>
+    </symbol>
+
+    <symbol id="visibility" viewBox="0 0 64 64">
+      <path class="w" d="M6 32s9-15 26-15 26 15 26 15-9 15-26 15S6 32 6 32Z"/>
+      <circle class="w" cx="32" cy="32" r="7"/>
+    </symbol>
+
+    <symbol id="spring" viewBox="0 0 64 64">
+      <path class="w" d="M32 55V28M32 38c-8-1-14-7-14-15 8 0 14 5 14 13M32 31c8-1 14-7 14-15-8 0-14 5-14 13"/>
+      <path class="w" d="M20 55h24"/>
+    </symbol>
+
+    <symbol id="summer" viewBox="0 0 64 64"><circle class="w" cx="32" cy="32" r="11"/><path class="w" d="M32 6v8M32 50v8M6 32h8M50 32h8M13.6 13.6l5.7 5.7M44.7 44.7l5.7 5.7M50.4 13.6l-5.7 5.7M19.3 44.7l-5.7 5.7"/></symbol>
+
+    <symbol id="autumn" viewBox="0 0 64 64">
+      <path class="w" d="M49 12C28 12 15 25 16 47c21 1 34-12 33-35Z"/>
+      <path class="w" d="M16 49c9-12 19-21 31-31M27 37l-1-10M34 31l10 1"/>
+    </symbol>
+
+    <symbol id="winter" viewBox="0 0 64 64">
+      <path class="w" d="M32 7v50M10.5 19.5l43 25M10.5 44.5l43-25M32 7l-5 6M32 7l5 6M32 57l-5-6M32 57l5-6M10.5 19.5l8 .5M10.5 19.5l3.5 7M53.5 44.5l-8-.5M53.5 44.5l-3.5-7"/>
+    </symbol>
+  </defs>
+</svg>

--- a/css/weather-director.css
+++ b/css/weather-director.css
@@ -1,0 +1,259 @@
+#tab-clima .weather-director {
+  --weather-cyan: #00d9f5;
+  --weather-gold: #c49a00;
+  --weather-red: #b83232;
+  --weather-panel: rgba(7, 10, 13, 0.96);
+  --weather-panel-2: rgba(13, 18, 23, 0.96);
+  width: min(1480px, 96vw);
+  margin: 18px auto 50px;
+  color: #ecf7fa;
+  font-family: "Share Tech Mono", monospace;
+}
+
+#tab-clima .weather-director *,
+#tab-clima .weather-director *::before,
+#tab-clima .weather-director *::after { box-sizing: border-box; }
+
+#tab-clima .weather-director__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  align-items: flex-end;
+  padding: 22px 26px;
+  border: 1px solid rgba(0, 217, 245, .48);
+  background:
+    linear-gradient(90deg, rgba(0, 217, 245, .08), transparent 42%),
+    #080b0e;
+  box-shadow: 0 0 22px rgba(0, 217, 245, .10), inset 0 -1px 0 rgba(196, 154, 0, .22);
+}
+
+#tab-clima .weather-kicker {
+  display: block;
+  color: #78929a;
+  letter-spacing: .18em;
+  font-size: 11px;
+  margin-bottom: 5px;
+}
+
+#tab-clima .weather-director__header h2 {
+  margin: 0;
+  font: 700 clamp(28px, 4vw, 48px)/.95 "BebasKai", "Share Tech Mono", sans-serif;
+  letter-spacing: .06em;
+  color: #f4fbfd;
+  text-shadow: 0 0 16px rgba(0, 217, 245, .18);
+}
+
+#tab-clima .weather-director__status { display: flex; gap: 12px; align-items: stretch; flex-wrap: wrap; justify-content: flex-end; }
+
+#tab-clima .weather-season-badge {
+  min-width: 150px;
+  padding: 10px 14px;
+  border-left: 3px solid var(--weather-gold);
+  background: rgba(196, 154, 0, .08);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+#tab-clima .weather-season-badge__label { color: #80765e; font-size: 9px; letter-spacing: .18em; }
+#tab-clima .weather-season-badge strong { color: #e2c35b; font-size: 16px; letter-spacing: .08em; }
+
+#tab-clima .weather-mode-switch { display: grid; grid-template-columns: 1fr 1fr; border: 1px solid #263840; background: #050708; }
+#tab-clima .weather-mode-switch button {
+  border: 0;
+  min-width: 88px;
+  padding: 11px 15px;
+  background: transparent;
+  color: #6f8187;
+  font: 700 12px "Share Tech Mono", monospace;
+  cursor: pointer;
+}
+#tab-clima .weather-mode-switch button + button { border-left: 1px solid #263840; }
+#tab-clima .weather-mode-switch button.is-active { color: #061113; background: var(--weather-cyan); box-shadow: 0 0 14px rgba(0,217,245,.35); }
+
+#tab-clima .weather-director__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(360px, .65fr);
+  gap: 16px;
+  margin-top: 16px;
+}
+
+#tab-clima .weather-graph-card,
+#tab-clima .weather-inspector-card,
+#tab-clima .weather-history-card,
+#tab-clima .weather-environment-editor {
+  border: 1px solid #263840;
+  background: var(--weather-panel);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.025);
+}
+
+#tab-clima .weather-card-head {
+  min-height: 46px;
+  padding: 11px 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid #202f35;
+  color: #9fc1ca;
+  letter-spacing: .08em;
+  font-size: 12px;
+}
+#tab-clima .weather-card-head > div { display: flex; align-items: center; gap: 9px; }
+#tab-clima .weather-card-index { color: var(--weather-gold); font-size: 10px; border-right: 1px solid #55491f; padding-right: 9px; }
+#tab-clima .weather-countdown { color: var(--weather-cyan); font-size: 11px; }
+
+#tab-clima .weather-graph {
+  position: relative;
+  min-height: 430px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at center, rgba(0,217,245,.08), transparent 34%),
+    linear-gradient(rgba(255,255,255,.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,.025) 1px, transparent 1px),
+    #06090b;
+  background-size: auto, 28px 28px, 28px 28px, auto;
+}
+
+#tab-clima #weather-graph-lines { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; }
+#tab-clima .weather-graph-line { stroke: rgba(196, 154, 0, .72); stroke-width: 1.6; stroke-dasharray: 8 7; filter: drop-shadow(0 0 3px rgba(196,154,0,.25)); }
+#tab-clima .weather-graph-probability {
+  fill: #f8e9ad;
+  font: 700 13px "Share Tech Mono", monospace;
+  text-anchor: middle;
+  dominant-baseline: central;
+  paint-order: stroke;
+  stroke: #06090b;
+  stroke-width: 5px;
+  stroke-linejoin: round;
+}
+#tab-clima .weather-graph__nodes { position: absolute; inset: 0; }
+
+#tab-clima .weather-node {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  width: 118px;
+  min-height: 78px;
+  padding: 8px 7px 7px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  border: 1px solid #3b4c52;
+  background: rgba(11,15,18,.96);
+  color: #d8e4e7;
+  font-family: inherit;
+  cursor: pointer;
+  clip-path: polygon(9% 0, 91% 0, 100% 16%, 100% 84%, 91% 100%, 9% 100%, 0 84%, 0 16%);
+  transition: transform .15s ease, border-color .15s ease, box-shadow .15s ease, background .15s ease;
+}
+#tab-clima .weather-node:hover,
+#tab-clima .weather-node.is-selected { transform: translate(-50%, -50%) scale(1.05); border-color: var(--weather-cyan); box-shadow: 0 0 16px rgba(0,217,245,.28); }
+#tab-clima .weather-node--current {
+  width: 148px;
+  min-height: 102px;
+  border: 2px solid var(--weather-cyan);
+  background: linear-gradient(145deg, rgba(0,217,245,.20), rgba(8,12,14,.98) 55%);
+  box-shadow: 0 0 26px rgba(0,217,245,.24);
+  z-index: 4;
+}
+#tab-clima .weather-node__icon { width: 30px; height: 30px; color: currentColor; fill: none; stroke: currentColor; }
+#tab-clima .weather-node--current .weather-node__icon { width: 39px; height: 39px; color: var(--weather-cyan); }
+#tab-clima .weather-node span { font-weight: 700; font-size: 11px; line-height: 1.05; text-align: center; }
+#tab-clima .weather-node small { color: var(--weather-gold); font-size: 9px; letter-spacing: .08em; }
+
+#tab-clima .weather-graph-legend {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+  padding: 10px 14px;
+  border-top: 1px solid #202f35;
+  color: #65777d;
+  font-size: 9px;
+  letter-spacing: .08em;
+}
+#tab-clima .weather-dot { width: 7px; height: 7px; display: inline-block; margin-right: 5px; }
+#tab-clima .weather-dot--current { background: var(--weather-cyan); box-shadow: 0 0 7px var(--weather-cyan); }
+#tab-clima .weather-dot--candidate { border: 1px solid var(--weather-gold); }
+
+#tab-clima .weather-inspector-card { background: linear-gradient(180deg, rgba(13,18,23,.98), rgba(6,9,11,.98)); }
+#tab-clima .weather-prob-badge { color: #061113; background: var(--weather-gold); padding: 4px 7px; font-size: 10px; font-weight: 800; }
+#tab-clima .weather-inspector-hero { display: grid; grid-template-columns: 88px 1fr; gap: 16px; padding: 20px 18px 14px; align-items: center; }
+#tab-clima .weather-inspector-icon { width: 88px; height: 88px; display: grid; place-items: center; border: 1px solid #2c444b; background: radial-gradient(circle, rgba(0,217,245,.10), transparent 68%); }
+#tab-clima .weather-inspector-icon__svg { width: 64px; height: 64px; fill: none; stroke: var(--weather-cyan); color: var(--weather-cyan); filter: drop-shadow(0 0 7px rgba(0,217,245,.32)); }
+#tab-clima .weather-inspector-state { color: var(--weather-gold); font-size: 9px; letter-spacing: .14em; }
+#tab-clima .weather-inspector-hero h3 { margin: 3px 0 5px; color: #fff; font: 700 25px "BebasKai", "Share Tech Mono", sans-serif; letter-spacing: .05em; }
+#tab-clima .weather-inspector-hero p { margin: 0; color: #71858c; font-size: 11px; line-height: 1.4; }
+
+#tab-clima .weather-metrics { padding: 4px 18px 14px; display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+#tab-clima .weather-metric { position: relative; min-height: 63px; padding: 9px 10px 13px; background: rgba(255,255,255,.025); border: 1px solid #1f3036; }
+#tab-clima .weather-metric--wide { grid-column: 1 / -1; }
+#tab-clima .weather-metric span { display: block; color: #5f737a; font-size: 8px; letter-spacing: .11em; }
+#tab-clima .weather-metric strong { display: block; margin-top: 3px; color: #e8f5f8; font-size: 15px; }
+#tab-clima .weather-metric i { position: absolute; left: 10px; right: 10px; bottom: 7px; height: 2px; background: #1d2a2f; overflow: hidden; }
+#tab-clima .weather-metric i b { display: block; width: 0; height: 100%; background: var(--weather-cyan); box-shadow: 0 0 6px rgba(0,217,245,.7); transition: width .3s ease; }
+
+#tab-clima .weather-transition-breakdown { margin: 0 18px 14px; padding: 11px 12px; border: 1px solid #29373c; background: #070a0c; }
+#tab-clima .weather-breakdown-title { color: var(--weather-gold); font-size: 9px; letter-spacing: .13em; margin-bottom: 8px; }
+#tab-clima .weather-breakdown-row,
+#tab-clima .weather-breakdown-final { display: flex; justify-content: space-between; gap: 10px; font-size: 10px; padding: 4px 0; color: #6d8187; }
+#tab-clima .weather-breakdown-row strong { color: #d7e5e8; }
+#tab-clima .weather-breakdown-reasons { display: flex; flex-wrap: wrap; gap: 4px; margin: 6px 0; }
+#tab-clima .weather-breakdown-reasons span { padding: 3px 5px; border: 1px solid #32454c; color: #8da0a6; font-size: 8px; }
+#tab-clima .weather-breakdown-final { border-top: 1px solid #24343a; margin-top: 7px; padding-top: 8px; }
+#tab-clima .weather-breakdown-final strong { color: var(--weather-cyan); font-size: 13px; }
+#tab-clima .weather-breakdown-empty { color: #5f7177; font-size: 9px; line-height: 1.5; }
+
+#tab-clima .weather-actions { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; padding: 0 18px 18px; }
+#tab-clima .weather-btn {
+  min-height: 38px;
+  padding: 9px 12px;
+  border: 1px solid #43565d;
+  background: #0c1215;
+  color: #b7c7cc;
+  font: 700 10px "Share Tech Mono", monospace;
+  letter-spacing: .06em;
+  cursor: pointer;
+}
+#tab-clima .weather-btn:hover:not(:disabled) { border-color: var(--weather-cyan); color: #fff; box-shadow: 0 0 11px rgba(0,217,245,.16); }
+#tab-clima .weather-btn--primary { border-color: var(--weather-cyan); color: var(--weather-cyan); background: rgba(0,217,245,.07); }
+#tab-clima .weather-btn:disabled { opacity: .35; cursor: default; }
+#tab-clima .weather-btn--compact { margin: 0 14px 14px auto; display: block; min-height: 32px; }
+
+#tab-clima .weather-director__lower { display: grid; grid-template-columns: 1.15fr .85fr; gap: 16px; margin-top: 16px; }
+#tab-clima .weather-environment-editor > summary { cursor: pointer; padding: 15px 16px; color: #8ea5ac; font-size: 11px; letter-spacing: .08em; border-bottom: 1px solid #202f35; list-style: none; }
+#tab-clima .weather-environment-editor > summary::-webkit-details-marker { display: none; }
+#tab-clima .weather-environment-editor > summary::after { content: "+"; float: right; color: var(--weather-cyan); }
+#tab-clima .weather-environment-editor[open] > summary::after { content: "−"; }
+#tab-clima .weather-env-grid { display: grid; grid-template-columns: repeat(5, minmax(110px, 1fr)); gap: 10px; padding: 14px; }
+#tab-clima .weather-env-grid label { display: grid; grid-template-columns: 1fr auto; gap: 6px; color: #61767d; font-size: 8px; letter-spacing: .08em; }
+#tab-clima .weather-env-grid input { grid-column: 1 / -1; width: 100%; accent-color: var(--weather-cyan); }
+#tab-clima .weather-env-grid output { color: #dff6fa; font-size: 10px; }
+
+#tab-clima .weather-history { min-height: 90px; padding: 10px 14px; display: grid; gap: 5px; }
+#tab-clima .weather-history-row { display: grid; grid-template-columns: 22px auto 1fr 22px auto auto; align-items: center; gap: 7px; min-height: 31px; border-bottom: 1px solid #18262b; color: #899da3; font-size: 9px; }
+#tab-clima .weather-history-row i { height: 1px; background: #33464d; }
+#tab-clima .weather-history-row strong { color: #dcecef; }
+#tab-clima .weather-history-row small { color: var(--weather-gold); font-size: 7px; }
+#tab-clima .weather-history-icon { width: 20px; height: 20px; fill: none; stroke: currentColor; }
+#tab-clima .weather-history-empty { color: #52666d; font-size: 9px; align-self: center; text-align: center; }
+
+@media (max-width: 980px) {
+  #tab-clima .weather-director__grid,
+  #tab-clima .weather-director__lower { grid-template-columns: 1fr; }
+  #tab-clima .weather-env-grid { grid-template-columns: repeat(2, minmax(120px, 1fr)); }
+  #tab-clima .weather-graph { min-height: 400px; }
+}
+
+@media (max-width: 620px) {
+  #tab-clima .weather-director__header { align-items: stretch; flex-direction: column; }
+  #tab-clima .weather-director__status { justify-content: stretch; }
+  #tab-clima .weather-season-badge, #tab-clima .weather-mode-switch { flex: 1; }
+  #tab-clima .weather-inspector-hero { grid-template-columns: 66px 1fr; }
+  #tab-clima .weather-inspector-icon { width: 66px; height: 66px; }
+  #tab-clima .weather-inspector-icon__svg { width: 48px; height: 48px; }
+  #tab-clima .weather-env-grid { grid-template-columns: 1fr; }
+  #tab-clima .weather-actions { grid-template-columns: 1fr; }
+}

--- a/css/weather-fx.css
+++ b/css/weather-fx.css
@@ -1,0 +1,94 @@
+#theatre-stage { position: relative; overflow: hidden; }
+.weather-fx-layer {
+  --weather-intensity: .5;
+  --weather-wind: .1;
+  --weather-visibility: 1;
+  position: absolute;
+  inset: 0;
+  z-index: 30;
+  overflow: hidden;
+  pointer-events: none;
+  isolation: isolate;
+}
+.weather-fx-layer > div { position: absolute; inset: 0; pointer-events: none; opacity: 0; }
+.weather-fx-darken { background: rgba(3,7,9, calc((1 - var(--weather-visibility)) * .38)); transition: opacity .5s ease; }
+.weather-fx-layer[data-weather="nublado"] .weather-fx-darken,
+.weather-fx-layer[data-weather="llovizna"] .weather-fx-darken,
+.weather-fx-layer[data-weather="lluvia"] .weather-fx-darken,
+.weather-fx-layer[data-weather="tormenta"] .weather-fx-darken,
+.weather-fx-layer[data-weather="niebla"] .weather-fx-darken,
+.weather-fx-layer[data-weather="nieve"] .weather-fx-darken,
+.weather-fx-layer[data-weather="nevada"] .weather-fx-darken { opacity: .8; }
+
+.weather-fx-rain {
+  background-image:
+    repeating-linear-gradient(calc(103deg + (var(--weather-wind) * 12deg)), transparent 0 11px, rgba(191,231,244,.42) 12px 13px, transparent 14px 22px),
+    repeating-linear-gradient(calc(101deg + (var(--weather-wind) * 10deg)), transparent 0 27px, rgba(162,213,231,.22) 28px 29px, transparent 30px 42px);
+  background-size: 90px 150px, 150px 220px;
+  transform: translateY(-35%);
+  animation: luminous-weather-rain .58s linear infinite;
+  filter: blur(.2px);
+}
+.weather-fx-layer[data-precipitation="rain"] .weather-fx-rain { opacity: calc(.18 + (var(--weather-intensity) * .70)); }
+.weather-fx-layer[data-weather="llovizna"] .weather-fx-rain { animation-duration: .95s; }
+.weather-fx-layer[data-weather="tormenta"] .weather-fx-rain { animation-duration: .42s; }
+@keyframes luminous-weather-rain { to { transform: translate(calc(-8% * var(--weather-wind)), 35%); background-position: 0 160px, 20px 230px; } }
+
+.weather-fx-fog {
+  inset: -20% !important;
+  background:
+    radial-gradient(ellipse at 20% 45%, rgba(202,220,220,.22), transparent 38%),
+    radial-gradient(ellipse at 70% 58%, rgba(196,213,216,.18), transparent 42%),
+    linear-gradient(90deg, transparent, rgba(190,209,211,.12), transparent);
+  filter: blur(18px);
+  animation: luminous-weather-fog 13s ease-in-out infinite alternate;
+}
+.weather-fx-layer[data-fog="true"] .weather-fx-fog { opacity: calc(.28 + (var(--weather-intensity) * .42)); }
+@keyframes luminous-weather-fog { from { transform: translateX(-5%) scale(1.03); } to { transform: translateX(7%) scale(1.1); } }
+
+.weather-fx-snow { overflow: hidden; }
+.weather-fx-snow i {
+  position: absolute;
+  top: -8%;
+  left: calc(var(--x) * 1%);
+  width: calc(var(--s) * 1px);
+  height: calc(var(--s) * 1px);
+  border-radius: 50%;
+  background: rgba(242,250,255,.9);
+  box-shadow: 0 0 4px rgba(255,255,255,.35);
+  animation: luminous-weather-snow calc(var(--d) * 1s) linear infinite;
+  animation-delay: calc(var(--i) * -.31s);
+}
+.weather-fx-layer[data-precipitation="snow"] .weather-fx-snow { opacity: calc(.25 + (var(--weather-intensity) * .72)); }
+@keyframes luminous-weather-snow { to { transform: translate(calc((12px + 34px * var(--weather-wind))), 118vh) rotate(240deg); } }
+
+.weather-fx-hail {
+  background-image: radial-gradient(circle, rgba(245,252,255,.72) 0 1.5px, transparent 2px);
+  background-size: 34px 52px;
+  animation: luminous-weather-hail .38s linear infinite;
+}
+.weather-fx-layer[data-hail="true"] .weather-fx-hail { opacity: calc(.2 + var(--weather-intensity) * .6); }
+@keyframes luminous-weather-hail { to { background-position: 8px 54px; } }
+
+.weather-fx-lightning { background: rgba(224,244,255,.85); mix-blend-mode: screen; }
+.weather-fx-layer[data-storm="true"] .weather-fx-lightning { animation: luminous-weather-lightning 6.7s steps(1,end) infinite; }
+@keyframes luminous-weather-lightning {
+  0%, 70%, 74%, 100% { opacity: 0; }
+  71% { opacity: .42; }
+  72% { opacity: .06; }
+  73% { opacity: .72; }
+}
+
+.weather-fx-heat {
+  inset: -3% !important;
+  background: repeating-linear-gradient(0deg, transparent 0 8px, rgba(255,210,130,.028) 9px 11px, transparent 12px 18px);
+  backdrop-filter: blur(.45px);
+  animation: luminous-weather-heat 2.8s ease-in-out infinite alternate;
+}
+.weather-fx-layer[data-heat="true"] .weather-fx-heat { opacity: calc(.16 + (var(--weather-intensity) * .28)); }
+@keyframes luminous-weather-heat { from { transform: translateY(-2px) skewX(-.4deg); } to { transform: translateY(3px) skewX(.5deg); } }
+
+@media (prefers-reduced-motion: reduce) {
+  .weather-fx-layer * { animation: none !important; }
+  .weather-fx-layer[data-storm="true"] .weather-fx-lightning { opacity: 0 !important; }
+}

--- a/css/weather-player.css
+++ b/css/weather-player.css
@@ -1,0 +1,79 @@
+.sheet-weather-widget.sheet-weather-widget--live {
+  padding: 0 !important;
+  overflow: hidden;
+  background: #070b0d !important;
+  border: 1px solid rgba(0, 217, 245, .42) !important;
+  box-shadow: inset 0 0 24px rgba(0,0,0,.55), 0 0 14px rgba(0,217,245,.08) !important;
+}
+
+.sheet-weather-widget--live .player-weather-live {
+  --pw-cyan: #00d9f5;
+  --pw-gold: #c49a00;
+  color: #eaf6f8;
+  font-family: "Share Tech Mono", monospace;
+  background:
+    linear-gradient(135deg, rgba(0,217,245,.055), transparent 42%),
+    #070b0d;
+}
+
+.sheet-weather-widget--live .player-weather-live__top {
+  min-height: 42px;
+  padding: 8px 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid #203138;
+}
+.sheet-weather-widget--live .player-weather-clock { display: flex; align-items: baseline; gap: 9px; min-width: 0; }
+.sheet-weather-widget--live .player-weather-clock strong { color: #fff; font-size: 20px; line-height: 1; }
+.sheet-weather-widget--live .player-weather-clock span { color: #60757d; font-size: 8px; letter-spacing: .08em; }
+.sheet-weather-widget--live .player-weather-network { color: #698087; font-size: 8px; letter-spacing: .09em; white-space: nowrap; }
+.sheet-weather-widget--live .player-weather-network i { display: inline-block; width: 6px; height: 6px; border-radius: 50%; margin-left: 5px; background: var(--pw-cyan); box-shadow: 0 0 7px var(--pw-cyan); }
+
+.sheet-weather-widget--live .player-weather-current {
+  display: grid;
+  grid-template-columns: 88px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  padding: 15px 14px 12px;
+}
+.sheet-weather-widget--live .player-weather-current__icon { width: 84px; height: 84px; display: grid; place-items: center; border: 1px solid #234047; background: radial-gradient(circle, rgba(0,217,245,.11), transparent 70%); }
+.sheet-weather-widget--live .player-weather-current__svg { width: 62px; height: 62px; fill: none; stroke: var(--pw-cyan); color: var(--pw-cyan); filter: drop-shadow(0 0 6px rgba(0,217,245,.3)); }
+.sheet-weather-widget--live .player-weather-current__main > span { color: var(--pw-gold); font-size: 8px; letter-spacing: .12em; }
+.sheet-weather-widget--live .player-weather-current__main h3 { margin: 2px 0 4px; color: #fff; font: 700 24px "BebasKai", "Share Tech Mono", sans-serif; letter-spacing: .04em; }
+.sheet-weather-widget--live .player-weather-current__main p { margin: 0; color: #71878e; font-size: 8px; letter-spacing: .06em; }
+.sheet-weather-widget--live .player-weather-temperature { color: #fff; font-size: 34px; font-weight: 400; align-self: start; }
+.sheet-weather-widget--live .player-weather-temperature small { color: var(--pw-cyan); font-size: 13px; vertical-align: top; }
+
+.sheet-weather-widget--live .player-weather-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-top: 1px solid #1c2c31;
+  border-bottom: 1px solid #1c2c31;
+}
+.sheet-weather-widget--live .player-weather-metrics > div { padding: 8px 9px; border-right: 1px solid #1c2c31; min-width: 0; }
+.sheet-weather-widget--live .player-weather-metrics > div:last-child { border-right: 0; }
+.sheet-weather-widget--live .player-weather-metrics span { display: block; color: #52686f; font-size: 7px; letter-spacing: .07em; }
+.sheet-weather-widget--live .player-weather-metrics strong { display: block; margin-top: 3px; color: #d7e8ec; font-size: 12px; white-space: nowrap; }
+.sheet-weather-widget--live .player-weather-metrics small { color: #70848a; font-size: 7px; }
+
+.sheet-weather-widget--live .player-weather-forecast-live { padding: 10px 12px 12px; }
+.sheet-weather-widget--live .player-weather-forecast-live__title { display: flex; justify-content: space-between; gap: 10px; color: #8aa0a7; font-size: 8px; letter-spacing: .07em; margin-bottom: 8px; }
+.sheet-weather-widget--live .player-weather-forecast-live__title small { color: #4f636a; }
+.sheet-weather-widget--live .player-weather-forecast-live__grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; }
+.sheet-weather-widget--live .player-weather-forecast-item { min-width: 0; min-height: 72px; padding: 7px; display: grid; grid-template-columns: 29px 1fr; grid-template-rows: auto auto auto; column-gap: 7px; align-items: center; background: rgba(255,255,255,.025); border: 1px solid #20343a; }
+.sheet-weather-widget--live .player-weather-forecast-item > span { grid-column: 1 / -1; color: var(--pw-gold); font-size: 7px; }
+.sheet-weather-widget--live .player-weather-forecast-icon { grid-row: 2 / 4; width: 28px; height: 28px; fill: none; stroke: #91b5bd; }
+.sheet-weather-widget--live .player-weather-forecast-item strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: #d8e8eb; font-size: 8px; }
+.sheet-weather-widget--live .player-weather-forecast-item small { color: #526a71; font-size: 6px; }
+.sheet-weather-widget--live .player-weather-forecast-empty { grid-column: 1 / -1; color: #52666d; font-size: 8px; text-align: center; padding: 14px; }
+
+@media (max-width: 680px) {
+  .sheet-weather-widget--live .player-weather-current { grid-template-columns: 62px minmax(0,1fr) auto; }
+  .sheet-weather-widget--live .player-weather-current__icon { width: 60px; height: 60px; }
+  .sheet-weather-widget--live .player-weather-current__svg { width: 44px; height: 44px; }
+  .sheet-weather-widget--live .player-weather-metrics { grid-template-columns: repeat(2, 1fr); }
+  .sheet-weather-widget--live .player-weather-metrics > div:nth-child(2) { border-right: 0; }
+  .sheet-weather-widget--live .player-weather-forecast-live__grid { grid-template-columns: 1fr; }
+}

--- a/database.rules.json
+++ b/database.rules.json
@@ -4,11 +4,29 @@
       // 1. CUALQUIERA CON CUENTA puede leer todo el juego (Calendario, Items, etc.)
       ".read": "auth != null",
 
-
       "estado_mundo": {
         ".write": "auth != null && auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1'"
       },
-"config": {
+
+      "clima": {
+        // Weather Director: todos los jugadores autenticados heredan lectura,
+        // pero solo el DM puede dirigir o alterar el estado meteorológico.
+        ".write": "auth != null && auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1'"
+      },
+
+      "worldData": {
+        "weatherForecast": {
+          // Compatibilidad con el widget/pronóstico legacy durante la migración.
+          ".write": "auth != null && auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1'"
+        }
+      },
+
+      "hora_actual": {
+        // El reloj legacy todavía sincroniza este valor junto con calendario.
+        ".write": "auth != null && auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1'"
+      },
+
+      "config": {
         // Solo el DM genera códigos
         ".write": "auth != null && auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1'"
       },

--- a/js/utils.js
+++ b/js/utils.js
@@ -131,6 +131,35 @@ function ensureTheatreModernIdentityHotfix(doc) {
     return ensureScriptAsset(documentRef, 'theatre-modern-identity-hotfix-script', 'js/theatre-modern-identity-hotfix.js', { engine: 'theatre-modern-identity-hotfix' });
 }
 
+function ensureWeatherSystemAssets(doc) {
+    const documentRef = doc || (typeof document !== 'undefined' ? document : null);
+    const isDirector = documentRef?.querySelector?.('#tab-clima');
+    const isPlayer = documentRef?.querySelector?.('.sheet-weather-widget');
+    const hasTheatre = documentRef?.querySelector?.('#theatre-stage, #theatre-view-player, #modulo-teatro');
+    if (!isDirector && !isPlayer && !hasTheatre) return null;
+
+    const engineSrc = isDirector ? 'js/weather-engine.js' : 'js/weather-readonly-engine.js';
+    const engine = ensureScriptAsset(documentRef, 'weather-engine-script', engineSrc, { engine: isDirector ? 'weather-director-engine' : 'weather-readonly' });
+    const assets = { engine };
+
+    if (isDirector) {
+        assets.directorStyle = ensureStyleAsset(documentRef, 'weather-director-stylesheet', 'css/weather-director.css', { ui: 'weather-director' });
+        assets.director = ensureScriptAsset(documentRef, 'weather-director-script', 'js/weather-director-ui.js', { ui: 'weather-director' });
+    }
+
+    if (isPlayer) {
+        assets.playerStyle = ensureStyleAsset(documentRef, 'weather-player-stylesheet', 'css/weather-player.css', { ui: 'weather-player' });
+        assets.player = ensureScriptAsset(documentRef, 'weather-player-script', 'js/weather-player-widget.js', { ui: 'weather-player' });
+    }
+
+    if (hasTheatre || isPlayer) {
+        assets.fxStyle = ensureStyleAsset(documentRef, 'weather-fx-stylesheet', 'css/weather-fx.css', { ui: 'weather-fx' });
+        assets.fx = ensureScriptAsset(documentRef, 'weather-fx-script', 'js/weather-fx.js', { ui: 'weather-fx' });
+    }
+
+    return assets;
+}
+
 function ensurePlayerTheatreLanguagePolicy(doc) {
     const documentRef = doc || (typeof document !== 'undefined' ? document : null);
     if (!documentRef?.querySelector?.('.sheet-phone-wrapper')) return null;
@@ -210,6 +239,7 @@ if (typeof document !== 'undefined') {
     ensureDmPlayerDndStudioAssets(document);
     ensurePlayerSplashFramingAssets(document);
     ensureTheatreModernIdentityHotfix(document);
+    ensureWeatherSystemAssets(document);
     ensurePlayerTheatreLanguagePolicy(document);
     ensureDmCharacterManagerAssets(document);
 }
@@ -225,6 +255,7 @@ if (typeof module !== 'undefined' && module.exports) {
         ensureDmPlayerDndStudioAssets,
         ensurePlayerSplashFramingAssets,
         ensureTheatreModernIdentityHotfix,
+        ensureWeatherSystemAssets,
         ensurePlayerTheatreLanguagePolicy,
         ensureDmCharacterManagerAssets
     };

--- a/js/weather-director-ui.js
+++ b/js/weather-director-ui.js
@@ -1,0 +1,404 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousWeatherDirectorUI) return;
+
+  const ICON_SPRITE = "Assets/Images/Weather/weather-icons.svg";
+  let engine = null;
+  let root = null;
+  let selectedWeather = null;
+  let currentState = null;
+  let unsubscribe = null;
+  let countdownTimer = null;
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
+  function iconSvg(weatherId, className) {
+    const def = engine.getDefinition(weatherId) || { icon: "sun", label: weatherId };
+    return `<svg class="${className || "weather-svg-icon"}" viewBox="0 0 64 64" aria-hidden="true"><use href="${ICON_SPRITE}#${def.icon}"></use></svg>`;
+  }
+
+  function weatherLabel(weatherId) {
+    return engine.getDefinition(weatherId)?.label || weatherId || "—";
+  }
+
+  function initialMarkup() {
+    return `
+      <section id="weather-director" class="weather-director" aria-label="Weather Director">
+        <header class="weather-director__header">
+          <div>
+            <span class="weather-kicker">LUMINOUS // WORLD ENVIRONMENT</span>
+            <h2>WEATHER DIRECTOR</h2>
+          </div>
+          <div class="weather-director__status">
+            <div class="weather-season-badge">
+              <span class="weather-season-badge__label">ESTACIÓN</span>
+              <strong id="weather-director-season">—</strong>
+            </div>
+            <div class="weather-mode-switch" role="group" aria-label="Modo climático">
+              <button type="button" data-weather-mode="auto">AUTO</button>
+              <button type="button" data-weather-mode="manual">MANUAL</button>
+            </div>
+          </div>
+        </header>
+
+        <div class="weather-director__grid">
+          <section class="weather-graph-card">
+            <div class="weather-card-head">
+              <div>
+                <span class="weather-card-index">01</span>
+                <strong>RED DE TRANSICIÓN</strong>
+              </div>
+              <span id="weather-next-change" class="weather-countdown">SIGUIENTE CAMBIO —</span>
+            </div>
+            <div id="weather-graph" class="weather-graph">
+              <svg id="weather-graph-lines" viewBox="0 0 560 430" preserveAspectRatio="none" aria-hidden="true"></svg>
+              <div id="weather-graph-nodes" class="weather-graph__nodes"></div>
+            </div>
+            <div class="weather-graph-legend">
+              <span><i class="weather-dot weather-dot--current"></i> ACTUAL</span>
+              <span><i class="weather-dot weather-dot--candidate"></i> POSIBLE</span>
+              <span>CLICK EN UN NODO PARA INSPECCIONAR</span>
+            </div>
+          </section>
+
+          <aside class="weather-inspector-card">
+            <div class="weather-card-head">
+              <div>
+                <span class="weather-card-index">02</span>
+                <strong>INSPECTOR ATMOSFÉRICO</strong>
+              </div>
+              <span id="weather-inspector-prob" class="weather-prob-badge">ACTUAL</span>
+            </div>
+
+            <div class="weather-inspector-hero">
+              <div id="weather-inspector-icon" class="weather-inspector-icon"></div>
+              <div>
+                <span id="weather-inspector-state" class="weather-inspector-state">—</span>
+                <h3 id="weather-inspector-name">—</h3>
+                <p id="weather-inspector-desc">—</p>
+              </div>
+            </div>
+
+            <div class="weather-metrics">
+              <div class="weather-metric"><span>TEMPERATURA</span><strong id="weather-metric-temperature">—</strong><i><b id="weather-bar-temperature"></b></i></div>
+              <div class="weather-metric"><span>HUMEDAD</span><strong id="weather-metric-humidity">—</strong><i><b id="weather-bar-humidity"></b></i></div>
+              <div class="weather-metric"><span>VIENTO</span><strong id="weather-metric-wind">—</strong><i><b id="weather-bar-wind"></b></i></div>
+              <div class="weather-metric"><span>VISIBILIDAD</span><strong id="weather-metric-visibility">—</strong><i><b id="weather-bar-visibility"></b></i></div>
+              <div class="weather-metric weather-metric--wide"><span>INTENSIDAD</span><strong id="weather-metric-intensity">—</strong><i><b id="weather-bar-intensity"></b></i></div>
+            </div>
+
+            <div id="weather-transition-breakdown" class="weather-transition-breakdown"></div>
+
+            <div class="weather-actions">
+              <button id="weather-force-selected" type="button" class="weather-btn weather-btn--primary">FORZAR CLIMA</button>
+              <button id="weather-roll-next" type="button" class="weather-btn">TIRAR TRANSICIÓN</button>
+            </div>
+          </aside>
+        </div>
+
+        <div class="weather-director__lower">
+          <details class="weather-environment-editor">
+            <summary>VARIABLES AMBIENTALES // AJUSTE MANUAL</summary>
+            <div class="weather-env-grid">
+              <label>TEMP °C <input id="weather-env-temperature" type="range" min="-20" max="45" step="1"><output id="weather-env-temperature-out"></output></label>
+              <label>HUMEDAD % <input id="weather-env-humidity" type="range" min="0" max="100" step="1"><output id="weather-env-humidity-out"></output></label>
+              <label>VIENTO KM/H <input id="weather-env-wind" type="range" min="0" max="120" step="1"><output id="weather-env-wind-out"></output></label>
+              <label>VISIBILIDAD % <input id="weather-env-visibility" type="range" min="0" max="100" step="1"><output id="weather-env-visibility-out"></output></label>
+              <label>INTENSIDAD % <input id="weather-env-intensity" type="range" min="0" max="100" step="1"><output id="weather-env-intensity-out"></output></label>
+            </div>
+            <button id="weather-apply-environment" type="button" class="weather-btn weather-btn--compact">APLICAR VARIABLES</button>
+          </details>
+
+          <section class="weather-history-card">
+            <div class="weather-card-head"><div><span class="weather-card-index">03</span><strong>HISTORIAL</strong></div></div>
+            <div id="weather-history" class="weather-history"></div>
+          </section>
+        </div>
+      </section>`;
+  }
+
+  function setMetric(id, barId, text, percent) {
+    const value = root.querySelector(`#${id}`);
+    const bar = root.querySelector(`#${barId}`);
+    if (value) value.textContent = text;
+    if (bar) bar.style.width = `${Math.max(0, Math.min(100, Number(percent) || 0))}%`;
+  }
+
+  function selectedBreakdown() {
+    if (!currentState) return [];
+    return engine.getTransitionBreakdown(currentState.actual.tipo, currentState);
+  }
+
+  function renderGraph() {
+    const svg = root.querySelector("#weather-graph-lines");
+    const nodesHost = root.querySelector("#weather-graph-nodes");
+    if (!svg || !nodesHost || !currentState) return;
+
+    svg.innerHTML = "";
+    nodesHost.innerHTML = "";
+
+    const current = currentState.actual.tipo;
+    const transitions = selectedBreakdown().slice(0, 6);
+    const center = { x: 280, y: 215 };
+    const radiusX = transitions.length <= 4 ? 205 : 220;
+    const radiusY = transitions.length <= 4 ? 145 : 160;
+
+    const centerNode = document.createElement("button");
+    centerNode.type = "button";
+    centerNode.className = "weather-node weather-node--current";
+    centerNode.style.left = `${(center.x / 560) * 100}%`;
+    centerNode.style.top = `${(center.y / 430) * 100}%`;
+    centerNode.dataset.weatherId = current;
+    centerNode.innerHTML = `${iconSvg(current, "weather-node__icon")}<span>${escapeHtml(weatherLabel(current))}</span><small>ACTUAL</small>`;
+    nodesHost.appendChild(centerNode);
+
+    transitions.forEach((row, index) => {
+      const angle = ((Math.PI * 2) / transitions.length) * index - Math.PI / 2;
+      const point = {
+        x: center.x + Math.cos(angle) * radiusX,
+        y: center.y + Math.sin(angle) * radiusY
+      };
+
+      const line = document.createElementNS("http://www.w3.org/2000/svg", "line");
+      line.setAttribute("x1", center.x);
+      line.setAttribute("y1", center.y);
+      line.setAttribute("x2", point.x);
+      line.setAttribute("y2", point.y);
+      line.setAttribute("class", "weather-graph-line");
+      svg.appendChild(line);
+
+      const midpointX = center.x + ((point.x - center.x) * 0.55);
+      const midpointY = center.y + ((point.y - center.y) * 0.55);
+      const probability = document.createElementNS("http://www.w3.org/2000/svg", "text");
+      probability.setAttribute("x", midpointX);
+      probability.setAttribute("y", midpointY);
+      probability.setAttribute("class", "weather-graph-probability");
+      probability.textContent = `${row.probability.toFixed(0)}%`;
+      svg.appendChild(probability);
+
+      const node = document.createElement("button");
+      node.type = "button";
+      node.className = `weather-node weather-node--candidate${selectedWeather === row.target ? " is-selected" : ""}`;
+      node.style.left = `${(point.x / 560) * 100}%`;
+      node.style.top = `${(point.y / 430) * 100}%`;
+      node.dataset.weatherId = row.target;
+      node.innerHTML = `${iconSvg(row.target, "weather-node__icon")}<span>${escapeHtml(weatherLabel(row.target))}</span><small>${row.probability.toFixed(0)}%</small>`;
+      nodesHost.appendChild(node);
+    });
+  }
+
+  function renderBreakdown(weatherId) {
+    const host = root.querySelector("#weather-transition-breakdown");
+    if (!host || !currentState) return;
+    const row = selectedBreakdown().find((item) => item.target === weatherId);
+    if (!row || weatherId === currentState.actual.tipo) {
+      host.innerHTML = `<div class="weather-breakdown-empty">ESTADO ACTUAL // Selecciona una transición del grafo para ver cómo la estación modifica su probabilidad.</div>`;
+      return;
+    }
+
+    host.innerHTML = `
+      <div class="weather-breakdown-title">CÁLCULO DE TRANSICIÓN</div>
+      <div class="weather-breakdown-row"><span>PESO BASE</span><strong>${row.baseWeight.toFixed(1)}</strong></div>
+      <div class="weather-breakdown-row"><span>MODIFICADOR FINAL</span><strong>×${row.multiplier.toFixed(2)}</strong></div>
+      <div class="weather-breakdown-reasons">${row.reasons.map((reason) => `<span>${escapeHtml(reason)}</span>`).join("")}</div>
+      <div class="weather-breakdown-final"><span>PROBABILIDAD</span><strong>${row.probability.toFixed(1)}%</strong></div>`;
+  }
+
+  function renderInspector() {
+    if (!currentState) return;
+    const current = currentState.actual.tipo;
+    const inspected = selectedWeather || current;
+    const isCurrent = inspected === current;
+    const def = engine.getDefinition(inspected) || {};
+    const actualEnv = currentState.actual;
+    const previewEnv = isCurrent ? actualEnv : { ...def.env, tipo: inspected };
+    const transition = selectedBreakdown().find((item) => item.target === inspected);
+
+    root.querySelector("#weather-inspector-icon").innerHTML = iconSvg(inspected, "weather-inspector-icon__svg");
+    root.querySelector("#weather-inspector-name").textContent = def.label || inspected;
+    root.querySelector("#weather-inspector-desc").textContent = def.description || "";
+    root.querySelector("#weather-inspector-state").textContent = isCurrent ? "CONDICIÓN ACTUAL" : "TRANSICIÓN CANDIDATA";
+    root.querySelector("#weather-inspector-prob").textContent = isCurrent ? "ACTUAL" : `${(transition?.probability || 0).toFixed(1)}%`;
+
+    setMetric("weather-metric-temperature", "weather-bar-temperature", `${Math.round(previewEnv.temperatura)}°C`, ((previewEnv.temperatura + 20) / 65) * 100);
+    setMetric("weather-metric-humidity", "weather-bar-humidity", `${Math.round(previewEnv.humedad)}%`, previewEnv.humedad);
+    setMetric("weather-metric-wind", "weather-bar-wind", `${Math.round(previewEnv.viento)} km/h`, (previewEnv.viento / 120) * 100);
+    setMetric("weather-metric-visibility", "weather-bar-visibility", `${Math.round(previewEnv.visibilidad)}%`, previewEnv.visibilidad);
+    setMetric("weather-metric-intensity", "weather-bar-intensity", `${Math.round(previewEnv.intensidad)}%`, previewEnv.intensidad);
+
+    const forceButton = root.querySelector("#weather-force-selected");
+    if (forceButton) {
+      forceButton.disabled = isCurrent;
+      forceButton.textContent = isCurrent ? "CLIMA ACTIVO" : `FORZAR ${String(def.label || inspected).toUpperCase()}`;
+    }
+
+    renderBreakdown(inspected);
+  }
+
+  function renderEnvironmentEditor() {
+    if (!currentState) return;
+    const values = {
+      temperature: currentState.actual.temperatura,
+      humidity: currentState.actual.humedad,
+      wind: currentState.actual.viento,
+      visibility: currentState.actual.visibilidad,
+      intensity: currentState.actual.intensidad
+    };
+    Object.entries(values).forEach(([name, value]) => {
+      const input = root.querySelector(`#weather-env-${name}`);
+      const output = root.querySelector(`#weather-env-${name}-out`);
+      if (input && document.activeElement !== input) input.value = value;
+      if (output) output.textContent = name === "temperature" ? `${Math.round(value)}°C` : `${Math.round(value)}${name === "wind" ? " km/h" : "%"}`;
+    });
+  }
+
+  function renderHistory() {
+    const host = root.querySelector("#weather-history");
+    if (!host || !currentState) return;
+    const history = Array.isArray(currentState.historial) ? [...currentState.historial].reverse() : [];
+    if (!history.length) {
+      host.innerHTML = `<span class="weather-history-empty">Aún no hay transiciones registradas.</span>`;
+      return;
+    }
+    host.innerHTML = history.map((entry) => `
+      <div class="weather-history-row">
+        ${iconSvg(entry.tipo, "weather-history-icon")}
+        <span>${escapeHtml(weatherLabel(entry.tipo))}</span>
+        <i></i>
+        ${iconSvg(entry.destino, "weather-history-icon")}
+        <strong>${escapeHtml(weatherLabel(entry.destino))}</strong>
+        <small>${escapeHtml(String(entry.motivo || "auto").toUpperCase())}</small>
+      </div>`).join("");
+  }
+
+  function worldCountdown() {
+    if (!currentState) return "SIGUIENTE CAMBIO —";
+    if (currentState.modo === "manual") return "AUTO PAUSADO";
+    const calendar = engine.getCalendar() || {};
+    let currentTs = 0;
+    if (calendar.timestamp) currentTs = new Date(calendar.timestamp).getTime();
+    if (!Number.isFinite(currentTs) || !currentTs) currentTs = currentState.ultimoCambioWorldTs || 0;
+    const remaining = Math.max(0, Number(currentState.siguienteCambioWorldTs || 0) - currentTs);
+    const minutes = Math.ceil(remaining / 60000);
+    if (minutes <= 0) return "CAMBIO PENDIENTE";
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    return `SIGUIENTE CAMBIO ${hours ? `${hours}H ` : ""}${mins}M`;
+  }
+
+  function renderStatus() {
+    if (!currentState) return;
+    root.querySelector("#weather-director-season").textContent = engine.displaySeason(currentState.estacion).toUpperCase();
+    root.querySelector("#weather-next-change").textContent = worldCountdown();
+    root.querySelectorAll("[data-weather-mode]").forEach((button) => {
+      button.classList.toggle("is-active", button.dataset.weatherMode === currentState.modo);
+    });
+  }
+
+  function renderAll() {
+    if (!root || !currentState) return;
+    if (!selectedWeather) selectedWeather = currentState.actual.tipo;
+    const all = engine.getDefinitions();
+    if (!all[selectedWeather]) selectedWeather = currentState.actual.tipo;
+    renderStatus();
+    renderGraph();
+    renderInspector();
+    renderEnvironmentEditor();
+    renderHistory();
+  }
+
+  function bindEvents() {
+    root.addEventListener("click", async (event) => {
+      const node = event.target.closest("[data-weather-id]");
+      if (node) {
+        selectedWeather = node.dataset.weatherId;
+        renderGraph();
+        renderInspector();
+        return;
+      }
+
+      const mode = event.target.closest("[data-weather-mode]");
+      if (mode) {
+        await engine.setMode(mode.dataset.weatherMode);
+        return;
+      }
+
+      if (event.target.closest("#weather-force-selected")) {
+        if (selectedWeather && selectedWeather !== currentState?.actual?.tipo) await engine.forceWeather(selectedWeather);
+        return;
+      }
+
+      if (event.target.closest("#weather-roll-next")) {
+        await engine.rollNext("director");
+        return;
+      }
+
+      if (event.target.closest("#weather-apply-environment")) {
+        await engine.updateEnvironment({
+          temperatura: Number(root.querySelector("#weather-env-temperature")?.value),
+          humedad: Number(root.querySelector("#weather-env-humidity")?.value),
+          viento: Number(root.querySelector("#weather-env-wind")?.value),
+          visibilidad: Number(root.querySelector("#weather-env-visibility")?.value),
+          intensidad: Number(root.querySelector("#weather-env-intensity")?.value)
+        });
+      }
+    });
+
+    root.addEventListener("input", (event) => {
+      if (!event.target.matches(".weather-env-grid input[type='range']")) return;
+      const output = root.querySelector(`#${event.target.id}-out`);
+      if (!output) return;
+      const suffix = event.target.id.includes("temperature") ? "°C" : event.target.id.includes("wind") ? " km/h" : "%";
+      output.textContent = `${event.target.value}${suffix}`;
+    });
+  }
+
+  function mount() {
+    const legacyTab = document.getElementById("tab-clima");
+    if (!legacyTab || legacyTab.dataset.weatherDirectorMounted === "true") return false;
+    legacyTab.dataset.weatherDirectorMounted = "true";
+    legacyTab.innerHTML = initialMarkup();
+    root = legacyTab.querySelector("#weather-director");
+    bindEvents();
+    unsubscribe = engine.onChange((nextState) => {
+      const oldCurrent = currentState?.actual?.tipo;
+      currentState = nextState;
+      if (!selectedWeather || selectedWeather === oldCurrent) selectedWeather = nextState.actual.tipo;
+      renderAll();
+    });
+    countdownTimer = global.setInterval(renderStatus, 1000);
+    return true;
+  }
+
+  function boot() {
+    engine = global.LuminousWeatherEngine;
+    if (!engine) {
+      global.setTimeout(boot, 60);
+      return;
+    }
+    global.setTimeout(() => {
+      if (!mount()) global.setTimeout(boot, 250);
+    }, 650);
+  }
+
+  global.LuminousWeatherDirectorUI = Object.freeze({
+    mount: () => { engine = global.LuminousWeatherEngine; return engine ? mount() : false; },
+    destroy: () => {
+      unsubscribe?.();
+      if (countdownTimer) global.clearInterval(countdownTimer);
+      unsubscribe = null;
+      countdownTimer = null;
+    }
+  });
+
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", boot, { once: true });
+  else boot();
+})(window);

--- a/js/weather-engine.js
+++ b/js/weather-engine.js
@@ -1,0 +1,594 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousWeatherEngine) return;
+
+  const ROOT = "campaña/clima";
+  const LEGACY_WORLD_ROOT = "campaña/estado_mundo";
+  const LEGACY_FORECAST_PATH = "campaña/worldData/weatherForecast";
+  const CALENDAR_ROOT = "campaña/calendario";
+  const VERSION = 1;
+  const AUTO_MIN_MINUTES = 180;
+  const AUTO_MAX_MINUTES = 480;
+
+  const WEATHER = Object.freeze({
+    soleado: {
+      label: "Soleado",
+      icon: "sun",
+      description: "Cielo abierto y alta iluminación.",
+      env: { temperatura: 23, humedad: 38, viento: 8, visibilidad: 100, intensidad: 35 },
+      transitions: { parcialmente_nublado: 34, nublado: 8, niebla: 3, tormenta: 2 }
+    },
+    parcialmente_nublado: {
+      label: "Parcialmente Nublado",
+      icon: "partly-cloudy",
+      description: "Cobertura variable con claros frecuentes.",
+      env: { temperatura: 19, humedad: 55, viento: 11, visibilidad: 94, intensidad: 42 },
+      transitions: { soleado: 24, nublado: 34, llovizna: 10, niebla: 7, lluvia: 5 }
+    },
+    nublado: {
+      label: "Nublado",
+      icon: "cloudy",
+      description: "Cobertura densa con luz ambiental reducida.",
+      env: { temperatura: 16, humedad: 72, viento: 13, visibilidad: 84, intensidad: 50 },
+      transitions: { parcialmente_nublado: 18, llovizna: 25, lluvia: 24, niebla: 15, tormenta: 8 }
+    },
+    llovizna: {
+      label: "Llovizna",
+      icon: "drizzle",
+      description: "Precipitación ligera y persistente.",
+      env: { temperatura: 14, humedad: 86, viento: 12, visibilidad: 75, intensidad: 40 },
+      transitions: { nublado: 25, lluvia: 39, niebla: 15, parcialmente_nublado: 8 }
+    },
+    lluvia: {
+      label: "Lluvia",
+      icon: "rain",
+      description: "Precipitación continua con visibilidad reducida.",
+      env: { temperatura: 12, humedad: 92, viento: 19, visibilidad: 62, intensidad: 66 },
+      transitions: { llovizna: 24, nublado: 19, tormenta: 27, niebla: 11, granizo: 4 }
+    },
+    tormenta: {
+      label: "Tormenta",
+      icon: "storm",
+      description: "Lluvia intensa, viento fuerte y actividad eléctrica.",
+      env: { temperatura: 11, humedad: 96, viento: 38, visibilidad: 42, intensidad: 88 },
+      transitions: { lluvia: 42, nublado: 23, granizo: 10, niebla: 6 }
+    },
+    niebla: {
+      label: "Niebla",
+      icon: "fog",
+      description: "Suspensión densa que limita la línea de visión.",
+      env: { temperatura: 10, humedad: 94, viento: 4, visibilidad: 28, intensidad: 65 },
+      transitions: { nublado: 32, parcialmente_nublado: 15, llovizna: 20, lluvia: 8, nieve: 6 }
+    },
+    nieve: {
+      label: "Nieve",
+      icon: "snow",
+      description: "Nevada ligera con acumulación gradual.",
+      env: { temperatura: -2, humedad: 82, viento: 15, visibilidad: 67, intensidad: 58 },
+      transitions: { nublado: 22, nevada: 34, niebla: 18, llovizna: 3 }
+    },
+    nevada: {
+      label: "Nevada",
+      icon: "snow-heavy",
+      description: "Nieve intensa y deterioro rápido de visibilidad.",
+      env: { temperatura: -6, humedad: 89, viento: 28, visibilidad: 35, intensidad: 84 },
+      transitions: { nieve: 43, nublado: 20, niebla: 17, granizo: 5 }
+    },
+    granizo: {
+      label: "Granizo",
+      icon: "hail",
+      description: "Precipitación sólida breve y agresiva.",
+      env: { temperatura: 4, humedad: 85, viento: 32, visibilidad: 48, intensidad: 80 },
+      transitions: { lluvia: 39, tormenta: 24, nublado: 22 }
+    }
+  });
+
+  const SEASON_MODIFIERS = Object.freeze({
+    primavera: {
+      soleado: 1.0, parcialmente_nublado: 1.08, nublado: 1.08, llovizna: 1.25,
+      lluvia: 1.35, tormenta: 1.22, niebla: 1.10, nieve: 0.08, nevada: 0.03, granizo: 1.05
+    },
+    verano: {
+      soleado: 1.50, parcialmente_nublado: 1.10, nublado: 0.82, llovizna: 0.68,
+      lluvia: 0.78, tormenta: 1.30, niebla: 0.52, nieve: 0.01, nevada: 0.01, granizo: 0.82
+    },
+    otono: {
+      soleado: 0.72, parcialmente_nublado: 1.08, nublado: 1.40, llovizna: 1.32,
+      lluvia: 1.34, tormenta: 1.10, niebla: 1.52, nieve: 0.22, nevada: 0.08, granizo: 0.82
+    },
+    invierno: {
+      soleado: 0.72, parcialmente_nublado: 0.82, nublado: 1.20, llovizna: 0.76,
+      lluvia: 0.72, tormenta: 0.68, niebla: 1.28, nieve: 1.85, nevada: 1.55, granizo: 1.22
+    }
+  });
+
+  const LEGACY_TO_ID = Object.freeze({
+    "Soleado": "soleado",
+    "Despejado": "soleado",
+    "Parcialmente Nublado": "parcialmente_nublado",
+    "Nublado": "nublado",
+    "Húmedo": "nublado",
+    "Humedo": "nublado",
+    "Calor": "soleado",
+    "Llovizna": "llovizna",
+    "Lluvia": "lluvia",
+    "Tormenta": "tormenta",
+    "Niebla": "niebla",
+    "Nieve": "nieve",
+    "Nevada": "nevada",
+    "Granizo": "granizo"
+  });
+
+  const listeners = new Set();
+  let db = null;
+  let state = null;
+  let calendar = null;
+  let initialized = false;
+  let currentDayKey = null;
+  let writing = false;
+  let lastLegacyRepairAt = 0;
+
+  function clamp(value, min, max, fallback) {
+    const n = Number(value);
+    return Number.isFinite(n) ? Math.max(min, Math.min(max, n)) : fallback;
+  }
+
+  function seasonFromMonth(month) {
+    const m = Math.max(1, Math.min(12, Number.parseInt(month, 10) || 1));
+    if (m >= 3 && m <= 5) return "primavera";
+    if (m >= 6 && m <= 8) return "verano";
+    if (m >= 9 && m <= 11) return "otono";
+    return "invierno";
+  }
+
+  function displaySeason(season) {
+    return ({ primavera: "Primavera", verano: "Verano", otono: "Otoño", invierno: "Invierno" })[season] || "Invierno";
+  }
+
+  function normalizeWeatherId(value) {
+    if (!value) return "soleado";
+    const direct = String(value).trim();
+    if (WEATHER[direct]) return direct;
+    if (LEGACY_TO_ID[direct]) return LEGACY_TO_ID[direct];
+    const normalized = direct
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "_")
+      .replace(/^_+|_+$/g, "");
+    return WEATHER[normalized] ? normalized : "soleado";
+  }
+
+  function iconHref(weatherId) {
+    const def = WEATHER[normalizeWeatherId(weatherId)] || WEATHER.soleado;
+    return `Assets/Images/Weather/weather-icons.svg#${def.icon}`;
+  }
+
+  function calendarInfo(raw) {
+    const data = raw && typeof raw === "object" ? raw : {};
+    let date = null;
+    if (data.timestamp) {
+      const parsed = new Date(data.timestamp);
+      if (!Number.isNaN(parsed.getTime())) date = parsed;
+    }
+    const month = date ? date.getMonth() + 1 : Number(data.mes) || 1;
+    const day = date ? date.getDate() : Number(data.dia) || 1;
+    const year = date ? date.getFullYear() : Number(data.año || data.anio) || 984;
+    const worldTs = date ? date.getTime() : Date.UTC(year, month - 1, day, 12, 0, 0);
+    return { date, month, day, year, worldTs, dayKey: `${year}-${month}-${day}` };
+  }
+
+  function environmentFor(weatherId, existing) {
+    const def = WEATHER[normalizeWeatherId(weatherId)] || WEATHER.soleado;
+    const base = def.env;
+    const current = existing && typeof existing === "object" ? existing : {};
+    return {
+      temperatura: clamp(current.temperatura, -40, 60, base.temperatura),
+      humedad: clamp(current.humedad, 0, 100, base.humedad),
+      viento: clamp(current.viento, 0, 180, base.viento),
+      visibilidad: clamp(current.visibilidad, 0, 100, base.visibilidad),
+      intensidad: clamp(current.intensidad, 0, 100, base.intensidad)
+    };
+  }
+
+  function targetEnvironment(weatherId, previousEnv) {
+    const def = WEATHER[normalizeWeatherId(weatherId)] || WEATHER.soleado;
+    const base = def.env;
+    const prev = environmentFor(weatherId, previousEnv);
+    const blend = (a, b) => Math.round((a * 0.35) + (b * 0.65));
+    return {
+      temperatura: blend(prev.temperatura, base.temperatura),
+      humedad: blend(prev.humedad, base.humedad),
+      viento: blend(prev.viento, base.viento),
+      visibilidad: blend(prev.visibilidad, base.visibilidad),
+      intensidad: blend(prev.intensidad, base.intensidad)
+    };
+  }
+
+  function getTransitionBreakdown(weatherId, sourceState) {
+    const source = normalizeWeatherId(weatherId);
+    const def = WEATHER[source] || WEATHER.soleado;
+    const snapshot = sourceState || state || {};
+    const season = snapshot.estacion || seasonFromMonth(calendarInfo(calendar).month);
+    const modifiers = SEASON_MODIFIERS[season] || SEASON_MODIFIERS.invierno;
+    const env = environmentFor(source, snapshot.actual || {});
+    const previous = normalizeWeatherId(snapshot.anterior || "");
+    const rows = [];
+
+    Object.entries(def.transitions || {}).forEach(([target, baseWeight]) => {
+      let multiplier = Number(modifiers[target]) || 1;
+      const reasons = [`${displaySeason(season)} ×${multiplier.toFixed(2)}`];
+
+      if ((target === "nieve" || target === "nevada") && env.temperatura > 4) {
+        multiplier *= 0.04;
+        reasons.push("Temperatura alta ×0.04");
+      } else if ((target === "nieve" || target === "nevada") && env.temperatura <= 1) {
+        multiplier *= 1.35;
+        reasons.push("Temperatura ≤1°C ×1.35");
+      }
+
+      if ((target === "lluvia" || target === "llovizna" || target === "tormenta") && env.humedad >= 75) {
+        multiplier *= 1.18;
+        reasons.push("Humedad alta ×1.18");
+      }
+
+      if (target === "niebla" && env.humedad >= 80 && env.viento <= 15) {
+        multiplier *= 1.30;
+        reasons.push("Aire húmedo/calma ×1.30");
+      }
+
+      if (target === "tormenta" && env.temperatura >= 18) {
+        multiplier *= 1.12;
+        reasons.push("Convección cálida ×1.12");
+      }
+
+      if (previous && target === previous && Object.keys(def.transitions || {}).length > 1) {
+        multiplier *= 0.12;
+        reasons.push("Anti-rebote ×0.12");
+      }
+
+      const weight = Math.max(0.001, Number(baseWeight) * multiplier);
+      rows.push({ target, baseWeight: Number(baseWeight), multiplier, weight, reasons });
+    });
+
+    const total = rows.reduce((sum, row) => sum + row.weight, 0) || 1;
+    return rows
+      .map((row) => ({ ...row, probability: (row.weight / total) * 100 }))
+      .sort((a, b) => b.probability - a.probability);
+  }
+
+  function getTransitionProbabilities(weatherId, sourceState) {
+    return getTransitionBreakdown(weatherId, sourceState).map(({ target, probability }) => ({ target, probability }));
+  }
+
+  function buildForecast(sourceState) {
+    const result = [];
+    let sim = JSON.parse(JSON.stringify(sourceState || state || defaultState()));
+    for (let i = 0; i < 3; i += 1) {
+      const options = getTransitionBreakdown(sim.actual?.tipo, sim);
+      const best = options[0];
+      if (!best) break;
+      result.push({ tipo: best.target, probabilidad: Math.round(best.probability), etaMin: (i + 1) * 180 });
+      sim.anterior = sim.actual?.tipo;
+      sim.actual = { ...targetEnvironment(best.target, sim.actual), tipo: best.target };
+    }
+    return result;
+  }
+
+  function randomAutoMinutes() {
+    return Math.round(AUTO_MIN_MINUTES + Math.random() * (AUTO_MAX_MINUTES - AUTO_MIN_MINUTES));
+  }
+
+  function defaultState(seedWeather) {
+    const info = calendarInfo(calendar);
+    const type = normalizeWeatherId(seedWeather || "soleado");
+    const actual = { tipo: type, ...environmentFor(type) };
+    const base = {
+      version: VERSION,
+      modo: "auto",
+      estacion: seasonFromMonth(info.month),
+      regionActual: "mundo",
+      actual,
+      anterior: null,
+      transicion: { activa: false, origen: null, destino: null, progreso: 0 },
+      pronostico: [],
+      siguienteCambioWorldTs: info.worldTs + (randomAutoMinutes() * 60000),
+      ultimoCambioWorldTs: info.worldTs,
+      historial: []
+    };
+    base.pronostico = buildForecast(base);
+    return base;
+  }
+
+  function normalizeHistory(raw) {
+    if (!raw) return [];
+    const list = Array.isArray(raw) ? raw : Object.keys(raw).sort().map((key) => raw[key]);
+    return list.filter(Boolean).slice(-5);
+  }
+
+  function normalizeState(raw) {
+    const info = calendarInfo(calendar);
+    const input = raw && typeof raw === "object" ? raw : {};
+    const type = normalizeWeatherId(input.actual?.tipo || input.actual || input.clima || "soleado");
+    const normalized = {
+      version: VERSION,
+      modo: input.modo === "manual" ? "manual" : "auto",
+      estacion: ["primavera", "verano", "otono", "invierno"].includes(input.estacion)
+        ? input.estacion
+        : seasonFromMonth(info.month),
+      regionActual: String(input.regionActual || "mundo"),
+      actual: { tipo: type, ...environmentFor(type, input.actual) },
+      anterior: input.anterior ? normalizeWeatherId(input.anterior) : null,
+      transicion: {
+        activa: Boolean(input.transicion?.activa),
+        origen: input.transicion?.origen ? normalizeWeatherId(input.transicion.origen) : null,
+        destino: input.transicion?.destino ? normalizeWeatherId(input.transicion.destino) : null,
+        progreso: clamp(input.transicion?.progreso, 0, 100, 0)
+      },
+      pronostico: Array.isArray(input.pronostico) ? input.pronostico : [],
+      siguienteCambioWorldTs: Number(input.siguienteCambioWorldTs) || (info.worldTs + randomAutoMinutes() * 60000),
+      ultimoCambioWorldTs: Number(input.ultimoCambioWorldTs) || info.worldTs,
+      historial: normalizeHistory(input.historial)
+    };
+    if (!normalized.pronostico.length) normalized.pronostico = buildForecast(normalized);
+    return normalized;
+  }
+
+  function clone(value) {
+    return value ? JSON.parse(JSON.stringify(value)) : value;
+  }
+
+  function notify() {
+    const snapshot = clone(state);
+    listeners.forEach((listener) => {
+      try { listener(snapshot); } catch (error) { console.error("Weather listener error:", error); }
+    });
+    global.dispatchEvent?.(new CustomEvent("luminous-weather-change", { detail: snapshot }));
+  }
+
+  function svgIcon(weatherId, className, title) {
+    const id = normalizeWeatherId(weatherId);
+    const label = title || WEATHER[id]?.label || id;
+    const cls = className ? ` class="${className}"` : "";
+    return `<svg${cls} viewBox="0 0 64 64" role="img" aria-label="${String(label).replace(/"/g, "&quot;")}"><use href="${iconHref(id)}"></use></svg>`;
+  }
+
+  function legacyForecast(forecast) {
+    return (forecast || []).map((entry) => ({
+      clima: WEATHER[normalizeWeatherId(entry.tipo)]?.label || "Soleado",
+      probabilidad: Number(entry.probabilidad) || 0
+    }));
+  }
+
+  async function writeState(next, options) {
+    if (!db) return false;
+    const opts = options || {};
+    const normalized = normalizeState(next);
+    normalized.pronostico = buildForecast(normalized);
+    writing = true;
+    try {
+      const updates = { [ROOT]: normalized };
+      if (opts.mirrorLegacy !== false) {
+        updates[`${LEGACY_WORLD_ROOT}/clima`] = WEATHER[normalized.actual.tipo]?.label || "Soleado";
+        updates[`${LEGACY_WORLD_ROOT}/clima_previo`] = normalized.anterior ? (WEATHER[normalized.anterior]?.label || null) : null;
+        updates[LEGACY_FORECAST_PATH] = legacyForecast(normalized.pronostico);
+      }
+      await db.ref().update(updates);
+      return true;
+    } finally {
+      global.setTimeout(() => { writing = false; }, 80);
+    }
+  }
+
+  async function forceWeather(weatherId, overrides) {
+    if (!state) return false;
+    const type = normalizeWeatherId(weatherId);
+    const info = calendarInfo(calendar);
+    const previous = state.actual.tipo;
+    const env = { ...targetEnvironment(type, state.actual), ...(overrides || {}) };
+    const history = [...normalizeHistory(state.historial), {
+      tipo: previous,
+      destino: type,
+      motivo: "manual",
+      worldTs: info.worldTs
+    }].slice(-5);
+    const next = {
+      ...state,
+      anterior: previous,
+      actual: { tipo: type, ...environmentFor(type, env) },
+      estacion: seasonFromMonth(info.month),
+      transicion: { activa: false, origen: previous, destino: type, progreso: 100 },
+      ultimoCambioWorldTs: info.worldTs,
+      siguienteCambioWorldTs: info.worldTs + randomAutoMinutes() * 60000,
+      historial: history
+    };
+    return writeState(next);
+  }
+
+  function weightedPick(rows) {
+    if (!rows.length) return null;
+    const roll = Math.random() * 100;
+    let sum = 0;
+    for (const row of rows) {
+      sum += row.probability;
+      if (roll <= sum) return row.target;
+    }
+    return rows[rows.length - 1].target;
+  }
+
+  async function rollNext(reason) {
+    if (!state) return false;
+    const options = getTransitionBreakdown(state.actual.tipo, state);
+    const target = weightedPick(options);
+    if (!target) return false;
+    const info = calendarInfo(calendar);
+    const previous = state.actual.tipo;
+    const history = [...normalizeHistory(state.historial), {
+      tipo: previous,
+      destino: target,
+      motivo: reason || "auto",
+      worldTs: info.worldTs
+    }].slice(-5);
+    const next = {
+      ...state,
+      anterior: previous,
+      actual: { tipo: target, ...targetEnvironment(target, state.actual) },
+      estacion: seasonFromMonth(info.month),
+      transicion: { activa: false, origen: previous, destino: target, progreso: 100 },
+      ultimoCambioWorldTs: info.worldTs,
+      siguienteCambioWorldTs: info.worldTs + randomAutoMinutes() * 60000,
+      historial: history
+    };
+    return writeState(next);
+  }
+
+  async function setMode(mode) {
+    if (!state) return false;
+    return writeState({ ...state, modo: mode === "manual" ? "manual" : "auto" });
+  }
+
+  async function updateEnvironment(patch) {
+    if (!state) return false;
+    const actual = { ...state.actual };
+    ["temperatura", "humedad", "viento", "visibilidad", "intensidad"].forEach((key) => {
+      if (patch && patch[key] !== undefined) actual[key] = patch[key];
+    });
+    return writeState({ ...state, actual: { tipo: state.actual.tipo, ...environmentFor(state.actual.tipo, actual) } });
+  }
+
+  async function syncSeasonFromCalendar() {
+    if (!state) return;
+    const info = calendarInfo(calendar);
+    const season = seasonFromMonth(info.month);
+    if (state.estacion !== season) {
+      await writeState({ ...state, estacion: season });
+    }
+  }
+
+  async function evaluateAuto() {
+    if (!state || state.modo !== "auto" || !global.document?.getElementById?.("tab-clima")) return;
+    const info = calendarInfo(calendar);
+    if (info.worldTs >= Number(state.siguienteCambioWorldTs || 0)) {
+      await rollNext("auto");
+    }
+  }
+
+  async function seed() {
+    const [modernSnap, legacySnap, calendarSnap] = await Promise.all([
+      db.ref(ROOT).once("value"),
+      db.ref(`${LEGACY_WORLD_ROOT}/clima`).once("value"),
+      db.ref(CALENDAR_ROOT).once("value")
+    ]);
+    calendar = calendarSnap.val() || {};
+    if (!modernSnap.exists()) {
+      const seeded = defaultState(legacySnap.val());
+      await writeState(seeded);
+    }
+  }
+
+  function bindFirebase() {
+    db.ref(ROOT).on("value", (snapshot) => {
+      state = normalizeState(snapshot.val() || {});
+      notify();
+    });
+
+    db.ref(CALENDAR_ROOT).on("value", (snapshot) => {
+      calendar = snapshot.val() || {};
+      const info = calendarInfo(calendar);
+      const changedDay = currentDayKey !== null && currentDayKey !== info.dayKey;
+      currentDayKey = info.dayKey;
+      syncSeasonFromCalendar().then(() => {
+        if (changedDay || (state && info.worldTs >= Number(state.siguienteCambioWorldTs || 0))) {
+          global.setTimeout(evaluateAuto, 120);
+        }
+      });
+    });
+
+    if (global.document?.getElementById?.("tab-clima")) {
+      db.ref(`${LEGACY_WORLD_ROOT}/clima`).on("value", (snapshot) => {
+        if (writing || !state) return;
+        const legacy = normalizeWeatherId(snapshot.val());
+        if (legacy === state.actual.tipo) return;
+        const now = Date.now();
+        if (now - lastLegacyRepairAt < 200) return;
+        lastLegacyRepairAt = now;
+        global.setTimeout(() => {
+          if (!state || writing) return;
+          const label = WEATHER[state.actual.tipo]?.label || "Soleado";
+          db.ref(`${LEGACY_WORLD_ROOT}/clima`).set(label).catch(() => {});
+        }, 160);
+      });
+    }
+  }
+
+  function onChange(listener) {
+    if (typeof listener !== "function") return () => {};
+    listeners.add(listener);
+    if (state) listener(clone(state));
+    return () => listeners.delete(listener);
+  }
+
+  function getState() { return clone(state); }
+  function getCalendar() { return clone(calendar); }
+  function getDefinition(weatherId) { return clone(WEATHER[normalizeWeatherId(weatherId)]); }
+  function getDefinitions() { return clone(WEATHER); }
+  function getSeasonModifiers() { return clone(SEASON_MODIFIERS); }
+
+  global.LuminousWeatherEngine = Object.freeze({
+    ROOT,
+    VERSION,
+    onChange,
+    getState,
+    getCalendar,
+    getDefinition,
+    getDefinitions,
+    getSeasonModifiers,
+    seasonFromMonth,
+    displaySeason,
+    normalizeWeatherId,
+    getTransitionBreakdown,
+    getTransitionProbabilities,
+    buildForecast,
+    iconHref,
+    svgIcon,
+    forceWeather,
+    rollNext,
+    setMode,
+    updateEnvironment,
+    evaluateAuto
+  });
+
+  function boot() {
+    if (initialized) return;
+    try {
+      if (!global.firebase?.apps?.length || !global.firebase?.database) {
+        global.setTimeout(boot, 50);
+        return;
+      }
+      db = global.firebase.database();
+      initialized = true;
+      seed()
+        .then(bindFirebase)
+        .catch((error) => {
+          initialized = false;
+          console.error("Weather Engine boot error:", error);
+          global.setTimeout(boot, 500);
+        });
+    } catch (error) {
+      global.setTimeout(boot, 100);
+    }
+  }
+
+  if (global.document) boot();
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = {
+      WEATHER,
+      SEASON_MODIFIERS,
+      seasonFromMonth,
+      normalizeWeatherId,
+      getTransitionBreakdown
+    };
+  }
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/weather-fx.js
+++ b/js/weather-fx.js
@@ -1,0 +1,109 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousWeatherFX) return;
+
+  let engine = null;
+  let currentState = null;
+  let unsubscribe = null;
+  let observer = null;
+
+  function buildSnow() {
+    return Array.from({ length: 32 }, (_, index) => `<i style="--i:${index};--x:${(index * 37) % 100};--d:${6 + (index % 8)};--s:${2 + (index % 5)}"></i>`).join("");
+  }
+
+  function ensureLayer(stage) {
+    if (!stage || stage.querySelector(":scope > .weather-fx-layer")) return;
+    const layer = document.createElement("div");
+    layer.className = "weather-fx-layer";
+    layer.setAttribute("aria-hidden", "true");
+    layer.innerHTML = `
+      <div class="weather-fx-darken"></div>
+      <div class="weather-fx-fog"></div>
+      <div class="weather-fx-rain"></div>
+      <div class="weather-fx-snow">${buildSnow()}</div>
+      <div class="weather-fx-hail"></div>
+      <div class="weather-fx-lightning"></div>
+      <div class="weather-fx-heat"></div>`;
+    stage.appendChild(layer);
+  }
+
+  function findStages() {
+    const stages = new Set();
+    document.querySelectorAll("#theatre-stage").forEach((stage) => stages.add(stage));
+    return [...stages];
+  }
+
+  function applyToStage(stage) {
+    if (!stage || !currentState) return;
+    ensureLayer(stage);
+    const layer = stage.querySelector(":scope > .weather-fx-layer");
+    if (!layer) return;
+
+    const actual = currentState.actual;
+    const type = actual.tipo;
+    const intensity = Math.max(0, Math.min(100, Number(actual.intensidad) || 0));
+    const wind = Math.max(0, Math.min(120, Number(actual.viento) || 0));
+    const humidity = Math.max(0, Math.min(100, Number(actual.humedad) || 0));
+
+    layer.dataset.weather = type;
+    layer.dataset.precipitation = ["llovizna", "lluvia", "tormenta", "granizo"].includes(type) ? "rain" : ["nieve", "nevada"].includes(type) ? "snow" : "none";
+    layer.dataset.fog = type === "niebla" || (humidity >= 90 && type === "nublado") ? "true" : "false";
+    layer.dataset.storm = type === "tormenta" ? "true" : "false";
+    layer.dataset.hail = type === "granizo" ? "true" : "false";
+    layer.dataset.heat = actual.temperatura >= 30 && ["soleado", "parcialmente_nublado"].includes(type) ? "true" : "false";
+    layer.style.setProperty("--weather-intensity", String(intensity / 100));
+    layer.style.setProperty("--weather-wind", String(wind / 120));
+    layer.style.setProperty("--weather-visibility", String(Math.max(0.15, (Number(actual.visibilidad) || 100) / 100)));
+  }
+
+  function render() {
+    findStages().forEach(applyToStage);
+  }
+
+  function bootObserver() {
+    if (observer || !document.body) return;
+    observer = new MutationObserver((mutations) => {
+      let shouldRender = false;
+      for (const mutation of mutations) {
+        for (const node of mutation.addedNodes) {
+          if (!(node instanceof Element)) continue;
+          if (node.id === "theatre-stage" || node.querySelector?.("#theatre-stage")) {
+            shouldRender = true;
+            break;
+          }
+        }
+        if (shouldRender) break;
+      }
+      if (shouldRender) render();
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
+
+  function boot() {
+    engine = global.LuminousWeatherEngine;
+    if (!engine) {
+      global.setTimeout(boot, 60);
+      return;
+    }
+    unsubscribe = engine.onChange((next) => {
+      currentState = next;
+      render();
+    });
+    bootObserver();
+    render();
+  }
+
+  global.LuminousWeatherFX = Object.freeze({
+    render,
+    destroy: () => {
+      unsubscribe?.();
+      observer?.disconnect?.();
+      unsubscribe = null;
+      observer = null;
+    }
+  });
+
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", boot, { once: true });
+  else boot();
+})(window);

--- a/js/weather-player-widget.js
+++ b/js/weather-player-widget.js
@@ -1,0 +1,137 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousWeatherPlayerWidget) return;
+
+  const ICON_SPRITE = "Assets/Images/Weather/weather-icons.svg";
+  let engine = null;
+  let widget = null;
+  let currentState = null;
+  let unsubscribe = null;
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
+  function iconSvg(weatherId, className) {
+    const def = engine.getDefinition(weatherId) || { icon: "sun" };
+    return `<svg class="${className || "player-weather-icon"}" viewBox="0 0 64 64" aria-hidden="true"><use href="${ICON_SPRITE}#${def.icon}"></use></svg>`;
+  }
+
+  function formatWorldClock() {
+    const cal = engine.getCalendar() || {};
+    if (!cal.timestamp) return { time: "--:--", date: "RED CLIMÁTICA" };
+    const d = new Date(cal.timestamp);
+    if (Number.isNaN(d.getTime())) return { time: "--:--", date: "RED CLIMÁTICA" };
+    const time = `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+    const date = `DÍA ${d.getDate()} · MES ${d.getMonth() + 1} · ${d.getFullYear()}`;
+    return { time, date };
+  }
+
+  function precipitationText(type, intensity) {
+    if (["lluvia", "llovizna", "tormenta", "granizo", "nieve", "nevada"].includes(type)) {
+      if (intensity >= 75) return "PRECIPITACIÓN INTENSA";
+      if (intensity >= 45) return "PRECIPITACIÓN MODERADA";
+      return "PRECIPITACIÓN LIGERA";
+    }
+    if (type === "niebla") return "NIEBLA EN SUPERFICIE";
+    return "SIN PRECIPITACIÓN";
+  }
+
+  function playerForecastText(probability) {
+    const p = Number(probability) || 0;
+    if (p >= 55) return "ALTA";
+    if (p >= 30) return "MEDIA";
+    return "BAJA";
+  }
+
+  function render() {
+    if (!widget || !currentState) return;
+    const actual = currentState.actual;
+    const def = engine.getDefinition(actual.tipo) || {};
+    const clock = formatWorldClock();
+    const forecast = Array.isArray(currentState.pronostico) ? currentState.pronostico.slice(0, 3) : [];
+
+    widget.innerHTML = `
+      <div class="player-weather-live" data-weather="${escapeHtml(actual.tipo)}">
+        <div class="player-weather-live__top">
+          <div class="player-weather-clock">
+            <strong>${escapeHtml(clock.time)}</strong>
+            <span>${escapeHtml(clock.date)}</span>
+          </div>
+          <span class="player-weather-network">WEATHER//NET <i></i></span>
+        </div>
+
+        <div class="player-weather-current">
+          <div class="player-weather-current__icon">${iconSvg(actual.tipo, "player-weather-current__svg")}</div>
+          <div class="player-weather-current__main">
+            <span>${escapeHtml(engine.displaySeason(currentState.estacion).toUpperCase())}</span>
+            <h3>${escapeHtml(def.label || actual.tipo)}</h3>
+            <p>${escapeHtml(precipitationText(actual.tipo, actual.intensidad))}</p>
+          </div>
+          <strong class="player-weather-temperature">${Math.round(actual.temperatura)}<small>°C</small></strong>
+        </div>
+
+        <div class="player-weather-metrics">
+          <div><span>HUMEDAD</span><strong>${Math.round(actual.humedad)}%</strong></div>
+          <div><span>VIENTO</span><strong>${Math.round(actual.viento)}<small> km/h</small></strong></div>
+          <div><span>VISIBILIDAD</span><strong>${Math.round(actual.visibilidad)}%</strong></div>
+          <div><span>INTENSIDAD</span><strong>${Math.round(actual.intensidad)}%</strong></div>
+        </div>
+
+        <div class="player-weather-forecast-live">
+          <div class="player-weather-forecast-live__title">
+            <span>PRONÓSTICO // PRÓXIMAS HORAS</span>
+            <small>Estimación de red</small>
+          </div>
+          <div class="player-weather-forecast-live__grid">
+            ${forecast.length ? forecast.map((entry, index) => {
+              const forecastDef = engine.getDefinition(entry.tipo) || {};
+              const hour = Math.max(1, Math.round((Number(entry.etaMin) || ((index + 1) * 180)) / 60));
+              return `<div class="player-weather-forecast-item">
+                <span>+${hour}H</span>
+                ${iconSvg(entry.tipo, "player-weather-forecast-icon")}
+                <strong>${escapeHtml(forecastDef.label || entry.tipo)}</strong>
+                <small>PROB. ${playerForecastText(entry.probabilidad)}</small>
+              </div>`;
+            }).join("") : `<div class="player-weather-forecast-empty">SIN DATOS DE PRONÓSTICO</div>`}
+          </div>
+        </div>
+      </div>`;
+  }
+
+  function mount() {
+    widget = document.querySelector(".sheet-weather-widget");
+    if (!widget || widget.dataset.weatherPlayerMounted === "true") return false;
+    widget.dataset.weatherPlayerMounted = "true";
+    widget.classList.add("sheet-weather-widget--live");
+    unsubscribe = engine.onChange((next) => {
+      currentState = next;
+      render();
+    });
+    return true;
+  }
+
+  function boot() {
+    engine = global.LuminousWeatherEngine;
+    if (!engine) {
+      global.setTimeout(boot, 60);
+      return;
+    }
+    if (!mount()) global.setTimeout(boot, 250);
+  }
+
+  global.LuminousWeatherPlayerWidget = Object.freeze({
+    mount: () => { engine = global.LuminousWeatherEngine; return engine ? mount() : false; },
+    render,
+    destroy: () => { unsubscribe?.(); unsubscribe = null; }
+  });
+
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", boot, { once: true });
+  else boot();
+})(window);

--- a/js/weather-readonly-engine.js
+++ b/js/weather-readonly-engine.js
@@ -1,0 +1,221 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousWeatherEngine) return;
+
+  const ROOT = "campaña/clima";
+  const LEGACY_WORLD_ROOT = "campaña/estado_mundo";
+  const LEGACY_FORECAST_PATH = "campaña/worldData/weatherForecast";
+  const CALENDAR_ROOT = "campaña/calendario";
+
+  const WEATHER = Object.freeze({
+    soleado: { label: "Soleado", icon: "sun", env: { temperatura: 23, humedad: 38, viento: 8, visibilidad: 100, intensidad: 35 } },
+    parcialmente_nublado: { label: "Parcialmente Nublado", icon: "partly-cloudy", env: { temperatura: 19, humedad: 55, viento: 11, visibilidad: 94, intensidad: 42 } },
+    nublado: { label: "Nublado", icon: "cloudy", env: { temperatura: 16, humedad: 72, viento: 13, visibilidad: 84, intensidad: 50 } },
+    llovizna: { label: "Llovizna", icon: "drizzle", env: { temperatura: 14, humedad: 86, viento: 12, visibilidad: 75, intensidad: 40 } },
+    lluvia: { label: "Lluvia", icon: "rain", env: { temperatura: 12, humedad: 92, viento: 19, visibilidad: 62, intensidad: 66 } },
+    tormenta: { label: "Tormenta", icon: "storm", env: { temperatura: 11, humedad: 96, viento: 38, visibilidad: 42, intensidad: 88 } },
+    niebla: { label: "Niebla", icon: "fog", env: { temperatura: 10, humedad: 94, viento: 4, visibilidad: 28, intensidad: 65 } },
+    nieve: { label: "Nieve", icon: "snow", env: { temperatura: -2, humedad: 82, viento: 15, visibilidad: 67, intensidad: 58 } },
+    nevada: { label: "Nevada", icon: "snow-heavy", env: { temperatura: -6, humedad: 89, viento: 28, visibilidad: 35, intensidad: 84 } },
+    granizo: { label: "Granizo", icon: "hail", env: { temperatura: 4, humedad: 85, viento: 32, visibilidad: 48, intensidad: 80 } }
+  });
+
+  const LEGACY_TO_ID = Object.freeze({
+    Soleado: "soleado",
+    Despejado: "soleado",
+    "Parcialmente Nublado": "parcialmente_nublado",
+    Nublado: "nublado",
+    "Húmedo": "nublado",
+    Humedo: "nublado",
+    Calor: "soleado",
+    Llovizna: "llovizna",
+    Lluvia: "lluvia",
+    Tormenta: "tormenta",
+    Niebla: "niebla",
+    Nieve: "nieve",
+    Nevada: "nevada",
+    Granizo: "granizo"
+  });
+
+  const listeners = new Set();
+  let db = null;
+  let state = null;
+  let calendar = {};
+  let legacyWeather = "soleado";
+  let legacyForecast = [];
+  let modernExists = false;
+  let initialized = false;
+
+  function clone(value) {
+    return value ? JSON.parse(JSON.stringify(value)) : value;
+  }
+
+  function clamp(value, min, max, fallback) {
+    const n = Number(value);
+    return Number.isFinite(n) ? Math.max(min, Math.min(max, n)) : fallback;
+  }
+
+  function seasonFromMonth(month) {
+    const m = Math.max(1, Math.min(12, Number.parseInt(month, 10) || 1));
+    if (m >= 3 && m <= 5) return "primavera";
+    if (m >= 6 && m <= 8) return "verano";
+    if (m >= 9 && m <= 11) return "otono";
+    return "invierno";
+  }
+
+  function displaySeason(season) {
+    return ({ primavera: "Primavera", verano: "Verano", otono: "Otoño", invierno: "Invierno" })[season] || "Invierno";
+  }
+
+  function monthFromCalendar() {
+    if (calendar?.timestamp) {
+      const parsed = new Date(calendar.timestamp);
+      if (!Number.isNaN(parsed.getTime())) return parsed.getMonth() + 1;
+    }
+    return Number(calendar?.mes) || 1;
+  }
+
+  function normalizeWeatherId(value) {
+    if (!value) return "soleado";
+    const direct = String(value).trim();
+    if (WEATHER[direct]) return direct;
+    if (LEGACY_TO_ID[direct]) return LEGACY_TO_ID[direct];
+    const normalized = direct
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "_")
+      .replace(/^_+|_+$/g, "");
+    return WEATHER[normalized] ? normalized : "soleado";
+  }
+
+  function normalizeForecast(raw) {
+    if (!raw) return [];
+    const list = Array.isArray(raw) ? raw : Object.keys(raw).sort().map((key) => raw[key]);
+    return list.filter(Boolean).slice(0, 3).map((entry, index) => ({
+      tipo: normalizeWeatherId(entry.tipo || entry.clima),
+      probabilidad: clamp(entry.probabilidad, 0, 100, 0),
+      etaMin: Number(entry.etaMin) || ((index + 1) * 180)
+    }));
+  }
+
+  function fallbackState() {
+    const type = normalizeWeatherId(legacyWeather);
+    const env = WEATHER[type]?.env || WEATHER.soleado.env;
+    return {
+      version: 1,
+      modo: "auto",
+      estacion: seasonFromMonth(monthFromCalendar()),
+      regionActual: "mundo",
+      actual: { tipo: type, ...env },
+      anterior: null,
+      transicion: { activa: false, origen: null, destino: null, progreso: 0 },
+      pronostico: normalizeForecast(legacyForecast),
+      historial: []
+    };
+  }
+
+  function normalizeState(raw) {
+    const input = raw && typeof raw === "object" ? raw : {};
+    const type = normalizeWeatherId(input.actual?.tipo || input.actual || input.clima || legacyWeather);
+    const env = WEATHER[type]?.env || WEATHER.soleado.env;
+    const actualInput = input.actual && typeof input.actual === "object" ? input.actual : {};
+    return {
+      ...input,
+      version: Number(input.version) || 1,
+      modo: input.modo === "manual" ? "manual" : "auto",
+      estacion: seasonFromMonth(monthFromCalendar()),
+      regionActual: String(input.regionActual || "mundo"),
+      actual: {
+        tipo: type,
+        temperatura: clamp(actualInput.temperatura, -40, 60, env.temperatura),
+        humedad: clamp(actualInput.humedad, 0, 100, env.humedad),
+        viento: clamp(actualInput.viento, 0, 180, env.viento),
+        visibilidad: clamp(actualInput.visibilidad, 0, 100, env.visibilidad),
+        intensidad: clamp(actualInput.intensidad, 0, 100, env.intensidad)
+      },
+      pronostico: normalizeForecast(input.pronostico?.length ? input.pronostico : legacyForecast),
+      historial: Array.isArray(input.historial) ? input.historial.slice(-5) : []
+    };
+  }
+
+  function notify() {
+    const snapshot = clone(state);
+    listeners.forEach((listener) => {
+      try { listener(snapshot); } catch (error) { console.error("Weather listener error:", error); }
+    });
+    global.dispatchEvent?.(new CustomEvent("luminous-weather-change", { detail: snapshot }));
+  }
+
+  function refreshFallback() {
+    if (modernExists) return;
+    state = fallbackState();
+    notify();
+  }
+
+  function bind() {
+    db.ref(CALENDAR_ROOT).on("value", (snapshot) => {
+      calendar = snapshot.val() || {};
+      if (modernExists && state) {
+        state = normalizeState(state);
+        notify();
+      } else refreshFallback();
+    });
+
+    db.ref(`${LEGACY_WORLD_ROOT}/clima`).on("value", (snapshot) => {
+      legacyWeather = normalizeWeatherId(snapshot.val());
+      refreshFallback();
+    });
+
+    db.ref(LEGACY_FORECAST_PATH).on("value", (snapshot) => {
+      legacyForecast = snapshot.val() || [];
+      refreshFallback();
+    });
+
+    db.ref(ROOT).on("value", (snapshot) => {
+      modernExists = snapshot.exists();
+      state = modernExists ? normalizeState(snapshot.val()) : fallbackState();
+      notify();
+    });
+  }
+
+  function onChange(listener) {
+    if (typeof listener !== "function") return () => {};
+    listeners.add(listener);
+    if (state) listener(clone(state));
+    return () => listeners.delete(listener);
+  }
+
+  function getDefinition(weatherId) {
+    return clone(WEATHER[normalizeWeatherId(weatherId)] || WEATHER.soleado);
+  }
+
+  global.LuminousWeatherEngine = Object.freeze({
+    ROOT,
+    VERSION: 1,
+    readOnly: true,
+    onChange,
+    getState: () => clone(state),
+    getCalendar: () => clone(calendar),
+    getDefinition,
+    getDefinitions: () => clone(WEATHER),
+    normalizeWeatherId,
+    seasonFromMonth,
+    displaySeason,
+    iconHref: (weatherId) => `Assets/Images/Weather/weather-icons.svg#${getDefinition(weatherId).icon}`
+  });
+
+  function boot() {
+    if (initialized) return;
+    if (!global.firebase?.apps?.length || !global.firebase?.database) {
+      global.setTimeout(boot, 60);
+      return;
+    }
+    initialized = true;
+    db = global.firebase.database();
+    bind();
+  }
+
+  if (global.document) boot();
+})(window);

--- a/tests/weather_engine.spec.js
+++ b/tests/weather_engine.spec.js
@@ -1,0 +1,48 @@
+const { test, expect } = require("@playwright/test");
+const {
+  seasonFromMonth,
+  normalizeWeatherId,
+  getTransitionBreakdown,
+} = require("../js/weather-engine.js");
+
+test.describe("Weather Engine seasonal rules", () => {
+  test("maps campaign months to the expected season", () => {
+    expect(seasonFromMonth(1)).toBe("invierno");
+    expect(seasonFromMonth(4)).toBe("primavera");
+    expect(seasonFromMonth(7)).toBe("verano");
+    expect(seasonFromMonth(10)).toBe("otono");
+    expect(seasonFromMonth(12)).toBe("invierno");
+  });
+
+  test("normalizes legacy weather labels", () => {
+    expect(normalizeWeatherId("Parcialmente Nublado")).toBe("parcialmente_nublado");
+    expect(normalizeWeatherId("Húmedo")).toBe("nublado");
+    expect(normalizeWeatherId("Despejado")).toBe("soleado");
+  });
+
+  test("winter makes snow more likely than summer under freezing conditions", () => {
+    const base = {
+      actual: { tipo: "niebla", temperatura: -5, humedad: 92, viento: 5, visibilidad: 30, intensidad: 60 },
+      anterior: "nublado",
+    };
+    const winter = getTransitionBreakdown("niebla", { ...base, estacion: "invierno" });
+    const summer = getTransitionBreakdown("niebla", { ...base, estacion: "verano" });
+    const winterSnow = winter.find((row) => row.target === "nieve").probability;
+    const summerSnow = summer.find((row) => row.target === "nieve").probability;
+    expect(winterSnow).toBeGreaterThan(summerSnow);
+  });
+
+  test("high humidity increases rain routes", () => {
+    const dry = getTransitionBreakdown("nublado", {
+      estacion: "primavera",
+      actual: { tipo: "nublado", temperatura: 15, humedad: 45, viento: 10, visibilidad: 90, intensidad: 50 },
+    });
+    const humid = getTransitionBreakdown("nublado", {
+      estacion: "primavera",
+      actual: { tipo: "nublado", temperatura: 15, humedad: 92, viento: 10, visibilidad: 75, intensidad: 50 },
+    });
+    const dryRain = dry.find((row) => row.target === "lluvia").probability;
+    const humidRain = humid.find((row) => row.target === "lluvia").probability;
+    expect(humidRain).toBeGreaterThan(dryRain);
+  });
+});


### PR DESCRIPTION
## Objetivo

Evoluciona el clima actual hacia un **Weather Director** compartido entre DM y jugador, con estado moderno en Firebase, probabilidades estacionales y presentación visual basada en SVG.

## Qué incluye

- Weather Engine moderno bajo `campaña/clima`.
- 10 climas base: Soleado, Parcialmente Nublado, Nublado, Llovizna, Lluvia, Tormenta, Niebla, Nieve, Nevada y Granizo.
- Variables ambientales: temperatura, humedad, viento, visibilidad e intensidad.
- Probabilidades de transición modificadas por estación, temperatura, humedad, viento y clima anterior.
- Modo AUTO / MANUAL y cálculo de siguiente transición.
- Compatibilidad con `campaña/estado_mundo/clima` y `campaña/worldData/weatherForecast` durante la migración.

## DM // Weather Director

- Sustituye visualmente el grafo climático fijo por un panel Weather Director.
- Clima actual centrado y transiciones posibles alrededor.
- Porcentajes en conexiones SVG.
- Inspector atmosférico con métricas.
- Desglose de factores que afectan una transición.
- Controles para forzar clima, tirar transición y editar variables ambientales.
- Historial reciente.

## Jugador

- Reutiliza el widget meteorológico existente como terminal Weather//Net.
- Icono SVG del clima actual.
- Estación, temperatura, humedad, viento, visibilidad e intensidad.
- Pronóstico de tres pasos.
- El jugador ve categorías de probabilidad (ALTA / MEDIA / BAJA), no la matemática interna exacta.
- Engine de jugador separado y read-only.

## FX visuales

Base para efectos ambientales en Theatre/HUD:

- lluvia / llovizna
- niebla
- nieve / nevada
- granizo
- flashes de tormenta
- oscurecimiento por baja visibilidad
- heat haze ligero

Toda la iconografía climática usa SVG; no se introducen emojis para el sistema de clima.

## Firebase / seguridad

- `campaña/clima` es legible por usuarios autenticados por herencia del nodo `campaña`.
- Escritura de `campaña/clima` solo para el DM.
- Se agregan permisos explícitos de compatibilidad para forecast y reloj legacy usados durante la migración.
- El cliente del jugador carga un Weather Engine read-only sin operaciones de dirección climática.

## Validación

- `node --check` aplicado a los nuevos módulos JS y loader durante la preparación de la rama.
- SVG validado durante la preparación de la rama.
- Smoke visual local con Chromium/Playwright sobre el markup y CSS del PR a 1440, 900 y 600 px: sin overflow horizontal; el layout cambia correctamente a una columna bajo el breakpoint.
- Smoke visual de Theatre con la jerarquía real de capas: `#theatre-stage` z=10, FX z=30 dentro del stage, diálogo z=8500; los FX usan `pointer-events:none` y el diálogo permanece visualmente por encima.
- No hay GitHub Actions asociados al head del PR.
- La rama vuelve a apuntar al commit original del feature `a90f7436c398da9fbd48bbcbe866e32ba519e035`.

## Alcance fuera de este PR

No incluye todavía:

- clima por múltiples regiones simultáneas;
- eventos climáticos anómalos avanzados;
- efectos mecánicos directos sobre combate;
- editor completo de grafo por nodo;
- simulador meteorológico regional complejo.

## Checklist de revisión

### DM
- [x] Weather Director monta correctamente sobre la pestaña de clima. **Wiring validado y smoke de layout pasado a 1440/900/600 px sin overflow horizontal.**
- [x] El grafo muestra clima actual y transiciones posibles.
- [ ] Los porcentajes cambian correctamente con la estación y variables ambientales. **La lógica estacional existe, pero se reproduce un falso anti-rebote cuando `anterior` es `null`: `normalizeWeatherId("")` se convierte en `soleado`. En `Parcialmente Nublado`, Soleado cae aprox. de 27.38% a 4.33% aunque no exista clima anterior.**
- [x] AUTO / MANUAL está conectado al estado moderno y `evaluateAuto()` respeta el modo.
- [x] Forzar clima y tirar transición escriben `campaña/clima` y espejan el estado legacy mediante `writeState()`.
- [x] El inspector y el historial se actualizan mediante la suscripción `engine.onChange()`.

### Jugador
- [x] El widget Weather//Net sustituye el contenido del widget meteorológico existente.
- [x] No aparecen emojis meteorológicos en los archivos del sistema; la iconografía viene del sprite SVG.
- [x] El pronóstico muestra ALTA / MEDIA / BAJA en lugar de exponer el porcentaje exacto.
- [x] El cliente del jugador permanece read-only y las reglas de Firebase reservan la escritura de `campaña/clima` al DM.
- [x] Los FX no interfieren con diálogo ni HUD. **Smoke headless pasado: FX dentro del stage, `pointer-events:none`, y diálogo en la capa superior.**

### Compatibilidad
- [x] `estado_mundo/clima` se espeja desde el Weather Engine y el engine repara divergencias del clima legacy.
- [ ] El forecast legacy continúa sincronizado durante la transición. **El motor inline antiguo de `pantalla_dm.html` sigue escribiendo `campaña/worldData/weatherForecast`, por lo que puede sobrescribir el espejo generado por el Weather Engine moderno.**
- [x] No hay cambios en Stats, Skills, Coin Engine, combate ni splash art; el diff está limitado a Weather, `utils.js` y reglas Firebase.

## Estado del checklist

**12 / 14 comprobaciones pasan.** Los dos pendientes son fallos reproducibles y requieren corrección antes de considerar el PR listo para merge.

## Hallazgos antes de merge

1. **Anti-rebote inicial:** cuando no existe clima anterior, el cálculo normaliza el valor vacío a `soleado`, pudiendo penalizar incorrectamente una transición hacia Soleado.
2. **Forecast legacy:** el código climático inline anterior sigue activo en `pantalla_dm.html` y puede sobrescribir el forecast espejo del engine moderno.
3. **FX en Theatre del DM:** `hoja_de_DM.html` contiene `#theatre-stage`, pero actualmente no carga `utils.js` ni los módulos Weather; los FX están integrados en la hoja del jugador, pero no todavía en esa vista Theatre del DM.