### PR TITLE
Feat: agrega raza Lanae al Character Build

### DIFF
--- a/js/character-build-rules.js
+++ b/js/character-build-rules.js
@@ -32,6 +32,7 @@
     { id: "kenku", name: "Kenku", hpCoefBonus: 0.00, defMod: 0, tags: ["organic", "humanoid", "avian"] },
     { id: "centaur", name: "Centauro", hpCoefBonus: 0.07, defMod: 0, tags: ["organic", "humanoid", "equine", "large_build"] },
     { id: "goliath", name: "Goliat", hpCoefBonus: 0.10, defMod: 1, tags: ["organic", "humanoid", "large_build", "mountain_adapted"] },
+    { id: "lanae", name: "Lanae", hpCoefBonus: 0.06, defMod: 0, tags: ["organic", "humanoid", "lanae", "mountain_adapted"] },
     { id: "goblin", name: "Goblin", hpCoefBonus: 0.02, defMod: 0, tags: ["organic", "humanoid", "goblinoid", "small"] },
     { id: "fairy", name: "Hada", hpCoefBonus: 0.00, defMod: 0, tags: ["organic", "humanoid", "fae", "arcane_core"], subtypes: [
       { id: "fire", name: "Fuego", hpCoefBonus: 0.00, defMod: 0 },

--- a/tests/character_build_rules.spec.js
+++ b/tests/character_build_rules.spec.js
@@ -27,13 +27,15 @@ function loadPlayerStatsApi() {
   return window.LuminousPlayerStats;
 }
 
-test("catálogos contienen las 13 clases, 16 razas y trasfondos Project Moon", () => {
+test("catálogos contienen las 13 clases, 17 razas y trasfondos Project Moon", () => {
   expect(rules.CLASSES).toHaveLength(13);
-  expect(rules.RACES).toHaveLength(16);
+  expect(rules.RACES).toHaveLength(17);
   expect(rules.BACKGROUNDS.length).toBeGreaterThanOrEqual(140);
   expect(rules.SETTINGS.defaultRaceId).toBe("human");
   expect(rules.RACES[0].id).toBe("human");
   expect(rules.getRace("human")).toMatchObject({ name: "Humano", hpCoefBonus: 0, defMod: 0, isDefault: true });
+  expect(rules.getRace("lanae")).toMatchObject({ name: "Lanae", hpCoefBonus: 0.06, defMod: 0 });
+  expect(rules.getRace("lanae")?.tags).toContain("mountain_adapted");
   expect(rules.getClass("rogue")?.hpCoefBase).toBe(2.78);
   expect(rules.getClass("sorcerer")?.offMod).toBe(2);
   expect(rules.getRace("yuan_ti_pureblood")?.hpCoefBonus).toBe(0.03);
@@ -44,6 +46,7 @@ test("las razas no aportan OFF permanente y DEF racial queda excepcional", () =>
   expect(rules.SETTINGS.raceOffModifier).toBe(0);
   for (const race of rules.RACES) expect(race.offMod).toBeUndefined();
   expect(rules.getRace("human")?.defMod).toBe(0);
+  expect(rules.getRace("lanae")?.defMod).toBe(0);
   expect(rules.getRace("goliath")?.defMod).toBe(1);
   expect(rules.getRace("warforged")?.defMod).toBe(1);
   expect(rules.getRace("yuan_ti_pureblood")?.defMod).toBe(0);
@@ -68,6 +71,28 @@ test("Humano es el baseline neutral y no altera HP Coef, OFF ni DEF", () => {
   expect(result.defLevel).toBe(11);
   expect(result.hpBase).toBe(20);
   expect(result.hp).toBe(53);
+});
+
+test("Lanae aporta resistencia natural moderada sin OFF ni DEF permanente", () => {
+  const result = rules.calculateBuild({
+    level: 10,
+    constitution: 10,
+    classes: [{ classId: "fighter", levels: 10 }],
+    backgroundId: "chef",
+    raceId: "lanae",
+  });
+
+  expect(result.valid).toBe(true);
+  expect(result.raceId).toBe("lanae");
+  expect(result.raceSubtypeId).toBeNull();
+  closeTo(result.raceHpCoefBonus, 0.06);
+  expect(result.raceDefMod).toBe(0);
+  closeTo(result.intrinsicHpCoef, 3.05);
+  expect(result.classOffMod).toBe(1);
+  expect(result.offLevel).toBe(11);
+  expect(result.defLevel).toBe(11);
+  expect(result.hpBase).toBe(20);
+  expect(result.hp).toBe(54);
 });
 
 test("subrazas se suman dentro de la capa racial sin aportar OFF", () => {


### PR DESCRIPTION
## Resumen

Agrega la raza **Lanae** al catálogo data-driven del Character Build que ya está en `main`.

### Lanae
Basado en el Homebrew aportado para Luminos Anima:
- HP Coef racial: **+0.06**
- OFF racial permanente: **0**
- DEF racial permanente: **0**
- Tags: `organic`, `humanoid`, `lanae`, `mountain_adapted`

El +0.06 representa su constitución y adaptación natural a un entorno montañoso exigente sin convertir sus otros rasgos en estadísticas planas. La resistencia al frío, aclimatación, velocidad de escalada, magia Lanae, inmunidad al sueño, Resiliencia Comunitaria y cuernos quedan reservados para la futura capa de Passives / Skills raciales.

### Regresión
- El catálogo pasa de 16 a **17 razas**.
- Se valida que Lanae aporte +0.06 HP Coef y 0 DEF.
- Se valida que no exista OFF racial permanente.
- Ejemplo cubierto: Guerrero 10 / Chef / CON 10 / Lanae → HP Coef natural 3.05, OFF 11, DEF 11, HP Base 20, HP Max 54.

### Alcance
Este PR sólo modifica:
- `js/character-build-rules.js`
- `tests/character_build_rules.spec.js`

No cambia el editor ni el esquema persistido, porque el selector de razas ya consume el catálogo automáticamente.