### PR TITLE
feat: add automatic racial Trait catalog

### DIFF
--- a/.github/workflows/trait-engine.yml
+++ b/.github/workflows/trait-engine.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "js/trait-engine.js"
       - "js/trait-catalog-core.js"
+      - "js/racial-trait-catalog.js"
       - "js/status-engine.js"
       - "js/universal-modifier-engine.js"
       - "js/universal-speed-runtime.js"
@@ -19,6 +20,7 @@ on:
       - "tests/trait_engine.spec.js"
       - "tests/trait_engine_codex_regressions.spec.js"
       - "tests/trait_catalog_core.spec.js"
+      - "tests/racial_trait_catalog.spec.js"
       - "tests/dm_trait_catalog_importer.spec.js"
       - "tests/barbarian_trait_rules_runtime.spec.js"
       - "tests/universal_modifier_engine.spec.js"
@@ -49,6 +51,7 @@ jobs:
         run: |
           node --check js/trait-engine.js
           node --check js/trait-catalog-core.js
+          node --check js/racial-trait-catalog.js
           node --check js/status-engine.js
           node --check js/universal-modifier-engine.js
           node --check js/universal-speed-runtime.js
@@ -61,6 +64,7 @@ jobs:
           node --check tests/trait_engine.spec.js
           node --check tests/trait_engine_codex_regressions.spec.js
           node --check tests/trait_catalog_core.spec.js
+          node --check tests/racial_trait_catalog.spec.js
           node --check tests/dm_trait_catalog_importer.spec.js
           node --check tests/barbarian_trait_rules_runtime.spec.js
           node --check tests/universal_modifier_engine.spec.js
@@ -73,6 +77,7 @@ jobs:
           tests/trait_engine.spec.js
           tests/trait_engine_codex_regressions.spec.js
           tests/trait_catalog_core.spec.js
+          tests/racial_trait_catalog.spec.js
           tests/dm_trait_catalog_importer.spec.js
           tests/barbarian_trait_rules_runtime.spec.js
           tests/universal_modifier_engine.spec.js

--- a/js/character-build-rules.js
+++ b/js/character-build-rules.js
@@ -80,7 +80,13 @@
       { id: "silver", name: "Plata", hpCoefBonus: 0.00, defMod: 0 },
     ] },
     { id: "lupae", name: "Lupae", hpCoefBonus: 0.06, defMod: 0, tags: ["organic", "humanoid", "canine"] },
-    { id: "moonfae", name: "Moonfae", hpCoefBonus: 0.02, defMod: 0, tags: ["organic", "humanoid", "fae", "lunar"] },
+    { id: "moonfae", name: "Moonfae", hpCoefBonus: 0.02, defMod: 0, tags: ["organic", "humanoid", "fae", "lunar"], subtypes: [
+      { id: "full_moon", name: "Luna Llena", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "crescent_moon", name: "Luna Creciente", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "new_moon", name: "Luna Nueva", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "crimson_moon", name: "Luna Carmesí", hpCoefBonus: 0.00, defMod: 0 },
+      { id: "blue_moon", name: "Luna Azul", hpCoefBonus: 0.00, defMod: 0 },
+    ] },
     { id: "yuan_ti_pureblood", name: "Yuan-ti Pura Sangre", hpCoefBonus: 0.03, defMod: 0, tags: ["organic", "humanoid", "reptilian", "yuan_ti"], subtypes: [
       { id: "red_eyes", name: "Ojos Rojos — Ira", hpCoefBonus: 0.00, defMod: 0 },
       { id: "purple_eyes", name: "Ojos Morados — Envidia", hpCoefBonus: 0.00, defMod: 0 },

--- a/js/player-trait-runtime.js
+++ b/js/player-trait-runtime.js
@@ -71,6 +71,7 @@
       .then(() => ensureScript("trait-engine-script", "js/trait-engine.js", () => Boolean(global.LuminousTraitEngine)))
       .then(() => Promise.all([
         ensureScript("trait-catalog-core-script", "js/trait-catalog-core.js", () => Boolean(global.LuminousTraitCatalogCore)),
+        ensureScript("racial-trait-catalog-script", "js/racial-trait-catalog.js", () => Boolean(global.LuminousRacialTraitCatalog)),
         ensureScript("class-milestone-engine-script", "js/class-milestone-engine.js", () => Boolean(global.LuminousClassMilestones)),
         ensureScript("trait-player-tray-script", "js/trait-player-tray.js", () => Boolean(global.LuminousTraitPlayerTray)),
       ]));
@@ -96,7 +97,8 @@
 
   function mergedDefinitions() {
     const core = global.LuminousTraitCatalogCore?.allDefinitions?.() || {};
-    return { ...core, ...(state.definitions || {}) };
+    const racial = global.LuminousRacialTraitCatalog?.allDefinitions?.() || {};
+    return { ...core, ...racial, ...(state.definitions || {}) };
   }
 
   function mergedGrants() {
@@ -119,17 +121,20 @@
 
   function resolveTraits() {
     const traitEngine = global.LuminousTraitEngine;
+    const racialCatalog = global.LuminousRacialTraitCatalog;
     const milestones = global.LuminousClassMilestones;
     if (!traitEngine?.resolveTraitGrants || !milestones?.resolveSelectedGeneralTraits) return [];
     const character = getCharacter();
+    const normalizedCharacter = normalizeCharacterForGrantResolution(character);
     const definitions = mergedDefinitions();
     const granted = traitEngine.resolveTraitGrants(
-      normalizeCharacterForGrantResolution(character),
+      normalizedCharacter,
       mergedGrants(),
       definitions,
     );
+    const racialGranted = racialCatalog?.resolveTraitGrants?.(normalizedCharacter, definitions) || [];
     const selected = milestones.resolveSelectedGeneralTraits(character, definitions);
-    return mergeTraitLists(granted, selected);
+    return mergeTraitLists([...granted, ...racialGranted], selected);
   }
 
   function inferContext() {

--- a/js/racial-trait-catalog.js
+++ b/js/racial-trait-catalog.js
@@ -1,0 +1,893 @@
+(function (global) {
+  "use strict";
+
+  const engine = global.LuminousTraitEngine || (typeof require === "function" ? require("./trait-engine.js") : null);
+  const CATALOG_VERSION = 1;
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/\s+/g, "_");
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+  function deepFreeze(value, seen = new WeakSet()) {
+    if (!value || typeof value !== "object" || seen.has(value)) return value;
+    seen.add(value);
+    Reflect.ownKeys(value).forEach((key) => deepFreeze(value[key], seen));
+    return Object.freeze(value);
+  }
+
+  const raceSource = (id) => Object.freeze({ type: "race", id });
+
+  const DEFINITIONS = deepFreeze({
+    pack_tactics: {
+      schemaVersion: 1,
+      id: "pack_tactics",
+      name: "Pack Tactics",
+      description: "On the first attack each Turn, if the target is already Targeted by an Ally, gain +1 Final Power.",
+      source: { type: "special", id: "shared" },
+      contexts: ["combat"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [{
+        type: "modifier",
+        trigger: "before_attack",
+        target: "self",
+        path: "skill.finalPower",
+        mode: "add",
+        value: 1,
+        scope: "once_per_turn",
+        conditions: [{ path: "target.targetedByAlly", operator: "truthy" }],
+      }],
+    },
+
+    keen_hearing: {
+      schemaVersion: 1,
+      id: "keen_hearing",
+      name: "Keen Hearing",
+      description: "Sound-based Perception checks reduce Threshold by 4.",
+      source: { type: "special", id: "shared" },
+      contexts: ["theatre"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [{
+        id: "keen_hearing_perception",
+        contexts: ["theatre"],
+        trigger: "before_check",
+        conditions: [
+          { path: "check.skillId", operator: "eq", value: "perception" },
+          { path: "check.senses", operator: "contains", value: "hearing" },
+        ],
+        operations: [{ type: "modify", path: "check.difficulty", mode: "add", value: -4 }],
+      }],
+      rules: [],
+    },
+
+    keen_hearing_and_smell: {
+      schemaVersion: 1,
+      id: "keen_hearing_and_smell",
+      name: "Keen Hearing and Smell",
+      description: "Perception checks based on hearing or smell reduce Threshold by 4.",
+      source: { type: "special", id: "shared" },
+      contexts: ["theatre"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [{
+        id: "keen_hearing_smell_perception",
+        contexts: ["theatre"],
+        trigger: "before_check",
+        conditions: [
+          { path: "check.skillId", operator: "eq", value: "perception" },
+          { any: [
+            { path: "check.senses", operator: "contains", value: "hearing" },
+            { path: "check.senses", operator: "contains", value: "smell" },
+          ] },
+        ],
+        operations: [{ type: "modify", path: "check.difficulty", mode: "add", value: -4 }],
+      }],
+      rules: [],
+    },
+
+    lizalin_natural_armor: {
+      schemaVersion: 1,
+      id: "lizalin_natural_armor",
+      name: "Natural Armor",
+      description: "Gain +1 Defensive Level.",
+      source: raceSource("lizalin"),
+      contexts: ["combat"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [{ type: "modifier", trigger: "passive", target: "self", channel: "defensive_level", mode: "add", value: 1 }],
+    },
+
+    kobold_burrow_mentality: {
+      schemaVersion: 1,
+      id: "kobold_burrow_mentality",
+      name: "Burrow Mentality",
+      description: "History and Survival checks related to tunnels, caverns, or underground structures reduce Threshold by 4.",
+      source: raceSource("kobold"),
+      contexts: ["theatre"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [{
+        id: "kobold_burrow_mentality_check",
+        contexts: ["theatre"],
+        trigger: "before_check",
+        conditions: [
+          { path: "check.skillId", operator: "in", value: ["history", "survival"] },
+          { any: [
+            { path: "check.environmentTags", operator: "contains", value: "underground" },
+            { path: "check.environmentTags", operator: "contains", value: "tunnel" },
+            { path: "check.environmentTags", operator: "contains", value: "cavern" },
+          ] },
+        ],
+        operations: [{ type: "modify", path: "check.difficulty", mode: "add", value: -4 }],
+      }],
+      rules: [],
+    },
+
+    kenku_expert_forger: {
+      schemaVersion: 1,
+      id: "kenku_expert_forger",
+      name: "Expert Forger",
+      description: "Forgery checks reduce Threshold by 1.",
+      source: raceSource("kenku"),
+      contexts: ["theatre"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [{
+        id: "kenku_forgery_check",
+        contexts: ["theatre"],
+        trigger: "before_check",
+        conditions: [{ any: [
+          { path: "check.skillId", operator: "eq", value: "forgery" },
+          { path: "check.tags", operator: "contains", value: "forgery" },
+        ] }],
+        operations: [{ type: "modify", path: "check.difficulty", mode: "add", value: -1 }],
+      }],
+      rules: [],
+    },
+
+    kenku_limited_communication: {
+      schemaVersion: 1,
+      id: "kenku_limited_communication",
+      name: "Limited Communication",
+      description: "For verbal communication, Persuasion Threshold +1 and Deception Threshold -1.",
+      source: raceSource("kenku"),
+      contexts: ["theatre"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [
+        {
+          id: "kenku_verbal_persuasion",
+          contexts: ["theatre"],
+          trigger: "before_check",
+          conditions: [
+            { path: "check.skillId", operator: "eq", value: "persuasion" },
+            { path: "check.communicationMode", operator: "eq", value: "verbal" },
+          ],
+          operations: [{ type: "modify", path: "check.difficulty", mode: "add", value: 1 }],
+        },
+        {
+          id: "kenku_verbal_deception",
+          contexts: ["theatre"],
+          trigger: "before_check",
+          conditions: [
+            { path: "check.skillId", operator: "eq", value: "deception" },
+            { path: "check.communicationMode", operator: "eq", value: "verbal" },
+          ],
+          operations: [{ type: "modify", path: "check.difficulty", mode: "add", value: -1 }],
+        },
+      ],
+      rules: [],
+    },
+
+    goliath_stone_endurance: {
+      schemaVersion: 1,
+      id: "goliath_stone_endurance",
+      name: "Stone's Endurance",
+      description: "When damage is taken, reduce incoming damage by Constitution Mod.",
+      source: raceSource("goliath"),
+      contexts: ["combat"],
+      activation: { type: "automatic", actionCost: "none" },
+      effects: [{
+        id: "goliath_stone_endurance_damage",
+        contexts: ["combat"],
+        trigger: "damage_taken",
+        conditions: [],
+        operations: [{ type: "modify", path: "damage.amount", mode: "add", formula: "-ConstitutionMod" }],
+      }],
+      rules: [],
+    },
+
+    goblin_nimble_escape: {
+      schemaVersion: 1,
+      id: "goblin_nimble_escape",
+      name: "Nimble Escape",
+      description: "Evade Skills gain +1 Final Power.",
+      source: raceSource("goblin"),
+      contexts: ["combat"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [{
+        type: "modifier",
+        trigger: "passive",
+        target: "self",
+        channel: "final_power",
+        mode: "add",
+        value: 1,
+        conditions: [{ path: "skill.type", operator: "eq", value: "evade" }],
+      }],
+    },
+
+    warforged_reinforced_body: {
+      schemaVersion: 1,
+      id: "warforged_reinforced_body",
+      name: "Reinforced Body",
+      description: "Gain +1 Defensive Level.",
+      source: raceSource("warforged"),
+      contexts: ["combat"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [{ type: "modifier", trigger: "passive", target: "self", channel: "defensive_level", mode: "add", value: 1 }],
+    },
+
+    warforged_lone_reconnaissance: {
+      schemaVersion: 1,
+      id: "warforged_lone_reconnaissance",
+      name: "Lone Reconnaissance",
+      description: "When no allies are present, Stealth checks reduce Threshold by 4.",
+      source: raceSource("warforged"),
+      contexts: ["theatre"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [{
+        id: "warforged_lone_stealth",
+        contexts: ["theatre"],
+        trigger: "before_check",
+        conditions: [
+          { path: "check.skillId", operator: "eq", value: "stealth" },
+          { formula: "AliveAllies", operator: "eq", value: 0 },
+        ],
+        operations: [{ type: "modify", path: "check.difficulty", mode: "add", value: -4 }],
+      }],
+      rules: [],
+    },
+
+    feline_reflexes: {
+      schemaVersion: 1,
+      id: "feline_reflexes",
+      name: "Feline Reflexes",
+      description: "Gain floor(Proficiency / 2) Max Speed and Proficiency Final Power on Evade Skills.",
+      source: raceSource("felinae"),
+      contexts: ["combat"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [
+        { type: "modifier", trigger: "passive", target: "self", channel: "max_speed", mode: "add", formula: "floor(Proficiency / 2)" },
+        {
+          type: "modifier",
+          trigger: "passive",
+          target: "self",
+          channel: "final_power",
+          mode: "add",
+          formula: "Proficiency",
+          conditions: [{ path: "skill.type", operator: "eq", value: "evade" }],
+        },
+      ],
+    },
+
+    felinae_light_footed: {
+      schemaVersion: 1,
+      id: "felinae_light_footed",
+      name: "Light-Footed",
+      description: "40 ft racial movement converts to +2 Max Speed.",
+      source: raceSource("felinae"),
+      contexts: ["combat"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [{ type: "modifier", trigger: "passive", target: "self", channel: "max_speed", mode: "add", value: 2 }],
+    },
+
+    half_dragon_indomitable: {
+      schemaVersion: 1,
+      id: "half_dragon_indomitable",
+      name: "Indomitable",
+      description: "Checks against Charmed or Frightened reduce Threshold by 4.",
+      source: raceSource("half_dragon"),
+      contexts: ["theatre"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [{
+        id: "half_dragon_indomitable_check",
+        contexts: ["theatre"],
+        trigger: "before_check",
+        conditions: [{ path: "check.effectTag", operator: "in", value: ["charmed", "frightened"] }],
+        operations: [{ type: "modify", path: "check.difficulty", mode: "add", value: -4 }],
+      }],
+      rules: [],
+    },
+
+    half_dragon_desert_predator: {
+      schemaVersion: 1,
+      id: "half_dragon_desert_predator",
+      name: "Desert Predator",
+      description: "Stealth checks in sand or loose earth reduce Threshold by 4.",
+      source: raceSource("half_dragon"),
+      contexts: ["theatre"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [{
+        id: "half_dragon_desert_stealth",
+        contexts: ["theatre"],
+        trigger: "before_check",
+        conditions: [
+          { path: "check.skillId", operator: "eq", value: "stealth" },
+          { path: "check.environmentTags", operator: "in", value: ["sand", "loose_earth", "burrowable_ground"] },
+        ],
+        operations: [{ type: "modify", path: "check.difficulty", mode: "add", value: -4 }],
+      }],
+      rules: [],
+    },
+
+    half_dragon_bold_speaker: {
+      schemaVersion: 1,
+      id: "half_dragon_bold_speaker",
+      name: "Bold Speaker",
+      description: "Persuasion checks reduce Threshold by 4. Magical Sleep immunity is handled by race capability/status immunity logic.",
+      source: raceSource("half_dragon"),
+      contexts: ["theatre"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [{
+        id: "half_dragon_bold_persuasion",
+        contexts: ["theatre"],
+        trigger: "before_check",
+        conditions: [{ path: "check.skillId", operator: "eq", value: "persuasion" }],
+        operations: [{ type: "modify", path: "check.difficulty", mode: "add", value: -4 }],
+      }],
+      rules: [],
+    },
+
+    lupae_canis_toughness: {
+      schemaVersion: 1,
+      id: "lupae_canis_toughness",
+      name: "Canis Toughness",
+      description: "Checks against Disease or Poison reduce Threshold by 4.",
+      source: raceSource("lupae"),
+      contexts: ["theatre"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [{
+        id: "lupae_canis_toughness_check",
+        contexts: ["theatre"],
+        trigger: "before_check",
+        conditions: [{ path: "check.effectTag", operator: "in", value: ["disease", "poison"] }],
+        operations: [{ type: "modify", path: "check.difficulty", mode: "add", value: -4 }],
+      }],
+      rules: [],
+    },
+
+    moonfae_intimidating_presence: {
+      schemaVersion: 1,
+      id: "moonfae_intimidating_presence",
+      name: "Intimidating Presence",
+      description: "Checks against Frightened reduce Threshold by 4. Intimidation proficiency is stored as racial metadata.",
+      source: raceSource("moonfae"),
+      contexts: ["theatre"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [{
+        id: "moonfae_frightened_check",
+        contexts: ["theatre"],
+        trigger: "before_check",
+        conditions: [{ path: "check.effectTag", operator: "eq", value: "frightened" }],
+        operations: [{ type: "modify", path: "check.difficulty", mode: "add", value: -4 }],
+      }],
+      rules: [],
+    },
+
+    moonfae_lunge: {
+      schemaVersion: 1,
+      id: "moonfae_lunge",
+      name: "Lunge",
+      description: "If no damage was taken during the previous Turn, gain +2 Clash Power when attacking.",
+      source: raceSource("moonfae"),
+      contexts: ["combat"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [{
+        type: "modifier",
+        trigger: "before_attack",
+        target: "self",
+        path: "skill.clashPower",
+        mode: "add",
+        value: 2,
+        conditions: [{ path: "self.damageTakenPreviousTurn", operator: "lte", value: 0 }],
+      }],
+    },
+
+    moonfae_crescent_speed: {
+      schemaVersion: 1,
+      id: "moonfae_crescent_speed",
+      name: "Fast",
+      description: "35 ft racial movement converts to +1 Max Speed.",
+      source: raceSource("moonfae"),
+      contexts: ["combat"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [{ type: "modifier", trigger: "passive", target: "self", channel: "max_speed", mode: "add", value: 1 }],
+    },
+
+    moonfae_agile_escape: {
+      schemaVersion: 1,
+      id: "moonfae_agile_escape",
+      name: "Agile Escape",
+      description: "Evade Skills gain +2 Final Power.",
+      source: raceSource("moonfae"),
+      contexts: ["combat"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [{
+        type: "modifier",
+        trigger: "passive",
+        target: "self",
+        channel: "final_power",
+        mode: "add",
+        value: 2,
+        conditions: [{ path: "skill.type", operator: "eq", value: "evade" }],
+      }],
+    },
+
+    moonfae_natural_talent: {
+      schemaVersion: 1,
+      id: "moonfae_natural_talent",
+      name: "Natural Talent",
+      description: "On a Dexterity Check, gain +2 Check Bonus. Uses equal Proficiency and recover on Long Rest.",
+      source: raceSource("moonfae"),
+      contexts: ["theatre"],
+      activation: {
+        type: "prompt",
+        actionCost: "none",
+        uses: { formula: "Proficiency", reset: "long_rest" },
+        conditions: [{ path: "check.abilityId", operator: "eq", value: "dex" }],
+      },
+      effects: [{
+        id: "moonfae_natural_talent_check",
+        contexts: ["theatre"],
+        trigger: "on_use",
+        conditions: [],
+        operations: [{ type: "modify", path: "check.finalPower", mode: "add", value: 2 }],
+      }],
+      rules: [],
+    },
+
+    moonfae_cautious_senses: {
+      schemaVersion: 1,
+      id: "moonfae_cautious_senses",
+      name: "Cautious Senses",
+      description: "At Turn Start gain +2 Haste.",
+      source: raceSource("moonfae"),
+      contexts: ["combat"],
+      activation: { type: "automatic", actionCost: "none" },
+      effects: [{
+        id: "moonfae_cautious_senses_haste",
+        contexts: ["combat"],
+        trigger: "turn_start",
+        conditions: [],
+        operations: [{ type: "apply_status", statusId: "haste", count: 2, duration: "this_turn" }],
+      }],
+      rules: [],
+    },
+
+    moonfae_rabbits_luck: {
+      schemaVersion: 1,
+      id: "moonfae_rabbits_luck",
+      name: "Rabbit's Luck",
+      description: "Reduce the active Check Threshold by 4. Uses equal Proficiency and recover on Long Rest.",
+      source: raceSource("moonfae"),
+      contexts: ["theatre"],
+      activation: {
+        type: "prompt",
+        actionCost: "none",
+        uses: { formula: "Proficiency", reset: "long_rest" },
+      },
+      effects: [{
+        id: "moonfae_rabbits_luck_check",
+        contexts: ["theatre"],
+        trigger: "on_use",
+        conditions: [],
+        operations: [{ type: "modify", path: "check.difficulty", mode: "add", value: -4 }],
+      }],
+      rules: [],
+    },
+
+    moonfae_favorable_action: {
+      schemaVersion: 1,
+      id: "moonfae_favorable_action",
+      name: "Favorable Action",
+      description: "Add Charisma Mod to the active Check. Uses equal Proficiency and recover on Long Rest.",
+      source: raceSource("moonfae"),
+      contexts: ["theatre"],
+      activation: {
+        type: "prompt",
+        actionCost: "none",
+        uses: { formula: "Proficiency", reset: "long_rest" },
+      },
+      effects: [{
+        id: "moonfae_favorable_action_check",
+        contexts: ["theatre"],
+        trigger: "on_use",
+        conditions: [],
+        operations: [{ type: "modify", path: "check.finalPower", mode: "add", formula: "CharismaMod" }],
+      }],
+      rules: [],
+    },
+
+    yuan_ti_magic_resistance: {
+      schemaVersion: 1,
+      id: "yuan_ti_magic_resistance",
+      name: "Magic Resistance",
+      description: "Checks against Spells or Magical Effects reduce Threshold by 4.",
+      source: raceSource("yuan_ti_pureblood"),
+      contexts: ["theatre"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [{
+        id: "yuan_ti_magic_resistance_check",
+        contexts: ["theatre"],
+        trigger: "before_check",
+        conditions: [{ path: "check.isMagical", operator: "truthy" }],
+        operations: [{ type: "modify", path: "check.difficulty", mode: "add", value: -4 }],
+      }],
+      rules: [],
+    },
+
+    yuan_ti_wrath_affinity: sinAffinityTrait("yuan_ti_wrath_affinity", "Wrath", "Red Eyes — Wrath"),
+    yuan_ti_envy_affinity: sinAffinityTrait("yuan_ti_envy_affinity", "Envy", "Purple Eyes — Envy"),
+    yuan_ti_gloom_affinity: sinAffinityTrait("yuan_ti_gloom_affinity", "Gloom", "Cyan Eyes — Gloom"),
+    yuan_ti_pride_affinity: sinAffinityTrait("yuan_ti_pride_affinity", "Pride", "Blue Eyes — Pride"),
+    yuan_ti_gluttony_affinity: sinAffinityTrait("yuan_ti_gluttony_affinity", "Gluttony", "Green Eyes — Gluttony"),
+    yuan_ti_lust_affinity: sinAffinityTrait("yuan_ti_lust_affinity", "Lust", "Orange Eyes — Lust"),
+    yuan_ti_sloth_affinity: sinAffinityTrait("yuan_ti_sloth_affinity", "Sloth", "Yellow Eyes — Sloth"),
+
+    yuan_ti_voracious_impulse: {
+      schemaVersion: 1,
+      id: "yuan_ti_voracious_impulse",
+      name: "Voracious Impulse",
+      description: "On Enemy Defeated, recover (5 + CHA Mod)% Max HP.",
+      source: raceSource("yuan_ti_pureblood"),
+      contexts: ["combat"],
+      activation: { type: "automatic", actionCost: "none" },
+      effects: [{
+        id: "yuan_ti_voracious_impulse_heal",
+        contexts: ["combat"],
+        trigger: "on_kill",
+        conditions: [],
+        operations: [{
+          type: "heal_hp",
+          path: "self.currentHp",
+          maxPath: "self.maxHp",
+          formula: "floor(MaxHP * (5 + CharismaMod) / 100)",
+        }],
+      }],
+      rules: [],
+    },
+
+    undae_regeneration: {
+      schemaVersion: 1,
+      id: "undae_regeneration",
+      name: "Undae Regeneration",
+      description: "At Turn Start, if no Acid or Fire damage was taken during the previous Turn and HP is above 0, recover (10 + CON Mod)% Max HP.",
+      source: raceSource("undae"),
+      contexts: ["combat"],
+      activation: { type: "automatic", actionCost: "none" },
+      effects: [{
+        id: "undae_regeneration_heal",
+        contexts: ["combat"],
+        trigger: "turn_start",
+        conditions: [
+          { formula: "CurrentHP", operator: "gt", value: 0 },
+          { path: "self.damageTakenPreviousTurnTypes", operator: "truthy" },
+          { path: "self.damageTakenPreviousTurnTypes", operator: "not_contains", value: "Acid" },
+          { path: "self.damageTakenPreviousTurnTypes", operator: "not_contains", value: "Fire" },
+        ],
+        operations: [{
+          type: "heal_hp",
+          path: "self.currentHp",
+          maxPath: "self.maxHp",
+          formula: "floor(MaxHP * (10 + ConstitutionMod) / 100)",
+        }],
+      }],
+      rules: [],
+    },
+
+    undae_thick_skin: {
+      schemaVersion: 1,
+      id: "undae_thick_skin",
+      name: "Thick Skin",
+      description: "Slashing damage taken is Halved.",
+      source: raceSource("undae"),
+      contexts: ["combat"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [{
+        type: "modifier",
+        trigger: "passive",
+        target: "self",
+        channel: "damage_taken_multiplier",
+        mode: "add",
+        value: 50,
+        unit: "percent_reduction",
+        conditions: [{ any: [
+          { path: "skill.attackType", operator: "eq", value: "Slash" },
+          { path: "skill.damageType", operator: "eq", value: "Slash" },
+        ] }],
+      }],
+    },
+
+    undae_stable_step: {
+      schemaVersion: 1,
+      id: "undae_stable_step",
+      name: "Stable Step",
+      description: "Checks to resist Knockdown or Forced Displacement reduce Threshold by 4.",
+      source: raceSource("undae"),
+      contexts: ["theatre"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [{
+        id: "undae_stable_step_check",
+        contexts: ["theatre"],
+        trigger: "before_check",
+        conditions: [{ path: "check.effectTag", operator: "in", value: ["knockdown", "forced_displacement"] }],
+        operations: [{ type: "modify", path: "check.difficulty", mode: "add", value: -4 }],
+      }],
+      rules: [],
+    },
+
+    undae_calming_presence: {
+      schemaVersion: 1,
+      id: "undae_calming_presence",
+      name: "Calming Presence",
+      description: "Persuasion checks against injured or frightened creatures reduce Threshold by 4.",
+      source: raceSource("undae"),
+      contexts: ["theatre"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [{
+        id: "undae_calming_presence_check",
+        contexts: ["theatre"],
+        trigger: "before_check",
+        conditions: [
+          { path: "check.skillId", operator: "eq", value: "persuasion" },
+          { any: [
+            { path: "target.injured", operator: "truthy" },
+            { path: "target.frightened", operator: "truthy" },
+          ] },
+        ],
+        operations: [{ type: "modify", path: "check.difficulty", mode: "add", value: -4 }],
+      }],
+      rules: [],
+    },
+
+    undae_silent_step: {
+      schemaVersion: 1,
+      id: "undae_silent_step",
+      name: "Silent Step",
+      description: "Stealth checks in natural terrain reduce Threshold by 4.",
+      source: raceSource("undae"),
+      contexts: ["theatre"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [{
+        id: "undae_silent_step_check",
+        contexts: ["theatre"],
+        trigger: "before_check",
+        conditions: [
+          { path: "check.skillId", operator: "eq", value: "stealth" },
+          { path: "check.environmentTags", operator: "contains", value: "natural" },
+        ],
+        operations: [{ type: "modify", path: "check.difficulty", mode: "add", value: -4 }],
+      }],
+      rules: [],
+    },
+  });
+
+  function sinAffinityTrait(id, affinity, name) {
+    return {
+      schemaVersion: 1,
+      id,
+      name,
+      description: `Deal +(Level / 4)% ${affinity} Sin Damage.`,
+      source: raceSource("yuan_ti_pureblood"),
+      contexts: ["combat"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [{
+        type: "modifier",
+        trigger: "passive",
+        target: "self",
+        channel: "damage_dealt_multiplier",
+        mode: "add",
+        formula: "Level / 4",
+        unit: "percent",
+        conditions: [{ any: [
+          { path: "skill.affinity", operator: "eq", value: affinity },
+          { path: "skill.sinAffinity", operator: "eq", value: affinity },
+        ] }],
+      }],
+    };
+  }
+
+  const raceGrant = (sourceId, traitId, options = {}) => ({
+    id: `core_race_${sourceId}${options.sourceSubtypeId ? `_${options.sourceSubtypeId}` : ""}${options.atLevel ? `_l${options.atLevel}` : ""}_${traitId}`,
+    sourceType: "race",
+    sourceId,
+    ...(options.sourceSubtypeId ? { sourceSubtypeId: options.sourceSubtypeId } : {}),
+    ...(options.atLevel ? { atLevel: options.atLevel } : {}),
+    traitId,
+    grantType: "trait",
+  });
+
+  const GRANTS = deepFreeze([
+    raceGrant("lizalin", "lizalin_natural_armor"),
+    raceGrant("kobold", "pack_tactics"),
+    raceGrant("kobold", "kobold_burrow_mentality"),
+    raceGrant("kenku", "kenku_expert_forger"),
+    raceGrant("kenku", "kenku_limited_communication"),
+    raceGrant("goliath", "goliath_stone_endurance"),
+    raceGrant("goblin", "goblin_nimble_escape"),
+    raceGrant("warforged", "warforged_reinforced_body", { sourceSubtypeId: "juggernaut" }),
+    raceGrant("warforged", "warforged_lone_reconnaissance", { sourceSubtypeId: "skirmisher" }),
+    raceGrant("felinae", "feline_reflexes"),
+    raceGrant("felinae", "felinae_light_footed", { sourceSubtypeId: "ordinary" }),
+    raceGrant("half_dragon", "half_dragon_indomitable", { sourceSubtypeId: "red" }),
+    raceGrant("half_dragon", "half_dragon_desert_predator", { sourceSubtypeId: "blue" }),
+    raceGrant("half_dragon", "half_dragon_bold_speaker", { sourceSubtypeId: "brass" }),
+    raceGrant("lupae", "keen_hearing_and_smell"),
+    raceGrant("lupae", "pack_tactics"),
+    raceGrant("lupae", "lupae_canis_toughness"),
+    raceGrant("moonfae", "keen_hearing"),
+    raceGrant("moonfae", "moonfae_intimidating_presence", { sourceSubtypeId: "full_moon" }),
+    raceGrant("moonfae", "moonfae_lunge", { sourceSubtypeId: "full_moon" }),
+    raceGrant("moonfae", "moonfae_crescent_speed", { sourceSubtypeId: "crescent_moon" }),
+    raceGrant("moonfae", "moonfae_agile_escape", { sourceSubtypeId: "crescent_moon" }),
+    raceGrant("moonfae", "moonfae_natural_talent", { sourceSubtypeId: "crescent_moon" }),
+    raceGrant("moonfae", "moonfae_cautious_senses", { sourceSubtypeId: "new_moon" }),
+    raceGrant("moonfae", "moonfae_rabbits_luck", { sourceSubtypeId: "blue_moon" }),
+    raceGrant("moonfae", "moonfae_favorable_action", { sourceSubtypeId: "blue_moon" }),
+    raceGrant("yuan_ti_pureblood", "yuan_ti_magic_resistance"),
+    raceGrant("yuan_ti_pureblood", "yuan_ti_wrath_affinity", { sourceSubtypeId: "red_eyes" }),
+    raceGrant("yuan_ti_pureblood", "yuan_ti_envy_affinity", { sourceSubtypeId: "purple_eyes" }),
+    raceGrant("yuan_ti_pureblood", "yuan_ti_gloom_affinity", { sourceSubtypeId: "cyan_eyes" }),
+    raceGrant("yuan_ti_pureblood", "yuan_ti_pride_affinity", { sourceSubtypeId: "blue_eyes" }),
+    raceGrant("yuan_ti_pureblood", "yuan_ti_gluttony_affinity", { sourceSubtypeId: "green_eyes" }),
+    raceGrant("yuan_ti_pureblood", "yuan_ti_voracious_impulse", { sourceSubtypeId: "green_eyes" }),
+    raceGrant("yuan_ti_pureblood", "yuan_ti_lust_affinity", { sourceSubtypeId: "orange_eyes" }),
+    raceGrant("yuan_ti_pureblood", "yuan_ti_sloth_affinity", { sourceSubtypeId: "yellow_eyes" }),
+    raceGrant("undae", "undae_regeneration"),
+    raceGrant("undae", "undae_thick_skin", { sourceSubtypeId: "rock" }),
+    raceGrant("undae", "undae_stable_step", { sourceSubtypeId: "rock" }),
+    raceGrant("undae", "undae_calming_presence", { sourceSubtypeId: "mystic" }),
+    raceGrant("undae", "undae_silent_step", { sourceSubtypeId: "wild" }),
+  ]);
+
+  const CAPABILITY_GRANTS = deepFreeze([
+    { raceId: "fairy", capabilityId: "flight", conditions: { requiresFairyForm: true, blockedArmor: ["medium", "heavy"] } },
+    { raceId: "half_dragon", raceSubtypeId: "blue", capabilityId: "burrow" },
+    { raceId: "half_dragon", raceSubtypeId: "bronze", capabilityId: "swim_speed" },
+    { raceId: "half_dragon", raceSubtypeId: "bronze", capabilityId: "underwater_breathing" },
+    { raceId: "undae", capabilityId: "amphibious" },
+    { raceId: "undae", raceSubtypeId: "war", capabilityId: "swim_speed" },
+    { raceId: "elnae", capabilityId: "flight", conditions: { blockedArmor: ["medium"] } },
+  ]);
+
+  const RETREATS = deepFreeze({
+    burrowed: {
+      id: "burrowed",
+      capabilityId: "burrow",
+      awayTurns: 1,
+      untargetable: true,
+      comebackStatus: { statusId: "protection", count: 3 },
+      encounterBonus: { channel: "defensive_level", value: 1 },
+      nonStackableGroup: "retreat_bonus",
+    },
+    sink: {
+      id: "sink",
+      capabilityId: "swim_speed",
+      awayTurns: 1,
+      untargetable: true,
+      comebackStatus: { statusId: "defense_power_up", count: 3 },
+      encounterBonus: { channel: "final_power", value: 1, conditions: [{ path: "skill.type", operator: "eq", value: "evade" }] },
+      nonStackableGroup: "retreat_bonus",
+    },
+    fly: {
+      id: "fly",
+      capabilityId: "flight",
+      awayTurns: 1,
+      untargetable: true,
+      comebackStatus: { statusId: "haste", count: 3 },
+      encounterBonus: [
+        { channel: "min_speed", value: 2 },
+        { channel: "max_speed", value: 2 },
+      ],
+      nonStackableGroup: "retreat_bonus",
+    },
+  });
+
+  function normalizeCharacter(character = {}) {
+    const build = character.characterBuild && typeof character.characterBuild === "object" ? character.characterBuild : {};
+    return {
+      ...character,
+      raceId: normalizeId(build.raceId ?? character.raceId ?? character.race?.id),
+      raceSubtypeId: normalizeId(build.raceSubtypeId ?? character.raceSubtypeId ?? character.race?.subtypeId),
+      level: Math.max(0, Number(build.calculatedAtLevel ?? character.level) || 0),
+    };
+  }
+
+  function grantMatches(characterInput, grant) {
+    const character = normalizeCharacter(characterInput);
+    if (normalizeId(grant.sourceType) !== "race") return false;
+    if (character.raceId !== normalizeId(grant.sourceId)) return false;
+    if (grant.sourceSubtypeId && character.raceSubtypeId !== normalizeId(grant.sourceSubtypeId)) return false;
+    if (grant.atLevel && character.level < Number(grant.atLevel)) return false;
+    return true;
+  }
+
+  function allDefinitions() {
+    return clone(DEFINITIONS);
+  }
+
+  function allGrants() {
+    return clone(GRANTS);
+  }
+
+  function getDefinition(id) {
+    return clone(DEFINITIONS[normalizeId(id)] || null);
+  }
+
+  function resolveTraitGrants(character, catalog = DEFINITIONS) {
+    const byId = catalog instanceof Map
+      ? catalog
+      : new Map(Object.entries(catalog || {}).map(([id, definition]) => [normalizeId(id), definition]));
+    return GRANTS.filter((grant) => grantMatches(character, grant)).map((grant) => {
+      const definition = byId.get(normalizeId(grant.traitId));
+      if (!definition) return null;
+      const trait = engine?.normalizeTrait ? engine.normalizeTrait(definition) : clone(definition);
+      trait.source = {
+        ...(trait.source || {}),
+        type: "race",
+        id: normalizeId(grant.sourceId),
+        ...(grant.sourceSubtypeId ? { subtypeId: normalizeId(grant.sourceSubtypeId) } : {}),
+      };
+      return trait;
+    }).filter(Boolean);
+  }
+
+  function resolveCapabilities(characterInput) {
+    const character = normalizeCharacter(characterInput);
+    return CAPABILITY_GRANTS.filter((grant) => {
+      if (normalizeId(grant.raceId) !== character.raceId) return false;
+      return !grant.raceSubtypeId || normalizeId(grant.raceSubtypeId) === character.raceSubtypeId;
+    }).map(clone);
+  }
+
+  function validateAll(customEngine = engine) {
+    const errors = [];
+    const warnings = [];
+    if (!customEngine?.validateTrait) return { valid: false, errors: ["Trait Engine is not available."], warnings };
+    Object.entries(DEFINITIONS).forEach(([id, definition]) => {
+      const result = customEngine.validateTrait(definition);
+      if (result.trait.id !== id) errors.push(`${id}: normalized id became ${result.trait.id}.`);
+      result.errors.forEach((message) => errors.push(`${id}: ${message}`));
+      result.warnings.forEach((message) => warnings.push(`${id}: ${message}`));
+    });
+    const seen = new Set();
+    GRANTS.forEach((grant) => {
+      if (seen.has(grant.id)) errors.push(`Duplicate racial grant id: ${grant.id}`);
+      seen.add(grant.id);
+      if (!DEFINITIONS[grant.traitId]) errors.push(`${grant.id}: missing Trait definition ${grant.traitId}.`);
+    });
+    return { valid: errors.length === 0, errors, warnings };
+  }
+
+  const api = Object.freeze({
+    CATALOG_VERSION,
+    DEFINITIONS,
+    GRANTS,
+    CAPABILITY_GRANTS,
+    RETREATS,
+    allDefinitions,
+    allGrants,
+    getDefinition,
+    grantMatches,
+    resolveTraitGrants,
+    resolveCapabilities,
+    validateAll,
+  });
+
+  global.LuminousRacialTraitCatalog = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/racial-trait-catalog.js
+++ b/js/racial-trait-catalog.js
@@ -34,7 +34,7 @@
         mode: "add",
         value: 1,
         scope: "once_per_turn",
-        conditions: [{ path: "target.targetedByAlly", operator: "truthy" }],
+        conditions: [{ path: "targetedByAlly", operator: "truthy" }],
       }],
     },
 
@@ -187,7 +187,7 @@
         contexts: ["combat"],
         trigger: "damage_taken",
         conditions: [],
-        operations: [{ type: "modify", path: "damage.amount", mode: "add", formula: "-ConstitutionMod" }],
+        operations: [{ type: "modify", path: "damage.amount", mode: "add", formula: "-max(0, ConstitutionMod)" }],
       }],
       rules: [],
     },
@@ -312,7 +312,11 @@
         trigger: "before_check",
         conditions: [
           { path: "check.skillId", operator: "eq", value: "stealth" },
-          { path: "check.environmentTags", operator: "in", value: ["sand", "loose_earth", "burrowable_ground"] },
+          { any: [
+            { path: "check.environmentTags", operator: "contains", value: "sand" },
+            { path: "check.environmentTags", operator: "contains", value: "loose_earth" },
+            { path: "check.environmentTags", operator: "contains", value: "burrowable_ground" },
+          ] },
         ],
         operations: [{ type: "modify", path: "check.difficulty", mode: "add", value: -4 }],
       }],
@@ -389,7 +393,7 @@
         path: "skill.clashPower",
         mode: "add",
         value: 2,
-        conditions: [{ path: "self.damageTakenPreviousTurn", operator: "lte", value: 0 }],
+        conditions: [{ path: "self.took_damage_last_turn", operator: "falsy" }],
       }],
     },
 
@@ -551,7 +555,7 @@
         conditions: [],
         operations: [{
           type: "heal_hp",
-          path: "self.currentHp",
+          path: "self.hp",
           maxPath: "self.maxHp",
           formula: "floor(MaxHP * (5 + CharismaMod) / 100)",
         }],
@@ -573,13 +577,12 @@
         trigger: "turn_start",
         conditions: [
           { formula: "CurrentHP", operator: "gt", value: 0 },
-          { path: "self.damageTakenPreviousTurnTypes", operator: "truthy" },
           { path: "self.damageTakenPreviousTurnTypes", operator: "not_contains", value: "Acid" },
           { path: "self.damageTakenPreviousTurnTypes", operator: "not_contains", value: "Fire" },
         ],
         operations: [{
           type: "heal_hp",
-          path: "self.currentHp",
+          path: "self.hp",
           maxPath: "self.maxHp",
           formula: "floor(MaxHP * (10 + ConstitutionMod) / 100)",
         }],

--- a/js/trait-standardization-runtime.js
+++ b/js/trait-standardization-runtime.js
@@ -82,6 +82,110 @@
     return Array.from(state.combatUnits.values());
   }
 
+  function viewerCombatData() {
+    if (global.combatData && typeof global.combatData === "object") return global.combatData;
+    try {
+      if (typeof global.eval === "function") {
+        const value = global.eval("typeof combatData !== 'undefined' ? combatData : null");
+        if (value && typeof value === "object") return value;
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  function viewerSlotTargets() {
+    if (global.slotTargets && typeof global.slotTargets === "object") return global.slotTargets;
+    try {
+      if (typeof global.eval === "function") {
+        const value = global.eval("typeof slotTargets !== 'undefined' ? slotTargets : null");
+        if (value && typeof value === "object") return value;
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  function factionId(unit) {
+    if (!unit || typeof unit !== "object") return null;
+    const explicit = unit.faction ?? unit.faccion;
+    if (explicit != null && String(explicit).trim() !== "") return normalizeId(explicit);
+    if (unit.isPlayer != null) return unit.isPlayer ? "player" : "enemy";
+    return null;
+  }
+
+  function isTargetedByAlly(attacker, target) {
+    if (!attacker || !target) return false;
+    if (target.targetedByAlly === true) return true;
+    const slotTargets = viewerSlotTargets();
+    if (!slotTargets) return false;
+
+    const combatData = viewerCombatData() || {};
+    const units = [...registeredCombatUnits(), ...Object.values(combatData || {}).filter(Boolean)];
+    const attackerIds = new Set(identityValues(attacker));
+    const targetIds = new Set(identityValues(target));
+    const attackerFaction = factionId(attacker);
+
+    for (const [attackerSlotId, targetSlotId] of Object.entries(slotTargets)) {
+      const allyBaseId = String(attackerSlotId || "").split("_slot_")[0];
+      const targetBaseId = String(targetSlotId || "").split("_slot_")[0];
+      const targetsRequestedUnit = targetIds.has(targetBaseId) || combatData?.[targetBaseId] === target;
+      if (!targetsRequestedUnit || attackerIds.has(allyBaseId)) continue;
+
+      const ally = combatData?.[allyBaseId] || units.find((unit) => identityValues(unit).includes(allyBaseId));
+      if (!ally || ally === attacker) continue;
+      const allyFaction = factionId(ally);
+      if (attackerFaction && allyFaction && attackerFaction === allyFaction) return true;
+    }
+    return false;
+  }
+
+  function ensureDamageHistory(unit) {
+    if (!unit || typeof unit !== "object") return unit;
+    if (!Array.isArray(unit.damageTakenThisTurnTypes)) unit.damageTakenThisTurnTypes = [];
+    if (!Array.isArray(unit.damageTakenPreviousTurnTypes)) unit.damageTakenPreviousTurnTypes = [];
+    return unit;
+  }
+
+  function classifyDamageTypes(...values) {
+    const labels = new Set();
+    values.flat(Infinity).filter((value) => value != null).forEach((value) => {
+      const id = normalizeId(value);
+      if (id.includes("acid")) labels.add("Acid");
+      if (id.includes("fire") || id.includes("burn")) labels.add("Fire");
+    });
+    return [...labels];
+  }
+
+  function recordDamageTypes(unit, types = []) {
+    ensureDamageHistory(unit);
+    (types || []).forEach((type) => {
+      if (!unit.damageTakenThisTurnTypes.includes(type)) unit.damageTakenThisTurnTypes.push(type);
+    });
+    return unit.damageTakenThisTurnTypes;
+  }
+
+  function advanceDamageHistory(unit) {
+    ensureDamageHistory(unit);
+    unit.damageTakenPreviousTurnTypes = unit.damageTakenThisTurnTypes.slice();
+    unit.damageTakenThisTurnTypes = [];
+    return unit.damageTakenPreviousTurnTypes;
+  }
+
+  function activeStatusDamageTypes(unit, triggerKey) {
+    const registry = global.STATUS_REGISTRY || {};
+    const types = new Set();
+    Object.keys(unit?.statusEffects || {}).forEach((statusId) => {
+      const definition = registry[statusId] || global.LuminousStatusEngine?.getDefinition?.(statusId) || null;
+      const damagesHp = (definition?.rules || []).some((rule) =>
+        normalizeId(rule?.trigger) === normalizeId(triggerKey) &&
+        normalizeId(rule?.affectation) === "hp" &&
+        ["sub", "lose", "spend"].includes(normalizeId(rule?.operation))
+      );
+      if (!damagesHp) return;
+      classifyDamageTypes(statusId, definition?.name, definition?.damageType, definition?.damage_type_tag).forEach((type) => types.add(type));
+    });
+    return [...types];
+  }
+
   function currentRegisteredPlayerUnit() {
     return registeredCombatUnits().find((unit) => isCurrentPlayerUnit(unit)) || null;
   }
@@ -102,6 +206,7 @@
 
   function registerCombatUnit(unit) {
     if (!unit || typeof unit !== "object") return unit;
+    ensureDamageHistory(unit);
     state.combatUnits.set(combatUnitKey(unit), unit);
     dispatchPendingEncounterStart();
     return unit;
@@ -143,10 +248,12 @@
   function enrichRuntime(runtime = {}) {
     const modifiers = global.LuminousUniversalModifiers;
     const self = runtime.self || runtime.character || null;
+    const target = runtime.target || runtime.defender || null;
     const skill = runtime.skill ? modifiers?.normalizeSkill?.(runtime.skill) || runtime.skill : runtime.skill;
     return {
       ...(runtime || {}),
       skill,
+      targetedByAlly: runtime.targetedByAlly ?? isTargetedByAlly(self, target),
       equipment: runtime.equipment || modifiers?.resolveEquipment?.(self || {}) || {},
     };
   }
@@ -341,11 +448,14 @@
     const originalFinalPower = typeof engine.calculateFinalPower === "function" ? engine.calculateFinalPower : null;
     const originalApplyDamage = typeof engine.applyDamage === "function" ? engine.applyDamage : null;
     const originalCoinDamage = typeof engine.calculateCoinDamage === "function" ? engine.calculateCoinDamage : null;
+    const originalProcessStatusEffects = typeof engine.processStatusEffects === "function" ? engine.processStatusEffects : null;
+    const originalTriggerPhase = typeof engine.triggerPhase === "function" ? engine.triggerPhase : null;
     const originalTriggerEvent = typeof engine.triggerEvent === "function" ? engine.triggerEvent : null;
 
     if (originalInitialize) engine.initializeUnitData = function (unit, ...rest) {
       const result = originalInitialize.call(this, unit, ...rest);
       statusEngine.ensureStore(unit);
+      ensureDamageHistory(unit);
       const equipment = modifiers.resolveEquipment(unit);
       unit.equipmentState = equipment;
       [].concat(unit.attack_tier_1_sequence || [], unit.attack_tier_2_sequence || [], unit.attack_tier_3_sequence || []).forEach((skill) => modifiers.normalizeSkill(skill));
@@ -454,24 +564,60 @@
       return result;
     };
 
+    if (originalProcessStatusEffects) engine.processStatusEffects = function (unit, triggerKey, context = {}) {
+      const hpBefore = numberOr(unit?.hp, 0);
+      const statusDamageTypes = activeStatusDamageTypes(unit, triggerKey);
+      const result = originalProcessStatusEffects.call(this, unit, triggerKey, context);
+      if (hpBefore > numberOr(unit?.hp, 0) && statusDamageTypes.length) recordDamageTypes(unit, statusDamageTypes);
+      return result;
+    };
+
     if (originalApplyDamage) engine.applyDamage = function (unit, damage, tipoDaño, isCritical, skillUsed) {
       const hpBefore = numberOr(unit?.hp, 0);
-      const result = originalApplyDamage.call(this, unit, damage, tipoDaño, isCritical, skillUsed);
+      let incomingDamage = Math.max(0, numberOr(damage, 0));
+
       if (isCurrentPlayerUnit(unit)) {
-        global.LuminousPlayerTraitRuntime?.dispatchCombatEvent?.("damage_taken", {
-          context: "combat", self: unit, defender: unit, skill: skillUsed || null, damageTaken: Math.max(0, hpBefore - numberOr(unit?.hp, 0)),
-        });
-        if (hpBefore > 0 && numberOr(unit?.hp, 0) <= 0) {
-          global.LuminousPlayerTraitRuntime?.dispatchCombatEvent?.("hp_zero", {
-            context: "combat",
-            self: unit,
-            defender: unit,
-            skill: skillUsed || null,
-            DefensiveLevel: this.getDefensiveLevel?.(unit, unit),
-            resolveCheck: (request) => resolveCombatCheck(unit, request),
-          });
-        }
+        const damageRuntime = {
+          context: "combat",
+          self: unit,
+          defender: unit,
+          skill: skillUsed || null,
+          damageType: tipoDaño || null,
+          damage: { amount: incomingDamage },
+        };
+        const traitResult = global.LuminousPlayerTraitRuntime?.dispatchCombatEvent?.("damage_taken", damageRuntime);
+        incomingDamage = Math.max(0, numberOr(traitResult?.runtime?.damage?.amount ?? damageRuntime.damage.amount, incomingDamage));
       }
+
+      const result = originalApplyDamage.call(this, unit, incomingDamage, tipoDaño, isCritical, skillUsed);
+      const actualDamage = Math.max(0, hpBefore - numberOr(unit?.hp, 0));
+      if (actualDamage > 0) {
+        recordDamageTypes(unit, classifyDamageTypes(
+          tipoDaño,
+          skillUsed?.damageType,
+          skillUsed?.damage_type,
+          skillUsed?.attackType,
+          skillUsed?.attack_type,
+          skillUsed?.name,
+        ));
+      }
+
+      if (isCurrentPlayerUnit(unit) && hpBefore > 0 && numberOr(unit?.hp, 0) <= 0) {
+        global.LuminousPlayerTraitRuntime?.dispatchCombatEvent?.("hp_zero", {
+          context: "combat",
+          self: unit,
+          defender: unit,
+          skill: skillUsed || null,
+          DefensiveLevel: this.getDefensiveLevel?.(unit, unit),
+          resolveCheck: (request) => resolveCombatCheck(unit, request),
+        });
+      }
+      return result;
+    };
+
+    if (originalTriggerPhase) engine.triggerPhase = function (phaseTag, allUnits, ...rest) {
+      const result = originalTriggerPhase.call(this, phaseTag, allUnits, ...rest);
+      if (phaseTag === "[Round End]") (allUnits || []).forEach(advanceDamageHistory);
       return result;
     };
 
@@ -716,6 +862,12 @@
     registerCombatUnit,
     registeredCombatUnits,
     currentRegisteredPlayerUnit,
+    viewerSlotTargets,
+    isTargetedByAlly,
+    ensureDamageHistory,
+    classifyDamageTypes,
+    recordDamageTypes,
+    advanceDamageHistory,
   });
   global.LuminousTraitStandardizationRuntime = api;
 

--- a/tests/racial_trait_catalog.spec.js
+++ b/tests/racial_trait_catalog.spec.js
@@ -2,6 +2,7 @@ const { test, expect } = require("@playwright/test");
 const engine = require("../js/trait-engine.js");
 const modifiers = require("../js/universal-modifier-engine.js");
 const catalog = require("../js/racial-trait-catalog.js");
+const buildRules = require("../js/character-build-rules.js");
 
 test("racial Trait catalog validates every declarative definition", () => {
   const result = catalog.validateAll(engine);
@@ -37,6 +38,20 @@ test("Lupae automatically receives shared Pack Tactics instead of a race-only du
   expect(catalog.getDefinition("pack_tactics").source).toMatchObject({ type: "special", id: "shared" });
 });
 
+test("Pack Tactics consumes the runtime ally-targeting predicate", () => {
+  const trait = catalog.getDefinition("pack_tactics");
+  const skill = { finalPower: 0 };
+  engine.dispatchCombatEvent("before_attack", {
+    character: { level: 20 },
+    self: {},
+    target: {},
+    targetedByAlly: true,
+    skill,
+    traits: [trait],
+  });
+  expect(skill.finalPower).toBe(1);
+});
+
 test("Moonfae cycle grants are isolated by raceSubtypeId", () => {
   const crescent = catalog.resolveTraitGrants({
     characterBuild: { raceId: "moonfae", raceSubtypeId: "crescent_moon", calculatedAtLevel: 30 },
@@ -58,6 +73,27 @@ test("Moonfae cycle grants are isolated by raceSubtypeId", () => {
   ]);
 });
 
+test("Moonfae cycle is a persisted production build subtype", () => {
+  expect(buildRules.getRace("moonfae")?.subtypes?.map((entry) => entry.id)).toEqual([
+    "full_moon",
+    "crescent_moon",
+    "new_moon",
+    "crimson_moon",
+    "blue_moon",
+  ]);
+
+  const build = buildRules.calculateBuild({
+    level: 10,
+    constitution: 10,
+    classes: [{ classId: "fighter", levels: 10 }],
+    backgroundId: "chef",
+    raceId: "moonfae",
+    raceSubtypeId: "new_moon",
+  });
+  expect(build.valid).toBe(true);
+  expect(build.raceSubtypeId).toBe("new_moon");
+});
+
 test("Yuan-ti eye colors grant the correct Sin affinity and Pale Eyes get no Sin bonus", () => {
   const green = catalog.resolveTraitGrants({ level: 80, raceId: "yuan_ti_pureblood", raceSubtypeId: "green_eyes" });
   const pale = catalog.resolveTraitGrants({ level: 80, raceId: "yuan_ti_pureblood", raceSubtypeId: "pale_eyes" });
@@ -71,21 +107,68 @@ test("Yuan-ti eye colors grant the correct Sin affinity and Pale Eyes get no Sin
   expect(pale.some((trait) => trait.id.includes("affinity"))).toBe(false);
 });
 
-test("Voracious Impulse heals (5 + CHA Mod)% Max HP on kill", () => {
+test("Voracious Impulse heals production hp by (5 + CHA Mod)% Max HP on kill", () => {
   const trait = catalog.getDefinition("yuan_ti_voracious_impulse");
   const character = {
     level: 40,
     stats: { carisma: 16 },
   };
-  const self = { currentHp: 40, maxHp: 100 };
+  const self = { hp: 40, maxHp: 100 };
   const result = engine.dispatchCombatEvent("on_kill", {
     character,
     self,
     traits: [trait],
   });
 
-  expect(self.currentHp).toBe(48);
+  expect(self.hp).toBe(48);
+  expect(self.currentHp).toBeUndefined();
   expect(result.outcomes[0]).toMatchObject({ type: "heal_hp", amount: 8, after: 48 });
+});
+
+test("Undae Regeneration heals production hp unless previous Turn included Fire or Acid", () => {
+  const trait = catalog.getDefinition("undae_regeneration");
+  const character = { level: 40, stats: { constitucion: 16 } };
+
+  const clear = { hp: 50, maxHp: 100, damageTakenPreviousTurnTypes: [] };
+  engine.dispatchCombatEvent("turn_start", { character, self: clear, traits: [trait] });
+  expect(clear.hp).toBe(63);
+
+  for (const blockedType of ["Fire", "Acid"]) {
+    const blocked = { hp: 50, maxHp: 100, damageTakenPreviousTurnTypes: [blockedType] };
+    engine.dispatchCombatEvent("turn_start", { character, self: blocked, traits: [trait] });
+    expect(blocked.hp).toBe(50);
+  }
+});
+
+test("Stone's Endurance mutates incoming damage before production application", () => {
+  const trait = catalog.getDefinition("goliath_stone_endurance");
+  const damage = { amount: 10 };
+  engine.dispatchCombatEvent("damage_taken", {
+    character: { level: 20, stats: { constitucion: 16 } },
+    self: {},
+    damage,
+    traits: [trait],
+  });
+  expect(damage.amount).toBe(7);
+});
+
+test("Desert Predator matches array environment tags with contains", () => {
+  const trait = catalog.getDefinition("half_dragon_desert_predator");
+  for (const tag of ["sand", "loose_earth", "burrowable_ground"]) {
+    const result = engine.resolveTheatreCheck({
+      character: { level: 20 },
+      traits: [trait],
+      check: { skillId: "stealth", environmentTags: [tag], difficulty: 16 },
+    });
+    expect(result.check.difficulty).toBe(12);
+  }
+
+  const forest = engine.resolveTheatreCheck({
+    character: { level: 20 },
+    traits: [trait],
+    check: { skillId: "stealth", environmentTags: ["forest"], difficulty: 16 },
+  });
+  expect(forest.check.difficulty).toBe(16);
 });
 
 test("Feline Reflexes resolves Max Speed and Evade Final Power from Proficiency", () => {

--- a/tests/racial_trait_catalog.spec.js
+++ b/tests/racial_trait_catalog.spec.js
@@ -1,0 +1,150 @@
+const { test, expect } = require("@playwright/test");
+const engine = require("../js/trait-engine.js");
+const modifiers = require("../js/universal-modifier-engine.js");
+const catalog = require("../js/racial-trait-catalog.js");
+
+test("racial Trait catalog validates every declarative definition", () => {
+  const result = catalog.validateAll(engine);
+  expect(result.valid).toBe(true);
+  expect(result.errors).toEqual([]);
+  expect(Object.keys(catalog.DEFINITIONS).length).toBeGreaterThan(20);
+});
+
+test("race and subtype grants resolve automatically without leaking other subtypes", () => {
+  const juggernaut = catalog.resolveTraitGrants({
+    level: 30,
+    raceId: "warforged",
+    raceSubtypeId: "juggernaut",
+  });
+  const skirmisher = catalog.resolveTraitGrants({
+    level: 30,
+    raceId: "warforged",
+    raceSubtypeId: "skirmisher",
+  });
+
+  expect(juggernaut.map((trait) => trait.id)).toEqual(["warforged_reinforced_body"]);
+  expect(skirmisher.map((trait) => trait.id)).toEqual(["warforged_lone_reconnaissance"]);
+  expect(juggernaut[0].source).toMatchObject({ type: "race", id: "warforged", subtypeId: "juggernaut" });
+});
+
+test("Lupae automatically receives shared Pack Tactics instead of a race-only duplicate", () => {
+  const granted = catalog.resolveTraitGrants({ level: 20, raceId: "lupae" });
+  expect(granted.map((trait) => trait.id)).toEqual([
+    "keen_hearing_and_smell",
+    "pack_tactics",
+    "lupae_canis_toughness",
+  ]);
+  expect(catalog.getDefinition("pack_tactics").source).toMatchObject({ type: "special", id: "shared" });
+});
+
+test("Moonfae cycle grants are isolated by raceSubtypeId", () => {
+  const crescent = catalog.resolveTraitGrants({
+    characterBuild: { raceId: "moonfae", raceSubtypeId: "crescent_moon", calculatedAtLevel: 30 },
+  });
+  const full = catalog.resolveTraitGrants({
+    characterBuild: { raceId: "moonfae", raceSubtypeId: "full_moon", calculatedAtLevel: 30 },
+  });
+
+  expect(crescent.map((trait) => trait.id)).toEqual([
+    "keen_hearing",
+    "moonfae_crescent_speed",
+    "moonfae_agile_escape",
+    "moonfae_natural_talent",
+  ]);
+  expect(full.map((trait) => trait.id)).toEqual([
+    "keen_hearing",
+    "moonfae_intimidating_presence",
+    "moonfae_lunge",
+  ]);
+});
+
+test("Yuan-ti eye colors grant the correct Sin affinity and Pale Eyes get no Sin bonus", () => {
+  const green = catalog.resolveTraitGrants({ level: 80, raceId: "yuan_ti_pureblood", raceSubtypeId: "green_eyes" });
+  const pale = catalog.resolveTraitGrants({ level: 80, raceId: "yuan_ti_pureblood", raceSubtypeId: "pale_eyes" });
+
+  expect(green.map((trait) => trait.id)).toEqual([
+    "yuan_ti_magic_resistance",
+    "yuan_ti_gluttony_affinity",
+    "yuan_ti_voracious_impulse",
+  ]);
+  expect(pale.map((trait) => trait.id)).toEqual(["yuan_ti_magic_resistance"]);
+  expect(pale.some((trait) => trait.id.includes("affinity"))).toBe(false);
+});
+
+test("Voracious Impulse heals (5 + CHA Mod)% Max HP on kill", () => {
+  const trait = catalog.getDefinition("yuan_ti_voracious_impulse");
+  const character = {
+    level: 40,
+    stats: { carisma: 16 },
+  };
+  const self = { currentHp: 40, maxHp: 100 };
+  const result = engine.dispatchCombatEvent("on_kill", {
+    character,
+    self,
+    traits: [trait],
+  });
+
+  expect(self.currentHp).toBe(48);
+  expect(result.outcomes[0]).toMatchObject({ type: "heal_hp", amount: 8, after: 48 });
+});
+
+test("Feline Reflexes resolves Max Speed and Evade Final Power from Proficiency", () => {
+  const trait = catalog.getDefinition("feline_reflexes");
+  const character = {
+    level: 60,
+    proficiency: 4,
+    combatStats: { minSpeed: 3, maxSpeed: 6 },
+  };
+  const snapshot = modifiers.resolveCharacterSnapshot({
+    character,
+    unit: character,
+    traits: [trait],
+    skill: { type: "evade", isDefense: true },
+    context: "combat",
+  });
+
+  expect(snapshot.maxSpeed).toBe(8);
+  expect(snapshot.modifiers.final_power).toBe(4);
+});
+
+test("Keen Hearing uses the global Advantage conversion of Threshold -4", () => {
+  const trait = catalog.getDefinition("keen_hearing");
+  const result = engine.resolveTheatreCheck({
+    character: { level: 20 },
+    traits: [trait],
+    check: { skillId: "perception", senses: ["hearing"], difficulty: 16 },
+  });
+
+  expect(result.check.difficulty).toBe(12);
+});
+
+test("mobility capabilities unlock the shared Retreat families", () => {
+  const undaeWar = catalog.resolveCapabilities({ raceId: "undae", raceSubtypeId: "war" });
+  const elnae = catalog.resolveCapabilities({ raceId: "elnae" });
+  const blueDragon = catalog.resolveCapabilities({ raceId: "half_dragon", raceSubtypeId: "blue" });
+
+  expect(undaeWar.map((entry) => entry.capabilityId)).toEqual(["amphibious", "swim_speed"]);
+  expect(elnae.map((entry) => entry.capabilityId)).toEqual(["flight"]);
+  expect(blueDragon.map((entry) => entry.capabilityId)).toEqual(["burrow"]);
+
+  expect(catalog.RETREATS.burrowed).toMatchObject({
+    capabilityId: "burrow",
+    nonStackableGroup: "retreat_bonus",
+    comebackStatus: { statusId: "protection", count: 3 },
+    encounterBonus: { channel: "defensive_level", value: 1 },
+  });
+  expect(catalog.RETREATS.sink).toMatchObject({
+    capabilityId: "swim_speed",
+    nonStackableGroup: "retreat_bonus",
+    comebackStatus: { statusId: "defense_power_up", count: 3 },
+  });
+  expect(catalog.RETREATS.fly).toMatchObject({
+    capabilityId: "flight",
+    nonStackableGroup: "retreat_bonus",
+    comebackStatus: { statusId: "haste", count: 3 },
+  });
+  expect(catalog.RETREATS.fly.encounterBonus).toEqual([
+    { channel: "min_speed", value: 2 },
+    { channel: "max_speed", value: 2 },
+  ]);
+});

--- a/tests/trait_standardization_review_fixes.spec.js
+++ b/tests/trait_standardization_review_fixes.spec.js
@@ -6,6 +6,7 @@ const vm = require("node:vm");
 const traitEngine = require("../js/trait-engine.js");
 const statusEngine = require("../js/status-engine.js");
 const modifiers = require("../js/universal-modifier-engine.js");
+const racialCatalog = require("../js/racial-trait-catalog.js");
 
 const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
 
@@ -75,6 +76,9 @@ function loadStandardizationRuntime(overrides = {}) {
     CombatEngine: overrides.combatEngine || null,
     datosJugador: overrides.datosJugador || null,
     firebase: overrides.firebase || null,
+    combatData: overrides.combatData || null,
+    slotTargets: overrides.slotTargets || null,
+    STATUS_REGISTRY: overrides.STATUS_REGISTRY || null,
     CustomEvent: class CustomEvent {
       constructor(type, init = {}) { this.type = type; this.detail = init.detail; }
     },
@@ -227,6 +231,104 @@ test("production combatants Firebase lifecycle dispatches encounter_start once p
   combatantsListener({ val: () => ({ player_1: { id: "player_1" } }) });
   expect(dispatched).toHaveLength(2);
   expect(dispatched[1].input.self).toBe(nextPlayerUnit);
+});
+
+test("Stone's Endurance reduces production incoming damage before HP is deducted", () => {
+  const stone = racialCatalog.getDefinition("goliath_stone_endurance");
+  const playerCharacter = { id: "goliath_1", level: 20, stats: { constitucion: 16 } };
+  const traitState = traitEngine.createState();
+  const playerRuntime = {
+    getCharacter() { return playerCharacter; },
+    getTraits() { return [stone]; },
+    dispatchCombatEvent(trigger, input) {
+      return traitEngine.dispatchCombatEvent(trigger, {
+        character: playerCharacter,
+        traits: [stone],
+        state: traitState,
+        ...input,
+      });
+    },
+  };
+  const combatEngine = {
+    initializeUnitData() {},
+    applyPassiveModifiers() { return {}; },
+    applyDamage(unit, damage) {
+      unit.hp = Math.max(0, unit.hp - damage);
+      return { hp: unit.hp, shield: unit.shield || 0 };
+    },
+  };
+  const { api } = loadStandardizationRuntime({ combatEngine, playerRuntime, datosJugador: playerCharacter });
+  api.installAll();
+
+  const unit = { id: "goliath_1", hp: 100, maxHp: 100, stats: { constitucion: 16 } };
+  combatEngine.initializeUnitData(unit);
+  combatEngine.applyDamage(unit, 10, "directo", false, { type: "Normal" });
+
+  expect(unit.hp).toBe(93);
+});
+
+test("damage history feeds Undae previous-Turn Fire and Acid conditions", () => {
+  const playerCharacter = { id: "undae_1", level: 20 };
+  const playerRuntime = {
+    getCharacter() { return playerCharacter; },
+    getTraits() { return []; },
+    dispatchCombatEvent(_trigger, input) {
+      return { runtime: input, state: traitEngine.createState(), outcomes: [] };
+    },
+  };
+  const combatEngine = {
+    initializeUnitData() {},
+    applyPassiveModifiers() { return {}; },
+    applyDamage(unit, damage) {
+      unit.hp = Math.max(0, unit.hp - damage);
+      return { hp: unit.hp };
+    },
+    triggerPhase() {},
+  };
+  const { api } = loadStandardizationRuntime({ combatEngine, playerRuntime, datosJugador: playerCharacter });
+  api.installAll();
+
+  const unit = { id: "undae_1", hp: 100, maxHp: 100 };
+  combatEngine.initializeUnitData(unit);
+  combatEngine.applyDamage(unit, 5, "Fire", false, { damageType: "Fire" });
+  expect(unit.damageTakenThisTurnTypes).toEqual(["Fire"]);
+  combatEngine.triggerPhase("[Round End]", [unit]);
+  expect(unit.damageTakenPreviousTurnTypes).toEqual(["Fire"]);
+  expect(unit.damageTakenThisTurnTypes).toEqual([]);
+
+  api.recordDamageTypes(unit, ["Acid"]);
+  api.advanceDamageHistory(unit);
+  expect(unit.damageTakenPreviousTurnTypes).toEqual(["Acid"]);
+});
+
+test("Pack Tactics computes another ally targeting the same defender from production slotTargets", () => {
+  const attacker = { id: "kobold", faction: "player", level: 20 };
+  const ally = { id: "ally", faction: "player", level: 20 };
+  const target = { id: "enemy", faction: "enemy", level: 20 };
+  const combatData = { kobold: attacker, ally, enemy: target };
+  const slotTargets = {
+    kobold_slot_0: "enemy_slot_0",
+    ally_slot_0: "enemy_slot_0",
+  };
+  const { window, api } = loadStandardizationRuntime({
+    combatData,
+    slotTargets,
+    datosJugador: attacker,
+  });
+  api.installAll();
+
+  expect(api.isTargetedByAlly(attacker, target)).toBe(true);
+
+  const skill = { finalPower: 0 };
+  window.LuminousTraitEngine.dispatchCombatEvent("before_attack", {
+    character: attacker,
+    self: attacker,
+    target,
+    skill,
+    traits: [racialCatalog.getDefinition("pack_tactics")],
+    state: traitEngine.createState(),
+  });
+  expect(skill.finalPower).toBe(1);
 });
 
 test("legacy sheet Coin roller can re-toss the last failed Strength Check without LuminousCoinEngine", () => {


### PR DESCRIPTION
## Summary
- adds `js/racial-trait-catalog.js` as a declarative racial Trait/grant layer on top of Trait Engine V1
- automatically resolves Traits by `raceId` + `raceSubtypeId`
- wires racial definitions into the player Trait runtime so selected races/subraces receive Traits without duplicating class/background logic
- keeps shared mechanics such as Pack Tactics reusable by races and enemies
- records global mobility capability grants and the confirmed non-stackable Retreat profiles for Burrow / Sink / Fly
- adds coverage for subtype isolation, Moonfae cycles, Yuan-ti Sin affinities, Feline Reflexes, Voracious Impulse, Threshold -4, capabilities and Retreat data

## Scope of this first automation pass
This PR intentionally starts with racial Traits that the current Trait Engine can execute safely. Natural Weapons/Dynamic Skills, spell-library grants, proficiency/inventory metadata, immunities/vision, and full Retreat execution remain separate systems to wire in follow-up passes rather than hardcoding them into Trait definitions.

## Confirmed rules represented here
- Advantage -> Threshold -4
- Pack Tactics is shared, not race-exclusive
- Feline Reflexes: floor(Proficiency/2) Max Speed + Proficiency Evade Final Power
- Yuan-ti eye Sin bonus: +(Level/4)% for the seven colored eyes; Pale Eyes get none
- Green Yuan-ti: (5 + CHA Mod)% Max HP on kill
- Retreat bonuses are in one non-stackable `retreat_bonus` group
- Burrow comeback: +3 Protection, encounter +1 Defensive Level
- Sink comeback: +3 Defense Power Up, encounter +1 Evade Final Power
- Fly comeback: +3 Haste, encounter +2 Min/+2 Max Speed
