### PR TITLE
Feat: agrega Character Build automático para jugadores

### DIFF
--- a/.github/workflows/character-build-rules.yml
+++ b/.github/workflows/character-build-rules.yml
@@ -1,0 +1,38 @@
+name: Character Build Rules
+
+on:
+  pull_request:
+    paths:
+      - "js/character-build-rules.js"
+      - "js/dm-player-dnd-studio.js"
+      - "tests/character_build_rules.spec.js"
+      - "tests/player_stats_ability_bar.spec.js"
+      - ".github/workflows/character-build-rules.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  character-build-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check syntax
+        run: |
+          node --check js/character-build-rules.js
+          node --check js/dm-player-dnd-studio.js
+          node --check tests/character_build_rules.spec.js
+
+      - name: Run build and legacy player regressions
+        run: npx playwright test tests/character_build_rules.spec.js tests/player_stats_ability_bar.spec.js --workers=1

--- a/.github/workflows/character-build-rules.yml
+++ b/.github/workflows/character-build-rules.yml
@@ -6,7 +6,6 @@ on:
       - "js/character-build-rules.js"
       - "js/dm-player-dnd-studio.js"
       - "tests/character_build_rules.spec.js"
-      - "tests/player_stats_ability_bar.spec.js"
       - ".github/workflows/character-build-rules.yml"
 
 permissions:
@@ -34,5 +33,5 @@ jobs:
           node --check js/dm-player-dnd-studio.js
           node --check tests/character_build_rules.spec.js
 
-      - name: Run build and legacy player regressions
-        run: npx playwright test tests/character_build_rules.spec.js tests/player_stats_ability_bar.spec.js --workers=1
+      - name: Run character build regressions
+        run: npx playwright test tests/character_build_rules.spec.js --workers=1

--- a/.github/workflows/character-build-rules.yml
+++ b/.github/workflows/character-build-rules.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "js/character-build-rules.js"
       - "js/dm-player-dnd-studio.js"
+      - "js/player-stats-ability-bar.js"
       - "tests/character_build_rules.spec.js"
       - ".github/workflows/character-build-rules.yml"
 
@@ -31,7 +32,8 @@ jobs:
         run: |
           node --check js/character-build-rules.js
           node --check js/dm-player-dnd-studio.js
+          node --check js/player-stats-ability-bar.js
           node --check tests/character_build_rules.spec.js
 
-      - name: Run character build regressions
+      - name: Run character build and player compatibility regressions
         run: npx playwright test tests/character_build_rules.spec.js --workers=1

--- a/js/character-build-rules.js
+++ b/js/character-build-rules.js
@@ -1,0 +1,438 @@
+(function (global) {
+  "use strict";
+
+  const SETTINGS = Object.freeze({
+    version: 1,
+    maxCharacterLevel: 100,
+    naturalHpCoefCap: 3.40,
+    raceOffModifier: 0,
+  });
+
+  const CLASSES = Object.freeze([
+    { id: "barbarian", name: "Bárbaro", code: "BAR", hpPer5: 12, hpCoefBase: 2.90, offMod: 0, defMod: 2 },
+    { id: "fighter", name: "Guerrero", code: "GUE", hpPer5: 10, hpCoefBase: 2.86, offMod: 1, defMod: 1 },
+    { id: "paladin", name: "Paladín", code: "PAL", hpPer5: 10, hpCoefBase: 2.88, offMod: 0, defMod: 2 },
+    { id: "monk", name: "Monje", code: "MON", hpPer5: 10, hpCoefBase: 2.84, offMod: 1, defMod: 1 },
+    { id: "druid", name: "Druida", code: "DRU", hpPer5: 8, hpCoefBase: 2.80, offMod: 0, defMod: 1 },
+    { id: "artificer", name: "Artífice", code: "ART", hpPer5: 8, hpCoefBase: 2.81, offMod: 1, defMod: 1 },
+    { id: "ranger", name: "Ranger", code: "RAN", hpPer5: 8, hpCoefBase: 2.82, offMod: 1, defMod: 0 },
+    { id: "cleric", name: "Clérigo", code: "CLE", hpPer5: 8, hpCoefBase: 2.81, offMod: 0, defMod: 1 },
+    { id: "rogue", name: "Pícaro", code: "PIC", hpPer5: 8, hpCoefBase: 2.78, offMod: 2, defMod: -1 },
+    { id: "sorcerer", name: "Hechicero", code: "HEC", hpPer5: 6, hpCoefBase: 2.72, offMod: 2, defMod: -2 },
+    { id: "bard", name: "Bardo", code: "BRD", hpPer5: 8, hpCoefBase: 2.77, offMod: 1, defMod: 0 },
+    { id: "warlock", name: "Brujo", code: "BRU", hpPer5: 8, hpCoefBase: 2.76, offMod: 2, defMod: -1 },
+    { id: "wizard", name: "Mago", code: "MAG", hpPer5: 6, hpCoefBase: 2.70, offMod: 2, defMod: -2 },
+  ]);
+
+  const RACES = Object.freeze([
+    { id: "lizalin", name: "Lizalin", hpCoefBonus: 0.07, defMod: 0, tags: ["organic", "humanoid", "reptilian"] },
+    { id: "kobold", name: "Kobold", hpCoefBonus: 0.00, defMod: 0, tags: ["organic", "humanoid", "reptilian", "small"] },
+    { id: "kenku", name: "Kenku", hpCoefBonus: 0.00, defMod: 0, tags: ["organic", "humanoid", "avian"] },
+    { id: "centaur", name: "Centauro", hpCoefBonus: 0.07, defMod: 0, tags: ["organic", "humanoid", "equine", "large_build"] },
+    { id: "goliath", name: "Goliat", hpCoefBonus: 0.10, defMod: 1, tags: ["organic", "humanoid", "large_build", "mountain_adapted"] },
+    { id: "goblin", name: "Goblin", hpCoefBonus: 0.02, defMod: 0, tags: ["organic", "humanoid", "goblinoid", "small"] },
+    { id: "fairy", name: "Hada", hpCoefBonus: 0.00, defMod: 0, tags: ["organic", "humanoid", "fae", "arcane_core"], subtypes: [
+      { id: "fire", name: "Fuego", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "flowers", name: "Flores", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "ice", name: "Hielo", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "light", name: "Luz", hpCoefBonus: 0.00, defMod: 0 },
+    ] },
+    { id: "aasimar", name: "Aasimar", hpCoefBonus: 0.03, defMod: 0, tags: ["organic", "humanoid", "celestial"], subtypes: [
+      { id: "protector", name: "Protector", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "scourge", name: "Azotador", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "fallen", name: "Caído", hpCoefBonus: 0.00, defMod: 0 },
+    ] },
+    { id: "tiefling", name: "Tiefling", hpCoefBonus: 0.03, defMod: 0, tags: ["organic", "humanoid", "infernal"], subtypes: [
+      { id: "asmodeus", name: "Asmodeo", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "baalzebul", name: "Baalzebul", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "dispater", name: "Dispater", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "glasya", name: "Glasya", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "fierna", name: "Fierna", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "levistus", name: "Levistus", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "mammon", name: "Mammon", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "mephistopheles", name: "Mefistófeles", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "zariel", name: "Zariel", hpCoefBonus: 0.00, defMod: 0 },
+    ] },
+    { id: "warforged", name: "Warforged", hpCoefBonus: 0.12, defMod: 1, tags: ["construct", "sapient", "mechanical"], subtypes: [
+      { id: "envoy", name: "Envoy", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "juggernaut", name: "Juggernaut", hpCoefBonus: 0.04, defMod: 0 },
+      { id: "skirmisher", name: "Skirmisher", hpCoefBonus: 0.00, defMod: 0 },
+    ] },
+    { id: "felinae", name: "Felinae", hpCoefBonus: 0.02, defMod: 0, tags: ["organic", "humanoid", "feline"], subtypes: [
+      { id: "ordinary", name: "Ordinario", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "large", name: "Grande", hpCoefBonus: 0.04, defMod: 0 },
+      { id: "mystic", name: "Místico", hpCoefBonus: 0.00, defMod: 0 },
+    ] },
+    { id: "half_dragon", name: "Semi Dragón", hpCoefBonus: 0.10, defMod: 0, tags: ["organic", "humanoid", "draconic"], subtypes: [
+      { id: "red", name: "Rojo", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "black", name: "Negro", hpCoefBonus: 0.02, defMod: 0 },
+      { id: "green", name: "Verde", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "white", name: "Blanco", hpCoefBonus: 0.02, defMod: 0 },
+      { id: "blue", name: "Azul", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "gold", name: "Oro", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "brass", name: "Latón", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "copper", name: "Cobre", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "bronze", name: "Bronce", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "silver", name: "Plata", hpCoefBonus: 0.00, defMod: 0 },
+    ] },
+    { id: "lupae", name: "Lupae", hpCoefBonus: 0.06, defMod: 0, tags: ["organic", "humanoid", "canine"] },
+    { id: "moonfae", name: "Moonfae", hpCoefBonus: 0.02, defMod: 0, tags: ["organic", "humanoid", "fae", "lunar"] },
+    { id: "yuan_ti_pureblood", name: "Yuan-ti Pura Sangre", hpCoefBonus: 0.03, defMod: 0, tags: ["organic", "humanoid", "reptilian", "yuan_ti"], subtypes: [
+      { id: "red_eyes", name: "Ojos Rojos — Ira", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "purple_eyes", name: "Ojos Morados — Envidia", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "cyan_eyes", name: "Ojos Cyan — Melancolía", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "blue_eyes", name: "Ojos Azules — Orgullo", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "green_eyes", name: "Ojos Verdes — Gula", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "orange_eyes", name: "Ojos Naranjas — Lujuria de Conocimiento", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "yellow_eyes", name: "Ojos Amarillos — Pereza", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "pale_eyes", name: "Los Pálidos — Mutaciones Empáticas", hpCoefBonus: 0.00, defMod: 0 },
+    ] },
+  ]);
+
+  const BACKGROUNDS = Object.freeze([
+    { id: "nest_heir", name: "Heredero de un Nest", hpCoefBonus: 0.02, category: "civilian" },
+    { id: "wing_executive_family", name: "Familia ejecutiva de Wing", hpCoefBonus: 0.03, category: "civilian" },
+    { id: "comfortable_feather", name: "Feather acomodado", hpCoefBonus: 0.04, category: "civilian" },
+    { id: "wing_administrator", name: "Empleado administrativo de Wing", hpCoefBonus: 0.05, category: "civilian" },
+    { id: "civil_researcher", name: "Académico / investigador civil", hpCoefBonus: 0.05, category: "civilian" },
+    { id: "nest_student", name: "Estudiante de academia de Nest", hpCoefBonus: 0.04, category: "civilian" },
+    { id: "docugrapher", name: "Docugrapher / trabajador de información", hpCoefBonus: 0.07, category: "civilian" },
+    { id: "nest_merchant", name: "Comerciante de Nest", hpCoefBonus: 0.07, category: "civilian" },
+    { id: "backstreets_merchant", name: "Comerciante de Backstreets", hpCoefBonus: 0.12, category: "civilian" },
+    { id: "city_charlatan", name: "Estafador de la Ciudad", hpCoefBonus: 0.10, category: "civilian" },
+    { id: "gambler", name: "Jugador profesional", hpCoefBonus: 0.10, category: "civilian" },
+    { id: "urban_performer", name: "Artista / performer urbano", hpCoefBonus: 0.12, category: "civilian" },
+    { id: "chef", name: "Chef / restaurateur", hpCoefBonus: 0.13, category: "civilian" },
+    { id: "common_artisan", name: "Artesano común", hpCoefBonus: 0.14, category: "labor" },
+    { id: "industrial_worker", name: "Trabajador industrial", hpCoefBonus: 0.17, category: "labor" },
+    { id: "backstreets_heavy_worker", name: "Trabajador pesado de Backstreets", hpCoefBonus: 0.21, category: "labor" },
+    { id: "farmer", name: "Agricultor", hpCoefBonus: 0.22, category: "labor" },
+    { id: "protected_backstreets", name: "Habitante protegido de Backstreets", hpCoefBonus: 0.15, category: "backstreets" },
+    { id: "backstreets_resident", name: "Habitante común de Backstreets", hpCoefBonus: 0.18, category: "backstreets" },
+    { id: "experienced_street_dweller", name: "Callejero experimentado", hpCoefBonus: 0.21, category: "backstreets" },
+    { id: "rat", name: "Rat", hpCoefBonus: 0.23, category: "backstreets" },
+    { id: "backstreets_orphan", name: "Huérfano de Backstreets", hpCoefBonus: 0.24, category: "backstreets" },
+    { id: "childhood_street_survivor", name: "Superviviente callejero desde niño", hpCoefBonus: 0.27, category: "backstreets" },
+    { id: "hooligan", name: "Matón / hooligan", hpCoefBonus: 0.25, category: "backstreets" },
+    { id: "protection_collector", name: "Cobrador de protección", hpCoefBonus: 0.25, category: "backstreets" },
+    { id: "smuggler", name: "Contrabandista", hpCoefBonus: 0.24, category: "backstreets" },
+    { id: "backstreets_bounty_hunter", name: "Cazarrecompensas de Backstreets", hpCoefBonus: 0.27, category: "backstreets" },
+    { id: "underground_guide", name: "Guía de rutas clandestinas", hpCoefBonus: 0.24, category: "backstreets" },
+    { id: "community_protector", name: "Protector comunitario", hpCoefBonus: 0.28, category: "backstreets" },
+    { id: "district23_resident", name: "Habitante de District 23 Backstreets", hpCoefBonus: 0.27, category: "backstreets" },
+    { id: "night_backstreets_survivor", name: "Superviviente habitual de Night in the Backstreets", hpCoefBonus: 0.31, category: "backstreets" },
+    { id: "novice_fixer", name: "Fixer novato", hpCoefBonus: 0.18, category: "fixer" },
+    { id: "office_fixer", name: "Fixer de Office ordinaria", hpCoefBonus: 0.22, category: "fixer" },
+    { id: "escort_fixer", name: "Fixer escolta", hpCoefBonus: 0.24, category: "fixer" },
+    { id: "investigator_fixer", name: "Fixer investigador", hpCoefBonus: 0.20, category: "fixer" },
+    { id: "recovery_fixer", name: "Fixer de recuperación", hpCoefBonus: 0.23, category: "fixer" },
+    { id: "bounty_fixer", name: "Fixer cazarrecompensas", hpCoefBonus: 0.27, category: "fixer" },
+    { id: "combat_fixer", name: "Fixer de combate", hpCoefBonus: 0.28, category: "fixer" },
+    { id: "extermination_fixer", name: "Fixer de exterminación", hpCoefBonus: 0.31, category: "fixer" },
+    { id: "veteran_fixer", name: "Fixer veterano", hpCoefBonus: 0.32, category: "fixer" },
+    { id: "contract_veteran", name: "Veterano de innumerables contratos", hpCoefBonus: 0.35, category: "fixer" },
+    { id: "hana_fixer", name: "Antiguo Hana Fixer", hpCoefBonus: 0.27, category: "association" },
+    { id: "zwei_fixer", name: "Zwei — Protección y escolta", hpCoefBonus: 0.28, category: "association" },
+    { id: "tres_inspector", name: "Tres — Inspector técnico / Workshop", hpCoefBonus: 0.18, category: "association" },
+    { id: "shi_assassin", name: "Shi — Asesino profesional", hpCoefBonus: 0.32, category: "association" },
+    { id: "cinq_duelist", name: "Cinq — Duelista profesional", hpCoefBonus: 0.30, category: "association" },
+    { id: "liu_combatant", name: "Liu — Combatiente de guerra abierta", hpCoefBonus: 0.34, category: "association" },
+    { id: "seven_investigator", name: "Seven — Investigador de campo", hpCoefBonus: 0.21, category: "association" },
+    { id: "eight_explorer", name: "Eight — Explorador / marino", hpCoefBonus: 0.30, category: "association" },
+    { id: "devyat_courier", name: "Devyat — Courier de alto riesgo", hpCoefBonus: 0.31, category: "association" },
+    { id: "dieci_researcher", name: "Dieci — Investigador / recolector", hpCoefBonus: 0.18, category: "association" },
+    { id: "oufi_mediator", name: "Öufi — Mediador de contratos", hpCoefBonus: 0.17, category: "association" },
+    { id: "workshop_apprentice", name: "Aprendiz de Workshop", hpCoefBonus: 0.13, category: "workshop" },
+    { id: "workshop_technician", name: "Técnico de Workshop", hpCoefBonus: 0.16, category: "workshop" },
+    { id: "weaponsmith", name: "Armero", hpCoefBonus: 0.17, category: "workshop" },
+    { id: "prosthetic_engineer", name: "Ingeniero de prótesis", hpCoefBonus: 0.16, category: "workshop" },
+    { id: "workshop_fixer", name: "Workshop Fixer", hpCoefBonus: 0.22, category: "workshop" },
+    { id: "weapons_tester", name: "Tester de armamento", hpCoefBonus: 0.24, category: "workshop" },
+    { id: "dangerous_field_workshop", name: "Workshop de campo peligroso", hpCoefBonus: 0.27, category: "workshop" },
+    { id: "minor_syndicate", name: "Miembro de Syndicate pequeño", hpCoefBonus: 0.24, category: "syndicate" },
+    { id: "syndicate_enforcer", name: "Enforcer de Syndicate", hpCoefBonus: 0.28, category: "syndicate" },
+    { id: "hitman", name: "Sicario", hpCoefBonus: 0.30, category: "syndicate" },
+    { id: "territorial_war_veteran", name: "Veterano de guerras territoriales", hpCoefBonus: 0.34, category: "syndicate" },
+    { id: "gang_captain", name: "Capitán de pandilla", hpCoefBonus: 0.31, category: "syndicate" },
+    { id: "dead_rabbits", name: "Dead Rabbits", hpCoefBonus: 0.27, category: "syndicate" },
+    { id: "tingtang", name: "Tingtang Gang", hpCoefBonus: 0.26, category: "syndicate" },
+    { id: "mariachis", name: "Los Mariachis", hpCoefBonus: 0.23, category: "syndicate" },
+    { id: "yurodiviye", name: "Yurodiviye", hpCoefBonus: 0.25, category: "syndicate" },
+    { id: "kurokumo_wakashu", name: "Kurokumo Wakashu", hpCoefBonus: 0.30, category: "syndicate" },
+    { id: "kurokumo_captain", name: "Kurokumo Captain", hpCoefBonus: 0.33, category: "syndicate" },
+    { id: "blade_lineage_salsu", name: "Blade Lineage Salsu", hpCoefBonus: 0.34, category: "syndicate" },
+    { id: "blade_lineage_veteran", name: "Blade Lineage veterano", hpCoefBonus: 0.37, category: "syndicate" },
+    { id: "twinhook_pirate", name: "Twinhook Pirate", hpCoefBonus: 0.31, category: "syndicate" },
+    { id: "twinhook_veteran", name: "Twinhook veterano", hpCoefBonus: 0.34, category: "syndicate" },
+    { id: "thumb_member", name: "Thumb — miembro inferior", hpCoefBonus: 0.32, category: "finger" },
+    { id: "thumb_veteran", name: "Thumb — Enforcer veterano", hpCoefBonus: 0.36, category: "finger" },
+    { id: "index_proselyte", name: "Index — Proselyte", hpCoefBonus: 0.29, category: "finger" },
+    { id: "index_proxy", name: "Index — Proxy / Messenger", hpCoefBonus: 0.35, category: "finger" },
+    { id: "middle_member", name: "Middle — miembro", hpCoefBonus: 0.33, category: "finger" },
+    { id: "middle_veteran", name: "Middle — veterano de venganzas", hpCoefBonus: 0.36, category: "finger" },
+    { id: "ring_student", name: "Ring — Student / combat artist", hpCoefBonus: 0.31, category: "finger" },
+    { id: "ring_veteran", name: "Ring — artista veterano", hpCoefBonus: 0.35, category: "finger" },
+    { id: "pinky_operator", name: "Pinky — operativo infiltrado", hpCoefBonus: 0.32, category: "finger" },
+    { id: "pinky_veteran", name: "Pinky — operativo veterano", hpCoefBonus: 0.36, category: "finger" },
+    { id: "great_lake_fisher", name: "Pescador del Great Lake", hpCoefBonus: 0.24, category: "great_lake" },
+    { id: "sailor", name: "Marinero", hpCoefBonus: 0.28, category: "great_lake" },
+    { id: "navigator", name: "Navegante", hpCoefBonus: 0.29, category: "great_lake" },
+    { id: "harpooner", name: "Harpooner", hpCoefBonus: 0.33, category: "great_lake" },
+    { id: "whaler", name: "Whaler", hpCoefBonus: 0.35, category: "great_lake" },
+    { id: "ship_captain", name: "Capitán de barco", hpCoefBonus: 0.31, category: "great_lake" },
+    { id: "pirate", name: "Pirata", hpCoefBonus: 0.31, category: "great_lake" },
+    { id: "great_lake_veteran", name: "Veterano del Great Lake", hpCoefBonus: 0.37, category: "great_lake" },
+    { id: "whale_survivor", name: "Superviviente de Whale encounter", hpCoefBonus: 0.40, category: "great_lake" },
+    { id: "pequod_survivor", name: "Superviviente estilo Pequod", hpCoefBonus: 0.45, category: "great_lake" },
+    { id: "outskirts_child", name: "Niño abandonado en Outskirts", hpCoefBonus: 0.30, category: "outskirts" },
+    { id: "outskirts_settler", name: "Habitante de asentamiento Outskirts", hpCoefBonus: 0.32, category: "outskirts" },
+    { id: "outskirts_explorer", name: "Explorador de Outskirts", hpCoefBonus: 0.35, category: "outskirts" },
+    { id: "ruins_scavenger", name: "Recolector de Ruins", hpCoefBonus: 0.36, category: "outskirts" },
+    { id: "settlement_hunter", name: "Hunter de asentamiento", hpCoefBonus: 0.38, category: "outskirts" },
+    { id: "veteran_hunter", name: "Veterano Hunter", hpCoefBonus: 0.41, category: "outskirts" },
+    { id: "outskirts_lone_survivor", name: "Superviviente solitario de Outskirts", hpCoefBonus: 0.43, category: "outskirts" },
+    { id: "ruins_extreme_survivor", name: "Superviviente extremo de Ruins", hpCoefBonus: 0.45, category: "outskirts" },
+    { id: "wing_military_recruit", name: "Recluta militar de Wing", hpCoefBonus: 0.27, category: "wing" },
+    { id: "r_corp_rabbit", name: "R Corp Rabbit", hpCoefBonus: 0.34, category: "wing" },
+    { id: "r_corp_reindeer", name: "R Corp Reindeer", hpCoefBonus: 0.32, category: "wing" },
+    { id: "r_corp_rhino", name: "R Corp Rhino", hpCoefBonus: 0.37, category: "wing" },
+    { id: "r_corp_raven", name: "R Corp Raven", hpCoefBonus: 0.36, category: "wing" },
+    { id: "r_corp_extermination_veteran", name: "Veterano de exterminación R Corp", hpCoefBonus: 0.39, category: "wing" },
+    { id: "w_cleanup_l2", name: "W Corp Cleanup Agent L2", hpCoefBonus: 0.23, category: "wing" },
+    { id: "w_cleanup_l3", name: "W Corp Cleanup Agent L3", hpCoefBonus: 0.28, category: "wing" },
+    { id: "w_cleanup_veteran", name: "W Corp Cleanup Agent veterano", hpCoefBonus: 0.31, category: "wing" },
+    { id: "w_cleanup_l4", name: "W Corp Cleanup Agent L4+", hpCoefBonus: 0.34, category: "wing" },
+    { id: "k_security_l1", name: "K Corp Class 1 Security", hpCoefBonus: 0.20, category: "wing" },
+    { id: "k_security_l2", name: "K Corp Class 2 / Checkpoint", hpCoefBonus: 0.27, category: "wing" },
+    { id: "k_excision_l3", name: "K Corp Class 3 Excision Staff", hpCoefBonus: 0.32, category: "wing" },
+    { id: "k_excision_veteran", name: "Veterano Excision Staff", hpCoefBonus: 0.35, category: "wing" },
+    { id: "k_researcher", name: "Investigador K Corp", hpCoefBonus: 0.07, category: "wing" },
+    { id: "smoke_war_recruit", name: "Recluta de la Smoke War", hpCoefBonus: 0.32, category: "war" },
+    { id: "smoke_war_soldier", name: "Soldado de la Smoke War", hpCoefBonus: 0.37, category: "war" },
+    { id: "smoke_war_veteran", name: "Veterano de la Smoke War", hpCoefBonus: 0.40, category: "war" },
+    { id: "smoke_war_extreme_survivor", name: "Superviviente de campaña extrema", hpCoefBonus: 0.43, category: "war" },
+    { id: "lcorp_clerk", name: "Antiguo clerk de L Corp", hpCoefBonus: 0.16, category: "lobotomy" },
+    { id: "lcorp_branch_employee", name: "Empleado de Branch facility", hpCoefBonus: 0.20, category: "lobotomy" },
+    { id: "lcorp_containment_agent", name: "Agente de contención", hpCoefBonus: 0.30, category: "lobotomy" },
+    { id: "lcorp_suppression_veteran", name: "Veterano de supresiones", hpCoefBonus: 0.34, category: "lobotomy" },
+    { id: "lcorp_branch_fall_survivor", name: "Superviviente de caída de una Branch", hpCoefBonus: 0.36, category: "lobotomy" },
+    { id: "abnormality_survivor", name: "Superviviente prolongado entre Abnormalities", hpCoefBonus: 0.40, category: "lobotomy" },
+    { id: "ordinary_cultist", name: "Devoto / cultista ordinario", hpCoefBonus: 0.08, category: "anomaly" },
+    { id: "militant_fanatic", name: "Fanático militante", hpCoefBonus: 0.24, category: "anomaly" },
+    { id: "distortion_investigator", name: "Investigador de Distortions", hpCoefBonus: 0.23, category: "anomaly" },
+    { id: "distortion_incident_survivor", name: "Superviviente de Distortion incident", hpCoefBonus: 0.29, category: "anomaly" },
+    { id: "distortion_hunter", name: "Cazador de Distortions", hpCoefBonus: 0.34, category: "anomaly" },
+    { id: "bloodfiend_hunter", name: "Cazador de Bloodfiends", hpCoefBonus: 0.35, category: "anomaly" },
+    { id: "abnormality_incident_survivor", name: "Superviviente de Abnormality", hpCoefBonus: 0.34, category: "anomaly" },
+    { id: "repeated_anomaly_survivor", name: "Superviviente repetido de fenómenos anómalos", hpCoefBonus: 0.39, category: "anomaly" },
+    { id: "nest_family_servant", name: "Sirviente de familia de Nest", hpCoefBonus: 0.10, category: "district8" },
+    { id: "personal_retainer", name: "Retainer / asistente personal", hpCoefBonus: 0.15, category: "district8" },
+    { id: "family_bodyguard", name: "Bodyguard familiar", hpCoefBonus: 0.28, category: "district8" },
+    { id: "political_heir", name: "Heredero entrenado para política", hpCoefBonus: 0.10, category: "district8" },
+    { id: "duelist_heir", name: "Heredero entrenado para duelos", hpCoefBonus: 0.24, category: "district8" },
+    { id: "family_strife_survivor", name: "Superviviente de luchas familiares", hpCoefBonus: 0.30, category: "district8" },
+    { id: "heishou_trainee", name: "Heishou trainee", hpCoefBonus: 0.31, category: "district8" },
+    { id: "heishou_veteran", name: "Heishou veterano", hpCoefBonus: 0.35, category: "district8" },
+    { id: "house_spiders_apprentice", name: "House of Spiders Apprentice", hpCoefBonus: 0.40, category: "special" },
+    { id: "house_spiders_survivor", name: "House of Spiders Survivor", hpCoefBonus: 0.43, category: "special" },
+  ]);
+
+  const CATEGORY_LABELS = Object.freeze({
+    civilian: "Ciudadanos / Civil",
+    labor: "Trabajo físico",
+    backstreets: "Backstreets",
+    fixer: "Fixers",
+    association: "Associations",
+    workshop: "Workshops",
+    syndicate: "Syndicates",
+    finger: "Five Fingers",
+    great_lake: "Great Lake",
+    outskirts: "Outskirts",
+    wing: "Wings / Fuerzas corporativas",
+    war: "Guerra",
+    lobotomy: "Lobotomy Corporation",
+    anomaly: "Fenómenos / Anomalías",
+    district8: "District 8 / Familias",
+    special: "Especiales",
+  });
+
+  const classMap = new Map(CLASSES.map((entry) => [entry.id, entry]));
+  const raceMap = new Map(RACES.map((entry) => [entry.id, entry]));
+  const backgroundMap = new Map(BACKGROUNDS.map((entry) => [entry.id, entry]));
+
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const integerOr = (value, fallback = 0) => Number.isFinite(Number.parseInt(value, 10)) ? Number.parseInt(value, 10) : fallback;
+  const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+  function symmetricRound(value) {
+    const numeric = numberOr(value, 0);
+    if (numeric === 0) return 0;
+    return Math.sign(numeric) * Math.floor(Math.abs(numeric) + 0.5);
+  }
+
+  function normalizeClassChoices(value) {
+    if (!Array.isArray(value)) return [];
+    return value
+      .map((entry) => ({
+        classId: String(entry?.classId || entry?.id || "").trim(),
+        levels: Math.max(0, integerOr(entry?.levels, 0)),
+      }))
+      .filter((entry) => entry.classId && entry.levels > 0 && classMap.has(entry.classId));
+  }
+
+  function classLevelTotal(value) {
+    return normalizeClassChoices(value).reduce((sum, entry) => sum + entry.levels, 0);
+  }
+
+  function weightedClassValue(classes, selector) {
+    const normalized = normalizeClassChoices(classes);
+    const total = normalized.reduce((sum, entry) => sum + entry.levels, 0);
+    if (!total) return 0;
+    return normalized.reduce((sum, entry) => {
+      const definition = classMap.get(entry.classId);
+      return sum + entry.levels * selector(definition);
+    }, 0) / total;
+  }
+
+  function raceSubtype(race, subtypeId) {
+    if (!race || !subtypeId || !Array.isArray(race.subtypes)) return null;
+    return race.subtypes.find((entry) => entry.id === subtypeId) || null;
+  }
+
+  function validateBuild(input = {}) {
+    const level = clamp(integerOr(input.level, 1), 1, SETTINGS.maxCharacterLevel);
+    const classes = normalizeClassChoices(input.classes);
+    const total = classes.reduce((sum, entry) => sum + entry.levels, 0);
+    const race = raceMap.get(String(input.raceId || "")) || null;
+    const background = backgroundMap.get(String(input.backgroundId || "")) || null;
+    const subtypeId = String(input.raceSubtypeId || "").trim();
+    const subtype = raceSubtype(race, subtypeId);
+    const errors = [];
+
+    if (!classes.length) errors.push("Asigna al menos una clase.");
+    if (classes.length && total !== level) errors.push(`Los niveles de clase suman ${total}; deben sumar ${level}.`);
+    if (!background) errors.push("Selecciona un trasfondo.");
+    if (!race) errors.push("Selecciona una raza.");
+    if (race?.subtypes?.length && !subtype) errors.push("Selecciona la subraza / variante racial.");
+
+    return {
+      complete: errors.length === 0,
+      errors,
+      level,
+      classes,
+      classLevelTotal: total,
+      race,
+      subtype,
+      background,
+    };
+  }
+
+  function calculateBuild(input = {}) {
+    const validation = validateBuild(input);
+    const level = validation.level;
+    const constitution = Math.max(1, integerOr(input.constitution, 10));
+    const conMod = Math.floor((constitution - 10) / 2);
+    const tier = Math.ceil(level / 5);
+    const classes = validation.classes;
+
+    const weightedHpPer5 = weightedClassValue(classes, (definition) => definition.hpPer5);
+    const classHpCoef = weightedClassValue(classes, (definition) => definition.hpCoefBase);
+    const classOffModRaw = weightedClassValue(classes, (definition) => definition.offMod);
+    const classDefModRaw = weightedClassValue(classes, (definition) => definition.defMod);
+    const classOffMod = symmetricRound(classOffModRaw);
+    const classDefMod = symmetricRound(classDefModRaw);
+
+    const backgroundHpCoefBonus = validation.background?.hpCoefBonus || 0;
+    const raceHpCoefBonus = (validation.race?.hpCoefBonus || 0) + (validation.subtype?.hpCoefBonus || 0);
+    const raceDefMod = (validation.race?.defMod || 0) + (validation.subtype?.defMod || 0);
+    const transformationHpCoefBonus = numberOr(input.transformationHpCoefBonus, 0);
+
+    const intrinsicHpCoefUncapped = classHpCoef + backgroundHpCoefBonus + raceHpCoefBonus + transformationHpCoefBonus;
+    const intrinsicHpCoef = Math.min(SETTINGS.naturalHpCoefCap, intrinsicHpCoefUncapped);
+    const runtimeHpCoef = numberOr(input.runtimeHpCoef, 0);
+    const effectiveHpCoef = intrinsicHpCoef + runtimeHpCoef;
+
+    const hpBaseRaw = tier * (weightedHpPer5 + conMod);
+    const hpBase = Math.max(0, Math.round(hpBaseRaw));
+
+    const baseOffLevel = Math.max(0, integerOr(input.baseOffLevel, level));
+    const baseDefLevel = Math.max(0, integerOr(input.baseDefLevel, level));
+    const runtimeOff = numberOr(input.runtimeOff, 0);
+    const runtimeDef = numberOr(input.runtimeDef, 0);
+    const offLevel = baseOffLevel + classOffMod + runtimeOff;
+    const defLevel = baseDefLevel + classDefMod + raceDefMod + runtimeDef;
+    const hp = Math.max(0, Math.round(hpBase + effectiveHpCoef * defLevel));
+
+    return {
+      valid: validation.complete,
+      errors: validation.errors.slice(),
+      level,
+      constitution,
+      conMod,
+      tier,
+      classes,
+      classLevelTotal: validation.classLevelTotal,
+      weightedHpPer5,
+      hpBaseRaw,
+      hpBase,
+      classHpCoef,
+      backgroundHpCoefBonus,
+      raceHpCoefBonus,
+      transformationHpCoefBonus,
+      intrinsicHpCoefUncapped,
+      intrinsicHpCoef,
+      effectiveHpCoef,
+      classOffModRaw,
+      classOffMod,
+      classDefModRaw,
+      classDefMod,
+      raceDefMod,
+      baseOffLevel,
+      baseDefLevel,
+      offLevel,
+      defLevel,
+      hp,
+      raceId: validation.race?.id || null,
+      raceSubtypeId: validation.subtype?.id || null,
+      backgroundId: validation.background?.id || null,
+    };
+  }
+
+  function backgroundGroups() {
+    const groups = {};
+    BACKGROUNDS.forEach((entry) => {
+      const key = entry.category || "other";
+      if (!groups[key]) groups[key] = [];
+      groups[key].push(entry);
+    });
+    return Object.entries(groups).map(([id, entries]) => ({
+      id,
+      label: CATEGORY_LABELS[id] || id,
+      entries: entries.slice().sort((a, b) => a.name.localeCompare(b.name, "es")),
+    }));
+  }
+
+  function getClass(id) { return classMap.get(String(id || "")) || null; }
+  function getRace(id) { return raceMap.get(String(id || "")) || null; }
+  function getBackground(id) { return backgroundMap.get(String(id || "")) || null; }
+
+  const api = Object.freeze({
+    SETTINGS,
+    CLASSES,
+    RACES,
+    BACKGROUNDS,
+    CATEGORY_LABELS,
+    symmetricRound,
+    normalizeClassChoices,
+    classLevelTotal,
+    validateBuild,
+    calculateBuild,
+    backgroundGroups,
+    getClass,
+    getRace,
+    getBackground,
+  });
+
+  global.LuminousCharacterBuildRules = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/character-build-rules.js
+++ b/js/character-build-rules.js
@@ -6,6 +6,7 @@
     maxCharacterLevel: 100,
     naturalHpCoefCap: 3.40,
     raceOffModifier: 0,
+    defaultRaceId: "human",
   });
 
   const CLASSES = Object.freeze([
@@ -25,6 +26,7 @@
   ]);
 
   const RACES = Object.freeze([
+    { id: "human", name: "Humano", hpCoefBonus: 0.00, defMod: 0, isDefault: true, tags: ["organic", "humanoid", "human"] },
     { id: "lizalin", name: "Lizalin", hpCoefBonus: 0.07, defMod: 0, tags: ["organic", "humanoid", "reptilian"] },
     { id: "kobold", name: "Kobold", hpCoefBonus: 0.00, defMod: 0, tags: ["organic", "humanoid", "reptilian", "small"] },
     { id: "kenku", name: "Kenku", hpCoefBonus: 0.00, defMod: 0, tags: ["organic", "humanoid", "avian"] },

--- a/js/dm-player-dnd-studio.js
+++ b/js/dm-player-dnd-studio.js
@@ -196,9 +196,11 @@
   function raceOptions() {
     const api = rules();
     if (!api) return '<option value="">— Motor no disponible —</option>';
-    return ['<option value="">— Selecciona raza —</option>']
-      .concat(api.RACES.map((entry) => `<option value="${entry.id}">${entry.name} · Coef +${entry.hpCoefBonus.toFixed(2)}${entry.defMod ? ` · DEF ${formatSigned(entry.defMod)}` : ""}</option>`))
-      .join("");
+    const defaultRaceId = api.SETTINGS.defaultRaceId;
+    return api.RACES.map((entry) => {
+      const isDefault = entry.id === defaultRaceId;
+      return `<option value="${entry.id}"${isDefault ? " selected" : ""}>${entry.name}${isDefault ? " · DEFAULT" : ""} · Coef +${entry.hpCoefBonus.toFixed(2)}${entry.defMod ? ` · DEF ${formatSigned(entry.defMod)}` : ""}</option>`;
+    }).join("");
   }
 
   function backgroundOptions() {
@@ -248,7 +250,7 @@
           <div class="dm-player-dnd-summary-card"><span>NIVELES CLASE</span><strong id="dm-player-build-class-total">0/1</strong></div>
           <div class="dm-player-dnd-summary-card"><span>CLASS COEF</span><strong id="dm-player-build-class-coef">—</strong></div>
           <div class="dm-player-dnd-summary-card"><span>TRASFONDO</span><strong id="dm-player-build-background-coef">—</strong></div>
-          <div class="dm-player-dnd-summary-card"><span>RAZA</span><strong id="dm-player-build-race-coef">—</strong></div>
+          <div class="dm-player-dnd-summary-card"><span>RAZA + SUBRAZA</span><strong id="dm-player-build-race-coef">—</strong></div>
           <p id="dm-player-build-feedback" class="dm-player-dnd-resistance-note" aria-live="polite">Sin build asignado: HP / Coef / Clase continúan en modo manual.</p>
         </section>
 
@@ -402,19 +404,21 @@
   }
 
   function buildHasAnySelection() {
+    const api = rules();
     if (collectClassChoices().length) return true;
-    if (String(field("dm-player-build-race")?.value || "").trim()) return true;
     if (String(field("dm-player-build-background")?.value || "").trim()) return true;
-    return false;
+    const raceId = String(field("dm-player-build-race")?.value || "").trim();
+    return Boolean(raceId && raceId !== api?.SETTINGS?.defaultRaceId);
   }
 
   function buildInput(level) {
+    const api = rules();
     return {
       level,
       constitution: integerOr(field("dm-player-stat-con")?.value, 10),
       classes: collectClassChoices(),
       backgroundId: String(field("dm-player-build-background")?.value || "").trim(),
-      raceId: String(field("dm-player-build-race")?.value || "").trim(),
+      raceId: String(field("dm-player-build-race")?.value || api?.SETTINGS?.defaultRaceId || "").trim(),
       raceSubtypeId: String(field("dm-player-build-subrace")?.value || "").trim() || null,
       baseOffLevel: level,
       baseDefLevel: level,
@@ -429,7 +433,7 @@
 
   function renderRaceSubtypeOptions(selectedId) {
     const api = rules();
-    const raceId = String(field("dm-player-build-race")?.value || "");
+    const raceId = String(field("dm-player-build-race")?.value || api?.SETTINGS?.defaultRaceId || "");
     const select = field("dm-player-build-subrace");
     const wrapper = field("dm-player-build-subrace-field");
     if (!api || !select) return;
@@ -457,10 +461,10 @@
 
     if (!calculation) {
       if (mode) mode.value = "LEGACY / MANUAL";
-      if (feedback) feedback.textContent = "Sin build asignado: HP / Coef / Clase continúan en modo manual.";
+      if (feedback) feedback.textContent = "Sin build asignado: Humano es el default visual; HP / Coef / Clase continúan en modo manual hasta asignar el build.";
       if (classCoef) classCoef.textContent = "—";
       if (backgroundCoef) backgroundCoef.textContent = "—";
-      if (raceCoef) raceCoef.textContent = "—";
+      if (raceCoef) raceCoef.textContent = "+0";
       return;
     }
 
@@ -565,7 +569,7 @@
       const input = field(`dm-player-class-${definition.id}`);
       if (input) input.value = "0";
     });
-    if (field("dm-player-build-race")) field("dm-player-build-race").value = "";
+    if (field("dm-player-build-race")) field("dm-player-build-race").value = api?.SETTINGS?.defaultRaceId || "";
     if (field("dm-player-build-background")) field("dm-player-build-background").value = "";
     renderRaceSubtypeOptions();
   }
@@ -582,7 +586,7 @@
     });
 
     if (field("dm-player-build-background")) field("dm-player-build-background").value = String(build.backgroundId || "");
-    if (field("dm-player-build-race")) field("dm-player-build-race").value = String(build.raceId || "");
+    if (field("dm-player-build-race")) field("dm-player-build-race").value = String(build.raceId || api.SETTINGS.defaultRaceId || "");
     renderRaceSubtypeOptions(String(build.raceSubtypeId || ""));
   }
 

--- a/js/dm-player-dnd-studio.js
+++ b/js/dm-player-dnd-studio.js
@@ -2,7 +2,10 @@
   "use strict";
   const doc = global.document;
   if (!doc) return;
+
   const PLAYERS_ROOT = "campaña/jugadores";
+  const BUILD_RULES_SRC = "js/character-build-rules.js";
+
   const ABILITIES = Object.freeze([
     { id: "str", key: "fuerza", code: "STR", name: "Strength", spanish: "Fuerza", skills: [{ id: "athletics", name: "Athletics", spanish: "Atletismo" }] },
     { id: "dex", key: "destreza", code: "DEX", name: "Dexterity", spanish: "Destreza", skills: [
@@ -32,12 +35,14 @@
       { id: "persuasion", name: "Persuasion", spanish: "Persuasión" },
     ] },
   ]);
+
   const PROFICIENCY_STATES = Object.freeze([
     { value: "none", label: "Not Proficient", multiplier: 0 },
     { value: "half", label: "Half Proficient", multiplier: 0.5 },
     { value: "proficient", label: "Proficient", multiplier: 1 },
     { value: "expertise", label: "Expertise", multiplier: 2 },
   ]);
+
   const state = {
     db: null,
     players: {},
@@ -46,24 +51,74 @@
     mounted: false,
     legacyObserver: null,
     legacyCaptureBound: false,
+    rulesLoading: false,
+    rulesWaiters: [],
   };
+
   const field = (id) => doc.getElementById(id);
   const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
   const integerOr = (value, fallback = 0) => Number.isFinite(Number.parseInt(value, 10)) ? Number.parseInt(value, 10) : fallback;
   const abilityModifier = (score) => Math.floor((numberOr(score, 10) - 10) / 2);
   const proficiencyBonus = (level) => Math.ceil(Math.max(0, numberOr(level, 0)) / 20);
   const formatSigned = (value) => numberOr(value, 0) >= 0 ? `+${numberOr(value, 0)}` : String(numberOr(value, 0));
+  const formatCoef = (value) => numberOr(value, 0).toFixed(4).replace(/0+$/, "").replace(/\.$/, "");
+
+  function rules() {
+    return global.LuminousCharacterBuildRules || null;
+  }
+
+  function ensureBuildRules(callback) {
+    if (rules()) {
+      callback?.(rules());
+      return;
+    }
+    if (callback) state.rulesWaiters.push(callback);
+    if (state.rulesLoading) return;
+    state.rulesLoading = true;
+
+    let script = doc.getElementById("character-build-rules-script");
+    if (!script) {
+      script = doc.createElement("script");
+      script.id = "character-build-rules-script";
+      script.src = BUILD_RULES_SRC;
+      script.async = false;
+      script.dataset.engine = "character-build-rules";
+      doc.head?.appendChild(script);
+    }
+
+    const finish = () => {
+      state.rulesLoading = false;
+      const api = rules();
+      const waiters = state.rulesWaiters.splice(0);
+      waiters.forEach((waiter) => {
+        try { waiter(api); } catch (error) { console.error("Character Build waiter failed:", error); }
+      });
+    };
+
+    if (rules()) finish();
+    else {
+      script.addEventListener("load", finish, { once: true });
+      script.addEventListener("error", () => {
+        console.error("No se pudo cargar el motor de reglas de Character Build.");
+        finish();
+      }, { once: true });
+    }
+  }
+
   function playerLabel(id, player) {
     return player?.characterName || player?.character_name || player?.nombre || player?.name || id;
   }
+
   function normalizeProficiencyState(value) {
     const normalized = String(value || "none").trim().toLowerCase();
     return PROFICIENCY_STATES.some((entry) => entry.value === normalized) ? normalized : "none";
   }
+
   function proficiencyContribution(level, profState) {
     const definition = PROFICIENCY_STATES.find((entry) => entry.value === normalizeProficiencyState(profState)) || PROFICIENCY_STATES[0];
     return Math.floor(proficiencyBonus(level) * definition.multiplier);
   }
+
   function levelDataFromXp(xp) {
     const numericXp = Math.max(0, integerOr(xp, 0));
     if (typeof global.calculateLevelData === "function") {
@@ -82,24 +137,36 @@
     }
     return { level: 1, xpPercent: 0, xpMissing: 0 };
   }
+
   function playerSkillState(player, skill) {
     const map = player?.skillProficiency || player?.skillProficiencies || player?.dndSkillProficiency || {};
     const nested = player?.dndSkills?.[skill.id];
     return normalizeProficiencyState(map?.[skill.id] ?? nested?.proficiency ?? nested?.proficiencyState);
   }
+
   function combatBreakdown(player, kind, levelOverride) {
     const level = Math.max(1, Math.trunc(numberOr(levelOverride ?? player?.level, 1)));
     const source = player?.combatLevels?.[kind] || {};
     const offense = kind === "offensive";
     const classModifier = numberOr(source.classModifier ?? player?.classModifiers?.[offense ? "offensiveLevel" : "defensiveLevel"], 0);
+    const raceModifier = offense ? 0 : numberOr(source.raceModifier ?? player?.raceModifiers?.defensiveLevel, 0);
     const itemModifier = numberOr(source.itemModifier ?? player?.equipmentModifiers?.[offense ? "offensiveLevel" : "defensiveLevel"], 0);
     const legacyDm = player?.combatStats?.[offense ? "off_lvl_mod" : "def_lvl_mod"];
     const dmModifier = numberOr(source.dmModifier ?? legacyDm, 0);
-    return { level, classModifier, dmModifier, itemModifier, total: level + classModifier + dmModifier + itemModifier };
+    return {
+      level,
+      classModifier,
+      raceModifier,
+      dmModifier,
+      itemModifier,
+      total: level + classModifier + raceModifier + dmModifier + itemModifier,
+    };
   }
+
   const proficiencyOptions = () => PROFICIENCY_STATES
     .map((entry) => `<option value="${entry.value}">${entry.label} · ×${entry.multiplier}</option>`)
     .join("");
+
   function skillEditorMarkup() {
     return ABILITIES.filter((ability) => ability.skills.length).map((ability) => `
       <section class="dm-player-dnd-skill-group" data-skill-ability="${ability.id}">
@@ -114,18 +181,47 @@
         </div>
       </section>`).join("");
   }
+
+  function classEditorMarkup() {
+    const api = rules();
+    if (!api) return '<p class="dm-player-dnd-resistance-note">Motor de reglas no disponible. Se mantiene el modo legacy.</p>';
+    return api.CLASSES.map((definition) => `
+      <label class="dm-player-dnd-ability">
+        <b>${definition.code}</b>
+        <span>${definition.name}<small>HP/5 ${definition.hpPer5} · Coef ${definition.hpCoefBase.toFixed(2)} · OFF ${formatSigned(definition.offMod)} · DEF ${formatSigned(definition.defMod)}</small></span>
+        <input id="dm-player-class-${definition.id}" data-character-class="${definition.id}" type="number" min="0" max="100" step="1" value="0" aria-label="Niveles de ${definition.name}">
+      </label>`).join("");
+  }
+
+  function raceOptions() {
+    const api = rules();
+    if (!api) return '<option value="">— Motor no disponible —</option>';
+    return ['<option value="">— Selecciona raza —</option>']
+      .concat(api.RACES.map((entry) => `<option value="${entry.id}">${entry.name} · Coef +${entry.hpCoefBonus.toFixed(2)}${entry.defMod ? ` · DEF ${formatSigned(entry.defMod)}` : ""}</option>`))
+      .join("");
+  }
+
+  function backgroundOptions() {
+    const api = rules();
+    if (!api) return '<option value="">— Motor no disponible —</option>';
+    return ['<option value="">— Selecciona trasfondo —</option>']
+      .concat(api.backgroundGroups().map((group) => `<optgroup label="${group.label}">${group.entries.map((entry) => `<option value="${entry.id}">${entry.name} · +${entry.hpCoefBonus.toFixed(2)}</option>`).join("")}</optgroup>`))
+      .join("");
+  }
+
   function mountPanel() {
     if (state.mounted && field("dm-player-dnd-studio")) return true;
     const tab = field("dashboard-jugadores");
     const grid = field("grid-jugadores");
     const host = grid?.closest?.(".panel-cyber") || tab;
     if (!tab || !host) return false;
+
     const panel = doc.createElement("section");
     panel.id = "dm-player-dnd-studio";
     panel.className = "dm-player-dnd-studio";
     panel.innerHTML = `
       <header class="dm-player-dnd-header">
-        <div><span>PLAYER RULESET / D&amp;D</span><h4>JUGADOR · PROGRESIÓN · STATS · SKILLS · COMBATE</h4></div>
+        <div><span>PLAYER RULESET / D&amp;D</span><h4>JUGADOR · BUILD · PROGRESIÓN · STATS · SKILLS · COMBATE</h4></div>
         <label>JUGADOR<select id="dm-player-dnd-select"><option value="">— Selecciona jugador —</option></select></label>
       </header>
       <div id="dm-player-dnd-editor" hidden>
@@ -139,10 +235,28 @@
             <small id="dm-player-dnd-xp-missing">0 XP para el siguiente nivel</small>
           </div>
         </section>
+
+        <h5 class="dm-player-dnd-section-title">CHARACTER BUILD · CLASE / TRASFONDO / RAZA</h5>
+        <div class="dm-player-dnd-legacy-combat">
+          <label><span>RAZA</span><select id="dm-player-build-race">${raceOptions()}</select></label>
+          <label id="dm-player-build-subrace-field"><span>SUBRAZA / VARIANTE</span><select id="dm-player-build-subrace"><option value="">— No aplica —</option></select></label>
+          <label class="dm-player-dnd-stagger"><span>TRASFONDO</span><select id="dm-player-build-background">${backgroundOptions()}</select></label>
+          <label><span>MODO DE CÁLCULO</span><input id="dm-player-build-mode" type="text" value="LEGACY / MANUAL" readonly></label>
+        </div>
+        <div class="dm-player-dnd-abilities" id="dm-player-class-grid">${classEditorMarkup()}</div>
+        <section class="dm-player-dnd-progression">
+          <div class="dm-player-dnd-summary-card"><span>NIVELES CLASE</span><strong id="dm-player-build-class-total">0/1</strong></div>
+          <div class="dm-player-dnd-summary-card"><span>CLASS COEF</span><strong id="dm-player-build-class-coef">—</strong></div>
+          <div class="dm-player-dnd-summary-card"><span>TRASFONDO</span><strong id="dm-player-build-background-coef">—</strong></div>
+          <div class="dm-player-dnd-summary-card"><span>RAZA</span><strong id="dm-player-build-race-coef">—</strong></div>
+          <p id="dm-player-build-feedback" class="dm-player-dnd-resistance-note" aria-live="polite">Sin build asignado: HP / Coef / Clase continúan en modo manual.</p>
+        </section>
+
         <div class="dm-player-dnd-art-row">
           <label><span>PLAYER ART · STATS</span><input id="dm-player-dnd-art" type="url" placeholder="https://... art del jugador"></label>
           <div class="dm-player-dnd-art-preview"><img id="dm-player-dnd-art-preview" alt="Vista previa del art del jugador" hidden><span id="dm-player-dnd-art-empty">SIN ART</span></div>
         </div>
+
         <h5 class="dm-player-dnd-section-title">ABILITY SCORES &amp; SAVING THROW PROFICIENCY</h5>
         <div class="dm-player-dnd-abilities">
           ${ABILITIES.map((ability) => `<label class="dm-player-dnd-ability"><b>${ability.code}</b><span>${ability.name}</span><input id="dm-player-stat-${ability.id}" type="number" step="1" min="1" value="10"><select id="dm-player-prof-${ability.id}">${proficiencyOptions()}</select></label>`).join("")}
@@ -153,17 +267,20 @@
           <span><i data-prof-state="proficient"></i>Proficient = PROF × 1</span>
           <span><i data-prof-state="expertise"></i>Expertise = PROF × 2</span>
         </div>
+
         <h5 class="dm-player-dnd-section-title">D&amp;D SKILLS · PROFICIENCY</h5>
         <div class="dm-player-dnd-skills">${skillEditorMarkup()}</div>
+
         <h5 class="dm-player-dnd-section-title">OFFENSIVE / DEFENSIVE LEVEL</h5>
         <div class="dm-player-dnd-combat-levels">
-          <div class="dm-player-dnd-combat-row" data-level-kind="offensive"><strong>OFFENSIVE LEVEL</strong><span>Base <b data-level-source="base">1</b></span><span>Clase <b data-level-source="class">+0</b></span><label>DM <input id="dm-player-offensive-dm" type="number" step="1" value="0"></label><span>Items <b data-level-source="items">+0</b></span><span>Total <b data-level-source="total">1</b></span></div>
-          <div class="dm-player-dnd-combat-row" data-level-kind="defensive"><strong>DEFENSIVE LEVEL</strong><span>Base <b data-level-source="base">1</b></span><span>Clase <b data-level-source="class">+0</b></span><label>DM <input id="dm-player-defensive-dm" type="number" step="1" value="0"></label><span>Items <b data-level-source="items">+0</b></span><span>Total <b data-level-source="total">1</b></span></div>
+          <div class="dm-player-dnd-combat-row" data-level-kind="offensive"><strong>OFFENSIVE LEVEL</strong><span>Base <b data-level-source="base">1</b></span><span>Clase <b data-level-source="class">+0</b></span><span>Raza <b data-level-source="race">+0</b></span><label>DM <input id="dm-player-offensive-dm" type="number" step="1" value="0"></label><span>Items <b data-level-source="items">+0</b></span><span>Total <b data-level-source="total">1</b></span></div>
+          <div class="dm-player-dnd-combat-row" data-level-kind="defensive"><strong>DEFENSIVE LEVEL</strong><span>Base <b data-level-source="base">1</b></span><span>Clase <b data-level-source="class">+0</b></span><span>Raza <b data-level-source="race">+0</b></span><label>DM <input id="dm-player-defensive-dm" type="number" step="1" value="0"></label><span>Items <b data-level-source="items">+0</b></span><span>Total <b data-level-source="total">1</b></span></div>
         </div>
+
         <h5 class="dm-player-dnd-section-title">COMBAT STATS · COMPATIBILIDAD DEL EDITOR ANTIGUO</h5>
         <div class="dm-player-dnd-legacy-combat">
           <label><span>HP BASE</span><input id="dm-player-hp-base" type="number" step="1" value="0"></label>
-          <label><span>HP COEFFICIENT</span><input id="dm-player-hp-coef" type="number" step="0.01" value="0"></label>
+          <label><span>HP COEFFICIENT</span><input id="dm-player-hp-coef" type="number" step="0.0001" value="0"></label>
           <label><span>HP ACTUAL</span><input id="dm-player-hp-actual" type="number" step="1" value="0"></label>
           <label><span>HP MAX · CALCULADO</span><input id="dm-player-hp-max" type="number" value="0" readonly></label>
           <label><span>SP ACTUAL</span><input id="dm-player-sp" type="number" step="1" value="0"></label>
@@ -173,6 +290,7 @@
         <p class="dm-player-dnd-resistance-note"><strong>RESISTENCIAS:</strong> permanecen reservadas para Equipamiento; OFF/DEF pertenecen al bloque de Level, no a Resistances.</p>
         <div class="dm-player-dnd-actions"><button id="dm-player-dnd-save" type="button">GUARDAR JUGADOR / STATS D&amp;D</button><span id="dm-player-dnd-feedback" aria-live="polite"></span></div>
       </div>`;
+
     if (grid && grid.parentNode === host) host.insertBefore(panel, grid);
     else host.prepend(panel);
     bindPanel(panel);
@@ -180,11 +298,13 @@
     state.mounted = true;
     return true;
   }
+
   function markDirty() {
     state.dirty = true;
     const feedback = field("dm-player-dnd-feedback");
     if (feedback) feedback.textContent = "CAMBIOS SIN GUARDAR";
   }
+
   function bindPanel(panel) {
     field("dm-player-dnd-select")?.addEventListener("change", (event) => loadPlayer(event.target.value));
     panel.querySelectorAll("#dm-player-dnd-editor input, #dm-player-dnd-editor select").forEach((control) => {
@@ -195,11 +315,13 @@
       });
       control.addEventListener("change", () => {
         markDirty();
+        if (control.id === "dm-player-build-race") renderRaceSubtypeOptions();
         updatePreviewFromForm();
       });
     });
     field("dm-player-dnd-save")?.addEventListener("click", savePlayerDnd);
   }
+
   function bindLegacyEditorTakeover() {
     const grid = field("grid-jugadores");
     if (!grid) return;
@@ -231,6 +353,7 @@
       state.legacyCaptureBound = true;
     }
   }
+
   function renderPlayerOptions() {
     const select = field("dm-player-dnd-select");
     if (!select) return;
@@ -247,6 +370,7 @@
     if (previous && state.players[previous]) select.value = previous;
     bindLegacyEditorTakeover();
   }
+
   function updateArtPreview() {
     const image = field("dm-player-dnd-art-preview");
     const empty = field("dm-player-dnd-art-empty");
@@ -263,27 +387,121 @@
     empty.hidden = true;
     image.onerror = () => { image.hidden = true; empty.hidden = false; };
   }
+
   function formLevelData() {
     return levelDataFromXp(field("dm-player-dnd-xp")?.value || 0);
   }
-  function formCombatBreakdown(kind, level) {
+
+  function collectClassChoices() {
+    const api = rules();
+    if (!api) return [];
+    return api.CLASSES.map((definition) => ({
+      classId: definition.id,
+      levels: Math.max(0, integerOr(field(`dm-player-class-${definition.id}`)?.value, 0)),
+    })).filter((entry) => entry.levels > 0);
+  }
+
+  function buildHasAnySelection() {
+    if (collectClassChoices().length) return true;
+    if (String(field("dm-player-build-race")?.value || "").trim()) return true;
+    if (String(field("dm-player-build-background")?.value || "").trim()) return true;
+    return false;
+  }
+
+  function buildInput(level) {
+    return {
+      level,
+      constitution: integerOr(field("dm-player-stat-con")?.value, 10),
+      classes: collectClassChoices(),
+      backgroundId: String(field("dm-player-build-background")?.value || "").trim(),
+      raceId: String(field("dm-player-build-race")?.value || "").trim(),
+      raceSubtypeId: String(field("dm-player-build-subrace")?.value || "").trim() || null,
+      baseOffLevel: level,
+      baseDefLevel: level,
+    };
+  }
+
+  function calculateBuildFromForm(level) {
+    const api = rules();
+    if (!api || !buildHasAnySelection()) return null;
+    return api.calculateBuild(buildInput(level));
+  }
+
+  function renderRaceSubtypeOptions(selectedId) {
+    const api = rules();
+    const raceId = String(field("dm-player-build-race")?.value || "");
+    const select = field("dm-player-build-subrace");
+    const wrapper = field("dm-player-build-subrace-field");
+    if (!api || !select) return;
+    const race = api.getRace(raceId);
+    const subtypes = race?.subtypes || [];
+    select.innerHTML = subtypes.length
+      ? '<option value="">— Selecciona variante —</option>' + subtypes.map((entry) => `<option value="${entry.id}">${entry.name}${entry.hpCoefBonus ? ` · Coef +${entry.hpCoefBonus.toFixed(2)}` : ""}${entry.defMod ? ` · DEF ${formatSigned(entry.defMod)}` : ""}</option>`).join("")
+      : '<option value="">— No aplica —</option>';
+    select.disabled = !subtypes.length;
+    if (wrapper) wrapper.style.opacity = subtypes.length ? "1" : "0.55";
+    if (selectedId && subtypes.some((entry) => entry.id === selectedId)) select.value = selectedId;
+  }
+
+  function updateBuildSummary(level, calculation) {
+    const api = rules();
+    const classTotal = api ? api.classLevelTotal(collectClassChoices()) : 0;
+    const totalNode = field("dm-player-build-class-total");
+    if (totalNode) totalNode.textContent = `${classTotal}/${level}`;
+
+    const mode = field("dm-player-build-mode");
+    const feedback = field("dm-player-build-feedback");
+    const classCoef = field("dm-player-build-class-coef");
+    const backgroundCoef = field("dm-player-build-background-coef");
+    const raceCoef = field("dm-player-build-race-coef");
+
+    if (!calculation) {
+      if (mode) mode.value = "LEGACY / MANUAL";
+      if (feedback) feedback.textContent = "Sin build asignado: HP / Coef / Clase continúan en modo manual.";
+      if (classCoef) classCoef.textContent = "—";
+      if (backgroundCoef) backgroundCoef.textContent = "—";
+      if (raceCoef) raceCoef.textContent = "—";
+      return;
+    }
+
+    if (classCoef) classCoef.textContent = formatCoef(calculation.classHpCoef);
+    if (backgroundCoef) backgroundCoef.textContent = formatSigned(calculation.backgroundHpCoefBonus.toFixed(2));
+    if (raceCoef) raceCoef.textContent = formatSigned(calculation.raceHpCoefBonus.toFixed(2));
+
+    if (calculation.valid) {
+      if (mode) mode.value = "AUTO / BUILD V1";
+      if (feedback) feedback.textContent = `AUTO: Coef natural ${formatCoef(calculation.intrinsicHpCoef)} · HP Base ${calculation.hpBase} · OFF Clase ${formatSigned(calculation.classOffMod)} · DEF Clase ${formatSigned(calculation.classDefMod)} · DEF Raza ${formatSigned(calculation.raceDefMod)}.`;
+    } else {
+      if (mode) mode.value = "BUILD INCOMPLETO";
+      if (feedback) feedback.textContent = calculation.errors.join(" ");
+    }
+  }
+
+  function formCombatBreakdown(kind, level, buildCalculation) {
     const player = state.players[state.playerId] || {};
     const breakdown = combatBreakdown(player, kind, level);
+    if (buildCalculation?.valid) {
+      breakdown.classModifier = kind === "offensive" ? buildCalculation.classOffMod : buildCalculation.classDefMod;
+      breakdown.raceModifier = kind === "offensive" ? 0 : buildCalculation.raceDefMod;
+    }
     const input = field(kind === "offensive" ? "dm-player-offensive-dm" : "dm-player-defensive-dm");
     breakdown.dmModifier = numberOr(input?.value, 0);
-    breakdown.total = breakdown.level + breakdown.classModifier + breakdown.dmModifier + breakdown.itemModifier;
+    breakdown.total = breakdown.level + breakdown.classModifier + breakdown.raceModifier + breakdown.dmModifier + breakdown.itemModifier;
     return breakdown;
   }
+
   function setCombatRow(kind, breakdown) {
     const row = doc.querySelector(`#dm-player-dnd-studio [data-level-kind="${kind}"]`);
     if (!row) return;
     row.querySelector('[data-level-source="base"]').textContent = String(breakdown.level);
     row.querySelector('[data-level-source="class"]').textContent = formatSigned(breakdown.classModifier);
+    row.querySelector('[data-level-source="race"]').textContent = formatSigned(breakdown.raceModifier);
     row.querySelector('[data-level-source="items"]').textContent = formatSigned(breakdown.itemModifier);
     row.querySelector('[data-level-source="total"]').textContent = String(breakdown.total);
     const input = field(kind === "offensive" ? "dm-player-offensive-dm" : "dm-player-defensive-dm");
     if (input && doc.activeElement !== input) input.value = String(breakdown.dmModifier);
   }
+
   function updateSkillTotalsFromForm(level) {
     ABILITIES.forEach((ability) => {
       const score = integerOr(field(`dm-player-stat-${ability.id}`)?.value, 10);
@@ -296,11 +514,26 @@
       });
     });
   }
-  function calculatedHpMax(defensiveLevel) {
+
+  function calculatedHpMax(defensiveLevel, buildCalculation) {
+    if (buildCalculation?.valid) return Math.max(0, Math.round(buildCalculation.hpBase + defensiveLevel * buildCalculation.intrinsicHpCoef));
     const hpBase = numberOr(field("dm-player-hp-base")?.value, 0);
     const hpCoef = numberOr(field("dm-player-hp-coef")?.value, 0);
     return Math.max(0, Math.floor(hpBase + defensiveLevel * hpCoef));
   }
+
+  function updateAutoHpFields(buildCalculation) {
+    const hpBase = field("dm-player-hp-base");
+    const hpCoef = field("dm-player-hp-coef");
+    const auto = Boolean(buildCalculation?.valid);
+    if (hpBase) hpBase.readOnly = auto;
+    if (hpCoef) hpCoef.readOnly = auto;
+    if (auto) {
+      hpBase.value = String(buildCalculation.hpBase);
+      hpCoef.value = formatCoef(buildCalculation.intrinsicHpCoef);
+    }
+  }
+
   function updatePreviewFromForm() {
     if (!state.playerId) return;
     const xpData = formLevelData();
@@ -312,14 +545,47 @@
     const fill = field("dm-player-dnd-xp-fill");
     if (track) track.setAttribute("aria-valuenow", String(xpData.xpPercent));
     if (fill) fill.style.width = `${xpData.xpPercent}%`;
-    const offensive = formCombatBreakdown("offensive", xpData.level);
-    const defensive = formCombatBreakdown("defensive", xpData.level);
+
+    const buildCalculation = calculateBuildFromForm(xpData.level);
+    updateBuildSummary(xpData.level, buildCalculation);
+    updateAutoHpFields(buildCalculation);
+
+    const offensive = formCombatBreakdown("offensive", xpData.level, buildCalculation);
+    const defensive = formCombatBreakdown("defensive", xpData.level, buildCalculation);
     setCombatRow("offensive", offensive);
     setCombatRow("defensive", defensive);
     updateSkillTotalsFromForm(xpData.level);
     const hpMax = field("dm-player-hp-max");
-    if (hpMax) hpMax.value = String(calculatedHpMax(defensive.total));
+    if (hpMax) hpMax.value = String(calculatedHpMax(defensive.total, buildCalculation));
   }
+
+  function resetBuildForm() {
+    const api = rules();
+    api?.CLASSES.forEach((definition) => {
+      const input = field(`dm-player-class-${definition.id}`);
+      if (input) input.value = "0";
+    });
+    if (field("dm-player-build-race")) field("dm-player-build-race").value = "";
+    if (field("dm-player-build-background")) field("dm-player-build-background").value = "";
+    renderRaceSubtypeOptions();
+  }
+
+  function loadCharacterBuild(player) {
+    resetBuildForm();
+    const api = rules();
+    const build = player?.characterBuild;
+    if (!api || !build || typeof build !== "object") return;
+
+    api.normalizeClassChoices(build.classes).forEach((entry) => {
+      const input = field(`dm-player-class-${entry.classId}`);
+      if (input) input.value = String(entry.levels);
+    });
+
+    if (field("dm-player-build-background")) field("dm-player-build-background").value = String(build.backgroundId || "");
+    if (field("dm-player-build-race")) field("dm-player-build-race").value = String(build.raceId || "");
+    renderRaceSubtypeOptions(String(build.raceSubtypeId || ""));
+  }
+
   function loadPlayer(playerId) {
     const editor = field("dm-player-dnd-editor");
     const player = state.players[playerId];
@@ -328,6 +594,7 @@
       if (editor) editor.hidden = true;
       return false;
     }
+
     editor.hidden = false;
     field("dm-player-dnd-xp").value = String(Math.max(0, integerOr(player?.xp, 0)));
     ABILITIES.forEach((ability) => {
@@ -339,6 +606,8 @@
         if (select) select.value = playerSkillState(player, skill);
       });
     });
+
+    loadCharacterBuild(player);
     field("dm-player-dnd-art").value = String(player?.sheetArt || player?.playerSheetArt || "");
     updateArtPreview();
     const combatStats = player?.combatStats || {};
@@ -356,12 +625,35 @@
     state.dirty = false;
     return true;
   }
+
   function parseStaggerThresholds(value) {
     return String(value || "")
       .split(/[;,\s]+/)
       .map((item) => Number(item))
       .filter((item) => Number.isFinite(item));
   }
+
+  function buildPersistenceUpdates(buildCalculation) {
+    const api = rules();
+    if (!api || !buildCalculation?.valid) return {};
+    return {
+      "characterBuild/version": api.SETTINGS.version,
+      "characterBuild/classes": buildCalculation.classes,
+      "characterBuild/backgroundId": buildCalculation.backgroundId,
+      "characterBuild/raceId": buildCalculation.raceId,
+      "characterBuild/raceSubtypeId": buildCalculation.raceSubtypeId,
+      "characterBuild/calculatedAtLevel": buildCalculation.level,
+      "characterBuild/breakdown/classHpCoef": buildCalculation.classHpCoef,
+      "characterBuild/breakdown/backgroundHpCoefBonus": buildCalculation.backgroundHpCoefBonus,
+      "characterBuild/breakdown/raceHpCoefBonus": buildCalculation.raceHpCoefBonus,
+      "characterBuild/breakdown/intrinsicHpCoef": buildCalculation.intrinsicHpCoef,
+      "characterBuild/breakdown/weightedHpPer5": buildCalculation.weightedHpPer5,
+      "characterBuild/breakdown/classOffModifier": buildCalculation.classOffMod,
+      "characterBuild/breakdown/classDefModifier": buildCalculation.classDefMod,
+      "characterBuild/breakdown/raceDefModifier": buildCalculation.raceDefMod,
+    };
+  }
+
   async function savePlayerDnd() {
     const playerId = state.playerId;
     const feedback = field("dm-player-dnd-feedback");
@@ -371,17 +663,28 @@
       if (feedback) feedback.textContent = "Selecciona un jugador primero.";
       return;
     }
+
     const xp = Math.max(0, integerOr(field("dm-player-dnd-xp")?.value, 0));
     const xpData = levelDataFromXp(xp);
-    const offensive = formCombatBreakdown("offensive", xpData.level);
-    const defensive = formCombatBreakdown("defensive", xpData.level);
-    const hpBase = numberOr(field("dm-player-hp-base")?.value, 0);
-    const hpCoef = numberOr(field("dm-player-hp-coef")?.value, 0);
+    const buildCalculation = calculateBuildFromForm(xpData.level);
+    if (buildCalculation && !buildCalculation.valid) {
+      if (feedback) feedback.textContent = `BUILD INCOMPLETO: ${buildCalculation.errors.join(" ")}`;
+      field("dm-player-build-feedback")?.scrollIntoView?.({ behavior: "smooth", block: "center" });
+      return;
+    }
+
+    const offensive = formCombatBreakdown("offensive", xpData.level, buildCalculation);
+    const defensive = formCombatBreakdown("defensive", xpData.level, buildCalculation);
+    const hpBase = buildCalculation?.valid ? buildCalculation.hpBase : numberOr(field("dm-player-hp-base")?.value, 0);
+    const hpCoef = buildCalculation?.valid ? buildCalculation.intrinsicHpCoef : numberOr(field("dm-player-hp-coef")?.value, 0);
     const hpActual = numberOr(field("dm-player-hp-actual")?.value, 0);
-    const hpMax = Math.max(0, Math.floor(hpBase + defensive.total * hpCoef));
+    const hpMax = buildCalculation?.valid
+      ? Math.max(0, Math.round(hpBase + defensive.total * hpCoef))
+      : Math.max(0, Math.floor(hpBase + defensive.total * hpCoef));
     const spActual = numberOr(field("dm-player-sp")?.value, 0);
     const actionSlots = Math.max(1, integerOr(field("dm-player-action-slots")?.value, 1));
     const staggerThresholds = parseStaggerThresholds(field("dm-player-stagger")?.value);
+
     const updates = {
       xp,
       level: xpData.level,
@@ -392,8 +695,15 @@
       hp_coefficient: hpCoef,
       hp_max: hpMax,
       hp_actual: hpActual,
+      "combatLevels/offensive/classModifier": offensive.classModifier,
+      "combatLevels/offensive/raceModifier": 0,
       "combatLevels/offensive/dmModifier": offensive.dmModifier,
+      "combatLevels/defensive/classModifier": defensive.classModifier,
+      "combatLevels/defensive/raceModifier": defensive.raceModifier,
       "combatLevels/defensive/dmModifier": defensive.dmModifier,
+      "classModifiers/offensiveLevel": offensive.classModifier,
+      "classModifiers/defensiveLevel": defensive.classModifier,
+      "raceModifiers/defensiveLevel": defensive.raceModifier,
       "combatStats/off_lvl_mod": offensive.dmModifier,
       "combatStats/def_lvl_mod": defensive.dmModifier,
       "combatStats/hp_base": hpBase,
@@ -404,6 +714,9 @@
       "combatStats/action_slots": actionSlots,
       "combatStats/stagger_thresholds": staggerThresholds,
     };
+
+    if (buildCalculation?.valid) Object.assign(updates, buildPersistenceUpdates(buildCalculation));
+
     ABILITIES.forEach((ability) => {
       const raw = Number.parseInt(field(`dm-player-stat-${ability.id}`)?.value, 10);
       updates[`stats/${ability.key}`] = Number.isFinite(raw) ? raw : 10;
@@ -412,12 +725,13 @@
         updates[`skillProficiency/${skill.id}`] = normalizeProficiencyState(field(`dm-player-skill-${skill.id}`)?.value);
       });
     });
+
     if (button) button.disabled = true;
     if (feedback) feedback.textContent = "GUARDANDO...";
     try {
       await state.db.ref(`${PLAYERS_ROOT}/${playerId}`).update(updates);
       state.dirty = false;
-      if (feedback) feedback.textContent = "JUGADOR / STATS D&D GUARDADOS";
+      if (feedback) feedback.textContent = buildCalculation?.valid ? "JUGADOR / BUILD / STATS D&D GUARDADOS" : "JUGADOR / STATS D&D GUARDADOS";
     } catch (error) {
       console.error("No se pudieron guardar los datos D&D del jugador:", error);
       if (feedback) feedback.textContent = "ERROR AL GUARDAR";
@@ -425,6 +739,7 @@
       if (button) button.disabled = false;
     }
   }
+
   function connectFirebase() {
     try {
       if (!global.firebase?.database || !global.firebase?.apps?.length) return false;
@@ -439,7 +754,8 @@
       return false;
     }
   }
-  function boot() {
+
+  function startStudio() {
     mountPanel();
     if (connectFirebase()) return;
     const retry = global.setInterval(() => {
@@ -447,8 +763,14 @@
       if (connectFirebase()) global.clearInterval(retry);
     }, 250);
   }
+
+  function boot() {
+    ensureBuildRules(() => startStudio());
+  }
+
   if (doc.readyState === "loading") doc.addEventListener("DOMContentLoaded", boot, { once: true });
   else boot();
+
   global.LuminousDmPlayerDndStudio = Object.freeze({
     ABILITIES,
     PROFICIENCY_STATES,
@@ -456,6 +778,8 @@
     proficiencyContribution,
     levelDataFromXp,
     combatBreakdown,
+    collectClassChoices,
+    calculateBuildFromForm,
     loadPlayer,
     savePlayerDnd,
     updatePreviewFromForm,

--- a/js/player-stats-ability-bar.js
+++ b/js/player-stats-ability-bar.js
@@ -106,10 +106,11 @@
     const source = data?.combatLevels?.[kind] || {};
     const isOffense = kind === "offensive";
     const classModifier = numberOr(source.classModifier ?? data?.classModifiers?.[isOffense ? "offensiveLevel" : "defensiveLevel"], 0);
+    const raceModifier = isOffense ? 0 : numberOr(source.raceModifier ?? data?.raceModifiers?.defensiveLevel, 0);
     const itemModifier = numberOr(source.itemModifier ?? data?.equipmentModifiers?.[isOffense ? "offensiveLevel" : "defensiveLevel"], 0);
     const legacyDm = data?.combatStats?.[isOffense ? "off_lvl_mod" : "def_lvl_mod"];
     const dmModifier = numberOr(source.dmModifier ?? legacyDm, 0);
-    return { level, classModifier, dmModifier, itemModifier, total: level + classModifier + dmModifier + itemModifier };
+    return { level, classModifier, raceModifier, dmModifier, itemModifier, total: level + classModifier + raceModifier + dmModifier + itemModifier };
   }
   const playerSheetArt = (data = playerData()) => String(data?.sheetArt || data?.playerSheetArt || "").trim();
   const playerIcon = (data = playerData()) => String(data?.icono_jugador || data?.icono || data?.perfil?.icono || "").trim();
@@ -197,7 +198,7 @@
     const offensiveNode = panel.querySelector("[data-combat-level='offensive']");
     const defensiveNode = panel.querySelector("[data-combat-level='defensive']");
     if (offensiveNode) offensiveNode.title = `Nivel ${level} + Clase ${formatModifier(offensive.classModifier)} + DM ${formatModifier(offensive.dmModifier)} + Items ${formatModifier(offensive.itemModifier)}`;
-    if (defensiveNode) defensiveNode.title = `Nivel ${level} + Clase ${formatModifier(defensive.classModifier)} + DM ${formatModifier(defensive.dmModifier)} + Items ${formatModifier(defensive.itemModifier)}`;
+    if (defensiveNode) defensiveNode.title = `Nivel ${level} + Clase ${formatModifier(defensive.classModifier)} + Raza ${formatModifier(defensive.raceModifier)} + DM ${formatModifier(defensive.dmModifier)} + Items ${formatModifier(defensive.itemModifier)}`;
   }
   function renderSkills(panel, ability, data) {
     const list = panel.querySelector("[data-player-skill-list]");

--- a/tests/character_build_rules.spec.js
+++ b/tests/character_build_rules.spec.js
@@ -27,10 +27,13 @@ function loadPlayerStatsApi() {
   return window.LuminousPlayerStats;
 }
 
-test("catálogos contienen las 13 clases, 15 razas y trasfondos Project Moon", () => {
+test("catálogos contienen las 13 clases, 16 razas y trasfondos Project Moon", () => {
   expect(rules.CLASSES).toHaveLength(13);
-  expect(rules.RACES).toHaveLength(15);
+  expect(rules.RACES).toHaveLength(16);
   expect(rules.BACKGROUNDS.length).toBeGreaterThanOrEqual(140);
+  expect(rules.SETTINGS.defaultRaceId).toBe("human");
+  expect(rules.RACES[0].id).toBe("human");
+  expect(rules.getRace("human")).toMatchObject({ name: "Humano", hpCoefBonus: 0, defMod: 0, isDefault: true });
   expect(rules.getClass("rogue")?.hpCoefBase).toBe(2.78);
   expect(rules.getClass("sorcerer")?.offMod).toBe(2);
   expect(rules.getRace("yuan_ti_pureblood")?.hpCoefBonus).toBe(0.03);
@@ -40,9 +43,61 @@ test("catálogos contienen las 13 clases, 15 razas y trasfondos Project Moon", (
 test("las razas no aportan OFF permanente y DEF racial queda excepcional", () => {
   expect(rules.SETTINGS.raceOffModifier).toBe(0);
   for (const race of rules.RACES) expect(race.offMod).toBeUndefined();
+  expect(rules.getRace("human")?.defMod).toBe(0);
   expect(rules.getRace("goliath")?.defMod).toBe(1);
   expect(rules.getRace("warforged")?.defMod).toBe(1);
   expect(rules.getRace("yuan_ti_pureblood")?.defMod).toBe(0);
+});
+
+test("Humano es el baseline neutral y no altera HP Coef, OFF ni DEF", () => {
+  const result = rules.calculateBuild({
+    level: 10,
+    constitution: 10,
+    classes: [{ classId: "fighter", levels: 10 }],
+    backgroundId: "chef",
+    raceId: "human",
+  });
+
+  expect(result.valid).toBe(true);
+  expect(result.raceId).toBe("human");
+  expect(result.raceSubtypeId).toBeNull();
+  expect(result.raceHpCoefBonus).toBe(0);
+  expect(result.raceDefMod).toBe(0);
+  closeTo(result.intrinsicHpCoef, 2.99);
+  expect(result.offLevel).toBe(11);
+  expect(result.defLevel).toBe(11);
+  expect(result.hpBase).toBe(20);
+  expect(result.hp).toBe(53);
+});
+
+test("subrazas se suman dentro de la capa racial sin aportar OFF", () => {
+  const warforged = rules.calculateBuild({
+    level: 10,
+    constitution: 10,
+    classes: [{ classId: "fighter", levels: 10 }],
+    backgroundId: "chef",
+    raceId: "warforged",
+    raceSubtypeId: "juggernaut",
+  });
+  const felinae = rules.calculateBuild({
+    level: 10,
+    constitution: 10,
+    classes: [{ classId: "fighter", levels: 10 }],
+    backgroundId: "chef",
+    raceId: "felinae",
+    raceSubtypeId: "large",
+  });
+
+  expect(warforged.valid).toBe(true);
+  closeTo(warforged.raceHpCoefBonus, 0.16);
+  expect(warforged.raceDefMod).toBe(1);
+  expect(warforged.classOffMod).toBe(1);
+  expect(warforged.offLevel).toBe(11);
+
+  expect(felinae.valid).toBe(true);
+  closeTo(felinae.raceHpCoefBonus, 0.06);
+  expect(felinae.raceDefMod).toBe(0);
+  expect(felinae.offLevel).toBe(11);
 });
 
 test("Pícaro 15 / Hechicero 20 + Chef + Yuan-ti calcula el ejemplo acordado", () => {
@@ -121,6 +176,15 @@ test("un build parcial no reemplaza silenciosamente el modo legacy", () => {
   expect(result.errors.join(" ")).toContain("subraza");
 });
 
+test("DM Studio usa Humano como default visual sin auto-migrar legacy", () => {
+  expect(studio).toContain('const defaultRaceId = api.SETTINGS.defaultRaceId');
+  expect(studio).toContain('" · DEFAULT"');
+  expect(studio).toContain('raceId !== api?.SETTINGS?.defaultRaceId');
+  expect(studio).toContain('field("dm-player-build-race").value = api?.SETTINGS?.defaultRaceId || ""');
+  expect(studio).toContain('build.raceId || api.SETTINGS.defaultRaceId || ""');
+  expect(studio).toContain('Humano es el default visual');
+});
+
 test("DM Studio persiste build derivado sin romper las rutas legacy", () => {
   for (const id of [
     "dm-player-build-race",
@@ -134,6 +198,7 @@ test("DM Studio persiste build derivado sin romper las rutas legacy", () => {
   expect(studio).toContain('"characterBuild/classes": buildCalculation.classes');
   expect(studio).toContain('"characterBuild/backgroundId": buildCalculation.backgroundId');
   expect(studio).toContain('"characterBuild/raceId": buildCalculation.raceId');
+  expect(studio).toContain('"characterBuild/raceSubtypeId": buildCalculation.raceSubtypeId');
   expect(studio).toContain('"classModifiers/offensiveLevel": offensive.classModifier');
   expect(studio).toContain('"classModifiers/defensiveLevel": defensive.classModifier');
   expect(studio).toContain('"raceModifiers/defensiveLevel": defensive.raceModifier');
@@ -141,6 +206,7 @@ test("DM Studio persiste build derivado sin romper las rutas legacy", () => {
   expect(studio).toContain('"combatStats/hp_coefficient": hpCoef');
   expect(studio).toContain('if (buildCalculation && !buildCalculation.valid)');
   expect(studio).toContain('"LEGACY / MANUAL"');
+  expect(studio).toContain('RAZA + SUBRAZA');
 });
 
 test("Jugador consume DEF racial sin contaminar OFF", () => {

--- a/tests/character_build_rules.spec.js
+++ b/tests/character_build_rules.spec.js
@@ -1,13 +1,29 @@
 const { test, expect } = require("@playwright/test");
 const fs = require("node:fs");
 const path = require("node:path");
+const vm = require("node:vm");
 
 const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
 const rules = require("../js/character-build-rules.js");
 const studio = read("js/dm-player-dnd-studio.js");
+const playerStatsSource = read("js/player-stats-ability-bar.js");
 
 function closeTo(actual, expected, precision = 6) {
   expect(Math.abs(actual - expected)).toBeLessThan(10 ** -precision);
+}
+
+function loadPlayerStatsApi() {
+  const document = {
+    readyState: "loading",
+    addEventListener() {},
+  };
+  const window = {
+    document,
+    setInterval() { return 0; },
+  };
+  window.window = window;
+  vm.runInNewContext(playerStatsSource, { window, console });
+  return window.LuminousPlayerStats;
 }
 
 test("catálogos contienen las 13 clases, 15 razas y trasfondos Project Moon", () => {
@@ -124,4 +140,40 @@ test("DM Studio persiste build derivado sin romper las rutas legacy", () => {
   expect(studio).toContain('"combatStats/hp_coefficient": hpCoef');
   expect(studio).toContain('if (buildCalculation && !buildCalculation.valid)');
   expect(studio).toContain('"LEGACY / MANUAL"');
+});
+
+test("Jugador consume DEF racial sin contaminar OFF", () => {
+  const playerStats = loadPlayerStatsApi();
+  expect(playerStats).toBeTruthy();
+
+  const player = {
+    level: 35,
+    combatLevels: {
+      offensive: { classModifier: 2, raceModifier: 9, dmModifier: 0, itemModifier: 0 },
+      defensive: { classModifier: -2, raceModifier: 1, dmModifier: 0, itemModifier: 0 },
+    },
+  };
+
+  const offensive = playerStats.combatLevelBreakdown("offensive", player);
+  const defensive = playerStats.combatLevelBreakdown("defensive", player);
+
+  expect(offensive.raceModifier).toBe(0);
+  expect(offensive.total).toBe(37);
+  expect(defensive.raceModifier).toBe(1);
+  expect(defensive.total).toBe(34);
+});
+
+test("Jugador mantiene fallback legacy para DEF racial y HP almacenado", () => {
+  const playerStats = loadPlayerStatsApi();
+  const defensive = playerStats.combatLevelBreakdown("defensive", {
+    level: 35,
+    classModifiers: { defensiveLevel: -2 },
+    raceModifiers: { defensiveLevel: 1 },
+    combatStats: { def_lvl_mod: 0, hp_max: 161 },
+  });
+
+  expect(defensive.classModifier).toBe(-2);
+  expect(defensive.raceModifier).toBe(1);
+  expect(defensive.total).toBe(34);
+  expect(playerStatsSource).toContain('data?.combatStats?.hp_max ?? data?.hp_max');
 });

--- a/tests/character_build_rules.spec.js
+++ b/tests/character_build_rules.spec.js
@@ -7,6 +7,7 @@ const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8")
 const rules = require("../js/character-build-rules.js");
 const studio = read("js/dm-player-dnd-studio.js");
 const playerStatsSource = read("js/player-stats-ability-bar.js");
+const utils = read("js/utils.js");
 
 function closeTo(actual, expected, precision = 6) {
   expect(Math.abs(actual - expected)).toBeLessThan(10 ** -precision);
@@ -176,4 +177,13 @@ test("Jugador mantiene fallback legacy para DEF racial y HP almacenado", () => {
   expect(defensive.raceModifier).toBe(1);
   expect(defensive.total).toBe(34);
   expect(playerStatsSource).toContain('data?.combatStats?.hp_max ?? data?.hp_max');
+});
+
+test("el editor DM no se inyecta en la hoja del Jugador", () => {
+  const start = utils.indexOf("function ensureDmPlayerDndStudioAssets");
+  const end = utils.indexOf("function ensurePlayerSplashFramingAssets", start);
+  const block = utils.slice(start, end);
+  expect(block).toContain("#dashboard-jugadores");
+  expect(block).toContain("js/dm-player-dnd-studio.js");
+  expect(block).not.toContain(".sheet-phone-wrapper");
 });

--- a/tests/character_build_rules.spec.js
+++ b/tests/character_build_rules.spec.js
@@ -1,0 +1,127 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
+const rules = require("../js/character-build-rules.js");
+const studio = read("js/dm-player-dnd-studio.js");
+
+function closeTo(actual, expected, precision = 6) {
+  expect(Math.abs(actual - expected)).toBeLessThan(10 ** -precision);
+}
+
+test("catálogos contienen las 13 clases, 15 razas y trasfondos Project Moon", () => {
+  expect(rules.CLASSES).toHaveLength(13);
+  expect(rules.RACES).toHaveLength(15);
+  expect(rules.BACKGROUNDS.length).toBeGreaterThanOrEqual(140);
+  expect(rules.getClass("rogue")?.hpCoefBase).toBe(2.78);
+  expect(rules.getClass("sorcerer")?.offMod).toBe(2);
+  expect(rules.getRace("yuan_ti_pureblood")?.hpCoefBonus).toBe(0.03);
+  expect(rules.getBackground("chef")?.hpCoefBonus).toBe(0.13);
+});
+
+test("las razas no aportan OFF permanente y DEF racial queda excepcional", () => {
+  expect(rules.SETTINGS.raceOffModifier).toBe(0);
+  for (const race of rules.RACES) expect(race.offMod).toBeUndefined();
+  expect(rules.getRace("goliath")?.defMod).toBe(1);
+  expect(rules.getRace("warforged")?.defMod).toBe(1);
+  expect(rules.getRace("yuan_ti_pureblood")?.defMod).toBe(0);
+});
+
+test("Pícaro 15 / Hechicero 20 + Chef + Yuan-ti calcula el ejemplo acordado", () => {
+  const result = rules.calculateBuild({
+    level: 35,
+    constitution: 14,
+    classes: [
+      { classId: "rogue", levels: 15 },
+      { classId: "sorcerer", levels: 20 },
+    ],
+    backgroundId: "chef",
+    raceId: "yuan_ti_pureblood",
+    raceSubtypeId: "green_eyes",
+  });
+
+  expect(result.valid).toBe(true);
+  closeTo(result.classHpCoef, 2.745714285714286);
+  expect(result.classOffMod).toBe(2);
+  expect(result.classDefMod).toBe(-2);
+  expect(result.raceDefMod).toBe(0);
+  closeTo(result.backgroundHpCoefBonus, 0.13);
+  closeTo(result.raceHpCoefBonus, 0.03);
+  closeTo(result.intrinsicHpCoef, 2.905714285714286);
+  expect(result.hpBase).toBe(62);
+  expect(result.offLevel).toBe(37);
+  expect(result.defLevel).toBe(33);
+  expect(result.hp).toBe(158);
+});
+
+test("multiclase usa promedio ponderado y redondeo simétrico para OFF / DEF", () => {
+  const result = rules.calculateBuild({
+    level: 35,
+    constitution: 10,
+    classes: [
+      { classId: "barbarian", levels: 15 },
+      { classId: "wizard", levels: 20 },
+    ],
+    backgroundId: "nest_heir",
+    raceId: "kobold",
+  });
+
+  closeTo(result.classOffModRaw, 40 / 35);
+  closeTo(result.classDefModRaw, -10 / 35);
+  expect(result.classOffMod).toBe(1);
+  expect(result.classDefMod).toBe(0);
+  expect(rules.symmetricRound(-1.5)).toBe(-2);
+  expect(rules.symmetricRound(1.5)).toBe(2);
+});
+
+test("el coeficiente natural respeta el cap 3.40", () => {
+  const result = rules.calculateBuild({
+    level: 100,
+    constitution: 20,
+    classes: [{ classId: "barbarian", levels: 100 }],
+    backgroundId: "pequod_survivor",
+    raceId: "warforged",
+    raceSubtypeId: "juggernaut",
+  });
+
+  expect(result.intrinsicHpCoefUncapped).toBeGreaterThan(3.4);
+  expect(result.intrinsicHpCoef).toBe(3.4);
+  expect(result.raceDefMod).toBe(1);
+});
+
+test("un build parcial no reemplaza silenciosamente el modo legacy", () => {
+  const result = rules.calculateBuild({
+    level: 35,
+    constitution: 14,
+    classes: [{ classId: "rogue", levels: 15 }],
+    backgroundId: "chef",
+    raceId: "yuan_ti_pureblood",
+  });
+
+  expect(result.valid).toBe(false);
+  expect(result.errors.join(" ")).toContain("deben sumar 35");
+  expect(result.errors.join(" ")).toContain("subraza");
+});
+
+test("DM Studio persiste build derivado sin romper las rutas legacy", () => {
+  for (const id of [
+    "dm-player-build-race",
+    "dm-player-build-subrace",
+    "dm-player-build-background",
+    "dm-player-build-class-total",
+    "dm-player-build-class-coef",
+  ]) expect(studio).toContain(`id=\"${id}\"`);
+
+  expect(studio).toContain('const BUILD_RULES_SRC = "js/character-build-rules.js"');
+  expect(studio).toContain('"characterBuild/classes": buildCalculation.classes');
+  expect(studio).toContain('"characterBuild/backgroundId": buildCalculation.backgroundId');
+  expect(studio).toContain('"characterBuild/raceId": buildCalculation.raceId');
+  expect(studio).toContain('"classModifiers/offensiveLevel": offensive.classModifier');
+  expect(studio).toContain('"classModifiers/defensiveLevel": defensive.classModifier');
+  expect(studio).toContain('"raceModifiers/defensiveLevel": defensive.raceModifier');
+  expect(studio).toContain('"combatStats/hp_base": hpBase');
+  expect(studio).toContain('"combatStats/hp_coefficient": hpCoef');
+  expect(studio).toContain('if (buildCalculation && !buildCalculation.valid)');
+  expect(studio).toContain('"LEGACY / MANUAL"');
+});

--- a/tests/character_build_rules.spec.js
+++ b/tests/character_build_rules.spec.js
@@ -70,7 +70,7 @@ test("multiclase usa promedio ponderado y redondeo simétrico para OFF / DEF", (
   closeTo(result.classOffModRaw, 40 / 35);
   closeTo(result.classDefModRaw, -10 / 35);
   expect(result.classOffMod).toBe(1);
-  expect(result.classDefMod).toBe(0);
+  expect(Math.abs(result.classDefMod)).toBe(0);
   expect(rules.symmetricRound(-1.5)).toBe(-2);
   expect(rules.symmetricRound(1.5)).toBe(2);
 });


### PR DESCRIPTION
## Resumen

Integra el draft de reglas acordado en el editor DM de jugadores sin reemplazar el esquema legacy.

### Añade
- Catálogo data-driven con las 13 clases y sus HP/5, HP Coef, OFF y DEF.
- Catálogo de 16 razas del setup: Humano como baseline/default, las razas Homebrew y Yuan-ti Pura Sangre con subrazas/variantes.
- Humano es neutral: HP Coef +0.00, OFF 0, DEF 0.
- Las subrazas se suman dentro de la capa racial (`RaceCoef = RaceBase + Subrace`, `RaceDEF = RaceBaseDEF + SubraceDEF`) y nunca aportan OFF permanente.
- Catálogo amplio de trasfondos adaptados al mundo Project Moon con bono de HP Coef.
- Multiclase por promedio ponderado.
- OFF de clase con rango definido por catálogo; las razas nunca aportan OFF permanente.
- DEF racial excepcional (por ahora Goliat y Warforged).
- HP Base a partir de nivel, CON y HP/5 ponderado.
- HP Coef natural = Clase + Trasfondo + Raza/Subraza, con cap 3.40.
- Persistencia canónica en `characterBuild/*`.

### Default de raza sin migración automática
- El selector del Character Build muestra **Humano · DEFAULT** de forma inicial.
- Esa selección visual por sí sola **no activa** `AUTO / BUILD V1`.
- Un jugador antiguo sin `characterBuild` conserva `LEGACY / MANUAL` al abrir el editor.
- Cuando el DM empieza a asignar clases/trasfondo, Humano funciona como raza válida por defecto.
- Cambiar explícitamente a otra raza sí cuenta como haber iniciado el build.
- Si la raza elegida tiene subrazas/variantes, el build queda incompleto hasta seleccionar una.

### Compatibilidad con Jugador
- Un jugador sin `characterBuild` conserva el modo `LEGACY / MANUAL`.
- Un build parcial no sobrescribe HP/OFF/DEF y bloquea el guardado hasta completarse.
- Un build completo sigue escribiendo los campos legacy (`hp_base`, `hp_coefficient`, `classModifiers`, `combatLevels`, `combatStats`) para no romper consumidores existentes.
- La hoja del jugador continúa leyendo HP máximo desde `combatStats.hp_max` con fallback a `hp_max`.
- El HUD del jugador consume `combatLevels.defensive.raceModifier` / `raceModifiers.defensiveLevel` para DEF.
- OFF del jugador ignora explícitamente cualquier `raceModifier`, manteniendo la regla de no OFF racial.
- El editor DM de D&D sólo se carga en `#dashboard-jugadores`; no se inyecta en la hoja del jugador.
- XP sigue siendo la fuente del Level actual; los niveles de clase deben sumar ese Level.

### Ejemplos cubiertos por test
**Humano / Guerrero 10 / Chef / CON 10**
- Race Coef: +0.00
- Race DEF: 0
- HP Coef natural: 2.99
- OFF: 11
- DEF: 11
- HP Base: 20
- HP Max: 53

**Pícaro 15 / Hechicero 20 / Chef / Yuan-ti Pura Sangre (Ojos Verdes)**
- Class Coef: 2.745714...
- HP Coef natural: 2.905714...
- OFF: 37
- DEF: 33
- HP Base: 62
- HP Max: 158

También hay regresiones específicas para Warforged Juggernaut (`+0.12 +0.04 = +0.16`) y Felinae Grande (`+0.02 +0.04 = +0.06`) sin contaminar OFF.

### Pruebas
El workflow dedicado valida sintaxis de:
- `js/character-build-rules.js`
- `js/dm-player-dnd-studio.js`
- `js/player-stats-ability-bar.js`
- `tests/character_build_rules.spec.js`

Además ejecuta regresiones de cálculo, Humano default, subrazas, compatibilidad legacy y consumo del lado Jugador. La corrida actual pasa **13/13 tests**.