### PR TITLE
Fix Theatre identity and viewer-scoped sprite visibility

### DIFF
--- a/hoja_personaje.js
+++ b/hoja_personaje.js
@@ -1364,9 +1364,27 @@ function initializeCharacterSheet() {
           return;
         }
 
+        const resolveCanonicalIdentityText = window.LuminousTheatreState?.resolveCanonicalIdentityText || ((...values) => {
+          for (const value of values) {
+            const candidate = typeof value === "string" ? value.trim() : "";
+            if (candidate && !/^\?{3,}$/.test(candidate)) return candidate;
+          }
+          return "";
+        });
+
         let actorParaEnviar = {
-            nombre: actorAssigned.nombre || window.datosJugador?.characterName || "Jugador",
-            titulo: actorAssigned.titulo || "",
+            nombre: resolveCanonicalIdentityText(
+              actorAssigned.nombre,
+              window.datosJugador?.characterName,
+              window.datosJugador?.character_name,
+              window.datosJugador?.nombre,
+              window.datosJugador?.name
+            ) || "Jugador",
+            titulo: resolveCanonicalIdentityText(
+              actorAssigned.titulo,
+              window.datosJugador?.titulo,
+              window.datosJugador?.title
+            ),
             color_nombre: actorAssigned.color_nombre || "#ffffff",
             color_titulo: actorAssigned.color_titulo || DEFAULT_TITLE_COLOR,
             escala: actorAssigned.escala !== undefined ? parseFloat(actorAssigned.escala) : 1.0,

--- a/js/theatre-engine.js
+++ b/js/theatre-engine.js
@@ -83,6 +83,92 @@
         return [value].filter(Boolean);
     }
 
+    function normalizeAssignedActorIds(value) {
+        const result = [];
+        const add = (candidate) => {
+            if (candidate === undefined || candidate === null || candidate === false) return;
+            const normalized = String(candidate).trim();
+            if (!normalized || normalized === "true" || normalized === "false" || result.includes(normalized)) return;
+            result.push(normalized);
+        };
+        const visit = (candidate) => {
+            if (candidate === undefined || candidate === null || candidate === false) return;
+            if (Array.isArray(candidate)) {
+                candidate.forEach(visit);
+                return;
+            }
+            if (typeof candidate !== "object") {
+                add(candidate);
+                return;
+            }
+
+            if (candidate.actorId !== undefined) add(candidate.actorId);
+            if (candidate.id !== undefined) add(candidate.id);
+            Object.entries(candidate).forEach(([key, entry]) => {
+                if (key === "actorId" || key === "id") return;
+                if (entry === true || entry === 1) add(key);
+                else if (typeof entry === "string" || typeof entry === "number") add(entry);
+                else if (entry && typeof entry === "object") visit(entry);
+            });
+        };
+        visit(value);
+        return result;
+    }
+
+    function cleanIdentityText(value) {
+        const candidate = typeof value === "string" ? value.trim() : "";
+        return candidate && !/^\?{3,}$/.test(candidate) ? candidate : "";
+    }
+
+    function resolveCanonicalIdentityText(...values) {
+        for (const value of values) {
+            const candidate = cleanIdentityText(value);
+            if (candidate) return candidate;
+        }
+        return "";
+    }
+
+    function resolveIdentityPresentation(options) {
+        const input = options || {};
+        const dialogData = input.dialogData || {};
+        const actor = input.actor || {};
+        const ownActor = input.ownActor || {};
+        const override = input.override || {};
+        const actorId = dialogData.actorId || null;
+        const type = dialogData.tipo_dialogo || "dialogo";
+
+        if (!actorId || type === "narracion" || type === "pensamiento" || dialogData.mostrar_identidad === false) {
+            return { visible: false, known: false, name: "", title: "" };
+        }
+
+        const privileged = input.isDm === true || input.isOwnActor === true;
+        const known = privileged || input.known === true;
+        const realName = resolveCanonicalIdentityText(
+            input.isOwnActor ? ownActor.nombre || ownActor.name : "",
+            actor.nombre || actor.name,
+            dialogData.nombre || dialogData.name
+        ) || "???";
+        const realTitle = resolveCanonicalIdentityText(
+            input.isOwnActor ? ownActor.titulo || ownActor.title : "",
+            actor.titulo || actor.title,
+            dialogData.titulo || dialogData.title
+        ) || "???";
+
+        // The DM and the player controlling the actor always keep canonical self-knowledge.
+        // Temporary nameplate overrides are presentation for other viewers, never censorship
+        // of the director or of the actor's owner.
+        if (privileged) {
+            return { visible: true, known: true, name: realName, title: realTitle };
+        }
+
+        return {
+            visible: true,
+            known,
+            name: override.nombre ?? override.name ?? (known ? realName : "???"),
+            title: override.titulo ?? override.title ?? (known ? realTitle : "???")
+        };
+    }
+
     function getVisibleLimit(scene) {
         return clampVisibleLimit(
             scene && (scene.max_actores_visibles ?? scene.maxVisibleActors ?? scene.config?.maxVisibleActors)
@@ -143,9 +229,72 @@
         return actor?.actorId || actor?.id || global.assignedActorId || null;
     }
 
-    function shouldShowOwnActor() {
+    function comparableId(value) {
+        if (value === undefined || value === null) return "";
+        return String(value).trim();
+    }
+
+    function stableActorId(actor, fallback) {
+        return comparableId(actor?.identityId || actor?.identidadId || actor?.sourceActorId || actor?.sourceId || actor?.actorId || actor?.id || fallback);
+    }
+
+    function actorsMatch(leftActor, leftFallback, rightActor, rightFallback) {
+        const leftIds = [
+            stableActorId(leftActor, leftFallback),
+            comparableId(leftActor?.actorId),
+            comparableId(leftActor?.id),
+            comparableId(leftFallback)
+        ].filter(Boolean);
+        const rightIds = new Set([
+            stableActorId(rightActor, rightFallback),
+            comparableId(rightActor?.actorId),
+            comparableId(rightActor?.id),
+            comparableId(rightFallback)
+        ].filter(Boolean));
+        return leftIds.some((id) => rightIds.has(id));
+    }
+
+    function getAssignedActorIds() {
+        const ids = [];
+        const addAll = (value) => {
+            normalizeAssignedActorIds(value).forEach((id) => {
+                if (!ids.includes(id)) ids.push(id);
+            });
+        };
+        const assignedActor = getAssignedTheatreActor();
+        addAll([assignedActor?.actorId, assignedActor?.id, assignedActor?.identityId, assignedActor?.identidadId]);
+        [currentViewerProfile?.actorIds, currentViewerProfile?.actores, currentViewerProfile?.actorId]
+            .forEach(addAll);
+        [global.datosJugador?.actorIds, global.datosJugador?.actores, global.datosJugador?.actorId, global.datosJugador?.vinculo_jugador]
+            .forEach(addAll);
+        addAll(global.assignedActorId);
+        return ids;
+    }
+
+    function getSelfVisibilityViewerKey(viewerKey) {
+        if (viewerKey) return comparableId(viewerKey);
+        const authUser = getCurrentAuthUser();
+        return comparableId(
+            currentViewerKey ||
+            authUser?.uid ||
+            global.playerId ||
+            global.datosJugador?.playerId ||
+            global.datosJugador?.id ||
+            global.datosJugador?.nombre ||
+            "local"
+        );
+    }
+
+    function getSelfVisibilityStorageKey(viewerKey, actorId) {
+        const viewer = getSelfVisibilityViewerKey(viewerKey) || "local";
+        const sceneActor = currentScene?.actores?.[actorId] || {};
+        const actor = stableActorId(sceneActor, actorId || getAssignedActorId()) || "unassigned";
+        return `${LOCAL_SHOW_SELF_KEY}.${encodeURIComponent(viewer)}.${encodeURIComponent(actor)}`;
+    }
+
+    function shouldShowOwnActor(actorId, viewerKey) {
         try {
-            return global.localStorage?.getItem(LOCAL_SHOW_SELF_KEY) === "true";
+            return global.localStorage?.getItem(getSelfVisibilityStorageKey(viewerKey, actorId)) === "true";
         } catch (error) {
             return false;
         }
@@ -170,9 +319,8 @@
             return actor && getValidSpriteUrl(actor.url || actor.sprite);
         });
 
-        if (!isDmView() && !shouldShowOwnActor()) {
-            const ownId = getAssignedActorId();
-            if (ownId) ids = ids.filter((id) => id !== ownId);
+        if (!isDmView()) {
+            ids = ids.filter((actorId) => !isOwnActorIdentity(actorId) || shouldShowOwnActor(actorId));
         }
 
         return ids;
@@ -212,8 +360,8 @@
 
         if (assignedActorId) {
             for (const [playerId, player] of Object.entries(playerDatabase)) {
-                const actorIds = normalizeIdList(player.actorIds || player.actores || player.actorId);
-                if (actorIds.includes(assignedActorId)) {
+                const actorIds = normalizeAssignedActorIds([player.actorIds, player.actores, player.actorId]);
+                if (actorIds.includes(comparableId(assignedActorId))) {
                     return { key: playerId, profile: player };
                 }
             }
@@ -240,7 +388,7 @@
         currentIdentityKnowledge = {};
 
         if (!currentViewerKey || currentViewerKey === "__dm__") {
-            renderDialogue(currentDialogue);
+            renderScene(currentScene);
             return;
         }
 
@@ -250,24 +398,42 @@
             renderDialogue(currentDialogue);
         };
         currentKnowledgeRef.on("value", currentKnowledgeListener);
+        renderScene(currentScene);
     }
 
     function actorIdentityKey(actorId) {
         if (!actorId) return null;
         const actor = currentScene?.actores?.[actorId] || {};
-        return actor.identityId || actor.identidadId || actor.sourceId || actorId;
+        return stableActorId(actor, actorId) || null;
     }
 
     function isOwnActorIdentity(actorId) {
         if (!actorId) return false;
-        const ownId = getAssignedActorId();
-        if (ownId && ownId === actorId) return true;
-
         const actor = currentScene?.actores?.[actorId] || {};
         const ownActor = getAssignedTheatreActor() || {};
-        const ownStableId = ownActor.identityId || ownActor.identidadId || ownActor.sourceId || ownActor.actorId || ownActor.id;
-        const stableId = actor.identityId || actor.identidadId || actor.sourceId || actorId;
-        return Boolean(ownStableId && stableId === ownStableId);
+        const ownId = getAssignedActorId();
+        if (actorsMatch(actor, actorId, ownActor, ownId)) return true;
+
+        const sceneIds = new Set([
+            comparableId(actorId),
+            stableActorId(actor, actorId),
+            comparableId(actor.actorId),
+            comparableId(actor.id)
+        ].filter(Boolean));
+        return getAssignedActorIds().some((id) => sceneIds.has(comparableId(id)));
+    }
+
+    function getOwnActorForIdentity(actorId) {
+        const sceneActor = currentScene?.actores?.[actorId] || {};
+        const selected = getAssignedTheatreActor() || {};
+        if (actorsMatch(sceneActor, actorId, selected, getAssignedActorId())) return selected;
+
+        const actorPool = global.actoresJugador || global.allActoresCache || {};
+        for (const assignedId of getAssignedActorIds()) {
+            const candidate = actorPool[assignedId];
+            if (candidate && actorsMatch(sceneActor, actorId, candidate, assignedId)) return candidate;
+        }
+        return {};
     }
 
     function isIdentityKnown(actorId) {
@@ -292,27 +458,17 @@
 
     function resolvePlateIdentity(dialogData) {
         const actorId = dialogData?.actorId || null;
-        const type = dialogData?.tipo_dialogo || "dialogo";
-        if (!actorId || type === "narracion") {
-            return { visible: false, known: false, name: "", title: "" };
-        }
-
-        if (type === "pensamiento" || dialogData?.mostrar_identidad === false) {
-            return { visible: false, known: false, name: "", title: "" };
-        }
-
         const actor = currentScene?.actores?.[actorId] || {};
-        const known = isIdentityKnown(actorId);
-        const override = getNameplateOverride(actorId) || {};
-        const realName = dialogData?.nombre || actor.nombre || "???";
-        const realTitle = dialogData?.titulo || actor.titulo || "???";
-
-        return {
-            visible: true,
-            known,
-            name: override.nombre ?? override.name ?? (known ? realName : "???"),
-            title: override.titulo ?? override.title ?? (known ? realTitle : "???")
-        };
+        const own = isOwnActorIdentity(actorId);
+        return resolveIdentityPresentation({
+            dialogData,
+            actor,
+            ownActor: own ? getOwnActorForIdentity(actorId) : {},
+            known: isIdentityKnown(actorId),
+            isDm: isDmView(),
+            isOwnActor: own,
+            override: getNameplateOverride(actorId) || {}
+        });
     }
 
     function extractLanguageKnowledge(profile, languageId) {
@@ -473,8 +629,21 @@
         });
     }
 
+    function syncSelfVisibilityControl() {
+        const checkbox = document.getElementById("theatre-show-own-actor");
+        if (!checkbox) return;
+        const actorId = getAssignedActorId();
+        checkbox.dataset.actorId = comparableId(actorId);
+        checkbox.disabled = !actorId;
+        checkbox.checked = actorId ? shouldShowOwnActor(actorId) : false;
+    }
+
     function ensureSelfVisibilityControl() {
-        if (isDmView() || document.getElementById("theatre-self-visibility-control")) return;
+        if (isDmView()) return;
+        if (document.getElementById("theatre-self-visibility-control")) {
+            syncSelfVisibilityControl();
+            return;
+        }
         const theatre = document.getElementById("theatre-view-player");
         if (!theatre) return;
 
@@ -485,8 +654,10 @@
         theatre.appendChild(label);
 
         const checkbox = label.querySelector("#theatre-show-own-actor");
-        checkbox.checked = shouldShowOwnActor();
-        checkbox.addEventListener("change", () => setShowOwnActor(checkbox.checked));
+        syncSelfVisibilityControl();
+        checkbox.addEventListener("change", () => {
+            setShowOwnActor(checkbox.checked, checkbox.dataset.actorId || getAssignedActorId());
+        });
     }
 
     function removeLegacyPrototypePanels() {
@@ -740,6 +911,13 @@
 
         const type = message?.tipo_dialogo || "dialogo";
         const active = Boolean(message?.actorId && type !== "pensamiento" && type !== "narracion");
+        const sceneActor = message?.actorId ? (scene?.actores?.[message.actorId] || {}) : {};
+        const canonicalName = type === "narracion"
+            ? ""
+            : resolveCanonicalIdentityText(sceneActor.nombre, message?.nombre);
+        const canonicalTitle = type === "narracion"
+            ? ""
+            : resolveCanonicalIdentityText(sceneActor.titulo, message?.titulo);
         if (active) {
             await updateVisibleActors(message.actorId, message);
             await revealPreparedExpression(message.actorId, message.expression, message.sprite);
@@ -747,8 +925,8 @@
 
         const activePayload = {
             messageId: messageId || null,
-            nombre: message?.nombre || "",
-            titulo: message?.titulo || "",
+            nombre: canonicalName,
+            titulo: canonicalTitle,
             mensaje: message?.mensaje || "",
             actorId: message?.actorId || null,
             expression: message?.expression || "Neutral",
@@ -885,9 +1063,12 @@
         return true;
     }
 
-    function setShowOwnActor(show) {
+    function setShowOwnActor(show, actorId, viewerKey) {
         try {
-            global.localStorage?.setItem(LOCAL_SHOW_SELF_KEY, show ? "true" : "false");
+            global.localStorage?.setItem(
+                getSelfVisibilityStorageKey(viewerKey, actorId || getAssignedActorId()),
+                show ? "true" : "false"
+            );
         } catch (error) {}
         renderScene(currentScene);
     }
@@ -1050,7 +1231,16 @@
         bindIdentityKnowledge();
     });
 
-    global.addEventListener("actoresCacheUpdated", installPlayerComposerCompatibility);
+    global.addEventListener("actoresCacheUpdated", () => {
+        installPlayerComposerCompatibility();
+        syncSelfVisibilityControl();
+        renderScene(currentScene);
+    });
+    document.addEventListener("change", (event) => {
+        if (event.target?.id !== "player-actor-select") return;
+        syncSelfVisibilityControl();
+        renderScene(currentScene);
+    });
     document.addEventListener("click", (event) => {
         if (event.target?.closest?.("#btn-abrir-escritura")) installPlayerComposerCompatibility();
     }, true);
@@ -1058,11 +1248,13 @@
     bindRoom(activeRoomId);
 
     global.LuminousTheatreState = {
-        normalizeAssignedActorIds: normalizeIdList,
+        normalizeAssignedActorIds,
         clampVisibleLimit,
         clampPercentage,
         getVisibleLimit,
         getRenderIds,
+        resolveCanonicalIdentityText,
+        resolveIdentityPresentation,
         getPaths,
         resolveRoomPaths,
         setRoom,
@@ -1083,6 +1275,7 @@
         messageIsStaleForScene,
         setShowOwnActor,
         getShowOwnActor: shouldShowOwnActor,
+        getSelfVisibilityStorageKey,
         getViewerKey: () => currentViewerKey,
         getViewerProfile: () => currentViewerProfile,
         getLanguageDefinitions: () => Object.assign({}, languageDatabase)

--- a/js/theatre-modern-identity-hotfix.js
+++ b/js/theatre-modern-identity-hotfix.js
@@ -76,6 +76,16 @@
     return result;
   }
 
+  function resolveCanonicalIdentityText(...values) {
+    const resolver = global.LuminousTheatreState?.resolveCanonicalIdentityText;
+    if (typeof resolver === "function") return resolver(...values);
+    for (const value of values) {
+      const candidate = typeof value === "string" ? value.trim() : "";
+      if (candidate && !/^\?{3,}$/.test(candidate)) return candidate;
+    }
+    return "";
+  }
+
   function playerProfile() {
     return global.datosJugador && typeof global.datosJugador === "object"
       ? global.datosJugador
@@ -190,14 +200,14 @@
       sourceId,
       sourceType: actor.sourceType || (record?.source === "legacy-assigned" ? "player-profile" : "player-profile"),
       identityId,
-      nombre:
-        actor.nombre ||
-        data.characterName ||
-        data.character_name ||
-        data.nombre ||
-        data.name ||
-        "Jugador",
-      titulo: actor.titulo || data.titulo || data.title || "",
+      nombre: resolveCanonicalIdentityText(
+        actor.nombre,
+        data.characterName,
+        data.character_name,
+        data.nombre,
+        data.name
+      ) || "Jugador",
+      titulo: resolveCanonicalIdentityText(actor.titulo, data.titulo, data.title),
       icono: actor.icono || actor.icono_jugador || data.icono || data.icono_jugador || "",
       icono_jugador: actor.icono_jugador || data.icono_jugador || data.icono || "",
       sprite: actor.sprite || actor.url || "",

--- a/tests/theatre_hud_detail_patch.spec.js
+++ b/tests/theatre_hud_detail_patch.spec.js
@@ -37,13 +37,13 @@ test("patch: color personalizado se aplica al fondo y borde, no al texto", () =>
 });
 
 test("patch: narrador nunca muestra identidad", () => {
-  expect(engine).toContain('if (!actorId || type === "narracion")');
+  expect(engine).toContain('if (!actorId || type === "narracion" || type === "pensamiento" || dialogData.mostrar_identidad === false)');
   expect(dashboard).toContain('type = "narracion";');
   expect(dashboard).toContain('mostrar_identidad: actorDialogue');
 });
 
 test("patch: pensamiento nunca muestra identidad", () => {
-  expect(engine).toContain('if (type === "pensamiento" || dialogData?.mostrar_identidad === false)');
+  expect(engine).toContain('if (!actorId || type === "narracion" || type === "pensamiento" || dialogData.mostrar_identidad === false)');
   expect(dashboard).toContain('mostrar_identidad: actorDialogue');
   expect(playerJs).toContain('const mostrarIdentidad = tipoDialogo !== "pensamiento";');
 });

--- a/tests/theatre_issue_511.spec.js
+++ b/tests/theatre_issue_511.spec.js
@@ -64,7 +64,8 @@ test("#511: No Actors and own-sprite hiding are render-only preferences", () => 
   expect(engine).toContain('const LOCAL_SHOW_SELF_KEY = "luminous.theatre.showOwnActor"');
   expect(engine).toContain("global.localStorage?.setItem");
   expect(engine).toContain('label.id = "theatre-self-visibility-control"');
-  expect(engine).toContain("if (!isDmView() && !shouldShowOwnActor())");
+  expect(engine).toContain("getSelfVisibilityStorageKey(viewerKey, actorId)");
+  expect(engine).toContain("!isOwnActorIdentity(actorId) || shouldShowOwnActor(actorId)");
 });
 
 test("#511: identity knowledge is per viewer and temporary nameplate presentation is separate", () => {

--- a/tests/theatre_realtime.spec.js
+++ b/tests/theatre_realtime.spec.js
@@ -312,7 +312,7 @@ test("el narrador y pensamientos no envían identidad ni modifican sprites", () 
   expect(dashboardScript).toContain('expression: actorDialogue ? speaker.expression : null');
   expect(dashboardScript).toContain('sprite: actorDialogue ? speaker.sprite : null');
   expect(dashboardScript).toContain('mostrar_identidad: actorDialogue');
-  expect(engineScript).toContain('if (type === "pensamiento" || dialogData?.mostrar_identidad === false)');
+  expect(engineScript).toContain('if (!actorId || type === "narracion" || type === "pensamiento" || dialogData.mostrar_identidad === false)');
 });
 
 test("el composer del jugador muestra selector solo cuando hay mas de un personaje", () => {

--- a/tests/theatre_viewer_scope.spec.js
+++ b/tests/theatre_viewer_scope.spec.js
@@ -1,0 +1,252 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const engineSource = fs.readFileSync(
+  path.join(__dirname, "..", "js", "theatre-engine.js"),
+  "utf8",
+);
+const playerSource = fs.readFileSync(
+  path.join(__dirname, "..", "hoja_personaje.js"),
+  "utf8",
+);
+const modernIdentitySource = fs.readFileSync(
+  path.join(__dirname, "..", "js", "theatre-modern-identity-hotfix.js"),
+  "utf8",
+);
+
+function loadEngine(scene = {}, options = {}) {
+  const writes = [];
+  const storage = options.storage || new Map();
+
+  const makeRef = (refPath = "") => ({
+    key: "test-message",
+    on(event, callback) {
+      if (event === "value" && refPath === "campaña/estado_mundo/escena_actual") {
+        callback({ val: () => scene });
+      }
+    },
+    off() {},
+    limitToLast() { return this; },
+    once: async () => ({
+      val: () => refPath === "campaña/estado_mundo/escena_actual" ? scene : {},
+    }),
+    push() { return makeRef(`${refPath}/test-message`); },
+    set: async (value) => { writes.push(["set", refPath, value]); },
+    update: async (value) => { writes.push(["update", refPath, value]); },
+    remove: async () => { writes.push(["remove", refPath]); },
+    transaction: async (callback) => callback(null),
+  });
+
+  const db = { ref: (refPath) => makeRef(refPath) };
+  const database = () => db;
+  database.ServerValue = { TIMESTAMP: 1234 };
+  const auth = () => ({ currentUser: null, onAuthStateChanged() {} });
+
+  const document = {
+    baseURI: "https://example.test/hoja_personaje.html",
+    body: {
+      dataset: {},
+      classList: { contains: (name) => options.dm === true && name === "on-game-dashboard" },
+    },
+    addEventListener() {},
+    getElementById() { return null; },
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+  };
+
+  const window = {
+    document,
+    firebase: { database, auth },
+    localStorage: {
+      getItem: (key) => storage.has(key) ? storage.get(key) : null,
+      setItem: (key, value) => storage.set(key, String(value)),
+    },
+    location: { href: "https://example.test/hoja_personaje.html" },
+    CSS: { supports: () => true },
+    playerId: options.viewerKey || null,
+    datosJugador: options.playerData || null,
+    getAssignedTheatreActor: () => options.assignedActor || null,
+    addEventListener() {},
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+  };
+  window.window = window;
+  window.globalThis = window;
+
+  vm.runInNewContext(engineSource, {
+    window,
+    document,
+    URL,
+    console,
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+  });
+
+  return { theatre: window.LuminousTheatreState, writes, storage };
+}
+
+test("la identidad canónica ignora ??? para el DM y para el actor propio", () => {
+  const { theatre } = loadEngine();
+  const message = {
+    actorId: "so-live",
+    nombre: "???",
+    titulo: "???",
+    tipo_dialogo: "dialogo",
+    mostrar_identidad: true,
+  };
+  const sceneActor = {
+    actorId: "so-live",
+    identityId: "so",
+    nombre: "So",
+    titulo: "Fixer",
+  };
+
+  const dm = theatre.resolveIdentityPresentation({
+    dialogData: message,
+    actor: sceneActor,
+    isDm: true,
+    override: { nombre: "???", titulo: "???" },
+  });
+  expect(dm).toMatchObject({ visible: true, known: true, name: "So", title: "Fixer" });
+
+  const owner = theatre.resolveIdentityPresentation({
+    dialogData: message,
+    actor: { ...sceneActor, nombre: "???", titulo: "???" },
+    ownActor: { actorId: "so", nombre: "So", titulo: "Fixer" },
+    isOwnActor: true,
+    override: { nombre: "???", titulo: "???" },
+  });
+  expect(owner).toMatchObject({ visible: true, known: true, name: "So", title: "Fixer" });
+});
+
+test("solo el espectador desconocido recibe ???", () => {
+  const { theatre } = loadEngine();
+  const input = {
+    dialogData: {
+      actorId: "so-live",
+      nombre: "So",
+      titulo: "Fixer",
+      tipo_dialogo: "dialogo",
+      mostrar_identidad: true,
+    },
+    actor: { nombre: "So", titulo: "Fixer" },
+  };
+
+  expect(theatre.resolveIdentityPresentation({ ...input, known: false }))
+    .toMatchObject({ visible: true, known: false, name: "???", title: "???" });
+  expect(theatre.resolveIdentityPresentation({ ...input, known: true }))
+    .toMatchObject({ visible: true, known: true, name: "So", title: "Fixer" });
+});
+
+test("narración y pensamiento ocultan las placas incluso para el DM", () => {
+  const { theatre } = loadEngine();
+  for (const tipo_dialogo of ["narracion", "pensamiento"]) {
+    expect(theatre.resolveIdentityPresentation({
+      dialogData: {
+        actorId: "so-live",
+        nombre: "So",
+        tipo_dialogo,
+        mostrar_identidad: false,
+      },
+      actor: { nombre: "So" },
+      isDm: true,
+    })).toEqual({ visible: false, known: false, name: "", title: "" });
+  }
+});
+
+test("asignaciones múltiples reconocen arrays, mapas y objetos numéricos", () => {
+  const { theatre } = loadEngine();
+  expect(theatre.normalizeAssignedActorIds(["so", "don"])).toEqual(["so", "don"]);
+  expect(theatre.normalizeAssignedActorIds({ so: true, don: false, faust: 1 }))
+    .toEqual(["so", "faust"]);
+  expect(theatre.normalizeAssignedActorIds({ 0: "so", 1: "don" }))
+    .toEqual(["so", "don"]);
+  expect(theatre.normalizeAssignedActorIds({ actorId: "so" })).toEqual(["so"]);
+});
+
+test("mostrar u ocultar el sprite propio usa preferencias separadas por jugador y actor", () => {
+  const { theatre, writes, storage } = loadEngine();
+  const soKey = theatre.getSelfVisibilityStorageKey("jugadora-so", "so");
+  const otherViewerKey = theatre.getSelfVisibilityStorageKey("jugador-p2", "so");
+  const otherActorKey = theatre.getSelfVisibilityStorageKey("jugadora-so", "don");
+
+  expect(new Set([soKey, otherViewerKey, otherActorKey]).size).toBe(3);
+
+  theatre.setShowOwnActor(true, "so", "jugadora-so");
+  expect(theatre.getShowOwnActor("so", "jugadora-so")).toBe(true);
+  expect(theatre.getShowOwnActor("so", "jugador-p2")).toBe(false);
+  expect(storage.get(soKey)).toBe("true");
+  expect(writes).toEqual([]);
+});
+
+test("ocultar el sprite propio filtra solo la vista del dueño", () => {
+  const scene = {
+    actores_visibles: ["so-live"],
+    actores: {
+      "so-live": {
+        identityId: "so",
+        nombre: "So",
+        sprite: "https://example.test/so.png",
+      },
+    },
+  };
+
+  const owner = loadEngine(scene, {
+    viewerKey: "jugadora-so",
+    assignedActor: { actorId: "so", identityId: "so", nombre: "So" },
+  }).theatre;
+  expect(owner.getRenderIds(scene)).toEqual([]);
+  owner.setShowOwnActor(true, "so-live", "jugadora-so");
+  expect(owner.getRenderIds(scene)).toEqual(["so-live"]);
+
+  const otherPlayer = loadEngine(scene, {
+    viewerKey: "jugador-p2",
+    assignedActor: { actorId: "p2", identityId: "p2", nombre: "P2" },
+  }).theatre;
+  expect(otherPlayer.getRenderIds(scene)).toEqual(["so-live"]);
+
+  const dm = loadEngine(scene, { dm: true }).theatre;
+  expect(dm.getRenderIds(scene)).toEqual(["so-live"]);
+});
+
+test("el compositor conserva identidad canónica y nunca publica ??? como nombre real", () => {
+  expect(playerSource).toContain("resolveCanonicalIdentityText(");
+  expect(modernIdentitySource).toContain("resolveCanonicalIdentityText(");
+  expect(playerSource).not.toMatch(/nombre:\s*actorAssigned\.nombre\s*\|\|/);
+});
+
+test("la publicación repara payloads antiguos enmascarados antes del estado activo y el log", async () => {
+  const { theatre } = loadEngine({
+    actores: {
+      "so-live": { identityId: "so", nombre: "So", titulo: "Fixer" },
+    },
+  });
+
+  const result = await theatre.publishIntervention("message-1", {
+    actorId: "so-live",
+    nombre: "???",
+    titulo: "???",
+    mensaje: "Hola",
+    tipo_dialogo: "dialogo",
+    mostrar_identidad: true,
+  });
+
+  expect(result.payload.nombre).toBe("So");
+  expect(result.payload.titulo).toBe("Fixer");
+});
+
+test("la carga o selección tardía del actor vuelve a resolver identidad y preferencia local", () => {
+  const cacheListener = engineSource.slice(
+    engineSource.indexOf('global.addEventListener("actoresCacheUpdated"'),
+    engineSource.indexOf('document.addEventListener("click"'),
+  );
+  expect(cacheListener).toContain("syncSelfVisibilityControl();");
+  expect(cacheListener).toContain("renderScene(currentScene);");
+  expect(cacheListener).toContain('event.target?.id !== "player-actor-select"');
+});


### PR DESCRIPTION
## Resumen

Parche localizado para separar el estado compartido del Teatro de la presentación por espectador.

- El DM siempre resuelve la identidad canónica de un actor.
- El jugador que controla al actor siempre ve su propio nombre y título reales.
- `???` queda reservado para otros jugadores que todavía no conocen la identidad.
- Los overrides temporales ya no pueden censurar al DM ni al dueño del actor.
- Los payloads antiguos con `???` se reparan desde el actor canónico antes de publicar el diálogo activo y archivarlo.
- Las asignaciones de actores aceptan arrays, mapas booleanos, objetos numéricos y el formato individual legado.
- “Mostrar mi personaje en escena” usa una preferencia local separada por jugador y actor.
- Ocultar el sprite propio no modifica Firebase, `actores_visibles`, LRU, expresión ni la vista del DM o de otros jugadores.
- La identidad y la preferencia local se recalculan cuando carga el actor o cambia la selección.

## Contrato verificado

| Espectador | Nameplate de So |
|---|---|
| DM | Identidad real |
| So, dueña del actor | Identidad real |
| Jugador que ya la descubrió | Identidad real |
| Jugador que no la conoce | `???` |

Al ocultar su sprite, solo So deja de verlo; el DM y los demás jugadores conservan el sprite.

## Pruebas

- Baseline focalizado antes del parche: **73 passed**.
- Suite completa del Teatro después del parche: **105 passed**.
- `node --check` pasó para:
  - `hoja_personaje.js`
  - `js/theatre-engine.js`
  - `js/theatre-modern-identity-hotfix.js`
- `git diff --check`: sin errores.
- Suite completa del repositorio: **204 passed, 6 failed**.
  - Cuatro fallos son aserciones preexistentes de idiomas/estadísticas en archivos no modificados por este PR.
  - Dos pruebas de UI requieren Chromium; el binario no está disponible y su descarga quedó bloqueada en este entorno.

## Alcance

Siete archivos modificados. No incluye dependencias, capturas, resultados de pruebas ni artefactos temporales.