### PR TITLE
Hotfix: colapsa Tipo, Facción y Etiqueta en Character Manager

### DIFF
--- a/js/character-manager-roster-ux.js
+++ b/js/character-manager-roster-ux.js
@@ -5,9 +5,14 @@
   "use strict";
 
   const STORAGE_KEY = "luminous.characterManager.rosterUx";
+  const GROUP_MODES = ["type", "faction", "tag"];
 
   function clean(value) {
     return typeof value === "string" ? value.trim() : "";
+  }
+
+  function rendererUpper(value) {
+    return clean(value).toUpperCase();
   }
 
   function normalizeTags(value) {
@@ -39,7 +44,12 @@
       .toLocaleLowerCase();
   }
 
-  const api = Object.freeze({ normalizeTags, factionLabel, actorSearchText });
+  function collapseKey(mode, label) {
+    const safeMode = GROUP_MODES.includes(mode) ? mode : "type";
+    return `${safeMode}:${rendererUpper(label)}`;
+  }
+
+  const api = Object.freeze({ normalizeTags, factionLabel, actorSearchText, collapseKey, rendererUpper });
   const doc = global?.document;
   const manager = global?.LuminousCharacterManager;
   if (!doc || !manager) return api;
@@ -63,8 +73,12 @@
     try {
       const parsed = JSON.parse(global.localStorage?.getItem(STORAGE_KEY) || "{}");
       state.faction = clean(parsed.faction);
-      state.groupMode = ["type", "faction", "tag"].includes(parsed.groupMode) ? parsed.groupMode : "type";
-      state.collapsed = new Set(Array.isArray(parsed.collapsed) ? parsed.collapsed.map(String) : []);
+      state.groupMode = GROUP_MODES.includes(parsed.groupMode) ? parsed.groupMode : "type";
+      state.collapsed = new Set(
+        (Array.isArray(parsed.collapsed) ? parsed.collapsed : [])
+          .map(String)
+          .map((entry) => entry.includes(":") ? entry : collapseKey("faction", entry))
+      );
     } catch (_) {}
   }
 
@@ -121,7 +135,7 @@
     allFactions().forEach((faction) => {
       const option = doc.createElement("option");
       option.value = faction;
-      option.textContent = faction.toUpperCase();
+      option.textContent = rendererUpper(faction);
       select.appendChild(option);
     });
     select.value = Array.from(select.options).some((option) => option.value === previous) ? previous : "";
@@ -164,11 +178,11 @@
     heading.setAttribute("tabindex", "0");
 
     const toggle = () => {
-      if (state.groupMode !== "faction") return;
       const label = groupName(section);
       if (!label) return;
-      if (state.collapsed.has(label)) state.collapsed.delete(label);
-      else state.collapsed.add(label);
+      const key = collapseKey(state.groupMode, label);
+      if (state.collapsed.has(key)) state.collapsed.delete(key);
+      else state.collapsed.add(key);
       persistState();
       apply();
     };
@@ -197,14 +211,18 @@
         ? String(entries.length).padStart(2, "0")
         : `${String(visible.length).padStart(2, "0")}/${String(entries.length).padStart(2, "0")}`;
 
-      const factionAllowed = state.groupMode !== "faction" || !state.faction || label === state.faction.toUpperCase() || factionLabel(manager.getActor(entries[0]?.dataset.actorId)).toUpperCase() === state.faction.toUpperCase();
-      const hasMatches = visible.length > 0;
-      section.hidden = !factionAllowed || !hasMatches;
-      const collapsed = state.groupMode === "faction" && state.collapsed.has(label);
+      const factionAllowed = state.groupMode !== "faction"
+        || !state.faction
+        || rendererUpper(label) === rendererUpper(state.faction);
+      section.hidden = !factionAllowed || visible.length === 0;
+
+      const key = collapseKey(state.groupMode, label);
+      const collapsed = state.collapsed.has(key);
       section.dataset.collapsed = collapsed ? "true" : "false";
       if (heading) {
         heading.setAttribute("aria-expanded", collapsed ? "false" : "true");
         heading.classList.toggle("is-collapsed", collapsed);
+        heading.title = collapsed ? `Expandir ${label}` : `Ocultar ${label}`;
       }
     });
   }
@@ -225,7 +243,7 @@
     state.applying = true;
     try {
       const mode = $("character-manager-group-mode")?.value;
-      if (["type", "faction", "tag"].includes(mode)) state.groupMode = mode;
+      if (GROUP_MODES.includes(mode)) state.groupMode = mode;
       bindGroupMode();
       ensureFactionFilter();
       applyEntryFilter();
@@ -262,12 +280,12 @@
     const select = $("character-manager-group-mode");
     if (!select || select.dataset.rosterUxBound === "true") return;
     select.dataset.rosterUxBound = "true";
-    if (["type", "faction", "tag"].includes(state.groupMode) && select.value !== state.groupMode) {
+    if (GROUP_MODES.includes(state.groupMode) && select.value !== state.groupMode) {
       select.value = state.groupMode;
       select.dispatchEvent(new global.Event("change", { bubbles: true }));
     }
     select.addEventListener("change", () => {
-      state.groupMode = select.value;
+      state.groupMode = GROUP_MODES.includes(select.value) ? select.value : "type";
       persistState();
       global.setTimeout(apply, 0);
     });

--- a/tests/character_manager_roster_ux.spec.js
+++ b/tests/character_manager_roster_ux.spec.js
@@ -25,14 +25,32 @@ test("roster search includes faction, type, tags and linked player label", () =>
   }
 });
 
-test("faction UX is dynamic, collapsible, sticky and persists local UI state", () => {
-  expect(uxSource).toContain("character-manager-faction-filter");
-  expect(uxSource).toContain("allFactions()");
+test("all roster grouping modes are collapsible with independent persisted keys", () => {
+  expect(rosterUx.collapseKey("type", "Aliado")).toBe("type:ALIADO");
+  expect(rosterUx.collapseKey("faction", "LCB")).toBe("faction:LCB");
+  expect(rosterUx.collapseKey("tag", "Contacto")).toBe("tag:CONTACTO");
+  expect(uxSource).toContain("collapseKey(state.groupMode, label)");
+  expect(uxSource).not.toContain('if (state.groupMode !== "faction") return;');
+  expect(uxSource).toContain('entry.includes(":") ? entry : collapseKey("faction", entry)');
   expect(uxSource).toContain('setAttribute("aria-expanded"');
   expect(uxSource).toContain("state.collapsed");
   expect(uxSource).toContain("localStorage");
   expect(cssSource).toContain("position: sticky");
   expect(cssSource).toContain('data-collapsed="true"');
+});
+
+test("faction comparison follows renderer casing instead of browser locale casing", () => {
+  expect("fixer".toLocaleUpperCase("tr")).toBe("FİXER");
+  expect(rosterUx.rendererUpper("fixer")).toBe("FIXER");
+  expect(rosterUx.rendererUpper("fixer")).not.toBe("fixer".toLocaleUpperCase("tr"));
+  expect(uxSource).toContain("rendererUpper(label) === rendererUpper(state.faction)");
+  expect(uxSource).not.toContain("label.toLocaleUpperCase()");
+});
+
+test("faction filter stays faction-only while collapse works for type faction and tag", () => {
+  expect(uxSource).toContain('select.hidden = state.groupMode !== "faction"');
+  expect(uxSource).toContain('state.groupMode !== "faction"');
+  expect(uxSource).toContain('GROUP_MODES = ["type", "faction", "tag"]');
 });
 
 test("search input is decoupled so the original renderer keeps all 100+ actors available", () => {


### PR DESCRIPTION
## Problema

Después de mergear #544, solo los grupos en modo **FACCIÓN** podían colapsarse. Los modos **TIPO** y **ETIQUETA** mostraban cabeceras de grupo pero al pulsarlas no ocurría nada.

## Causa

`character-manager-roster-ux.js` tenía dos restricciones explícitas a `groupMode === "faction"`: una en el handler de toggle y otra al calcular el estado colapsado.

Además, la comparación del filtro de facción usaba `toLocaleUpperCase()`, mientras el renderer de `character-manager-social-studio.js` construye las cabeceras con `toUpperCase()`. En locales turcos/azeríes, una facción como `fixer` podía convertirse en `FİXER` en el filtro pero renderizarse como `FIXER`, ocultando incorrectamente la sección seleccionada.

## Corrección

- `TIPO`, `FACCIÓN` y `ETIQUETA` ahora comparten el mismo comportamiento de expandir/ocultar grupos.
- El estado colapsado se guarda con claves independientes por modo:
  - `type:ALIADO`
  - `faction:LCB`
  - `tag:CONTACTO`
- Se conserva compatibilidad con el estado local creado por #544: claves antiguas sin namespace se migran como facciones.
- El filtro desplegable de facciones sigue apareciendo únicamente en modo `FACCIÓN`; esto no cambia.
- Las cabeceras mantienen `aria-expanded`, teclado Enter/Espacio y el indicador visual de colapso.
- La normalización de cabeceras/facciones usa la misma regla locale-independent del renderer (`toUpperCase()`), evitando `FIXER` vs `FİXER`.
- La misma normalización se reutiliza para las claves de colapso, evitando que el estado dependa del locale del navegador.
- Se añaden regresiones para los tres modos y para el caso turco `fixer`.

## Validación

- Rama basada en el `main` posterior al merge de #544.
- 1 commit, limitado a `js/character-manager-roster-ux.js` y su spec.
- El workflow existente `Theatre Log and Roster UX` cubre la regresión.

## Smoke recomendado

1. Cambiar a `TIPO` y ocultar/mostrar ALIADO/JUGADORES/etc.
2. Cambiar a `FACCIÓN` y ocultar/mostrar LCB/FIXER/etc.
3. Cambiar a `ETIQUETA` y ocultar/mostrar grupos.
4. Cambiar entre modos y confirmar que cada uno recuerda su estado sin interferir con los otros.
5. Con locale turco/azerí, seleccionar una facción en minúsculas que contenga `i` (por ejemplo `fixer`) y confirmar que la sección sigue visible.
