### PR TITLE
Hotfix: fuerza idioma especial de Dante en el payload

### DIFF
--- a/js/theatre-language-policy.js
+++ b/js/theatre-language-policy.js
@@ -8,14 +8,17 @@
   const db = firebase.database();
   const theatre = global.LuminousTheatreState || null;
   const LANGUAGE_ROOTS = ["campaña/idiomas", "campaña/teatro/idiomas"];
+  const ACTOR_ROOTS = ["campaña/base_datos_npcs", "campaña/actores"];
   const QUEUE_PATH = "campaña/teatro/cola";
   const sources = {};
+  const actorSources = {};
   let definitions = {};
   let currentScene = {};
   let sceneRef = null;
   let scenePath = null;
   let manager = global.LuminousCharacterManager || null;
   let managerSubscribed = false;
+  let manualLanguageOverrideSpeaker = null;
 
   function isDmView() {
     return Boolean(document.body?.classList.contains("on-game-dashboard"));
@@ -69,8 +72,8 @@
     if (typeof value === "number" || typeof value === "string") return { porcentaje: Math.max(0, Math.min(100, Number(value) || 0)), comprendido: false };
     if (!value || typeof value !== "object") return { porcentaje: 0, comprendido: false };
     return {
-      porcentaje: Math.max(0, Math.min(100, Number(value.porcentaje ?? value.percent ?? value.conocimiento ?? value.knowledge ?? 0) || 0)),
-      comprendido: Boolean(value.comprendido ?? value.understood ?? value.distortionUnderstood ?? false),
+      porcentaje: Math.max(0, Math.min(100, Number(value.porcentaje ?? value.percent ?? value.conocimiento ?? value.knowledge ?? (value.habla === true ? 100 : 0)) || 0)),
+      comprendido: Boolean(value.entiende ?? value.understands ?? value.comprendido ?? value.understood ?? value.distortionUnderstood ?? false),
     };
   }
 
@@ -81,6 +84,34 @@
       Object.entries(container).forEach(([languageId, entry]) => { merged[languageId] = normalizeKnowledge(entry); });
     });
     return merged;
+  }
+
+  function mergedActorCatalog() {
+    return Object.assign(
+      {},
+      actorSources["campaña/actores"] || {},
+      actorSources["campaña/base_datos_npcs"] || {},
+    );
+  }
+
+  function isSpecialDefinition(definition) {
+    const system = String(definition?.sistema || definition?.system || "").toLowerCase();
+    const type = String(definition?.tipo || definition?.type || "").toLowerCase();
+    return definition?.especial === true
+      || definition?.special === true
+      || definition?.binario === true
+      || definition?.binary === true
+      || definition?.distortion === true
+      || system === "special"
+      || ["distortion", "distorsion", "singularity", "singularidad", "special"].includes(type);
+  }
+
+  function preferredSpecialLanguage(knowledge) {
+    const candidates = Object.entries(definitions)
+      .filter(([languageId, definition]) => languageId !== "common" && isSpecialDefinition(definition))
+      .filter(([languageId]) => normalizeKnowledge(knowledge?.[languageId]).porcentaje > 0)
+      .map(([languageId]) => languageId);
+    return candidates.length === 1 ? candidates[0] : null;
   }
 
   function commonOption() {
@@ -105,6 +136,7 @@
         const option = document.createElement("option");
         option.value = languageId;
         option.textContent = label(languageId, definition);
+        option.dataset.specialLanguage = isSpecialDefinition(definition) ? "true" : "false";
         fragment.appendChild(option);
       });
     select.replaceChildren(fragment);
@@ -127,12 +159,31 @@
 
   function speakerKnowledge() {
     const speakerId = document.getElementById("theatre-speaker-select")?.value;
-    if (!speakerId || speakerId === "narrador") return { all: true, knowledge: {} };
+    if (!speakerId || speakerId === "narrador") return { speakerId: speakerId || "narrador", all: true, knowledge: {} };
+
     const liveActor = currentScene?.actores?.[speakerId] || {};
-    const masterId = liveActor.identityId || liveActor.identidadId || liveActor.sourceActorId || speakerId;
+    const masterId = liveActor.identityId || liveActor.identidadId || liveActor.sourceActorId || liveActor.sourceId || speakerId;
     const characterManager = getManager();
-    if (characterManager?.getActor?.(masterId)) return { all: false, knowledge: characterManager.languageKnowledgeForActor(masterId) };
-    return { all: false, knowledge: mergeKnowledge(liveActor.idiomas, liveActor.languages) };
+    const managerRecord = characterManager?.getActor?.(masterId);
+    if (managerRecord?.actor) {
+      return {
+        speakerId,
+        all: false,
+        knowledge: mergeKnowledge(managerRecord.actor.idiomas, managerRecord.actor.languages, liveActor.idiomas, liveActor.languages),
+      };
+    }
+
+    const catalog = mergedActorCatalog();
+    const masterActor = catalog[masterId]
+      || catalog[liveActor.sourceActorId]
+      || catalog[liveActor.sourceId]
+      || catalog[speakerId]
+      || {};
+    return {
+      speakerId,
+      all: false,
+      knowledge: mergeKnowledge(masterActor.idiomas, masterActor.languages, liveActor.idiomas, liveActor.languages),
+    };
   }
 
   function refreshDmSelector() {
@@ -143,6 +194,33 @@
     if (!select) return;
     const source = speakerKnowledge();
     fillSelector(select, source.knowledge, source.all);
+  }
+
+  function ensureDmOutgoingLanguage() {
+    if (!isDmView()) return null;
+    const speakerSelect = document.getElementById("theatre-speaker-select");
+    const languageSelect = document.getElementById("theatre-language-select");
+    const speakerId = speakerSelect?.value || "narrador";
+    if (!languageSelect || speakerId === "narrador") return languageSelect?.value || null;
+    if (languageSelect.value) return languageSelect.value;
+    if (manualLanguageOverrideSpeaker === speakerId) return null;
+
+    const source = speakerKnowledge();
+    const preferred = preferredSpecialLanguage(source.knowledge);
+    if (!preferred) return null;
+
+    let option = Array.from(languageSelect.options || []).find((entry) => entry.value === preferred);
+    if (!option) {
+      option = document.createElement("option");
+      option.value = preferred;
+      option.textContent = label(preferred, definitions[preferred] || {});
+      option.dataset.specialLanguage = "true";
+      languageSelect.appendChild(option);
+    }
+    languageSelect.value = preferred;
+    languageSelect.dataset.autoSpecialLanguage = preferred;
+    languageSelect.title = `AUTO · ${label(preferred, definitions[preferred] || {})}`;
+    return preferred;
   }
 
   function playerKnowledge() {
@@ -216,14 +294,34 @@
   });
 
   if (isDmView()) {
+    ACTOR_ROOTS.forEach((root) => {
+      db.ref(root).on("value", (snapshot) => {
+        actorSources[root] = snapshot.val() || {};
+        refreshDmSelector();
+      });
+    });
     bindScene();
     getManager();
     const managerTimer = global.setInterval(() => {
       if (getManager()) global.clearInterval(managerTimer);
     }, 100);
     document.addEventListener("change", (event) => {
-      if (event.target?.id === "theatre-speaker-select") refreshDmSelector();
+      if (event.target?.id === "theatre-speaker-select") {
+        manualLanguageOverrideSpeaker = null;
+        refreshDmSelector();
+      }
+      if (event.target?.id === "theatre-language-select") {
+        manualLanguageOverrideSpeaker = document.getElementById("theatre-speaker-select")?.value || null;
+        delete event.target.dataset.autoSpecialLanguage;
+      }
     });
+    document.addEventListener("click", (event) => {
+      if (!event.target?.closest?.("#btn-send-dialogue")) return;
+      // Captura antes del handler de on-game-dashboard: el payload debe salir con
+      // idiomaId aunque la UI no haya terminado una autoselección asíncrona.
+      refreshDmSelector();
+      ensureDmOutgoingLanguage();
+    }, true);
   } else {
     ensurePlayerSpecialLanguageRuntime();
     patchPlayerQueueWrites();
@@ -241,5 +339,7 @@
     refresh,
     getDefinitions: () => ({ ...definitions }),
     getPlayerKnowledge: playerKnowledge,
+    getDmSpeakerKnowledge: () => ({ ...speakerKnowledge().knowledge }),
+    ensureDmOutgoingLanguage,
   });
 })(window);

--- a/tests/theatre_special_language_enforcement.spec.js
+++ b/tests/theatre_special_language_enforcement.spec.js
@@ -13,6 +13,7 @@ test.describe("special language hotfix", () => {
       especial: true,
       binario: true,
       tipo: "distortion",
+      distortion: true,
       texto_desconocido: "Tik... Tok...",
     },
   };
@@ -153,5 +154,218 @@ test.describe("special language hotfix", () => {
     expect(textEl.dataset.specialLanguage).toBe("dante_clock");
     expect(textEl.dataset.specialLanguageBlocked).toBe("true");
     expect(textEl.attrs["aria-label"]).toBe("Tik... Tok...");
+  });
+
+  test("DM recupera HABLA de Dante desde el actor maestro antes de construir el payload", () => {
+    const source = fs.readFileSync(
+      path.join(__dirname, "..", "js", "theatre-language-policy.js"),
+      "utf8",
+    );
+
+    const firebaseListeners = new Map();
+    const domListeners = new Map();
+    const snapshot = (value) => ({ val: () => value });
+
+    function optionNode() {
+      return { value: "", textContent: "", dataset: {} };
+    }
+
+    const speakerSelect = { id: "theatre-speaker-select", value: "dante_live" };
+    const languageSelect = {
+      id: "theatre-language-select",
+      value: "",
+      options: [],
+      dataset: {},
+      title: "",
+      replaceChildren(fragment) {
+        this.options = [...fragment.children];
+        this.value = "";
+      },
+      appendChild(option) {
+        this.options.push(option);
+      },
+    };
+
+    const document = {
+      body: { classList: { contains: (name) => name === "on-game-dashboard" } },
+      readyState: "complete",
+      head: { appendChild() {} },
+      getElementById(id) {
+        if (id === "theatre-speaker-select") return speakerSelect;
+        if (id === "theatre-language-select") return languageSelect;
+        return null;
+      },
+      createElement(tag) {
+        if (tag === "option") return optionNode();
+        return { dataset: {}, addEventListener() {} };
+      },
+      createDocumentFragment() {
+        return {
+          children: [],
+          appendChild(node) { this.children.push(node); },
+        };
+      },
+      addEventListener(type, callback, options) {
+        if (!domListeners.has(type)) domListeners.set(type, []);
+        domListeners.get(type).push({ callback, capture: options === true || options?.capture === true });
+      },
+    };
+
+    const db = {
+      ref(firebasePath) {
+        return {
+          on(eventName, callback) {
+            if (eventName === "value") firebaseListeners.set(firebasePath, callback);
+          },
+          off() {},
+        };
+      },
+    };
+
+    const database = () => db;
+    const context = {
+      console,
+      document,
+      firebase: { database },
+      LuminousTheatreState: {
+        getPaths: () => ({ scene: "runtime/scene", queue: "runtime/queue" }),
+      },
+      setTimeout() { return 1; },
+      setInterval() { return 1; },
+      clearInterval() {},
+      addEventListener() {},
+    };
+    context.window = context;
+    context.globalThis = context;
+
+    vm.createContext(context);
+    vm.runInContext(source, context);
+
+    firebaseListeners.get("campaña/idiomas")(snapshot({ common: { nombre: "Común", universal: true } }));
+    firebaseListeners.get("campaña/teatro/idiomas")(snapshot(defs));
+    firebaseListeners.get("campaña/base_datos_npcs")(snapshot({
+      dante: {
+        nombre: "Dante",
+        idiomas: { dante_clock: { porcentaje: 100, comprendido: true } },
+      },
+    }));
+    firebaseListeners.get("campaña/actores")(snapshot({}));
+    firebaseListeners.get("runtime/scene")(snapshot({
+      actores: {
+        dante_live: {
+          nombre: "Dante",
+          identityId: "dante",
+          // El actor vivo reproduce el bug real: no carga idiomas al spawn.
+        },
+      },
+    }));
+
+    let languageSeenByDashboard = null;
+    document.addEventListener("click", () => {
+      languageSeenByDashboard = languageSelect.value || null;
+    });
+
+    const event = {
+      target: {
+        closest(selector) {
+          return selector === "#btn-send-dialogue" ? this : null;
+        },
+      },
+    };
+    const clickListeners = domListeners.get("click") || [];
+    clickListeners.filter((entry) => entry.capture).forEach((entry) => entry.callback(event));
+    clickListeners.filter((entry) => !entry.capture).forEach((entry) => entry.callback(event));
+
+    expect(languageSelect.value).toBe("dante_clock");
+    expect(languageSeenByDashboard).toBe("dante_clock");
+    expect(languageSelect.dataset.autoSpecialLanguage).toBe("dante_clock");
+  });
+
+  test("el Theatre Engine bloquea a So cuando el payload sí lleva idiomaId", () => {
+    const source = fs.readFileSync(
+      path.join(__dirname, "..", "js", "theatre-engine.js"),
+      "utf8",
+    );
+
+    const firebaseListeners = new Map();
+    const snapshot = (value) => ({ val: () => value });
+
+    const db = {
+      ref(firebasePath) {
+        return {
+          key: "test-key",
+          on(eventName, callback) {
+            if (eventName === "value") firebaseListeners.set(firebasePath, callback);
+          },
+          off() {},
+          once() { return Promise.resolve(snapshot(null)); },
+          set() { return Promise.resolve(); },
+          update() { return Promise.resolve(); },
+          remove() { return Promise.resolve(); },
+          transaction() { return Promise.resolve(); },
+          push() { return this; },
+        };
+      },
+    };
+    const database = () => db;
+    database.ServerValue = { TIMESTAMP: 123456 };
+
+    const document = {
+      body: { dataset: {}, classList: { contains: () => false } },
+      baseURI: "https://local.invalid/",
+      readyState: "complete",
+      getElementById() { return null; },
+      querySelector() { return null; },
+      querySelectorAll() { return []; },
+      createElement() { return { style: {}, dataset: {}, addEventListener() {}, appendChild() {}, querySelector() { return null; } }; },
+      addEventListener() {},
+    };
+
+    class MutationObserverMock {
+      observe() {}
+      disconnect() {}
+    }
+
+    const context = {
+      console,
+      document,
+      firebase: {
+        database,
+        auth: () => ({ currentUser: { uid: "so" }, onAuthStateChanged() {} }),
+      },
+      MutationObserver: MutationObserverMock,
+      Element: function Element() {},
+      URL,
+      CSS: { supports: () => true },
+      localStorage: { getItem: () => null, setItem() {} },
+      location: { href: "https://local.invalid/hoja_personaje.html" },
+      getAssignedTheatreActor: () => ({ actorId: "so_actor", id: "so_actor" }),
+      getComputedStyle: () => ({ fontSize: "24px" }),
+      addEventListener() {},
+      setTimeout() { return 1; },
+      setInterval() { return 1; },
+      clearInterval() {},
+      Promise,
+      Date,
+    };
+    context.window = context;
+    context.globalThis = context;
+
+    vm.createContext(context);
+    vm.runInContext(source, context);
+
+    firebaseListeners.get("campaña/idiomas")(snapshot(defs));
+    firebaseListeners.get("campaña/teatro/idiomas")(snapshot({}));
+    firebaseListeners.get("campaña/jugadores")(snapshot({
+      so: {
+        uid: "so",
+        actorId: "so_actor",
+        idiomas: { dante_clock: { porcentaje: 0, comprendido: false } },
+      },
+    }));
+
+    const engine = context.LuminousTheatreState;
+    expect(engine.resolveLanguageText("Debemos irnos.", { idiomaId: null })).toBe("Debemos irnos.");
+    expect(engine.resolveLanguageText("Debemos irnos.", { idiomaId: "dante_clock" })).toBe("Tik... Tok...");
   });
 });


### PR DESCRIPTION
## Resumen

Corrige el caso real observado donde So veía `???` como identidad pero seguía leyendo el texto de Dante aunque `ENTIENDE` estuviera apagado.

### Causa raíz
El actor vivo de Dante en escena no lleva sus idiomas. El Centro de Mando podía reconstruir identidad/sprite/icono/expresiones, pero `theatre-language-policy.js` no siempre encontraba el permiso **HABLA** del actor maestro. Si el selector quedaba en Común, `on-game-dashboard.js` enviaba `idiomaId: null` y el Theatre Engine devolvía el texto original por diseño.

### Cambios
- resuelve idiomas del hablante desde el actor maestro en `campaña/base_datos_npcs` / `campaña/actores` cuando el actor vivo no los tiene;
- antes de ENVIAR, en fase capture, revalida el hablante y autoselecciona su único idioma especial con HABLA activo;
- respeta una selección manual de Común como override explícito;
- mantiene HABLA y ENTIENDE separados;
- añade regresión para Dante vivo sin idiomas + Dante maestro con `dante_clock`;
- ejecuta `theatre-engine.js` con `vm` y verifica que `idiomaId=null` deja pasar el texto mientras `idiomaId=dante_clock` devuelve `Tik... Tok...` para So con ENTIENDE OFF.

### Caso objetivo
Dante habla `Reloj de Dante` y So tiene:
- HABLA: OFF
- ENTIENDE: OFF

Resultado esperado: So ve `Tik... Tok...` tanto en el diálogo activo como en el Log, mientras la identidad puede seguir apareciendo como `???` si aún no la conoce.

## Checklist
- [x] lookup del actor maestro para idiomas del hablante
- [x] guard de payload antes del handler del dashboard
- [x] override manual a Común respetado
- [x] prueba del caso Dante vivo sin idiomas
- [x] prueba del Theatre Engine con `idiomaId`
- [ ] GitHub Actions verde
- [ ] smoke real con So y Dante
