### PR TITLE
Feat: widget climático compacto y app Weather//Net

### DIFF
--- a/css/weather-player.css
+++ b/css/weather-player.css
@@ -1,95 +1,398 @@
 .sheet-weather-widget.sheet-weather-widget--live {
+  --pw-cyan: #00d9f5;
+  --pw-gold: #c49a00;
   box-sizing: border-box;
   flex: 0 0 auto;
+  display: block !important;
   width: calc(100% - 40px);
   max-width: calc(100% - 40px);
-  margin: 15px 20px 0 !important;
+  margin: 12px 20px 0 !important;
   padding: 0 !important;
+  gap: 0 !important;
   overflow: hidden;
   background: #070b0d !important;
   border: 1px solid rgba(0, 217, 245, .42) !important;
+  border-radius: 10px !important;
   box-shadow: inset 0 0 24px rgba(0,0,0,.55), 0 0 14px rgba(0,217,245,.08) !important;
 }
 
-/* El Home del terminal debe poder crecer y desplazarse cuando Weather//Net ocupa más alto. */
+/* El Home vuelve a ser una pantalla de vistazo: sin scroll por el clima. */
 .sheet-tab-home {
   align-items: stretch !important;
   justify-content: flex-start !important;
   min-height: 0 !important;
-  overflow-x: hidden !important;
-  overflow-y: auto !important;
-  overscroll-behavior: contain;
-  scrollbar-width: thin;
-  scrollbar-color: rgba(0, 217, 245, .45) transparent;
-  padding-bottom: 20px;
+  overflow: hidden !important;
+  padding-bottom: 0 !important;
 }
-.sheet-tab-home::-webkit-scrollbar { width: 5px; }
-.sheet-tab-home::-webkit-scrollbar-thumb { background: rgba(0, 217, 245, .42); }
 
-.sheet-weather-widget--live .player-weather-live {
+.player-weather-glance {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 100%;
+  min-height: 92px;
+  margin: 0;
+  padding: 10px 12px;
+  border: 0;
+  background:
+    linear-gradient(115deg, rgba(0,217,245,.09), transparent 46%),
+    #070b0d;
+  color: #eaf6f8;
+  display: grid;
+  grid-template-columns: 62px minmax(0, 1fr) auto;
+  grid-template-rows: 1fr auto;
+  column-gap: 12px;
+  align-items: center;
+  text-align: left;
+  font-family: "Share Tech Mono", monospace;
+  cursor: pointer;
+  position: relative;
+}
+
+.player-weather-glance::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border: 1px solid transparent;
+  pointer-events: none;
+  transition: border-color .16s ease, box-shadow .16s ease;
+}
+
+.player-weather-glance:hover::after,
+.player-weather-glance:focus-visible::after {
+  border-color: rgba(0,217,245,.62);
+  box-shadow: inset 0 0 18px rgba(0,217,245,.08);
+}
+.player-weather-glance:focus-visible { outline: none; }
+
+.player-weather-glance__icon {
+  grid-row: 1 / 3;
+  width: 58px;
+  height: 58px;
+  display: grid;
+  place-items: center;
+  border: 1px solid #244149;
+  background: radial-gradient(circle, rgba(0,217,245,.12), transparent 70%);
+}
+.player-weather-glance__svg {
+  width: 42px;
+  height: 42px;
+  fill: none;
+  stroke: var(--pw-cyan);
+  color: var(--pw-cyan);
+  filter: drop-shadow(0 0 6px rgba(0,217,245,.28));
+}
+
+.player-weather-glance__copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.player-weather-glance__copy small {
+  color: #698087;
+  font-size: 7px;
+  letter-spacing: .12em;
+}
+.player-weather-glance__copy strong {
+  margin-top: 2px;
+  color: #fff;
+  font: 700 20px/1 "BebasKai", "Share Tech Mono", sans-serif;
+  letter-spacing: .04em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.player-weather-glance__copy > span {
+  margin-top: 4px;
+  color: #71878e;
+  font-size: 7px;
+  letter-spacing: .04em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.player-weather-glance__temp {
+  align-self: center;
+  color: #fff;
+  font-size: 29px;
+  line-height: 1;
+  white-space: nowrap;
+}
+.player-weather-glance__temp small {
+  color: var(--pw-cyan);
+  font-size: 10px;
+  vertical-align: top;
+}
+.player-weather-glance__open {
+  grid-column: 2 / 4;
+  justify-self: end;
+  color: var(--pw-gold);
+  font-size: 7px;
+  letter-spacing: .14em;
+}
+
+/* Weather//Net app: ocupa el área de pantalla del teléfono, sin alargar el Home. */
+.player-weather-app[hidden] { display: none !important; }
+.player-weather-app {
   --pw-cyan: #00d9f5;
   --pw-gold: #c49a00;
-  width: 100%;
+  position: absolute;
+  inset: 0;
+  z-index: 85;
+  display: none;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(0,217,245,.09), transparent 30%),
+    linear-gradient(180deg, rgba(9,16,20,.99), rgba(4,7,9,.995));
   color: #eaf6f8;
   font-family: "Share Tech Mono", monospace;
-  background:
-    linear-gradient(135deg, rgba(0,217,245,.055), transparent 42%),
-    #070b0d;
 }
+.player-weather-app.is-open { display: block; }
+.player-weather-app *,
+.player-weather-app *::before,
+.player-weather-app *::after { box-sizing: border-box; }
 
-.sheet-weather-widget--live .player-weather-live__top {
-  min-height: 42px;
-  padding: 8px 12px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  border-bottom: 1px solid #203138;
-}
-.sheet-weather-widget--live .player-weather-clock { display: flex; align-items: baseline; gap: 9px; min-width: 0; }
-.sheet-weather-widget--live .player-weather-clock strong { color: #fff; font-size: 20px; line-height: 1; }
-.sheet-weather-widget--live .player-weather-clock span { min-width: 0; color: #60757d; font-size: 8px; letter-spacing: .08em; overflow-wrap: anywhere; }
-.sheet-weather-widget--live .player-weather-network { color: #698087; font-size: 8px; letter-spacing: .09em; white-space: nowrap; }
-.sheet-weather-widget--live .player-weather-network i { display: inline-block; width: 6px; height: 6px; border-radius: 50%; margin-left: 5px; background: var(--pw-cyan); box-shadow: 0 0 7px var(--pw-cyan); }
-
-.sheet-weather-widget--live .player-weather-current {
+.player-weather-app__frame {
+  height: 100%;
+  min-height: 0;
   display: grid;
-  grid-template-columns: 88px minmax(0, 1fr) auto;
+  grid-template-rows: auto minmax(0, 1fr);
+  overflow: hidden;
+}
+
+.player-weather-app__header {
+  min-height: 48px;
+  padding: 7px 10px;
+  border-bottom: 1px solid #20353c;
+  background: rgba(3,7,9,.84);
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 10px;
+}
+.player-weather-app__header > div { min-width: 0; }
+.player-weather-app__header small {
+  display: block;
+  color: #5d737b;
+  font-size: 6px;
+  letter-spacing: .12em;
+}
+.player-weather-app__header strong {
+  display: block;
+  margin-top: 1px;
+  color: #fff;
+  font-size: 13px;
+  letter-spacing: .12em;
+}
+.player-weather-app__back {
+  appearance: none;
+  border: 1px solid #35515a;
+  background: #080d10;
+  color: var(--pw-cyan);
+  padding: 7px 9px;
+  font: 700 8px "Share Tech Mono", monospace;
+  letter-spacing: .08em;
+  cursor: pointer;
+}
+.player-weather-app__back:hover,
+.player-weather-app__back:focus-visible {
+  outline: none;
+  border-color: var(--pw-cyan);
+  box-shadow: 0 0 10px rgba(0,217,245,.16);
+}
+.player-weather-app__network {
+  color: #72868d;
+  font-size: 7px;
+  letter-spacing: .08em;
+  white-space: nowrap;
+}
+.player-weather-app__network i {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-left: 5px;
+  border-radius: 50%;
+  background: var(--pw-cyan);
+  box-shadow: 0 0 7px var(--pw-cyan);
+}
+
+.player-weather-app__body {
+  min-height: 0;
+  overflow: hidden;
+  padding: 10px;
+  display: grid;
+  grid-template-rows: minmax(108px, 1.25fr) minmax(70px, .75fr) minmax(118px, 1fr);
+  gap: 8px;
+}
+
+.player-weather-app__hero {
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 86px minmax(0, 1fr) auto;
   align-items: center;
   gap: 12px;
-  padding: 15px 14px 12px;
+  padding: 10px 12px;
+  border: 1px solid #27424a;
+  background:
+    linear-gradient(115deg, rgba(0,217,245,.10), transparent 48%),
+    rgba(5,10,13,.82);
 }
-.sheet-weather-widget--live .player-weather-current__icon { width: 84px; height: 84px; display: grid; place-items: center; border: 1px solid #234047; background: radial-gradient(circle, rgba(0,217,245,.11), transparent 70%); }
-.sheet-weather-widget--live .player-weather-current__svg { width: 62px; height: 62px; fill: none; stroke: var(--pw-cyan); color: var(--pw-cyan); filter: drop-shadow(0 0 6px rgba(0,217,245,.3)); }
-.sheet-weather-widget--live .player-weather-current__main { min-width: 0; }
-.sheet-weather-widget--live .player-weather-current__main > span { color: var(--pw-gold); font-size: 8px; letter-spacing: .12em; }
-.sheet-weather-widget--live .player-weather-current__main h3 { margin: 2px 0 4px; color: #fff; font: 700 24px "BebasKai", "Share Tech Mono", sans-serif; letter-spacing: .04em; overflow-wrap: anywhere; }
-.sheet-weather-widget--live .player-weather-current__main p { margin: 0; color: #71878e; font-size: 8px; letter-spacing: .06em; overflow-wrap: anywhere; }
-.sheet-weather-widget--live .player-weather-temperature { color: #fff; font-size: 34px; font-weight: 400; align-self: start; white-space: nowrap; }
-.sheet-weather-widget--live .player-weather-temperature small { color: var(--pw-cyan); font-size: 13px; vertical-align: top; }
+.player-weather-app__hero-icon {
+  width: 78px;
+  height: 78px;
+  display: grid;
+  place-items: center;
+  border: 1px solid #2b4a53;
+  background: radial-gradient(circle, rgba(0,217,245,.14), transparent 70%);
+}
+.player-weather-app__hero-svg {
+  width: 56px;
+  height: 56px;
+  fill: none;
+  stroke: var(--pw-cyan);
+  color: var(--pw-cyan);
+  filter: drop-shadow(0 0 7px rgba(0,217,245,.32));
+}
+.player-weather-app__hero-copy { min-width: 0; }
+.player-weather-app__hero-copy small {
+  color: var(--pw-gold);
+  font-size: 7px;
+  letter-spacing: .08em;
+}
+.player-weather-app__hero-copy h2 {
+  margin: 3px 0 4px;
+  color: #fff;
+  font: 700 clamp(22px, 5vw, 32px)/.95 "BebasKai", "Share Tech Mono", sans-serif;
+  letter-spacing: .04em;
+  overflow-wrap: anywhere;
+}
+.player-weather-app__hero-copy p {
+  margin: 0;
+  color: #789098;
+  font-size: 7px;
+  letter-spacing: .05em;
+}
+.player-weather-app__temperature {
+  align-self: start;
+  color: #fff;
+  font-size: clamp(28px, 7vw, 40px);
+  line-height: 1;
+  text-align: right;
+  white-space: nowrap;
+}
+.player-weather-app__temperature small {
+  color: var(--pw-cyan);
+  font-size: 11px;
+  vertical-align: top;
+}
+.player-weather-app__temperature span {
+  display: block;
+  margin-top: 7px;
+  color: #62777e;
+  font-size: 8px;
+  letter-spacing: .08em;
+}
 
-.sheet-weather-widget--live .player-weather-metrics {
+.player-weather-app__metrics {
+  min-height: 0;
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  border-top: 1px solid #1c2c31;
-  border-bottom: 1px solid #1c2c31;
+  border: 1px solid #243b42;
+  background: rgba(5,9,11,.72);
 }
-.sheet-weather-widget--live .player-weather-metrics > div { padding: 8px 9px; border-right: 1px solid #1c2c31; min-width: 0; }
-.sheet-weather-widget--live .player-weather-metrics > div:last-child { border-right: 0; }
-.sheet-weather-widget--live .player-weather-metrics span { display: block; color: #52686f; font-size: 7px; letter-spacing: .07em; overflow-wrap: anywhere; }
-.sheet-weather-widget--live .player-weather-metrics strong { display: block; margin-top: 3px; color: #d7e8ec; font-size: 12px; white-space: nowrap; }
-.sheet-weather-widget--live .player-weather-metrics small { color: #70848a; font-size: 7px; }
+.player-weather-app__metrics > div {
+  min-width: 0;
+  padding: 9px 8px;
+  border-right: 1px solid #1d3036;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.player-weather-app__metrics > div:last-child { border-right: 0; }
+.player-weather-app__metrics span {
+  color: #596e75;
+  font-size: 6px;
+  letter-spacing: .08em;
+}
+.player-weather-app__metrics strong {
+  margin-top: 4px;
+  color: #d9e8eb;
+  font-size: clamp(13px, 3.6vw, 18px);
+  white-space: nowrap;
+}
+.player-weather-app__metrics strong small {
+  color: #72878e;
+  font-size: 7px;
+}
 
-.sheet-weather-widget--live .player-weather-forecast-live { padding: 10px 12px 12px; }
-.sheet-weather-widget--live .player-weather-forecast-live__title { display: flex; justify-content: space-between; gap: 10px; color: #8aa0a7; font-size: 8px; letter-spacing: .07em; margin-bottom: 8px; }
-.sheet-weather-widget--live .player-weather-forecast-live__title small { color: #4f636a; text-align: right; }
-.sheet-weather-widget--live .player-weather-forecast-live__grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 6px; }
-.sheet-weather-widget--live .player-weather-forecast-item { min-width: 0; min-height: 72px; padding: 7px; display: grid; grid-template-columns: 29px minmax(0, 1fr); grid-template-rows: auto auto auto; column-gap: 7px; align-items: center; background: rgba(255,255,255,.025); border: 1px solid #20343a; }
-.sheet-weather-widget--live .player-weather-forecast-item > span { grid-column: 1 / -1; color: var(--pw-gold); font-size: 7px; }
-.sheet-weather-widget--live .player-weather-forecast-icon { grid-row: 2 / 4; width: 28px; height: 28px; fill: none; stroke: #91b5bd; }
-.sheet-weather-widget--live .player-weather-forecast-item strong { min-width: 0; color: #d8e8eb; font-size: 8px; line-height: 1.1; white-space: normal; overflow-wrap: anywhere; }
-.sheet-weather-widget--live .player-weather-forecast-item small { color: #526a71; font-size: 6px; line-height: 1.1; }
-.sheet-weather-widget--live .player-weather-forecast-empty { grid-column: 1 / -1; color: #52666d; font-size: 8px; text-align: center; padding: 14px; }
+.player-weather-app__forecast {
+  min-height: 0;
+  padding: 8px;
+  border: 1px solid #243b42;
+  background: rgba(5,9,11,.72);
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+}
+.player-weather-app__section-title {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+  color: #91a7ae;
+  font-size: 7px;
+  letter-spacing: .07em;
+}
+.player-weather-app__section-title small { color: #50636a; }
+.player-weather-app__forecast-grid {
+  min-height: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 5px;
+}
+.player-weather-app__forecast-card {
+  min-width: 0;
+  min-height: 0;
+  padding: 5px;
+  border: 1px solid #20343a;
+  background: rgba(255,255,255,.025);
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr);
+  grid-template-rows: auto auto auto;
+  column-gap: 6px;
+  align-items: center;
+}
+.player-weather-app__forecast-card > span {
+  grid-column: 1 / -1;
+  color: var(--pw-gold);
+  font-size: 6px;
+}
+.player-weather-app__forecast-icon {
+  grid-row: 2 / 4;
+  width: 28px;
+  height: 28px;
+  fill: none;
+  stroke: #91b5bd;
+  color: #91b5bd;
+}
+.player-weather-app__forecast-card strong {
+  min-width: 0;
+  color: #d8e8eb;
+  font-size: 8px;
+  line-height: 1.05;
+  overflow-wrap: anywhere;
+}
+.player-weather-app__forecast-card small {
+  color: #536a71;
+  font-size: 6px;
+}
+.player-weather-app__forecast-empty {
+  grid-column: 1 / -1;
+  display: grid;
+  place-items: center;
+  color: #52666d;
+  font-size: 8px;
+}
 
 @media (max-width: 680px) {
   .sheet-weather-widget.sheet-weather-widget--live {
@@ -97,54 +400,90 @@
     max-width: calc(100% - 20px);
     margin: 8px 10px 0 !important;
   }
-  .sheet-weather-widget--live .player-weather-live__top { padding: 7px 9px; gap: 7px; }
-  .sheet-weather-widget--live .player-weather-clock { gap: 6px; }
-  .sheet-weather-widget--live .player-weather-clock strong { font-size: 17px; }
-  .sheet-weather-widget--live .player-weather-clock span,
-  .sheet-weather-widget--live .player-weather-network { font-size: 7px; }
+  .player-weather-glance {
+    min-height: 82px;
+    padding: 8px 9px;
+    grid-template-columns: 54px minmax(0, 1fr) auto;
+    column-gap: 9px;
+  }
+  .player-weather-glance__icon { width: 50px; height: 50px; }
+  .player-weather-glance__svg { width: 36px; height: 36px; }
+  .player-weather-glance__copy strong { font-size: 18px; }
+  .player-weather-glance__temp { font-size: 25px; }
 
-  .sheet-weather-widget--live .player-weather-current {
-    grid-template-columns: 58px minmax(0,1fr) auto;
+  .player-weather-app__body {
+    padding: 8px;
+    grid-template-rows: minmax(98px, 1.15fr) minmax(64px, .70fr) minmax(110px, 1fr);
+    gap: 6px;
+  }
+  .player-weather-app__hero {
+    grid-template-columns: 70px minmax(0, 1fr) auto;
     gap: 8px;
-    padding: 10px 9px;
+    padding: 8px;
   }
-  .sheet-weather-widget--live .player-weather-current__icon { width: 56px; height: 56px; }
-  .sheet-weather-widget--live .player-weather-current__svg { width: 40px; height: 40px; }
-  .sheet-weather-widget--live .player-weather-current__main h3 { font-size: 20px; }
-  .sheet-weather-widget--live .player-weather-temperature { font-size: 27px; }
-  .sheet-weather-widget--live .player-weather-temperature small { font-size: 10px; }
-
-  .sheet-weather-widget--live .player-weather-metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .sheet-weather-widget--live .player-weather-metrics > div { padding: 6px 8px; border-bottom: 1px solid #1c2c31; }
-  .sheet-weather-widget--live .player-weather-metrics > div:nth-child(2n) { border-right: 0; }
-  .sheet-weather-widget--live .player-weather-metrics > div:nth-last-child(-n + 2) { border-bottom: 0; }
-
-  /* Mantener las tres previsiones visibles en una sola fila; antes se apilaban y recortaban el Home. */
-  .sheet-weather-widget--live .player-weather-forecast-live { padding: 8px 8px 9px; }
-  .sheet-weather-widget--live .player-weather-forecast-live__grid { grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 4px; }
-  .sheet-weather-widget--live .player-weather-forecast-item {
-    min-height: 84px;
-    padding: 5px 3px;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    align-items: center;
-    gap: 3px;
-    text-align: center;
+  .player-weather-app__hero-icon { width: 64px; height: 64px; }
+  .player-weather-app__hero-svg { width: 46px; height: 46px; }
+  .player-weather-app__metrics > div { padding: 7px 5px; }
+  .player-weather-app__forecast { padding: 6px; }
+  .player-weather-app__forecast-card {
+    grid-template-columns: 25px minmax(0, 1fr);
+    column-gap: 4px;
+    padding: 4px;
   }
-  .sheet-weather-widget--live .player-weather-forecast-item > span { width: 100%; }
-  .sheet-weather-widget--live .player-weather-forecast-icon { width: 24px; height: 24px; flex: 0 0 auto; }
-  .sheet-weather-widget--live .player-weather-forecast-item strong { width: 100%; font-size: 7px; }
-  .sheet-weather-widget--live .player-weather-forecast-item small { width: 100%; font-size: 6px; }
+  .player-weather-app__forecast-icon { width: 23px; height: 23px; }
+  .player-weather-app__forecast-card strong { font-size: 7px; }
+  .player-weather-app__forecast-card small { font-size: 5.5px; }
 }
 
 @media (max-width: 390px) {
-  .sheet-weather-widget--live .player-weather-live__top { align-items: flex-start; }
-  .sheet-weather-widget--live .player-weather-network { white-space: normal; text-align: right; max-width: 86px; }
-  .sheet-weather-widget--live .player-weather-current { grid-template-columns: 52px minmax(0, 1fr) auto; }
-  .sheet-weather-widget--live .player-weather-current__icon { width: 50px; height: 50px; }
-  .sheet-weather-widget--live .player-weather-current__svg { width: 36px; height: 36px; }
-  .sheet-weather-widget--live .player-weather-current__main h3 { font-size: 18px; }
-  .sheet-weather-widget--live .player-weather-temperature { font-size: 23px; }
-  .sheet-weather-widget--live .player-weather-forecast-live__title { font-size: 7px; }
+  .player-weather-glance {
+    min-height: 76px;
+    grid-template-columns: 48px minmax(0, 1fr) auto;
+  }
+  .player-weather-glance__icon { width: 44px; height: 44px; }
+  .player-weather-glance__svg { width: 32px; height: 32px; }
+  .player-weather-glance__copy small,
+  .player-weather-glance__copy > span { font-size: 6px; }
+  .player-weather-glance__copy strong { font-size: 17px; }
+  .player-weather-glance__temp { font-size: 22px; }
+  .player-weather-glance__open { font-size: 6px; }
+
+  .player-weather-app__header { gap: 7px; padding: 6px 7px; }
+  .player-weather-app__back { padding: 6px 7px; }
+  .player-weather-app__header strong { font-size: 11px; }
+  .player-weather-app__network { font-size: 6px; }
+  .player-weather-app__body {
+    padding: 6px;
+    grid-template-rows: minmax(90px, 1.1fr) minmax(60px, .68fr) minmax(104px, 1fr);
+    gap: 5px;
+  }
+  .player-weather-app__hero {
+    grid-template-columns: 58px minmax(0, 1fr) auto;
+    gap: 6px;
+    padding: 6px;
+  }
+  .player-weather-app__hero-icon { width: 54px; height: 54px; }
+  .player-weather-app__hero-svg { width: 38px; height: 38px; }
+  .player-weather-app__hero-copy small,
+  .player-weather-app__hero-copy p { font-size: 6px; }
+  .player-weather-app__temperature span { font-size: 7px; }
+  .player-weather-app__metrics span { font-size: 5.5px; }
+  .player-weather-app__forecast-card { display: flex; flex-direction: column; justify-content: center; text-align: center; gap: 2px; }
+  .player-weather-app__forecast-card > span { width: 100%; }
+  .player-weather-app__forecast-icon { flex: 0 0 auto; }
+  .player-weather-app__forecast-card strong,
+  .player-weather-app__forecast-card small { width: 100%; }
+}
+
+@media (max-height: 600px) {
+  .player-weather-app__header { min-height: 42px; }
+  .player-weather-app__body {
+    padding: 5px 7px 7px;
+    grid-template-rows: minmax(82px, 1.05fr) minmax(54px, .62fr) minmax(94px, .9fr);
+    gap: 5px;
+  }
+  .player-weather-app__hero-icon { width: 50px; height: 50px; }
+  .player-weather-app__hero-svg { width: 36px; height: 36px; }
+  .player-weather-app__hero { grid-template-columns: 56px minmax(0, 1fr) auto; padding: 5px 7px; }
+  .player-weather-app__forecast { padding: 5px; }
 }

--- a/js/weather-player-widget.js
+++ b/js/weather-player-widget.js
@@ -6,8 +6,10 @@
   const ICON_SPRITE = "Assets/Images/Weather/weather-icons.svg";
   let engine = null;
   let widget = null;
+  let appPanel = null;
   let currentState = null;
   let unsubscribe = null;
+  let appOpen = false;
 
   function escapeHtml(value) {
     return String(value ?? "")
@@ -18,6 +20,11 @@
       .replaceAll("'", "&#039;");
   }
 
+  function round(value, fallback) {
+    const n = Number(value);
+    return Number.isFinite(n) ? Math.round(n) : (fallback ?? 0);
+  }
+
   function iconSvg(weatherId, className) {
     const def = engine.getDefinition(weatherId) || { icon: "sun" };
     return `<svg class="${className || "player-weather-icon"}" viewBox="0 0 64 64" aria-hidden="true"><use href="${ICON_SPRITE}#${def.icon}"></use></svg>`;
@@ -25,7 +32,12 @@
 
   function formatWorldClock() {
     const cal = engine.getCalendar() || {};
-    if (!cal.timestamp) return { time: "--:--", date: "RED CLIMÁTICA" };
+    if (!cal.timestamp) {
+      const day = Number(cal.dia) || 1;
+      const month = Number(cal.mes) || 1;
+      const year = Number(cal.año || cal.anio) || 984;
+      return { time: "--:--", date: `DÍA ${day} · MES ${month} · ${year}` };
+    }
     const d = new Date(cal.timestamp);
     if (Number.isNaN(d.getTime())) return { time: "--:--", date: "RED CLIMÁTICA" };
     const time = `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
@@ -50,59 +62,135 @@
     return "BAJA";
   }
 
-  function render() {
-    if (!widget || !currentState) return;
-    const actual = currentState.actual;
-    const def = engine.getDefinition(actual.tipo) || {};
-    const clock = formatWorldClock();
-    const forecast = Array.isArray(currentState.pronostico) ? currentState.pronostico.slice(0, 3) : [];
+  function forecastMarkup(forecast) {
+    if (!forecast.length) {
+      return `<div class="player-weather-app__forecast-empty">SIN DATOS DE PRONÓSTICO</div>`;
+    }
+    return forecast.map((entry, index) => {
+      const def = engine.getDefinition(entry.tipo) || {};
+      const hour = Math.max(1, Math.round((Number(entry.etaMin) || ((index + 1) * 180)) / 60));
+      return `<div class="player-weather-app__forecast-card">
+        <span>+${hour}H</span>
+        ${iconSvg(entry.tipo, "player-weather-app__forecast-icon")}
+        <strong>${escapeHtml(def.label || entry.tipo)}</strong>
+        <small>PROB. ${playerForecastText(entry.probabilidad)}</small>
+      </div>`;
+    }).join("");
+  }
 
+  function renderWidget(actual, def, clock, season) {
     widget.innerHTML = `
-      <div class="player-weather-live" data-weather="${escapeHtml(actual.tipo)}">
-        <div class="player-weather-live__top">
-          <div class="player-weather-clock">
-            <strong>${escapeHtml(clock.time)}</strong>
-            <span>${escapeHtml(clock.date)}</span>
-          </div>
-          <span class="player-weather-network">WEATHER//NET <i></i></span>
-        </div>
+      <button type="button" class="player-weather-glance" data-weather-open aria-controls="player-weather-app" aria-haspopup="dialog" aria-label="Abrir Weather Net">
+        <span class="player-weather-glance__icon">${iconSvg(actual.tipo, "player-weather-glance__svg")}</span>
+        <span class="player-weather-glance__copy">
+          <small>WEATHER//NET · ${escapeHtml(clock.time)}</small>
+          <strong>${escapeHtml(def.label || actual.tipo)}</strong>
+          <span>${escapeHtml(season)} · ${escapeHtml(precipitationText(actual.tipo, actual.intensidad))}</span>
+        </span>
+        <span class="player-weather-glance__temp">${round(actual.temperatura)}<small>°C</small></span>
+        <span class="player-weather-glance__open">ABRIR</span>
+      </button>`;
+  }
 
-        <div class="player-weather-current">
-          <div class="player-weather-current__icon">${iconSvg(actual.tipo, "player-weather-current__svg")}</div>
-          <div class="player-weather-current__main">
-            <span>${escapeHtml(engine.displaySeason(currentState.estacion).toUpperCase())}</span>
-            <h3>${escapeHtml(def.label || actual.tipo)}</h3>
-            <p>${escapeHtml(precipitationText(actual.tipo, actual.intensidad))}</p>
+  function renderApp(actual, def, clock, season, forecast) {
+    if (!appPanel) return;
+    appPanel.innerHTML = `
+      <div class="player-weather-app__frame" role="dialog" aria-modal="true" aria-labelledby="player-weather-app-title">
+        <header class="player-weather-app__header">
+          <button type="button" class="player-weather-app__back" data-weather-close>VOLVER</button>
+          <div>
+            <small>TERMINAL AMBIENTAL</small>
+            <strong id="player-weather-app-title">WEATHER//NET</strong>
           </div>
-          <strong class="player-weather-temperature">${Math.round(actual.temperatura)}<small>°C</small></strong>
-        </div>
+          <span class="player-weather-app__network">ONLINE <i></i></span>
+        </header>
 
-        <div class="player-weather-metrics">
-          <div><span>HUMEDAD</span><strong>${Math.round(actual.humedad)}%</strong></div>
-          <div><span>VIENTO</span><strong>${Math.round(actual.viento)}<small> km/h</small></strong></div>
-          <div><span>VISIBILIDAD</span><strong>${Math.round(actual.visibilidad)}%</strong></div>
-          <div><span>INTENSIDAD</span><strong>${Math.round(actual.intensidad)}%</strong></div>
-        </div>
+        <div class="player-weather-app__body">
+          <section class="player-weather-app__hero" data-weather="${escapeHtml(actual.tipo)}">
+            <div class="player-weather-app__hero-icon">${iconSvg(actual.tipo, "player-weather-app__hero-svg")}</div>
+            <div class="player-weather-app__hero-copy">
+              <small>${escapeHtml(season.toUpperCase())} · ${escapeHtml(clock.date)}</small>
+              <h2>${escapeHtml(def.label || actual.tipo)}</h2>
+              <p>${escapeHtml(precipitationText(actual.tipo, actual.intensidad))}</p>
+            </div>
+            <div class="player-weather-app__temperature">${round(actual.temperatura)}<small>°C</small><span>${escapeHtml(clock.time)}</span></div>
+          </section>
 
-        <div class="player-weather-forecast-live">
-          <div class="player-weather-forecast-live__title">
-            <span>PRONÓSTICO // PRÓXIMAS HORAS</span>
-            <small>Estimación de red</small>
-          </div>
-          <div class="player-weather-forecast-live__grid">
-            ${forecast.length ? forecast.map((entry, index) => {
-              const forecastDef = engine.getDefinition(entry.tipo) || {};
-              const hour = Math.max(1, Math.round((Number(entry.etaMin) || ((index + 1) * 180)) / 60));
-              return `<div class="player-weather-forecast-item">
-                <span>+${hour}H</span>
-                ${iconSvg(entry.tipo, "player-weather-forecast-icon")}
-                <strong>${escapeHtml(forecastDef.label || entry.tipo)}</strong>
-                <small>PROB. ${playerForecastText(entry.probabilidad)}</small>
-              </div>`;
-            }).join("") : `<div class="player-weather-forecast-empty">SIN DATOS DE PRONÓSTICO</div>`}
-          </div>
+          <section class="player-weather-app__metrics" aria-label="Condiciones ambientales">
+            <div><span>HUMEDAD</span><strong>${round(actual.humedad)}%</strong></div>
+            <div><span>VIENTO</span><strong>${round(actual.viento)}<small> km/h</small></strong></div>
+            <div><span>VISIBILIDAD</span><strong>${round(actual.visibilidad)}%</strong></div>
+            <div><span>INTENSIDAD</span><strong>${round(actual.intensidad)}%</strong></div>
+          </section>
+
+          <section class="player-weather-app__forecast">
+            <div class="player-weather-app__section-title">
+              <span>PRONÓSTICO // PRÓXIMAS HORAS</span>
+              <small>Estimación de red</small>
+            </div>
+            <div class="player-weather-app__forecast-grid">
+              ${forecastMarkup(forecast)}
+            </div>
+          </section>
         </div>
       </div>`;
+  }
+
+  function render() {
+    if (!widget || !currentState) return;
+    const actual = currentState.actual || { tipo: "soleado", temperatura: 0, humedad: 0, viento: 0, visibilidad: 0, intensidad: 0 };
+    const def = engine.getDefinition(actual.tipo) || {};
+    const clock = formatWorldClock();
+    const season = engine.displaySeason(currentState.estacion || "invierno");
+    const forecast = Array.isArray(currentState.pronostico) ? currentState.pronostico.slice(0, 3) : [];
+
+    renderWidget(actual, def, clock, season);
+    renderApp(actual, def, clock, season, forecast);
+  }
+
+  function ensureAppPanel() {
+    if (appPanel?.isConnected) return appPanel;
+    const screen = widget?.closest?.(".sheet-phone-screen") || document.querySelector(".sheet-phone-screen");
+    if (!screen) return null;
+    appPanel = document.createElement("section");
+    appPanel.id = "player-weather-app";
+    appPanel.className = "player-weather-app";
+    appPanel.hidden = true;
+    appPanel.setAttribute("aria-hidden", "true");
+    screen.appendChild(appPanel);
+    appPanel.addEventListener("click", (event) => {
+      if (event.target.closest("[data-weather-close]")) closeApp();
+    });
+    return appPanel;
+  }
+
+  function openApp() {
+    if (!currentState || !ensureAppPanel()) return false;
+    render();
+    appOpen = true;
+    appPanel.hidden = false;
+    appPanel.setAttribute("aria-hidden", "false");
+    appPanel.classList.add("is-open");
+    global.requestAnimationFrame?.(() => appPanel.querySelector("[data-weather-close]")?.focus());
+    return true;
+  }
+
+  function closeApp() {
+    if (!appPanel) return false;
+    appOpen = false;
+    appPanel.classList.remove("is-open");
+    appPanel.setAttribute("aria-hidden", "true");
+    appPanel.hidden = true;
+    widget?.querySelector?.("[data-weather-open]")?.focus();
+    return true;
+  }
+
+  function onWidgetClick(event) {
+    if (event.target.closest("[data-weather-open]")) openApp();
+  }
+
+  function onKeydown(event) {
+    if (event.key === "Escape" && appOpen) closeApp();
   }
 
   function mount() {
@@ -110,11 +198,24 @@
     if (!widget || widget.dataset.weatherPlayerMounted === "true") return false;
     widget.dataset.weatherPlayerMounted = "true";
     widget.classList.add("sheet-weather-widget--live");
+    ensureAppPanel();
+    widget.addEventListener("click", onWidgetClick);
+    document.addEventListener("keydown", onKeydown);
     unsubscribe = engine.onChange((next) => {
       currentState = next;
       render();
     });
     return true;
+  }
+
+  function destroy() {
+    unsubscribe?.();
+    unsubscribe = null;
+    widget?.removeEventListener?.("click", onWidgetClick);
+    document.removeEventListener("keydown", onKeydown);
+    appPanel?.remove?.();
+    appPanel = null;
+    appOpen = false;
   }
 
   function boot() {
@@ -129,7 +230,9 @@
   global.LuminousWeatherPlayerWidget = Object.freeze({
     mount: () => { engine = global.LuminousWeatherEngine; return engine ? mount() : false; },
     render,
-    destroy: () => { unsubscribe?.(); unsubscribe = null; }
+    openApp,
+    closeApp,
+    destroy
   });
 
   if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", boot, { once: true });

--- a/tests/weather_post_merge_hotfix.spec.js
+++ b/tests/weather_post_merge_hotfix.spec.js
@@ -1,3 +1,5 @@
+const fs = require("fs");
+const path = require("path");
 const { test, expect } = require("@playwright/test");
 const {
   repairedPreviousState,
@@ -60,5 +62,19 @@ test.describe("Weather post-merge hotfix", () => {
 
     expect(forecastsEqual(modernMirror, modernMirror)).toBe(true);
     expect(forecastsEqual(staleLegacy, modernMirror)).toBe(false);
+  });
+
+  test("keeps Home compact and opens the detailed weather app from the widget", () => {
+    const widgetSource = fs.readFileSync(path.join(__dirname, "../js/weather-player-widget.js"), "utf8");
+    const playerCss = fs.readFileSync(path.join(__dirname, "../css/weather-player.css"), "utf8");
+
+    expect(widgetSource).toContain("data-weather-open");
+    expect(widgetSource).toContain('appPanel.id = "player-weather-app"');
+    expect(widgetSource).toContain("function openApp()");
+    expect(widgetSource).toContain("function closeApp()");
+    expect(playerCss).toContain(".player-weather-glance");
+    expect(playerCss).toContain(".player-weather-app.is-open");
+    expect(playerCss).toMatch(/\.sheet-tab-home\s*\{[\s\S]*?overflow:\s*hidden\s*!important;/);
+    expect(playerCss).not.toMatch(/\.sheet-tab-home\s*\{[\s\S]*?overflow-y:\s*auto\s*!important;/);
   });
 });


### PR DESCRIPTION
## Resumen
- reemplaza el panel climático completo del Home por un widget compacto de una sola mirada
- elimina el scroll del Home provocado por Weather//Net
- abre el detalle climático como una app independiente dentro de la pantalla del teléfono
- mantiene SVG para toda la iconografía meteorológica

## UX
### Home
El jugador ve únicamente:
- icono SVG del clima actual
- nombre del clima
- temperatura
- estación / estado de precipitación
- acceso `ABRIR`

### App Weather//Net
Al tocar el widget se abre una vista dedicada con:
- clima actual e icono SVG grande
- temperatura, hora y estación
- humedad
- viento
- visibilidad
- intensidad
- pronóstico de 3 pasos
- botón `VOLVER`
- cierre con tecla `Escape`

## Implementación
- `js/weather-player-widget.js`: separa render compacto y app detallada, crea `openApp()` / `closeApp()` y monta la app dentro de `.sheet-phone-screen`
- `css/weather-player.css`: Home vuelve a `overflow: hidden`; estilos responsivos para widget y pantalla Weather//Net
- `tests/weather_post_merge_hotfix.spec.js`: regresión que impide volver a activar scroll vertical en Home y verifica el contrato widget → app

## Alcance
Este PR no modifica:
- Weather Engine
- Firebase
- reglas de Firebase
- Weather Director del DM
- Theatre / FX

Parte del `main` posterior al merge de #536.

## Checklist
- [x] Widget de clima compacto en Home
- [x] Home sin scroll por Weather//Net
- [x] Widget abre la app detallada
- [x] App muestra clima, temperatura y estación
- [x] App muestra humedad, viento, visibilidad e intensidad
- [x] App muestra 3 previsiones
- [x] App usa iconos SVG
- [x] Botón `VOLVER`
- [x] Cierre con `Escape`
- [x] Regresión para impedir `overflow-y:auto` en Home
- [x] Confirmar GitHub Actions
- [x] Smoke visual final en celular