### PR TITLE
Trait Engine V1: reglas declarativas para Rol y Combate

### DIFF
--- a/dm-trait-creator.html
+++ b/dm-trait-creator.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Luminous · Trait Builder V1</title>
+  <style>
+    :root { color-scheme: dark; --bg:#090909; --panel:#151515; --line:#48413a; --accent:#d39a49; --bad:#d75a5a; --good:#78bd78; }
+    * { box-sizing:border-box; }
+    body { margin:0; background:var(--bg); color:#eee; font-family:Arial,sans-serif; }
+    #trait-builder-root { display:grid; grid-template-columns:minmax(520px,1.2fr) minmax(380px,.8fr); min-height:100vh; }
+    .builder-main,.builder-preview { padding:24px; }
+    .builder-preview { border-left:1px solid var(--line); background:#0d0d0d; position:sticky; top:0; height:100vh; overflow:auto; }
+    h1,h2 { margin:0 0 16px; text-transform:uppercase; letter-spacing:.08em; }
+    h1 { color:var(--accent); }
+    .trait-builder-grid { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:10px; }
+    .trait-builder-field { display:flex; flex-direction:column; gap:5px; font-size:12px; text-transform:uppercase; color:#aaa; }
+    input,select,textarea,button { font:inherit; }
+    input,select,textarea { width:100%; background:#090909; color:#fff; border:1px solid var(--line); padding:9px; }
+    textarea { min-height:80px; resize:vertical; }
+    button { background:#1b1b1b; color:#eee; border:1px solid var(--accent); padding:9px 13px; cursor:pointer; text-transform:uppercase; font-weight:700; }
+    button:hover { background:#292119; }
+    .trait-builder-effect { margin-top:14px; padding:14px; border:1px solid var(--line); background:var(--panel); }
+    .trait-builder-effect header { display:flex; justify-content:space-between; align-items:center; margin-bottom:10px; color:var(--accent); }
+    .builder-section { border:1px solid var(--line); background:var(--panel); padding:16px; margin-bottom:16px; }
+    .context-row,.action-row { display:flex; gap:16px; align-items:center; flex-wrap:wrap; }
+    .context-row label { display:flex; gap:6px; align-items:center; }
+    .context-row input { width:auto; }
+    .trait-validation { padding:10px; border:1px solid var(--line); margin-bottom:12px; font-size:12px; }
+    .trait-validation.is-valid { border-color:var(--good); color:var(--good); }
+    .trait-validation.is-invalid { border-color:var(--bad); color:var(--bad); }
+    pre { white-space:pre-wrap; overflow-wrap:anywhere; font:12px/1.45 monospace; }
+    .note { color:#999; font-size:13px; line-height:1.5; }
+    @media (max-width:1000px) { #trait-builder-root { grid-template-columns:1fr; } .builder-preview { position:static; height:auto; border-left:0; border-top:1px solid var(--line); } .trait-builder-grid { grid-template-columns:1fr 1fr; } }
+  </style>
+</head>
+<body>
+<div id="trait-builder-root">
+  <main class="builder-main">
+    <h1>Trait Builder V1</h1>
+    <p class="note">Construye reglas declarativas. No acepta JavaScript arbitrario: las fórmulas pasan por el Formula Engine seguro.</p>
+
+    <section class="builder-section">
+      <h2>Definition</h2>
+      <div class="trait-builder-grid">
+        <label class="trait-builder-field"><span>Name</span><input id="trait-name" value="Danger Senses"></label>
+        <label class="trait-builder-field"><span>ID</span><input id="trait-id" value="danger_senses"></label>
+        <label class="trait-builder-field"><span>Source Type</span><select id="trait-source-type"><option>class</option><option>race</option><option>background</option><option>lineage</option><option>item</option><option>special</option></select></label>
+        <label class="trait-builder-field"><span>Source ID</span><input id="trait-source-id" value="barbarian"></label>
+        <label class="trait-builder-field" style="grid-column:span 2"><span>Description</span><textarea id="trait-description">Lower Dexterity Check difficulty by 4.</textarea></label>
+      </div>
+      <div class="context-row" style="margin-top:12px"><strong>Contexts</strong><label><input type="checkbox" id="trait-context-theatre" checked>Theatre / Role</label><label><input type="checkbox" id="trait-context-combat">Combat</label></div>
+    </section>
+
+    <section class="builder-section">
+      <h2>Activation</h2>
+      <div class="trait-builder-grid">
+        <label class="trait-builder-field"><span>Type</span><select id="trait-activation"><option>passive</option><option>automatic</option><option>manual</option><option>prompt</option><option>choice</option></select></label>
+        <label class="trait-builder-field"><span>Action Cost</span><select id="trait-action-cost"><option>none</option><option>action</option><option>quick_action</option><option>reaction</option><option>special</option></select></label>
+        <label class="trait-builder-field"><span>Uses Formula</span><input id="trait-uses-formula" placeholder="floor(ClassLevel / 7)"></label>
+        <label class="trait-builder-field"><span>Reset</span><select id="trait-reset"><option>never</option><option>turn</option><option>encounter</option><option>short_rest</option><option>long_rest</option><option>day</option></select></label>
+      </div>
+    </section>
+
+    <section class="builder-section">
+      <div class="action-row" style="justify-content:space-between"><h2 style="margin:0">Effects</h2><button id="trait-add-effect" type="button">+ Add Effect</button></div>
+      <div id="trait-effects"></div>
+    </section>
+  </main>
+
+  <aside class="builder-preview">
+    <h2>Validated JSON</h2>
+    <div id="trait-validation" class="trait-validation"></div>
+    <div class="action-row"><button id="trait-copy-json" type="button">Copy JSON</button><button id="trait-save-local" type="button">Save Local Draft</button></div>
+    <pre id="trait-json-output"></pre>
+  </aside>
+</div>
+<script src="js/trait-engine.js"></script>
+<script src="js/trait-builder.js"></script>
+</body>
+</html>

--- a/docs/trait-engine-v1.md
+++ b/docs/trait-engine-v1.md
@@ -1,0 +1,93 @@
+# Trait Engine V1
+
+Trait Engine V1 is the shared rule layer for role/theatre checks and combat passives/actions. It is declarative: the DM defines Traits as data instead of writing JavaScript per Trait.
+
+## Domain model
+
+- **Trait**: permanent feature granted by class, race, background, lineage, item, or special source.
+- **Effect**: atomic rule inside a Trait.
+- **Status**: temporary state produced by rules.
+- **Resource**: numeric pool/counter used by rules.
+- **Grant**: progression rule that gives a Trait definition to a character.
+
+A Trait Effect follows the same shape in every context:
+
+`WHEN trigger` → `IF conditions` → `DO operations` → using a safe `VALUE/formula`.
+
+## Level semantics
+
+- `Level`: total character level.
+- `ClassLevel`: level in the class that granted the current Trait.
+
+For a level 30 character with Barbarian 20 / Fighter 10, a Barbarian Trait sees `Level = 30` and `ClassLevel = 20`.
+
+## Activation modes
+
+- `passive`: no player button.
+- `automatic`: engine executes on its trigger.
+- `manual`: player activates from the Trait Tray.
+- `prompt`: a caller can ask the player Use/Skip when its event becomes relevant.
+- `choice`: caller resolves a choice/preparation before activation.
+
+Manual actions can consume `action`, `quick_action`, `reaction`, `special`, or no action cost, and can have formula-based use limits/reset scopes.
+
+## Formula language
+
+Allowed arithmetic: `+ - * / %`, parentheses, numeric constants and approved variables. Allowed functions:
+
+`floor`, `ceil`, `round`, `abs`, `min`, `max`, `clamp`.
+
+The parser does not use `eval` or `Function` and rejects unsupported tokens/functions.
+
+## V1 event vocabulary
+
+Role/Theatre: `before_check`, `after_check`.
+
+Combat/runtime: `encounter_start`, `encounter_end`, `turn_start`, `turn_end`, `before_skill`, `after_skill`, `before_clash`, `clash_win`, `clash_lose`, `before_attack`, `on_hit`, `on_crit`, `on_kill`, `on_evade`, `attack_end`.
+
+Rest/world: `short_rest`, `long_rest`, `day_start`.
+
+Activation: `on_use`.
+
+## V1 operations
+
+- `modify`: generic numeric path modification (`add`, `multiply`, `set/override`, `min`, `max`).
+- `resource`: `gain`, `spend`, `set`, `consume_all`; can store consumed amount for later threshold Effects.
+- `apply_status` / `remove_status`.
+- `heal_hp` / `heal_sp` / `gain_shield`.
+- `set_flag` / `clear_flag`.
+- `log`.
+
+Additional skill/coin/deck-specific operations can be added later without changing the Trait schema.
+
+## Theatre adapter
+
+`resolveTheatreCheck({ character, traits, check, state })` dispatches `before_check` in `theatre` context and returns the modified check plus an auditable list of outcomes.
+
+Example: Danger Senses checks `check.abilityId === "dex"` and performs `modify check.difficulty add -4`.
+
+## Combat adapter
+
+`dispatchCombatEvent(trigger, runtime)` sends a combat event through all Traits. Automatic effects use the same condition/formula/operation pipeline as Theatre.
+
+Example: Devil Body listens to `turn_start` and heals `floor(DefensiveLevel / 2)`.
+
+## Player execution
+
+`listAvailableTraitActions` filters out passive/automatic Traits and returns only player decisions, including availability, action cost, uses remaining, target/input metadata, and blocking reasons.
+
+`trait-player-tray.js` renders that contract into buttons. It never renders passive Traits as actions. Manual activation validates conditions, action economy, and use limits before dispatching `on_use`.
+
+## Progression grants
+
+`resolveTraitGrants(character, grants, catalog)` keeps definitions separate from progression. Class grants compare `atLevel` to the matching class level, while race/background/lineage grants match their own source IDs.
+
+This lets one Trait definition be granted by different sources without duplicating its mechanics.
+
+## DM Trait Builder V1
+
+`dm-trait-creator.html` is a standalone visual authoring surface backed by `trait-builder.js`. It exposes source, contexts, activation, use formula/reset, Effects, conditions, and operations as fields/options, validates the resulting definition with Trait Engine, and can copy validated JSON or keep a local draft. It never accepts arbitrary JavaScript. Campaign/Firebase persistence can be wired after the data contract is accepted.
+
+## Next integration step
+
+The existing Theatre coordinator should pass its roll spec/check object to `resolveTheatreCheck` before a roll is armed. Combat should emit its existing lifecycle events into `dispatchCombatEvent`. After that, the DM builder can persist validated Trait JSON/grants in the campaign data and the player HUD can mount `trait-player-tray.js` in the chosen combat action area.

--- a/js/trait-builder.js
+++ b/js/trait-builder.js
@@ -1,0 +1,264 @@
+(function (global) {
+  "use strict";
+
+  const doc = global.document;
+  const engine = global.LuminousTraitEngine;
+  if (!doc || !engine || global.LuminousTraitBuilder) return;
+
+  const TRIGGER_OPTIONS = [
+    "passive", "on_use", "encounter_start", "encounter_end", "turn_start", "turn_end",
+    "before_check", "after_check", "before_skill", "after_skill", "before_clash", "clash_win",
+    "clash_lose", "before_attack", "on_hit", "on_crit", "on_kill", "on_evade", "attack_end",
+    "short_rest", "long_rest", "day_start",
+  ];
+  const CONDITION_OPERATORS = ["eq", "ne", "gt", "gte", "lt", "lte", "truthy", "falsy", "contains", "not_contains", "in", "not_in", "between"];
+  const OPERATION_TYPES = ["modify", "resource", "apply_status", "remove_status", "heal_hp", "heal_sp", "gain_shield", "set_flag", "clear_flag", "log"];
+  const MODIFY_MODES = ["add", "multiply", "set", "override", "min", "max"];
+  const RESOURCE_MODES = ["gain", "spend", "set", "consume_all"];
+
+  const $ = (id, root = doc) => root.querySelector(`#${id}`);
+  const value = (id, root = doc) => String($(id, root)?.value ?? "").trim();
+
+  function parseLiteral(raw) {
+    const text = String(raw ?? "").trim();
+    if (!text) return "";
+    if (text === "true") return true;
+    if (text === "false") return false;
+    if (text === "null") return null;
+    if (/^-?\d+(?:\.\d+)?$/.test(text)) return Number(text);
+    if ((text.startsWith("[") && text.endsWith("]")) || (text.startsWith("{") && text.endsWith("}"))) {
+      try { return JSON.parse(text); } catch (_) { return text; }
+    }
+    return text;
+  }
+
+  function selectOptions(select, values) {
+    values.forEach((entry) => {
+      const option = doc.createElement("option");
+      option.value = entry;
+      option.textContent = entry.replaceAll("_", " ").toUpperCase();
+      select.appendChild(option);
+    });
+  }
+
+  function field(label, input) {
+    const wrapper = doc.createElement("label");
+    wrapper.className = "trait-builder-field";
+    const span = doc.createElement("span");
+    span.textContent = label;
+    wrapper.append(span, input);
+    return wrapper;
+  }
+
+  function input(name, placeholder = "") {
+    const node = doc.createElement("input");
+    node.type = "text";
+    node.dataset.field = name;
+    node.placeholder = placeholder;
+    return node;
+  }
+
+  function select(name, options) {
+    const node = doc.createElement("select");
+    node.dataset.field = name;
+    selectOptions(node, options);
+    return node;
+  }
+
+  function effectCard(seed = {}) {
+    const card = doc.createElement("article");
+    card.className = "trait-builder-effect";
+    card.innerHTML = `<header><strong>EFFECT</strong><button type="button" data-remove-effect>REMOVE</button></header>`;
+
+    const grid = doc.createElement("div");
+    grid.className = "trait-builder-grid";
+    const context = select("context", ["any", "theatre", "combat"]);
+    const trigger = select("trigger", TRIGGER_OPTIONS);
+    const conditionPath = input("conditionPath", "check.abilityId / skill.coinCount");
+    const conditionOperator = select("conditionOperator", CONDITION_OPERATORS);
+    const conditionValue = input("conditionValue", "dex / 5 / [\"insight\",\"perception\"]");
+    const operationType = select("operationType", OPERATION_TYPES);
+    const operationPath = input("operationPath", "check.finalPower / self.damagePercent");
+    const operationMode = select("operationMode", MODIFY_MODES);
+    const operationFormula = input("operationFormula", "2 / floor(ClassLevel / 7)");
+    const resourceId = input("resourceId", "devil_gauge");
+    const resourceMode = select("resourceMode", RESOURCE_MODES);
+    const statusId = input("statusId", "rage");
+    const duration = select("duration", Object.values(engine.DURATION_TYPES));
+    const flagId = input("flagId", "spell_skills_blocked");
+    const storeAs = input("storeAs", "ConsumedGauge");
+
+    [
+      field("Context", context), field("Trigger", trigger),
+      field("Condition path / formula", conditionPath), field("Condition operator", conditionOperator), field("Condition value", conditionValue),
+      field("Operation", operationType), field("Target path", operationPath), field("Modify mode", operationMode), field("Value / formula", operationFormula),
+      field("Resource id", resourceId), field("Resource mode", resourceMode), field("Store result as", storeAs),
+      field("Status id", statusId), field("Duration", duration), field("Flag id", flagId),
+    ].forEach((node) => grid.appendChild(node));
+    card.appendChild(grid);
+
+    const set = (name, val) => {
+      const node = card.querySelector(`[data-field="${name}"]`);
+      if (node && val != null) node.value = val;
+    };
+    set("context", seed.context || "any");
+    set("trigger", seed.trigger || "passive");
+    set("conditionPath", seed.conditionPath || "");
+    set("conditionOperator", seed.conditionOperator || "eq");
+    set("conditionValue", seed.conditionValue || "");
+    set("operationType", seed.operationType || "modify");
+    set("operationPath", seed.operationPath || "");
+    set("operationMode", seed.operationMode || "add");
+    set("operationFormula", seed.operationFormula || "");
+    set("resourceId", seed.resourceId || "");
+    set("resourceMode", seed.resourceMode || "gain");
+    set("storeAs", seed.storeAs || "");
+    set("statusId", seed.statusId || "");
+    set("duration", seed.duration || "immediate");
+    set("flagId", seed.flagId || "");
+
+    card.querySelector("[data-remove-effect]").addEventListener("click", () => {
+      card.remove();
+      updatePreview();
+    });
+    card.addEventListener("input", updatePreview);
+    card.addEventListener("change", updatePreview);
+    return card;
+  }
+
+  function readEffect(card, index) {
+    const read = (name) => String(card.querySelector(`[data-field="${name}"]`)?.value ?? "").trim();
+    const conditionPath = read("conditionPath");
+    const conditionOperator = read("conditionOperator") || "eq";
+    const conditionValue = parseLiteral(read("conditionValue"));
+    const operationType = read("operationType");
+    const operationFormula = read("operationFormula");
+    const operation = { type: operationType };
+
+    if (operationType === "modify") {
+      operation.path = read("operationPath");
+      operation.mode = read("operationMode") || "add";
+      if (operationFormula) operation.formula = operationFormula;
+      else operation.value = 0;
+    } else if (operationType === "resource") {
+      operation.resourceId = read("resourceId");
+      operation.mode = read("resourceMode") || "gain";
+      if (operationFormula) operation.formula = operationFormula;
+      if (read("storeAs")) operation.storeAs = read("storeAs");
+    } else if (["apply_status", "remove_status"].includes(operationType)) {
+      operation.statusId = read("statusId");
+      if (operationType === "apply_status") {
+        operation.duration = read("duration") || "until_removed";
+        if (operationFormula) operation.potency = { formula: operationFormula };
+      }
+    } else if (["heal_hp", "heal_sp", "gain_shield"].includes(operationType)) {
+      if (read("operationPath")) operation.path = read("operationPath");
+      if (operationFormula) operation.formula = operationFormula;
+    } else if (["set_flag", "clear_flag"].includes(operationType)) {
+      operation.flagId = read("flagId");
+    } else if (operationType === "log") {
+      operation.message = operationFormula;
+    }
+
+    const conditions = [];
+    if (conditionPath) {
+      if (conditionPath.startsWith("=")) conditions.push({ formula: conditionPath.slice(1), operator: conditionOperator, value: conditionValue });
+      else conditions.push({ path: conditionPath, operator: conditionOperator, value: conditionValue });
+    }
+
+    return {
+      id: `effect_${index + 1}`,
+      context: read("context") || "any",
+      trigger: read("trigger") || "passive",
+      conditions,
+      operations: [operation],
+    };
+  }
+
+  function readTrait() {
+    const contexts = [];
+    if ($("trait-context-theatre")?.checked) contexts.push("theatre");
+    if ($("trait-context-combat")?.checked) contexts.push("combat");
+    if (!contexts.length) contexts.push("any");
+    const activation = {
+      type: value("trait-activation") || "passive",
+      actionCost: value("trait-action-cost") || "none",
+    };
+    const usesFormula = value("trait-uses-formula");
+    if (usesFormula) activation.uses = { formula: usesFormula, reset: value("trait-reset") || "never" };
+    const sourceType = value("trait-source-type") || "special";
+    const sourceId = value("trait-source-id");
+    const effects = Array.from(doc.querySelectorAll("#trait-effects .trait-builder-effect")).map(readEffect);
+
+    return {
+      schemaVersion: engine.SCHEMA_VERSION,
+      id: value("trait-id") || engine.normalizeId(value("trait-name")),
+      name: value("trait-name"),
+      description: value("trait-description"),
+      source: { type: sourceType, id: sourceId, ...(sourceType === "class" ? { classId: sourceId } : {}) },
+      contexts,
+      activation,
+      effects,
+    };
+  }
+
+  function updatePreview() {
+    const output = $("trait-json-output");
+    const validationNode = $("trait-validation");
+    if (!output || !validationNode) return;
+    const trait = readTrait();
+    const validation = engine.validateTrait(trait);
+    output.textContent = JSON.stringify(validation.trait, null, 2);
+    validationNode.className = `trait-validation ${validation.valid ? "is-valid" : "is-invalid"}`;
+    validationNode.textContent = validation.valid
+      ? (validation.warnings.length ? `VALID · ${validation.warnings.join(" · ")}` : "VALID TRAIT")
+      : validation.errors.join(" · ");
+  }
+
+  function addEffect(seed) {
+    $("trait-effects")?.appendChild(effectCard(seed));
+    updatePreview();
+  }
+
+  async function copyJson() {
+    const validation = engine.validateTrait(readTrait());
+    if (!validation.valid) return false;
+    const text = JSON.stringify(validation.trait, null, 2);
+    if (global.navigator?.clipboard?.writeText) await global.navigator.clipboard.writeText(text);
+    return text;
+  }
+
+  function saveLocal() {
+    const validation = engine.validateTrait(readTrait());
+    if (!validation.valid) return false;
+    const key = `luminous_trait_${validation.trait.id}`;
+    global.localStorage?.setItem(key, JSON.stringify(validation.trait));
+    return key;
+  }
+
+  function boot() {
+    if (!$("trait-builder-root")) return;
+    $("trait-add-effect")?.addEventListener("click", () => addEffect());
+    $("trait-copy-json")?.addEventListener("click", () => copyJson().catch(console.error));
+    $("trait-save-local")?.addEventListener("click", saveLocal);
+    $("trait-builder-root")?.addEventListener("input", updatePreview);
+    $("trait-builder-root")?.addEventListener("change", updatePreview);
+    if (!$("trait-effects")?.children.length) addEffect({
+      trigger: "before_check",
+      context: "theatre",
+      conditionPath: "check.abilityId",
+      conditionOperator: "eq",
+      conditionValue: "dex",
+      operationType: "modify",
+      operationPath: "check.difficulty",
+      operationMode: "add",
+      operationFormula: "-4",
+    });
+    updatePreview();
+  }
+
+  const api = Object.freeze({ readTrait, updatePreview, addEffect, copyJson, saveLocal, parseLiteral });
+  global.LuminousTraitBuilder = api;
+  if (doc.readyState === "loading") doc.addEventListener("DOMContentLoaded", boot, { once: true });
+  else boot();
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/trait-builder.js
+++ b/js/trait-builder.js
@@ -12,7 +12,9 @@
     "short_rest", "long_rest", "day_start",
   ];
   const CONDITION_OPERATORS = ["eq", "ne", "gt", "gte", "lt", "lte", "truthy", "falsy", "contains", "not_contains", "in", "not_in", "between"];
-  const OPERATION_TYPES = ["modify", "resource", "apply_status", "remove_status", "heal_hp", "heal_sp", "gain_shield", "set_flag", "clear_flag", "log"];
+  const OPERATION_TYPES = Array.isArray(engine.OPERATION_TYPES)
+    ? engine.OPERATION_TYPES
+    : ["modify", "resource", "apply_status", "remove_status", "heal_hp", "heal_sp", "gain_shield", "set_flag", "clear_flag", "log"];
   const MODIFY_MODES = ["add", "multiply", "set", "override", "min", "max"];
   const RESOURCE_MODES = ["gain", "spend", "set", "consume_all"];
 
@@ -32,21 +34,21 @@
     return text;
   }
 
-  function selectOptions(select, values) {
+  function selectOptions(selectNode, values) {
     values.forEach((entry) => {
       const option = doc.createElement("option");
       option.value = entry;
       option.textContent = entry.replaceAll("_", " ").toUpperCase();
-      select.appendChild(option);
+      selectNode.appendChild(option);
     });
   }
 
-  function field(label, input) {
+  function field(label, control) {
     const wrapper = doc.createElement("label");
     wrapper.className = "trait-builder-field";
     const span = doc.createElement("span");
     span.textContent = label;
-    wrapper.append(span, input);
+    wrapper.append(span, control);
     return wrapper;
   }
 
@@ -77,6 +79,7 @@
     const conditionPath = input("conditionPath", "check.abilityId / skill.coinCount");
     const conditionOperator = select("conditionOperator", CONDITION_OPERATORS);
     const conditionValue = input("conditionValue", "dex / 5 / [\"insight\",\"perception\"]");
+    const conditionMax = input("conditionMax", "10 (required for BETWEEN)");
     const operationType = select("operationType", OPERATION_TYPES);
     const operationPath = input("operationPath", "check.finalPower / self.damagePercent");
     const operationMode = select("operationMode", MODIFY_MODES);
@@ -90,7 +93,8 @@
 
     [
       field("Context", context), field("Trigger", trigger),
-      field("Condition path / formula", conditionPath), field("Condition operator", conditionOperator), field("Condition value", conditionValue),
+      field("Condition path / formula", conditionPath), field("Condition operator", conditionOperator),
+      field("Condition value / min", conditionValue), field("Condition max (BETWEEN)", conditionMax),
       field("Operation", operationType), field("Target path", operationPath), field("Modify mode", operationMode), field("Value / formula", operationFormula),
       field("Resource id", resourceId), field("Resource mode", resourceMode), field("Store result as", storeAs),
       field("Status id", statusId), field("Duration", duration), field("Flag id", flagId),
@@ -106,6 +110,7 @@
     set("conditionPath", seed.conditionPath || "");
     set("conditionOperator", seed.conditionOperator || "eq");
     set("conditionValue", seed.conditionValue || "");
+    set("conditionMax", seed.conditionMax || "");
     set("operationType", seed.operationType || "modify");
     set("operationPath", seed.operationPath || "");
     set("operationMode", seed.operationMode || "add");
@@ -131,6 +136,7 @@
     const conditionPath = read("conditionPath");
     const conditionOperator = read("conditionOperator") || "eq";
     const conditionValue = parseLiteral(read("conditionValue"));
+    const conditionMax = parseLiteral(read("conditionMax"));
     const operationType = read("operationType");
     const operationFormula = read("operationFormula");
     const operation = { type: operationType };
@@ -162,8 +168,11 @@
 
     const conditions = [];
     if (conditionPath) {
-      if (conditionPath.startsWith("=")) conditions.push({ formula: conditionPath.slice(1), operator: conditionOperator, value: conditionValue });
-      else conditions.push({ path: conditionPath, operator: conditionOperator, value: conditionValue });
+      const condition = conditionPath.startsWith("=")
+        ? { formula: conditionPath.slice(1), operator: conditionOperator, value: conditionValue }
+        : { path: conditionPath, operator: conditionOperator, value: conditionValue };
+      if (conditionOperator === "between") condition.max = conditionMax;
+      conditions.push(condition);
     }
 
     return {

--- a/js/trait-engine.js
+++ b/js/trait-engine.js
@@ -1,0 +1,248 @@
+(function (global) {
+  "use strict";
+
+  const SCHEMA_VERSION = 1;
+  const CONTEXTS = Object.freeze({ ANY: "any", THEATRE: "theatre", COMBAT: "combat" });
+  const ACTIVATION_TYPES = Object.freeze({ PASSIVE: "passive", AUTOMATIC: "automatic", MANUAL: "manual", PROMPT: "prompt", CHOICE: "choice" });
+  const ACTION_COSTS = Object.freeze({ NONE: "none", ACTION: "action", QUICK_ACTION: "quick_action", REACTION: "reaction", SPECIAL: "special" });
+  const TRIGGERS = Object.freeze({
+    PASSIVE: "passive", ON_USE: "on_use", ENCOUNTER_START: "encounter_start", ENCOUNTER_END: "encounter_end",
+    TURN_START: "turn_start", TURN_END: "turn_end", BEFORE_CHECK: "before_check", AFTER_CHECK: "after_check",
+    BEFORE_SKILL: "before_skill", AFTER_SKILL: "after_skill", BEFORE_CLASH: "before_clash", CLASH_WIN: "clash_win",
+    CLASH_LOSE: "clash_lose", BEFORE_ATTACK: "before_attack", ON_HIT: "on_hit", ON_CRIT: "on_crit",
+    ON_KILL: "on_kill", ON_EVADE: "on_evade", ATTACK_END: "attack_end", SHORT_REST: "short_rest",
+    LONG_REST: "long_rest", DAY_START: "day_start",
+  });
+  const RESET_SCOPES = Object.freeze({ TURN: "turn", ENCOUNTER: "encounter", SHORT_REST: "short_rest", LONG_REST: "long_rest", DAY: "day", NEVER: "never" });
+  const DURATION_TYPES = Object.freeze({ IMMEDIATE: "immediate", THIS_SKILL: "this_skill", THIS_TURN: "this_turn", NEXT_TURN: "next_turn", NEXT_SKILL: "next_skill", ENCOUNTER: "encounter", UNTIL_REMOVED: "until_removed", PERMANENT: "permanent" });
+  const ALLOWED_FUNCTIONS = Object.freeze({ floor: Math.floor, ceil: Math.ceil, round: Math.round, abs: Math.abs, min: Math.min, max: Math.max, clamp: (v, lo, hi) => Math.max(lo, Math.min(hi, v)) });
+
+  const num = (v, fallback = 0) => Number.isFinite(Number(v)) ? Number(v) : fallback;
+  const int = (v, fallback = 0) => Number.isFinite(Number.parseInt(v, 10)) ? Number.parseInt(v, 10) : fallback;
+  const normalizeId = (v) => String(v ?? "").trim().toLowerCase().replace(/\s+/g, "_");
+  const clone = (v) => v == null ? v : JSON.parse(JSON.stringify(v));
+
+  function getPath(root, path, fallback) {
+    let cur = root;
+    for (const key of String(path || "").split(".").filter(Boolean)) {
+      if (cur == null || !Object.prototype.hasOwnProperty.call(Object(cur), key)) return fallback;
+      cur = cur[key];
+    }
+    return cur === undefined ? fallback : cur;
+  }
+
+  function setPath(root, path, value) {
+    const parts = String(path || "").split(".").filter(Boolean);
+    if (!parts.length) throw new Error("Trait operation requires a target path.");
+    let cur = root;
+    for (const key of parts.slice(0, -1)) {
+      if (!cur[key] || typeof cur[key] !== "object") cur[key] = {};
+      cur = cur[key];
+    }
+    cur[parts.at(-1)] = value;
+    return value;
+  }
+
+  function classEntries(character = {}) {
+    if (Array.isArray(character.classes)) return character.classes.map((x) => ({ classId: normalizeId(x?.classId || x?.id), levels: Math.max(0, int(x?.levels ?? x?.level)) })).filter((x) => x.classId && x.levels);
+    const source = character.classLevels || character.classesById || {};
+    return Object.entries(source).map(([classId, levels]) => ({ classId: normalizeId(classId), levels: Math.max(0, int(levels?.levels ?? levels?.level ?? levels)) })).filter((x) => x.classId && x.levels);
+  }
+
+  function getClassLevel(character = {}, classId) {
+    return classEntries(character).find((x) => x.classId === normalizeId(classId))?.levels || 0;
+  }
+
+  function statMod(score) { return Math.floor((num(score, 10) - 10) / 2); }
+
+  function buildVariables(character = {}, runtime = {}, trait = {}) {
+    const level = Math.max(0, int(runtime.Level ?? runtime.level ?? character.level));
+    const source = trait.source || {};
+    const classId = normalizeId(source.type || trait.sourceType) === "class" ? normalizeId(source.classId || source.id || trait.sourceId) : normalizeId(runtime.sourceClassId);
+    const stats = character.stats || {};
+    const combat = character.combatStats || {};
+    return Object.assign({
+      Level: level,
+      ClassLevel: classId ? getClassLevel(character, classId) : Math.max(0, int(runtime.ClassLevel ?? runtime.classLevel)),
+      Proficiency: num(runtime.Proficiency ?? character.proficiency, Math.ceil(level / 20)),
+      StrengthMod: num(runtime.StrengthMod, statMod(stats.fuerza ?? stats.strength ?? character.strength)),
+      DexterityMod: num(runtime.DexterityMod, statMod(stats.destreza ?? stats.dexterity ?? character.dexterity)),
+      ConstitutionMod: num(runtime.ConstitutionMod, statMod(stats.constitucion ?? stats.constitution ?? character.constitution)),
+      IntelligenceMod: num(runtime.IntelligenceMod, statMod(stats.inteligencia ?? stats.intelligence ?? character.intelligence)),
+      WisdomMod: num(runtime.WisdomMod, statMod(stats.sabiduria ?? stats.wisdom ?? character.wisdom)),
+      CharismaMod: num(runtime.CharismaMod, statMod(stats.carisma ?? stats.charisma ?? character.charisma)),
+      OffensiveLevel: num(runtime.OffensiveLevel ?? runtime.offensiveLevel ?? combat.offensiveLevel ?? combat.off_level ?? character.offensiveLevel, level),
+      DefensiveLevel: num(runtime.DefensiveLevel ?? runtime.defensiveLevel ?? combat.defensiveLevel ?? combat.def_level ?? character.defensiveLevel, level),
+      MinSpeed: num(runtime.MinSpeed ?? runtime.minSpeed ?? combat.minSpeed ?? character.minSpeed),
+      MaxSpeed: num(runtime.MaxSpeed ?? runtime.maxSpeed ?? combat.maxSpeed ?? character.maxSpeed),
+      MaxHP: num(runtime.MaxHP ?? runtime.maxHp ?? combat.hp_max ?? character.maxHp), CurrentHP: num(runtime.CurrentHP ?? runtime.currentHp ?? combat.hp_actual ?? character.currentHp),
+      MaxSP: num(runtime.MaxSP ?? runtime.maxSp ?? combat.sp_max ?? character.maxSp), CurrentSP: num(runtime.CurrentSP ?? runtime.currentSp ?? combat.sp_actual ?? character.sp),
+      SkillCoinCount: num(runtime.SkillCoinCount ?? getPath(runtime, "skill.coinCount")), SkillWeight: num(runtime.SkillWeight ?? getPath(runtime, "skill.weight")), SpellSlotLevel: num(runtime.SpellSlotLevel ?? getPath(runtime, "skill.spellSlotLevel")),
+      TargetLevel: num(runtime.TargetLevel ?? getPath(runtime, "target.level")), TargetMaxHP: num(runtime.TargetMaxHP ?? getPath(runtime, "target.maxHp")), TargetCurrentHP: num(runtime.TargetCurrentHP ?? getPath(runtime, "target.currentHp")),
+      TargetOffensiveLevel: num(runtime.TargetOffensiveLevel ?? getPath(runtime, "target.offensiveLevel")), TargetDefensiveLevel: num(runtime.TargetDefensiveLevel ?? getPath(runtime, "target.defensiveLevel")),
+      AliveAllies: num(runtime.AliveAllies ?? runtime.aliveAllies), AliveEnemies: num(runtime.AliveEnemies ?? runtime.aliveEnemies), TurnNumber: num(runtime.TurnNumber ?? runtime.turnNumber), RoundNumber: num(runtime.RoundNumber ?? runtime.roundNumber),
+    }, runtime.variables || {});
+  }
+
+  function tokenize(source) {
+    const text = String(source ?? "0").trim();
+    const out = [];
+    for (let i = 0; i < text.length;) {
+      const c = text[i];
+      if (/\s/.test(c)) { i += 1; continue; }
+      if (/[0-9.]/.test(c)) {
+        const start = i; while (i < text.length && /[0-9.]/.test(text[i])) i += 1;
+        const raw = text.slice(start, i); if (!/^\d*\.?\d+$/.test(raw)) throw new Error(`Invalid number in formula: ${raw}`);
+        out.push(["n", Number(raw)]); continue;
+      }
+      if (/[A-Za-z_]/.test(c)) {
+        const start = i; while (i < text.length && /[A-Za-z0-9_.]/.test(text[i])) i += 1;
+        out.push(["id", text.slice(start, i)]); continue;
+      }
+      if ("+-*/%(),".includes(c)) { out.push([c, c]); i += 1; continue; }
+      throw new Error(`Unsupported token in formula: ${c}`);
+    }
+    out.push(["eof", null]); return out;
+  }
+
+  function evaluateFormula(formula, vars = {}) {
+    if (formula == null || formula === "") return 0;
+    if (typeof formula === "number") return Number.isFinite(formula) ? formula : 0;
+    const t = tokenize(formula); let i = 0;
+    const peek = () => t[i][0];
+    const take = (type) => { if (peek() !== type) throw new Error(`Expected ${type}, received ${peek()}.`); return t[i++][1]; };
+    const variable = (name) => { const key = Object.keys(vars).find((k) => k.toLowerCase() === name.toLowerCase()); return num(key ? vars[key] : 0); };
+    let expression;
+    const primary = () => {
+      if (peek() === "n") return take("n");
+      if (peek() === "id") {
+        const name = take("id");
+        if (peek() !== "(") return variable(name);
+        take("("); const args = [];
+        if (peek() !== ")") { do { args.push(expression()); if (peek() !== ",") break; take(","); } while (true); }
+        take(")"); const fn = ALLOWED_FUNCTIONS[name.toLowerCase()]; if (!fn) throw new Error(`Formula function is not allowed: ${name}`);
+        return num(fn(...args));
+      }
+      if (peek() === "(") { take("("); const v = expression(); take(")"); return v; }
+      throw new Error(`Unexpected formula token: ${peek()}`);
+    };
+    const unary = () => peek() === "+" ? (take("+"), unary()) : peek() === "-" ? (take("-"), -unary()) : primary();
+    const term = () => { let v = unary(); while (["*", "/", "%"].includes(peek())) { const op = take(peek()), r = unary(); if ((op === "/" || op === "%") && r === 0) return 0; v = op === "*" ? v * r : op === "/" ? v / r : v % r; } return v; };
+    expression = () => { let v = term(); while (["+", "-"].includes(peek())) { const op = take(peek()), r = term(); v = op === "+" ? v + r : v - r; } return v; };
+    const result = expression(); if (peek() !== "eof") throw new Error("Unexpected trailing formula input."); return num(result);
+  }
+
+  function normalizeContexts(v) { return [...new Set((Array.isArray(v) ? v : v ? [v] : ["any"]).map(normalizeId).filter(Boolean))]; }
+  function contextMatches(expected, actual) { const list = normalizeContexts(expected); return list.includes("any") || list.includes(normalizeId(actual || "any")); }
+
+  function normalizeTrait(input = {}) {
+    const t = clone(input) || {};
+    t.schemaVersion = int(t.schemaVersion, SCHEMA_VERSION); t.id = normalizeId(t.id || t.name); t.name = String(t.name || t.id || "Unnamed Trait").trim();
+    t.contexts = normalizeContexts(t.contexts || t.context); t.source = Object.assign({ type: "special", id: "" }, t.source || {});
+    t.source.type = normalizeId(t.source.type || t.sourceType || "special"); t.source.id = normalizeId(t.source.id || t.sourceId || t.source.classId); if (t.source.type === "class") t.source.classId = normalizeId(t.source.classId || t.source.id);
+    t.activation = Object.assign({ type: "passive", actionCost: "none" }, t.activation || {}); t.activation.type = normalizeId(t.activation.type); t.activation.actionCost = normalizeId(t.activation.actionCost || "none");
+    t.effects = (Array.isArray(t.effects) ? t.effects : []).map((e, idx) => { const x = clone(e) || {}; x.id = normalizeId(x.id || `${t.id}_effect_${idx + 1}`); x.contexts = normalizeContexts(x.contexts || x.context || t.contexts); x.trigger = normalizeId(x.trigger || "passive"); x.conditions = Array.isArray(x.conditions) ? x.conditions : x.condition ? [x.condition] : []; x.operations = Array.isArray(x.operations) ? x.operations : x.operation ? [x.operation] : []; return x; });
+    return t;
+  }
+
+  function validateTrait(input = {}) {
+    const trait = normalizeTrait(input), errors = [], warnings = [];
+    if (!trait.id) errors.push("Trait requires an id or name.");
+    if (!Object.values(ACTIVATION_TYPES).includes(trait.activation.type)) errors.push(`Unknown activation type: ${trait.activation.type}`);
+    if (!Object.values(ACTION_COSTS).includes(trait.activation.actionCost)) errors.push(`Unknown action cost: ${trait.activation.actionCost}`);
+    const formula = (f, label) => { if (f == null || f === "") return; try { evaluateFormula(f, {}); } catch (e) { errors.push(`${label}: ${e.message}`); } };
+    formula(trait.activation?.uses?.formula, `${trait.id} uses formula`);
+    trait.effects.forEach((effect) => {
+      if (!effect.operations.length) warnings.push(`${effect.id} has no operations.`);
+      effect.conditions.forEach((c, idx) => { formula(c?.formula, `${effect.id} condition ${idx + 1}`); formula(c?.valueFormula, `${effect.id} condition value ${idx + 1}`); });
+      effect.operations.forEach((op, idx) => {
+        const type = normalizeId(op?.type); if (!type) errors.push(`${effect.id} contains an operation without type.`);
+        if (type === "modify" && !op.path) errors.push(`${effect.id} modify operation requires path.`);
+        if (type === "resource" && !op.resourceId) errors.push(`${effect.id} resource operation requires resourceId.`);
+        if (["apply_status", "remove_status"].includes(type) && !op.statusId) errors.push(`${effect.id} ${type} requires statusId.`);
+        formula(op?.formula, `${effect.id} operation ${idx + 1}`); formula(op?.value?.formula, `${effect.id} operation value ${idx + 1}`);
+      });
+    });
+    return { valid: !errors.length, errors, warnings, trait };
+  }
+
+  function createState(initial = {}) { return { resources: clone(initial.resources || {}), statuses: clone(initial.statuses || {}), usages: clone(initial.usages || {}), choices: clone(initial.choices || {}), flags: clone(initial.flags || {}), history: clone(initial.history || []) }; }
+  function environment(trait, runtime, state) { const character = runtime.character || runtime.self || {}; return { trait, runtime, state, context: runtime.context || "any", variables: buildVariables(character, runtime, trait) }; }
+  function valueOf(v, env, fallback = 0) { if (v && typeof v === "object" && v.formula != null) return evaluateFormula(v.formula, env.variables); if (typeof v === "string" && /[A-Za-z()+*/%]/.test(v)) return evaluateFormula(v, env.variables); return num(v, fallback); }
+
+  function conditionMatches(c, env) {
+    if (!c || typeof c !== "object") return Boolean(c);
+    if (Array.isArray(c.all)) return c.all.every((x) => conditionMatches(x, env)); if (Array.isArray(c.any)) return c.any.some((x) => conditionMatches(x, env)); if (c.not) return !conditionMatches(c.not, env);
+    let left = c.formula != null ? evaluateFormula(c.formula, env.variables) : c.resourceId ? num(env.state.resources[normalizeId(c.resourceId)]?.value) : c.statusId ? Boolean(env.state.statuses[normalizeId(c.statusId)]) : c.variable ? env.variables[c.variable] : c.path ? getPath(env.runtime, c.path) : c.left;
+    const right = c.valueFormula != null ? evaluateFormula(c.valueFormula, env.variables) : c.value, op = normalizeId(c.operator || "eq");
+    if (["eq", "equals"].includes(op)) return left === right; if (["ne", "not_equals"].includes(op)) return left !== right;
+    if (op === "gt") return Number(left) > Number(right); if (op === "gte") return Number(left) >= Number(right); if (op === "lt") return Number(left) < Number(right); if (op === "lte") return Number(left) <= Number(right);
+    if (op === "truthy") return Boolean(left); if (op === "falsy") return !left; if (op === "contains") return Array.isArray(left) ? left.includes(right) : String(left ?? "").includes(String(right ?? "")); if (op === "not_contains") return !(Array.isArray(left) ? left.includes(right) : String(left ?? "").includes(String(right ?? "")));
+    if (op === "in") return Array.isArray(right) && right.includes(left); if (op === "not_in") return Array.isArray(right) && !right.includes(left); if (op === "between") return Number(left) >= Number(right) && Number(left) <= Number(c.max);
+    throw new Error(`Unsupported trait condition operator: ${c.operator}`);
+  }
+  function conditionsMatch(list, env) { return (list || []).every((c) => conditionMatches(c, env)); }
+
+  function mutate(root, path, mode, amount) {
+    const before = num(getPath(root, path)), m = normalizeId(mode || "add"); let after;
+    if (m === "add") after = before + amount; else if (m === "multiply") after = before * amount; else if (["set", "override"].includes(m)) after = amount; else if (m === "min") after = Math.max(before, amount); else if (m === "max") after = Math.min(before, amount); else throw new Error(`Unsupported trait modification mode: ${mode}`);
+    setPath(root, path, after); return { before, after, delta: after - before };
+  }
+
+  function executeOperation(operation, env, effect) {
+    const op = clone(operation) || {}, type = normalizeId(op.type), amount = op.formula != null ? evaluateFormula(op.formula, env.variables) : valueOf(op.value, env), base = { type, traitId: env.trait.id, effectId: effect.id }; let out;
+    if (type === "modify") out = Object.assign(base, { path: op.path, mode: normalizeId(op.mode || "add"), amount }, mutate(env.runtime, op.path, op.mode, amount));
+    else if (type === "resource") {
+      const id = normalizeId(op.resourceId); if (!env.state.resources[id]) env.state.resources[id] = { value: valueOf(op.definition?.initial, env), min: num(op.definition?.min), max: op.definition?.max == null ? null : Math.max(0, valueOf(op.definition.max, env)) };
+      const r = env.state.resources[id], before = num(r.value), mode = normalizeId(op.mode || "gain"); let after = mode === "consume_all" ? 0 : mode === "set" ? amount : mode === "spend" || mode === "subtract" ? before - amount : before + amount;
+      if (r.max != null) after = Math.min(num(r.max), after); after = Math.max(num(r.min), after); r.value = after; if (op.storeAs) env.variables[op.storeAs] = mode === "consume_all" ? before : Math.abs(after - before); out = Object.assign(base, { resourceId: id, mode, before, after, amount: mode === "consume_all" ? before : amount });
+    } else if (type === "apply_status") {
+      const id = normalizeId(op.statusId); env.state.statuses[id] = { id, name: op.name || id, potency: valueOf(op.potency ?? op.value, env), count: valueOf(op.count ?? 1, env, 1), duration: normalizeId(op.duration || "until_removed"), sourceTraitId: env.trait.id, sourceUnitId: env.runtime.sourceUnitId || env.runtime.character?.id || null, data: clone(op.data || {}) }; out = Object.assign(base, { statusId: id, status: clone(env.state.statuses[id]) });
+    } else if (type === "remove_status") { const id = normalizeId(op.statusId), removed = Boolean(env.state.statuses[id]); delete env.state.statuses[id]; out = Object.assign(base, { statusId: id, removed }); }
+    else if (["heal_hp", "heal_sp", "gain_shield"].includes(type)) { const path = op.path || (type === "heal_hp" ? "self.currentHp" : type === "heal_sp" ? "self.currentSp" : "self.shield"), m = mutate(env.runtime, path, "add", amount); if (op.maxPath) setPath(env.runtime, path, Math.min(num(getPath(env.runtime, op.maxPath), m.after), m.after)); out = Object.assign(base, { path, amount, before: m.before, after: num(getPath(env.runtime, path), m.after) }); }
+    else if (type === "set_flag") { const id = normalizeId(op.flagId || op.path); env.state.flags[id] = op.value == null ? true : op.value; out = Object.assign(base, { flagId: id, value: env.state.flags[id] }); }
+    else if (type === "clear_flag") { const id = normalizeId(op.flagId || op.path); delete env.state.flags[id]; out = Object.assign(base, { flagId: id, cleared: true }); }
+    else if (type === "log") out = Object.assign(base, { message: String(op.message || "") }); else throw new Error(`Unsupported trait operation type: ${op.type}`);
+    env.state.history.push(Object.assign({ at: Date.now() }, clone(out))); return out;
+  }
+
+  function dispatchTrait(input, trigger, runtime = {}, stateInput) {
+    const trait = normalizeTrait(input), state = stateInput || createState(), env = environment(trait, runtime, state), outcomes = [];
+    trait.effects.forEach((effect) => { if (effect.trigger === normalizeId(trigger) && contextMatches(effect.contexts, env.context) && conditionsMatch(effect.conditions, env)) effect.operations.forEach((op) => outcomes.push(executeOperation(op, env, effect))); });
+    return { trait, state, runtime, variables: env.variables, outcomes };
+  }
+  function dispatchTraits(traits, trigger, runtime = {}, stateInput) { const state = stateInput || createState(), outcomes = []; (traits || []).forEach((t) => outcomes.push(...dispatchTrait(t, trigger, runtime, state).outcomes)); return { state, runtime, outcomes }; }
+  function usageRecord(state, trait) { const id = trait.id; if (!state.usages[id]) state.usages[id] = { used: 0, reset: normalizeId(trait.activation?.uses?.reset || "never") }; return state.usages[id]; }
+  function maxUses(trait, runtime) { const uses = trait.activation?.uses; if (!uses) return null; const env = environment(trait, runtime, createState()), v = uses.formula != null ? evaluateFormula(uses.formula, env.variables) : valueOf(uses.max ?? uses.value, env); return Math.max(0, Math.floor(v)); }
+  function actionAvailable(runtime, cost) { const c = normalizeId(cost || "none"); if (["none", "special"].includes(c) || !runtime.actionEconomy) return true; return num(runtime.actionEconomy[c] ?? getPath(runtime.actionEconomy, `available.${c}`)) > 0; }
+
+  function canActivateTrait(input, runtime = {}, stateInput) {
+    const trait = normalizeTrait(input), state = stateInput || createState(), activation = trait.activation, env = environment(trait, runtime, state), reasons = [];
+    if (!["manual", "prompt", "choice"].includes(activation.type)) reasons.push("Trait is not player-activated."); if (!contextMatches(trait.contexts, runtime.context)) reasons.push(`Trait is not available in ${runtime.context || "any"}.`); if (!conditionsMatch(activation.conditions || [], env)) reasons.push("Activation conditions are not met."); if (!actionAvailable(runtime, activation.actionCost)) reasons.push(`No ${activation.actionCost} remaining.`);
+    const maximum = maxUses(trait, runtime), record = usageRecord(state, trait), remaining = maximum == null ? null : Math.max(0, maximum - record.used); if (maximum != null && remaining <= 0) reasons.push(`No uses remaining until ${record.reset}.`);
+    return { available: !reasons.length, reasons, maximum, remaining, actionCost: activation.actionCost, trait, state };
+  }
+
+  function activateTrait(input, runtime = {}, stateInput) {
+    const state = stateInput || createState(), check = canActivateTrait(input, runtime, state); if (!check.available) return Object.assign(check, { outcomes: [] }); const trait = check.trait, cost = trait.activation.actionCost;
+    if (!["none", "special"].includes(cost) && runtime.actionEconomy) { if (Object.prototype.hasOwnProperty.call(runtime.actionEconomy, cost)) runtime.actionEconomy[cost] = Math.max(0, num(runtime.actionEconomy[cost]) - 1); else if (runtime.actionEconomy.available) runtime.actionEconomy.available[cost] = Math.max(0, num(runtime.actionEconomy.available[cost]) - 1); }
+    const record = usageRecord(state, trait); if (check.maximum != null) record.used += 1; if (trait.activation.type === "choice" && runtime.choice != null) state.choices[trait.id] = clone(runtime.choice);
+    const result = dispatchTrait(trait, "on_use", runtime, state); return { available: true, reasons: [], maximum: check.maximum, remaining: check.maximum == null ? null : Math.max(0, check.maximum - record.used), actionCost: cost, trait, state, runtime, outcomes: result.outcomes };
+  }
+
+  function resetUsage(state, scope) { Object.values(state?.usages || {}).forEach((r) => { if (normalizeId(r.reset) === normalizeId(scope)) r.used = 0; }); return state; }
+  function listAvailableTraitActions(traits, runtime = {}, stateInput) { const state = stateInput || createState(); return (traits || []).map((t) => canActivateTrait(t, runtime, state)).filter((r) => ["manual", "prompt", "choice"].includes(r.trait.activation.type)).map((r) => ({ traitId: r.trait.id, name: r.trait.name, activationType: r.trait.activation.type, actionCost: r.actionCost, available: r.available, reasons: r.reasons, maximum: r.maximum, remaining: r.remaining, target: r.trait.activation.target || "self", inputs: clone(r.trait.activation.inputs || []) })); }
+  function resolveTheatreCheck({ character = {}, traits = [], check = {}, state } = {}) { const runtime = { context: "theatre", character, self: character, check: Object.assign({ difficulty: 0, abilityPower: 0, finalPower: 0 }, clone(check || {})) }, result = dispatchTraits(traits, "before_check", runtime, state || createState()); return { check: runtime.check, state: result.state, outcomes: result.outcomes }; }
+  function dispatchCombatEvent(trigger, { character = {}, traits = [], state, ...input } = {}) { const runtime = Object.assign({ context: "combat", character, self: input.self || character }, input); return dispatchTraits(traits, trigger, runtime, state || createState()); }
+
+  function resolveTraitGrants(character = {}, grants = [], catalog = {}) {
+    const byId = catalog instanceof Map ? catalog : new Map(Object.entries(catalog || {}).map(([k, v]) => [normalizeId(k), v]));
+    return (grants || []).filter((g) => { const type = normalizeId(g.sourceType || g.source?.type), id = normalizeId(g.sourceId || g.source?.id || g.source?.classId), required = Math.max(0, int(g.atLevel ?? g.level)); if (type === "class") return getClassLevel(character, id) >= required; if (type === "race") return normalizeId(character.raceId || character.race?.id) === id; if (type === "background") return normalizeId(character.backgroundId || character.background?.id) === id; if (type === "lineage") return (Array.isArray(character.lineages) ? character.lineages : [character.lineageId]).filter(Boolean).map(normalizeId).includes(id); return true; }).map((g) => {
+      const definition = byId.get(normalizeId(g.traitId || g.id)); if (!definition) return null; const t = normalizeTrait(definition), type = normalizeId(g.sourceType || g.source?.type || t.source.type), id = normalizeId(g.sourceId || g.source?.id || t.source.id); t.source = Object.assign({}, t.source, g.source || {}, { type, id }); if (type === "class") t.source.classId = id; return t;
+    }).filter(Boolean);
+  }
+
+  const api = Object.freeze({ SCHEMA_VERSION, CONTEXTS, ACTIVATION_TYPES, ACTION_COSTS, TRIGGERS, RESET_SCOPES, DURATION_TYPES, normalizeId, getPath, setPath, getClassLevel, buildVariables, evaluateFormula, normalizeTrait, validateTrait, createState, conditionMatches, conditionsMatch, dispatchTrait, dispatchTraits, canActivateTrait, activateTrait, listAvailableTraitActions, resetUsage, resolveTheatreCheck, dispatchCombatEvent, resolveTraitGrants });
+  global.LuminousTraitEngine = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/trait-engine.js
+++ b/js/trait-engine.js
@@ -15,6 +15,9 @@
   });
   const RESET_SCOPES = Object.freeze({ TURN: "turn", ENCOUNTER: "encounter", SHORT_REST: "short_rest", LONG_REST: "long_rest", DAY: "day", NEVER: "never" });
   const DURATION_TYPES = Object.freeze({ IMMEDIATE: "immediate", THIS_SKILL: "this_skill", THIS_TURN: "this_turn", NEXT_TURN: "next_turn", NEXT_SKILL: "next_skill", ENCOUNTER: "encounter", UNTIL_REMOVED: "until_removed", PERMANENT: "permanent" });
+  const OPERATION_TYPES = Object.freeze(["modify", "resource", "apply_status", "remove_status", "heal_hp", "heal_sp", "gain_shield", "set_flag", "clear_flag", "log"]);
+  const CONDITION_OPERATORS = Object.freeze(["eq", "equals", "ne", "not_equals", "gt", "gte", "lt", "lte", "truthy", "falsy", "contains", "not_contains", "in", "not_in", "between"]);
+  const FORBIDDEN_PATH_SEGMENTS = new Set(["__proto__", "prototype", "constructor"]);
   const ALLOWED_FUNCTIONS = Object.freeze({ floor: Math.floor, ceil: Math.ceil, round: Math.round, abs: Math.abs, min: Math.min, max: Math.max, clamp: (v, lo, hi) => Math.max(lo, Math.min(hi, v)) });
 
   const num = (v, fallback = 0) => Number.isFinite(Number(v)) ? Number(v) : fallback;
@@ -22,9 +25,23 @@
   const normalizeId = (v) => String(v ?? "").trim().toLowerCase().replace(/\s+/g, "_");
   const clone = (v) => v == null ? v : JSON.parse(JSON.stringify(v));
 
+  function assertSafeKey(value, label = "Trait key") {
+    const key = normalizeId(value);
+    if (FORBIDDEN_PATH_SEGMENTS.has(key)) throw new Error(`${label} uses unsafe key: ${key}`);
+    return key;
+  }
+
+  function pathParts(path, required = false) {
+    const parts = String(path || "").split(".").filter(Boolean);
+    if (required && !parts.length) throw new Error("Trait operation requires a target path.");
+    const forbidden = parts.find((part) => FORBIDDEN_PATH_SEGMENTS.has(part));
+    if (forbidden) throw new Error(`Unsafe trait path segment: ${forbidden}`);
+    return parts;
+  }
+
   function getPath(root, path, fallback) {
     let cur = root;
-    for (const key of String(path || "").split(".").filter(Boolean)) {
+    for (const key of pathParts(path)) {
       if (cur == null || !Object.prototype.hasOwnProperty.call(Object(cur), key)) return fallback;
       cur = cur[key];
     }
@@ -32,11 +49,10 @@
   }
 
   function setPath(root, path, value) {
-    const parts = String(path || "").split(".").filter(Boolean);
-    if (!parts.length) throw new Error("Trait operation requires a target path.");
+    const parts = pathParts(path, true);
     let cur = root;
     for (const key of parts.slice(0, -1)) {
-      if (!cur[key] || typeof cur[key] !== "object") cur[key] = {};
+      if (!Object.prototype.hasOwnProperty.call(Object(cur), key) || !cur[key] || typeof cur[key] !== "object") cur[key] = {};
       cur = cur[key];
     }
     cur[parts.at(-1)] = value;
@@ -145,22 +161,42 @@
     return t;
   }
 
+  function validatePath(path, label, errors, required = false) {
+    try { pathParts(path, required); } catch (error) { errors.push(`${label}: ${error.message}`); }
+  }
+
   function validateTrait(input = {}) {
     const trait = normalizeTrait(input), errors = [], warnings = [];
     if (!trait.id) errors.push("Trait requires an id or name.");
+    else try { assertSafeKey(trait.id, "Trait id"); } catch (error) { errors.push(error.message); }
     if (!Object.values(ACTIVATION_TYPES).includes(trait.activation.type)) errors.push(`Unknown activation type: ${trait.activation.type}`);
     if (!Object.values(ACTION_COSTS).includes(trait.activation.actionCost)) errors.push(`Unknown action cost: ${trait.activation.actionCost}`);
     const formula = (f, label) => { if (f == null || f === "") return; try { evaluateFormula(f, {}); } catch (e) { errors.push(`${label}: ${e.message}`); } };
     formula(trait.activation?.uses?.formula, `${trait.id} uses formula`);
     trait.effects.forEach((effect) => {
       if (!effect.operations.length) warnings.push(`${effect.id} has no operations.`);
-      effect.conditions.forEach((c, idx) => { formula(c?.formula, `${effect.id} condition ${idx + 1}`); formula(c?.valueFormula, `${effect.id} condition value ${idx + 1}`); });
+      effect.conditions.forEach((c, idx) => {
+        const label = `${effect.id} condition ${idx + 1}`;
+        formula(c?.formula, label); formula(c?.valueFormula, `${label} value`);
+        if (c?.path) validatePath(c.path, `${label} path`, errors);
+        const op = normalizeId(c?.operator || "eq");
+        if (!CONDITION_OPERATORS.includes(op)) errors.push(`${label} has unsupported operator: ${c?.operator}`);
+        if (op === "between" && c?.max == null) errors.push(`${label} between operator requires max.`);
+      });
       effect.operations.forEach((op, idx) => {
-        const type = normalizeId(op?.type); if (!type) errors.push(`${effect.id} contains an operation without type.`);
-        if (type === "modify" && !op.path) errors.push(`${effect.id} modify operation requires path.`);
+        const type = normalizeId(op?.type), label = `${effect.id} operation ${idx + 1}`;
+        if (!type) errors.push(`${effect.id} contains an operation without type.`);
+        else if (!OPERATION_TYPES.includes(type)) errors.push(`${effect.id} contains unsupported operation type: ${op?.type}`);
+        if (type === "modify") validatePath(op.path, `${effect.id} modify operation path`, errors, true);
         if (type === "resource" && !op.resourceId) errors.push(`${effect.id} resource operation requires resourceId.`);
+        if (type === "resource" && op.resourceId) try { assertSafeKey(op.resourceId, `${label} resourceId`); } catch (error) { errors.push(error.message); }
+        if (type === "resource" && op.storeAs) try { assertSafeKey(op.storeAs, `${label} storeAs`); } catch (error) { errors.push(error.message); }
         if (["apply_status", "remove_status"].includes(type) && !op.statusId) errors.push(`${effect.id} ${type} requires statusId.`);
-        formula(op?.formula, `${effect.id} operation ${idx + 1}`); formula(op?.value?.formula, `${effect.id} operation value ${idx + 1}`);
+        if (["apply_status", "remove_status"].includes(type) && op.statusId) try { assertSafeKey(op.statusId, `${label} statusId`); } catch (error) { errors.push(error.message); }
+        if (["set_flag", "clear_flag"].includes(type) && (op.flagId || op.path)) try { assertSafeKey(op.flagId || op.path, `${label} flagId`); } catch (error) { errors.push(error.message); }
+        if (["heal_hp", "heal_sp", "gain_shield"].includes(type) && op.path) validatePath(op.path, `${label} path`, errors);
+        if (["heal_hp", "heal_sp", "gain_shield"].includes(type) && op.maxPath) validatePath(op.maxPath, `${label} maxPath`, errors);
+        formula(op?.formula, label); formula(op?.value?.formula, `${label} value`);
       });
     });
     return { valid: !errors.length, errors, warnings, trait };
@@ -173,7 +209,7 @@
   function conditionMatches(c, env) {
     if (!c || typeof c !== "object") return Boolean(c);
     if (Array.isArray(c.all)) return c.all.every((x) => conditionMatches(x, env)); if (Array.isArray(c.any)) return c.any.some((x) => conditionMatches(x, env)); if (c.not) return !conditionMatches(c.not, env);
-    let left = c.formula != null ? evaluateFormula(c.formula, env.variables) : c.resourceId ? num(env.state.resources[normalizeId(c.resourceId)]?.value) : c.statusId ? Boolean(env.state.statuses[normalizeId(c.statusId)]) : c.variable ? env.variables[c.variable] : c.path ? getPath(env.runtime, c.path) : c.left;
+    const left = c.formula != null ? evaluateFormula(c.formula, env.variables) : c.resourceId ? num(env.state.resources[normalizeId(c.resourceId)]?.value) : c.statusId ? Boolean(env.state.statuses[normalizeId(c.statusId)]) : c.variable ? env.variables[c.variable] : c.path ? getPath(env.runtime, c.path) : c.left;
     const right = c.valueFormula != null ? evaluateFormula(c.valueFormula, env.variables) : c.value, op = normalizeId(c.operator || "eq");
     if (["eq", "equals"].includes(op)) return left === right; if (["ne", "not_equals"].includes(op)) return left !== right;
     if (op === "gt") return Number(left) > Number(right); if (op === "gte") return Number(left) >= Number(right); if (op === "lt") return Number(left) < Number(right); if (op === "lte") return Number(left) <= Number(right);
@@ -193,31 +229,35 @@
     const op = clone(operation) || {}, type = normalizeId(op.type), amount = op.formula != null ? evaluateFormula(op.formula, env.variables) : valueOf(op.value, env), base = { type, traitId: env.trait.id, effectId: effect.id }; let out;
     if (type === "modify") out = Object.assign(base, { path: op.path, mode: normalizeId(op.mode || "add"), amount }, mutate(env.runtime, op.path, op.mode, amount));
     else if (type === "resource") {
-      const id = normalizeId(op.resourceId); if (!env.state.resources[id]) env.state.resources[id] = { value: valueOf(op.definition?.initial, env), min: num(op.definition?.min), max: op.definition?.max == null ? null : Math.max(0, valueOf(op.definition.max, env)) };
+      const id = assertSafeKey(op.resourceId, "Resource id"); if (!env.state.resources[id]) env.state.resources[id] = { value: valueOf(op.definition?.initial, env), min: num(op.definition?.min), max: op.definition?.max == null ? null : Math.max(0, valueOf(op.definition.max, env)) };
       const r = env.state.resources[id], before = num(r.value), mode = normalizeId(op.mode || "gain"); let after = mode === "consume_all" ? 0 : mode === "set" ? amount : mode === "spend" || mode === "subtract" ? before - amount : before + amount;
-      if (r.max != null) after = Math.min(num(r.max), after); after = Math.max(num(r.min), after); r.value = after; if (op.storeAs) env.variables[op.storeAs] = mode === "consume_all" ? before : Math.abs(after - before); out = Object.assign(base, { resourceId: id, mode, before, after, amount: mode === "consume_all" ? before : amount });
+      if (r.max != null) after = Math.min(num(r.max), after); after = Math.max(num(r.min), after); r.value = after; if (op.storeAs) env.variables[assertSafeKey(op.storeAs, "Resource storeAs")] = mode === "consume_all" ? before : Math.abs(after - before); out = Object.assign(base, { resourceId: id, mode, before, after, amount: mode === "consume_all" ? before : amount });
     } else if (type === "apply_status") {
-      const id = normalizeId(op.statusId); env.state.statuses[id] = { id, name: op.name || id, potency: valueOf(op.potency ?? op.value, env), count: valueOf(op.count ?? 1, env, 1), duration: normalizeId(op.duration || "until_removed"), sourceTraitId: env.trait.id, sourceUnitId: env.runtime.sourceUnitId || env.runtime.character?.id || null, data: clone(op.data || {}) }; out = Object.assign(base, { statusId: id, status: clone(env.state.statuses[id]) });
-    } else if (type === "remove_status") { const id = normalizeId(op.statusId), removed = Boolean(env.state.statuses[id]); delete env.state.statuses[id]; out = Object.assign(base, { statusId: id, removed }); }
+      const id = assertSafeKey(op.statusId, "Status id"); env.state.statuses[id] = { id, name: op.name || id, potency: valueOf(op.potency ?? op.value, env), count: valueOf(op.count ?? 1, env, 1), duration: normalizeId(op.duration || "until_removed"), sourceTraitId: env.trait.id, sourceUnitId: env.runtime.sourceUnitId || env.runtime.character?.id || null, data: clone(op.data || {}) }; out = Object.assign(base, { statusId: id, status: clone(env.state.statuses[id]) });
+    } else if (type === "remove_status") { const id = assertSafeKey(op.statusId, "Status id"), removed = Boolean(env.state.statuses[id]); delete env.state.statuses[id]; out = Object.assign(base, { statusId: id, removed }); }
     else if (["heal_hp", "heal_sp", "gain_shield"].includes(type)) { const path = op.path || (type === "heal_hp" ? "self.currentHp" : type === "heal_sp" ? "self.currentSp" : "self.shield"), m = mutate(env.runtime, path, "add", amount); if (op.maxPath) setPath(env.runtime, path, Math.min(num(getPath(env.runtime, op.maxPath), m.after), m.after)); out = Object.assign(base, { path, amount, before: m.before, after: num(getPath(env.runtime, path), m.after) }); }
-    else if (type === "set_flag") { const id = normalizeId(op.flagId || op.path); env.state.flags[id] = op.value == null ? true : op.value; out = Object.assign(base, { flagId: id, value: env.state.flags[id] }); }
-    else if (type === "clear_flag") { const id = normalizeId(op.flagId || op.path); delete env.state.flags[id]; out = Object.assign(base, { flagId: id, cleared: true }); }
+    else if (type === "set_flag") { const id = assertSafeKey(op.flagId || op.path, "Flag id"); env.state.flags[id] = op.value == null ? true : op.value; out = Object.assign(base, { flagId: id, value: env.state.flags[id] }); }
+    else if (type === "clear_flag") { const id = assertSafeKey(op.flagId || op.path, "Flag id"); delete env.state.flags[id]; out = Object.assign(base, { flagId: id, cleared: true }); }
     else if (type === "log") out = Object.assign(base, { message: String(op.message || "") }); else throw new Error(`Unsupported trait operation type: ${op.type}`);
     env.state.history.push(Object.assign({ at: Date.now() }, clone(out))); return out;
   }
 
   function dispatchTrait(input, trigger, runtime = {}, stateInput) {
-    const trait = normalizeTrait(input), state = stateInput || createState(), env = environment(trait, runtime, state), outcomes = [];
+    const validation = validateTrait(input);
+    if (!validation.valid) throw new Error(`Invalid Trait ${validation.trait.id || "<unknown>"}: ${validation.errors.join(" | ")}`);
+    const trait = validation.trait, state = stateInput || createState(), env = environment(trait, runtime, state), outcomes = [];
     trait.effects.forEach((effect) => { if (effect.trigger === normalizeId(trigger) && contextMatches(effect.contexts, env.context) && conditionsMatch(effect.conditions, env)) effect.operations.forEach((op) => outcomes.push(executeOperation(op, env, effect))); });
     return { trait, state, runtime, variables: env.variables, outcomes };
   }
   function dispatchTraits(traits, trigger, runtime = {}, stateInput) { const state = stateInput || createState(), outcomes = []; (traits || []).forEach((t) => outcomes.push(...dispatchTrait(t, trigger, runtime, state).outcomes)); return { state, runtime, outcomes }; }
-  function usageRecord(state, trait) { const id = trait.id; if (!state.usages[id]) state.usages[id] = { used: 0, reset: normalizeId(trait.activation?.uses?.reset || "never") }; return state.usages[id]; }
+  function usageRecord(state, trait) { const id = assertSafeKey(trait.id, "Trait id"); if (!state.usages[id]) state.usages[id] = { used: 0, reset: normalizeId(trait.activation?.uses?.reset || "never") }; return state.usages[id]; }
   function maxUses(trait, runtime) { const uses = trait.activation?.uses; if (!uses) return null; const env = environment(trait, runtime, createState()), v = uses.formula != null ? evaluateFormula(uses.formula, env.variables) : valueOf(uses.max ?? uses.value, env); return Math.max(0, Math.floor(v)); }
   function actionAvailable(runtime, cost) { const c = normalizeId(cost || "none"); if (["none", "special"].includes(c) || !runtime.actionEconomy) return true; return num(runtime.actionEconomy[c] ?? getPath(runtime.actionEconomy, `available.${c}`)) > 0; }
 
   function canActivateTrait(input, runtime = {}, stateInput) {
-    const trait = normalizeTrait(input), state = stateInput || createState(), activation = trait.activation, env = environment(trait, runtime, state), reasons = [];
+    const validation = validateTrait(input), state = stateInput || createState();
+    if (!validation.valid) return { available: false, reasons: validation.errors.slice(), maximum: null, remaining: null, actionCost: validation.trait.activation.actionCost, trait: validation.trait, state };
+    const trait = validation.trait, activation = trait.activation, env = environment(trait, runtime, state), reasons = [];
     if (!["manual", "prompt", "choice"].includes(activation.type)) reasons.push("Trait is not player-activated."); if (!contextMatches(trait.contexts, runtime.context)) reasons.push(`Trait is not available in ${runtime.context || "any"}.`); if (!conditionsMatch(activation.conditions || [], env)) reasons.push("Activation conditions are not met."); if (!actionAvailable(runtime, activation.actionCost)) reasons.push(`No ${activation.actionCost} remaining.`);
     const maximum = maxUses(trait, runtime), record = usageRecord(state, trait), remaining = maximum == null ? null : Math.max(0, maximum - record.used); if (maximum != null && remaining <= 0) reasons.push(`No uses remaining until ${record.reset}.`);
     return { available: !reasons.length, reasons, maximum, remaining, actionCost: activation.actionCost, trait, state };
@@ -226,7 +266,7 @@
   function activateTrait(input, runtime = {}, stateInput) {
     const state = stateInput || createState(), check = canActivateTrait(input, runtime, state); if (!check.available) return Object.assign(check, { outcomes: [] }); const trait = check.trait, cost = trait.activation.actionCost;
     if (!["none", "special"].includes(cost) && runtime.actionEconomy) { if (Object.prototype.hasOwnProperty.call(runtime.actionEconomy, cost)) runtime.actionEconomy[cost] = Math.max(0, num(runtime.actionEconomy[cost]) - 1); else if (runtime.actionEconomy.available) runtime.actionEconomy.available[cost] = Math.max(0, num(runtime.actionEconomy.available[cost]) - 1); }
-    const record = usageRecord(state, trait); if (check.maximum != null) record.used += 1; if (trait.activation.type === "choice" && runtime.choice != null) state.choices[trait.id] = clone(runtime.choice);
+    const record = usageRecord(state, trait); if (check.maximum != null) record.used += 1; if (trait.activation.type === "choice" && runtime.choice != null) state.choices[assertSafeKey(trait.id, "Trait id")] = clone(runtime.choice);
     const result = dispatchTrait(trait, "on_use", runtime, state); return { available: true, reasons: [], maximum: check.maximum, remaining: check.maximum == null ? null : Math.max(0, check.maximum - record.used), actionCost: cost, trait, state, runtime, outcomes: result.outcomes };
   }
 
@@ -242,7 +282,7 @@
     }).filter(Boolean);
   }
 
-  const api = Object.freeze({ SCHEMA_VERSION, CONTEXTS, ACTIVATION_TYPES, ACTION_COSTS, TRIGGERS, RESET_SCOPES, DURATION_TYPES, normalizeId, getPath, setPath, getClassLevel, buildVariables, evaluateFormula, normalizeTrait, validateTrait, createState, conditionMatches, conditionsMatch, dispatchTrait, dispatchTraits, canActivateTrait, activateTrait, listAvailableTraitActions, resetUsage, resolveTheatreCheck, dispatchCombatEvent, resolveTraitGrants });
+  const api = Object.freeze({ SCHEMA_VERSION, CONTEXTS, ACTIVATION_TYPES, ACTION_COSTS, TRIGGERS, RESET_SCOPES, DURATION_TYPES, OPERATION_TYPES, normalizeId, getPath, setPath, getClassLevel, buildVariables, evaluateFormula, normalizeTrait, validateTrait, createState, conditionMatches, conditionsMatch, dispatchTrait, dispatchTraits, canActivateTrait, activateTrait, listAvailableTraitActions, resetUsage, resolveTheatreCheck, dispatchCombatEvent, resolveTraitGrants });
   global.LuminousTraitEngine = api;
   if (typeof module !== "undefined" && module.exports) module.exports = api;
 })(typeof window !== "undefined" ? window : globalThis);

--- a/js/trait-player-tray.js
+++ b/js/trait-player-tray.js
@@ -1,0 +1,140 @@
+(function (global) {
+  "use strict";
+
+  const engine = global.LuminousTraitEngine || (typeof require !== "undefined" ? require("./trait-engine.js") : null);
+  if (!engine) return;
+
+  function resolveHost(host) {
+    if (!host) return null;
+    if (typeof host === "string") return global.document?.querySelector(host) || null;
+    return host;
+  }
+
+  function createElement(tag, className, text) {
+    const node = global.document.createElement(tag);
+    if (className) node.className = className;
+    if (text != null) node.textContent = String(text);
+    return node;
+  }
+
+  function useLabel(action) {
+    if (action.maximum == null) return "";
+    return `${action.remaining}/${action.maximum}`;
+  }
+
+  function reasonLabel(action) {
+    return (action.reasons || []).join(" ") || "Unavailable";
+  }
+
+  class TraitPlayerTray {
+    constructor(options = {}) {
+      this.host = resolveHost(options.host);
+      this.getTraits = typeof options.getTraits === "function" ? options.getTraits : () => options.traits || [];
+      this.getRuntime = typeof options.getRuntime === "function" ? options.getRuntime : () => options.runtime || {};
+      this.state = options.state || engine.createState();
+      this.onActivated = typeof options.onActivated === "function" ? options.onActivated : () => {};
+      this.onBlocked = typeof options.onBlocked === "function" ? options.onBlocked : () => {};
+      this.resolveChoice = typeof options.resolveChoice === "function" ? options.resolveChoice : null;
+      this.resolveInputs = typeof options.resolveInputs === "function" ? options.resolveInputs : null;
+      this.title = options.title || "TRAITS";
+      this.expanded = options.expanded !== false;
+      this.root = null;
+      if (this.host && global.document) this.mount();
+    }
+
+    mount() {
+      if (!this.host || this.root) return this.root;
+      this.root = createElement("section", "luminous-trait-tray");
+      this.root.dataset.expanded = this.expanded ? "true" : "false";
+      this.host.appendChild(this.root);
+      this.render();
+      return this.root;
+    }
+
+    actions() {
+      return engine.listAvailableTraitActions(this.getTraits() || [], this.getRuntime() || {}, this.state);
+    }
+
+    async activate(action) {
+      const trait = (this.getTraits() || []).map(engine.normalizeTrait).find((entry) => entry.id === action.traitId);
+      if (!trait) return null;
+      if (!action.available) {
+        this.onBlocked(action);
+        return { available: false, reasons: action.reasons || [] };
+      }
+
+      const runtime = Object.assign({}, this.getRuntime() || {});
+      if (action.activationType === engine.ACTIVATION_TYPES.CHOICE && this.resolveChoice) {
+        const choice = await this.resolveChoice({ action, trait, runtime, state: this.state });
+        if (choice == null) return { available: false, cancelled: true, reasons: ["Choice cancelled."] };
+        runtime.choice = choice;
+      }
+      if (action.inputs?.length && this.resolveInputs) {
+        const inputs = await this.resolveInputs({ action, trait, runtime, state: this.state });
+        if (inputs == null) return { available: false, cancelled: true, reasons: ["Input cancelled."] };
+        runtime.inputs = inputs;
+      }
+
+      const result = engine.activateTrait(trait, runtime, this.state);
+      if (result.available) this.onActivated(result);
+      else this.onBlocked(result);
+      this.render();
+      return result;
+    }
+
+    render() {
+      if (!this.root) return;
+      this.root.replaceChildren();
+      const header = createElement("button", "luminous-trait-tray__toggle", this.title);
+      header.type = "button";
+      header.setAttribute("aria-expanded", this.expanded ? "true" : "false");
+      header.addEventListener("click", () => {
+        this.expanded = !this.expanded;
+        this.root.dataset.expanded = this.expanded ? "true" : "false";
+        this.render();
+      });
+      this.root.appendChild(header);
+      if (!this.expanded) return;
+
+      const list = createElement("div", "luminous-trait-tray__list");
+      const actions = this.actions();
+      if (!actions.length) {
+        list.appendChild(createElement("div", "luminous-trait-tray__empty", "NO ACTIVE TRAIT ACTIONS"));
+        this.root.appendChild(list);
+        return;
+      }
+
+      actions.forEach((action) => {
+        const row = createElement("div", `luminous-trait-tray__row${action.available ? "" : " is-disabled"}`);
+        const button = createElement("button", "luminous-trait-tray__action");
+        button.type = "button";
+        button.disabled = !action.available;
+        button.title = action.available ? `${action.name} · ${action.actionCost}` : reasonLabel(action);
+
+        const copy = createElement("span", "luminous-trait-tray__copy");
+        copy.append(
+          createElement("strong", "luminous-trait-tray__name", action.name),
+          createElement("small", "luminous-trait-tray__cost", action.actionCost.replaceAll("_", " ").toUpperCase()),
+        );
+        button.appendChild(copy);
+        const uses = useLabel(action);
+        if (uses) button.appendChild(createElement("b", "luminous-trait-tray__uses", uses));
+        button.addEventListener("click", () => this.activate(action));
+        row.appendChild(button);
+        if (!action.available) row.appendChild(createElement("small", "luminous-trait-tray__reason", reasonLabel(action)));
+        list.appendChild(row);
+      });
+      this.root.appendChild(list);
+    }
+
+    refresh() { this.render(); }
+  }
+
+  function mount(options) {
+    return new TraitPlayerTray(options);
+  }
+
+  const api = Object.freeze({ TraitPlayerTray, mount });
+  global.LuminousTraitPlayerTray = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/tests/trait_engine.spec.js
+++ b/tests/trait_engine.spec.js
@@ -1,0 +1,238 @@
+const { test, expect } = require("@playwright/test");
+const traits = require("../js/trait-engine.js");
+
+const character = {
+  id: "dante",
+  level: 30,
+  classes: [
+    { classId: "barbarian", levels: 20 },
+    { classId: "fighter", levels: 10 },
+  ],
+  stats: {
+    fuerza: 18,
+    destreza: 14,
+    constitucion: 16,
+    inteligencia: 10,
+    sabiduria: 12,
+    carisma: 16,
+  },
+  combatStats: {
+    offensiveLevel: 34,
+    defensiveLevel: 32,
+    hp_actual: 80,
+    hp_max: 100,
+    sp_actual: 10,
+    sp_max: 45,
+  },
+  raceId: "tiefling",
+  backgroundId: "chef",
+};
+
+const dangerSenses = {
+  id: "danger_senses",
+  name: "Danger Senses",
+  source: { type: "class", id: "barbarian" },
+  contexts: ["theatre"],
+  activation: { type: "passive" },
+  effects: [{
+    trigger: "before_check",
+    conditions: [{ path: "check.abilityId", operator: "eq", value: "dex" }],
+    operations: [{ type: "modify", path: "check.difficulty", mode: "add", value: -4 }],
+  }],
+};
+
+const rage = {
+  id: "rage",
+  name: "Rage",
+  source: { type: "class", id: "barbarian" },
+  contexts: ["combat"],
+  activation: {
+    type: "manual",
+    actionCost: "quick_action",
+    uses: { formula: "floor(ClassLevel / 7)", reset: "long_rest" },
+    conditions: [{ statusId: "rage", operator: "falsy" }],
+  },
+  effects: [{
+    trigger: "on_use",
+    operations: [{ type: "apply_status", statusId: "rage", duration: "until_removed" }],
+  }],
+};
+
+const devilBody = {
+  id: "devil_body",
+  name: "Devil Body",
+  source: { type: "lineage", id: "devil_lineage" },
+  contexts: ["combat"],
+  activation: { type: "automatic" },
+  effects: [{
+    trigger: "turn_start",
+    operations: [{ type: "heal_hp", path: "self.currentHp", maxPath: "self.maxHp", formula: "floor(DefensiveLevel / 2)" }],
+  }],
+};
+
+test("formula engine soporta Level y ClassLevel sin ejecutar JS arbitrario", () => {
+  const variables = traits.buildVariables(character, {}, rage);
+  expect(variables.Level).toBe(30);
+  expect(variables.ClassLevel).toBe(20);
+  expect(variables.StrengthMod).toBe(4);
+  expect(traits.evaluateFormula("1 + floor(ClassLevel / 7)", variables)).toBe(3);
+  expect(traits.evaluateFormula("clamp(Level / 10, 1, 3)", variables)).toBe(3);
+  expect(() => traits.evaluateFormula("constructor.constructor('return 1')()", variables)).toThrow();
+});
+
+test("multiclase conserva nivel total y nivel de la clase fuente por separado", () => {
+  expect(traits.getClassLevel(character, "barbarian")).toBe(20);
+  expect(traits.getClassLevel(character, "fighter")).toBe(10);
+  expect(traits.buildVariables(character, {}, { source: { type: "class", id: "fighter" } }).ClassLevel).toBe(10);
+});
+
+test("Rol/Theatre aplica Traits pasivos solamente a la tirada que cumple condiciones", () => {
+  const dex = traits.resolveTheatreCheck({
+    character,
+    traits: [dangerSenses],
+    check: { kind: "skill", abilityId: "dex", skillId: "acrobatics", difficulty: 16 },
+  });
+  const wis = traits.resolveTheatreCheck({
+    character,
+    traits: [dangerSenses],
+    check: { kind: "skill", abilityId: "wis", skillId: "perception", difficulty: 16 },
+  });
+
+  expect(dex.check.difficulty).toBe(12);
+  expect(dex.outcomes).toHaveLength(1);
+  expect(wis.check.difficulty).toBe(16);
+  expect(wis.outcomes).toHaveLength(0);
+});
+
+test("Rol puede apilar bonificadores de habilidad y Final Power como operaciones independientes", () => {
+  const greenEyedHeir = {
+    id: "green_eyed_heir",
+    name: "Green Eyed Heir",
+    contexts: ["theatre"],
+    effects: [{
+      trigger: "before_check",
+      conditions: [{ path: "check.skillId", operator: "in", value: ["insight", "perception"] }],
+      operations: [{ type: "modify", path: "check.finalPower", mode: "add", value: 2 }],
+    }],
+  };
+  const result = traits.resolveTheatreCheck({
+    character,
+    traits: [greenEyedHeir],
+    check: { abilityId: "wis", skillId: "perception", finalPower: 0 },
+  });
+  expect(result.check.finalPower).toBe(2);
+});
+
+test("Traits automáticos de combate reaccionan al Turn Start y escalan con DefensiveLevel", () => {
+  const self = { currentHp: 70, maxHp: 100 };
+  const state = traits.createState();
+  const result = traits.dispatchCombatEvent("turn_start", {
+    character,
+    self,
+    traits: [devilBody],
+    state,
+    DefensiveLevel: 32,
+  });
+  expect(self.currentHp).toBe(86);
+  expect(result.outcomes[0]).toMatchObject({ type: "heal_hp", amount: 16 });
+});
+
+test("Trait manual consume Quick Action, respeta usos por ClassLevel y aplica Status", () => {
+  const state = traits.createState();
+  const runtime = {
+    context: "combat",
+    character,
+    self: character,
+    actionEconomy: { quick_action: 1 },
+  };
+  const first = traits.activateTrait(rage, runtime, state);
+  expect(first.available).toBe(true);
+  expect(first.maximum).toBe(2);
+  expect(first.remaining).toBe(1);
+  expect(runtime.actionEconomy.quick_action).toBe(0);
+  expect(state.statuses.rage).toMatchObject({ sourceTraitId: "rage" });
+
+  const again = traits.canActivateTrait(rage, { ...runtime, actionEconomy: { quick_action: 1 } }, state);
+  expect(again.available).toBe(false);
+  expect(again.reasons.join(" ")).toContain("conditions");
+});
+
+test("Trait Tray API devuelve solamente decisiones del jugador y explica por qué están bloqueadas", () => {
+  const state = traits.createState();
+  const actions = traits.listAvailableTraitActions([dangerSenses, devilBody, rage], {
+    context: "combat",
+    character,
+    actionEconomy: { quick_action: 0 },
+  }, state);
+
+  expect(actions).toHaveLength(1);
+  expect(actions[0]).toMatchObject({ traitId: "rage", available: false, actionCost: "quick_action", maximum: 2, remaining: 2 });
+  expect(actions[0].reasons.join(" ")).toContain("quick_action");
+});
+
+test("Resources permiten gain/spend/consume_all y guardar el valor consumido para umbrales", () => {
+  const devilTrigger = {
+    id: "devil_trigger",
+    name: "Devil Trigger",
+    contexts: ["combat"],
+    activation: { type: "manual", actionCost: "none" },
+    effects: [
+      {
+        id: "consume",
+        trigger: "on_use",
+        operations: [{ type: "resource", resourceId: "devil_gauge", mode: "consume_all", storeAs: "ConsumedGauge" }],
+      },
+      {
+        id: "threshold_7",
+        trigger: "on_use",
+        conditions: [{ formula: "ConsumedGauge", operator: "gte", value: 7 }],
+        operations: [{ type: "modify", path: "self.damagePercent", mode: "add", formula: "OffensiveLevel" }],
+      },
+    ],
+  };
+  const state = traits.createState({ resources: { devil_gauge: { value: 8, min: 0, max: 10 } } });
+  const self = { damagePercent: 0 };
+  const result = traits.activateTrait(devilTrigger, { context: "combat", character, self, OffensiveLevel: 34 }, state);
+
+  expect(result.available).toBe(true);
+  expect(state.resources.devil_gauge.value).toBe(0);
+  expect(self.damagePercent).toBe(34);
+  expect(result.outcomes.map((entry) => entry.effectId)).toEqual(["consume", "threshold_7"]);
+});
+
+test("reset de usos devuelve Traits limitados al scope configurado", () => {
+  const state = traits.createState();
+  const runtime = { context: "combat", character, actionEconomy: { quick_action: 1 } };
+  const result = traits.activateTrait(rage, runtime, state);
+  expect(result.remaining).toBe(1);
+  delete state.statuses.rage;
+  traits.resetUsage(state, "long_rest");
+  const ready = traits.canActivateTrait(rage, { ...runtime, actionEconomy: { quick_action: 1 } }, state);
+  expect(ready.remaining).toBe(2);
+});
+
+test("Class/Race/Background grants se resuelven sin duplicar definiciones de Traits", () => {
+  const catalog = {
+    rage,
+    mountain_born: { id: "mountain_born", name: "Mountain Born" },
+    chef_passion: { id: "chef_passion", name: "Chef's Passion" },
+  };
+  const grants = [
+    { sourceType: "class", sourceId: "barbarian", atLevel: 15, traitId: "rage" },
+    { sourceType: "class", sourceId: "fighter", atLevel: 20, traitId: "mountain_born" },
+    { sourceType: "background", sourceId: "chef", traitId: "chef_passion" },
+  ];
+  const granted = traits.resolveTraitGrants(character, grants, catalog);
+  expect(granted.map((trait) => trait.id)).toEqual(["rage", "chef_passion"]);
+  expect(granted[0].source).toMatchObject({ type: "class", id: "barbarian", classId: "barbarian" });
+});
+
+test("validator rechaza operaciones incompletas y mantiene el schema declarativo", () => {
+  const invalid = traits.validateTrait({ name: "Broken", effects: [{ trigger: "on_hit", operations: [{ type: "modify" }] }] });
+  expect(invalid.valid).toBe(false);
+  expect(invalid.errors.join(" ")).toContain("requires path");
+
+  const valid = traits.validateTrait(rage);
+  expect(valid.valid).toBe(true);
+  expect(valid.trait.schemaVersion).toBe(1);
+});

--- a/tests/trait_engine_codex_regressions.spec.js
+++ b/tests/trait_engine_codex_regressions.spec.js
@@ -1,0 +1,81 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+const traits = require("../js/trait-engine.js");
+
+const builderSource = fs.readFileSync(path.join(__dirname, "..", "js", "trait-builder.js"), "utf8");
+
+test("mutation paths reject prototype-pollution segments before execution", () => {
+  delete Object.prototype.traitPwned;
+
+  expect(() => traits.setPath({}, "__proto__.traitPwned", 1)).toThrow(/Unsafe trait path segment/);
+  expect(Object.prototype.traitPwned).toBeUndefined();
+
+  const malicious = {
+    id: "prototype_attack",
+    effects: [{
+      trigger: "on_use",
+      operations: [{ type: "modify", path: "__proto__.traitPwned", mode: "set", value: 1 }],
+    }],
+  };
+  const validation = traits.validateTrait(malicious);
+  expect(validation.valid).toBe(false);
+  expect(validation.errors.join(" ")).toContain("Unsafe trait path segment");
+  expect(() => traits.dispatchTrait(malicious, "on_use", {})).toThrow(/Invalid Trait/);
+  expect(Object.prototype.traitPwned).toBeUndefined();
+});
+
+test("dynamic Trait keys also reject prototype-sensitive identifiers", () => {
+  const maliciousResource = {
+    id: "resource_attack",
+    effects: [{
+      trigger: "on_use",
+      operations: [{ type: "resource", resourceId: "__proto__", mode: "gain", value: 1 }],
+    }],
+  };
+  const validation = traits.validateTrait(maliciousResource);
+  expect(validation.valid).toBe(false);
+  expect(validation.errors.join(" ")).toContain("unsafe key");
+  expect(Object.prototype.value).toBeUndefined();
+});
+
+test("validator rejects operation types outside the V1 vocabulary", () => {
+  const validation = traits.validateTrait({
+    id: "unsupported_operation",
+    effects: [{ trigger: "on_hit", operations: [{ type: "damage", value: 10 }] }],
+  });
+
+  expect(validation.valid).toBe(false);
+  expect(validation.errors.join(" ")).toContain("unsupported operation type");
+  expect(traits.OPERATION_TYPES).not.toContain("damage");
+});
+
+test("between conditions require max and execute when both bounds exist", () => {
+  const missingMax = traits.validateTrait({
+    id: "missing_between_max",
+    effects: [{
+      trigger: "before_check",
+      conditions: [{ path: "check.score", operator: "between", value: 2 }],
+      operations: [{ type: "log", message: "inside" }],
+    }],
+  });
+  expect(missingMax.valid).toBe(false);
+  expect(missingMax.errors.join(" ")).toContain("between operator requires max");
+
+  const valid = {
+    id: "valid_between",
+    effects: [{
+      trigger: "before_check",
+      conditions: [{ path: "check.score", operator: "between", value: 2, max: 5 }],
+      operations: [{ type: "log", message: "inside" }],
+    }],
+  };
+  const result = traits.dispatchTrait(valid, "before_check", { check: { score: 4 } });
+  expect(result.outcomes).toHaveLength(1);
+});
+
+test("Trait Builder emits a dedicated max bound for between", () => {
+  expect(builderSource).toContain('input("conditionMax", "10 (required for BETWEEN)")');
+  expect(builderSource).toContain('const conditionMax = parseLiteral(read("conditionMax"))');
+  expect(builderSource).toContain('if (conditionOperator === "between") condition.max = conditionMax');
+});


### PR DESCRIPTION
## Objetivo

Introduce la primera base programable para Traits/Rasgos sin hardcodear cada rasgo en Teatro o Combate.

El Trait Engine usa un contrato declarativo común:

`WHEN trigger -> IF conditions -> DO operations -> VALUE/formula`

## Incluye

- Motor compartido de Traits para contextos `theatre`, `combat` o ambos.
- Separación Trait / Effect / Status / Resource / Grant.
- Variables `Level` y `ClassLevel` separadas para multiclass.
- Formula Engine seguro sin `eval`/`Function`.
- Funciones permitidas: `floor`, `ceil`, `round`, `abs`, `min`, `max`, `clamp`.
- Activaciones `passive`, `automatic`, `manual`, `prompt` y `choice`.
- Costes `action`, `quick_action`, `reaction`, `special` y `none`.
- Usos escalables por fórmula y reset por turno/encuentro/rest/día.
- Conditions genéricas por path, variable, Status o Resource.
- Operations V1: modify, resource gain/spend/set/consume_all, apply/remove status, heal HP/SP, shield, flags y log.
- `resolveTheatreCheck()` para modificar checks antes de tirar.
- `dispatchCombatEvent()` para pasivas/triggers de combate.
- `resolveTraitGrants()` para que Class/Race/Background/Lineage concedan definiciones sin duplicarlas.
- `Trait Player Tray` reusable: solo muestra decisiones manuales, usos y razones de bloqueo; no convierte pasivas en botones.
- `dm-trait-creator.html` + `trait-builder.js`: editor visual inicial para construir y validar Traits sin escribir JavaScript.

## Casos cubiertos en tests

- Danger Senses: reduce Difficulty de checks de Dexterity.
- Green Eyed Heir: añade Final Power a Insight/Perception.
- Devil Body: cura en Turn Start escalando con DefensiveLevel.
- Rage: Quick Action, Status y usos `floor(ClassLevel / 7)`.
- Devil Trigger: consume Devil Gauge y usa el valor consumido para umbrales posteriores.
- Multiclass: Level 30 / Barbarian 20 / Fighter 10 conserva `Level=30`, `ClassLevel=20` o `10` según la fuente.
- Grants por Class y Background sin duplicar Trait definitions.

## Validación realizada

- `node --check` sobre los módulos nuevos.
- 11 pruebas del nuevo Trait Engine ejecutadas localmente mediante el mismo contrato de assertions de la suite: todas pasan.
- El blob de `js/trait-engine.js` en GitHub coincide con el archivo probado localmente.
- La rama está 6 commits ahead / 0 behind y solo agrega 6 archivos nuevos.

## Límite intencional de este PR

Este PR crea el motor, los adapters y las superficies de autoría/ejecución, pero **no modifica todavía los archivos legacy grandes de Teatro/Combate**. `theatre-check-coordinator` deberá llamar `resolveTheatreCheck()` y el Combat Engine deberá emitir sus lifecycle events a `dispatchCombatEvent()` en el parche de integración. Esto mantiene V1 aislado y evita romper sistemas actuales mientras validamos el lenguaje de Traits.

## Archivos

- `js/trait-engine.js`
- `js/trait-player-tray.js`
- `js/trait-builder.js`
- `dm-trait-creator.html`
- `tests/trait_engine.spec.js`
- `docs/trait-engine-v1.md`
