### PR TITLE
Feat: Check HUD local y resultados de tiradas en Theatre

### DIFF
--- a/.github/workflows/theatre-roll-visualizer.yml
+++ b/.github/workflows/theatre-roll-visualizer.yml
@@ -7,6 +7,7 @@ on:
       - "css/theatre-roll-visualizer.css"
       - "js/instance-control.js"
       - "tests/theatre_roll_visualizer.spec.js"
+      - "database.rules.json"
       - ".github/workflows/theatre-roll-visualizer.yml"
   push:
     paths:
@@ -14,6 +15,7 @@ on:
       - "css/theatre-roll-visualizer.css"
       - "js/instance-control.js"
       - "tests/theatre_roll_visualizer.spec.js"
+      - "database.rules.json"
       - ".github/workflows/theatre-roll-visualizer.yml"
 
 jobs:

--- a/.github/workflows/theatre-roll-visualizer.yml
+++ b/.github/workflows/theatre-roll-visualizer.yml
@@ -1,0 +1,31 @@
+name: Theatre Roll Visualizer
+
+on:
+  pull_request:
+    paths:
+      - "js/theatre-roll-visualizer.js"
+      - "css/theatre-roll-visualizer.css"
+      - "js/instance-control.js"
+      - "tests/theatre_roll_visualizer.spec.js"
+      - ".github/workflows/theatre-roll-visualizer.yml"
+  push:
+    paths:
+      - "js/theatre-roll-visualizer.js"
+      - "css/theatre-roll-visualizer.css"
+      - "js/instance-control.js"
+      - "tests/theatre_roll_visualizer.spec.js"
+      - ".github/workflows/theatre-roll-visualizer.yml"
+
+jobs:
+  theatre-roll-visualizer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: node --check js/theatre-roll-visualizer.js
+      - run: node --check js/instance-control.js
+      - run: npx playwright test tests/theatre_roll_visualizer.spec.js

--- a/css/theatre-roll-visualizer.css
+++ b/css/theatre-roll-visualizer.css
@@ -1,0 +1,248 @@
+.theatre-roll-layer{
+  position:absolute;
+  top:clamp(48px,7vh,86px);
+  right:clamp(18px,2.4vw,38px);
+  z-index:7000;
+  width:min(360px,32vw);
+  display:flex;
+  flex-direction:column;
+  align-items:stretch;
+  gap:10px;
+  pointer-events:none;
+}
+.theatre-roll-card{
+  position:relative;
+  box-sizing:border-box;
+  min-width:0;
+  padding:12px 14px 14px;
+  overflow:hidden;
+  border:1px solid rgba(214,181,119,.72);
+  border-left:4px solid #8a1c1c;
+  background:linear-gradient(135deg,rgba(18,17,16,.96),rgba(34,29,24,.94));
+  box-shadow:0 12px 28px rgba(0,0,0,.42);
+  color:#f4ead6;
+  font-family:"Roboto",sans-serif;
+  animation:theatre-roll-enter .24s ease-out both;
+}
+.theatre-roll-card::before{
+  content:"";
+  position:absolute;
+  inset:0 0 auto 0;
+  height:2px;
+  background:linear-gradient(90deg,#8a1c1c,#c6a56d,transparent);
+}
+.theatre-roll-card-header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:10px;
+  margin-bottom:2px;
+}
+.theatre-roll-roller{
+  min-width:0;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+  font-family:"BebasKai","Roboto",sans-serif;
+  font-size:1.05rem;
+  letter-spacing:.08em;
+}
+.theatre-roll-mode{
+  flex:0 0 auto;
+  padding:2px 6px;
+  border:1px solid rgba(214,181,119,.45);
+  color:#d8bc88;
+  font-size:.62rem;
+  letter-spacing:.12em;
+}
+.theatre-roll-label{
+  margin-top:3px;
+  color:#b7aa95;
+  font-size:.72rem;
+  font-weight:700;
+  letter-spacing:.1em;
+  text-transform:uppercase;
+}
+.theatre-roll-coins{
+  display:flex;
+  gap:7px;
+  margin:11px 0 8px;
+}
+.theatre-roll-coin{
+  width:20px;
+  height:20px;
+  box-sizing:border-box;
+  border-radius:50%;
+  border:2px solid #c7a56d;
+  background:#2b2721;
+  box-shadow:inset 0 0 0 2px rgba(0,0,0,.28);
+}
+.theatre-roll-coin[data-side="head"]{
+  background:radial-gradient(circle at 35% 30%,#f2db9f 0 18%,#c29a53 20% 62%,#76552d 64% 100%);
+}
+.theatre-roll-coin[data-side="tail"]{
+  background:radial-gradient(circle at 35% 30%,#7d7568 0 18%,#423d36 20% 62%,#1d1b19 64% 100%);
+  border-color:#8e8373;
+}
+.theatre-roll-coin[data-side="unknown"]{
+  border-style:dashed;
+  opacity:.65;
+}
+.theatre-roll-detail{
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px 12px;
+  color:#d5c6ad;
+  font-family:"Share Tech Mono","Roboto",monospace;
+  font-size:.68rem;
+  letter-spacing:.04em;
+}
+.theatre-roll-total{
+  margin-top:8px;
+  color:#f2d694;
+  font-family:"BebasKai","Roboto",sans-serif;
+  font-size:2.35rem;
+  line-height:.9;
+  letter-spacing:.04em;
+}
+.theatre-roll-total::after{
+  content:" TOTAL";
+  margin-left:6px;
+  color:#8f8372;
+  font-family:"Roboto",sans-serif;
+  font-size:.58rem;
+  font-weight:700;
+  letter-spacing:.12em;
+}
+.theatre-roll-director-note{
+  margin-top:8px;
+  border-top:1px solid rgba(255,255,255,.08);
+  padding-top:6px;
+  color:#b88a7c;
+  font-size:.62rem;
+  font-weight:700;
+  letter-spacing:.08em;
+}
+.theatre-roll-card.is-hidden-result{
+  padding:14px 16px;
+  text-align:center;
+}
+.theatre-roll-hidden-result{
+  margin-top:10px;
+  color:#f0d38d;
+  font-family:"BebasKai","Roboto",sans-serif;
+  font-size:1.65rem;
+  letter-spacing:.08em;
+}
+.theatre-roll-card.is-leaving{
+  animation:theatre-roll-leave .24s ease-in both;
+}
+.theatre-roll-director{
+  margin-bottom:18px;
+  padding:12px;
+  border-top:1px solid #a37c35;
+  border-bottom:1px solid #28231d;
+  background:#090b0e;
+}
+.theatre-roll-director-title{
+  margin-bottom:9px;
+  color:#a37c35;
+  font-family:"BebasKai","Roboto",sans-serif;
+  font-size:.92rem;
+  letter-spacing:.09em;
+}
+.theatre-roll-visibility-buttons{
+  display:grid;
+  grid-template-columns:repeat(3,minmax(0,1fr));
+  gap:6px;
+}
+.theatre-roll-visibility-buttons button{
+  min-width:0;
+  padding:7px 6px;
+  border:1px solid #4c4f52;
+  background:#15191d;
+  color:#d6d2c8;
+  cursor:pointer;
+  font-size:.7rem;
+  font-weight:700;
+  letter-spacing:.05em;
+}
+.theatre-roll-visibility-buttons button.is-active{
+  border-color:#c49a00;
+  background:#5b1717;
+  color:#fff4d2;
+}
+.theatre-roll-hidden-options{
+  display:none;
+  grid-template-columns:repeat(2,minmax(0,1fr));
+  gap:7px;
+  margin-top:8px;
+}
+.theatre-roll-director[data-visibility="hidden"] .theatre-roll-hidden-options{
+  display:grid;
+}
+.theatre-roll-hidden-options label{
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  min-width:0;
+  color:#928b7f;
+  font-size:.58rem;
+  font-weight:700;
+  letter-spacing:.08em;
+}
+.theatre-roll-hidden-options select,
+.theatre-roll-hidden-options input{
+  box-sizing:border-box;
+  width:100%;
+  min-width:0;
+  padding:6px 7px;
+  border:1px solid #4e5358;
+  background:#11161a;
+  color:#f4efe5;
+  font:inherit;
+  letter-spacing:0;
+}
+.theatre-roll-hidden-text-label{
+  grid-column:1/-1;
+}
+.theatre-roll-director[data-hidden-output="none"] [data-roll-hidden-outcome],
+.theatre-roll-director[data-hidden-output="none"] [data-roll-hidden-text],
+.theatre-roll-director[data-hidden-output="outcome"] [data-roll-hidden-text],
+.theatre-roll-director[data-hidden-output="custom"] [data-roll-hidden-outcome]{
+  opacity:.38;
+  pointer-events:none;
+}
+@keyframes theatre-roll-enter{
+  from{opacity:0;transform:translateX(18px) scale(.98)}
+  to{opacity:1;transform:translateX(0) scale(1)}
+}
+@keyframes theatre-roll-leave{
+  to{opacity:0;transform:translateX(18px) scale(.98)}
+}
+@media (max-width:900px){
+  .theatre-roll-layer{
+    width:min(310px,44vw);
+    right:14px;
+  }
+}
+@media (max-width:620px){
+  .theatre-roll-layer{
+    top:50px;
+    left:12px;
+    right:12px;
+    width:auto;
+  }
+  .theatre-roll-card{
+    padding:10px 12px 12px;
+  }
+  .theatre-roll-total{
+    font-size:1.9rem;
+  }
+}
+@media (prefers-reduced-motion:reduce){
+  .theatre-roll-card,
+  .theatre-roll-card.is-leaving{
+    animation:none;
+  }
+}

--- a/css/theatre-roll-visualizer.css
+++ b/css/theatre-roll-visualizer.css
@@ -1,142 +1,222 @@
 .theatre-roll-layer{
   position:absolute;
-  top:clamp(48px,7vh,86px);
-  right:clamp(18px,2.4vw,38px);
+  inset:0;
   z-index:7000;
-  width:min(360px,32vw);
-  display:flex;
-  flex-direction:column;
-  align-items:stretch;
-  gap:10px;
   pointer-events:none;
-}
-.theatre-roll-card{
-  position:relative;
-  box-sizing:border-box;
-  min-width:0;
-  padding:12px 14px 14px;
   overflow:hidden;
-  border:1px solid rgba(214,181,119,.72);
-  border-left:4px solid #8a1c1c;
-  background:linear-gradient(135deg,rgba(18,17,16,.96),rgba(34,29,24,.94));
-  box-shadow:0 12px 28px rgba(0,0,0,.42);
-  color:#f4ead6;
-  font-family:"Roboto",sans-serif;
-  animation:theatre-roll-enter .24s ease-out both;
 }
-.theatre-roll-card::before{
+
+/* Full HUD: only rendered locally by the client that is rolling. */
+.theatre-check-hud{
+  --frame:#8a6137;
+  --frame-dark:#52331d;
+  --neutral:#e1ddd5;
+  --advantage:#e7c34d;
+  --disadvantage:#d74a40;
+  --pass:#d7b54e;
+  --fail:#c03228;
+  position:absolute;
+  top:clamp(40px,7vh,78px);
+  left:50%;
+  width:min(720px,72vw);
+  transform:translateX(-50%);
+  color:#eee4d4;
+  font-family:"Roboto",sans-serif;
+  filter:drop-shadow(0 18px 30px rgba(0,0,0,.55));
+  animation:theatre-check-enter .22s ease-out both;
+}
+
+.theatre-check-tip{
+  position:relative;
+  width:min(590px,84%);
+  margin:0 auto 12px;
+  padding:18px 30px 20px;
+  border:5px solid var(--frame-dark);
+  border-radius:14px;
+  outline:4px solid var(--frame);
+  background:linear-gradient(180deg,#dac9b7,#cbb49d);
+  text-align:center;
+  color:#2a2018;
+}
+.theatre-check-tip::before{
   content:"";
   position:absolute;
-  inset:0 0 auto 0;
-  height:2px;
-  background:linear-gradient(90deg,#8a1c1c,#c6a56d,transparent);
+  left:50%;
+  top:-37px;
+  width:10px;
+  height:32px;
+  transform:translateX(-50%);
+  border-radius:6px;
+  background:#89633a;
+  box-shadow:0 0 0 4px #2e1c10;
 }
-.theatre-roll-card-header{
+.theatre-check-tip-title{
+  margin-bottom:10px;
+  font-family:"BebasKai","Roboto",sans-serif;
+  font-size:1.55rem;
+  font-weight:800;
+  letter-spacing:.04em;
+}
+.theatre-check-hud[data-modifier="advantage"] .theatre-check-tip-title{color:#9d7610}
+.theatre-check-hud[data-modifier="disadvantage"] .theatre-check-tip-title{color:#a72e27}
+.theatre-check-tip-copy{
+  font-size:1.05rem;
+  line-height:1.35;
+}
+
+.theatre-check-body{
+  border:5px solid var(--frame-dark);
+  border-radius:11px;
+  outline:4px solid var(--frame);
+  background:linear-gradient(180deg,#33271f,#17110e);
+  overflow:hidden;
+}
+
+/* Exact Coin Engine images: no replacement circles or synthetic coin graphics. */
+.theatre-check-coins{
+  min-height:108px;
   display:flex;
   align-items:center;
-  justify-content:space-between;
-  gap:10px;
-  margin-bottom:2px;
+  justify-content:center;
+  gap:15px;
+  padding:18px 24px 14px;
+  background:linear-gradient(180deg,#342920,#211914);
 }
-.theatre-roll-roller{
-  min-width:0;
+.theatre-check-coin-image{
+  display:block;
+  width:60px;
+  height:60px;
+  flex:0 0 60px;
+  object-fit:cover;
+  border:0;
+  border-radius:0;
+  background:transparent;
+  box-shadow:none;
+}
+
+.theatre-check-comparison{
+  min-height:238px;
+  display:grid;
+  grid-template-columns:minmax(0,1fr) 105px minmax(0,1fr);
+  align-items:center;
+  border-top:9px solid rgba(0,0,0,.24);
+  border-bottom:9px solid rgba(0,0,0,.24);
+  background:linear-gradient(180deg,rgba(255,255,255,.025),rgba(0,0,0,.07));
+}
+.theatre-check-block{
+  height:166px;
+  margin:0 24px;
+  border:3px solid #5e5548;
+  background:linear-gradient(180deg,#5a5046,#493f38);
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  justify-content:center;
+  gap:7px;
+  text-align:center;
+}
+.theatre-check-block-label{
+  color:#ead9bc;
+  font-family:"BebasKai","Roboto",sans-serif;
+  font-size:1.35rem;
+  letter-spacing:.03em;
+}
+.theatre-check-block-value{
+  color:var(--neutral);
+  font-family:"BebasKai","Roboto",sans-serif;
+  font-size:4.8rem;
+  font-weight:900;
+  line-height:.82;
+}
+.theatre-check-threshold.advantage .theatre-check-block-value{color:var(--advantage)}
+.theatre-check-threshold.disadvantage .theatre-check-block-value{color:var(--disadvantage)}
+.theatre-check-block-sub{
+  min-height:24px;
+  color:#dfcfb7;
+  font-size:.92rem;
+  font-weight:700;
+}
+.theatre-check-operator{
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  color:#b81713;
+  font-family:"BebasKai","Roboto",sans-serif;
+  font-size:5.5rem;
+  font-weight:900;
+  text-shadow:0 5px 0 rgba(0,0,0,.32);
+}
+.theatre-check-status{
+  min-height:62px;
+  margin:15px 22px 18px;
+  border:4px solid #49331f;
+  background:linear-gradient(180deg,#171410,#0f0c09);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  color:#b9aa92;
+  font-family:"BebasKai","Roboto",sans-serif;
+  font-size:2rem;
+  font-weight:900;
+  letter-spacing:.05em;
+}
+.theatre-check-status.is-pass{color:var(--pass)}
+.theatre-check-status.is-fail{color:var(--fail)}
+.theatre-check-hud.is-leaving{animation:theatre-check-leave .24s ease-in both}
+
+/* Remote viewers never receive the full HUD; only this compact final result. */
+.theatre-roll-result-card{
+  position:absolute;
+  top:clamp(58px,8vh,92px);
+  right:clamp(18px,2.4vw,38px);
+  width:min(315px,29vw);
+  padding:12px 15px 14px;
+  border:1px solid rgba(190,157,99,.7);
+  border-left:4px solid #7f2320;
+  background:linear-gradient(135deg,rgba(18,17,16,.96),rgba(34,29,24,.94));
+  box-shadow:0 12px 28px rgba(0,0,0,.42);
+  animation:theatre-result-enter .22s ease-out both;
+}
+.theatre-roll-result-card:nth-of-type(2){top:calc(clamp(58px,8vh,92px) + 120px)}
+.theatre-roll-result-card:nth-of-type(3){top:calc(clamp(58px,8vh,92px) + 240px)}
+.theatre-roll-result-name{
   overflow:hidden;
   text-overflow:ellipsis;
   white-space:nowrap;
+  color:#e9dfcf;
   font-family:"BebasKai","Roboto",sans-serif;
-  font-size:1.05rem;
+  font-size:1rem;
   letter-spacing:.08em;
 }
-.theatre-roll-mode{
-  flex:0 0 auto;
-  padding:2px 6px;
-  border:1px solid rgba(214,181,119,.45);
-  color:#d8bc88;
-  font-size:.62rem;
-  letter-spacing:.12em;
-}
-.theatre-roll-label{
-  margin-top:3px;
-  color:#b7aa95;
-  font-size:.72rem;
-  font-weight:700;
-  letter-spacing:.1em;
-  text-transform:uppercase;
-}
-.theatre-roll-coins{
-  display:flex;
-  gap:7px;
-  margin:11px 0 8px;
-}
-.theatre-roll-coin{
-  width:20px;
-  height:20px;
-  box-sizing:border-box;
-  border-radius:50%;
-  border:2px solid #c7a56d;
-  background:#2b2721;
-  box-shadow:inset 0 0 0 2px rgba(0,0,0,.28);
-}
-.theatre-roll-coin[data-side="head"]{
-  background:radial-gradient(circle at 35% 30%,#f2db9f 0 18%,#c29a53 20% 62%,#76552d 64% 100%);
-}
-.theatre-roll-coin[data-side="tail"]{
-  background:radial-gradient(circle at 35% 30%,#7d7568 0 18%,#423d36 20% 62%,#1d1b19 64% 100%);
-  border-color:#8e8373;
-}
-.theatre-roll-coin[data-side="unknown"]{
-  border-style:dashed;
-  opacity:.65;
-}
-.theatre-roll-detail{
-  display:flex;
-  flex-wrap:wrap;
-  gap:6px 12px;
-  color:#d5c6ad;
-  font-family:"Share Tech Mono","Roboto",monospace;
-  font-size:.68rem;
-  letter-spacing:.04em;
-}
-.theatre-roll-total{
-  margin-top:8px;
-  color:#f2d694;
+.theatre-roll-result-total{
+  margin-top:4px;
+  color:#eee7dc;
   font-family:"BebasKai","Roboto",sans-serif;
-  font-size:2.35rem;
-  line-height:.9;
-  letter-spacing:.04em;
+  font-size:2.7rem;
+  line-height:.95;
 }
-.theatre-roll-total::after{
+.theatre-roll-result-total::after{
   content:" TOTAL";
-  margin-left:6px;
+  margin-left:5px;
   color:#8f8372;
   font-family:"Roboto",sans-serif;
   font-size:.58rem;
   font-weight:700;
-  letter-spacing:.12em;
+  letter-spacing:.1em;
 }
-.theatre-roll-director-note{
-  margin-top:8px;
+.theatre-roll-result-outcome{
+  margin-top:7px;
   border-top:1px solid rgba(255,255,255,.08);
-  padding-top:6px;
-  color:#b88a7c;
-  font-size:.62rem;
-  font-weight:700;
+  padding-top:7px;
+  color:#c7b89d;
+  font-size:.72rem;
+  font-weight:800;
   letter-spacing:.08em;
 }
-.theatre-roll-card.is-hidden-result{
-  padding:14px 16px;
-  text-align:center;
-}
-.theatre-roll-hidden-result{
-  margin-top:10px;
-  color:#f0d38d;
-  font-family:"BebasKai","Roboto",sans-serif;
-  font-size:1.65rem;
-  letter-spacing:.08em;
-}
-.theatre-roll-card.is-leaving{
-  animation:theatre-roll-leave .24s ease-in both;
-}
+.theatre-roll-result-outcome.is-pass{color:#d7b54e}
+.theatre-roll-result-outcome.is-fail{color:#c94439}
+.theatre-roll-result-card.is-leaving{animation:theatre-result-leave .24s ease-in both}
+
 .theatre-roll-director{
   margin-bottom:18px;
   padding:12px;
@@ -174,13 +254,11 @@
 }
 .theatre-roll-hidden-options{
   display:none;
-  grid-template-columns:repeat(2,minmax(0,1fr));
+  grid-template-columns:1fr;
   gap:7px;
   margin-top:8px;
 }
-.theatre-roll-director[data-visibility="hidden"] .theatre-roll-hidden-options{
-  display:grid;
-}
+.theatre-roll-director[data-visibility="hidden"] .theatre-roll-hidden-options{display:grid}
 .theatre-roll-hidden-options label{
   display:flex;
   flex-direction:column;
@@ -203,46 +281,27 @@
   font:inherit;
   letter-spacing:0;
 }
-.theatre-roll-hidden-text-label{
-  grid-column:1/-1;
-}
-.theatre-roll-director[data-hidden-output="none"] [data-roll-hidden-outcome],
-.theatre-roll-director[data-hidden-output="none"] [data-roll-hidden-text],
-.theatre-roll-director[data-hidden-output="outcome"] [data-roll-hidden-text],
-.theatre-roll-director[data-hidden-output="custom"] [data-roll-hidden-outcome]{
-  opacity:.38;
-  pointer-events:none;
-}
-@keyframes theatre-roll-enter{
-  from{opacity:0;transform:translateX(18px) scale(.98)}
-  to{opacity:1;transform:translateX(0) scale(1)}
-}
-@keyframes theatre-roll-leave{
-  to{opacity:0;transform:translateX(18px) scale(.98)}
-}
+
+@keyframes theatre-check-enter{from{opacity:0;transform:translateX(-50%) translateY(-10px) scale(.985)}to{opacity:1;transform:translateX(-50%) translateY(0) scale(1)}}
+@keyframes theatre-check-leave{to{opacity:0;transform:translateX(-50%) translateY(-8px) scale(.985)}}
+@keyframes theatre-result-enter{from{opacity:0;transform:translateX(16px)}to{opacity:1;transform:translateX(0)}}
+@keyframes theatre-result-leave{to{opacity:0;transform:translateX(16px)}}
+
 @media (max-width:900px){
-  .theatre-roll-layer{
-    width:min(310px,44vw);
-    right:14px;
-  }
+  .theatre-check-hud{width:min(680px,86vw)}
+  .theatre-check-block{margin:0 14px}
+  .theatre-roll-result-card{width:min(290px,39vw);right:14px}
 }
 @media (max-width:620px){
-  .theatre-roll-layer{
-    top:50px;
-    left:12px;
-    right:12px;
-    width:auto;
-  }
-  .theatre-roll-card{
-    padding:10px 12px 12px;
-  }
-  .theatre-roll-total{
-    font-size:1.9rem;
-  }
+  .theatre-check-hud{width:94vw;top:48px}
+  .theatre-check-coins{gap:9px}
+  .theatre-check-coin-image{width:48px;height:48px;flex-basis:48px}
+  .theatre-check-comparison{grid-template-columns:1fr 72px 1fr;min-height:205px}
+  .theatre-check-block{height:145px;margin:0 8px}
+  .theatre-check-block-value{font-size:3.6rem}
+  .theatre-check-operator{font-size:4rem}
+  .theatre-roll-result-card{left:12px;right:12px;width:auto}
 }
 @media (prefers-reduced-motion:reduce){
-  .theatre-roll-card,
-  .theatre-roll-card.is-leaving{
-    animation:none;
-  }
+  .theatre-check-hud,.theatre-check-hud.is-leaving,.theatre-roll-result-card,.theatre-roll-result-card.is-leaving{animation:none}
 }

--- a/database.rules.json
+++ b/database.rules.json
@@ -59,8 +59,23 @@
       },
 
       "teatro": {
-        // Log abierto para todos los reclutas con cuenta
+        // Log y stream público/redactado de tiradas para todos los reclutas con cuenta.
         ".write": "auth != null"
+      }
+    },
+
+    // Los detalles reales de tiradas ocultas/TOTAL y thresholds ocultos viven fuera de
+    // `campaña`, porque `campaña/.read` ya concede lectura a todo usuario autenticado.
+    "dm_private": {
+      ".read": "auth != null && auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1'",
+      "theatre_rolls": {
+        "$room": {
+          "$rollId": {
+            // El DM puede escribir cualquier detalle. Un jugador solo puede crear una vez
+            // su propio registro privado y nunca leerlo desde Firebase.
+            ".write": "auth != null && (auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1' || (!data.exists() && newData.child('rollerUid').val() === auth.uid && newData.child('privateRoomKey').val() === $room))"
+          }
+        }
       }
     }
   }

--- a/js/instance-control.js
+++ b/js/instance-control.js
@@ -112,6 +112,35 @@
     return global.LuminousTheatreState?.getPaths?.().scene || DEFAULT_THEATRE_SCENE_PATH;
   }
 
+  function ensureTheatreRollVisualizerAssets(doc) {
+    const documentRef = doc || global.document;
+    if (!documentRef?.head) return null;
+    const hasTheatre = documentRef.getElementById("theatre-view-player") || documentRef.getElementById("modulo-teatro");
+    if (!hasTheatre) return null;
+
+    let link = documentRef.getElementById("theatre-roll-visualizer-stylesheet");
+    if (!link) {
+      link = documentRef.createElement("link");
+      link.id = "theatre-roll-visualizer-stylesheet";
+      link.rel = "stylesheet";
+      link.href = "css/theatre-roll-visualizer.css";
+      link.dataset.ui = "theatre-roll-visualizer";
+      documentRef.head.appendChild(link);
+    }
+
+    let script = documentRef.getElementById("theatre-roll-visualizer-script");
+    if (!script) {
+      script = documentRef.createElement("script");
+      script.id = "theatre-roll-visualizer-script";
+      script.src = "js/theatre-roll-visualizer.js";
+      script.async = false;
+      script.dataset.ui = "theatre-roll-visualizer";
+      documentRef.head.appendChild(script);
+    }
+
+    return { link, script };
+  }
+
   function ensureDmLocationControl({ db, doc } = {}) {
     const documentRef = doc || global.document;
     if (!db || !documentRef?.body?.classList.contains("on-game-dashboard")) return null;
@@ -228,6 +257,7 @@
     if (!db || !documentRef) return;
     const instanceRef = db.ref(INSTANCE_PATH);
 
+    ensureTheatreRollVisualizerAssets(documentRef);
     ensureDashboardCharacterManager({ db, doc: documentRef });
     ensureDashboardActorStudioAssets(documentRef);
     ensureDmLocationControl({ db, doc: documentRef });
@@ -257,6 +287,7 @@
   function bindPlayer({ db, doc } = {}) {
     const documentRef = doc || global.document;
     if (!db || !documentRef) return;
+    ensureTheatreRollVisualizerAssets(documentRef);
     db.ref(INSTANCE_PATH).on("value", (snapshot) => {
       applyPlayerInstance(snapshot.val(), documentRef);
     });
@@ -268,6 +299,7 @@
     applyPlayerInstance,
     applyDashboardInstance,
     ensureDmLocationControl,
+    ensureTheatreRollVisualizerAssets,
     ensureDashboardCharacterManager,
     ensureDashboardActorStudioAssets,
     bindDm,

--- a/js/theatre-roll-visualizer.js
+++ b/js/theatre-roll-visualizer.js
@@ -8,6 +8,7 @@
   const db = firebase.database();
   const DEFAULT_ROOM_ID = "default";
   const CONFIG_PATH = "campaña/config/theatre_rolls";
+  const PRIVATE_ROLL_ROOT = "dm_private/theatre_rolls";
   const MAX_RECENT_AGE_MS = 20000;
   const DEFAULT_DURATION_MS = 7000;
   const COIN_COUNT = 5;
@@ -48,6 +49,8 @@
   let coinObserver = null;
   let localHud = null;
   let localHudTimer = null;
+  let rollStartPending = false;
+  let rollStartTimer = null;
   const renderedKeys = new Set();
   const removalTimers = new Map();
 
@@ -67,6 +70,15 @@
     const normalized = roomId && roomId !== DEFAULT_ROOM_ID ? String(roomId) : DEFAULT_ROOM_ID;
     if (normalized === DEFAULT_ROOM_ID) return "campaña/teatro/tiradas";
     return `campaña/teatro/salas/${normalized}/tiradas`;
+  }
+
+  function privateRoomKey(roomId) {
+    const normalized = roomId && roomId !== DEFAULT_ROOM_ID ? String(roomId) : DEFAULT_ROOM_ID;
+    return normalized.replace(/[.#$\[\]\/]/g, "_") || DEFAULT_ROOM_ID;
+  }
+
+  function resolvePrivateRollPath(roomId) {
+    return `${PRIVATE_ROLL_ROOT}/${privateRoomKey(roomId)}`;
   }
 
   function normalizeVisibility(value) {
@@ -315,28 +327,131 @@
   }
 
   function captureLocalRollStart() {
+    if (rollStartPending || pendingLocalRoll) return false;
     const panel = doc.getElementById("coin-toss-panel");
     const result = doc.getElementById("roll-total-score");
-    if (!panel || panel.style.display === "none") return;
+    if (!panel || panel.style.display === "none") return false;
 
-    global.setTimeout(() => {
-      const check = normalizeCheckContext(nextCheckContext);
-      nextCheckContext = null;
-      pendingLocalRoll = {
-        base: numberFromText(result),
-        startedAt: Date.now(),
-        check,
-      };
-      createLocalHud(check);
-      syncLocalCoinsFromEngine();
+    const armedCheck = nextCheckContext;
+    nextCheckContext = null;
+    rollStartPending = true;
+    rollStartTimer = global.setTimeout(() => {
+      try {
+        if (pendingLocalRoll) return;
+        const check = normalizeCheckContext(armedCheck);
+        pendingLocalRoll = {
+          base: numberFromText(result),
+          startedAt: Date.now(),
+          check,
+        };
+        createLocalHud(check);
+        syncLocalCoinsFromEngine();
 
-      coinObserver?.disconnect();
-      const coinContainer = doc.getElementById("coin-toss-coins-container");
-      if (coinContainer) {
-        coinObserver = new MutationObserver(syncLocalCoinsFromEngine);
-        coinObserver.observe(coinContainer, { childList: true, subtree: true, attributes: true, attributeFilter: ["src"] });
+        coinObserver?.disconnect();
+        const coinContainer = doc.getElementById("coin-toss-coins-container");
+        if (coinContainer) {
+          coinObserver = new MutationObserver(syncLocalCoinsFromEngine);
+          coinObserver.observe(coinContainer, { childList: true, subtree: true, attributes: true, attributeFilter: ["src"] });
+        }
+      } finally {
+        rollStartTimer = null;
+        rollStartPending = false;
       }
     }, 40);
+    return true;
+  }
+
+  function buildFullRollRecord({ source, total, effectiveConfig, roller, check, coins, heads, roomId, privateAvailable }) {
+    const outcome = checkOutcome(total, check);
+    return {
+      schemaVersion: 3,
+      kind: Number.isFinite(check.thresholdRaw) ? "check-result" : "coin-roll-result",
+      presentation: "result-only",
+      roller: {
+        uid: roller.uid || null,
+        actorId: roller.actorId || null,
+        name: String(roller.name || "PLAYER").slice(0, 80),
+      },
+      rollerUid: roller.uid || null,
+      rollerClientId: CLIENT_ID,
+      base: Number.isFinite(Number(source.base)) ? Number(source.base) : null,
+      total: Math.trunc(total),
+      heads,
+      coinCount: coins.length || COIN_COUNT,
+      coinHeadBonus: COIN_HEAD_BONUS,
+      check: {
+        thresholdRaw: check.thresholdRaw,
+        hiddenThreshold: check.hiddenThreshold,
+        modifierType: check.modifierType,
+        modifierValue: check.modifierValue,
+        outcome,
+      },
+      visibility: effectiveConfig.visibility,
+      hiddenOutput: effectiveConfig.hiddenOutput,
+      hiddenOutcome: effectiveConfig.hiddenOutcome,
+      hiddenText: effectiveConfig.hiddenText,
+      durationMs: effectiveConfig.durationMs,
+      createdAt: firebase.database.ServerValue.TIMESTAMP,
+      clientCreatedAt: Date.now(),
+      roomId,
+      privateRoomKey: privateRoomKey(roomId),
+      privateAvailable: Boolean(privateAvailable),
+    };
+  }
+
+  function buildPublicRollRecord(full) {
+    const visibility = normalizeVisibility(full?.visibility);
+    const hiddenOutput = normalizeHiddenOutput(full?.hiddenOutput);
+    const publicRecord = {
+      schemaVersion: Number(full?.schemaVersion) || 3,
+      kind: full?.kind || "coin-roll-result",
+      presentation: "result-only",
+      rollerClientId: full?.rollerClientId || null,
+      visibility,
+      hiddenOutput,
+      durationMs: Number(full?.durationMs) || DEFAULT_DURATION_MS,
+      createdAt: full?.createdAt ?? firebase.database.ServerValue.TIMESTAMP,
+      clientCreatedAt: Number(full?.clientCreatedAt) || Date.now(),
+      roomId: full?.roomId || DEFAULT_ROOM_ID,
+      privateAvailable: Boolean(full?.privateAvailable),
+    };
+
+    if (visibility === VISIBILITY.HIDDEN) {
+      if (hiddenOutput === HIDDEN_OUTPUT.NONE) return publicRecord;
+      publicRecord.roller = full?.roller || null;
+      if (hiddenOutput === HIDDEN_OUTPUT.OUTCOME) {
+        publicRecord.publicOutcome = full?.check?.outcome || full?.hiddenOutcome || null;
+      } else if (hiddenOutput === HIDDEN_OUTPUT.CUSTOM) {
+        publicRecord.hiddenText = String(full?.hiddenText || "").trim().slice(0, 80);
+      }
+      return publicRecord;
+    }
+
+    publicRecord.roller = full?.roller || null;
+    publicRecord.total = Number.isFinite(Number(full?.total)) ? Math.trunc(Number(full.total)) : null;
+
+    // TOTAL means exactly that for player-readable data: no outcome, threshold, heads or base.
+    if (visibility === VISIBILITY.TOTAL) return publicRecord;
+
+    publicRecord.base = Number.isFinite(Number(full?.base)) ? Number(full.base) : null;
+    publicRecord.heads = Math.max(0, Math.trunc(Number(full?.heads) || 0));
+    publicRecord.coinCount = Math.max(0, Math.trunc(Number(full?.coinCount) || COIN_COUNT));
+    publicRecord.coinHeadBonus = COIN_HEAD_BONUS;
+
+    const check = full?.check || {};
+    if (check.outcome || Number.isFinite(Number(check.thresholdRaw))) {
+      publicRecord.check = {
+        hiddenThreshold: Boolean(check.hiddenThreshold),
+        outcome: check.outcome || null,
+      };
+      // A hidden threshold is never placed in the authenticated-player-readable tree.
+      if (!check.hiddenThreshold) {
+        publicRecord.check.thresholdRaw = Number.isFinite(Number(check.thresholdRaw)) ? Math.trunc(Number(check.thresholdRaw)) : null;
+        publicRecord.check.modifierType = normalizeModifier(check.modifierType);
+        publicRecord.check.modifierValue = Math.max(0, Math.trunc(Number(check.modifierValue) || 0));
+      }
+    }
+    return publicRecord;
   }
 
   async function publishRoll(payload) {
@@ -349,49 +464,46 @@
     const check = normalizeCheckContext(source.check);
     const coins = Array.isArray(source.coins) ? source.coins.slice(0, COIN_COUNT) : [];
     const heads = countHeadsFromCoins(coins);
-    const ref = db.ref(resolveRollPath(getRoomId())).push();
-
-    await ref.set({
-      schemaVersion: 2,
-      kind: Number.isFinite(check.thresholdRaw) ? "check-result" : "coin-roll-result",
-      presentation: "result-only",
-      roller: {
-        uid: roller.uid || null,
-        actorId: roller.actorId || null,
-        name: String(roller.name || "PLAYER").slice(0, 80),
-      },
-      rollerClientId: CLIENT_ID,
-      base: Number.isFinite(Number(source.base)) ? Number(source.base) : null,
-      total: Math.trunc(total),
+    const roomId = getRoomId();
+    const publicRef = db.ref(resolveRollPath(roomId)).push();
+    const needsPrivateRecord = effectiveConfig.visibility !== VISIBILITY.PUBLIC || check.hiddenThreshold;
+    const fullRecord = buildFullRollRecord({
+      source,
+      total,
+      effectiveConfig,
+      roller,
+      check,
+      coins,
       heads,
-      coinCount: coins.length || COIN_COUNT,
-      coinHeadBonus: COIN_HEAD_BONUS,
-      check: {
-        thresholdRaw: check.thresholdRaw,
-        hiddenThreshold: check.hiddenThreshold,
-        modifierType: check.modifierType,
-        modifierValue: check.modifierValue,
-        outcome: checkOutcome(total, check),
-      },
-      visibility: effectiveConfig.visibility,
-      hiddenOutput: effectiveConfig.hiddenOutput,
-      hiddenOutcome: effectiveConfig.hiddenOutcome,
-      hiddenText: effectiveConfig.hiddenText,
-      durationMs: effectiveConfig.durationMs,
-      createdAt: firebase.database.ServerValue.TIMESTAMP,
-      clientCreatedAt: Date.now(),
-      roomId: getRoomId(),
+      roomId,
+      privateAvailable: needsPrivateRecord,
     });
+    const publicRecord = buildPublicRollRecord(fullRecord);
+    const updates = {
+      [`${resolveRollPath(roomId)}/${publicRef.key}`]: publicRecord,
+    };
 
-    return { published: true, key: ref.key };
+    if (needsPrivateRecord) {
+      updates[`${resolvePrivateRollPath(roomId)}/${publicRef.key}`] = fullRecord;
+    }
+
+    // Multi-location update keeps the public redaction and DM-private copy atomic.
+    await db.ref().update(updates);
+    return { published: true, key: publicRef.key };
   }
 
   function finalizeLocalRoll() {
-    if (!pendingLocalRoll) return;
+    if (!pendingLocalRoll) {
+      if (rollStartTimer) global.clearTimeout(rollStartTimer);
+      rollStartTimer = null;
+      rollStartPending = false;
+      return;
+    }
     coinObserver?.disconnect();
     const total = numberFromText(doc.getElementById("roll-total-score"));
     const pending = pendingLocalRoll;
     pendingLocalRoll = null;
+    rollStartPending = false;
     if (!Number.isFinite(total)) return;
 
     syncLocalCoinsFromEngine();
@@ -426,7 +538,8 @@
   }
 
   function shouldSuppressRemoteForLocalRoller(roll) {
-    if (roll?.rollerClientId && roll.rollerClientId === CLIENT_ID) return true;
+    // Modern records are session-scoped. Another tab/device with the same UID must still see the remote result.
+    if (roll?.rollerClientId) return roll.rollerClientId === CLIENT_ID;
     const uid = currentUid();
     return Boolean(uid && roll?.roller?.uid && uid === roll.roller.uid && !isDmView());
   }
@@ -434,10 +547,10 @@
   function hiddenRemoteMessage(roll) {
     const output = normalizeHiddenOutput(roll?.hiddenOutput);
     if (output === HIDDEN_OUTPUT.OUTCOME) {
-      const actual = roll?.check?.outcome;
+      const actual = roll?.publicOutcome || roll?.check?.outcome || roll?.hiddenOutcome;
       if (actual === "passed") return "CHECK PASSED";
       if (actual === "failed") return "CHECK FAILED";
-      return String(roll?.hiddenOutcome || "").toLowerCase() === "failure" ? "FALLO" : "ÉXITO";
+      return String(actual || "success").toLowerCase() === "failure" ? "FALLO" : "ÉXITO";
     }
     if (output === HIDDEN_OUTPUT.CUSTOM) return String(roll?.hiddenText || "").trim() || "RESULTADO OCULTO";
     return "";
@@ -461,6 +574,10 @@
 
     const total = textNode("theatre-roll-result-total", roll?.total ?? "—");
     card.appendChild(total);
+
+    // TOTAL is intentionally distinct from PUBLIC for non-DM viewers.
+    if (!isDmView() && visibility === VISIBILITY.TOTAL) return card;
+
     const outcome = roll?.check?.outcome;
     if (outcome === "passed" || outcome === "failed") {
       const result = textNode("theatre-roll-result-outcome", outcome === "passed" ? "CHECK PASSED" : "CHECK FAILED");
@@ -477,7 +594,18 @@
     return Number.isFinite(client) ? client : 0;
   }
 
-  function renderIncomingRoll(snapshot) {
+  async function hydrateDmRoll(key, roll) {
+    if (!isDmView() || !roll?.privateAvailable) return roll;
+    try {
+      const snapshot = await db.ref(`${resolvePrivateRollPath(roll.roomId || getRoomId())}/${key}`).once("value");
+      return snapshot.val() || roll;
+    } catch (error) {
+      console.warn("No se pudo leer el detalle privado de la tirada:", error);
+      return roll;
+    }
+  }
+
+  async function renderIncomingRoll(snapshot) {
     const key = snapshot?.key;
     const roll = snapshot?.val?.() || {};
     if (!key || renderedKeys.has(key)) return;
@@ -488,14 +616,15 @@
     if (timestamp && Date.now() - timestamp > MAX_RECENT_AGE_MS) return;
     const layer = ensureLayer();
     if (!layer) return;
-    const card = buildRemoteResultCard(key, roll);
+    const displayRoll = await hydrateDmRoll(key, roll);
+    const card = buildRemoteResultCard(key, displayRoll);
     if (!card) return;
 
     layer.appendChild(card);
     while (layer.querySelectorAll(".theatre-roll-result-card").length > 3) {
       layer.querySelector(".theatre-roll-result-card")?.remove();
     }
-    const duration = normalizeConfig({ durationMs: roll.durationMs }).durationMs;
+    const duration = normalizeConfig({ durationMs: displayRoll.durationMs }).durationMs;
     removalTimers.set(key, global.setTimeout(() => {
       card.classList.add("is-leaving");
       global.setTimeout(() => card.remove(), 260);
@@ -506,7 +635,9 @@
   function bindRollStream() {
     rollQuery?.off();
     rollQuery = db.ref(resolveRollPath(getRoomId())).limitToLast(8);
-    rollQuery.on("child_added", renderIncomingRoll);
+    rollQuery.on("child_added", (snapshot) => {
+      renderIncomingRoll(snapshot).catch((error) => console.warn("No se pudo renderizar la tirada remota:", error));
+    });
   }
 
   function setControlState(root) {
@@ -621,15 +752,19 @@
     HEAD_SRC,
     TAIL_SRC,
     resolveRollPath,
+    resolvePrivateRollPath,
     normalizeConfig,
     normalizeCheckContext,
     effectiveThreshold,
     checkOutcome,
     captureCoinImages,
+    buildPublicRollRecord,
+    shouldSuppressRemoteForLocalRoller,
     armCheck,
     clearArmedCheck,
     publishRoll,
     renderIncomingRoll,
+    getClientId: () => CLIENT_ID,
     getConfig: () => Object.assign({}, config),
   });
 })(window);

--- a/js/theatre-roll-visualizer.js
+++ b/js/theatre-roll-visualizer.js
@@ -12,16 +12,26 @@
   const DEFAULT_DURATION_MS = 7000;
   const COIN_COUNT = 5;
   const COIN_HEAD_BONUS = 4;
-  const VISIBILITY = Object.freeze({
-    PUBLIC: "public",
-    TOTAL: "total",
-    HIDDEN: "hidden",
-  });
-  const HIDDEN_OUTPUT = Object.freeze({
-    NONE: "none",
-    OUTCOME: "outcome",
-    CUSTOM: "custom",
-  });
+  const HEAD_SRC_MARKER = "yshLPnQ";
+  const TAIL_SRC_MARKER = "XDx0ICt";
+  const HEAD_SRC = "https://imgur.com/yshLPnQ.png";
+  const TAIL_SRC = "https://imgur.com/XDx0ICt.png";
+
+  const VISIBILITY = Object.freeze({ PUBLIC: "public", TOTAL: "total", HIDDEN: "hidden" });
+  const HIDDEN_OUTPUT = Object.freeze({ NONE: "none", OUTCOME: "outcome", CUSTOM: "custom" });
+  const MODIFIER = Object.freeze({ NEUTRAL: "neutral", ADVANTAGE: "advantage", DISADVANTAGE: "disadvantage" });
+
+  const CLIENT_ID = (() => {
+    try {
+      const existing = global.sessionStorage?.getItem("luminousTheatreRollClientId");
+      if (existing) return existing;
+      const value = `roll_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+      global.sessionStorage?.setItem("luminousTheatreRollClientId", value);
+      return value;
+    } catch (_) {
+      return `roll_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+    }
+  })();
 
   let config = {
     visibility: VISIBILITY.PUBLIC,
@@ -31,14 +41,22 @@
     durationMs: DEFAULT_DURATION_MS,
   };
   let pendingLocalRoll = null;
+  let nextCheckContext = null;
   let rollQuery = null;
   let configRef = null;
   let closeButtonObserver = null;
+  let coinObserver = null;
+  let localHud = null;
+  let localHudTimer = null;
   const renderedKeys = new Set();
   const removalTimers = new Map();
 
   function isDmView() {
     return Boolean(doc.body?.classList?.contains("on-game-dashboard"));
+  }
+
+  function currentUid() {
+    return firebase.auth?.().currentUser?.uid || null;
   }
 
   function getRoomId() {
@@ -61,6 +79,11 @@
     return Object.values(HIDDEN_OUTPUT).includes(normalized) ? normalized : HIDDEN_OUTPUT.NONE;
   }
 
+  function normalizeModifier(value) {
+    const normalized = String(value || "").trim().toLowerCase();
+    return Object.values(MODIFIER).includes(normalized) ? normalized : MODIFIER.NEUTRAL;
+  }
+
   function normalizeConfig(value) {
     const source = value || {};
     const duration = Number(source.durationMs);
@@ -73,15 +96,45 @@
     };
   }
 
+  function normalizeCheckContext(value) {
+    const source = value || {};
+    const raw = Number(source.thresholdRaw ?? source.threshold);
+    const modifierValue = Math.max(0, Math.trunc(Number(source.modifierValue ?? source.x) || 0));
+    const modifierType = modifierValue > 0 ? normalizeModifier(source.modifierType) : MODIFIER.NEUTRAL;
+    return {
+      thresholdRaw: Number.isFinite(raw) ? Math.trunc(raw) : null,
+      hiddenThreshold: Boolean(source.hiddenThreshold),
+      modifierType,
+      modifierValue,
+      tipText: modifierValue > 0 ? String(source.tipText || source.tip || "").trim().slice(0, 180) : "",
+    };
+  }
+
+  function effectiveThreshold(check) {
+    const normalized = normalizeCheckContext(check);
+    if (!Number.isFinite(normalized.thresholdRaw)) return null;
+    if (normalized.modifierType === MODIFIER.ADVANTAGE) {
+      return Math.max(0, normalized.thresholdRaw - normalized.modifierValue);
+    }
+    if (normalized.modifierType === MODIFIER.DISADVANTAGE) {
+      return normalized.thresholdRaw + normalized.modifierValue;
+    }
+    return normalized.thresholdRaw;
+  }
+
+  function checkOutcome(total, check) {
+    const threshold = effectiveThreshold(check);
+    if (!Number.isFinite(threshold) || !Number.isFinite(Number(total))) return null;
+    return Number(total) >= threshold ? "passed" : "failed";
+  }
+
   function playerData() {
     return global.datosJugador || {};
   }
 
   function assignedActor() {
     try {
-      return typeof global.getAssignedTheatreActor === "function"
-        ? (global.getAssignedTheatreActor() || {})
-        : {};
+      return typeof global.getAssignedTheatreActor === "function" ? (global.getAssignedTheatreActor() || {}) : {};
     } catch (_) {
       return {};
     }
@@ -90,22 +143,11 @@
   function getRollerIdentity() {
     const data = playerData();
     const actor = assignedActor();
-    const user = firebase.auth?.().currentUser || null;
     const name = String(
-      actor.nombre ||
-      actor.name ||
-      data.characterName ||
-      data.character_name ||
-      data.nombre ||
-      data.name ||
-      "PLAYER"
+      actor.nombre || actor.name || data.characterName || data.character_name || data.nombre || data.name || "PLAYER"
     ).trim() || "PLAYER";
     const actorId = actor.actorId || actor.id || data.actorId || data.vinculo_jugador || null;
-    return {
-      uid: user?.uid || null,
-      actorId: actorId ? String(actorId) : null,
-      name,
-    };
+    return { uid: currentUid(), actorId: actorId ? String(actorId) : null, name };
   }
 
   function numberFromText(node) {
@@ -114,102 +156,27 @@
     return Number.isFinite(parsed) ? parsed : null;
   }
 
-  function captureLocalRollStart() {
-    const panel = doc.getElementById("coin-toss-panel");
-    const label = doc.getElementById("coin-toss-skill-name");
-    const result = doc.getElementById("roll-total-score");
-    if (!panel || panel.style.display === "none") return;
+  function sideFromSrc(src) {
+    const value = String(src || "");
+    if (value.includes(HEAD_SRC_MARKER)) return "head";
+    if (value.includes(TAIL_SRC_MARKER)) return "tail";
+    return "unknown";
+  }
 
-    global.setTimeout(() => {
-      const base = numberFromText(result);
-      pendingLocalRoll = {
-        label: String(label?.textContent || "TIRADA").trim() || "TIRADA",
-        base,
-        startedAt: Date.now(),
+  function captureCoinImages() {
+    const images = Array.from(doc.querySelectorAll("#coin-toss-coins-container img"));
+    return images.slice(0, COIN_COUNT).map((image) => {
+      const src = String(image.currentSrc || image.src || "");
+      const side = sideFromSrc(src);
+      return {
+        side,
+        src: side === "head" ? HEAD_SRC : side === "tail" ? TAIL_SRC : src,
       };
-    }, 40);
-  }
-
-  function countHeads(base, total) {
-    if (!Number.isFinite(base) || !Number.isFinite(total)) return null;
-    const delta = total - base;
-    if (delta < 0 || delta % COIN_HEAD_BONUS !== 0) return null;
-    const heads = delta / COIN_HEAD_BONUS;
-    return Math.max(0, Math.min(COIN_COUNT, heads));
-  }
-
-  async function publishRoll(payload) {
-    const source = payload || {};
-    const total = Number(source.total);
-    if (!Number.isFinite(total)) return { published: false, reason: "invalid-total" };
-
-    const base = Number(source.base);
-    const normalizedBase = Number.isFinite(base) ? base : null;
-    const heads = source.heads == null ? countHeads(normalizedBase, total) : Number(source.heads);
-    const safeHeads = Number.isFinite(heads) ? Math.max(0, Math.min(COIN_COUNT, Math.trunc(heads))) : null;
-    const effectiveConfig = normalizeConfig(config);
-    const roller = source.roller || getRollerIdentity();
-    const ref = db.ref(resolveRollPath(getRoomId())).push();
-
-    await ref.set({
-      schemaVersion: 1,
-      kind: String(source.kind || "coin-roll"),
-      roller: {
-        uid: roller.uid || null,
-        actorId: roller.actorId || null,
-        name: String(roller.name || "PLAYER").slice(0, 80),
-      },
-      label: String(source.label || "TIRADA").slice(0, 100),
-      base: normalizedBase,
-      total: Math.trunc(total),
-      heads: safeHeads,
-      coinCount: COIN_COUNT,
-      coinHeadBonus: COIN_HEAD_BONUS,
-      visibility: effectiveConfig.visibility,
-      hiddenOutput: effectiveConfig.hiddenOutput,
-      hiddenOutcome: effectiveConfig.hiddenOutcome,
-      hiddenText: effectiveConfig.hiddenText,
-      durationMs: effectiveConfig.durationMs,
-      createdAt: firebase.database.ServerValue.TIMESTAMP,
-      clientCreatedAt: Date.now(),
-      roomId: getRoomId(),
     });
-
-    return { published: true, key: ref.key };
   }
 
-  function finalizeLocalRoll() {
-    if (!pendingLocalRoll) return;
-    const result = doc.getElementById("roll-total-score");
-    const total = numberFromText(result);
-    const pending = pendingLocalRoll;
-    pendingLocalRoll = null;
-    if (!Number.isFinite(total)) return;
-
-    publishRoll({
-      label: pending.label,
-      base: pending.base,
-      total,
-      heads: countHeads(pending.base, total),
-    }).catch((error) => console.warn("No se pudo publicar la tirada en Theatre:", error));
-  }
-
-  function installCoinCapture() {
-    const closeButton = doc.getElementById("coin-toss-close-btn");
-    if (!closeButton || closeButtonObserver) return false;
-
-    closeButtonObserver = new MutationObserver(() => {
-      if (closeButton.disabled) captureLocalRollStart();
-      else finalizeLocalRoll();
-    });
-    closeButtonObserver.observe(closeButton, { attributes: true, attributeFilter: ["disabled"] });
-
-    doc.addEventListener("click", (event) => {
-      if (!event.target?.closest?.(".sheet-roll-skill-btn, [data-dnd-roll]")) return;
-      global.setTimeout(captureLocalRollStart, 0);
-    }, true);
-
-    return true;
+  function countHeadsFromCoins(coins) {
+    return (coins || []).filter((coin) => coin?.side === "head").length;
   }
 
   function ensureLayer() {
@@ -234,96 +201,272 @@
     return node;
   }
 
-  function visibilityLabel(value) {
-    if (value === VISIBILITY.TOTAL) return "TOTAL";
-    if (value === VISIBILITY.HIDDEN) return "OCULTA";
-    return "PÚBLICA";
+  function buildCoinImage(coin) {
+    const img = doc.createElement("img");
+    img.className = "theatre-check-coin-image";
+    img.alt = coin?.side === "head" ? "Head" : coin?.side === "tail" ? "Tail" : "Coin";
+    img.src = coin?.src || (coin?.side === "head" ? HEAD_SRC : TAIL_SRC);
+    img.dataset.side = coin?.side || "unknown";
+    return img;
   }
 
-  function shouldHideFromPlayer(roll) {
-    return !isDmView() &&
-      normalizeVisibility(roll?.visibility) === VISIBILITY.HIDDEN &&
-      normalizeHiddenOutput(roll?.hiddenOutput) === HIDDEN_OUTPUT.NONE;
+  function createLocalHud(check) {
+    const layer = ensureLayer();
+    if (!layer) return null;
+    localHud?.remove();
+    if (localHudTimer) global.clearTimeout(localHudTimer);
+
+    const normalized = normalizeCheckContext(check);
+    const hud = doc.createElement("article");
+    hud.className = "theatre-check-hud is-rolling";
+    hud.dataset.modifier = normalized.modifierType;
+
+    if (normalized.modifierValue > 0 && normalized.tipText) {
+      const tip = doc.createElement("section");
+      tip.className = "theatre-check-tip";
+      const sign = normalized.modifierType === MODIFIER.ADVANTAGE ? "-" : "+";
+      const label = normalized.modifierType === MODIFIER.ADVANTAGE ? "ADVANTAGE" : "DISADVANTAGE";
+      tip.appendChild(textNode("theatre-check-tip-title", `${label} ${sign}${normalized.modifierValue}`));
+      tip.appendChild(textNode("theatre-check-tip-copy", normalized.tipText));
+      hud.appendChild(tip);
+    }
+
+    const body = doc.createElement("section");
+    body.className = "theatre-check-body";
+
+    const coins = doc.createElement("div");
+    coins.className = "theatre-check-coins";
+    coins.dataset.localCoins = "true";
+    body.appendChild(coins);
+
+    const comparison = doc.createElement("div");
+    comparison.className = "theatre-check-comparison";
+
+    const thresholdBlock = doc.createElement("div");
+    thresholdBlock.className = `theatre-check-block theatre-check-threshold ${normalized.modifierType}`;
+    thresholdBlock.appendChild(textNode("theatre-check-block-label", "Threshold"));
+    const thresholdValue = textNode("theatre-check-block-value", normalized.hiddenThreshold ? "??" : (effectiveThreshold(normalized) ?? "—"));
+    thresholdValue.dataset.localThreshold = "true";
+    thresholdBlock.appendChild(thresholdValue);
+    const thresholdSub = textNode("theatre-check-block-sub", "");
+    thresholdSub.dataset.localThresholdSub = "true";
+    thresholdBlock.appendChild(thresholdSub);
+
+    const operator = textNode("theatre-check-operator", "VS");
+    operator.dataset.localOperator = "true";
+
+    const resultBlock = doc.createElement("div");
+    resultBlock.className = "theatre-check-block theatre-check-result";
+    resultBlock.appendChild(textNode("theatre-check-block-label", "Outcome"));
+    const resultValue = textNode("theatre-check-block-value", "—");
+    resultValue.dataset.localResult = "true";
+    resultBlock.appendChild(resultValue);
+    resultBlock.appendChild(textNode("theatre-check-block-sub", ""));
+
+    comparison.append(thresholdBlock, operator, resultBlock);
+    body.appendChild(comparison);
+
+    const status = textNode("theatre-check-status", "ROLLING...");
+    status.dataset.localStatus = "true";
+    body.appendChild(status);
+    hud.appendChild(body);
+    layer.appendChild(hud);
+    localHud = hud;
+    return hud;
   }
 
-  function hiddenPlayerMessage(roll) {
+  function syncLocalCoinsFromEngine() {
+    if (!localHud) return;
+    const row = localHud.querySelector("[data-local-coins]");
+    if (!row) return;
+    const coins = captureCoinImages();
+    row.replaceChildren(...coins.map(buildCoinImage));
+  }
+
+  function syncLocalResult(total, check) {
+    if (!localHud) return;
+    const normalized = normalizeCheckContext(check);
+    const threshold = effectiveThreshold(normalized);
+    const outcome = checkOutcome(total, normalized);
+    const resultNode = localHud.querySelector("[data-local-result]");
+    const operatorNode = localHud.querySelector("[data-local-operator]");
+    const statusNode = localHud.querySelector("[data-local-status]");
+    const thresholdSub = localHud.querySelector("[data-local-threshold-sub]");
+    if (resultNode) resultNode.textContent = String(total);
+    if (operatorNode) operatorNode.textContent = outcome === "passed" ? "≤" : outcome === "failed" ? ">" : "VS";
+    if (thresholdSub && Number.isFinite(threshold) && normalized.modifierValue > 0) {
+      if (normalized.hiddenThreshold) {
+        thresholdSub.textContent = normalized.modifierType === MODIFIER.ADVANTAGE
+          ? `-${normalized.modifierValue}`
+          : `+${normalized.modifierValue}`;
+      } else {
+        thresholdSub.textContent = normalized.modifierType === MODIFIER.ADVANTAGE
+          ? `${normalized.thresholdRaw} - ${normalized.modifierValue}`
+          : `${normalized.thresholdRaw} + ${normalized.modifierValue}`;
+      }
+    }
+    if (statusNode) {
+      statusNode.textContent = outcome === "passed" ? "CHECK PASSED" : outcome === "failed" ? "CHECK FAILED" : "ROLL COMPLETE";
+      statusNode.classList.toggle("is-pass", outcome === "passed");
+      statusNode.classList.toggle("is-fail", outcome === "failed");
+    }
+    localHud.classList.remove("is-rolling");
+    localHud.classList.add("is-resolved");
+  }
+
+  function captureLocalRollStart() {
+    const panel = doc.getElementById("coin-toss-panel");
+    const result = doc.getElementById("roll-total-score");
+    if (!panel || panel.style.display === "none") return;
+
+    global.setTimeout(() => {
+      const check = normalizeCheckContext(nextCheckContext);
+      nextCheckContext = null;
+      pendingLocalRoll = {
+        base: numberFromText(result),
+        startedAt: Date.now(),
+        check,
+      };
+      createLocalHud(check);
+      syncLocalCoinsFromEngine();
+
+      coinObserver?.disconnect();
+      const coinContainer = doc.getElementById("coin-toss-coins-container");
+      if (coinContainer) {
+        coinObserver = new MutationObserver(syncLocalCoinsFromEngine);
+        coinObserver.observe(coinContainer, { childList: true, subtree: true, attributes: true, attributeFilter: ["src"] });
+      }
+    }, 40);
+  }
+
+  async function publishRoll(payload) {
+    const source = payload || {};
+    const total = Number(source.total);
+    if (!Number.isFinite(total)) return { published: false, reason: "invalid-total" };
+
+    const effectiveConfig = normalizeConfig(config);
+    const roller = source.roller || getRollerIdentity();
+    const check = normalizeCheckContext(source.check);
+    const coins = Array.isArray(source.coins) ? source.coins.slice(0, COIN_COUNT) : [];
+    const heads = countHeadsFromCoins(coins);
+    const ref = db.ref(resolveRollPath(getRoomId())).push();
+
+    await ref.set({
+      schemaVersion: 2,
+      kind: Number.isFinite(check.thresholdRaw) ? "check-result" : "coin-roll-result",
+      presentation: "result-only",
+      roller: {
+        uid: roller.uid || null,
+        actorId: roller.actorId || null,
+        name: String(roller.name || "PLAYER").slice(0, 80),
+      },
+      rollerClientId: CLIENT_ID,
+      base: Number.isFinite(Number(source.base)) ? Number(source.base) : null,
+      total: Math.trunc(total),
+      heads,
+      coinCount: coins.length || COIN_COUNT,
+      coinHeadBonus: COIN_HEAD_BONUS,
+      check: {
+        thresholdRaw: check.thresholdRaw,
+        hiddenThreshold: check.hiddenThreshold,
+        modifierType: check.modifierType,
+        modifierValue: check.modifierValue,
+        outcome: checkOutcome(total, check),
+      },
+      visibility: effectiveConfig.visibility,
+      hiddenOutput: effectiveConfig.hiddenOutput,
+      hiddenOutcome: effectiveConfig.hiddenOutcome,
+      hiddenText: effectiveConfig.hiddenText,
+      durationMs: effectiveConfig.durationMs,
+      createdAt: firebase.database.ServerValue.TIMESTAMP,
+      clientCreatedAt: Date.now(),
+      roomId: getRoomId(),
+    });
+
+    return { published: true, key: ref.key };
+  }
+
+  function finalizeLocalRoll() {
+    if (!pendingLocalRoll) return;
+    coinObserver?.disconnect();
+    const total = numberFromText(doc.getElementById("roll-total-score"));
+    const pending = pendingLocalRoll;
+    pendingLocalRoll = null;
+    if (!Number.isFinite(total)) return;
+
+    syncLocalCoinsFromEngine();
+    const coins = captureCoinImages();
+    syncLocalResult(total, pending.check);
+
+    publishRoll({ base: pending.base, total, coins, check: pending.check })
+      .catch((error) => console.warn("No se pudo publicar el resultado en Theatre:", error));
+
+    localHudTimer = global.setTimeout(() => {
+      localHud?.classList.add("is-leaving");
+      global.setTimeout(() => {
+        localHud?.remove();
+        localHud = null;
+      }, 260);
+    }, config.durationMs);
+  }
+
+  function installCoinCapture() {
+    const closeButton = doc.getElementById("coin-toss-close-btn");
+    if (!closeButton || closeButtonObserver) return false;
+    closeButtonObserver = new MutationObserver(() => {
+      if (closeButton.disabled) captureLocalRollStart();
+      else finalizeLocalRoll();
+    });
+    closeButtonObserver.observe(closeButton, { attributes: true, attributeFilter: ["disabled"] });
+    doc.addEventListener("click", (event) => {
+      if (!event.target?.closest?.(".sheet-roll-skill-btn, [data-dnd-roll]")) return;
+      global.setTimeout(captureLocalRollStart, 0);
+    }, true);
+    return true;
+  }
+
+  function shouldSuppressRemoteForLocalRoller(roll) {
+    if (roll?.rollerClientId && roll.rollerClientId === CLIENT_ID) return true;
+    const uid = currentUid();
+    return Boolean(uid && roll?.roller?.uid && uid === roll.roller.uid && !isDmView());
+  }
+
+  function hiddenRemoteMessage(roll) {
     const output = normalizeHiddenOutput(roll?.hiddenOutput);
     if (output === HIDDEN_OUTPUT.OUTCOME) {
+      const actual = roll?.check?.outcome;
+      if (actual === "passed") return "CHECK PASSED";
+      if (actual === "failed") return "CHECK FAILED";
       return String(roll?.hiddenOutcome || "").toLowerCase() === "failure" ? "FALLO" : "ÉXITO";
     }
-    if (output === HIDDEN_OUTPUT.CUSTOM) {
-      return String(roll?.hiddenText || "").trim() || "RESULTADO OCULTO";
-    }
+    if (output === HIDDEN_OUTPUT.CUSTOM) return String(roll?.hiddenText || "").trim() || "RESULTADO OCULTO";
     return "";
   }
 
-  function buildCoinRow(roll) {
-    const row = doc.createElement("div");
-    row.className = "theatre-roll-coins";
-    const count = Number.isFinite(Number(roll?.coinCount)) ? Math.max(1, Math.min(10, Number(roll.coinCount))) : COIN_COUNT;
-    const heads = Number.isFinite(Number(roll?.heads)) ? Math.max(0, Math.min(count, Number(roll.heads))) : null;
-    for (let index = 0; index < count; index += 1) {
-      const coin = doc.createElement("i");
-      coin.className = "theatre-roll-coin";
-      if (heads == null) coin.dataset.side = "unknown";
-      else coin.dataset.side = index < heads ? "head" : "tail";
-      coin.setAttribute("aria-hidden", "true");
-      row.appendChild(coin);
-    }
-    if (heads != null) row.setAttribute("aria-label", `${heads} caras de ${count}`);
-    return row;
-  }
-
-  function buildFullCard(card, roll) {
-    const base = Number(roll?.base);
-    const heads = Number(roll?.heads);
-    const headBonus = Number(roll?.coinHeadBonus) || COIN_HEAD_BONUS;
-    card.appendChild(buildCoinRow(roll));
-
-    const detail = doc.createElement("div");
-    detail.className = "theatre-roll-detail";
-    if (Number.isFinite(base)) detail.appendChild(textNode("theatre-roll-detail-item", `BASE ${base >= 0 ? "+" : ""}${base}`));
-    if (Number.isFinite(heads)) detail.appendChild(textNode("theatre-roll-detail-item", `HEADS ${heads} × ${headBonus}`));
-    card.appendChild(detail);
-  }
-
-  function buildRollCard(key, roll) {
+  function buildRemoteResultCard(key, roll) {
     const visibility = normalizeVisibility(roll?.visibility);
-    if (shouldHideFromPlayer(roll)) return null;
+    if (!isDmView() && visibility === VISIBILITY.HIDDEN && normalizeHiddenOutput(roll?.hiddenOutput) === HIDDEN_OUTPUT.NONE) return null;
 
     const card = doc.createElement("article");
-    card.className = "theatre-roll-card";
+    card.className = "theatre-roll-result-card";
     card.dataset.rollKey = key;
-    card.dataset.visibility = visibility;
 
-    const head = doc.createElement("header");
-    head.className = "theatre-roll-card-header";
-    head.appendChild(textNode("theatre-roll-roller", roll?.roller?.name || "PLAYER"));
-    head.appendChild(textNode("theatre-roll-mode", visibilityLabel(visibility)));
-    card.appendChild(head);
-
-    card.appendChild(textNode("theatre-roll-label", roll?.label || "TIRADA"));
+    const name = textNode("theatre-roll-result-name", roll?.roller?.name || "PLAYER");
+    card.appendChild(name);
 
     if (!isDmView() && visibility === VISIBILITY.HIDDEN) {
-      card.classList.add("is-hidden-result");
-      card.appendChild(textNode("theatre-roll-hidden-result", hiddenPlayerMessage(roll)));
+      card.appendChild(textNode("theatre-roll-result-outcome", hiddenRemoteMessage(roll)));
       return card;
     }
 
-    if (visibility === VISIBILITY.PUBLIC || isDmView()) buildFullCard(card, roll);
-    if (visibility === VISIBILITY.TOTAL && !isDmView()) card.classList.add("is-total-only");
-
-    const total = textNode("theatre-roll-total", roll?.total ?? "—");
-    total.setAttribute("aria-label", `Total ${roll?.total ?? "desconocido"}`);
+    const total = textNode("theatre-roll-result-total", roll?.total ?? "—");
     card.appendChild(total);
-
-    if (isDmView() && visibility !== VISIBILITY.PUBLIC) {
-      card.appendChild(textNode(
-        "theatre-roll-director-note",
-        visibility === VISIBILITY.HIDDEN ? "OCULTA PARA JUGADORES" : "JUGADORES VEN SOLO EL TOTAL"
-      ));
+    const outcome = roll?.check?.outcome;
+    if (outcome === "passed" || outcome === "failed") {
+      const result = textNode("theatre-roll-result-outcome", outcome === "passed" ? "CHECK PASSED" : "CHECK FAILED");
+      result.classList.add(outcome === "passed" ? "is-pass" : "is-fail");
+      card.appendChild(result);
     }
-
     return card;
   }
 
@@ -338,22 +481,20 @@
     const key = snapshot?.key;
     const roll = snapshot?.val?.() || {};
     if (!key || renderedKeys.has(key)) return;
+    renderedKeys.add(key);
+    if (shouldSuppressRemoteForLocalRoller(roll)) return;
 
     const timestamp = eventTimestamp(roll);
-    if (timestamp && Date.now() - timestamp > MAX_RECENT_AGE_MS) {
-      renderedKeys.add(key);
-      return;
-    }
-
+    if (timestamp && Date.now() - timestamp > MAX_RECENT_AGE_MS) return;
     const layer = ensureLayer();
     if (!layer) return;
-    const card = buildRollCard(key, roll);
-    renderedKeys.add(key);
+    const card = buildRemoteResultCard(key, roll);
     if (!card) return;
 
     layer.appendChild(card);
-    while (layer.children.length > 3) layer.firstElementChild?.remove();
-
+    while (layer.querySelectorAll(".theatre-roll-result-card").length > 3) {
+      layer.querySelector(".theatre-roll-result-card")?.remove();
+    }
     const duration = normalizeConfig({ durationMs: roll.durationMs }).durationMs;
     removalTimers.set(key, global.setTimeout(() => {
       card.classList.add("is-leaving");
@@ -363,7 +504,7 @@
   }
 
   function bindRollStream() {
-    if (rollQuery) rollQuery.off();
+    rollQuery?.off();
     rollQuery = db.ref(resolveRollPath(getRoomId())).limitToLast(8);
     rollQuery.on("child_added", renderIncomingRoll);
   }
@@ -376,10 +517,8 @@
       button.setAttribute("aria-pressed", active ? "true" : "false");
     });
     const output = root.querySelector("[data-roll-hidden-output]");
-    const outcome = root.querySelector("[data-roll-hidden-outcome]");
     const custom = root.querySelector("[data-roll-hidden-text]");
     if (output) output.value = config.hiddenOutput;
-    if (outcome) outcome.value = config.hiddenOutcome;
     if (custom && doc.activeElement !== custom) custom.value = config.hiddenText;
     root.dataset.visibility = config.visibility;
     root.dataset.hiddenOutput = config.hiddenOutput;
@@ -403,8 +542,8 @@
     root = doc.createElement("section");
     root.className = "theatre-roll-director";
     root.innerHTML = `
-      <div class="theatre-roll-director-title">VISIBILIDAD DE TIRADAS</div>
-      <div class="theatre-roll-visibility-buttons" role="group" aria-label="Visibilidad de tiradas">
+      <div class="theatre-roll-director-title">RESULTADO DE TIRADAS</div>
+      <div class="theatre-roll-visibility-buttons" role="group" aria-label="Visibilidad del resultado">
         <button type="button" data-roll-visibility="public" aria-pressed="false">PÚBLICA</button>
         <button type="button" data-roll-visibility="total" aria-pressed="false">TOTAL</button>
         <button type="button" data-roll-visibility="hidden" aria-pressed="false">OCULTA</button>
@@ -415,12 +554,6 @@
             <option value="none">NADA</option>
             <option value="outcome">ÉXITO / FALLO</option>
             <option value="custom">TEXTO DM</option>
-          </select>
-        </label>
-        <label>RESULTADO
-          <select data-roll-hidden-outcome>
-            <option value="success">ÉXITO</option>
-            <option value="failure">FALLO</option>
           </select>
         </label>
         <label class="theatre-roll-hidden-text-label">TEXTO
@@ -435,19 +568,14 @@
     root.addEventListener("click", (event) => {
       const button = event.target?.closest?.("[data-roll-visibility]");
       if (!button) return;
-      writeConfig({ visibility: button.dataset.rollVisibility }).catch((error) => console.warn("No se pudo cambiar visibilidad de tiradas:", error));
+      writeConfig({ visibility: button.dataset.rollVisibility }).catch((error) => console.warn("No se pudo cambiar visibilidad:", error));
     });
-
     root.querySelector("[data-roll-hidden-output]")?.addEventListener("change", (event) => {
       writeConfig({ hiddenOutput: event.target.value }).catch((error) => console.warn("No se pudo cambiar salida oculta:", error));
-    });
-    root.querySelector("[data-roll-hidden-outcome]")?.addEventListener("change", (event) => {
-      writeConfig({ hiddenOutcome: event.target.value }).catch((error) => console.warn("No se pudo cambiar resultado oculto:", error));
     });
     root.querySelector("[data-roll-hidden-text]")?.addEventListener("change", (event) => {
       writeConfig({ hiddenText: String(event.target.value || "").trim().slice(0, 80) }).catch((error) => console.warn("No se pudo cambiar texto oculto:", error));
     });
-
     setControlState(root);
     return root;
   }
@@ -460,13 +588,21 @@
     });
   }
 
+  function armCheck(options) {
+    nextCheckContext = normalizeCheckContext(options);
+    return Object.assign({}, nextCheckContext);
+  }
+
+  function clearArmedCheck() {
+    nextCheckContext = null;
+  }
+
   function boot() {
     ensureLayer();
     installCoinCapture();
     bindConfig();
     bindRollStream();
     mountDirectorControls();
-
     const observer = new MutationObserver(() => {
       ensureLayer();
       installCoinCapture();
@@ -481,8 +617,17 @@
   global.LuminousTheatreRolls = Object.freeze({
     VISIBILITY,
     HIDDEN_OUTPUT,
+    MODIFIER,
+    HEAD_SRC,
+    TAIL_SRC,
     resolveRollPath,
     normalizeConfig,
+    normalizeCheckContext,
+    effectiveThreshold,
+    checkOutcome,
+    captureCoinImages,
+    armCheck,
+    clearArmedCheck,
     publishRoll,
     renderIncomingRoll,
     getConfig: () => Object.assign({}, config),

--- a/js/theatre-roll-visualizer.js
+++ b/js/theatre-roll-visualizer.js
@@ -1,0 +1,490 @@
+(function (global) {
+  "use strict";
+
+  const doc = global.document;
+  const firebase = global.firebase;
+  if (!doc || !firebase?.database) return;
+
+  const db = firebase.database();
+  const DEFAULT_ROOM_ID = "default";
+  const CONFIG_PATH = "campaña/config/theatre_rolls";
+  const MAX_RECENT_AGE_MS = 20000;
+  const DEFAULT_DURATION_MS = 7000;
+  const COIN_COUNT = 5;
+  const COIN_HEAD_BONUS = 4;
+  const VISIBILITY = Object.freeze({
+    PUBLIC: "public",
+    TOTAL: "total",
+    HIDDEN: "hidden",
+  });
+  const HIDDEN_OUTPUT = Object.freeze({
+    NONE: "none",
+    OUTCOME: "outcome",
+    CUSTOM: "custom",
+  });
+
+  let config = {
+    visibility: VISIBILITY.PUBLIC,
+    hiddenOutput: HIDDEN_OUTPUT.NONE,
+    hiddenOutcome: "success",
+    hiddenText: "",
+    durationMs: DEFAULT_DURATION_MS,
+  };
+  let pendingLocalRoll = null;
+  let rollQuery = null;
+  let configRef = null;
+  let closeButtonObserver = null;
+  const renderedKeys = new Set();
+  const removalTimers = new Map();
+
+  function isDmView() {
+    return Boolean(doc.body?.classList?.contains("on-game-dashboard"));
+  }
+
+  function getRoomId() {
+    return doc.body?.dataset?.theatreRoomId || DEFAULT_ROOM_ID;
+  }
+
+  function resolveRollPath(roomId) {
+    const normalized = roomId && roomId !== DEFAULT_ROOM_ID ? String(roomId) : DEFAULT_ROOM_ID;
+    if (normalized === DEFAULT_ROOM_ID) return "campaña/teatro/tiradas";
+    return `campaña/teatro/salas/${normalized}/tiradas`;
+  }
+
+  function normalizeVisibility(value) {
+    const normalized = String(value || "").trim().toLowerCase();
+    return Object.values(VISIBILITY).includes(normalized) ? normalized : VISIBILITY.PUBLIC;
+  }
+
+  function normalizeHiddenOutput(value) {
+    const normalized = String(value || "").trim().toLowerCase();
+    return Object.values(HIDDEN_OUTPUT).includes(normalized) ? normalized : HIDDEN_OUTPUT.NONE;
+  }
+
+  function normalizeConfig(value) {
+    const source = value || {};
+    const duration = Number(source.durationMs);
+    return {
+      visibility: normalizeVisibility(source.visibility),
+      hiddenOutput: normalizeHiddenOutput(source.hiddenOutput),
+      hiddenOutcome: String(source.hiddenOutcome || "success").toLowerCase() === "failure" ? "failure" : "success",
+      hiddenText: String(source.hiddenText || "").trim().slice(0, 80),
+      durationMs: Number.isFinite(duration) ? Math.max(2500, Math.min(15000, duration)) : DEFAULT_DURATION_MS,
+    };
+  }
+
+  function playerData() {
+    return global.datosJugador || {};
+  }
+
+  function assignedActor() {
+    try {
+      return typeof global.getAssignedTheatreActor === "function"
+        ? (global.getAssignedTheatreActor() || {})
+        : {};
+    } catch (_) {
+      return {};
+    }
+  }
+
+  function getRollerIdentity() {
+    const data = playerData();
+    const actor = assignedActor();
+    const user = firebase.auth?.().currentUser || null;
+    const name = String(
+      actor.nombre ||
+      actor.name ||
+      data.characterName ||
+      data.character_name ||
+      data.nombre ||
+      data.name ||
+      "PLAYER"
+    ).trim() || "PLAYER";
+    const actorId = actor.actorId || actor.id || data.actorId || data.vinculo_jugador || null;
+    return {
+      uid: user?.uid || null,
+      actorId: actorId ? String(actorId) : null,
+      name,
+    };
+  }
+
+  function numberFromText(node) {
+    if (!node) return null;
+    const parsed = Number.parseInt(String(node.textContent || "").trim(), 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  function captureLocalRollStart() {
+    const panel = doc.getElementById("coin-toss-panel");
+    const label = doc.getElementById("coin-toss-skill-name");
+    const result = doc.getElementById("roll-total-score");
+    if (!panel || panel.style.display === "none") return;
+
+    global.setTimeout(() => {
+      const base = numberFromText(result);
+      pendingLocalRoll = {
+        label: String(label?.textContent || "TIRADA").trim() || "TIRADA",
+        base,
+        startedAt: Date.now(),
+      };
+    }, 40);
+  }
+
+  function countHeads(base, total) {
+    if (!Number.isFinite(base) || !Number.isFinite(total)) return null;
+    const delta = total - base;
+    if (delta < 0 || delta % COIN_HEAD_BONUS !== 0) return null;
+    const heads = delta / COIN_HEAD_BONUS;
+    return Math.max(0, Math.min(COIN_COUNT, heads));
+  }
+
+  async function publishRoll(payload) {
+    const source = payload || {};
+    const total = Number(source.total);
+    if (!Number.isFinite(total)) return { published: false, reason: "invalid-total" };
+
+    const base = Number(source.base);
+    const normalizedBase = Number.isFinite(base) ? base : null;
+    const heads = source.heads == null ? countHeads(normalizedBase, total) : Number(source.heads);
+    const safeHeads = Number.isFinite(heads) ? Math.max(0, Math.min(COIN_COUNT, Math.trunc(heads))) : null;
+    const effectiveConfig = normalizeConfig(config);
+    const roller = source.roller || getRollerIdentity();
+    const ref = db.ref(resolveRollPath(getRoomId())).push();
+
+    await ref.set({
+      schemaVersion: 1,
+      kind: String(source.kind || "coin-roll"),
+      roller: {
+        uid: roller.uid || null,
+        actorId: roller.actorId || null,
+        name: String(roller.name || "PLAYER").slice(0, 80),
+      },
+      label: String(source.label || "TIRADA").slice(0, 100),
+      base: normalizedBase,
+      total: Math.trunc(total),
+      heads: safeHeads,
+      coinCount: COIN_COUNT,
+      coinHeadBonus: COIN_HEAD_BONUS,
+      visibility: effectiveConfig.visibility,
+      hiddenOutput: effectiveConfig.hiddenOutput,
+      hiddenOutcome: effectiveConfig.hiddenOutcome,
+      hiddenText: effectiveConfig.hiddenText,
+      durationMs: effectiveConfig.durationMs,
+      createdAt: firebase.database.ServerValue.TIMESTAMP,
+      clientCreatedAt: Date.now(),
+      roomId: getRoomId(),
+    });
+
+    return { published: true, key: ref.key };
+  }
+
+  function finalizeLocalRoll() {
+    if (!pendingLocalRoll) return;
+    const result = doc.getElementById("roll-total-score");
+    const total = numberFromText(result);
+    const pending = pendingLocalRoll;
+    pendingLocalRoll = null;
+    if (!Number.isFinite(total)) return;
+
+    publishRoll({
+      label: pending.label,
+      base: pending.base,
+      total,
+      heads: countHeads(pending.base, total),
+    }).catch((error) => console.warn("No se pudo publicar la tirada en Theatre:", error));
+  }
+
+  function installCoinCapture() {
+    const closeButton = doc.getElementById("coin-toss-close-btn");
+    if (!closeButton || closeButtonObserver) return false;
+
+    closeButtonObserver = new MutationObserver(() => {
+      if (closeButton.disabled) captureLocalRollStart();
+      else finalizeLocalRoll();
+    });
+    closeButtonObserver.observe(closeButton, { attributes: true, attributeFilter: ["disabled"] });
+
+    doc.addEventListener("click", (event) => {
+      if (!event.target?.closest?.(".sheet-roll-skill-btn, [data-dnd-roll]")) return;
+      global.setTimeout(captureLocalRollStart, 0);
+    }, true);
+
+    return true;
+  }
+
+  function ensureLayer() {
+    const stage = doc.getElementById("theatre-stage");
+    if (!stage) return null;
+    let layer = stage.querySelector(":scope > #theatre-roll-layer");
+    if (!layer) {
+      layer = doc.createElement("div");
+      layer.id = "theatre-roll-layer";
+      layer.className = "theatre-roll-layer";
+      layer.setAttribute("aria-live", "polite");
+      layer.setAttribute("aria-label", "Tiradas del Theatre");
+      stage.appendChild(layer);
+    }
+    return layer;
+  }
+
+  function textNode(className, value) {
+    const node = doc.createElement("div");
+    node.className = className;
+    node.textContent = String(value ?? "");
+    return node;
+  }
+
+  function visibilityLabel(value) {
+    if (value === VISIBILITY.TOTAL) return "TOTAL";
+    if (value === VISIBILITY.HIDDEN) return "OCULTA";
+    return "PÚBLICA";
+  }
+
+  function shouldHideFromPlayer(roll) {
+    return !isDmView() &&
+      normalizeVisibility(roll?.visibility) === VISIBILITY.HIDDEN &&
+      normalizeHiddenOutput(roll?.hiddenOutput) === HIDDEN_OUTPUT.NONE;
+  }
+
+  function hiddenPlayerMessage(roll) {
+    const output = normalizeHiddenOutput(roll?.hiddenOutput);
+    if (output === HIDDEN_OUTPUT.OUTCOME) {
+      return String(roll?.hiddenOutcome || "").toLowerCase() === "failure" ? "FALLO" : "ÉXITO";
+    }
+    if (output === HIDDEN_OUTPUT.CUSTOM) {
+      return String(roll?.hiddenText || "").trim() || "RESULTADO OCULTO";
+    }
+    return "";
+  }
+
+  function buildCoinRow(roll) {
+    const row = doc.createElement("div");
+    row.className = "theatre-roll-coins";
+    const count = Number.isFinite(Number(roll?.coinCount)) ? Math.max(1, Math.min(10, Number(roll.coinCount))) : COIN_COUNT;
+    const heads = Number.isFinite(Number(roll?.heads)) ? Math.max(0, Math.min(count, Number(roll.heads))) : null;
+    for (let index = 0; index < count; index += 1) {
+      const coin = doc.createElement("i");
+      coin.className = "theatre-roll-coin";
+      if (heads == null) coin.dataset.side = "unknown";
+      else coin.dataset.side = index < heads ? "head" : "tail";
+      coin.setAttribute("aria-hidden", "true");
+      row.appendChild(coin);
+    }
+    if (heads != null) row.setAttribute("aria-label", `${heads} caras de ${count}`);
+    return row;
+  }
+
+  function buildFullCard(card, roll) {
+    const base = Number(roll?.base);
+    const heads = Number(roll?.heads);
+    const headBonus = Number(roll?.coinHeadBonus) || COIN_HEAD_BONUS;
+    card.appendChild(buildCoinRow(roll));
+
+    const detail = doc.createElement("div");
+    detail.className = "theatre-roll-detail";
+    if (Number.isFinite(base)) detail.appendChild(textNode("theatre-roll-detail-item", `BASE ${base >= 0 ? "+" : ""}${base}`));
+    if (Number.isFinite(heads)) detail.appendChild(textNode("theatre-roll-detail-item", `HEADS ${heads} × ${headBonus}`));
+    card.appendChild(detail);
+  }
+
+  function buildRollCard(key, roll) {
+    const visibility = normalizeVisibility(roll?.visibility);
+    if (shouldHideFromPlayer(roll)) return null;
+
+    const card = doc.createElement("article");
+    card.className = "theatre-roll-card";
+    card.dataset.rollKey = key;
+    card.dataset.visibility = visibility;
+
+    const head = doc.createElement("header");
+    head.className = "theatre-roll-card-header";
+    head.appendChild(textNode("theatre-roll-roller", roll?.roller?.name || "PLAYER"));
+    head.appendChild(textNode("theatre-roll-mode", visibilityLabel(visibility)));
+    card.appendChild(head);
+
+    card.appendChild(textNode("theatre-roll-label", roll?.label || "TIRADA"));
+
+    if (!isDmView() && visibility === VISIBILITY.HIDDEN) {
+      card.classList.add("is-hidden-result");
+      card.appendChild(textNode("theatre-roll-hidden-result", hiddenPlayerMessage(roll)));
+      return card;
+    }
+
+    if (visibility === VISIBILITY.PUBLIC || isDmView()) buildFullCard(card, roll);
+    if (visibility === VISIBILITY.TOTAL && !isDmView()) card.classList.add("is-total-only");
+
+    const total = textNode("theatre-roll-total", roll?.total ?? "—");
+    total.setAttribute("aria-label", `Total ${roll?.total ?? "desconocido"}`);
+    card.appendChild(total);
+
+    if (isDmView() && visibility !== VISIBILITY.PUBLIC) {
+      card.appendChild(textNode(
+        "theatre-roll-director-note",
+        visibility === VISIBILITY.HIDDEN ? "OCULTA PARA JUGADORES" : "JUGADORES VEN SOLO EL TOTAL"
+      ));
+    }
+
+    return card;
+  }
+
+  function eventTimestamp(roll) {
+    const server = Number(roll?.createdAt);
+    if (Number.isFinite(server) && server > 0) return server;
+    const client = Number(roll?.clientCreatedAt);
+    return Number.isFinite(client) ? client : 0;
+  }
+
+  function renderIncomingRoll(snapshot) {
+    const key = snapshot?.key;
+    const roll = snapshot?.val?.() || {};
+    if (!key || renderedKeys.has(key)) return;
+
+    const timestamp = eventTimestamp(roll);
+    if (timestamp && Date.now() - timestamp > MAX_RECENT_AGE_MS) {
+      renderedKeys.add(key);
+      return;
+    }
+
+    const layer = ensureLayer();
+    if (!layer) return;
+    const card = buildRollCard(key, roll);
+    renderedKeys.add(key);
+    if (!card) return;
+
+    layer.appendChild(card);
+    while (layer.children.length > 3) layer.firstElementChild?.remove();
+
+    const duration = normalizeConfig({ durationMs: roll.durationMs }).durationMs;
+    removalTimers.set(key, global.setTimeout(() => {
+      card.classList.add("is-leaving");
+      global.setTimeout(() => card.remove(), 260);
+      removalTimers.delete(key);
+    }, duration));
+  }
+
+  function bindRollStream() {
+    if (rollQuery) rollQuery.off();
+    rollQuery = db.ref(resolveRollPath(getRoomId())).limitToLast(8);
+    rollQuery.on("child_added", renderIncomingRoll);
+  }
+
+  function setControlState(root) {
+    if (!root) return;
+    root.querySelectorAll("[data-roll-visibility]").forEach((button) => {
+      const active = button.dataset.rollVisibility === config.visibility;
+      button.classList.toggle("is-active", active);
+      button.setAttribute("aria-pressed", active ? "true" : "false");
+    });
+    const output = root.querySelector("[data-roll-hidden-output]");
+    const outcome = root.querySelector("[data-roll-hidden-outcome]");
+    const custom = root.querySelector("[data-roll-hidden-text]");
+    if (output) output.value = config.hiddenOutput;
+    if (outcome) outcome.value = config.hiddenOutcome;
+    if (custom && doc.activeElement !== custom) custom.value = config.hiddenText;
+    root.dataset.visibility = config.visibility;
+    root.dataset.hiddenOutput = config.hiddenOutput;
+  }
+
+  function writeConfig(patch) {
+    if (!isDmView()) return Promise.resolve(false);
+    return db.ref(CONFIG_PATH).update(patch).then(() => true);
+  }
+
+  function mountDirectorControls() {
+    if (!isDmView()) return null;
+    const panel = doc.getElementById("theatre-director-panel");
+    if (!panel) return null;
+    let root = panel.querySelector(".theatre-roll-director");
+    if (root) {
+      setControlState(root);
+      return root;
+    }
+
+    root = doc.createElement("section");
+    root.className = "theatre-roll-director";
+    root.innerHTML = `
+      <div class="theatre-roll-director-title">VISIBILIDAD DE TIRADAS</div>
+      <div class="theatre-roll-visibility-buttons" role="group" aria-label="Visibilidad de tiradas">
+        <button type="button" data-roll-visibility="public" aria-pressed="false">PÚBLICA</button>
+        <button type="button" data-roll-visibility="total" aria-pressed="false">TOTAL</button>
+        <button type="button" data-roll-visibility="hidden" aria-pressed="false">OCULTA</button>
+      </div>
+      <div class="theatre-roll-hidden-options">
+        <label>SALIDA OCULTA
+          <select data-roll-hidden-output>
+            <option value="none">NADA</option>
+            <option value="outcome">ÉXITO / FALLO</option>
+            <option value="custom">TEXTO DM</option>
+          </select>
+        </label>
+        <label>RESULTADO
+          <select data-roll-hidden-outcome>
+            <option value="success">ÉXITO</option>
+            <option value="failure">FALLO</option>
+          </select>
+        </label>
+        <label class="theatre-roll-hidden-text-label">TEXTO
+          <input type="text" maxlength="80" data-roll-hidden-text placeholder="Mensaje visible para jugadores">
+        </label>
+      </div>`;
+
+    const composer = panel.querySelector(".theatre-controls");
+    if (composer) panel.insertBefore(root, composer);
+    else panel.appendChild(root);
+
+    root.addEventListener("click", (event) => {
+      const button = event.target?.closest?.("[data-roll-visibility]");
+      if (!button) return;
+      writeConfig({ visibility: button.dataset.rollVisibility }).catch((error) => console.warn("No se pudo cambiar visibilidad de tiradas:", error));
+    });
+
+    root.querySelector("[data-roll-hidden-output]")?.addEventListener("change", (event) => {
+      writeConfig({ hiddenOutput: event.target.value }).catch((error) => console.warn("No se pudo cambiar salida oculta:", error));
+    });
+    root.querySelector("[data-roll-hidden-outcome]")?.addEventListener("change", (event) => {
+      writeConfig({ hiddenOutcome: event.target.value }).catch((error) => console.warn("No se pudo cambiar resultado oculto:", error));
+    });
+    root.querySelector("[data-roll-hidden-text]")?.addEventListener("change", (event) => {
+      writeConfig({ hiddenText: String(event.target.value || "").trim().slice(0, 80) }).catch((error) => console.warn("No se pudo cambiar texto oculto:", error));
+    });
+
+    setControlState(root);
+    return root;
+  }
+
+  function bindConfig() {
+    configRef = db.ref(CONFIG_PATH);
+    configRef.on("value", (snapshot) => {
+      config = normalizeConfig(snapshot.val());
+      setControlState(doc.querySelector(".theatre-roll-director"));
+    });
+  }
+
+  function boot() {
+    ensureLayer();
+    installCoinCapture();
+    bindConfig();
+    bindRollStream();
+    mountDirectorControls();
+
+    const observer = new MutationObserver(() => {
+      ensureLayer();
+      installCoinCapture();
+      mountDirectorControls();
+    });
+    observer.observe(doc.body, { childList: true, subtree: true });
+  }
+
+  if (doc.readyState === "loading") doc.addEventListener("DOMContentLoaded", boot, { once: true });
+  else boot();
+
+  global.LuminousTheatreRolls = Object.freeze({
+    VISIBILITY,
+    HIDDEN_OUTPUT,
+    resolveRollPath,
+    normalizeConfig,
+    publishRoll,
+    renderIncomingRoll,
+    getConfig: () => Object.assign({}, config),
+  });
+})(window);

--- a/tests/theatre_roll_visualizer.spec.js
+++ b/tests/theatre_roll_visualizer.spec.js
@@ -1,0 +1,78 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
+const rolls = read("js/theatre-roll-visualizer.js");
+const css = read("css/theatre-roll-visualizer.css");
+const instanceControl = read("js/instance-control.js");
+
+test("Theatre muestra tiradas sin tocar diálogo ni sprites", () => {
+  expect(rolls).toContain('resolveRollPath');
+  expect(rolls).toContain('"campaña/teatro/tiradas"');
+  expect(rolls).toContain('limitToLast(8)');
+  expect(rolls).toContain('ensureLayer()');
+  expect(rolls).toContain('stage.appendChild(layer)');
+  expect(rolls).not.toContain('dialogo_activo');
+  expect(rolls).not.toContain('actores_visibles');
+  expect(rolls).not.toContain('active_actor');
+});
+
+test("visualizador conserva un único Coin Engine y deriva las caras del total", () => {
+  expect(rolls).toContain('doc.getElementById("coin-toss-panel")');
+  expect(rolls).toContain('doc.getElementById("roll-total-score")');
+  expect(rolls).toContain('doc.getElementById("coin-toss-close-btn")');
+  expect(rolls).toContain('const COIN_COUNT = 5');
+  expect(rolls).toContain('const COIN_HEAD_BONUS = 4');
+  expect(rolls).toContain('const heads = delta / COIN_HEAD_BONUS');
+  expect(rolls).not.toContain('Math.random');
+});
+
+test("existen los tres modos visuales acordados", () => {
+  for (const value of ['PUBLIC: "public"', 'TOTAL: "total"', 'HIDDEN: "hidden"']) {
+    expect(rolls).toContain(value);
+  }
+  expect(rolls).toContain('data-roll-visibility="public"');
+  expect(rolls).toContain('data-roll-visibility="total"');
+  expect(rolls).toContain('data-roll-visibility="hidden"');
+  expect(rolls).toContain('PÚBLICA');
+  expect(rolls).toContain('OCULTA');
+});
+
+test("oculta permite nada, éxito/fallo o texto del DM", () => {
+  expect(rolls).toContain('NONE: "none"');
+  expect(rolls).toContain('OUTCOME: "outcome"');
+  expect(rolls).toContain('CUSTOM: "custom"');
+  expect(rolls).toContain('ÉXITO');
+  expect(rolls).toContain('FALLO');
+  expect(rolls).toContain('TEXTO DM');
+  expect(rolls).toContain('shouldHideFromPlayer');
+});
+
+test("DM controla visibilidad desde config DM-only existente", () => {
+  expect(rolls).toContain('const CONFIG_PATH = "campaña/config/theatre_rolls"');
+  expect(rolls).toContain('function writeConfig(patch)');
+  expect(rolls).toContain('if (!isDmView()) return Promise.resolve(false)');
+  expect(rolls).toContain('db.ref(CONFIG_PATH).update(patch)');
+});
+
+test("instance-control carga el visualizador tanto en jugador como en ON GAME", () => {
+  expect(instanceControl).toContain("function ensureTheatreRollVisualizerAssets");
+  expect(instanceControl).toContain("css/theatre-roll-visualizer.css");
+  expect(instanceControl).toContain("js/theatre-roll-visualizer.js");
+  expect(instanceControl).toContain("ensureTheatreRollVisualizerAssets(documentRef)");
+});
+
+test("la tarjeta queda sobre sprites y debajo del diálogo", () => {
+  expect(css).toContain("z-index:7000");
+  expect(css).toContain("pointer-events:none");
+  expect(css).toContain(".theatre-roll-coins");
+  expect(css).toContain(".theatre-roll-total");
+  expect(css).toContain("@media (prefers-reduced-motion:reduce)");
+});
+
+test("queda API pública para futuras tiradas enfrentadas", () => {
+  expect(rolls).toContain("global.LuminousTheatreRolls = Object.freeze");
+  expect(rolls).toContain("publishRoll,");
+  expect(rolls).toContain("VISIBILITY,");
+});

--- a/tests/theatre_roll_visualizer.spec.js
+++ b/tests/theatre_roll_visualizer.spec.js
@@ -7,72 +7,87 @@ const rolls = read("js/theatre-roll-visualizer.js");
 const css = read("css/theatre-roll-visualizer.css");
 const instanceControl = read("js/instance-control.js");
 
-test("Theatre muestra tiradas sin tocar diálogo ni sprites", () => {
-  expect(rolls).toContain('resolveRollPath');
-  expect(rolls).toContain('"campaña/teatro/tiradas"');
-  expect(rolls).toContain('limitToLast(8)');
-  expect(rolls).toContain('ensureLayer()');
-  expect(rolls).toContain('stage.appendChild(layer)');
+test("reutiliza las imágenes reales del Coin Engine", () => {
+  expect(rolls).toContain('const HEAD_SRC_MARKER = "yshLPnQ"');
+  expect(rolls).toContain('const TAIL_SRC_MARKER = "XDx0ICt"');
+  expect(rolls).toContain('const HEAD_SRC = "https://imgur.com/yshLPnQ.png"');
+  expect(rolls).toContain('const TAIL_SRC = "https://imgur.com/XDx0ICt.png"');
+  expect(rolls).toContain('#coin-toss-coins-container img');
+  expect(rolls).toContain('img.className = "theatre-check-coin-image"');
+  expect(css).toContain('.theatre-check-coin-image');
+  expect(css).toContain('width:60px');
+  expect(css).toContain('height:60px');
+  expect(css).not.toContain('.theatre-roll-coin[data-side="head"]');
+});
+
+test("el HUD completo solo se renderiza en el cliente que está tirando", () => {
+  expect(rolls).toContain('function createLocalHud(check)');
+  expect(rolls).toContain('function shouldSuppressRemoteForLocalRoller(roll)');
+  expect(rolls).toContain('roll?.rollerClientId && roll.rollerClientId === CLIENT_ID');
+  expect(rolls).toContain('presentation: "result-only"');
+  expect(rolls).toContain('buildRemoteResultCard');
+  expect(css).toContain('Full HUD: only rendered locally');
+  expect(css).toContain('Remote viewers never receive the full HUD');
+});
+
+test("los demás clientes reciben solo nombre total y outcome", () => {
+  expect(rolls).toContain('theatre-roll-result-name');
+  expect(rolls).toContain('theatre-roll-result-total');
+  expect(rolls).toContain('theatre-roll-result-outcome');
+  expect(rolls).not.toContain('card.appendChild(buildCoinRow');
+  expect(css).toContain('.theatre-roll-result-card');
+});
+
+test("threshold aplica neutral ventaja y desventaja", () => {
+  expect(rolls).toContain('ADVANTAGE: "advantage"');
+  expect(rolls).toContain('DISADVANTAGE: "disadvantage"');
+  expect(rolls).toContain('normalized.thresholdRaw - normalized.modifierValue');
+  expect(rolls).toContain('normalized.thresholdRaw + normalized.modifierValue');
+  expect(rolls).toContain('Number(total) >= threshold');
+});
+
+test("X igual a cero elimina el tip y fuerza neutral", () => {
+  expect(rolls).toContain('modifierValue > 0 ? normalizeModifier(source.modifierType) : MODIFIER.NEUTRAL');
+  expect(rolls).toContain('tipText: modifierValue > 0 ?');
+  expect(rolls).toContain('if (normalized.modifierValue > 0 && normalized.tipText)');
+});
+
+test("threshold oculto muestra interrogantes solo en HUD local", () => {
+  expect(rolls).toContain('normalized.hiddenThreshold ? "??"');
+  expect(rolls).toContain('hiddenThreshold: check.hiddenThreshold');
+});
+
+test("colores del threshold son neutro amarillo y rojo", () => {
+  expect(css).toContain('--neutral:#e1ddd5');
+  expect(css).toContain('--advantage:#e7c34d');
+  expect(css).toContain('--disadvantage:#d74a40');
+  expect(css).toContain('.theatre-check-threshold.advantage .theatre-check-block-value');
+  expect(css).toContain('.theatre-check-threshold.disadvantage .theatre-check-block-value');
+});
+
+test("no agrega skill o iconos de skill al HUD local", () => {
+  expect(rolls).not.toContain('theatre-check-skill');
+  expect(rolls).not.toContain('theatre-check-roll-label');
+  expect(css).not.toContain('.theatre-check-skill');
+});
+
+test("no toca diálogo sprites foco ni crea un segundo motor", () => {
   expect(rolls).not.toContain('dialogo_activo');
   expect(rolls).not.toContain('actores_visibles');
   expect(rolls).not.toContain('active_actor');
+  expect(rolls).not.toContain('publishIntervention');
+  expect(rolls).not.toContain('currentTotal += 4');
 });
 
-test("visualizador conserva un único Coin Engine y deriva las caras del total", () => {
-  expect(rolls).toContain('doc.getElementById("coin-toss-panel")');
-  expect(rolls).toContain('doc.getElementById("roll-total-score")');
-  expect(rolls).toContain('doc.getElementById("coin-toss-close-btn")');
-  expect(rolls).toContain('const COIN_COUNT = 5');
-  expect(rolls).toContain('const COIN_HEAD_BONUS = 4');
-  expect(rolls).toContain('const heads = delta / COIN_HEAD_BONUS');
-  expect(rolls).not.toContain('Math.random');
+test("mantiene API para armar el siguiente check y publicar resultados", () => {
+  expect(rolls).toContain('function armCheck(options)');
+  expect(rolls).toContain('armCheck,');
+  expect(rolls).toContain('publishRoll,');
+  expect(rolls).toContain('effectiveThreshold,');
+  expect(rolls).toContain('checkOutcome,');
 });
 
-test("existen los tres modos visuales acordados", () => {
-  for (const value of ['PUBLIC: "public"', 'TOTAL: "total"', 'HIDDEN: "hidden"']) {
-    expect(rolls).toContain(value);
-  }
-  expect(rolls).toContain('data-roll-visibility="public"');
-  expect(rolls).toContain('data-roll-visibility="total"');
-  expect(rolls).toContain('data-roll-visibility="hidden"');
-  expect(rolls).toContain('PÚBLICA');
-  expect(rolls).toContain('OCULTA');
-});
-
-test("oculta permite nada, éxito/fallo o texto del DM", () => {
-  expect(rolls).toContain('NONE: "none"');
-  expect(rolls).toContain('OUTCOME: "outcome"');
-  expect(rolls).toContain('CUSTOM: "custom"');
-  expect(rolls).toContain('ÉXITO');
-  expect(rolls).toContain('FALLO');
-  expect(rolls).toContain('TEXTO DM');
-  expect(rolls).toContain('shouldHideFromPlayer');
-});
-
-test("DM controla visibilidad desde config DM-only existente", () => {
-  expect(rolls).toContain('const CONFIG_PATH = "campaña/config/theatre_rolls"');
-  expect(rolls).toContain('function writeConfig(patch)');
-  expect(rolls).toContain('if (!isDmView()) return Promise.resolve(false)');
-  expect(rolls).toContain('db.ref(CONFIG_PATH).update(patch)');
-});
-
-test("instance-control carga el visualizador tanto en jugador como en ON GAME", () => {
-  expect(instanceControl).toContain("function ensureTheatreRollVisualizerAssets");
-  expect(instanceControl).toContain("css/theatre-roll-visualizer.css");
-  expect(instanceControl).toContain("js/theatre-roll-visualizer.js");
-  expect(instanceControl).toContain("ensureTheatreRollVisualizerAssets(documentRef)");
-});
-
-test("la tarjeta queda sobre sprites y debajo del diálogo", () => {
-  expect(css).toContain("z-index:7000");
-  expect(css).toContain("pointer-events:none");
-  expect(css).toContain(".theatre-roll-coins");
-  expect(css).toContain(".theatre-roll-total");
-  expect(css).toContain("@media (prefers-reduced-motion:reduce)");
-});
-
-test("queda API pública para futuras tiradas enfrentadas", () => {
-  expect(rolls).toContain("global.LuminousTheatreRolls = Object.freeze");
-  expect(rolls).toContain("publishRoll,");
-  expect(rolls).toContain("VISIBILITY,");
+test("instance-control sigue cargando los assets", () => {
+  expect(instanceControl).toContain('theatre-roll-visualizer.css');
+  expect(instanceControl).toContain('theatre-roll-visualizer.js');
 });

--- a/tests/theatre_roll_visualizer.spec.js
+++ b/tests/theatre_roll_visualizer.spec.js
@@ -1,11 +1,81 @@
 const { test, expect } = require("@playwright/test");
 const fs = require("node:fs");
 const path = require("node:path");
+const vm = require("node:vm");
 
 const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
 const rolls = read("js/theatre-roll-visualizer.js");
 const css = read("css/theatre-roll-visualizer.css");
 const instanceControl = read("js/instance-control.js");
+const rules = read("database.rules.json");
+
+function loadRollApi(uid = "player-uid") {
+  const database = () => ({});
+  database.ServerValue = { TIMESTAMP: { ".sv": "timestamp" } };
+  const fakeDocument = {
+    readyState: "loading",
+    addEventListener() {},
+    body: { classList: { contains: () => false } },
+  };
+  const window = {
+    document: fakeDocument,
+    firebase: {
+      database,
+      auth: () => ({ currentUser: { uid } }),
+    },
+    sessionStorage: {
+      getItem: () => "client-a",
+      setItem() {},
+    },
+  };
+  const context = vm.createContext({
+    window,
+    console,
+    Date,
+    Math,
+    MutationObserver: class MutationObserver {},
+    setTimeout,
+    clearTimeout,
+  });
+  vm.runInContext(rolls, context);
+  return window.LuminousTheatreRolls;
+}
+
+function fullRecord(overrides = {}) {
+  const base = {
+    schemaVersion: 3,
+    kind: "check-result",
+    presentation: "result-only",
+    roller: { uid: "player-uid", actorId: "actor-a", name: "SO" },
+    rollerUid: "player-uid",
+    rollerClientId: "client-a",
+    base: 6,
+    total: 18,
+    heads: 3,
+    coinCount: 5,
+    coinHeadBonus: 4,
+    check: {
+      thresholdRaw: 20,
+      hiddenThreshold: false,
+      modifierType: "advantage",
+      modifierValue: 4,
+      outcome: "passed",
+    },
+    visibility: "public",
+    hiddenOutput: "none",
+    hiddenOutcome: "success",
+    hiddenText: "",
+    durationMs: 7000,
+    createdAt: 1,
+    clientCreatedAt: 1,
+    roomId: "default",
+    privateRoomKey: "default",
+    privateAvailable: false,
+  };
+  return Object.assign(base, overrides, {
+    check: Object.assign({}, base.check, overrides.check || {}),
+  });
+}
 
 test("reutiliza las imágenes reales del Coin Engine", () => {
   expect(rolls).toContain('const HEAD_SRC_MARKER = "yshLPnQ"');
@@ -20,22 +90,105 @@ test("reutiliza las imágenes reales del Coin Engine", () => {
   expect(css).not.toContain('.theatre-roll-coin[data-side="head"]');
 });
 
-test("el HUD completo solo se renderiza en el cliente que está tirando", () => {
+test("HUD local conserva el Coin Engine y el resultado remoto", () => {
   expect(rolls).toContain('function createLocalHud(check)');
   expect(rolls).toContain('function shouldSuppressRemoteForLocalRoller(roll)');
-  expect(rolls).toContain('roll?.rollerClientId && roll.rollerClientId === CLIENT_ID');
+  expect(rolls).toContain('return roll.rollerClientId === CLIENT_ID;');
   expect(rolls).toContain('presentation: "result-only"');
   expect(rolls).toContain('buildRemoteResultCard');
-  expect(css).toContain('Full HUD: only rendered locally');
-  expect(css).toContain('Remote viewers never receive the full HUD');
 });
 
-test("los demás clientes reciben solo nombre total y outcome", () => {
-  expect(rolls).toContain('theatre-roll-result-name');
-  expect(rolls).toContain('theatre-roll-result-total');
-  expect(rolls).toContain('theatre-roll-result-outcome');
-  expect(rolls).not.toContain('card.appendChild(buildCoinRow');
-  expect(css).toContain('.theatre-roll-result-card');
+test("una tirada oculta no publica total threshold ni outcome real en campaña", () => {
+  const api = loadRollApi();
+  const publicRecord = api.buildPublicRollRecord(fullRecord({
+    visibility: "hidden",
+    hiddenOutput: "outcome",
+    privateAvailable: true,
+    check: { hiddenThreshold: true },
+  }));
+
+  expect(publicRecord.publicOutcome).toBe("passed");
+  expect(publicRecord.total).toBeUndefined();
+  expect(publicRecord.base).toBeUndefined();
+  expect(publicRecord.heads).toBeUndefined();
+  expect(publicRecord.check).toBeUndefined();
+  const serialized = JSON.stringify(publicRecord);
+  expect(serialized).not.toContain("thresholdRaw");
+  expect(serialized).not.toContain("modifierValue");
+});
+
+test("NADA no publica ni identidad ni resultado de una tirada oculta", () => {
+  const api = loadRollApi();
+  const publicRecord = api.buildPublicRollRecord(fullRecord({
+    visibility: "hidden",
+    hiddenOutput: "none",
+    privateAvailable: true,
+  }));
+  expect(publicRecord.roller).toBeUndefined();
+  expect(publicRecord.publicOutcome).toBeUndefined();
+  expect(publicRecord.total).toBeUndefined();
+});
+
+test("hiddenThreshold mantiene el threshold fuera del stream público aunque la tirada sea pública", () => {
+  const api = loadRollApi();
+  const publicRecord = api.buildPublicRollRecord(fullRecord({
+    visibility: "public",
+    privateAvailable: true,
+    check: { hiddenThreshold: true },
+  }));
+  expect(publicRecord.total).toBe(18);
+  expect(publicRecord.check.outcome).toBe("passed");
+  expect(publicRecord.check.hiddenThreshold).toBe(true);
+  expect(publicRecord.check.thresholdRaw).toBeUndefined();
+  expect(publicRecord.check.modifierType).toBeUndefined();
+  expect(publicRecord.check.modifierValue).toBeUndefined();
+});
+
+test("datos privados viven fuera de campaña y solo el DM puede leerlos", () => {
+  expect(rolls).toContain('const PRIVATE_ROLL_ROOT = "dm_private/theatre_rolls"');
+  expect(rolls).toContain('resolvePrivateRollPath');
+  expect(rolls).toContain('Multi-location update keeps the public redaction and DM-private copy atomic.');
+  expect(rules).toContain('"dm_private"');
+  expect(rules).toContain('".read": "auth != null && auth.uid === \'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1\'"');
+  expect(rules).toContain("newData.child('rollerUid').val() === auth.uid");
+  expect(rules).toContain("newData.child('privateRoomKey').val() === $room");
+});
+
+test("el inicio de una tirada es idempotente y no consume dos veces armCheck", () => {
+  expect(rolls).toContain('let rollStartPending = false');
+  expect(rolls).toContain('if (rollStartPending || pendingLocalRoll) return false;');
+  expect(rolls).toContain('const armedCheck = nextCheckContext;');
+  expect(rolls).toContain('nextCheckContext = null;');
+  expect(rolls).toContain('rollStartPending = true;');
+});
+
+test("TOTAL publica y renderiza solo el total para jugadores", () => {
+  const api = loadRollApi();
+  const publicRecord = api.buildPublicRollRecord(fullRecord({
+    visibility: "total",
+    privateAvailable: true,
+  }));
+  expect(publicRecord.total).toBe(18);
+  expect(publicRecord.check).toBeUndefined();
+  expect(publicRecord.base).toBeUndefined();
+  expect(publicRecord.heads).toBeUndefined();
+  expect(rolls).toContain('if (!isDmView() && visibility === VISIBILITY.TOTAL) return card;');
+});
+
+test("rollerClientId solo suprime la sesión que originó la tirada", () => {
+  const api = loadRollApi("player-uid");
+  expect(api.getClientId()).toBe("client-a");
+  expect(api.shouldSuppressRemoteForLocalRoller({
+    rollerClientId: "client-a",
+    roller: { uid: "player-uid" },
+  })).toBe(true);
+  expect(api.shouldSuppressRemoteForLocalRoller({
+    rollerClientId: "client-b",
+    roller: { uid: "player-uid" },
+  })).toBe(false);
+  expect(api.shouldSuppressRemoteForLocalRoller({
+    roller: { uid: "player-uid" },
+  })).toBe(true);
 });
 
 test("threshold aplica neutral ventaja y desventaja", () => {
@@ -52,7 +205,7 @@ test("X igual a cero elimina el tip y fuerza neutral", () => {
   expect(rolls).toContain('if (normalized.modifierValue > 0 && normalized.tipText)');
 });
 
-test("threshold oculto muestra interrogantes solo en HUD local", () => {
+test("threshold oculto muestra interrogantes en HUD local", () => {
   expect(rolls).toContain('normalized.hiddenThreshold ? "??"');
   expect(rolls).toContain('hiddenThreshold: check.hiddenThreshold');
 });


### PR DESCRIPTION
## Objetivo

Mostrar las tiradas del Coin Engine dentro del Theatre sin crear un segundo motor y sin tocar diálogo, sprites, foco, expresiones ni `publishIntervention()`.

## HUD local

- Reutiliza las 5 imágenes reales del Coin Engine (`yshLPnQ.png` / `XDx0ICt.png`).
- No muestra Skill, icono de Skill ni barra de nombre.
- `Threshold` a la izquierda y `Outcome` a la derecha.
- PASS cuando `Outcome >= Threshold efectivo`.
- Threshold oculto se presenta como `??`.
- Neutral usa color neutro; Advantage resta X y usa amarillo; Disadvantage suma X y usa rojo.
- X=0 elimina por completo el Tip superior.

## Visibilidad remota

- `PÚBLICA`: jugadores ven total + outcome permitido.
- `TOTAL`: jugadores ven únicamente el total. El DM conserva el detalle completo.
- `OCULTA / NADA`: no se publica identidad, total, threshold ni outcome en el stream legible por jugadores.
- `OCULTA / ÉXITO-FALLO`: solo se publica el outcome permitido.
- `OCULTA / TEXTO DM`: solo se publica el texto permitido.

## Seguridad de datos privados

`campaña/.read` ya concede lectura a cualquier usuario autenticado, por lo que los datos secretos no pueden protegerse debajo de `campaña`.

Este PR separa los datos en dos audiencias:

- `campaña/teatro/.../tiradas`: registro público/redactado.
- `dm_private/theatre_rolls/{room}/{rollId}`: detalle real para el DM.

El registro privado contiene total real, raw threshold, modificadores y outcome completo cuando la visibilidad lo requiere. `database.rules.json` permite leer `dm_private` únicamente al DM. Un jugador puede crear una sola vez su propio registro privado mediante su UID, pero no puede leerlo ni sobrescribirlo.

La publicación público + privado se hace con un único multi-location update para que ambos registros sean atómicos.

`hiddenThreshold` también queda protegido aunque la tirada sea pública: el raw threshold y sus modificadores no se colocan en el árbol legible por jugadores.

## Sesión del jugador

`rollerClientId` es la autoridad para registros modernos:

- solo la sesión que originó la tirada suprime su propia tarjeta remota;
- otra pestaña, perfil o dispositivo con el mismo UID sí recibe el resultado;
- el fallback por UID se usa únicamente para registros legacy sin `rollerClientId`.

## Inicio de tirada

El doble disparador existente (MutationObserver + click hook) ahora es idempotente mediante `rollStartPending` / `pendingLocalRoll`. `armCheck()` se consume una sola vez y no pierde Threshold ni modificadores aunque ambos hooks observen el mismo inicio.

## Integración

- Sala default pública: `campaña/teatro/tiradas`.
- Salas futuras públicas: `campaña/teatro/salas/{roomId}/tiradas`.
- Detalle DM-only: `dm_private/theatre_rolls/{room}/{rollId}`.
- `js/instance-control.js` solo carga los assets del visualizador.

## Archivos

- `js/theatre-roll-visualizer.js`
- `css/theatre-roll-visualizer.css`
- `js/instance-control.js`
- `tests/theatre_roll_visualizer.spec.js`
- `database.rules.json`
- `.github/workflows/theatre-roll-visualizer.yml`

## Regresiones

Los tests cubren:

- assets reales del Coin Engine;
- redacción de tiradas ocultas;
- `NADA` sin identidad ni resultado;
- `hiddenThreshold` fuera del stream público;
- datos privados fuera de `campaña` y lectura DM-only;
- inicio idempotente de tirada;
- `TOTAL` distinto de `PÚBLICA`;
- supresión limitada al `rollerClientId` exacto;
- Advantage / Disadvantage / X=0 / colores;
- ausencia de mutaciones de diálogo, sprites o foco.

## CI

Commit `52d55c2fc12b725102201eb3792c30584b2f49fa`:

- `node --check js/theatre-roll-visualizer.js` ✅
- `node --check js/instance-control.js` ✅
- `npx playwright test tests/theatre_roll_visualizer.spec.js` ✅
- Workflow `Theatre Roll Visualizer` #31 ✅