### PR TITLE
Hotfix: corrige Weather Engine y HUD climático del jugador

### DIFF
--- a/.github/workflows/weather-engine.yml
+++ b/.github/workflows/weather-engine.yml
@@ -1,0 +1,52 @@
+name: "Weather Engine"
+
+on:
+  pull_request:
+    paths:
+      - "js/weather-engine.js"
+      - "js/weather-readonly-engine.js"
+      - "js/weather-post-merge-hotfix.js"
+      - "js/weather-player-widget.js"
+      - "js/weather-fx.js"
+      - "js/utils.js"
+      - "css/weather-player.css"
+      - "css/weather-fx.css"
+      - "hoja_de_DM.html"
+      - "tests/weather_engine.spec.js"
+      - "tests/weather_post_merge_hotfix.spec.js"
+      - ".github/workflows/weather-engine.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  weather-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Syntax check Weather JavaScript
+        run: |
+          node --check js/weather-engine.js
+          node --check js/weather-readonly-engine.js
+          node --check js/weather-post-merge-hotfix.js
+          node --check js/weather-player-widget.js
+          node --check js/weather-fx.js
+          node --check js/utils.js
+          node --check tests/weather_engine.spec.js
+          node --check tests/weather_post_merge_hotfix.spec.js
+
+      - name: Verify Weather contracts
+        run: npx playwright test tests/weather_engine.spec.js tests/weather_post_merge_hotfix.spec.js --workers=1

--- a/css/weather-player.css
+++ b/css/weather-player.css
@@ -1,4 +1,9 @@
 .sheet-weather-widget.sheet-weather-widget--live {
+  box-sizing: border-box;
+  flex: 0 0 auto;
+  width: calc(100% - 40px);
+  max-width: calc(100% - 40px);
+  margin: 15px 20px 0 !important;
   padding: 0 !important;
   overflow: hidden;
   background: #070b0d !important;
@@ -6,9 +11,25 @@
   box-shadow: inset 0 0 24px rgba(0,0,0,.55), 0 0 14px rgba(0,217,245,.08) !important;
 }
 
+/* El Home del terminal debe poder crecer y desplazarse cuando Weather//Net ocupa más alto. */
+.sheet-tab-home {
+  align-items: stretch !important;
+  justify-content: flex-start !important;
+  min-height: 0 !important;
+  overflow-x: hidden !important;
+  overflow-y: auto !important;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(0, 217, 245, .45) transparent;
+  padding-bottom: 20px;
+}
+.sheet-tab-home::-webkit-scrollbar { width: 5px; }
+.sheet-tab-home::-webkit-scrollbar-thumb { background: rgba(0, 217, 245, .42); }
+
 .sheet-weather-widget--live .player-weather-live {
   --pw-cyan: #00d9f5;
   --pw-gold: #c49a00;
+  width: 100%;
   color: #eaf6f8;
   font-family: "Share Tech Mono", monospace;
   background:
@@ -27,7 +48,7 @@
 }
 .sheet-weather-widget--live .player-weather-clock { display: flex; align-items: baseline; gap: 9px; min-width: 0; }
 .sheet-weather-widget--live .player-weather-clock strong { color: #fff; font-size: 20px; line-height: 1; }
-.sheet-weather-widget--live .player-weather-clock span { color: #60757d; font-size: 8px; letter-spacing: .08em; }
+.sheet-weather-widget--live .player-weather-clock span { min-width: 0; color: #60757d; font-size: 8px; letter-spacing: .08em; overflow-wrap: anywhere; }
 .sheet-weather-widget--live .player-weather-network { color: #698087; font-size: 8px; letter-spacing: .09em; white-space: nowrap; }
 .sheet-weather-widget--live .player-weather-network i { display: inline-block; width: 6px; height: 6px; border-radius: 50%; margin-left: 5px; background: var(--pw-cyan); box-shadow: 0 0 7px var(--pw-cyan); }
 
@@ -40,40 +61,90 @@
 }
 .sheet-weather-widget--live .player-weather-current__icon { width: 84px; height: 84px; display: grid; place-items: center; border: 1px solid #234047; background: radial-gradient(circle, rgba(0,217,245,.11), transparent 70%); }
 .sheet-weather-widget--live .player-weather-current__svg { width: 62px; height: 62px; fill: none; stroke: var(--pw-cyan); color: var(--pw-cyan); filter: drop-shadow(0 0 6px rgba(0,217,245,.3)); }
+.sheet-weather-widget--live .player-weather-current__main { min-width: 0; }
 .sheet-weather-widget--live .player-weather-current__main > span { color: var(--pw-gold); font-size: 8px; letter-spacing: .12em; }
-.sheet-weather-widget--live .player-weather-current__main h3 { margin: 2px 0 4px; color: #fff; font: 700 24px "BebasKai", "Share Tech Mono", sans-serif; letter-spacing: .04em; }
-.sheet-weather-widget--live .player-weather-current__main p { margin: 0; color: #71878e; font-size: 8px; letter-spacing: .06em; }
-.sheet-weather-widget--live .player-weather-temperature { color: #fff; font-size: 34px; font-weight: 400; align-self: start; }
+.sheet-weather-widget--live .player-weather-current__main h3 { margin: 2px 0 4px; color: #fff; font: 700 24px "BebasKai", "Share Tech Mono", sans-serif; letter-spacing: .04em; overflow-wrap: anywhere; }
+.sheet-weather-widget--live .player-weather-current__main p { margin: 0; color: #71878e; font-size: 8px; letter-spacing: .06em; overflow-wrap: anywhere; }
+.sheet-weather-widget--live .player-weather-temperature { color: #fff; font-size: 34px; font-weight: 400; align-self: start; white-space: nowrap; }
 .sheet-weather-widget--live .player-weather-temperature small { color: var(--pw-cyan); font-size: 13px; vertical-align: top; }
 
 .sheet-weather-widget--live .player-weather-metrics {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   border-top: 1px solid #1c2c31;
   border-bottom: 1px solid #1c2c31;
 }
 .sheet-weather-widget--live .player-weather-metrics > div { padding: 8px 9px; border-right: 1px solid #1c2c31; min-width: 0; }
 .sheet-weather-widget--live .player-weather-metrics > div:last-child { border-right: 0; }
-.sheet-weather-widget--live .player-weather-metrics span { display: block; color: #52686f; font-size: 7px; letter-spacing: .07em; }
+.sheet-weather-widget--live .player-weather-metrics span { display: block; color: #52686f; font-size: 7px; letter-spacing: .07em; overflow-wrap: anywhere; }
 .sheet-weather-widget--live .player-weather-metrics strong { display: block; margin-top: 3px; color: #d7e8ec; font-size: 12px; white-space: nowrap; }
 .sheet-weather-widget--live .player-weather-metrics small { color: #70848a; font-size: 7px; }
 
 .sheet-weather-widget--live .player-weather-forecast-live { padding: 10px 12px 12px; }
 .sheet-weather-widget--live .player-weather-forecast-live__title { display: flex; justify-content: space-between; gap: 10px; color: #8aa0a7; font-size: 8px; letter-spacing: .07em; margin-bottom: 8px; }
-.sheet-weather-widget--live .player-weather-forecast-live__title small { color: #4f636a; }
-.sheet-weather-widget--live .player-weather-forecast-live__grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; }
-.sheet-weather-widget--live .player-weather-forecast-item { min-width: 0; min-height: 72px; padding: 7px; display: grid; grid-template-columns: 29px 1fr; grid-template-rows: auto auto auto; column-gap: 7px; align-items: center; background: rgba(255,255,255,.025); border: 1px solid #20343a; }
+.sheet-weather-widget--live .player-weather-forecast-live__title small { color: #4f636a; text-align: right; }
+.sheet-weather-widget--live .player-weather-forecast-live__grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 6px; }
+.sheet-weather-widget--live .player-weather-forecast-item { min-width: 0; min-height: 72px; padding: 7px; display: grid; grid-template-columns: 29px minmax(0, 1fr); grid-template-rows: auto auto auto; column-gap: 7px; align-items: center; background: rgba(255,255,255,.025); border: 1px solid #20343a; }
 .sheet-weather-widget--live .player-weather-forecast-item > span { grid-column: 1 / -1; color: var(--pw-gold); font-size: 7px; }
 .sheet-weather-widget--live .player-weather-forecast-icon { grid-row: 2 / 4; width: 28px; height: 28px; fill: none; stroke: #91b5bd; }
-.sheet-weather-widget--live .player-weather-forecast-item strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: #d8e8eb; font-size: 8px; }
-.sheet-weather-widget--live .player-weather-forecast-item small { color: #526a71; font-size: 6px; }
+.sheet-weather-widget--live .player-weather-forecast-item strong { min-width: 0; color: #d8e8eb; font-size: 8px; line-height: 1.1; white-space: normal; overflow-wrap: anywhere; }
+.sheet-weather-widget--live .player-weather-forecast-item small { color: #526a71; font-size: 6px; line-height: 1.1; }
 .sheet-weather-widget--live .player-weather-forecast-empty { grid-column: 1 / -1; color: #52666d; font-size: 8px; text-align: center; padding: 14px; }
 
 @media (max-width: 680px) {
-  .sheet-weather-widget--live .player-weather-current { grid-template-columns: 62px minmax(0,1fr) auto; }
-  .sheet-weather-widget--live .player-weather-current__icon { width: 60px; height: 60px; }
-  .sheet-weather-widget--live .player-weather-current__svg { width: 44px; height: 44px; }
-  .sheet-weather-widget--live .player-weather-metrics { grid-template-columns: repeat(2, 1fr); }
-  .sheet-weather-widget--live .player-weather-metrics > div:nth-child(2) { border-right: 0; }
-  .sheet-weather-widget--live .player-weather-forecast-live__grid { grid-template-columns: 1fr; }
+  .sheet-weather-widget.sheet-weather-widget--live {
+    width: calc(100% - 20px);
+    max-width: calc(100% - 20px);
+    margin: 8px 10px 0 !important;
+  }
+  .sheet-weather-widget--live .player-weather-live__top { padding: 7px 9px; gap: 7px; }
+  .sheet-weather-widget--live .player-weather-clock { gap: 6px; }
+  .sheet-weather-widget--live .player-weather-clock strong { font-size: 17px; }
+  .sheet-weather-widget--live .player-weather-clock span,
+  .sheet-weather-widget--live .player-weather-network { font-size: 7px; }
+
+  .sheet-weather-widget--live .player-weather-current {
+    grid-template-columns: 58px minmax(0,1fr) auto;
+    gap: 8px;
+    padding: 10px 9px;
+  }
+  .sheet-weather-widget--live .player-weather-current__icon { width: 56px; height: 56px; }
+  .sheet-weather-widget--live .player-weather-current__svg { width: 40px; height: 40px; }
+  .sheet-weather-widget--live .player-weather-current__main h3 { font-size: 20px; }
+  .sheet-weather-widget--live .player-weather-temperature { font-size: 27px; }
+  .sheet-weather-widget--live .player-weather-temperature small { font-size: 10px; }
+
+  .sheet-weather-widget--live .player-weather-metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .sheet-weather-widget--live .player-weather-metrics > div { padding: 6px 8px; border-bottom: 1px solid #1c2c31; }
+  .sheet-weather-widget--live .player-weather-metrics > div:nth-child(2n) { border-right: 0; }
+  .sheet-weather-widget--live .player-weather-metrics > div:nth-last-child(-n + 2) { border-bottom: 0; }
+
+  /* Mantener las tres previsiones visibles en una sola fila; antes se apilaban y recortaban el Home. */
+  .sheet-weather-widget--live .player-weather-forecast-live { padding: 8px 8px 9px; }
+  .sheet-weather-widget--live .player-weather-forecast-live__grid { grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 4px; }
+  .sheet-weather-widget--live .player-weather-forecast-item {
+    min-height: 84px;
+    padding: 5px 3px;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 3px;
+    text-align: center;
+  }
+  .sheet-weather-widget--live .player-weather-forecast-item > span { width: 100%; }
+  .sheet-weather-widget--live .player-weather-forecast-icon { width: 24px; height: 24px; flex: 0 0 auto; }
+  .sheet-weather-widget--live .player-weather-forecast-item strong { width: 100%; font-size: 7px; }
+  .sheet-weather-widget--live .player-weather-forecast-item small { width: 100%; font-size: 6px; }
+}
+
+@media (max-width: 390px) {
+  .sheet-weather-widget--live .player-weather-live__top { align-items: flex-start; }
+  .sheet-weather-widget--live .player-weather-network { white-space: normal; text-align: right; max-width: 86px; }
+  .sheet-weather-widget--live .player-weather-current { grid-template-columns: 52px minmax(0, 1fr) auto; }
+  .sheet-weather-widget--live .player-weather-current__icon { width: 50px; height: 50px; }
+  .sheet-weather-widget--live .player-weather-current__svg { width: 36px; height: 36px; }
+  .sheet-weather-widget--live .player-weather-current__main h3 { font-size: 18px; }
+  .sheet-weather-widget--live .player-weather-temperature { font-size: 23px; }
+  .sheet-weather-widget--live .player-weather-forecast-live__title { font-size: 7px; }
 }

--- a/hoja_de_DM.html
+++ b/hoja_de_DM.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="css/theatre-dialogue.css">
   <link rel="stylesheet" href="css/theatre-hud.css">
   <link rel="stylesheet" href="css/theatre-message-policy.css">
+  <link rel="stylesheet" href="css/weather-fx.css">
 </head>
 <body class="on-game-dashboard">
   <nav class="master-control-bar" aria-label="Control de instancia">
@@ -129,6 +130,8 @@
   <script>
     firebase.initializeApp({apiKey:"AIzaSyAIVIuKgXUsdrb9Mmss9PH7R3FpWAMG2hU",authDomain:"luminous-system.firebaseapp.com",databaseURL:"https://luminous-system-default-rtdb.firebaseio.com",projectId:"luminous-system",storageBucket:"luminous-system.firebasestorage.app",messagingSenderId:"330473029689",appId:"1:330473029689:web:44a05e870d493a3b294de8"});
   </script>
+  <script src="js/weather-readonly-engine.js"></script>
+  <script src="js/weather-fx.js"></script>
   <script src="js/instance-control.js"></script>
   <script src="js/language-catalog-engine.js"></script>
   <script src="js/bond-engine.js"></script>

--- a/js/utils.js
+++ b/js/utils.js
@@ -145,6 +145,7 @@ function ensureWeatherSystemAssets(doc) {
     if (isDirector) {
         assets.directorStyle = ensureStyleAsset(documentRef, 'weather-director-stylesheet', 'css/weather-director.css', { ui: 'weather-director' });
         assets.director = ensureScriptAsset(documentRef, 'weather-director-script', 'js/weather-director-ui.js', { ui: 'weather-director' });
+        assets.hotfix = ensureScriptAsset(documentRef, 'weather-post-merge-hotfix-script', 'js/weather-post-merge-hotfix.js', { engine: 'weather-post-merge-hotfix' });
     }
 
     if (isPlayer) {

--- a/js/weather-post-merge-hotfix.js
+++ b/js/weather-post-merge-hotfix.js
@@ -1,0 +1,178 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousWeatherPostMergeHotfix) return;
+
+  const ROOT = "campaña/clima";
+  const LEGACY_FORECAST_PATH = "campaña/worldData/weatherForecast";
+  const REPAIR_DELAY_MS = 120;
+
+  let db = null;
+  let engine = null;
+  let unsubscribe = null;
+  let legacyForecastHandler = null;
+  let initialized = false;
+  let repairingPrevious = false;
+  let rebuildAfterPreviousRepair = false;
+  let repairingForecast = false;
+  let forecastRepairTimer = null;
+
+  function normalizeProbability(value) {
+    const n = Number(value);
+    return Number.isFinite(n) ? Math.max(0, Math.min(100, n)) : 0;
+  }
+
+  function repairedPreviousState(sourceState) {
+    if (!sourceState || typeof sourceState !== "object") return sourceState;
+    const current = sourceState.actual?.tipo;
+    if (!current || sourceState.anterior) return sourceState;
+    return { ...sourceState, anterior: current };
+  }
+
+  function legacyForecastFromState(sourceState, sourceEngine) {
+    const source = sourceState && typeof sourceState === "object" ? sourceState : {};
+    const weatherEngine = sourceEngine || engine;
+    const forecast = Array.isArray(source.pronostico) ? source.pronostico.slice(0, 3) : [];
+    return forecast.map((entry) => {
+      const def = weatherEngine?.getDefinition?.(entry.tipo) || {};
+      return {
+        clima: def.label || String(entry.tipo || "Soleado"),
+        probabilidad: normalizeProbability(entry.probabilidad)
+      };
+    });
+  }
+
+  function normalizeLegacyForecast(raw) {
+    if (!raw) return [];
+    const list = Array.isArray(raw) ? raw : Object.keys(raw).sort().map((key) => raw[key]);
+    return list.filter(Boolean).map((entry) => ({
+      clima: String(entry.clima || entry.tipo || ""),
+      probabilidad: normalizeProbability(entry.probabilidad)
+    }));
+  }
+
+  function forecastsEqual(left, right) {
+    const a = normalizeLegacyForecast(left);
+    const b = normalizeLegacyForecast(right);
+    if (a.length !== b.length) return false;
+    return a.every((entry, index) => (
+      entry.clima === b[index].clima
+      && Math.abs(entry.probabilidad - b[index].probabilidad) < 0.001
+    ));
+  }
+
+  async function repairMissingPrevious(state) {
+    if (!db || !engine || repairingPrevious || !state?.actual?.tipo || state.anterior) return false;
+    repairingPrevious = true;
+    rebuildAfterPreviousRepair = true;
+    try {
+      const repaired = repairedPreviousState(state);
+      await db.ref(`${ROOT}/anterior`).set(repaired.anterior);
+      return true;
+    } catch (error) {
+      rebuildAfterPreviousRepair = false;
+      console.warn("Weather hotfix: no se pudo reparar el clima anterior inicial.", error);
+      return false;
+    } finally {
+      repairingPrevious = false;
+    }
+  }
+
+  async function rebuildForecastAfterPreviousRepair(state) {
+    if (!rebuildAfterPreviousRepair || !state?.anterior || !engine?.updateEnvironment) return false;
+    rebuildAfterPreviousRepair = false;
+    try {
+      await engine.updateEnvironment({});
+      return true;
+    } catch (error) {
+      console.warn("Weather hotfix: no se pudo recalcular el pronóstico tras reparar anterior.", error);
+      return false;
+    }
+  }
+
+  function scheduleLegacyForecastRepair(rawForecast) {
+    if (!db || !engine || repairingForecast) return;
+    const state = engine.getState?.();
+    if (!state) return;
+    const expected = legacyForecastFromState(state, engine);
+    if (forecastsEqual(rawForecast, expected)) return;
+
+    if (forecastRepairTimer) global.clearTimeout(forecastRepairTimer);
+    forecastRepairTimer = global.setTimeout(async () => {
+      forecastRepairTimer = null;
+      if (repairingForecast) return;
+      const latestState = engine.getState?.();
+      if (!latestState) return;
+      const latestExpected = legacyForecastFromState(latestState, engine);
+      repairingForecast = true;
+      try {
+        await db.ref(LEGACY_FORECAST_PATH).set(latestExpected);
+      } catch (error) {
+        console.warn("Weather hotfix: no se pudo resincronizar el forecast legacy.", error);
+      } finally {
+        global.setTimeout(() => { repairingForecast = false; }, REPAIR_DELAY_MS);
+      }
+    }, REPAIR_DELAY_MS);
+  }
+
+  function handleStateChange(state) {
+    if (!state) return;
+    if (!state.anterior) {
+      repairMissingPrevious(state);
+      return;
+    }
+    rebuildForecastAfterPreviousRepair(state);
+  }
+
+  function bind() {
+    if (!db || !engine || unsubscribe) return;
+    unsubscribe = engine.onChange?.(handleStateChange) || null;
+    legacyForecastHandler = (snapshot) => {
+      if (repairingForecast) return;
+      scheduleLegacyForecastRepair(snapshot.val());
+    };
+    db.ref(LEGACY_FORECAST_PATH).on("value", legacyForecastHandler);
+  }
+
+  function boot() {
+    if (initialized) return;
+    engine = global.LuminousWeatherEngine;
+    if (!engine || engine.readOnly || !global.firebase?.apps?.length || !global.firebase?.database) {
+      global.setTimeout(boot, 60);
+      return;
+    }
+    db = global.firebase.database();
+    initialized = true;
+    bind();
+  }
+
+  function destroy() {
+    unsubscribe?.();
+    unsubscribe = null;
+    if (db && legacyForecastHandler) db.ref(LEGACY_FORECAST_PATH).off("value", legacyForecastHandler);
+    legacyForecastHandler = null;
+    if (forecastRepairTimer) global.clearTimeout(forecastRepairTimer);
+    forecastRepairTimer = null;
+    initialized = false;
+  }
+
+  global.LuminousWeatherPostMergeHotfix = Object.freeze({
+    ROOT,
+    LEGACY_FORECAST_PATH,
+    repairedPreviousState,
+    legacyForecastFromState,
+    forecastsEqual,
+    destroy
+  });
+
+  if (global.document) boot();
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = {
+      repairedPreviousState,
+      legacyForecastFromState,
+      forecastsEqual,
+      normalizeLegacyForecast
+    };
+  }
+})(typeof window !== "undefined" ? window : globalThis);

--- a/tests/weather_post_merge_hotfix.spec.js
+++ b/tests/weather_post_merge_hotfix.spec.js
@@ -1,0 +1,64 @@
+const { test, expect } = require("@playwright/test");
+const {
+  repairedPreviousState,
+  legacyForecastFromState,
+  forecastsEqual,
+} = require("../js/weather-post-merge-hotfix.js");
+
+test.describe("Weather post-merge hotfix", () => {
+  test("neutralizes the initial anti-bounce when there is no previous weather", () => {
+    const state = {
+      actual: { tipo: "parcialmente_nublado" },
+      anterior: null,
+    };
+
+    const repaired = repairedPreviousState(state);
+    expect(repaired.anterior).toBe("parcialmente_nublado");
+    expect(state.anterior).toBeNull();
+  });
+
+  test("builds the three-entry legacy mirror from the modern forecast", () => {
+    const state = {
+      pronostico: [
+        { tipo: "lluvia", probabilidad: 42 },
+        { tipo: "nublado", probabilidad: 33 },
+        { tipo: "niebla", probabilidad: 25 },
+        { tipo: "soleado", probabilidad: 10 },
+      ],
+    };
+    const engine = {
+      getDefinition(id) {
+        return {
+          lluvia: { label: "Lluvia" },
+          nublado: { label: "Nublado" },
+          niebla: { label: "Niebla" },
+          soleado: { label: "Soleado" },
+        }[id];
+      },
+    };
+
+    expect(legacyForecastFromState(state, engine)).toEqual([
+      { clima: "Lluvia", probabilidad: 42 },
+      { clima: "Nublado", probabilidad: 33 },
+      { clima: "Niebla", probabilidad: 25 },
+    ]);
+  });
+
+  test("detects the seven-entry legacy writer as drift", () => {
+    const modernMirror = [
+      { clima: "Lluvia", probabilidad: 42 },
+      { clima: "Nublado", probabilidad: 33 },
+      { clima: "Niebla", probabilidad: 25 },
+    ];
+    const staleLegacy = [
+      ...modernMirror,
+      { clima: "Soleado", probabilidad: 10 },
+      { clima: "Llovizna", probabilidad: 8 },
+      { clima: "Tormenta", probabilidad: 7 },
+      { clima: "Granizo", probabilidad: 5 },
+    ];
+
+    expect(forecastsEqual(modernMirror, modernMirror)).toBe(true);
+    expect(forecastsEqual(staleLegacy, modernMirror)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Resumen
- corrige el anti-rebote inicial cuando `anterior` aún no existe
- evita que el generador legacy de 7 días deje desincronizado `campaña/worldData/weatherForecast`
- compacta y hace desplazable el Weather//Net del celular para que se vean clima actual, métricas y las 3 previsiones
- carga los FX meteorológicos también en el Theatre del DM
- añade un workflow propio de CI para Weather y regresiones específicas del hotfix

## Cambios principales
- `js/weather-post-merge-hotfix.js`: repara `anterior` inicial y resincroniza el mirror legacy desde el estado moderno
- `css/weather-player.css`: corrige clipping/overflow del HUD y mantiene las 3 previsiones visibles en móvil
- `hoja_de_DM.html`: carga engine read-only + Weather FX en Theatre DM
- `js/utils.js`: carga el hotfix solo en el Weather Director
- `tests/weather_post_merge_hotfix.spec.js`: contratos de anti-rebote y forecast legacy
- `.github/workflows/weather-engine.yml`: sintaxis + Playwright para Weather

## Validación realizada
- rama basada exactamente en el `main` posterior al merge #535
- 6 commits adelante / 0 detrás de `main`
- `node --check` de los módulos modificados/nuevos
- mock local de Firebase para reparación de `anterior` y resincronización de forecast
- revisión del layout móvil para evitar el apilado vertical que recortaba Weather//Net

## Pendiente externo
- verificar que `database.rules.json` esté efectivamente desplegado en Firebase Realtime Database; el repo no tiene un workflow de deployment de reglas.

## Checklist
- [x] Neutralizar anti-rebote falso cuando `anterior` es nulo
- [x] Restaurar forecast moderno si el escritor legacy lo sobrescribe
- [x] Mantener 3 previsiones visibles en el HUD móvil
- [x] Mantener humedad, viento, visibilidad e intensidad visibles
- [x] Permitir scroll vertical real en Home del celular
- [x] Cargar Weather FX en Theatre DM
- [x] Añadir regresiones del hotfix
- [x] Añadir workflow Weather Engine
- [x] Confirmar checks del PR en GitHub Actions
- [x] Verificar reglas Firebase desplegadas en el entorno vivo