### PR TITLE
Core Trait Catalog: Definitions, Grants e importador DM

### DIFF
--- a/docs/trait-catalog-core.md
+++ b/docs/trait-catalog-core.md
@@ -10,6 +10,8 @@ Every entry is declarative and follows the same rule shape:
 
 Definitions and progression Grants are separate. No Trait is implemented with `if (traitId === ...)` inside Theatre or Combat.
 
+The exported canonical `DEFINITIONS` and `GRANTS` graphs are recursively frozen. Consumers that need editable values must use `getDefinition()`, `allDefinitions()` or `allGrants()`, which return copies.
+
 ## Programmed definitions
 
 ### Danger Senses
@@ -71,15 +73,17 @@ The DM can assign those Definitions through the normal Grant UI after their inte
 
 `js/dm-trait-catalog-importer.js` imports the catalog into `campaña/config/traits`.
 
-Before planning writes it reads fresh Firebase snapshots for both `definitions` and `grants`. It does not depend on the Trait Library UI having received its asynchronous initial listeners, preventing an early click from treating an existing library as empty.
+Import uses one Firebase Realtime Database transaction at `campaña/config/traits`. The transaction callback rebuilds the import plan from the current transaction state every time Firebase invokes or retries it. This makes the absence check and write atomic: if another DM creates or edits a Trait/Grant during import, Firebase retries against that newer state before the catalog can commit.
 
 The importer:
 
-- does not overwrite an existing Definition with the same ID;
-- deduplicates Grants by semantic identity;
+- never replaces an existing Definition with the same ID;
+- preserves unrelated data under the Traits root;
+- deduplicates Grants by semantic identity, including Grants stored under arbitrary push IDs;
 - uses deterministic IDs for catalog Grants;
-- writes through one multi-path update;
-- is idempotent.
+- adds missing Definitions and Grants inside the same root transaction;
+- is idempotent;
+- aborts cleanly when there is nothing to add.
 
 ## Tests
 
@@ -92,14 +96,17 @@ The importer:
 - Devil Trigger resource consumption and threshold behavior;
 - confirmed Lineage Grant resolution;
 - absence of guessed Class acquisition Grants;
-- immutable access through catalog copy helpers.
+- copy-based mutable accessors;
+- recursive immutability of exported canonical Definitions and Grants.
 
 `tests/dm_trait_catalog_importer.spec.js` covers:
 
 - import planning for an empty library;
 - no overwrite of DM-custom Definitions;
 - semantic Grant deduplication;
-- fresh Firebase snapshot reads before planning;
+- atomic mutation preserving custom concurrent state;
+- simulated Firebase transaction retry after a concurrent DM write;
+- preservation of unrelated data under the Traits root;
 - Firebase-safe deterministic Grant IDs;
 - DM loader ordering contract.
 

--- a/docs/trait-catalog-core.md
+++ b/docs/trait-catalog-core.md
@@ -1,0 +1,84 @@
+# Core Trait Catalog
+
+This module is the canonical code catalog for Traits whose mechanics were explicitly fixed while designing Trait Engine V1.
+
+## Contract
+
+Every entry is declarative and follows the same rule shape:
+
+`WHEN trigger -> IF conditions -> DO operations -> VALUE/formula`
+
+Definitions and progression Grants are separate. No Trait is implemented with `if (traitId === ...)` inside Theatre or Combat.
+
+## Programmed definitions
+
+### Danger Senses
+
+- Context: Theatre
+- Activation: Passive
+- Trigger: `before_check`
+- Condition: `check.abilityId === "dex"`
+- Operation: `check.difficulty += -4`
+- Core Grant: Barbarian level 2
+
+### Green Eyed Heir
+
+- Context: Theatre
+- Activation: Passive
+- Trigger: `before_check`
+- Condition: `check.skillId in ["insight", "perception"]`
+- Operation: `check.finalPower += 2`
+- No progression Grant is hardcoded because its source/progression was not fixed in the recovered rules.
+
+### Rage
+
+- Context: Combat
+- Activation: Manual
+- Action Cost: Quick Action
+- Uses: `floor(ClassLevel / 7)`
+- Reset: Long Rest
+- Activation condition: Rage Status is absent
+- On Use: apply `rage` Status until removed
+- Core Grant: Barbarian level 2
+
+### Devil Body
+
+- Context: Combat
+- Activation: Automatic
+- Trigger: `turn_start`
+- Operation: heal HP by `floor(DefensiveLevel / 2)` capped by Max HP
+- Core Grant: `devil_lineage`
+
+### Devil Trigger
+
+- Context: Combat
+- Activation: Manual
+- Action Cost: None
+- On Use: consume all `devil_gauge` and store the consumed value as `ConsumedGauge`
+- Known threshold: if `ConsumedGauge >= 7`, add `OffensiveLevel` to `self.damagePercent`
+- No progression Grant is hardcoded because its exact source/progression was not fixed in the recovered rules.
+
+## Why some Grants are absent
+
+The catalog only persists progression that is known. A missing Grant does not mean the Trait is unfinished mechanically; it means Class/Race/Background/Lineage ownership must be assigned through the DM Grant system instead of guessed in source code.
+
+## Tests
+
+`tests/trait_catalog_core.spec.js` covers:
+
+- validation of every Definition;
+- positive and negative Theatre conditions;
+- Rage action economy, ClassLevel scaling, Status and reactivation guard;
+- Devil Body healing and HP cap;
+- Devil Trigger resource consumption and threshold behavior;
+- Class and Lineage Grant resolution;
+- level-gated Grants;
+- immutable access through catalog copy helpers.
+
+## Adding another Trait
+
+1. Add one Definition to `js/trait-catalog-core.js`.
+2. Add a Grant only when its source/progression is explicitly known.
+3. Validate it with `TraitEngine.validateTrait()`.
+4. Add at least one positive and one negative behavior test.
+5. If the mechanic cannot be expressed with current operations, add a generic operation to Trait Engine first. Do not special-case the Trait by name.

--- a/docs/trait-catalog-core.md
+++ b/docs/trait-catalog-core.md
@@ -19,7 +19,8 @@ Definitions and progression Grants are separate. No Trait is implemented with `i
 - Trigger: `before_check`
 - Condition: `check.abilityId === "dex"`
 - Operation: `check.difficulty += -4`
-- Core Grant: Barbarian level 2
+- Source metadata: Barbarian
+- No acquisition level is hardcoded until the original class progression is explicitly confirmed.
 
 ### Green Eyed Heir
 
@@ -39,7 +40,8 @@ Definitions and progression Grants are separate. No Trait is implemented with `i
 - Reset: Long Rest
 - Activation condition: Rage Status is absent
 - On Use: apply `rage` Status until removed
-- Core Grant: Barbarian level 2
+- Source metadata: Barbarian
+- No acquisition level is hardcoded until the original class progression is explicitly confirmed.
 
 ### Devil Body
 
@@ -47,7 +49,8 @@ Definitions and progression Grants are separate. No Trait is implemented with `i
 - Activation: Automatic
 - Trigger: `turn_start`
 - Operation: heal HP by `floor(DefensiveLevel / 2)` capped by Max HP
-- Core Grant: `devil_lineage`
+- Confirmed source: `devil_lineage`
+- Core Grant: `devil_lineage -> devil_body`
 
 ### Devil Trigger
 
@@ -58,9 +61,25 @@ Definitions and progression Grants are separate. No Trait is implemented with `i
 - Known threshold: if `ConsumedGauge >= 7`, add `OffensiveLevel` to `self.damagePercent`
 - No progression Grant is hardcoded because its exact source/progression was not fixed in the recovered rules.
 
-## Why some Grants are absent
+## Progression rule
 
-The catalog only persists progression that is known. A missing Grant does not mean the Trait is unfinished mechanically; it means Class/Race/Background/Lineage ownership must be assigned through the DM Grant system instead of guessed in source code.
+A Definition can be mechanically complete without a Grant. Grants are only included in the code catalog when ownership/progression is known without guessing. Class acquisition levels that appeared only as examples are deliberately not converted into canonical progression.
+
+The DM can assign those Definitions through the normal Grant UI after their intended Class/Race/Background/Lineage and level are confirmed.
+
+## Safe DM import
+
+`js/dm-trait-catalog-importer.js` imports the catalog into `campaña/config/traits`.
+
+Before planning writes it reads fresh Firebase snapshots for both `definitions` and `grants`. It does not depend on the Trait Library UI having received its asynchronous initial listeners, preventing an early click from treating an existing library as empty.
+
+The importer:
+
+- does not overwrite an existing Definition with the same ID;
+- deduplicates Grants by semantic identity;
+- uses deterministic IDs for catalog Grants;
+- writes through one multi-path update;
+- is idempotent.
 
 ## Tests
 
@@ -71,9 +90,18 @@ The catalog only persists progression that is known. A missing Grant does not me
 - Rage action economy, ClassLevel scaling, Status and reactivation guard;
 - Devil Body healing and HP cap;
 - Devil Trigger resource consumption and threshold behavior;
-- Class and Lineage Grant resolution;
-- level-gated Grants;
+- confirmed Lineage Grant resolution;
+- absence of guessed Class acquisition Grants;
 - immutable access through catalog copy helpers.
+
+`tests/dm_trait_catalog_importer.spec.js` covers:
+
+- import planning for an empty library;
+- no overwrite of DM-custom Definitions;
+- semantic Grant deduplication;
+- fresh Firebase snapshot reads before planning;
+- Firebase-safe deterministic Grant IDs;
+- DM loader ordering contract.
 
 ## Adding another Trait
 

--- a/js/dm-trait-catalog-importer.js
+++ b/js/dm-trait-catalog-importer.js
@@ -8,6 +8,10 @@
   const DEFINITIONS_ROOT = `${TRAITS_ROOT}/definitions`;
   const GRANTS_ROOT = `${TRAITS_ROOT}/grants`;
 
+  function asRecord(value) {
+    return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+  }
+
   function grantIdentity(grant = {}) {
     const type = engine?.normalizeId ? engine.normalizeId(grant.sourceType || grant.source?.type) : String(grant.sourceType || "").trim().toLowerCase();
     const sourceId = engine?.normalizeId ? engine.normalizeId(grant.sourceId || grant.source?.id || grant.source?.classId) : String(grant.sourceId || "").trim().toLowerCase();
@@ -65,16 +69,80 @@
     };
   }
 
-  async function readPersistedTraitState(database) {
+  function buildAtomicImportMutation(currentTree = {}, helpers = {}, stamp = Date.now()) {
+    const root = asRecord(currentTree);
+    const definitions = asRecord(root.definitions);
+    const grantMap = asRecord(root.grants);
+    const existingGrants = Object.entries(grantMap).map(([id, grant]) => ({ id, ...(grant || {}) }));
+    const plan = buildImportPlan(definitions, existingGrants, helpers);
+
+    if (!plan.valid) {
+      return { valid: false, changed: false, errors: plan.errors, plan, next: root };
+    }
+
+    const changed = Boolean(plan.definitionWrites.length || plan.grantWrites.length);
+    if (!changed) return { valid: true, changed: false, errors: [], plan, next: root };
+
+    const nextDefinitions = { ...definitions };
+    const nextGrants = { ...grantMap };
+
+    plan.definitionWrites.forEach(({ id, definition }) => {
+      nextDefinitions[id] = {
+        ...definition,
+        createdAt: stamp,
+        updatedAt: stamp,
+        catalogVersion: catalog.CATALOG_VERSION,
+      };
+    });
+    plan.grantWrites.forEach(({ id, grant }) => {
+      nextGrants[id] = {
+        ...grant,
+        createdAt: stamp,
+        updatedAt: stamp,
+        catalogVersion: catalog.CATALOG_VERSION,
+      };
+    });
+
+    return {
+      valid: true,
+      changed: true,
+      errors: [],
+      plan,
+      next: { ...root, definitions: nextDefinitions, grants: nextGrants },
+    };
+  }
+
+  async function runAtomicImport(database, helpers = {}, stamp = Date.now()) {
     if (!database?.ref) throw new Error("Firebase database is not available.");
-    const [definitionsSnapshot, grantsSnapshot] = await Promise.all([
-      database.ref(DEFINITIONS_ROOT).once("value"),
-      database.ref(GRANTS_ROOT).once("value"),
-    ]);
-    const definitions = definitionsSnapshot?.val?.() || {};
-    const rawGrants = grantsSnapshot?.val?.() || {};
-    const grants = Object.entries(rawGrants).map(([id, grant]) => ({ id, ...(grant || {}) }));
-    return { definitions, grants };
+    const rootRef = database.ref(TRAITS_ROOT);
+    if (!rootRef?.transaction) throw new Error("Firebase transaction API is not available.");
+
+    let lastMutation = null;
+    let planningErrors = null;
+
+    const result = await rootRef.transaction((currentTree) => {
+      const mutation = buildAtomicImportMutation(currentTree, helpers, stamp);
+      lastMutation = mutation;
+
+      if (!mutation.valid) {
+        planningErrors = mutation.errors;
+        return undefined;
+      }
+
+      // Returning undefined aborts a no-op transaction. If another editor writes
+      // while this transaction is in flight, Firebase retries this callback with
+      // the newest server state before any catalog data can be committed.
+      if (!mutation.changed) return undefined;
+      return mutation.next;
+    });
+
+    if (planningErrors?.length) throw new Error(planningErrors.join(" · "));
+    if (!lastMutation) throw new Error("Firebase transaction did not evaluate the Trait catalog.");
+    if (lastMutation.changed && !result?.committed) {
+      throw new Error("Trait catalog transaction was not committed.");
+    }
+
+    return { ...lastMutation.plan, committed: Boolean(result?.committed) };
   }
 
   if (typeof module !== "undefined" && module.exports) {
@@ -84,7 +152,8 @@
       GRANTS_ROOT,
       grantIdentity,
       buildImportPlan,
-      readPersistedTraitState,
+      buildAtomicImportMutation,
+      runAtomicImport,
     };
   }
 
@@ -113,37 +182,21 @@
     const catalogValidation = catalog.validateAll(engine);
     if (!catalogValidation.valid) throw new Error(catalogValidation.errors.join(" · "));
 
-    // Read Firebase directly at click time. The Trait Library UI listeners are
-    // asynchronous and may not have delivered their initial snapshots yet.
-    // Import planning must never assume an empty library from stale UI state.
-    const database = global.firebase.database();
-    const persisted = await readPersistedTraitState(database);
-    const plan = buildImportPlan(
-      persisted.definitions,
-      persisted.grants,
+    const plan = await runAtomicImport(
+      global.firebase.database(),
       {
         validateDefinitionForPersistence: lib.validateDefinitionForPersistence,
         validateGrant: lib.validateGrant,
         validateFirebaseKey: lib.validateFirebaseKey,
       },
+      timestamp(),
     );
-    if (!plan.valid) throw new Error(plan.errors.join(" · "));
 
     if (!plan.definitionWrites.length && !plan.grantWrites.length) {
       feedback("El catálogo base ya está importado. No hay cambios.", "success");
       return plan;
     }
 
-    const stamp = timestamp();
-    const updates = {};
-    plan.definitionWrites.forEach(({ id, definition }) => {
-      updates[`definitions/${id}`] = { ...definition, createdAt: stamp, updatedAt: stamp, catalogVersion: catalog.CATALOG_VERSION };
-    });
-    plan.grantWrites.forEach(({ id, grant }) => {
-      updates[`grants/${id}`] = { ...grant, createdAt: stamp, updatedAt: stamp, catalogVersion: catalog.CATALOG_VERSION };
-    });
-
-    await database.ref(TRAITS_ROOT).update(updates);
     feedback(`Catálogo base importado: ${plan.definitionWrites.length} Traits · ${plan.grantWrites.length} Grants.`, "success");
     return plan;
   }
@@ -191,7 +244,8 @@
     GRANTS_ROOT,
     grantIdentity,
     buildImportPlan,
-    readPersistedTraitState,
+    buildAtomicImportMutation,
+    runAtomicImport,
     importCatalog,
     mountButton,
   });

--- a/js/dm-trait-catalog-importer.js
+++ b/js/dm-trait-catalog-importer.js
@@ -129,20 +129,21 @@
         return undefined;
       }
 
-      // Returning undefined aborts a no-op transaction. If another editor writes
-      // while this transaction is in flight, Firebase retries this callback with
-      // the newest server state before any catalog data can be committed.
-      if (!mutation.changed) return undefined;
+      // A no-op still returns the unchanged tree. In Firebase 8, returning
+      // undefined aborts locally and can accept a stale cache as authoritative.
+      // Returning the tree forces the transaction to confirm against the server;
+      // if another DM deleted or changed catalog data, Firebase retries this
+      // callback with the newest server state before declaring the import done.
       return mutation.next;
     });
 
     if (planningErrors?.length) throw new Error(planningErrors.join(" · "));
     if (!lastMutation) throw new Error("Firebase transaction did not evaluate the Trait catalog.");
-    if (lastMutation.changed && !result?.committed) {
-      throw new Error("Trait catalog transaction was not committed.");
+    if (!result?.committed) {
+      throw new Error("Trait catalog transaction was not committed or server-confirmed.");
     }
 
-    return { ...lastMutation.plan, committed: Boolean(result?.committed) };
+    return { ...lastMutation.plan, committed: true };
   }
 
   if (typeof module !== "undefined" && module.exports) {

--- a/js/dm-trait-catalog-importer.js
+++ b/js/dm-trait-catalog-importer.js
@@ -5,6 +5,8 @@
   const engine = global.LuminousTraitEngine || (typeof require === "function" ? require("./trait-engine.js") : null);
   const catalog = global.LuminousTraitCatalogCore || (typeof require === "function" ? require("./trait-catalog-core.js") : null);
   const TRAITS_ROOT = "campaña/config/traits";
+  const DEFINITIONS_ROOT = `${TRAITS_ROOT}/definitions`;
+  const GRANTS_ROOT = `${TRAITS_ROOT}/grants`;
 
   function grantIdentity(grant = {}) {
     const type = engine?.normalizeId ? engine.normalizeId(grant.sourceType || grant.source?.type) : String(grant.sourceType || "").trim().toLowerCase();
@@ -63,8 +65,27 @@
     };
   }
 
+  async function readPersistedTraitState(database) {
+    if (!database?.ref) throw new Error("Firebase database is not available.");
+    const [definitionsSnapshot, grantsSnapshot] = await Promise.all([
+      database.ref(DEFINITIONS_ROOT).once("value"),
+      database.ref(GRANTS_ROOT).once("value"),
+    ]);
+    const definitions = definitionsSnapshot?.val?.() || {};
+    const rawGrants = grantsSnapshot?.val?.() || {};
+    const grants = Object.entries(rawGrants).map(([id, grant]) => ({ id, ...(grant || {}) }));
+    return { definitions, grants };
+  }
+
   if (typeof module !== "undefined" && module.exports) {
-    module.exports = { TRAITS_ROOT, grantIdentity, buildImportPlan };
+    module.exports = {
+      TRAITS_ROOT,
+      DEFINITIONS_ROOT,
+      GRANTS_ROOT,
+      grantIdentity,
+      buildImportPlan,
+      readPersistedTraitState,
+    };
   }
 
   if (!doc || !engine || !catalog || global.LuminousTraitCatalogImporter) return;
@@ -92,9 +113,14 @@
     const catalogValidation = catalog.validateAll(engine);
     if (!catalogValidation.valid) throw new Error(catalogValidation.errors.join(" · "));
 
+    // Read Firebase directly at click time. The Trait Library UI listeners are
+    // asynchronous and may not have delivered their initial snapshots yet.
+    // Import planning must never assume an empty library from stale UI state.
+    const database = global.firebase.database();
+    const persisted = await readPersistedTraitState(database);
     const plan = buildImportPlan(
-      lib.getDefinitions?.() || {},
-      lib.getGrants?.() || [],
+      persisted.definitions,
+      persisted.grants,
       {
         validateDefinitionForPersistence: lib.validateDefinitionForPersistence,
         validateGrant: lib.validateGrant,
@@ -117,7 +143,7 @@
       updates[`grants/${id}`] = { ...grant, createdAt: stamp, updatedAt: stamp, catalogVersion: catalog.CATALOG_VERSION };
     });
 
-    await global.firebase.database().ref(TRAITS_ROOT).update(updates);
+    await database.ref(TRAITS_ROOT).update(updates);
     feedback(`Catálogo base importado: ${plan.definitionWrites.length} Traits · ${plan.grantWrites.length} Grants.`, "success");
     return plan;
   }
@@ -161,8 +187,11 @@
 
   global.LuminousTraitCatalogImporter = Object.freeze({
     TRAITS_ROOT,
+    DEFINITIONS_ROOT,
+    GRANTS_ROOT,
     grantIdentity,
     buildImportPlan,
+    readPersistedTraitState,
     importCatalog,
     mountButton,
   });

--- a/js/dm-trait-catalog-importer.js
+++ b/js/dm-trait-catalog-importer.js
@@ -1,0 +1,172 @@
+(function (global) {
+  "use strict";
+
+  const doc = global.document || null;
+  const engine = global.LuminousTraitEngine || (typeof require === "function" ? require("./trait-engine.js") : null);
+  const catalog = global.LuminousTraitCatalogCore || (typeof require === "function" ? require("./trait-catalog-core.js") : null);
+  const TRAITS_ROOT = "campaña/config/traits";
+
+  function grantIdentity(grant = {}) {
+    const type = engine?.normalizeId ? engine.normalizeId(grant.sourceType || grant.source?.type) : String(grant.sourceType || "").trim().toLowerCase();
+    const sourceId = engine?.normalizeId ? engine.normalizeId(grant.sourceId || grant.source?.id || grant.source?.classId) : String(grant.sourceId || "").trim().toLowerCase();
+    const traitId = engine?.normalizeId ? engine.normalizeId(grant.traitId || grant.id) : String(grant.traitId || "").trim().toLowerCase();
+    const level = type === "class" ? Number(grant.atLevel ?? grant.level ?? 0) : 0;
+    return `${type}:${sourceId}:${traitId}:${level}`;
+  }
+
+  function buildImportPlan(existingDefinitions = {}, existingGrants = [], helpers = {}) {
+    const definitions = catalog?.allDefinitions?.() || {};
+    const grants = catalog?.allGrants?.() || [];
+    const errors = [];
+    const definitionWrites = [];
+    const grantWrites = [];
+    const existingIdentities = new Set((existingGrants || []).map(grantIdentity));
+
+    Object.entries(definitions).forEach(([id, definition]) => {
+      const validation = helpers.validateDefinitionForPersistence
+        ? helpers.validateDefinitionForPersistence(definition)
+        : engine?.validateTrait?.(definition);
+      if (!validation?.valid) {
+        (validation?.errors || ["Invalid Trait definition."]).forEach((message) => errors.push(`${id}: ${message}`));
+        return;
+      }
+      if (!Object.prototype.hasOwnProperty.call(existingDefinitions || {}, id)) {
+        definitionWrites.push({ id, definition: validation.trait });
+      }
+    });
+
+    grants.forEach((grant) => {
+      const idValidation = helpers.validateFirebaseKey ? helpers.validateFirebaseKey(grant.id) : { valid: Boolean(grant.id), errors: [] };
+      const validation = helpers.validateGrant ? helpers.validateGrant(grant) : { valid: true, grant };
+      if (!idValidation.valid) {
+        (idValidation.errors || ["Invalid Firebase key."]).forEach((message) => errors.push(`${grant.id || "<grant>"}: ${message}`));
+        return;
+      }
+      if (!validation.valid) {
+        (validation.errors || ["Invalid Grant."]).forEach((message) => errors.push(`${grant.id}: ${message}`));
+        return;
+      }
+      const identity = grantIdentity(validation.grant);
+      if (!existingIdentities.has(identity)) {
+        grantWrites.push({ id: grant.id, grant: validation.grant });
+        existingIdentities.add(identity);
+      }
+    });
+
+    return {
+      valid: !errors.length,
+      errors,
+      definitionWrites,
+      grantWrites,
+      skippedDefinitions: Math.max(0, Object.keys(definitions).length - definitionWrites.length),
+      skippedGrants: Math.max(0, grants.length - grantWrites.length),
+    };
+  }
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = { TRAITS_ROOT, grantIdentity, buildImportPlan };
+  }
+
+  if (!doc || !engine || !catalog || global.LuminousTraitCatalogImporter) return;
+
+  function timestamp() {
+    return global.firebase?.database?.ServerValue?.TIMESTAMP || Date.now();
+  }
+
+  function feedback(message, kind = "") {
+    const node = doc.getElementById("dm-trait-feedback");
+    if (!node) return;
+    node.textContent = message || "";
+    node.dataset.kind = kind;
+  }
+
+  function library() {
+    return global.LuminousDmTraitLibrary || null;
+  }
+
+  async function importCatalog() {
+    const lib = library();
+    if (!lib) throw new Error("Trait Library no está lista.");
+    if (!global.firebase?.database || !global.firebase?.apps?.length) throw new Error("Firebase no está disponible.");
+
+    const catalogValidation = catalog.validateAll(engine);
+    if (!catalogValidation.valid) throw new Error(catalogValidation.errors.join(" · "));
+
+    const plan = buildImportPlan(
+      lib.getDefinitions?.() || {},
+      lib.getGrants?.() || [],
+      {
+        validateDefinitionForPersistence: lib.validateDefinitionForPersistence,
+        validateGrant: lib.validateGrant,
+        validateFirebaseKey: lib.validateFirebaseKey,
+      },
+    );
+    if (!plan.valid) throw new Error(plan.errors.join(" · "));
+
+    if (!plan.definitionWrites.length && !plan.grantWrites.length) {
+      feedback("El catálogo base ya está importado. No hay cambios.", "success");
+      return plan;
+    }
+
+    const stamp = timestamp();
+    const updates = {};
+    plan.definitionWrites.forEach(({ id, definition }) => {
+      updates[`definitions/${id}`] = { ...definition, createdAt: stamp, updatedAt: stamp, catalogVersion: catalog.CATALOG_VERSION };
+    });
+    plan.grantWrites.forEach(({ id, grant }) => {
+      updates[`grants/${id}`] = { ...grant, createdAt: stamp, updatedAt: stamp, catalogVersion: catalog.CATALOG_VERSION };
+    });
+
+    await global.firebase.database().ref(TRAITS_ROOT).update(updates);
+    feedback(`Catálogo base importado: ${plan.definitionWrites.length} Traits · ${plan.grantWrites.length} Grants.`, "success");
+    return plan;
+  }
+
+  function mountButton() {
+    if (doc.getElementById("dm-trait-import-core")) return true;
+    const create = doc.getElementById("dm-trait-create");
+    if (!create?.parentElement) return false;
+
+    const button = doc.createElement("button");
+    button.id = "dm-trait-import-core";
+    button.className = "btn-cyber";
+    button.type = "button";
+    button.textContent = "IMPORTAR CATÁLOGO BASE";
+    button.addEventListener("click", async () => {
+      button.disabled = true;
+      const oldText = button.textContent;
+      button.textContent = "IMPORTANDO...";
+      try {
+        await importCatalog();
+      } catch (error) {
+        console.error("Core Trait Catalog Import:", error);
+        feedback(error.message || "No se pudo importar el catálogo base.", "error");
+      } finally {
+        button.disabled = false;
+        button.textContent = oldText;
+      }
+    });
+
+    create.parentElement.insertBefore(button, create);
+    return true;
+  }
+
+  function start() {
+    if (mountButton()) return;
+    const observer = new MutationObserver(() => {
+      if (mountButton()) observer.disconnect();
+    });
+    observer.observe(doc.body || doc.documentElement, { childList: true, subtree: true });
+  }
+
+  global.LuminousTraitCatalogImporter = Object.freeze({
+    TRAITS_ROOT,
+    grantIdentity,
+    buildImportPlan,
+    importCatalog,
+    mountButton,
+  });
+
+  if (doc.readyState === "loading") doc.addEventListener("DOMContentLoaded", start, { once: true });
+  else start();
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/trait-catalog-core.js
+++ b/js/trait-catalog-core.js
@@ -115,21 +115,10 @@
     }),
   });
 
+  // Grants are progression data, not mechanical definitions. Only keep a Grant
+  // when its source requires no guessed class level. Class acquisition levels
+  // remain DM-authored until the original progression is explicitly confirmed.
   const GRANTS = Object.freeze([
-    Object.freeze({
-      id: "core_class_barbarian_2_danger_senses",
-      sourceType: "class",
-      sourceId: "barbarian",
-      atLevel: 2,
-      traitId: "danger_senses",
-    }),
-    Object.freeze({
-      id: "core_class_barbarian_2_rage",
-      sourceType: "class",
-      sourceId: "barbarian",
-      atLevel: 2,
-      traitId: "rage",
-    }),
     Object.freeze({
       id: "core_lineage_devil_lineage_devil_body",
       sourceType: "lineage",

--- a/js/trait-catalog-core.js
+++ b/js/trait-catalog-core.js
@@ -1,0 +1,197 @@
+(function (global) {
+  "use strict";
+
+  const engine = global.LuminousTraitEngine || (typeof require === "function" ? require("./trait-engine.js") : null);
+  const CATALOG_VERSION = 1;
+
+  const DEFINITIONS = Object.freeze({
+    danger_senses: Object.freeze({
+      schemaVersion: 1,
+      id: "danger_senses",
+      name: "Danger Senses",
+      description: "Reduce Dexterity check Difficulty by 4 before the roll resolves.",
+      source: { type: "class", id: "barbarian", classId: "barbarian" },
+      contexts: ["theatre"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [{
+        id: "danger_senses_dex_check",
+        contexts: ["theatre"],
+        trigger: "before_check",
+        conditions: [{ path: "check.abilityId", operator: "eq", value: "dex" }],
+        operations: [{ type: "modify", path: "check.difficulty", mode: "add", value: -4 }],
+      }],
+    }),
+
+    green_eyed_heir: Object.freeze({
+      schemaVersion: 1,
+      id: "green_eyed_heir",
+      name: "Green Eyed Heir",
+      description: "Gain +2 Final Power on Insight and Perception checks.",
+      source: { type: "special", id: "" },
+      contexts: ["theatre"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [{
+        id: "green_eyed_heir_awareness",
+        contexts: ["theatre"],
+        trigger: "before_check",
+        conditions: [{ path: "check.skillId", operator: "in", value: ["insight", "perception"] }],
+        operations: [{ type: "modify", path: "check.finalPower", mode: "add", value: 2 }],
+      }],
+    }),
+
+    rage: Object.freeze({
+      schemaVersion: 1,
+      id: "rage",
+      name: "Rage",
+      description: "Spend a Quick Action to enter Rage. Uses scale with Barbarian ClassLevel and reset on Long Rest.",
+      source: { type: "class", id: "barbarian", classId: "barbarian" },
+      contexts: ["combat"],
+      activation: {
+        type: "manual",
+        actionCost: "quick_action",
+        uses: { formula: "floor(ClassLevel / 7)", reset: "long_rest" },
+        conditions: [{ statusId: "rage", operator: "falsy" }],
+      },
+      effects: [{
+        id: "rage_activate",
+        contexts: ["combat"],
+        trigger: "on_use",
+        conditions: [],
+        operations: [{ type: "apply_status", statusId: "rage", duration: "until_removed" }],
+      }],
+    }),
+
+    devil_body: Object.freeze({
+      schemaVersion: 1,
+      id: "devil_body",
+      name: "Devil Body",
+      description: "At Turn Start, heal HP equal to floor(DefensiveLevel / 2), capped by Max HP.",
+      source: { type: "lineage", id: "devil_lineage" },
+      contexts: ["combat"],
+      activation: { type: "automatic", actionCost: "none" },
+      effects: [{
+        id: "devil_body_regeneration",
+        contexts: ["combat"],
+        trigger: "turn_start",
+        conditions: [],
+        operations: [{
+          type: "heal_hp",
+          path: "self.currentHp",
+          maxPath: "self.maxHp",
+          formula: "floor(DefensiveLevel / 2)",
+        }],
+      }],
+    }),
+
+    devil_trigger: Object.freeze({
+      schemaVersion: 1,
+      id: "devil_trigger",
+      name: "Devil Trigger",
+      description: "Consume all Devil Gauge on use and evaluate threshold effects from the consumed amount.",
+      source: { type: "special", id: "" },
+      contexts: ["combat"],
+      activation: { type: "manual", actionCost: "none" },
+      effects: [
+        {
+          id: "devil_trigger_consume_gauge",
+          contexts: ["combat"],
+          trigger: "on_use",
+          conditions: [],
+          operations: [{
+            type: "resource",
+            resourceId: "devil_gauge",
+            mode: "consume_all",
+            storeAs: "ConsumedGauge",
+          }],
+        },
+        {
+          id: "devil_trigger_threshold_7",
+          contexts: ["combat"],
+          trigger: "on_use",
+          conditions: [{ formula: "ConsumedGauge", operator: "gte", value: 7 }],
+          operations: [{ type: "modify", path: "self.damagePercent", mode: "add", formula: "OffensiveLevel" }],
+        },
+      ],
+    }),
+  });
+
+  const GRANTS = Object.freeze([
+    Object.freeze({
+      id: "core_class_barbarian_2_danger_senses",
+      sourceType: "class",
+      sourceId: "barbarian",
+      atLevel: 2,
+      traitId: "danger_senses",
+    }),
+    Object.freeze({
+      id: "core_class_barbarian_2_rage",
+      sourceType: "class",
+      sourceId: "barbarian",
+      atLevel: 2,
+      traitId: "rage",
+    }),
+    Object.freeze({
+      id: "core_lineage_devil_lineage_devil_body",
+      sourceType: "lineage",
+      sourceId: "devil_lineage",
+      traitId: "devil_body",
+    }),
+  ]);
+
+  function clone(value) {
+    return value == null ? value : JSON.parse(JSON.stringify(value));
+  }
+
+  function allDefinitions() {
+    return clone(DEFINITIONS);
+  }
+
+  function allGrants() {
+    return clone(GRANTS);
+  }
+
+  function getDefinition(id) {
+    const key = engine?.normalizeId ? engine.normalizeId(id) : String(id ?? "").trim().toLowerCase().replace(/\s+/g, "_");
+    return clone(DEFINITIONS[key] || null);
+  }
+
+  function validateAll(customEngine = engine) {
+    const errors = [];
+    const warnings = [];
+    if (!customEngine?.validateTrait) return { valid: false, errors: ["Trait Engine is not available."], warnings };
+
+    Object.entries(DEFINITIONS).forEach(([key, definition]) => {
+      const result = customEngine.validateTrait(definition);
+      if (result.trait.id !== key) errors.push(`${key}: normalized id became ${result.trait.id}.`);
+      result.errors.forEach((message) => errors.push(`${key}: ${message}`));
+      result.warnings.forEach((message) => warnings.push(`${key}: ${message}`));
+    });
+
+    const seenGrantIds = new Set();
+    const seenIdentities = new Set();
+    GRANTS.forEach((grant) => {
+      if (!grant.id) errors.push("Core grant is missing deterministic id.");
+      if (seenGrantIds.has(grant.id)) errors.push(`Duplicate core grant id: ${grant.id}`);
+      seenGrantIds.add(grant.id);
+      if (!DEFINITIONS[grant.traitId]) errors.push(`${grant.id}: missing Trait definition ${grant.traitId}.`);
+      const identity = `${grant.sourceType}:${grant.sourceId}:${grant.traitId}:${grant.sourceType === "class" ? grant.atLevel : 0}`;
+      if (seenIdentities.has(identity)) errors.push(`Duplicate core grant identity: ${identity}`);
+      seenIdentities.add(identity);
+    });
+
+    return { valid: !errors.length, errors, warnings };
+  }
+
+  const api = Object.freeze({
+    CATALOG_VERSION,
+    DEFINITIONS,
+    GRANTS,
+    allDefinitions,
+    allGrants,
+    getDefinition,
+    validateAll,
+  });
+
+  global.LuminousTraitCatalogCore = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/trait-catalog-core.js
+++ b/js/trait-catalog-core.js
@@ -4,8 +4,15 @@
   const engine = global.LuminousTraitEngine || (typeof require === "function" ? require("./trait-engine.js") : null);
   const CATALOG_VERSION = 1;
 
-  const DEFINITIONS = Object.freeze({
-    danger_senses: Object.freeze({
+  function deepFreeze(value, seen = new WeakSet()) {
+    if (!value || typeof value !== "object" || seen.has(value)) return value;
+    seen.add(value);
+    Reflect.ownKeys(value).forEach((key) => deepFreeze(value[key], seen));
+    return Object.freeze(value);
+  }
+
+  const DEFINITIONS = deepFreeze({
+    danger_senses: {
       schemaVersion: 1,
       id: "danger_senses",
       name: "Danger Senses",
@@ -20,9 +27,9 @@
         conditions: [{ path: "check.abilityId", operator: "eq", value: "dex" }],
         operations: [{ type: "modify", path: "check.difficulty", mode: "add", value: -4 }],
       }],
-    }),
+    },
 
-    green_eyed_heir: Object.freeze({
+    green_eyed_heir: {
       schemaVersion: 1,
       id: "green_eyed_heir",
       name: "Green Eyed Heir",
@@ -37,9 +44,9 @@
         conditions: [{ path: "check.skillId", operator: "in", value: ["insight", "perception"] }],
         operations: [{ type: "modify", path: "check.finalPower", mode: "add", value: 2 }],
       }],
-    }),
+    },
 
-    rage: Object.freeze({
+    rage: {
       schemaVersion: 1,
       id: "rage",
       name: "Rage",
@@ -59,9 +66,9 @@
         conditions: [],
         operations: [{ type: "apply_status", statusId: "rage", duration: "until_removed" }],
       }],
-    }),
+    },
 
-    devil_body: Object.freeze({
+    devil_body: {
       schemaVersion: 1,
       id: "devil_body",
       name: "Devil Body",
@@ -81,9 +88,9 @@
           formula: "floor(DefensiveLevel / 2)",
         }],
       }],
-    }),
+    },
 
-    devil_trigger: Object.freeze({
+    devil_trigger: {
       schemaVersion: 1,
       id: "devil_trigger",
       name: "Devil Trigger",
@@ -112,19 +119,19 @@
           operations: [{ type: "modify", path: "self.damagePercent", mode: "add", formula: "OffensiveLevel" }],
         },
       ],
-    }),
+    },
   });
 
   // Grants are progression data, not mechanical definitions. Only keep a Grant
   // when its source requires no guessed class level. Class acquisition levels
   // remain DM-authored until the original progression is explicitly confirmed.
-  const GRANTS = Object.freeze([
-    Object.freeze({
+  const GRANTS = deepFreeze([
+    {
       id: "core_lineage_devil_lineage_devil_body",
       sourceType: "lineage",
       sourceId: "devil_lineage",
       traitId: "devil_body",
-    }),
+    },
   ]);
 
   function clone(value) {

--- a/js/utils.js
+++ b/js/utils.js
@@ -140,16 +140,26 @@ function ensureDmTraitLibraryAssets(doc) {
     }
 
     const link = ensureStyleAsset(documentRef, 'dm-trait-library-stylesheet', 'css/dm-trait-library-studio.css', { ui: 'dm-trait-library' });
-    const ensureStudio = () => ensureScriptAsset(documentRef, 'dm-trait-library-script', 'js/dm-trait-library-studio.js', { ui: 'dm-trait-library' });
-    let engine = documentRef.getElementById('trait-engine-script');
+    const ensureTraitStack = () => {
+        const catalog = ensureScriptAsset(documentRef, 'trait-catalog-core-script', 'js/trait-catalog-core.js', { engine: 'trait-catalog-core' });
+        const studio = ensureScriptAsset(documentRef, 'dm-trait-library-script', 'js/dm-trait-library-studio.js', { ui: 'dm-trait-library' });
+        const importer = ensureScriptAsset(documentRef, 'dm-trait-catalog-importer-script', 'js/dm-trait-catalog-importer.js', { ui: 'dm-trait-catalog-importer' });
+        return { catalog, studio, importer };
+    };
 
+    let engine = documentRef.getElementById('trait-engine-script');
     if (!engine) {
-        engine = ensureScriptAsset(documentRef, 'trait-engine-script', 'js/trait-engine.js', { engine: 'trait-engine' });
-        engine.addEventListener('load', ensureStudio, { once: true });
+        engine = documentRef.createElement('script');
+        engine.id = 'trait-engine-script';
+        engine.src = 'js/trait-engine.js';
+        engine.async = false;
+        engine.dataset.engine = 'trait-engine';
+        engine.addEventListener('load', ensureTraitStack, { once: true });
+        documentRef.head?.appendChild(engine);
     } else if (typeof window !== 'undefined' && window.LuminousTraitEngine) {
-        ensureStudio();
+        ensureTraitStack();
     } else {
-        engine.addEventListener('load', ensureStudio, { once: true });
+        engine.addEventListener('load', ensureTraitStack, { once: true });
     }
 
     return { link, engine, traitTab };

--- a/tests/dm_trait_catalog_importer.spec.js
+++ b/tests/dm_trait_catalog_importer.spec.js
@@ -127,6 +127,42 @@ test("Firebase transaction retry replans against a concurrent DM write before co
   ]));
 });
 
+test("no-op cache is server-confirmed and retries when the server lost a catalog definition", async () => {
+  const completeTree = {
+    definitions: catalog.allDefinitions(),
+    grants: Object.fromEntries(catalog.allGrants().map(({ id, ...grant }) => [id, grant])),
+  };
+  const serverTree = JSON.parse(JSON.stringify(completeTree));
+  delete serverTree.definitions.rage;
+
+  let attempts = 0;
+  let committedTree = null;
+  const database = {
+    ref(refPath) {
+      expect(refPath).toBe(importer.TRAITS_ROOT);
+      return {
+        async transaction(update) {
+          attempts += 1;
+          const cachedCandidate = update(completeTree);
+          expect(cachedCandidate).toEqual(completeTree);
+
+          attempts += 1;
+          committedTree = update(serverTree);
+          return { committed: true, snapshot: { val: () => committedTree } };
+        },
+      };
+    },
+  };
+
+  const result = await importer.runAtomicImport(database, helpers, 9012);
+  expect(attempts).toBe(2);
+  expect(result.committed).toBe(true);
+  expect(result.definitionWrites.map((entry) => entry.id)).toEqual(["rage"]);
+  expect(result.grantWrites).toHaveLength(0);
+  expect(committedTree.definitions.rage.name).toBe("Rage");
+  expect(committedTree.definitions.rage.createdAt).toBe(9012);
+});
+
 test("core Grant ids are Firebase-safe and deterministic", () => {
   catalog.GRANTS.forEach((grant) => {
     expect(studio.validateFirebaseKey(grant.id).valid).toBe(true);

--- a/tests/dm_trait_catalog_importer.spec.js
+++ b/tests/dm_trait_catalog_importer.spec.js
@@ -53,6 +53,44 @@ test("core import deduplicates Grants by semantic identity even with another Fir
   expect(plan.grantWrites).toHaveLength(2);
 });
 
+test("import reads persisted Firebase state directly before building its plan", async () => {
+  const reads = [];
+  const persistedDefinitions = {
+    rage: { id: "rage", name: "Rage - Existing DM Version" },
+  };
+  const persistedGrants = {
+    custom_push_id: {
+      sourceType: "class",
+      sourceId: "barbarian",
+      atLevel: 2,
+      traitId: "rage",
+    },
+  };
+  const database = {
+    ref(refPath) {
+      return {
+        async once(eventName) {
+          reads.push([refPath, eventName]);
+          const value = refPath === importer.DEFINITIONS_ROOT ? persistedDefinitions : persistedGrants;
+          return { val: () => value };
+        },
+      };
+    },
+  };
+
+  const persisted = await importer.readPersistedTraitState(database);
+  expect(reads).toEqual([
+    ["campaña/config/traits/definitions", "value"],
+    ["campaña/config/traits/grants", "value"],
+  ]);
+  expect(persisted.definitions.rage.name).toBe("Rage - Existing DM Version");
+  expect(persisted.grants).toEqual([{ id: "custom_push_id", ...persistedGrants.custom_push_id }]);
+
+  const plan = importer.buildImportPlan(persisted.definitions, persisted.grants, helpers);
+  expect(plan.definitionWrites.some((entry) => entry.id === "rage")).toBe(false);
+  expect(plan.grantWrites.some((entry) => entry.grant.traitId === "rage")).toBe(false);
+});
+
 test("core Grant ids are Firebase-safe and deterministic", () => {
   catalog.GRANTS.forEach((grant) => {
     expect(studio.validateFirebaseKey(grant.id).valid).toBe(true);

--- a/tests/dm_trait_catalog_importer.spec.js
+++ b/tests/dm_trait_catalog_importer.spec.js
@@ -52,41 +52,79 @@ test("core import deduplicates confirmed Grants by semantic identity even with a
   expect(plan.grantWrites).toHaveLength(0);
 });
 
-test("import reads persisted Firebase state directly before building its plan", async () => {
-  const reads = [];
-  const persistedDefinitions = {
-    rage: { id: "rage", name: "Rage - Existing DM Version" },
+test("atomic mutation preserves concurrent custom definitions and semantic Grants", () => {
+  const currentTree = {
+    definitions: {
+      rage: { id: "rage", name: "Rage - Concurrent DM Version" },
+    },
+    grants: {
+      custom_push_id: {
+        sourceType: "lineage",
+        sourceId: "devil_lineage",
+        traitId: "devil_body",
+      },
+    },
+    unrelated: { keep: true },
   };
-  const persistedGrants = {
-    custom_push_id: {
-      sourceType: "lineage",
-      sourceId: "devil_lineage",
-      traitId: "devil_body",
+
+  const mutation = importer.buildAtomicImportMutation(currentTree, helpers, 1234);
+  expect(mutation.valid).toBe(true);
+  expect(mutation.changed).toBe(true);
+  expect(mutation.plan.definitionWrites.some((entry) => entry.id === "rage")).toBe(false);
+  expect(mutation.plan.grantWrites).toHaveLength(0);
+  expect(mutation.next.definitions.rage.name).toBe("Rage - Concurrent DM Version");
+  expect(mutation.next.grants.custom_push_id.traitId).toBe("devil_body");
+  expect(mutation.next.unrelated).toEqual({ keep: true });
+  expect(mutation.next.definitions.danger_senses.createdAt).toBe(1234);
+});
+
+test("Firebase transaction retry replans against a concurrent DM write before commit", async () => {
+  const concurrentTree = {
+    definitions: {
+      rage: { id: "rage", name: "Rage - Saved During Import" },
+    },
+    grants: {
+      another_dm_grant: {
+        sourceType: "lineage",
+        sourceId: "devil_lineage",
+        traitId: "devil_body",
+      },
     },
   };
+
+  let attempts = 0;
+  let committedTree = null;
   const database = {
     ref(refPath) {
+      expect(refPath).toBe(importer.TRAITS_ROOT);
       return {
-        async once(eventName) {
-          reads.push([refPath, eventName]);
-          const value = refPath === importer.DEFINITIONS_ROOT ? persistedDefinitions : persistedGrants;
-          return { val: () => value };
+        async transaction(update) {
+          attempts += 1;
+          const staleCandidate = update({ definitions: {}, grants: {} });
+          expect(staleCandidate.definitions.rage.name).toBe("Rage");
+
+          attempts += 1;
+          committedTree = update(concurrentTree);
+          return { committed: true, snapshot: { val: () => committedTree } };
         },
       };
     },
   };
 
-  const persisted = await importer.readPersistedTraitState(database);
-  expect(reads).toEqual([
-    ["campaña/config/traits/definitions", "value"],
-    ["campaña/config/traits/grants", "value"],
-  ]);
-  expect(persisted.definitions.rage.name).toBe("Rage - Existing DM Version");
-  expect(persisted.grants).toEqual([{ id: "custom_push_id", ...persistedGrants.custom_push_id }]);
-
-  const plan = importer.buildImportPlan(persisted.definitions, persisted.grants, helpers);
-  expect(plan.definitionWrites.some((entry) => entry.id === "rage")).toBe(false);
-  expect(plan.grantWrites.some((entry) => entry.grant.traitId === "devil_body")).toBe(false);
+  const result = await importer.runAtomicImport(database, helpers, 5678);
+  expect(attempts).toBe(2);
+  expect(result.committed).toBe(true);
+  expect(result.definitionWrites.some((entry) => entry.id === "rage")).toBe(false);
+  expect(result.grantWrites).toHaveLength(0);
+  expect(committedTree.definitions.rage.name).toBe("Rage - Saved During Import");
+  expect(committedTree.grants.another_dm_grant.traitId).toBe("devil_body");
+  expect(Object.keys(committedTree.definitions)).toEqual(expect.arrayContaining([
+    "danger_senses",
+    "devil_body",
+    "devil_trigger",
+    "green_eyed_heir",
+    "rage",
+  ]));
 });
 
 test("core Grant ids are Firebase-safe and deterministic", () => {

--- a/tests/dm_trait_catalog_importer.spec.js
+++ b/tests/dm_trait_catalog_importer.spec.js
@@ -1,0 +1,77 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+const studio = require("../js/dm-trait-library-studio.js");
+const catalog = require("../js/trait-catalog-core.js");
+const importer = require("../js/dm-trait-catalog-importer.js");
+
+const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
+
+const helpers = {
+  validateDefinitionForPersistence: studio.validateDefinitionForPersistence,
+  validateGrant: studio.validateGrant,
+  validateFirebaseKey: studio.validateFirebaseKey,
+};
+
+test("empty Trait Library imports all known core definitions and Grants", () => {
+  const plan = importer.buildImportPlan({}, [], helpers);
+  expect(plan.valid).toBe(true);
+  expect(plan.errors).toEqual([]);
+  expect(plan.definitionWrites.map((entry) => entry.id).sort()).toEqual(Object.keys(catalog.DEFINITIONS).sort());
+  expect(plan.grantWrites.map((entry) => entry.id).sort()).toEqual(catalog.GRANTS.map((entry) => entry.id).sort());
+  expect(plan.definitionWrites).toHaveLength(5);
+  expect(plan.grantWrites).toHaveLength(3);
+});
+
+test("core import never overwrites an existing DM Trait definition", () => {
+  const existing = {
+    rage: {
+      id: "rage",
+      name: "Rage - DM Custom",
+      contexts: ["combat"],
+      activation: { type: "manual", actionCost: "quick_action" },
+      effects: [{ trigger: "on_use", operations: [{ type: "apply_status", statusId: "rage" }] }],
+    },
+  };
+  const plan = importer.buildImportPlan(existing, [], helpers);
+  expect(plan.valid).toBe(true);
+  expect(plan.definitionWrites.some((entry) => entry.id === "rage")).toBe(false);
+  expect(plan.skippedDefinitions).toBe(1);
+});
+
+test("core import deduplicates Grants by semantic identity even with another Firebase push id", () => {
+  const existingGrants = [{
+    id: "firebase_random_key",
+    sourceType: "class",
+    sourceId: "barbarian",
+    atLevel: 2,
+    traitId: "rage",
+  }];
+  const plan = importer.buildImportPlan({}, existingGrants, helpers);
+  expect(plan.valid).toBe(true);
+  expect(plan.grantWrites.some((entry) => entry.grant.traitId === "rage")).toBe(false);
+  expect(plan.grantWrites).toHaveLength(2);
+});
+
+test("core Grant ids are Firebase-safe and deterministic", () => {
+  catalog.GRANTS.forEach((grant) => {
+    expect(studio.validateFirebaseKey(grant.id).valid).toBe(true);
+    expect(importer.grantIdentity(grant)).toBe(studio.grantIdentity(grant));
+  });
+  expect(new Set(catalog.GRANTS.map((grant) => grant.id)).size).toBe(catalog.GRANTS.length);
+});
+
+test("DM loader orders Trait Engine before catalog, studio and importer", () => {
+  const utils = read("js/utils.js");
+  const engine = utils.indexOf("js/trait-engine.js");
+  const catalogIndex = utils.indexOf("js/trait-catalog-core.js");
+  const studioIndex = utils.indexOf("js/dm-trait-library-studio.js");
+  const importerIndex = utils.indexOf("js/dm-trait-catalog-importer.js");
+
+  expect(engine).toBeGreaterThan(-1);
+  expect(catalogIndex).toBeGreaterThan(-1);
+  expect(studioIndex).toBeGreaterThan(-1);
+  expect(importerIndex).toBeGreaterThan(-1);
+  expect(catalogIndex).toBeLessThan(studioIndex);
+  expect(studioIndex).toBeLessThan(importerIndex);
+});

--- a/tests/dm_trait_catalog_importer.spec.js
+++ b/tests/dm_trait_catalog_importer.spec.js
@@ -13,14 +13,14 @@ const helpers = {
   validateFirebaseKey: studio.validateFirebaseKey,
 };
 
-test("empty Trait Library imports all known core definitions and Grants", () => {
+test("empty Trait Library imports all known core definitions and confirmed Grants", () => {
   const plan = importer.buildImportPlan({}, [], helpers);
   expect(plan.valid).toBe(true);
   expect(plan.errors).toEqual([]);
   expect(plan.definitionWrites.map((entry) => entry.id).sort()).toEqual(Object.keys(catalog.DEFINITIONS).sort());
   expect(plan.grantWrites.map((entry) => entry.id).sort()).toEqual(catalog.GRANTS.map((entry) => entry.id).sort());
   expect(plan.definitionWrites).toHaveLength(5);
-  expect(plan.grantWrites).toHaveLength(3);
+  expect(plan.grantWrites).toHaveLength(1);
 });
 
 test("core import never overwrites an existing DM Trait definition", () => {
@@ -39,18 +39,17 @@ test("core import never overwrites an existing DM Trait definition", () => {
   expect(plan.skippedDefinitions).toBe(1);
 });
 
-test("core import deduplicates Grants by semantic identity even with another Firebase push id", () => {
+test("core import deduplicates confirmed Grants by semantic identity even with another Firebase push id", () => {
   const existingGrants = [{
     id: "firebase_random_key",
-    sourceType: "class",
-    sourceId: "barbarian",
-    atLevel: 2,
-    traitId: "rage",
+    sourceType: "lineage",
+    sourceId: "devil_lineage",
+    traitId: "devil_body",
   }];
   const plan = importer.buildImportPlan({}, existingGrants, helpers);
   expect(plan.valid).toBe(true);
-  expect(plan.grantWrites.some((entry) => entry.grant.traitId === "rage")).toBe(false);
-  expect(plan.grantWrites).toHaveLength(2);
+  expect(plan.grantWrites.some((entry) => entry.grant.traitId === "devil_body")).toBe(false);
+  expect(plan.grantWrites).toHaveLength(0);
 });
 
 test("import reads persisted Firebase state directly before building its plan", async () => {
@@ -60,10 +59,9 @@ test("import reads persisted Firebase state directly before building its plan", 
   };
   const persistedGrants = {
     custom_push_id: {
-      sourceType: "class",
-      sourceId: "barbarian",
-      atLevel: 2,
-      traitId: "rage",
+      sourceType: "lineage",
+      sourceId: "devil_lineage",
+      traitId: "devil_body",
     },
   };
   const database = {
@@ -88,7 +86,7 @@ test("import reads persisted Firebase state directly before building its plan", 
 
   const plan = importer.buildImportPlan(persisted.definitions, persisted.grants, helpers);
   expect(plan.definitionWrites.some((entry) => entry.id === "rage")).toBe(false);
-  expect(plan.grantWrites.some((entry) => entry.grant.traitId === "rage")).toBe(false);
+  expect(plan.grantWrites.some((entry) => entry.grant.traitId === "devil_body")).toBe(false);
 });
 
 test("core Grant ids are Firebase-safe and deterministic", () => {

--- a/tests/dm_trait_catalog_importer.spec.js
+++ b/tests/dm_trait_catalog_importer.spec.js
@@ -61,17 +61,18 @@ test("core Grant ids are Firebase-safe and deterministic", () => {
   expect(new Set(catalog.GRANTS.map((grant) => grant.id)).size).toBe(catalog.GRANTS.length);
 });
 
-test("DM loader orders Trait Engine before catalog, studio and importer", () => {
+test("DM loader gates the catalog stack on Trait Engine load and orders catalog before studio/importer", () => {
   const utils = read("js/utils.js");
-  const engine = utils.indexOf("js/trait-engine.js");
-  const catalogIndex = utils.indexOf("js/trait-catalog-core.js");
-  const studioIndex = utils.indexOf("js/dm-trait-library-studio.js");
-  const importerIndex = utils.indexOf("js/dm-trait-catalog-importer.js");
+  expect(utils).toContain("engine.addEventListener('load', ensureTraitStack, { once: true })");
+  expect(utils).toContain("window.LuminousTraitEngine");
 
-  expect(engine).toBeGreaterThan(-1);
-  expect(catalogIndex).toBeGreaterThan(-1);
-  expect(studioIndex).toBeGreaterThan(-1);
-  expect(importerIndex).toBeGreaterThan(-1);
-  expect(catalogIndex).toBeLessThan(studioIndex);
-  expect(studioIndex).toBeLessThan(importerIndex);
+  const stackStart = utils.indexOf("const ensureTraitStack = () =>");
+  const catalogIndex = utils.indexOf("js/trait-catalog-core.js", stackStart);
+  const studioIndex = utils.indexOf("js/dm-trait-library-studio.js", stackStart);
+  const importerIndex = utils.indexOf("js/dm-trait-catalog-importer.js", stackStart);
+
+  expect(stackStart).toBeGreaterThan(-1);
+  expect(catalogIndex).toBeGreaterThan(stackStart);
+  expect(studioIndex).toBeGreaterThan(catalogIndex);
+  expect(importerIndex).toBeGreaterThan(studioIndex);
 });

--- a/tests/trait_catalog_core.spec.js
+++ b/tests/trait_catalog_core.spec.js
@@ -155,28 +155,23 @@ test("Devil Trigger below threshold consumes gauge without applying threshold bo
   ]);
 });
 
-test("core Grants resolve ClassLevel and Lineage without duplicating definitions", () => {
+test("core catalog only auto-grants progression that is not guessed", () => {
+  expect(catalog.allGrants()).toEqual([{
+    id: "core_lineage_devil_lineage_devil_body",
+    sourceType: "lineage",
+    sourceId: "devil_lineage",
+    traitId: "devil_body",
+  }]);
+
   const granted = engine.resolveTraitGrants(character, catalog.allGrants(), catalog.allDefinitions());
-  expect(granted.map((trait) => trait.id)).toEqual([
-    "danger_senses",
-    "rage",
-    "devil_body",
-  ]);
-  expect(granted.find((trait) => trait.id === "danger_senses").source).toMatchObject({
-    type: "class",
-    id: "barbarian",
-    classId: "barbarian",
-  });
+  expect(granted.map((trait) => trait.id)).toEqual(["devil_body"]);
+  expect(granted[0].source).toMatchObject({ type: "lineage", id: "devil_lineage" });
 });
 
-test("core Grants do not unlock Barbarian Traits below their configured level", () => {
-  const lowLevel = {
-    level: 1,
-    classes: [{ classId: "barbarian", levels: 1 }],
-    lineageId: "none",
-  };
-  const granted = engine.resolveTraitGrants(lowLevel, catalog.allGrants(), catalog.allDefinitions());
-  expect(granted).toEqual([]);
+test("class Trait mechanics remain defined without inventing acquisition levels", () => {
+  expect(catalog.getDefinition("danger_senses").source).toMatchObject({ type: "class", id: "barbarian" });
+  expect(catalog.getDefinition("rage").source).toMatchObject({ type: "class", id: "barbarian" });
+  expect(catalog.allGrants().some((grant) => grant.sourceType === "class")).toBe(false);
 });
 
 test("catalog accessors return copies instead of mutable canonical objects", () => {

--- a/tests/trait_catalog_core.spec.js
+++ b/tests/trait_catalog_core.spec.js
@@ -183,3 +183,26 @@ test("catalog accessors return copies instead of mutable canonical objects", () 
   expect(second.name).toBe("Rage");
   expect(second.effects[0].operations[0].statusId).toBe("rage");
 });
+
+test("exported canonical definitions and Grants are deeply frozen", () => {
+  const operation = catalog.DEFINITIONS.rage.effects[0].operations[0];
+  expect(Object.isFrozen(catalog.DEFINITIONS)).toBe(true);
+  expect(Object.isFrozen(catalog.DEFINITIONS.rage)).toBe(true);
+  expect(Object.isFrozen(catalog.DEFINITIONS.rage.effects)).toBe(true);
+  expect(Object.isFrozen(catalog.DEFINITIONS.rage.effects[0])).toBe(true);
+  expect(Object.isFrozen(operation)).toBe(true);
+  expect(Object.isFrozen(catalog.GRANTS)).toBe(true);
+  expect(Object.isFrozen(catalog.GRANTS[0])).toBe(true);
+
+  const before = operation.statusId;
+  try {
+    operation.statusId = "corrupted";
+    catalog.DEFINITIONS.rage.effects.push({ id: "corrupted" });
+  } catch (_) {
+    // Strict-mode consumers may throw; non-strict consumers silently fail.
+  }
+
+  expect(catalog.DEFINITIONS.rage.effects[0].operations[0].statusId).toBe(before);
+  expect(catalog.DEFINITIONS.rage.effects).toHaveLength(1);
+  expect(catalog.getDefinition("rage").effects[0].operations[0].statusId).toBe("rage");
+});

--- a/tests/trait_catalog_core.spec.js
+++ b/tests/trait_catalog_core.spec.js
@@ -1,0 +1,190 @@
+const { test, expect } = require("@playwright/test");
+const engine = require("../js/trait-engine.js");
+const catalog = require("../js/trait-catalog-core.js");
+
+const character = {
+  id: "catalog_test_character",
+  level: 30,
+  classes: [
+    { classId: "barbarian", levels: 20 },
+    { classId: "fighter", levels: 10 },
+  ],
+  lineageId: "devil_lineage",
+  combatStats: {
+    offensiveLevel: 34,
+    defensiveLevel: 32,
+  },
+};
+
+test("core Trait catalog validates every declarative definition", () => {
+  const validation = catalog.validateAll(engine);
+  expect(validation.valid).toBe(true);
+  expect(validation.errors).toEqual([]);
+  expect(Object.keys(catalog.DEFINITIONS).sort()).toEqual([
+    "danger_senses",
+    "devil_body",
+    "devil_trigger",
+    "green_eyed_heir",
+    "rage",
+  ]);
+});
+
+test("Danger Senses only reduces Dexterity check Difficulty", () => {
+  const trait = catalog.getDefinition("danger_senses");
+  const dex = engine.resolveTheatreCheck({
+    character,
+    traits: [trait],
+    check: { abilityId: "dex", skillId: "acrobatics", difficulty: 16 },
+  });
+  const wis = engine.resolveTheatreCheck({
+    character,
+    traits: [trait],
+    check: { abilityId: "wis", skillId: "perception", difficulty: 16 },
+  });
+
+  expect(dex.check.difficulty).toBe(12);
+  expect(dex.outcomes).toHaveLength(1);
+  expect(wis.check.difficulty).toBe(16);
+  expect(wis.outcomes).toHaveLength(0);
+});
+
+test("Green Eyed Heir grants Final Power only to Insight and Perception", () => {
+  const trait = catalog.getDefinition("green_eyed_heir");
+  const perception = engine.resolveTheatreCheck({
+    character,
+    traits: [trait],
+    check: { abilityId: "wis", skillId: "perception", finalPower: 0 },
+  });
+  const insight = engine.resolveTheatreCheck({
+    character,
+    traits: [trait],
+    check: { abilityId: "wis", skillId: "insight", finalPower: 1 },
+  });
+  const survival = engine.resolveTheatreCheck({
+    character,
+    traits: [trait],
+    check: { abilityId: "wis", skillId: "survival", finalPower: 0 },
+  });
+
+  expect(perception.check.finalPower).toBe(2);
+  expect(insight.check.finalPower).toBe(3);
+  expect(survival.check.finalPower).toBe(0);
+});
+
+test("Rage consumes Quick Action, scales uses by Barbarian ClassLevel and blocks reactivation while active", () => {
+  const trait = catalog.getDefinition("rage");
+  const state = engine.createState();
+  const runtime = {
+    context: "combat",
+    character,
+    self: {},
+    actionEconomy: { quick_action: 1 },
+  };
+
+  const result = engine.activateTrait(trait, runtime, state);
+  expect(result.available).toBe(true);
+  expect(result.maximum).toBe(2);
+  expect(result.remaining).toBe(1);
+  expect(runtime.actionEconomy.quick_action).toBe(0);
+  expect(state.statuses.rage).toMatchObject({ id: "rage", sourceTraitId: "rage" });
+
+  const blocked = engine.canActivateTrait(trait, {
+    context: "combat",
+    character,
+    self: {},
+    actionEconomy: { quick_action: 1 },
+  }, state);
+  expect(blocked.available).toBe(false);
+  expect(blocked.reasons.join(" ")).toContain("conditions");
+});
+
+test("Devil Body heals at Turn Start using DefensiveLevel and respects Max HP", () => {
+  const trait = catalog.getDefinition("devil_body");
+  const self = { currentHp: 90, maxHp: 100 };
+  const result = engine.dispatchCombatEvent("turn_start", {
+    character,
+    self,
+    traits: [trait],
+    DefensiveLevel: 32,
+  });
+
+  expect(self.currentHp).toBe(100);
+  expect(result.outcomes).toHaveLength(1);
+  expect(result.outcomes[0]).toMatchObject({ type: "heal_hp", amount: 16, after: 100 });
+});
+
+test("Devil Trigger consumes all gauge and threshold 7 uses the consumed value", () => {
+  const trait = catalog.getDefinition("devil_trigger");
+  const state = engine.createState({
+    resources: { devil_gauge: { value: 8, min: 0, max: 10 } },
+  });
+  const self = { damagePercent: 0 };
+  const result = engine.activateTrait(trait, {
+    context: "combat",
+    character,
+    self,
+    OffensiveLevel: 34,
+  }, state);
+
+  expect(result.available).toBe(true);
+  expect(state.resources.devil_gauge.value).toBe(0);
+  expect(self.damagePercent).toBe(34);
+  expect(result.outcomes.map((entry) => entry.effectId)).toEqual([
+    "devil_trigger_consume_gauge",
+    "devil_trigger_threshold_7",
+  ]);
+});
+
+test("Devil Trigger below threshold consumes gauge without applying threshold bonus", () => {
+  const trait = catalog.getDefinition("devil_trigger");
+  const state = engine.createState({
+    resources: { devil_gauge: { value: 6, min: 0, max: 10 } },
+  });
+  const self = { damagePercent: 0 };
+  const result = engine.activateTrait(trait, {
+    context: "combat",
+    character,
+    self,
+    OffensiveLevel: 34,
+  }, state);
+
+  expect(state.resources.devil_gauge.value).toBe(0);
+  expect(self.damagePercent).toBe(0);
+  expect(result.outcomes.map((entry) => entry.effectId)).toEqual([
+    "devil_trigger_consume_gauge",
+  ]);
+});
+
+test("core Grants resolve ClassLevel and Lineage without duplicating definitions", () => {
+  const granted = engine.resolveTraitGrants(character, catalog.allGrants(), catalog.allDefinitions());
+  expect(granted.map((trait) => trait.id)).toEqual([
+    "danger_senses",
+    "rage",
+    "devil_body",
+  ]);
+  expect(granted.find((trait) => trait.id === "danger_senses").source).toMatchObject({
+    type: "class",
+    id: "barbarian",
+    classId: "barbarian",
+  });
+});
+
+test("core Grants do not unlock Barbarian Traits below their configured level", () => {
+  const lowLevel = {
+    level: 1,
+    classes: [{ classId: "barbarian", levels: 1 }],
+    lineageId: "none",
+  };
+  const granted = engine.resolveTraitGrants(lowLevel, catalog.allGrants(), catalog.allDefinitions());
+  expect(granted).toEqual([]);
+});
+
+test("catalog accessors return copies instead of mutable canonical objects", () => {
+  const first = catalog.getDefinition("rage");
+  first.name = "MUTATED";
+  first.effects[0].operations[0].statusId = "other";
+
+  const second = catalog.getDefinition("rage");
+  expect(second.name).toBe("Rage");
+  expect(second.effects[0].operations[0].statusId).toBe("rage");
+});


### PR DESCRIPTION
## Base

Este PR ahora apunta directamente a `main`. La dependencia #557 ya fue mergeada.

## Objetivo

Convertir las Traits cuya mecánica ya quedó explícitamente fijada en nuestro diseño al estándar declarativo de Trait Engine V1, sin hardcodear lógica por nombre de Trait.

Contrato común:

`WHEN trigger -> IF conditions -> DO operations -> VALUE/formula`

## Catálogo programado

`js/trait-catalog-core.js` añade Definitions canónicas para:

- **Danger Senses** — Theatre / passive / `before_check` / Dexterity -> Difficulty -4 / source Barbarian.
- **Green Eyed Heir** — Theatre / passive / Insight o Perception -> Final Power +2.
- **Rage** — Combat / manual / Quick Action / usos `floor(ClassLevel / 7)` / Long Rest / evita reactivación con `rage` activo / aplica Status `rage` / source Barbarian.
- **Devil Body** — Combat / automatic / Turn Start / cura `floor(DefensiveLevel / 2)` con cap de Max HP.
- **Devil Trigger** — Combat / manual / consume todo `devil_gauge`, guarda `ConsumedGauge`, umbral conocido `>= 7` -> `self.damagePercent += OffensiveLevel`.

## Definitions y Grants separados

No se convierten ejemplos de adquisición en progresión canónica. Danger Senses y Rage quedan mecánicamente programados pero sin `atLevel` hardcodeado hasta confirmar la progresión original.

El único Grant base incluido es el que no requiere inventar nivel de clase:

- `devil_lineage -> Devil Body`

Green Eyed Heir y Devil Trigger quedan con Definition mecánica lista, pero sin Grant hardcodeado hasta confirmar su origen/progresión o asignarlos desde el DM.

## Inmutabilidad del catálogo

`DEFINITIONS` y `GRANTS` se construyen con `deepFreeze()` recursivo. Arrays, Effects, Conditions y Operations canónicas no pueden ser mutadas por consumidores. `getDefinition()`, `allDefinitions()` y `allGrants()` siguen devolviendo copias editables.

## Importador DM

Añade `js/dm-trait-catalog-importer.js` y el botón `IMPORTAR CATÁLOGO BASE`.

La importación usa una sola transacción Firebase RTDB sobre `campaña/config/traits`. El callback reconstruye el plan contra el estado actual en cada intento/reintento, por lo que la comprobación de ausencia y la escritura son atómicas.

El importador:

- valida Definitions, IDs Firebase y Grants;
- no depende del cache asíncrono de la UI;
- no sobreescribe Definitions editadas por otro DM;
- deduplica Grants por identidad semántica dentro del estado transaccional actual;
- preserva datos no relacionados bajo `campaña/config/traits`;
- usa IDs deterministas para Grants base;
- incluso un no-op debe ser confirmado por el servidor antes de reportar éxito;
- restaura faltantes si el cache local parecía completo pero el servidor perdió una Definition o Grant;
- es idempotente.

Esto cubre los hallazgos de Codex sobre cache inicial, carrera `once()/update()`, inmutabilidad profunda y confirmación server-side de no-op.

## Carga

`js/utils.js` carga:

`Trait Engine -> Core Catalog -> Trait Library -> Catalog Importer`

No modifica `pantalla_dm.html`, Theatre ni Combat legacy.

## Pruebas

- `tests/trait_catalog_core.spec.js`
- `tests/dm_trait_catalog_importer.spec.js`

Cubren validación de Definitions, condiciones positivas/negativas, Rage, ClassLevel, Status, Devil Body, Devil Trigger, Grant confirmado de Lineage, ausencia de niveles inventados, importación vacía, no-overwrite, deduplicación, concurrencia transaccional, no-op confirmado por servidor, deep-freeze, IDs Firebase-safe y orden de carga.

## Review

Última revisión de Codex sobre `8119099d8e`: **Didn't find any major issues.** Todos los threads P1/P2 previos están resueltos.

## Archivos

- `js/trait-catalog-core.js`
- `js/dm-trait-catalog-importer.js`
- `js/utils.js`
- `tests/trait_catalog_core.spec.js`
- `tests/dm_trait_catalog_importer.spec.js`
- `docs/trait-catalog-core.md`