### PR TITLE
Hotfix: carga reglas de idiomas especiales en jugador

### DIFF
--- a/.github/workflows/theatre-special-languages.yml
+++ b/.github/workflows/theatre-special-languages.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "js/language-catalog-engine.js"
+      - "js/theatre-language-policy.js"
       - "js/theatre-special-language-access.js"
       - "js/theatre-special-language-enforcement-hotfix.js"
       - "js/theatre-special-language-log-hotfix.js"
@@ -33,6 +34,7 @@ jobs:
       - name: Check JavaScript syntax
         run: |
           node --check js/language-catalog-engine.js
+          node --check js/theatre-language-policy.js
           node --check js/theatre-special-language-access.js
           node --check js/theatre-special-language-enforcement-hotfix.js
           node --check js/theatre-special-language-log-hotfix.js

--- a/js/theatre-language-policy.js
+++ b/js/theatre-language-policy.js
@@ -21,6 +21,37 @@
     return Boolean(document.body?.classList.contains("on-game-dashboard"));
   }
 
+  function ensureRuntimeScript(id, src, datasetKey) {
+    let script = document.getElementById(id);
+    if (script) return script;
+    script = document.createElement("script");
+    script.id = id;
+    script.src = src;
+    script.async = false;
+    if (datasetKey) script.dataset[datasetKey] = "true";
+    document.head?.appendChild(script);
+    return script;
+  }
+
+  function ensurePlayerSpecialLanguageRuntime() {
+    if (isDmView()) return;
+    const ensureLog = () => ensureRuntimeScript(
+      "theatre-special-language-log-runtime-script",
+      "js/theatre-special-language-log-hotfix.js",
+      "luminousSpecialLanguageLogRuntime",
+    );
+    if (global.LuminousSpecialLanguageEnforcement) {
+      ensureLog();
+      return;
+    }
+    const enforcement = ensureRuntimeScript(
+      "theatre-special-language-enforcement-runtime-script",
+      "js/theatre-special-language-enforcement-hotfix.js",
+      "luminousSpecialLanguageEnforcementRuntime",
+    );
+    enforcement.addEventListener("load", ensureLog, { once: true });
+  }
+
   function getManager() {
     if (!manager) manager = global.LuminousCharacterManager || null;
     if (manager && isDmView() && !managerSubscribed) {
@@ -165,7 +196,7 @@
         }
         return originalPush.apply(ref, [next].concat(Array.prototype.slice.call(arguments, 1)));
       };
-      ref.__luminousLanguagePushPatched = true;
+      ref.__luminousLanguageRefPatched = true;
       return ref;
     };
     database.__luminousLanguageRefPatched = true;
@@ -194,6 +225,7 @@
       if (event.target?.id === "theatre-speaker-select") refreshDmSelector();
     });
   } else {
+    ensurePlayerSpecialLanguageRuntime();
     patchPlayerQueueWrites();
     document.addEventListener("click", (event) => {
       if (event.target?.closest?.("#btn-abrir-escritura")) global.setTimeout(ensurePlayerSelector, 0);

--- a/js/theatre-language-policy.js
+++ b/js/theatre-language-policy.js
@@ -196,7 +196,7 @@
         }
         return originalPush.apply(ref, [next].concat(Array.prototype.slice.call(arguments, 1)));
       };
-      ref.__luminousLanguageRefPatched = true;
+      ref.__luminousLanguagePushPatched = true;
       return ref;
     };
     database.__luminousLanguageRefPatched = true;

--- a/tests/theatre_special_language_enforcement.spec.js
+++ b/tests/theatre_special_language_enforcement.spec.js
@@ -1,4 +1,6 @@
 const { test, expect } = require("@playwright/test");
+const fs = require("fs");
+const path = require("path");
 const rules = require("../js/theatre-special-language-enforcement-hotfix.js");
 const logRules = require("../js/theatre-special-language-log-hotfix.js");
 
@@ -35,5 +37,13 @@ test.describe("special language hotfix", () => {
     const so = { idiomas: { dante_clock: { porcentaje: 0, comprendido: false } } };
     const message = { nombre: "Dante", mensaje: "Debemos irnos.", idiomaId: "dante_clock" };
     expect(logRules.resolveLogMessageText(message, defs, [so], rules)).toBe("Tik... Tok...");
+  });
+
+  test("the player language policy actually loads enforcement and log privacy", () => {
+    const source = fs.readFileSync(path.join(__dirname, "..", "js", "theatre-language-policy.js"), "utf8");
+    expect(source).toContain("ensurePlayerSpecialLanguageRuntime();");
+    expect(source).toContain("js/theatre-special-language-enforcement-hotfix.js");
+    expect(source).toContain("js/theatre-special-language-log-hotfix.js");
+    expect(source).toContain("ref.__luminousLanguagePushPatched = true");
   });
 });

--- a/tests/theatre_special_language_enforcement.spec.js
+++ b/tests/theatre_special_language_enforcement.spec.js
@@ -1,6 +1,7 @@
 const { test, expect } = require("@playwright/test");
 const fs = require("fs");
 const path = require("path");
+const vm = require("vm");
 const rules = require("../js/theatre-special-language-enforcement-hotfix.js");
 const logRules = require("../js/theatre-special-language-log-hotfix.js");
 
@@ -45,5 +46,112 @@ test.describe("special language hotfix", () => {
     expect(source).toContain("js/theatre-special-language-enforcement-hotfix.js");
     expect(source).toContain("js/theatre-special-language-log-hotfix.js");
     expect(source).toContain("ref.__luminousLanguagePushPatched = true");
+  });
+
+  test("runtime del jugador bloquea a Dante para So con ENTIENDE apagado", () => {
+    const source = fs.readFileSync(
+      path.join(__dirname, "..", "js", "theatre-special-language-enforcement-hotfix.js"),
+      "utf8",
+    );
+
+    const listeners = new Map();
+    const textEl = {
+      textContent: "Debemos irnos.",
+      dataset: {},
+      attrs: {},
+      setAttribute(name, value) {
+        this.attrs[name] = value;
+      },
+    };
+
+    const snapshot = (value) => ({ val: () => value });
+    const db = {
+      ref(firebasePath) {
+        return {
+          on(eventName, callback) {
+            if (eventName === "value") listeners.set(firebasePath, callback);
+          },
+          off() {},
+        };
+      },
+    };
+
+    class MutationObserverMock {
+      constructor(callback) {
+        this.callback = callback;
+      }
+      observe() {}
+      disconnect() {}
+    }
+
+    const auth = () => ({
+      currentUser: { uid: "so" },
+      onAuthStateChanged() {},
+    });
+
+    const context = {
+      console,
+      document: {
+        body: { classList: { contains: () => false } },
+        readyState: "complete",
+        getElementById(id) {
+          return id === "dialogue-text" ? textEl : null;
+        },
+        addEventListener() {},
+      },
+      firebase: {
+        database: () => db,
+        auth,
+      },
+      MutationObserver: MutationObserverMock,
+      LuminousTheatreState: {
+        getPaths: () => ({ scene: "runtime/scene", dialogue: "runtime/dialogue" }),
+      },
+      getAssignedTheatreActor: () => ({ actorId: "so_actor", id: "so_actor" }),
+      setTimeout(fn) {
+        fn();
+        return 1;
+      },
+      setInterval() {
+        return 1;
+      },
+      clearInterval() {},
+      queueMicrotask(fn) {
+        fn();
+      },
+    };
+    context.window = context;
+    context.globalThis = context;
+
+    vm.createContext(context);
+    vm.runInContext(source, context);
+
+    expect(listeners.has("campaña/idiomas")).toBe(true);
+    expect(listeners.has("campaña/jugadores")).toBe(true);
+    expect(listeners.has("runtime/dialogue")).toBe(true);
+
+    listeners.get("campaña/idiomas")(snapshot(defs));
+    listeners.get("campaña/teatro/idiomas")(snapshot({}));
+    listeners.get("campaña/jugadores")(snapshot({
+      so: {
+        uid: "so",
+        actorId: "so_actor",
+        idiomas: { dante_clock: { porcentaje: 0, comprendido: false } },
+        distortion_languages: { dante_clock: true },
+      },
+    }));
+
+    textEl.textContent = "Debemos irnos.";
+    listeners.get("runtime/dialogue")(snapshot({
+      actorId: "dante",
+      nombre: "Dante",
+      mensaje: "Debemos irnos.",
+      idiomaId: "dante_clock",
+    }));
+
+    expect(textEl.textContent).toBe("Tik... Tok...");
+    expect(textEl.dataset.specialLanguage).toBe("dante_clock");
+    expect(textEl.dataset.specialLanguageBlocked).toBe("true");
+    expect(textEl.attrs["aria-label"]).toBe("Tik... Tok...");
   });
 });


### PR DESCRIPTION
## Resumen

Corrige el hueco de integración que dejó #540: las reglas de idiomas especiales existían en `main`, pero la hoja del jugador no cargaba los módulos que hacen cumplir **ENTIENDE** en el diálogo activo y en el Log.

### Cambios
- `theatre-language-policy.js` carga explícitamente el runtime de enforcement en jugador.
- el módulo de Log se carga después del enforcement para compartir la misma política.
- se mantiene intacta la separación **HABLA / ENTIENDE**.
- se conserva el parche de cola existente (`__luminousLanguagePushPatched`).
- el workflow de idiomas especiales ahora también se dispara y valida cuando cambia `theatre-language-policy.js`.
- se añade una regresión para impedir que el player vuelva a quedar sin los módulos de privacidad.
- se añade una prueba de runtime con `vm` que ejecuta el enforcement con Firebase simulado: So autenticado, `ENTIENDE=false`, permiso legacy contradictorio y diálogo de Dante con `idiomaId=dante_clock` debe terminar visualmente en `Tik... Tok...`.

### Caso objetivo
So con `Reloj de Dante` en **HABLA ✗ / ENTIENDE ✗** debe ver el texto desconocido configurado (`Tik... Tok...`) tanto en el diálogo activo como en el historial.

## Checklist
- [x] Player carga enforcement de idiomas especiales
- [x] Player carga protección del Log
- [x] ENTIENDE OFF sigue siendo autoritativo
- [x] HABLA y ENTIENDE siguen separados
- [x] CI escucha cambios del loader de jugador
- [x] Regresión de integración del loader
- [x] Prueba de runtime que ejecuta la regla con Firebase simulado
- [ ] GitHub Actions verde
- [ ] Smoke real con So y Dante
