### PR TITLE
Feat: rediseña el shell del DM con un control deck más Limbus

### DIFF
--- a/.github/workflows/dm-limbus-shell.yml
+++ b/.github/workflows/dm-limbus-shell.yml
@@ -1,0 +1,36 @@
+name: DM Limbus Shell
+
+on:
+  pull_request:
+    paths:
+      - "css/actor-studio.css"
+      - "css/dm-limbus-shell.css"
+      - "css/dm-limbus-shell-fixes.css"
+      - "pantalla_dm.html"
+      - "tests/dm_limbus_shell.spec.js"
+      - ".github/workflows/dm-limbus-shell.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  shell-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check test syntax
+        run: node --check tests/dm_limbus_shell.spec.js
+
+      - name: Run DM shell regressions
+        run: npx playwright test tests/dm_limbus_shell.spec.js --workers=1

--- a/css/actor-studio.css
+++ b/css/actor-studio.css
@@ -1,3 +1,6 @@
+@import url("dm-limbus-shell.css");
+@import url("dm-limbus-shell-fixes.css");
+
 /* css/actor-studio.css */
 
 /*

--- a/css/dm-limbus-shell-fixes.css
+++ b/css/dm-limbus-shell-fixes.css
@@ -1,0 +1,35 @@
+/* Follow-up fixes for the DM Limbus shell review. */
+
+/*
+ * Grid and flex auto-placement use the order-modified document order.
+ * Keep the visible deck aligned with the 01-12 module taxonomy even though
+ * pantalla_dm.html retains its legacy DOM order for compatibility.
+ */
+body:has(.dm-tabs-nav) .dm-tabs-nav .dm-tab-btn[data-tab="tab-tiempo"] { order: 1; }
+body:has(.dm-tabs-nav) .dm-tabs-nav .dm-tab-btn[data-tab="tab-clima"] { order: 2; }
+body:has(.dm-tabs-nav) .dm-tabs-nav .dm-tab-btn[data-tab="tab-turnos"] { order: 3; }
+body:has(.dm-tabs-nav) .dm-tabs-nav .dm-tab-btn[data-tab="tab-combate"] { order: 4; }
+body:has(.dm-tabs-nav) .dm-tabs-nav .dm-tab-btn[data-tab="dashboard-actores"] { order: 5; }
+body:has(.dm-tabs-nav) .dm-tabs-nav .dm-tab-btn[data-tab="dashboard-jugadores"] { order: 6; }
+body:has(.dm-tabs-nav) .dm-tabs-nav .dm-tab-btn[data-tab="tab-comms"] { order: 7; }
+body:has(.dm-tabs-nav) .dm-tabs-nav .dm-tab-btn[data-tab="tab-banco"] { order: 8; }
+body:has(.dm-tabs-nav) .dm-tabs-nav .dm-tab-btn[data-tab="tab-forja"] { order: 9; }
+body:has(.dm-tabs-nav) .dm-tabs-nav .dm-tab-btn[data-tab="tab-loot"] { order: 10; }
+body:has(.dm-tabs-nav) .dm-tabs-nav .dm-tab-btn[data-tab="tab-keywords"] { order: 11; }
+body:has(.dm-tabs-nav) .dm-tabs-nav .dm-tab-btn[data-tab="tab-acceso"] { order: 12; }
+body:has(.dm-tabs-nav) .dm-tabs-nav .btn-modo-director { order: 13; }
+
+/*
+ * pantalla_dm.html gives .form-cyber min-width: 100% !important on mobile.
+ * With content-box sizing, its padding/borders extend beyond the panel and the
+ * shell's clipped industrial frame cuts off the right edge. Force the mobile
+ * forms into the panel's border box instead of removing the frame clipping.
+ */
+@media (max-width: 768px) {
+  body:has(.dm-tabs-nav) .panel-cyber .form-cyber {
+    box-sizing: border-box !important;
+    width: 100% !important;
+    min-width: 0 !important;
+    max-width: 100% !important;
+  }
+}

--- a/css/dm-limbus-shell.css
+++ b/css/dm-limbus-shell.css
@@ -1,0 +1,415 @@
+/* DM Limbus-inspired shell: visual-only layer for pantalla_dm.html. */
+
+:root {
+  --dm-ink: #070705;
+  --dm-panel: #11100d;
+  --dm-panel-soft: #171510;
+  --dm-ivory: #d8d1bd;
+  --dm-muted: #8c887d;
+  --dm-gold: #a98a4f;
+  --dm-gold-dim: #66573a;
+  --dm-red: #7d1e19;
+  --dm-red-hot: #aa2a22;
+  --dm-line: #3f3a30;
+  --dm-cyan: #69a7aa;
+}
+
+body:has(.dm-tabs-nav) {
+  background-color: var(--dm-ink) !important;
+  background-image:
+    linear-gradient(rgba(7, 7, 5, 0.92), rgba(7, 7, 5, 0.96)),
+    repeating-linear-gradient(90deg, transparent 0 47px, rgba(169, 138, 79, 0.035) 47px 48px),
+    repeating-linear-gradient(0deg, transparent 0 47px, rgba(169, 138, 79, 0.025) 47px 48px) !important;
+  color: var(--dm-ivory) !important;
+}
+
+body:has(.dm-tabs-nav) .dm-global-header {
+  min-height: 52px;
+  box-sizing: border-box;
+  padding: 9px clamp(14px, 3vw, 34px) !important;
+  background:
+    linear-gradient(90deg, rgba(125, 30, 25, 0.2), transparent 26%),
+    #090906 !important;
+  border-bottom: 1px solid var(--dm-gold-dim) !important;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+  position: relative;
+  z-index: 20;
+}
+
+body:has(.dm-tabs-nav) .dm-global-header::before {
+  content: "LUMINOUS // DIRECTOR TERMINAL";
+  align-self: center;
+  color: var(--dm-muted);
+  font-family: "BebasKai", "Share Tech Mono", monospace;
+  font-size: 13px;
+  letter-spacing: 0.18em;
+}
+
+body:has(.dm-tabs-nav) #btn-cerrar-sesion {
+  margin-left: auto;
+  min-height: 30px;
+  padding: 4px 14px !important;
+  color: #c56d65 !important;
+  background: #0a0907 !important;
+  border: 1px solid #6d2d28 !important;
+  border-radius: 0 !important;
+  clip-path: polygon(6px 0, 100% 0, 100% calc(100% - 6px), calc(100% - 6px) 100%, 0 100%, 0 6px);
+  font-size: 11px !important;
+  letter-spacing: 0.08em;
+  box-shadow: none !important;
+}
+
+body:has(.dm-tabs-nav) #btn-cerrar-sesion:hover {
+  color: #f0b2aa !important;
+  border-color: #a9483e !important;
+  background: rgba(125, 30, 25, 0.18) !important;
+}
+
+/* Main DM navigation deck */
+body:has(.dm-tabs-nav) .dm-tabs-nav {
+  width: min(1240px, calc(100% - 28px)) !important;
+  max-width: none !important;
+  box-sizing: border-box;
+  display: grid !important;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 7px !important;
+  margin: 18px auto 12px !important;
+  padding: 38px 12px 12px !important;
+  justify-content: initial !important;
+  background:
+    linear-gradient(135deg, rgba(169, 138, 79, 0.06), transparent 24%),
+    linear-gradient(0deg, rgba(0, 0, 0, 0.18), rgba(0, 0, 0, 0.18)),
+    #0e0d0a !important;
+  border: 1px solid #494337 !important;
+  border-left: 3px solid var(--dm-red) !important;
+  border-radius: 0 !important;
+  box-shadow:
+    0 12px 28px rgba(0, 0, 0, 0.48),
+    inset 0 0 0 1px rgba(216, 209, 189, 0.025) !important;
+  position: relative;
+  overflow: hidden;
+}
+
+body:has(.dm-tabs-nav) .dm-tabs-nav::before {
+  content: "DIRECTOR CONTROL DECK  /  MODULE SELECT";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 27px;
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  box-sizing: border-box;
+  color: #b7ae95;
+  background: linear-gradient(90deg, #22130f 0, #12100c 45%, #0d0c09 100%);
+  border-bottom: 1px solid #453a2c;
+  font-family: "BebasKai", "Share Tech Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.16em;
+}
+
+body:has(.dm-tabs-nav) .dm-tabs-nav::after {
+  content: "SYS // ONLINE";
+  position: absolute;
+  top: 7px;
+  right: 12px;
+  color: #7fa4a0;
+  font-size: 9px;
+  letter-spacing: 0.12em;
+}
+
+body:has(.dm-tabs-nav) .dm-tabs-nav .dm-tab-btn {
+  --dm-code: "--";
+  --dm-section: "MODULE";
+  grid-column: span 2;
+  min-width: 0;
+  min-height: 58px;
+  margin: 0 !important;
+  padding: 16px 9px 15px 42px !important;
+  box-sizing: border-box;
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  display: flex !important;
+  align-items: center;
+  justify-content: flex-start;
+  text-align: left;
+  color: #bdb7a8 !important;
+  background:
+    linear-gradient(115deg, rgba(255, 255, 255, 0.015), transparent 46%),
+    #12110e !important;
+  border: 1px solid #403c34 !important;
+  border-radius: 0 !important;
+  clip-path: polygon(7px 0, 100% 0, 100% calc(100% - 7px), calc(100% - 7px) 100%, 0 100%, 0 7px);
+  box-shadow: inset 3px 0 0 #2b2923 !important;
+  font-family: "BebasKai", "Share Tech Mono", monospace !important;
+  font-size: clamp(12px, 1.05vw, 15px) !important;
+  line-height: 1.05;
+  letter-spacing: 0.035em;
+  text-transform: uppercase;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease,
+    color 120ms ease,
+    transform 120ms ease !important;
+}
+
+body:has(.dm-tabs-nav) .dm-tabs-nav .dm-tab-btn::before {
+  content: var(--dm-code);
+  position: absolute;
+  left: 10px;
+  top: 10px;
+  min-width: 23px;
+  color: #8f7a4d;
+  font-family: "Share Tech Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+}
+
+body:has(.dm-tabs-nav) .dm-tabs-nav .dm-tab-btn::after {
+  content: var(--dm-section);
+  position: absolute;
+  left: 42px;
+  bottom: 7px;
+  color: #69655c;
+  font-family: "Share Tech Mono", monospace;
+  font-size: 7px;
+  line-height: 1;
+  letter-spacing: 0.15em;
+}
+
+body:has(.dm-tabs-nav) .dm-tabs-nav .dm-tab-btn:hover {
+  color: #eee5cd !important;
+  background: #191712 !important;
+  border-color: #75694f !important;
+  transform: translateY(-1px);
+  box-shadow: inset 3px 0 0 var(--dm-gold) !important;
+}
+
+body:has(.dm-tabs-nav) .dm-tabs-nav .dm-tab-btn.active {
+  color: #f0e7d0 !important;
+  background:
+    linear-gradient(90deg, rgba(125, 30, 25, 0.95), rgba(72, 24, 20, 0.92) 68%, #19110e 100%) !important;
+  border-color: #aa8c53 !important;
+  box-shadow:
+    inset 4px 0 0 #d0b06e,
+    inset 0 -2px 0 rgba(0, 0, 0, 0.4),
+    0 0 0 1px rgba(125, 30, 25, 0.18) !important;
+}
+
+body:has(.dm-tabs-nav) .dm-tabs-nav .dm-tab-btn.active::before {
+  color: #e3c47c;
+}
+
+body:has(.dm-tabs-nav) .dm-tabs-nav .dm-tab-btn.active::after {
+  color: #d4b98a;
+}
+
+/* Codes and subtle section taxonomy. */
+.dm-tabs-nav .dm-tab-btn[data-tab="tab-tiempo"] { --dm-code: "01"; --dm-section: "WORLD / CLOCK"; }
+.dm-tabs-nav .dm-tab-btn[data-tab="tab-clima"] { --dm-code: "02"; --dm-section: "WORLD / WEATHER"; }
+.dm-tabs-nav .dm-tab-btn[data-tab="tab-turnos"] { --dm-code: "03"; --dm-section: "SESSION / FLOW"; }
+.dm-tabs-nav .dm-tab-btn[data-tab="tab-combate"] { --dm-code: "04"; --dm-section: "SESSION / COMBAT"; }
+.dm-tabs-nav .dm-tab-btn[data-tab="dashboard-actores"] { --dm-code: "05"; --dm-section: "PERSONNEL / ACTORS"; grid-column: span 3; }
+.dm-tabs-nav .dm-tab-btn[data-tab="dashboard-jugadores"] { --dm-code: "06"; --dm-section: "PERSONNEL / PLAYERS"; grid-column: span 3; }
+.dm-tabs-nav .dm-tab-btn[data-tab="tab-comms"] { --dm-code: "07"; --dm-section: "NETWORK / COMMS"; }
+.dm-tabs-nav .dm-tab-btn[data-tab="tab-banco"] { --dm-code: "08"; --dm-section: "RESOURCES / BANK"; }
+.dm-tabs-nav .dm-tab-btn[data-tab="tab-forja"] { --dm-code: "09"; --dm-section: "RESOURCES / MARKET"; }
+.dm-tabs-nav .dm-tab-btn[data-tab="tab-loot"] { --dm-code: "10"; --dm-section: "RESOURCES / LOOT"; }
+.dm-tabs-nav .dm-tab-btn[data-tab="tab-keywords"] { --dm-code: "11"; --dm-section: "SYSTEM / FLAGS"; }
+.dm-tabs-nav .dm-tab-btn[data-tab="tab-acceso"] { --dm-code: "12"; --dm-section: "SYSTEM / ACCESS"; }
+
+body:has(.dm-tabs-nav) .dm-tabs-nav .btn-modo-director {
+  --dm-code: "LIVE";
+  --dm-section: "DIRECTOR / DEPLOY";
+  grid-column: span 4;
+  min-height: 64px;
+  color: #f1dfb2 !important;
+  background:
+    linear-gradient(90deg, #3c1712 0, #6f2119 58%, #20110e 100%) !important;
+  border: 1px solid #b28c49 !important;
+  box-shadow:
+    inset 4px 0 0 #bc3130,
+    inset 0 0 0 1px rgba(255, 222, 151, 0.045) !important;
+  letter-spacing: 0.08em;
+}
+
+body:has(.dm-tabs-nav) .dm-tabs-nav .btn-modo-director:hover {
+  color: #fff1cd !important;
+  background:
+    linear-gradient(90deg, #4a1914 0, #8b2a20 58%, #27130f 100%) !important;
+  border-color: #d0a85d !important;
+}
+
+/* Content frame: retain module logic, replace the generic neon box language. */
+body:has(.dm-tabs-nav) .dm-tabs-content {
+  width: min(1320px, 100%) !important;
+  box-sizing: border-box;
+  padding: 0 12px 34px;
+}
+
+body:has(.dm-tabs-nav) .dm-tabs-content > .dm-tab-pane {
+  animation: dm-shell-in 130ms ease-out;
+}
+
+@keyframes dm-shell-in {
+  from { opacity: 0.65; transform: translateY(3px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+body:has(.dm-tabs-nav) .dm-tabs-content > .dm-tab-pane > .panel-cyber {
+  width: min(1180px, 94%) !important;
+  max-width: 1180px !important;
+  box-sizing: border-box;
+  position: relative;
+  overflow: hidden;
+  padding: clamp(18px, 2.5vw, 28px) !important;
+  background:
+    linear-gradient(135deg, rgba(169, 138, 79, 0.035), transparent 32%),
+    #0e0e0b !important;
+  border: 1px solid #4a4438 !important;
+  border-left: 3px solid #70211b !important;
+  border-radius: 0 !important;
+  box-shadow:
+    0 15px 30px rgba(0, 0, 0, 0.4),
+    inset 0 0 0 1px rgba(216, 209, 189, 0.018) !important;
+}
+
+body:has(.dm-tabs-nav) .dm-tabs-content > .dm-tab-pane > .panel-cyber::before {
+  content: "DIRECTOR MODULE";
+  position: absolute;
+  top: 7px;
+  right: 10px;
+  color: #5e5a50;
+  font-family: "Share Tech Mono", monospace;
+  font-size: 8px;
+  letter-spacing: 0.15em;
+  pointer-events: none;
+}
+
+body:has(.dm-tabs-nav) .dm-tabs-content > .dm-tab-pane > .panel-cyber > h3 {
+  color: #d3c8aa !important;
+  text-shadow: none !important;
+  border-bottom: 1px solid #4b4435 !important;
+  padding: 0 72px 10px 10px !important;
+  text-align: left !important;
+  letter-spacing: 0.11em !important;
+  position: relative;
+}
+
+body:has(.dm-tabs-nav) .dm-tabs-content > .dm-tab-pane > .panel-cyber > h3::before {
+  content: "//";
+  color: #8c2b24;
+  margin-right: 9px;
+}
+
+body:has(.dm-tabs-nav) .dm-tabs-content > .dm-tab-pane > .panel-cyber > p:first-of-type {
+  color: #8d897f !important;
+}
+
+/* Tame generic cyan glow without touching semantic state colors inside modules. */
+body:has(.dm-tabs-nav) .panel-cyber .form-cyber,
+body:has(.dm-tabs-nav) .panel-cyber .card-cyber,
+body:has(.dm-tabs-nav) .panel-cyber .dm-toolbar {
+  border-radius: 0 !important;
+  box-shadow: none !important;
+}
+
+body:has(.dm-tabs-nav) input:focus,
+body:has(.dm-tabs-nav) select:focus,
+body:has(.dm-tabs-nav) textarea:focus {
+  box-shadow: 0 0 0 1px rgba(169, 138, 79, 0.28) !important;
+}
+
+/* Tablet */
+@media (max-width: 980px) {
+  body:has(.dm-tabs-nav) .dm-tabs-nav {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  body:has(.dm-tabs-nav) .dm-tabs-nav .dm-tab-btn,
+  .dm-tabs-nav .dm-tab-btn[data-tab="dashboard-actores"],
+  .dm-tabs-nav .dm-tab-btn[data-tab="dashboard-jugadores"] {
+    grid-column: span 2;
+  }
+
+  body:has(.dm-tabs-nav) .dm-tabs-nav .btn-modo-director {
+    grid-column: span 6;
+  }
+}
+
+/* Mobile: compact command rail instead of a three-row button cloud. */
+@media (max-width: 640px) {
+  body:has(.dm-tabs-nav) .dm-global-header {
+    min-height: 44px;
+    padding: 6px 10px !important;
+  }
+
+  body:has(.dm-tabs-nav) .dm-global-header::before {
+    content: "DM // TERMINAL";
+    font-size: 10px;
+  }
+
+  body:has(.dm-tabs-nav) .dm-tabs-nav {
+    width: calc(100% - 12px) !important;
+    display: flex !important;
+    overflow-x: auto;
+    overflow-y: hidden;
+    gap: 6px !important;
+    padding: 34px 8px 9px !important;
+    margin-top: 10px !important;
+    scroll-snap-type: x proximity;
+    scrollbar-width: thin;
+  }
+
+  body:has(.dm-tabs-nav) .dm-tabs-nav::before {
+    font-size: 10px;
+  }
+
+  body:has(.dm-tabs-nav) .dm-tabs-nav::after {
+    display: none;
+  }
+
+  body:has(.dm-tabs-nav) .dm-tabs-nav .dm-tab-btn,
+  .dm-tabs-nav .dm-tab-btn[data-tab="dashboard-actores"],
+  .dm-tabs-nav .dm-tab-btn[data-tab="dashboard-jugadores"],
+  body:has(.dm-tabs-nav) .dm-tabs-nav .btn-modo-director {
+    flex: 0 0 150px !important;
+    min-height: 54px;
+    scroll-snap-align: start;
+    font-size: 12px !important;
+  }
+
+  body:has(.dm-tabs-nav) .dm-tabs-nav .btn-modo-director {
+    flex-basis: 205px !important;
+  }
+
+  body:has(.dm-tabs-nav) .dm-tabs-content {
+    padding-inline: 6px;
+  }
+
+  body:has(.dm-tabs-nav) .dm-tabs-content > .dm-tab-pane > .panel-cyber {
+    width: 98% !important;
+    padding: 15px !important;
+  }
+
+  body:has(.dm-tabs-nav) .dm-tabs-content > .dm-tab-pane > .panel-cyber > h3 {
+    padding-right: 10px !important;
+    font-size: 15px !important;
+  }
+
+  body:has(.dm-tabs-nav) .dm-tabs-content > .dm-tab-pane > .panel-cyber::before {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body:has(.dm-tabs-nav) .dm-tabs-content > .dm-tab-pane {
+    animation: none;
+  }
+
+  body:has(.dm-tabs-nav) .dm-tabs-nav .dm-tab-btn {
+    transition: none !important;
+  }
+}

--- a/tests/dm_limbus_shell.spec.js
+++ b/tests/dm_limbus_shell.spec.js
@@ -1,0 +1,82 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
+const actorCss = read("css/actor-studio.css");
+const shellCss = read("css/dm-limbus-shell.css");
+const shellFixesCss = read("css/dm-limbus-shell-fixes.css");
+const dmHtml = read("pantalla_dm.html");
+
+const tabs = [
+  "tab-tiempo",
+  "tab-clima",
+  "tab-turnos",
+  "tab-combate",
+  "dashboard-actores",
+  "dashboard-jugadores",
+  "tab-comms",
+  "tab-banco",
+  "tab-forja",
+  "tab-loot",
+  "tab-keywords",
+  "tab-acceso",
+];
+
+test("DM shell loads through the existing actor studio stylesheet entrypoint", () => {
+  expect(actorCss.trimStart().startsWith('@import url("dm-limbus-shell.css");')).toBeTruthy();
+  expect(actorCss).toContain('@import url("dm-limbus-shell-fixes.css");');
+  expect(dmHtml).toContain('<link rel="stylesheet" href="css/actor-studio.css" />');
+});
+
+test("DM control deck keeps every existing data-tab contract while giving it a module code", () => {
+  for (const tab of tabs) {
+    expect(dmHtml).toContain(`data-tab="${tab}"`);
+    expect(shellCss).toContain(`data-tab="${tab}"`);
+  }
+  expect(dmHtml).toContain('id="btn-modo-director"');
+  expect(shellCss).toContain(".btn-modo-director");
+});
+
+test("visible module order follows the 01-12 taxonomy regardless of legacy DOM order", () => {
+  tabs.forEach((tab, index) => {
+    const order = index + 1;
+    expect(shellFixesCss).toContain(`.dm-tab-btn[data-tab="${tab}"] { order: ${order}; }`);
+  });
+  expect(shellFixesCss).toContain(".btn-modo-director { order: 13; }");
+});
+
+test("shell is scoped to the DM navigation and does not replace tab visibility logic", () => {
+  expect(shellCss).toContain("body:has(.dm-tabs-nav)");
+  expect(shellCss).toContain(".dm-tabs-content > .dm-tab-pane");
+  expect(shellCss).not.toMatch(/\.dm-tab-pane\s*\{[^}]*display\s*:\s*none/is);
+  expect(shellCss).not.toContain("data-tab =");
+});
+
+test("active, live-session and mobile states have dedicated visual treatment", () => {
+  expect(shellCss).toContain(".dm-tab-btn.active");
+  expect(shellCss).toContain("DIRECTOR / DEPLOY");
+  expect(shellCss).toContain("@media (max-width: 640px)");
+  expect(shellCss).toContain("overflow-x: auto");
+  expect(shellCss).toContain("scroll-snap-type: x proximity");
+});
+
+test("mobile cyber forms stay inside clipped director panels", () => {
+  expect(shellFixesCss).toContain("@media (max-width: 768px)");
+  expect(shellFixesCss).toContain(".panel-cyber .form-cyber");
+  expect(shellFixesCss).toContain("box-sizing: border-box !important");
+  expect(shellFixesCss).toContain("min-width: 0 !important");
+  expect(shellFixesCss).toContain("max-width: 100% !important");
+});
+
+test("generic DM panels are reframed without erasing semantic state colors inside modules", () => {
+  expect(shellCss).toContain(".dm-tabs-content > .dm-tab-pane > .panel-cyber");
+  expect(shellCss).toContain("DIRECTOR MODULE");
+  expect(shellCss).toContain("Tame generic cyan glow without touching semantic state colors inside modules");
+  expect(shellCss).not.toMatch(/#rol-turns-container[^}]*color\s*:/i);
+});
+
+test("reduced motion users do not get the panel entrance animation", () => {
+  expect(shellCss).toContain("@media (prefers-reduced-motion: reduce)");
+  expect(shellCss).toContain("animation: none");
+});


### PR DESCRIPTION
## Resumen

Rediseña la navegación y el marco visual general de `pantalla_dm.html` para que el panel del DM se sienta como una sola consola de dirección, más cercana al lenguaje visual industrial de Limbus/Luminous y menos como una colección de botones cyberpunk genéricos.

El cambio es **visual**: conserva los `data-tab`, IDs y la lógica existente de cada módulo.

## Control Deck del DM

- La navegación pasa de un `flex-wrap` de botones equivalentes a un **Director Control Deck** estructurado.
- Cada módulo recibe un código corto y una taxonomía secundaria:
  - `01` Tiempo · `WORLD / CLOCK`
  - `02` Clima · `WORLD / WEATHER`
  - `03` Turnos · `SESSION / FLOW`
  - `04` Combate · `SESSION / COMBAT`
  - `05/06` Personajes/Jugadores · `PERSONNEL`
  - `07` Comms · `NETWORK`
  - `08/09/10` Banco/Forja/Botín · `RESOURCES`
  - `11/12` Keywords/Acceso · `SYSTEM`
- El orden visual del grid/rail se fuerza a `01 → 12`, independientemente del orden legacy de los botones en el HTML.
- El tab activo usa placa rojo oscuro + marfil/dorado, con esquinas recortadas y menos glow de neón.
- `ENTRAR A SESIÓN EN VIVO` queda visualmente separado como acción primaria `LIVE / DIRECTOR / DEPLOY` y aparece después del módulo 12.
- `CERRAR SESIÓN` se integra en una cabecera de terminal más discreta.

## Panel activo

- Los `.panel-cyber` principales se reencuadran como módulos industriales: fondo carbón, borde cálido, acento rojo lateral y encabezado `DIRECTOR MODULE`.
- Se reduce el cyan/glow genérico del contenedor sin sobrescribir colores semánticos internos de estados, combate o módulos específicos.
- No se reescribe ninguna función de Tiempo, Clima, Turnos, Combate, Character Manager, Comms, Banco, etc.

## Responsive

- Escritorio: grid de módulos con jerarquía clara.
- Tablet: grid de 6 columnas.
- Móvil: la navegación se convierte en un **command rail horizontal** con scroll/snap en lugar de volver a formar 3 filas densas de botones.
- Los `.form-cyber` móviles usan `border-box` y límites de ancho explícitos para no sobresalir del panel ni quedar recortados por el marco industrial.
- Incluye `prefers-reduced-motion` para evitar la animación de entrada cuando el usuario la desactiva.

## Correcciones de revisión

Se incorporan los dos P2 detectados por Codex:

1. **Mobile form clipping**: `pantalla_dm.html` aplica `min-width: 100% !important` a `.form-cyber` en móvil; ahora el shell fuerza `box-sizing: border-box`, `width/max-width: 100%` y neutraliza el `min-width` heredado dentro de los paneles.
2. **Module ordering**: CSS Grid/Flex usa `order` explícito para que la presentación siga `01 Tiempo → 12 Acceso`, con `LIVE` al final, sin alterar el DOM ni los contratos `data-tab`.

## Implementación

Para no seguir inflando `pantalla_dm.html` (~357 KB), el cambio vive fuera del HTML monolítico:

- `css/dm-limbus-shell.css` — lenguaje visual principal.
- `css/dm-limbus-shell-fixes.css` — invariantes de layout detectadas en review (orden y sizing móvil).
- `css/actor-studio.css` — carga ambos stylesheets porque ya es el entrypoint usado por la pantalla del DM.

Esto reduce el riesgo sobre la lógica existente.

## Validación

- 1 commit sobre `main` posterior al merge de #545.
- Regresión `tests/dm_limbus_shell.spec.js` verifica:
  - carga del shell y sus fixes;
  - preservación de todos los `data-tab`;
  - orden visual `01–12` + `LIVE`;
  - sizing `border-box` de formularios móviles;
  - tratamiento dedicado de activo/live/mobile;
  - que el CSS no sustituya la lógica de visibilidad de tabs;
  - reduced-motion.
- Workflow dedicado `DM Limbus Shell`, incluyendo el stylesheet de fixes en sus paths.

## Smoke recomendado

1. Abrir `pantalla_dm.html` en escritorio y confirmar orden `01 → 12`, seguido de `LIVE`.
2. Recorrer todos los tabs y confirmar que cada botón conserva su navegación original.
3. Confirmar que `ENTRAR A SESIÓN EN VIVO` sigue ejecutando su acción actual.
4. Probar 768 px y menos: formularios completos sin borde derecho cortado ni overflow lateral nuevo.
5. Probar móvil estrecho: rail horizontal, tab activo visible y orden `01 → 12`.
6. Revisar Turnos/Combate para confirmar que colores de estado internos siguen siendo legibles.
