### PR TITLE
Feat: facciones escalables y semántica correcta del Theatre Log

### DIFF
--- a/.github/workflows/theatre-log-roster-ux.yml
+++ b/.github/workflows/theatre-log-roster-ux.yml
@@ -1,0 +1,48 @@
+name: Theatre Log and Roster UX
+
+on:
+  pull_request:
+    paths:
+      - "js/theatre-intervention-ux.js"
+      - "css/theatre-intervention-ux.css"
+      - "js/theatre-language-policy.js"
+      - "js/theatre-special-language-log-hotfix.js"
+      - "js/character-manager-roster-ux.js"
+      - "css/character-manager-roster-ux.css"
+      - "js/character-manager-language-ux.js"
+      - "tests/theatre_intervention_ux.spec.js"
+      - "tests/character_manager_roster_ux.spec.js"
+      - "tests/theatre_special_language_enforcement.spec.js"
+      - ".github/workflows/theatre-log-roster-ux.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  ux-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check JavaScript syntax
+        run: |
+          node --check js/theatre-intervention-ux.js
+          node --check js/theatre-language-policy.js
+          node --check js/theatre-special-language-log-hotfix.js
+          node --check js/character-manager-roster-ux.js
+          node --check js/character-manager-language-ux.js
+          node --check tests/theatre_intervention_ux.spec.js
+          node --check tests/character_manager_roster_ux.spec.js
+
+      - name: Run UX regressions
+        run: npx playwright test tests/theatre_intervention_ux.spec.js tests/character_manager_roster_ux.spec.js tests/theatre_special_language_enforcement.spec.js --workers=1

--- a/css/character-manager-roster-ux.css
+++ b/css/character-manager-roster-ux.css
@@ -1,0 +1,64 @@
+.character-manager-studio .cm-faction-filter {
+  max-width: 112px;
+  min-width: 72px;
+  padding: 3px 5px;
+  color: #b8a270;
+  background: #0e0e0d;
+  border: 1px solid #39352c;
+  font: 9px "Share Tech Mono", monospace;
+}
+
+.character-manager-studio .cm-faction-filter[hidden],
+.character-manager-studio #character-manager-search[hidden] {
+  display: none !important;
+}
+
+.character-manager-studio .cm-roster-group-heading {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  cursor: pointer;
+  background: #0c0c0b;
+  user-select: none;
+}
+
+.character-manager-studio .cm-roster-group-heading::before {
+  content: "▾";
+  display: inline-block;
+  width: 10px;
+  margin-right: 4px;
+  color: #6d675d;
+  font-size: 9px;
+  transform-origin: center;
+}
+
+.character-manager-studio .cm-roster-group-heading.is-collapsed::before {
+  transform: rotate(-90deg);
+}
+
+.character-manager-studio .cm-roster-group[data-collapsed="true"] > .cm-roster-entry {
+  display: none !important;
+}
+
+.character-manager-studio .cm-roster-entry[hidden],
+.character-manager-studio .cm-roster-group[hidden] {
+  display: none !important;
+}
+
+.character-manager-studio .cm-roster-heading {
+  gap: 5px;
+}
+
+.character-manager-studio .cm-roster-heading > span:first-child {
+  flex: 0 0 auto;
+}
+
+.character-manager-studio #character-manager-search-ux {
+  min-width: 0;
+}
+
+@media (max-width: 820px) {
+  .character-manager-studio .cm-faction-filter {
+    max-width: 94px;
+  }
+}

--- a/css/theatre-intervention-ux.css
+++ b/css/theatre-intervention-ux.css
@@ -1,0 +1,44 @@
+#theatre-log-container .dialogue-row.is-centered-log-entry {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  justify-items: stretch;
+  align-items: center;
+}
+
+#theatre-log-container .dialogue-row.is-centered-log-entry .character-col {
+  display: none !important;
+}
+
+#theatre-log-container .dialogue-row.is-centered-log-entry .text-col {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  padding-left: 18px;
+  padding-right: 18px;
+  text-align: center;
+}
+
+#theatre-log-container .dialogue-row.is-centered-log-entry .text-col p {
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
+}
+
+#theatre-log-container .dialogue-row.is-action .text-col p {
+  font-style: italic;
+  letter-spacing: .02em;
+}
+
+#theatre-log-container .dialogue-row.is-thought .text-col p {
+  font-style: italic;
+}
+
+#theatre-log-container .dialogue-row.is-narration .text-col,
+#theatre-log-container .dialogue-row.is-system .text-col {
+  opacity: .9;
+}
+
+#theatre-log-container .dialogue-row .hex-portrait img[data-actor-icon="canonical"],
+#theatre-log-container .dialogue-row .hex-portrait img[data-actor-icon="initials"] {
+  object-fit: cover;
+}

--- a/js/character-manager-language-ux.js
+++ b/js/character-manager-language-ux.js
@@ -136,11 +136,31 @@
     }, 0);
   }
 
+  function ensureRosterUxAssets() {
+    if (!doc.getElementById("character-manager-roster-ux-stylesheet")) {
+      const link = doc.createElement("link");
+      link.id = "character-manager-roster-ux-stylesheet";
+      link.rel = "stylesheet";
+      link.href = "css/character-manager-roster-ux.css";
+      link.dataset.ui = "character-manager-roster-ux";
+      doc.head?.appendChild(link);
+    }
+    if (!doc.getElementById("character-manager-roster-ux-script")) {
+      const script = doc.createElement("script");
+      script.id = "character-manager-roster-ux-script";
+      script.src = "js/character-manager-roster-ux.js";
+      script.async = false;
+      script.dataset.ui = "character-manager-roster-ux";
+      doc.head?.appendChild(script);
+    }
+  }
+
   function install() {
     if (!getManager()) return false;
     const host = doc.getElementById("character-manager-languages");
     if (!host) return false;
     decorate();
+    ensureRosterUxAssets();
     if (!observer) {
       observer = new MutationObserver(scheduleDecorate);
       // Solo observamos altas/bajas de filas. Observar subtree haría que la
@@ -152,6 +172,7 @@
   }
 
   function boot() {
+    ensureRosterUxAssets();
     if (install()) return;
     if (retryTimer) return;
     retryTimer = global.setInterval(() => {

--- a/js/character-manager-roster-ux.js
+++ b/js/character-manager-roster-ux.js
@@ -1,0 +1,296 @@
+(function (root, factory) {
+  const api = factory(root || globalThis);
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis, function (global) {
+  "use strict";
+
+  const STORAGE_KEY = "luminous.characterManager.rosterUx";
+
+  function clean(value) {
+    return typeof value === "string" ? value.trim() : "";
+  }
+
+  function normalizeTags(value) {
+    if (Array.isArray(value)) return value.map((tag) => clean(String(tag || ""))).filter(Boolean);
+    if (typeof value === "string") return value.split(",").map((tag) => tag.trim()).filter(Boolean);
+    if (value && typeof value === "object") return Object.values(value).map((tag) => clean(String(tag || ""))).filter(Boolean);
+    return [];
+  }
+
+  function factionLabel(record) {
+    const actor = record?.actor || record || {};
+    return clean(actor.faccion || actor.alineamiento) || "SIN FACCIÓN";
+  }
+
+  function actorSearchText(record, linkedPlayerLabel) {
+    const actor = record?.actor || {};
+    return [
+      actor.nombre,
+      record?.actorId,
+      actor.titulo,
+      actor.faccion,
+      actor.alineamiento,
+      actor.tipo,
+      ...normalizeTags(actor.etiquetas || actor.tags),
+      linkedPlayerLabel,
+    ]
+      .filter(Boolean)
+      .join(" ")
+      .toLocaleLowerCase();
+  }
+
+  const api = Object.freeze({ normalizeTags, factionLabel, actorSearchText });
+  const doc = global?.document;
+  const manager = global?.LuminousCharacterManager;
+  if (!doc || !manager) return api;
+  if (global.LuminousCharacterRosterUx) return global.LuminousCharacterRosterUx;
+  global.LuminousCharacterRosterUx = api;
+
+  const state = {
+    search: "",
+    faction: "",
+    groupMode: "type",
+    collapsed: new Set(),
+    rosterObserver: null,
+    managerUnsubscribe: null,
+    applying: false,
+    timer: null,
+  };
+
+  function $(id) { return doc.getElementById(id); }
+
+  function readStoredState() {
+    try {
+      const parsed = JSON.parse(global.localStorage?.getItem(STORAGE_KEY) || "{}");
+      state.faction = clean(parsed.faction);
+      state.groupMode = ["type", "faction", "tag"].includes(parsed.groupMode) ? parsed.groupMode : "type";
+      state.collapsed = new Set(Array.isArray(parsed.collapsed) ? parsed.collapsed.map(String) : []);
+    } catch (_) {}
+  }
+
+  function persistState() {
+    try {
+      global.localStorage?.setItem(STORAGE_KEY, JSON.stringify({
+        faction: state.faction,
+        groupMode: state.groupMode,
+        collapsed: Array.from(state.collapsed),
+      }));
+    } catch (_) {}
+  }
+
+  function playerLabel(record) {
+    if (!record?.playerId) return "";
+    return manager.getPlayer?.(record.playerId)?.label || "";
+  }
+
+  function recordMatches(record) {
+    const query = clean(state.search).toLocaleLowerCase();
+    const faction = factionLabel(record);
+    if (state.groupMode === "faction" && state.faction && faction !== state.faction) return false;
+    if (!query) return true;
+    return actorSearchText(record, playerLabel(record)).includes(query);
+  }
+
+  function allFactions() {
+    return [...new Set(manager.listActors().map(factionLabel))]
+      .sort((a, b) => a.localeCompare(b, "es", { sensitivity: "base" }));
+  }
+
+  function ensureFactionFilter() {
+    const heading = doc.querySelector("#character-manager-studio .cm-roster-heading");
+    if (!heading) return null;
+    let select = $("character-manager-faction-filter");
+    if (!select) {
+      select = doc.createElement("select");
+      select.id = "character-manager-faction-filter";
+      select.className = "cm-faction-filter";
+      select.setAttribute("aria-label", "Filtrar roster por facción");
+      select.title = "Filtrar por facción";
+      select.addEventListener("change", () => {
+        state.faction = select.value;
+        persistState();
+        apply();
+      });
+      const groupMode = $("character-manager-group-mode");
+      if (groupMode?.nextSibling) heading.insertBefore(select, groupMode.nextSibling);
+      else heading.insertBefore(select, heading.lastElementChild || null);
+    }
+
+    const previous = state.faction;
+    select.innerHTML = '<option value="">TODAS</option>';
+    allFactions().forEach((faction) => {
+      const option = doc.createElement("option");
+      option.value = faction;
+      option.textContent = faction.toUpperCase();
+      select.appendChild(option);
+    });
+    select.value = Array.from(select.options).some((option) => option.value === previous) ? previous : "";
+    state.faction = select.value;
+    select.hidden = state.groupMode !== "faction";
+    return select;
+  }
+
+  function replaceSearchInput() {
+    if ($("character-manager-search-ux")) return $("character-manager-search-ux");
+    const source = $("character-manager-search");
+    if (!source) return null;
+    const visible = source.cloneNode(false);
+    visible.id = "character-manager-search-ux";
+    visible.value = source.value || "";
+    visible.setAttribute("aria-label", "Buscar por nombre, facción, tipo, etiqueta o jugador");
+    visible.placeholder = "Buscar actor, facción o etiqueta";
+    source.value = "";
+    source.hidden = true;
+    source.setAttribute("aria-hidden", "true");
+    source.tabIndex = -1;
+    source.parentNode?.appendChild(visible);
+    state.search = visible.value;
+    visible.addEventListener("input", () => {
+      state.search = visible.value;
+      apply();
+    });
+    return visible;
+  }
+
+  function groupName(section) {
+    return clean(section.querySelector(".cm-roster-group-heading span")?.textContent);
+  }
+
+  function installGroupToggle(section) {
+    const heading = section.querySelector(".cm-roster-group-heading");
+    if (!heading || heading.dataset.rosterUxToggle === "true") return;
+    heading.dataset.rosterUxToggle = "true";
+    heading.setAttribute("role", "button");
+    heading.setAttribute("tabindex", "0");
+
+    const toggle = () => {
+      if (state.groupMode !== "faction") return;
+      const label = groupName(section);
+      if (!label) return;
+      if (state.collapsed.has(label)) state.collapsed.delete(label);
+      else state.collapsed.add(label);
+      persistState();
+      apply();
+    };
+    heading.addEventListener("click", (event) => {
+      if (event.target?.closest?.("select, input, button")) return;
+      toggle();
+    });
+    heading.addEventListener("keydown", (event) => {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      toggle();
+    });
+  }
+
+  function decorateSections() {
+    const roster = $("character-manager-roster");
+    if (!roster) return;
+    roster.querySelectorAll(".cm-roster-group").forEach((section) => {
+      installGroupToggle(section);
+      const label = groupName(section);
+      const entries = Array.from(section.querySelectorAll(".cm-roster-entry"));
+      const visible = entries.filter((entry) => entry.dataset.rosterUxMatch !== "false");
+      const heading = section.querySelector(".cm-roster-group-heading");
+      const count = heading?.querySelector("code");
+      if (count) count.textContent = visible.length === entries.length
+        ? String(entries.length).padStart(2, "0")
+        : `${String(visible.length).padStart(2, "0")}/${String(entries.length).padStart(2, "0")}`;
+
+      const factionAllowed = state.groupMode !== "faction" || !state.faction || label === state.faction.toUpperCase() || factionLabel(manager.getActor(entries[0]?.dataset.actorId)).toUpperCase() === state.faction.toUpperCase();
+      const hasMatches = visible.length > 0;
+      section.hidden = !factionAllowed || !hasMatches;
+      const collapsed = state.groupMode === "faction" && state.collapsed.has(label);
+      section.dataset.collapsed = collapsed ? "true" : "false";
+      if (heading) {
+        heading.setAttribute("aria-expanded", collapsed ? "false" : "true");
+        heading.classList.toggle("is-collapsed", collapsed);
+      }
+    });
+  }
+
+  function applyEntryFilter() {
+    const roster = $("character-manager-roster");
+    if (!roster) return;
+    roster.querySelectorAll(".cm-roster-entry").forEach((entry) => {
+      const record = manager.getActor(entry.dataset.actorId);
+      const matches = Boolean(record && recordMatches(record));
+      entry.dataset.rosterUxMatch = matches ? "true" : "false";
+      entry.hidden = !matches;
+    });
+  }
+
+  function apply() {
+    if (state.applying) return;
+    state.applying = true;
+    try {
+      const mode = $("character-manager-group-mode")?.value;
+      if (["type", "faction", "tag"].includes(mode)) state.groupMode = mode;
+      bindGroupMode();
+      ensureFactionFilter();
+      applyEntryFilter();
+      decorateSections();
+      const count = $("character-manager-count");
+      if (count) {
+        const visibleCount = Array.from(doc.querySelectorAll("#character-manager-roster .cm-roster-entry"))
+          .filter((entry) => entry.dataset.rosterUxMatch !== "false").length;
+        count.textContent = String(visibleCount).padStart(2, "0");
+      }
+    } finally {
+      state.applying = false;
+    }
+  }
+
+  function scheduleApply() {
+    global.clearTimeout(state.timer);
+    state.timer = global.setTimeout(() => {
+      state.timer = null;
+      apply();
+    }, 0);
+  }
+
+  function observeRoster() {
+    const roster = $("character-manager-roster");
+    if (!roster || state.rosterObserver) return;
+    state.rosterObserver = new MutationObserver(() => {
+      if (!state.applying) scheduleApply();
+    });
+    state.rosterObserver.observe(roster, { childList: true });
+  }
+
+  function bindGroupMode() {
+    const select = $("character-manager-group-mode");
+    if (!select || select.dataset.rosterUxBound === "true") return;
+    select.dataset.rosterUxBound = "true";
+    if (["type", "faction", "tag"].includes(state.groupMode) && select.value !== state.groupMode) {
+      select.value = state.groupMode;
+      select.dispatchEvent(new global.Event("change", { bubbles: true }));
+    }
+    select.addEventListener("change", () => {
+      state.groupMode = select.value;
+      persistState();
+      global.setTimeout(apply, 0);
+    });
+  }
+
+  function install() {
+    if (!$("character-manager-studio") || !$("character-manager-roster")) return false;
+    replaceSearchInput();
+    bindGroupMode();
+    ensureFactionFilter();
+    observeRoster();
+    apply();
+    if (!state.managerUnsubscribe) state.managerUnsubscribe = manager.subscribeActors?.(scheduleApply) || null;
+    return true;
+  }
+
+  readStoredState();
+  if (!install()) {
+    const retry = global.setInterval(() => {
+      if (install()) global.clearInterval(retry);
+    }, 100);
+  }
+  if (doc.readyState === "loading") doc.addEventListener("DOMContentLoaded", install, { once: true });
+
+  return api;
+});

--- a/js/theatre-intervention-ux.js
+++ b/js/theatre-intervention-ux.js
@@ -1,0 +1,415 @@
+(function (root, factory) {
+  const api = factory(root || globalThis);
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis, function (global) {
+  "use strict";
+
+  const ACTOR_ROOTS = ["campaña/actores", "campaña/base_datos_npcs"];
+  const NO_PORTRAIT_TYPES = new Set(["pensamiento", "narracion", "sistema"]);
+  const ACTOR_LOG_TYPES = new Set(["dialogo", "actuar"]);
+
+  function clean(value) {
+    return typeof value === "string" ? value.trim() : "";
+  }
+
+  function normalizedType(message) {
+    const raw = clean(message?.mensaje || message?.message);
+    if (/^\/em(?:\s+|$)/i.test(raw)) return "actuar";
+    const type = clean(message?.tipo_dialogo || message?.dialogueType || message?.type).toLowerCase();
+    if (["actuar", "pensamiento", "narracion", "sistema", "dialogo"].includes(type)) return type;
+    return "dialogo";
+  }
+
+  function iconFromActor(record) {
+    return clean(record?.icono)
+      || clean(record?.icono_jugador)
+      || clean(record?.icon_url)
+      || clean(record?.avatar)
+      || "";
+  }
+
+  function sameAsset(a, b) {
+    const left = clean(a);
+    const right = clean(b);
+    return Boolean(left && right && left === right);
+  }
+
+  function normalizeInterventionMessage(message, sceneActor) {
+    if (!message || typeof message !== "object") return message;
+    const next = { ...message };
+    const actor = sceneActor && typeof sceneActor === "object" ? sceneActor : {};
+    const type = normalizedType(next);
+    next.tipo_dialogo = type;
+
+    if (type === "actuar") {
+      const text = clean(next.mensaje || next.message);
+      if (text && !/^\/em(?:\s+|$)/i.test(text)) next.mensaje = `/em ${text}`;
+      if (!clean(next.sprite)) next.sprite = clean(actor.sprite || actor.url) || null;
+      if (!clean(next.expression)) next.expression = clean(actor.expresionPreparada || actor.expresionActiva) || null;
+      if (!clean(next.icono)) next.icono = iconFromActor(actor) || null;
+    }
+
+    if (type === "narracion" || type === "sistema") {
+      next.actorId = null;
+      next.sprite = null;
+      next.expression = null;
+      next.icono = null;
+    }
+
+    // Only spoken dialogue may present a nameplate. Actions still keep actor identity
+    // in the payload/log, while thoughts, narration and system copy are anonymous rows.
+    if (type !== "dialogo") next.mostrar_identidad = false;
+    else if (next.mostrar_identidad === undefined) next.mostrar_identidad = true;
+
+    return next;
+  }
+
+  function mergeCatalogs(actorCatalogs) {
+    return Object.assign({}, ...(actorCatalogs || []).filter((entry) => entry && typeof entry === "object"));
+  }
+
+  function resolveCanonicalActorIcon(message, sceneActors, actorCatalogs) {
+    const msg = message || {};
+    const actors = sceneActors && typeof sceneActors === "object" ? sceneActors : {};
+    const catalog = mergeCatalogs(actorCatalogs);
+    const actorId = clean(msg.actorId);
+    const liveActor = actorId ? actors[actorId] || null : null;
+
+    const stableIds = [
+      clean(liveActor?.identityId),
+      clean(liveActor?.identidadId),
+      clean(liveActor?.sourceActorId),
+      clean(liveActor?.sourceId),
+      clean(msg.identityId),
+      clean(msg.identidadId),
+      clean(msg.sourceActorId),
+      clean(msg.sourceId),
+      actorId,
+    ].filter(Boolean);
+
+    for (const stableId of stableIds) {
+      const icon = iconFromActor(catalog[stableId]);
+      if (icon) return icon;
+    }
+
+    const targetName = clean(msg.nombre || liveActor?.nombre).toLowerCase();
+    if (targetName) {
+      const byName = Object.values(catalog).find((actor) => clean(actor?.nombre).toLowerCase() === targetName);
+      const icon = iconFromActor(byName);
+      if (icon) return icon;
+    }
+
+    const liveIcon = iconFromActor(liveActor);
+    if (liveIcon && !sameAsset(liveIcon, liveActor?.sprite || liveActor?.url)) return liveIcon;
+
+    // Archived icon is accepted only as a final historical fallback and never when
+    // it is the same asset as the scene sprite. Sprite itself is never a fallback.
+    const archivedIcon = iconFromActor(msg);
+    if (archivedIcon && !sameAsset(archivedIcon, msg.sprite)) return archivedIcon;
+    return "";
+  }
+
+  function logPresentation(message) {
+    const type = normalizedType(message);
+    return {
+      type,
+      showActor: ACTOR_LOG_TYPES.has(type),
+      centered: NO_PORTRAIT_TYPES.has(type),
+      showPortrait: ACTOR_LOG_TYPES.has(type),
+      showNameplate: type === "dialogo" && message?.mostrar_identidad !== false,
+    };
+  }
+
+  function initials(name) {
+    return (clean(name) || "?")
+      .split(/\s+/)
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((part) => part.charAt(0))
+      .join("")
+      .toUpperCase() || "?";
+  }
+
+  function initialsIcon(name) {
+    const text = initials(name).replace(/[&<>"']/g, (char) => ({
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+    })[char]);
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80"><rect width="80" height="80" fill="#111111"/><text x="40" y="49" text-anchor="middle" font-family="Arial,sans-serif" font-size="27" font-weight="700" fill="#d7c8aa">${text}</text></svg>`;
+    return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`;
+  }
+
+  const api = Object.freeze({
+    normalizedType,
+    normalizeInterventionMessage,
+    resolveCanonicalActorIcon,
+    logPresentation,
+    iconFromActor,
+  });
+
+  const doc = global?.document;
+  const firebase = global?.firebase;
+  if (!doc || !firebase?.database) return api;
+  if (global.LuminousTheatreInterventionUx) return global.LuminousTheatreInterventionUx;
+  global.LuminousTheatreInterventionUx = api;
+
+  const db = firebase.database();
+  const actorCatalogs = {};
+  let sceneActors = {};
+  let logEntries = [];
+  let logRef = null;
+  let logListener = null;
+  let logPath = null;
+  let sceneRef = null;
+  let sceneListener = null;
+  let scenePath = null;
+  let logObserver = null;
+  let observedLog = null;
+  let decoratingLog = false;
+  let repairTimer = null;
+  let installTimer = null;
+
+  function isDmView() {
+    return Boolean(doc.body?.classList.contains("on-game-dashboard"));
+  }
+
+  function theatre() {
+    return global.LuminousTheatreState || null;
+  }
+
+  function currentPaths() {
+    return theatre()?.getPaths?.() || {
+      scene: "campaña/estado_mundo/escena_actual",
+      queue: "campaña/teatro/cola",
+      log: "campaña/teatro/log",
+    };
+  }
+
+  function ensureStyles() {
+    if (doc.getElementById("theatre-intervention-ux-stylesheet")) return;
+    const link = doc.createElement("link");
+    link.id = "theatre-intervention-ux-stylesheet";
+    link.rel = "stylesheet";
+    link.href = "css/theatre-intervention-ux.css";
+    link.dataset.ui = "theatre-intervention-ux";
+    doc.head?.appendChild(link);
+  }
+
+  function ensureActuarOption(select) {
+    if (!select || Array.from(select.options || []).some((option) => option.value === "actuar")) return select;
+    const option = doc.createElement("option");
+    option.value = "actuar";
+    option.textContent = "Actuar";
+    const dialogue = Array.from(select.options || []).find((entry) => entry.value === "dialogo");
+    if (dialogue?.nextSibling) select.insertBefore(option, dialogue.nextSibling);
+    else select.appendChild(option);
+    return select;
+  }
+
+  function ensureComposerOptions() {
+    ensureActuarOption(doc.getElementById("dm-tipo-dialogo-select"));
+    ensureActuarOption(doc.getElementById("player-tipo-dialogo-select"));
+  }
+
+  function normalizeComposerBeforeSend(event) {
+    const button = event.target?.closest?.("#btn-send-dialogue, #btn-enviar-teatro-modal");
+    if (!button) return;
+    const dm = Boolean(button.id === "btn-send-dialogue");
+    const select = doc.getElementById(dm ? "dm-tipo-dialogo-select" : "player-tipo-dialogo-select");
+    const textNode = doc.getElementById(dm ? "theatre-dialogue-input" : "theatre-message-input")
+      || (!dm ? doc.querySelector("#modal-escritura textarea") : null);
+    const text = clean(textNode?.value);
+    if (/^\/em(?:\s+|$)/i.test(text) && select) select.value = "actuar";
+  }
+
+  function bindScene() {
+    const path = currentPaths().scene;
+    if (!path || path === scenePath) return;
+    if (sceneRef && sceneListener) sceneRef.off("value", sceneListener);
+    scenePath = path;
+    sceneRef = db.ref(path);
+    sceneListener = (snapshot) => {
+      sceneActors = snapshot.val()?.actores || {};
+      scheduleLogDecoration();
+      scheduleRepair();
+    };
+    sceneRef.on("value", sceneListener);
+  }
+
+  function bindActorCatalogs() {
+    ACTOR_ROOTS.forEach((root) => {
+      db.ref(root).on("value", (snapshot) => {
+        actorCatalogs[root] = snapshot.val() || {};
+        scheduleLogDecoration();
+        scheduleRepair();
+      });
+    });
+  }
+
+  function catalogs() {
+    // Legacy first, modern last: the modern actor database wins collisions.
+    return ACTOR_ROOTS.map((root) => actorCatalogs[root] || {});
+  }
+
+  function patchEnqueue() {
+    const state = theatre();
+    if (!state?.enqueueIntervention || state.__luminousInterventionUxPatched) return false;
+    const original = state.enqueueIntervention.bind(state);
+    state.enqueueIntervention = async function (message) {
+      bindScene();
+      const actorId = clean(message?.actorId);
+      let actor = actorId ? sceneActors[actorId] || null : null;
+      if (!actor && actorId) {
+        try {
+          const snapshot = await db.ref(`${currentPaths().scene}/actores/${actorId}`).once("value");
+          actor = snapshot.val() || null;
+        } catch (_) {}
+      }
+      return original(normalizeInterventionMessage(message, actor));
+    };
+    state.__luminousInterventionUxPatched = true;
+    return true;
+  }
+
+  function patchDirectQueueWrites() {
+    if (db.__luminousInterventionUxRefPatched) return;
+    const originalRef = db.ref.bind(db);
+    db.ref = function (path) {
+      const ref = originalRef.apply(db, arguments);
+      const normalized = String(path || "").replace(/^\/+|\/+$/g, "");
+      const expected = String(currentPaths().queue || "campaña/teatro/cola").replace(/^\/+|\/+$/g, "");
+      if (normalized !== expected || ref.__luminousInterventionUxPushPatched) return ref;
+      const originalPush = ref.push.bind(ref);
+      ref.push = function (value) {
+        const actorId = clean(value?.actorId);
+        const actor = actorId ? sceneActors[actorId] || null : null;
+        const next = normalizeInterventionMessage(value, actor);
+        return originalPush.apply(ref, [next].concat(Array.prototype.slice.call(arguments, 1)));
+      };
+      ref.__luminousInterventionUxPushPatched = true;
+      return ref;
+    };
+    db.__luminousInterventionUxRefPatched = true;
+  }
+
+  function ensureLogObserver() {
+    const container = doc.getElementById("theatre-log-container");
+    if (!container || isDmView()) return null;
+    if (container === observedLog && logObserver) return container;
+    logObserver?.disconnect();
+    observedLog = container;
+    logObserver = new MutationObserver(() => {
+      if (!decoratingLog) scheduleLogDecoration();
+    });
+    logObserver.observe(container, { childList: true, subtree: true });
+    return container;
+  }
+
+  function decorateLog() {
+    if (isDmView()) return;
+    const container = ensureLogObserver();
+    if (!container || !logEntries.length) return;
+    const rows = Array.from(container.querySelectorAll(".dialogue-scroll-area .dialogue-row"));
+    if (!rows.length) return;
+    decoratingLog = true;
+    try {
+      logEntries.forEach(([messageId, message], index) => {
+        const row = rows[index];
+        if (!row) return;
+        const presentation = logPresentation(message);
+        row.dataset.messageId = messageId;
+        row.dataset.dialogueType = presentation.type;
+        row.classList.toggle("is-dialogue", presentation.type === "dialogo");
+        row.classList.toggle("is-action", presentation.type === "actuar");
+        row.classList.toggle("is-thought", presentation.type === "pensamiento");
+        row.classList.toggle("is-narration", presentation.type === "narracion");
+        row.classList.toggle("is-system", presentation.type === "sistema");
+        row.classList.toggle("is-centered-log-entry", presentation.centered);
+
+        const characterCol = row.querySelector(".character-col");
+        if (!presentation.showPortrait) {
+          characterCol?.remove();
+          return;
+        }
+
+        const image = characterCol?.querySelector(".hex-portrait img");
+        if (!image) return;
+        const icon = resolveCanonicalActorIcon(message, sceneActors, catalogs());
+        const safeIcon = icon || initialsIcon(message?.nombre || "?");
+        if (image.getAttribute("src") !== safeIcon) image.src = safeIcon;
+        image.dataset.actorIcon = icon ? "canonical" : "initials";
+      });
+    } finally {
+      decoratingLog = false;
+    }
+  }
+
+  function scheduleLogDecoration() {
+    if (isDmView()) return;
+    if (typeof global.queueMicrotask === "function") global.queueMicrotask(decorateLog);
+    else global.setTimeout(decorateLog, 0);
+    global.setTimeout(decorateLog, 40);
+  }
+
+  function repairLogIcons() {
+    if (!isDmView() || !logEntries.length) return Promise.resolve();
+    const tasks = [];
+    logEntries.forEach(([messageId, message]) => {
+      if (!ACTOR_LOG_TYPES.has(normalizedType(message))) return;
+      const icon = resolveCanonicalActorIcon(message, sceneActors, catalogs());
+      if (!icon || clean(message?.icono) === icon) return;
+      tasks.push(db.ref(`${currentPaths().log}/${messageId}`).update({ icono: icon }));
+    });
+    return Promise.all(tasks);
+  }
+
+  function scheduleRepair() {
+    if (!isDmView()) return;
+    global.clearTimeout(repairTimer);
+    repairTimer = global.setTimeout(() => {
+      repairLogIcons().catch((error) => console.warn("No se pudieron normalizar iconos del Theatre Log:", error));
+    }, 120);
+  }
+
+  function bindLog() {
+    const path = currentPaths().log;
+    if (!path || path === logPath) return;
+    if (logRef && logListener) logRef.off("value", logListener);
+    logPath = path;
+    logRef = db.ref(path).limitToLast(20);
+    logListener = (snapshot) => {
+      logEntries = Object.entries(snapshot.val() || {});
+      scheduleLogDecoration();
+      scheduleRepair();
+    };
+    logRef.on("value", logListener);
+  }
+
+  function install() {
+    ensureStyles();
+    ensureComposerOptions();
+    bindScene();
+    bindLog();
+    patchEnqueue();
+    patchDirectQueueWrites();
+    ensureLogObserver();
+    return true;
+  }
+
+  bindActorCatalogs();
+  doc.addEventListener("click", normalizeComposerBeforeSend, true);
+  doc.addEventListener("change", (event) => {
+    if (event.target?.id === "dm-tipo-dialogo-select" || event.target?.id === "player-tipo-dialogo-select") ensureComposerOptions();
+  });
+  global.addEventListener?.("actoresCacheUpdated", scheduleLogDecoration);
+
+  install();
+  if (doc.readyState === "loading") doc.addEventListener("DOMContentLoaded", install, { once: true });
+  installTimer = global.setInterval(() => {
+    install();
+    if (doc.getElementById("dm-tipo-dialogo-select") || doc.getElementById("player-tipo-dialogo-select")) {
+      if (patchEnqueue()) scheduleLogDecoration();
+    }
+  }, 750);
+
+  return api;
+});

--- a/js/theatre-language-policy.js
+++ b/js/theatre-language-policy.js
@@ -36,6 +36,14 @@
     return script;
   }
 
+  function ensureInterventionUxRuntime() {
+    return ensureRuntimeScript(
+      "theatre-intervention-ux-runtime-script",
+      "js/theatre-intervention-ux.js",
+      "luminousTheatreInterventionUxRuntime",
+    );
+  }
+
   function ensurePlayerSpecialLanguageRuntime() {
     if (isDmView()) return;
     const ensureLog = () => ensureRuntimeScript(
@@ -281,9 +289,12 @@
   }
 
   function refresh() {
+    ensureInterventionUxRuntime();
     if (isDmView()) refreshDmSelector();
     else ensurePlayerSelector();
   }
+
+  ensureInterventionUxRuntime();
 
   LANGUAGE_ROOTS.forEach((root) => {
     db.ref(root).on("value", (snapshot) => {

--- a/js/theatre-special-language-log-hotfix.js
+++ b/js/theatre-special-language-log-hotfix.js
@@ -8,18 +8,31 @@
     return typeof value === "string" ? value.trim() : "";
   }
 
+  function formatActionText(message, text) {
+    const type = clean(message?.tipo_dialogo || message?.dialogueType).toLowerCase();
+    const raw = String(text || "");
+    if (type !== "actuar" && !/^\/em(?:\s+|$)/i.test(raw)) return raw;
+    const action = raw.replace(/^\/em\s*/i, "").trim();
+    const name = clean(message?.nombre) || "???";
+    return action ? `(${name} ${action})` : `(${name})`;
+  }
+
   function resolveLogMessageText(message, definitions, profiles, rules) {
     const raw = String(message?.mensaje || message?.message || "");
     const languageId = clean(message?.idiomaId || message?.languageId || message?.idioma);
-    if (!languageId || !rules) return raw;
-    const definition = definitions?.[languageId] || {};
-    if (!rules.isSpecialLanguage?.(languageId, definition)) return raw;
-    return rules.resolveSpecialUnderstanding?.(profiles, languageId)
-      ? raw
-      : rules.unknownTextForDefinition?.(definition) || "[No comprendes este lenguaje especial.]";
+    let resolved = raw;
+    if (languageId && rules) {
+      const definition = definitions?.[languageId] || {};
+      if (rules.isSpecialLanguage?.(languageId, definition)) {
+        resolved = rules.resolveSpecialUnderstanding?.(profiles, languageId)
+          ? raw
+          : rules.unknownTextForDefinition?.(definition) || "[No comprendes este lenguaje especial.]";
+      }
+    }
+    return formatActionText(message, resolved);
   }
 
-  const api = Object.freeze({ resolveLogMessageText });
+  const api = Object.freeze({ resolveLogMessageText, formatActionText });
   if (!global?.document || !global?.firebase?.database) return api;
   if (global.LuminousSpecialLanguageLogEnforcement) return global.LuminousSpecialLanguageLogEnforcement;
   global.LuminousSpecialLanguageLogEnforcement = api;
@@ -128,7 +141,7 @@
     if (isDmView()) return;
     const activeRules = rules();
     const container = ensureObserver();
-    if (!activeRules || !container || !logEntries.length) return;
+    if (!container || !logEntries.length) return;
     const rows = Array.from(container.querySelectorAll(".dialogue-scroll-area .dialogue-row"));
     if (!rows.length) return;
     const profiles = viewerProfiles();
@@ -147,8 +160,8 @@
         const definition = definitions[languageId] || {};
         const blocked = Boolean(
           languageId
-          && activeRules.isSpecialLanguage?.(languageId, definition)
-          && !activeRules.resolveSpecialUnderstanding?.(profiles, languageId)
+          && activeRules?.isSpecialLanguage?.(languageId, definition)
+          && !activeRules?.resolveSpecialUnderstanding?.(profiles, languageId)
         );
         row.dataset.specialLanguageBlocked = blocked ? "true" : "false";
       });

--- a/tests/character_manager_roster_ux.spec.js
+++ b/tests/character_manager_roster_ux.spec.js
@@ -1,0 +1,59 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
+const rosterUx = require("../js/character-manager-roster-ux.js");
+const uxSource = read("js/character-manager-roster-ux.js");
+const loaderSource = read("js/character-manager-language-ux.js");
+const cssSource = read("css/character-manager-roster-ux.css");
+
+test("roster search includes faction, type, tags and linked player label", () => {
+  const text = rosterUx.actorSearchText({
+    actorId: "npc_77",
+    actor: {
+      nombre: "Operador Gris",
+      titulo: "Supervisor",
+      faccion: "SINDICATO",
+      tipo: "Neutral",
+      etiquetas: ["contacto", "muelle"],
+    },
+  }, "Agatha");
+
+  for (const term of ["operador gris", "npc_77", "supervisor", "sindicato", "neutral", "contacto", "muelle", "agatha"]) {
+    expect(text).toContain(term);
+  }
+});
+
+test("faction UX is dynamic, collapsible, sticky and persists local UI state", () => {
+  expect(uxSource).toContain("character-manager-faction-filter");
+  expect(uxSource).toContain("allFactions()");
+  expect(uxSource).toContain('setAttribute("aria-expanded"');
+  expect(uxSource).toContain("state.collapsed");
+  expect(uxSource).toContain("localStorage");
+  expect(cssSource).toContain("position: sticky");
+  expect(cssSource).toContain('data-collapsed="true"');
+});
+
+test("search input is decoupled so the original renderer keeps all 100+ actors available", () => {
+  expect(uxSource).toContain('source.hidden = true');
+  expect(uxSource).toContain('visible.id = "character-manager-search-ux"');
+  expect(uxSource).toContain("actorSearchText(record, playerLabel(record))");
+});
+
+test("faction values are never hardcoded", () => {
+  expect(rosterUx.factionLabel({ actor: { faccion: "LCB" } })).toBe("LCB");
+  expect(rosterUx.factionLabel({ actor: {} })).toBe("SIN FACCIÓN");
+  expect(uxSource).not.toMatch(/<option[^>]+value=["']LCB/i);
+  expect(uxSource).not.toMatch(/<option[^>]+value=["']FIXER/i);
+  expect(uxSource).not.toMatch(/<option[^>]+value=["']SINDICATO/i);
+});
+
+test("Character Manager language UX loads the roster extension without changing campaign data", () => {
+  expect(loaderSource).toContain("ensureRosterUxAssets");
+  expect(loaderSource).toContain("js/character-manager-roster-ux.js");
+  expect(loaderSource).toContain("css/character-manager-roster-ux.css");
+  expect(uxSource).not.toContain("firebase.database");
+  expect(uxSource).not.toContain(".set(");
+  expect(uxSource).not.toContain(".update(");
+});

--- a/tests/theatre_intervention_ux.spec.js
+++ b/tests/theatre_intervention_ux.spec.js
@@ -1,0 +1,110 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
+const interventionUx = require("../js/theatre-intervention-ux.js");
+const logPolicy = require("../js/theatre-special-language-log-hotfix.js");
+
+const uxSource = read("js/theatre-intervention-ux.js");
+const policySource = read("js/theatre-language-policy.js");
+const cssSource = read("css/theatre-intervention-ux.css");
+
+test("Actuar is explicit and /em normalizes to actuar without a nameplate", () => {
+  const explicit = interventionUx.normalizeInterventionMessage({
+    actorId: "actor_dante",
+    tipo_dialogo: "actuar",
+    mensaje: "levanta la mano",
+  }, { sprite: "dante-sprite.png", icono: "dante-icon.png" });
+
+  expect(explicit.tipo_dialogo).toBe("actuar");
+  expect(explicit.mensaje).toBe("/em levanta la mano");
+  expect(explicit.mostrar_identidad).toBe(false);
+  expect(explicit.sprite).toBe("dante-sprite.png");
+  expect(explicit.icono).toBe("dante-icon.png");
+
+  const legacy = interventionUx.normalizeInterventionMessage({
+    tipo_dialogo: "dialogo",
+    mensaje: "/em mira el reloj",
+  });
+  expect(legacy.tipo_dialogo).toBe("actuar");
+  expect(legacy.mostrar_identidad).toBe(false);
+});
+
+test("Only dialogue is eligible for a nameplate", () => {
+  expect(interventionUx.logPresentation({ tipo_dialogo: "dialogo" }).showNameplate).toBe(true);
+  expect(interventionUx.logPresentation({ tipo_dialogo: "actuar" }).showNameplate).toBe(false);
+  expect(interventionUx.logPresentation({ tipo_dialogo: "pensamiento" }).showNameplate).toBe(false);
+  expect(interventionUx.logPresentation({ tipo_dialogo: "narracion" }).showNameplate).toBe(false);
+  expect(interventionUx.logPresentation({ tipo_dialogo: "sistema" }).showNameplate).toBe(false);
+  const system = interventionUx.normalizeInterventionMessage({ tipo_dialogo: "sistema", actorId: "actor_x", icono: "x.png" });
+  expect(system.actorId).toBeNull();
+  expect(system.icono).toBeNull();
+});
+
+test("thought, narration and system are centered portrait-less rows; acting keeps actor portrait", () => {
+  for (const type of ["pensamiento", "narracion", "sistema"]) {
+    const presentation = interventionUx.logPresentation({ tipo_dialogo: type });
+    expect(presentation.centered).toBe(true);
+    expect(presentation.showPortrait).toBe(false);
+  }
+  const acting = interventionUx.logPresentation({ tipo_dialogo: "actuar" });
+  expect(acting.centered).toBe(false);
+  expect(acting.showPortrait).toBe(true);
+  expect(cssSource).toContain(".dialogue-row.is-centered-log-entry");
+  expect(cssSource).toContain(".dialogue-row.is-action");
+});
+
+test("Dante log portrait resolves the master actor icon, never the scene sprite", () => {
+  const sceneActors = {
+    actor_123: {
+      nombre: "Dante",
+      identityId: "dante",
+      sprite: "dante-expression-sprite.png",
+      icono: "dante-live-icon.png",
+    },
+  };
+  const modernCatalog = {
+    dante: {
+      nombre: "Dante",
+      icono: "dante-actor-icon.png",
+      sprite: "dante-master-sprite.png",
+    },
+  };
+  const message = {
+    actorId: "actor_123",
+    nombre: "Dante",
+    icono: "dante-expression-sprite.png",
+    sprite: "dante-expression-sprite.png",
+  };
+
+  expect(interventionUx.resolveCanonicalActorIcon(message, sceneActors, [modernCatalog]))
+    .toBe("dante-actor-icon.png");
+  expect(uxSource).not.toMatch(/return\s+.*sprite.*fallback/i);
+});
+
+test("archived sprite contamination is rejected when no canonical icon exists", () => {
+  const message = { nombre: "Dante", icono: "same.png", sprite: "same.png" };
+  expect(interventionUx.resolveCanonicalActorIcon(message, {}, [])).toBe("");
+});
+
+test("log text formats actuar and keeps special-language privacy", () => {
+  const rules = {
+    isSpecialLanguage: () => true,
+    resolveSpecialUnderstanding: () => false,
+    unknownTextForDefinition: () => "Tik... Tok...",
+  };
+  expect(logPolicy.resolveLogMessageText({
+    tipo_dialogo: "actuar",
+    nombre: "Dante",
+    mensaje: "/em señala la puerta",
+    idiomaId: "dante_clock",
+  }, { dante_clock: {} }, [{}], rules)).toBe("(Dante Tik... Tok...)");
+});
+
+test("language policy loads intervention UX for both DM and player contexts", () => {
+  expect(policySource).toContain("ensureInterventionUxRuntime");
+  expect(policySource).toContain("js/theatre-intervention-ux.js");
+  expect(uxSource).toContain('option.value = "actuar"');
+  expect(uxSource).toContain("#btn-send-dialogue, #btn-enviar-teatro-modal");
+});


### PR DESCRIPTION
## Resumen

Implementa el alcance de #543 para que Character Manager siga siendo navegable con ~100+ NPCs y para separar correctamente **Icono de Actor** de **Sprite** en Theatre Log.

Closes #543

## Character Manager · roster por facciones

- Mantiene `TIPO / FACCIÓN / ETIQUETA`.
- Añade filtro rápido de facción generado dinámicamente desde los actores existentes (`TODAS` + facciones reales, sin hardcode).
- Los grupos de facción conservan nombre + contador y pasan a ser colapsables/expandibles.
- Cabeceras de grupo sticky mientras se recorre un roster largo.
- Búsqueda ampliada a nombre, `actorId`, título, facción/alineamiento, tipo, etiquetas/tags y jugador vinculado.
- La búsqueda se desacopla del filtro legacy para que el renderer mantenga disponibles todos los actores y el filtrado ampliado no pierda NPCs.
- Agrupación, filtro de facción y grupos colapsados se recuerdan en `localStorage`; no se escriben datos de campaña.
- La selección existente del actor se conserva porque el UX filtra/colapsa entradas sin reconstruir su identidad ni persistencia.

## Theatre · nuevo tipo ACTUAR

- Añade `ACTUAR` a los selectores de intervención de DM y jugador.
- `/em ...` sigue siendo compatible y se normaliza a `tipo_dialogo: "actuar"`.
- Una intervención `ACTUAR` explícita se normaliza al formato de acción existente (`/em`) para reutilizar el renderer actual.
- `ACTUAR` mantiene actor activo/sprite de escena cuando corresponde, pero fuerza `mostrar_identidad: false`.
- Solo `DIÁLOGO` puede usar Nameplate.
- Narración/Sistema eliminan identidad visual del payload; Pensamiento continúa sin activar al actor.

## Theatre Log · Icono de Actor canónico

- El retrato del Log resuelve primero el actor maestro por `identityId` / `sourceId` / actor persistente y luego por nombre como fallback de compatibilidad.
- Solo se consideran campos de icono (`icono`, `icono_jugador`, `icon_url`, `avatar`).
- `sprite` nunca se usa como fallback de retrato.
- Un `icono` archivado contaminado que sea igual al `sprite` se rechaza.
- Si no existe icono canónico, se muestran iniciales neutrales.
- En vista DM, las últimas entradas del Log se reparan con el icono maestro cuando se puede resolver de forma segura.
- Regresión específica para Dante con `icono !== sprite`.

## Semántica visual del Log

| Tipo | Nameplate | Retrato Log | Layout Log |
| --- | --- | --- | --- |
| `dialogo` | Sí | Icono de Actor | normal |
| `actuar` | No | Icono de Actor | acción del actor |
| `pensamiento` | No | ninguno | centrado |
| `narracion` | No | ninguno | centrado |
| `sistema` | No | ninguno | centrado |

Las acciones se muestran como `(Personaje acción)` y respetan la privacidad de idiomas especiales: si el espectador no entiende el idioma, el texto desconocido sigue siendo el que aparece.

## Archivos principales

- `js/theatre-intervention-ux.js`
- `css/theatre-intervention-ux.css`
- `js/character-manager-roster-ux.js`
- `css/character-manager-roster-ux.css`
- loaders existentes de Theatre/Character Manager
- regresiones nuevas de Theatre y roster
- workflow `Theatre Log and Roster UX`

## Validación

- `node --check` local sobre los módulos y specs nuevos/modificados.
- Smoke de helpers: normalización `/em → actuar`, Nameplate, Dante icono vs sprite, rechazo de contaminación y búsqueda por facción/tags.
- El workflow nuevo ejecuta las regresiones nuevas y `tests/theatre_special_language_enforcement.spec.js` con Playwright en GitHub Actions.

## Smoke recomendado antes de merge

- Character Manager con roster grande: cambiar a FACCIÓN, filtrar, colapsar varios grupos, buscar por facción/tag y abrir un NPC.
- Dante: hablar/actuar con expresión distinta del icono y comprobar que el Log usa el Icono de Actor.
- `ACTUAR`: sin Nameplate y con icono en Log.
- `PENSAMIENTO`, Narrador y Sistema: texto centrado y sin columna de retrato.
