### PR TITLE
Add Traits tab to player Stats

### DIFF
--- a/css/player-trait-tabs.css
+++ b/css/player-trait-tabs.css
@@ -1,0 +1,328 @@
+/* Player Stats > Traits tab ------------------------------------------------ */
+body:not(.on-game-dashboard) #stats-modal .player-stats-view-tabs{
+  display:flex;
+  align-items:stretch;
+  gap:8px;
+  min-width:270px;
+  height:42px;
+}
+body:not(.on-game-dashboard) #stats-modal .player-stats-view-tab{
+  min-width:126px;
+  height:42px;
+  appearance:none;
+  border:2px solid #57462f;
+  background:linear-gradient(180deg,#1d1a16,#0d0c0a);
+  color:#8f8576;
+  font:700 18px Georgia,"Times New Roman",serif;
+  box-shadow:inset 0 0 12px rgba(0,0,0,.55);
+  cursor:pointer;
+  transition:border-color .15s,color .15s,box-shadow .15s,background .15s;
+}
+body:not(.on-game-dashboard) #stats-modal .player-stats-view-tab::after{
+  display:none;
+}
+body:not(.on-game-dashboard) #stats-modal .player-stats-view-tab:hover,
+body:not(.on-game-dashboard) #stats-modal .player-stats-view-tab:focus-visible{
+  outline:0;
+  border-color:#a6752b;
+  color:#d8c6a7;
+}
+body:not(.on-game-dashboard) #stats-modal .player-stats-view-tab.is-active{
+  position:relative;
+  border-color:#f2a716;
+  background:linear-gradient(180deg,#2a241c,#12100d);
+  color:#fff;
+  box-shadow:inset 0 0 17px rgba(255,155,0,.15),0 0 9px rgba(255,155,0,.25);
+}
+body:not(.on-game-dashboard) #stats-modal .player-stats-view-tab.is-active::after{
+  content:"";
+  display:block;
+  position:absolute;
+  left:50%;
+  bottom:-10px;
+  transform:translateX(-50%);
+  border-left:8px solid transparent;
+  border-right:8px solid transparent;
+  border-top:9px solid #f2a716;
+}
+body:not(.on-game-dashboard) #stats-modal .player-ability-bar[hidden],
+body:not(.on-game-dashboard) #stats-modal .player-stat-content[hidden],
+body:not(.on-game-dashboard) #stats-modal #player-trait-runtime-host[hidden]{
+  display:none!important;
+}
+body:not(.on-game-dashboard) #stats-modal #player-trait-runtime-host{
+  flex:1 1 auto;
+  min-height:0;
+  width:100%;
+  overflow:hidden;
+}
+body:not(.on-game-dashboard) #stats-modal .player-traits-panel{
+  width:100%;
+  height:100%;
+  min-height:0;
+}
+body:not(.on-game-dashboard) #stats-modal .player-traits-panel:not([hidden]){
+  display:flex!important;
+}
+body:not(.on-game-dashboard) #stats-modal .player-traits-catalog{
+  flex:1 1 auto;
+  min-width:0;
+  min-height:0;
+  display:flex;
+  flex-direction:column;
+  overflow:hidden;
+  color:#d7d0c5;
+}
+body:not(.on-game-dashboard) #stats-modal .player-traits-catalog__header{
+  flex:0 0 auto;
+  display:flex;
+  align-items:flex-end;
+  justify-content:space-between;
+  gap:20px;
+  padding:4px 2px 13px;
+  border-bottom:1px solid #4b3a27;
+}
+body:not(.on-game-dashboard) #stats-modal .player-traits-catalog__title{
+  min-width:0;
+}
+body:not(.on-game-dashboard) #stats-modal .player-traits-catalog__title h2{
+  margin:0;
+  color:#ead9ba;
+  font:700 23px/1.1 Georgia,"Times New Roman",serif;
+  letter-spacing:.06em;
+}
+body:not(.on-game-dashboard) #stats-modal .player-traits-catalog__title p{
+  margin:5px 0 0;
+  max-width:590px;
+  color:#807669;
+  font-size:10px;
+  line-height:1.4;
+  letter-spacing:.035em;
+}
+body:not(.on-game-dashboard) #stats-modal .player-traits-catalog__total{
+  flex:0 0 auto;
+  min-width:68px;
+  padding:7px 10px 6px;
+  border:1px solid #604a2e;
+  background:#0d0c0a;
+  text-align:center;
+  color:#817666;
+  font-size:8px;
+  font-weight:700;
+  letter-spacing:.12em;
+}
+body:not(.on-game-dashboard) #stats-modal .player-traits-catalog__total strong{
+  display:block;
+  margin-bottom:1px;
+  color:#ffb52a;
+  font:700 24px/1 Georgia,"Times New Roman",serif;
+}
+body:not(.on-game-dashboard) #stats-modal .player-trait-filters{
+  flex:0 0 auto;
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px;
+  padding:10px 0 9px;
+}
+body:not(.on-game-dashboard) #stats-modal .player-trait-filter{
+  appearance:none;
+  min-height:26px;
+  padding:4px 9px;
+  border:1px solid #4a4034;
+  background:#0c0b09;
+  color:#8c8274;
+  font-size:8px;
+  font-weight:700;
+  letter-spacing:.08em;
+  text-transform:uppercase;
+  cursor:pointer;
+  transition:.15s;
+}
+body:not(.on-game-dashboard) #stats-modal .player-trait-filter b{
+  margin-left:5px;
+  color:#b49967;
+  font:700 10px Georgia,"Times New Roman",serif;
+}
+body:not(.on-game-dashboard) #stats-modal .player-trait-filter:hover,
+body:not(.on-game-dashboard) #stats-modal .player-trait-filter:focus-visible{
+  outline:0;
+  border-color:#9b7133;
+  color:#d7c6a8;
+}
+body:not(.on-game-dashboard) #stats-modal .player-trait-filter.is-active{
+  border-color:#e7a32d;
+  background:linear-gradient(180deg,#2d2417,#151009);
+  color:#f4e4c4;
+  box-shadow:inset 0 0 10px rgba(233,155,33,.12),0 0 6px rgba(233,155,33,.12);
+}
+body:not(.on-game-dashboard) #stats-modal .player-trait-filter.is-active b{
+  color:#ffb52a;
+}
+body:not(.on-game-dashboard) #stats-modal .player-trait-card-list{
+  flex:1 1 auto;
+  min-height:0;
+  display:grid;
+  grid-template-columns:repeat(2,minmax(0,1fr));
+  align-content:start;
+  gap:9px;
+  overflow-y:auto;
+  padding:1px 6px 18px 0;
+  scrollbar-width:thin;
+  scrollbar-color:#705532 #0c0b09;
+}
+body:not(.on-game-dashboard) #stats-modal .player-trait-card-list::-webkit-scrollbar{width:8px}
+body:not(.on-game-dashboard) #stats-modal .player-trait-card-list::-webkit-scrollbar-track{background:#0c0b09}
+body:not(.on-game-dashboard) #stats-modal .player-trait-card-list::-webkit-scrollbar-thumb{background:#705532;border:2px solid #0c0b09}
+body:not(.on-game-dashboard) #stats-modal .player-trait-card{
+  --trait-accent:#8f754e;
+  position:relative;
+  min-width:0;
+  display:flex;
+  flex-direction:column;
+  gap:7px;
+  padding:11px 12px 10px 14px;
+  border:1px solid #42392e;
+  border-left:4px solid var(--trait-accent);
+  background:radial-gradient(circle at 92% 0,rgba(157,116,55,.09),transparent 37%),linear-gradient(180deg,#171512,#0e0d0b);
+  box-shadow:inset 0 0 18px rgba(0,0,0,.28);
+}
+body:not(.on-game-dashboard) #stats-modal .player-trait-card[data-trait-category="racial"]{--trait-accent:#c59a50}
+body:not(.on-game-dashboard) #stats-modal .player-trait-card[data-trait-category="class"]{--trait-accent:#db852e}
+body:not(.on-game-dashboard) #stats-modal .player-trait-card[data-trait-category="archetype"]{--trait-accent:#b94a35}
+body:not(.on-game-dashboard) #stats-modal .player-trait-card[data-trait-category="background"]{--trait-accent:#4c8b8e}
+body:not(.on-game-dashboard) #stats-modal .player-trait-card[data-trait-category="general"]{--trait-accent:#8770a9}
+body:not(.on-game-dashboard) #stats-modal .player-trait-card[data-trait-category="other"]{--trait-accent:#706b64}
+body:not(.on-game-dashboard) #stats-modal .player-trait-card__header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px;
+  min-width:0;
+}
+body:not(.on-game-dashboard) #stats-modal .player-trait-source{
+  min-width:0;
+  overflow:hidden;
+  color:var(--trait-accent);
+  font-size:8px;
+  font-weight:800;
+  letter-spacing:.08em;
+  text-overflow:ellipsis;
+  text-transform:uppercase;
+  white-space:nowrap;
+}
+body:not(.on-game-dashboard) #stats-modal .player-trait-activation{
+  flex:0 0 auto;
+  padding:2px 5px;
+  border:1px solid #453d33;
+  background:#090807;
+  color:#756c60;
+  font-size:7px;
+  font-weight:700;
+  letter-spacing:.08em;
+}
+body:not(.on-game-dashboard) #stats-modal .player-trait-card__name{
+  margin:0;
+  color:#e7dac3;
+  font:700 16px/1.15 Georgia,"Times New Roman",serif;
+  letter-spacing:.02em;
+}
+body:not(.on-game-dashboard) #stats-modal .player-trait-card__description{
+  margin:0;
+  color:#aaa095;
+  font-size:10px;
+  line-height:1.45;
+}
+body:not(.on-game-dashboard) #stats-modal .player-trait-contexts{
+  display:flex;
+  flex-wrap:wrap;
+  gap:5px;
+  margin-top:auto;
+}
+body:not(.on-game-dashboard) #stats-modal .player-trait-context{
+  padding:2px 5px;
+  border:1px solid #38332d;
+  background:#0a0908;
+  color:#746c61;
+  font-size:7px;
+  font-weight:700;
+  letter-spacing:.09em;
+}
+body:not(.on-game-dashboard) #stats-modal .player-trait-card__meta{
+  display:flex;
+  flex-wrap:wrap;
+  align-items:center;
+  gap:5px;
+  min-width:0;
+}
+body:not(.on-game-dashboard) #stats-modal .player-trait-card__footer{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:10px;
+  margin-top:2px;
+  padding-top:7px;
+  border-top:1px solid #302a23;
+}
+body:not(.on-game-dashboard) #stats-modal .player-trait-card__passive,
+body:not(.on-game-dashboard) #stats-modal .luminous-trait-tray__reason{
+  min-width:0;
+  color:#696258;
+  font-size:8px;
+  line-height:1.35;
+  letter-spacing:.025em;
+}
+body:not(.on-game-dashboard) #stats-modal .luminous-trait-tray__reason{
+  color:#9a6a56;
+}
+body:not(.on-game-dashboard) #stats-modal .player-trait-use{
+  flex:0 0 auto;
+  min-width:106px;
+  padding:7px 9px;
+  border:1px solid #d79529;
+  background:linear-gradient(180deg,#342512,#171008);
+  color:#ffc45b;
+  font-size:8px;
+  font-weight:800;
+  letter-spacing:.07em;
+  text-transform:uppercase;
+  cursor:pointer;
+  box-shadow:inset 0 0 9px rgba(237,157,38,.11);
+}
+body:not(.on-game-dashboard) #stats-modal .player-trait-use:hover,
+body:not(.on-game-dashboard) #stats-modal .player-trait-use:focus-visible{
+  outline:0;
+  background:linear-gradient(180deg,#543614,#211307);
+  color:#ffe1a0;
+}
+body:not(.on-game-dashboard) #stats-modal .player-trait-use:disabled{
+  border-color:#494139;
+  background:#12100e;
+  color:#615b54;
+  cursor:not-allowed;
+  box-shadow:none;
+}
+body:not(.on-game-dashboard) #stats-modal .luminous-trait-tray__uses{
+  display:block;
+  margin-top:2px;
+  color:#a1875e;
+  font-size:7px;
+}
+body:not(.on-game-dashboard) #stats-modal .player-traits-empty{
+  grid-column:1/-1;
+  min-height:150px;
+  display:grid;
+  place-items:center;
+  padding:24px;
+  border:1px dashed #493e30;
+  color:#71695f;
+  text-align:center;
+  font:700 12px Georgia,"Times New Roman",serif;
+  letter-spacing:.08em;
+}
+
+@media (max-width:1180px){
+  body:not(.on-game-dashboard) #stats-modal .player-trait-card-list{grid-template-columns:1fr}
+  body:not(.on-game-dashboard) #stats-modal .player-stats-engine{display:none}
+  body:not(.on-game-dashboard) #stats-modal .player-stats-view-tabs{min-width:0;width:100%}
+  body:not(.on-game-dashboard) #stats-modal .player-stats-view-tab{flex:1;min-width:0}
+}

--- a/js/trait-player-tray.js
+++ b/js/trait-player-tray.js
@@ -4,6 +4,17 @@
   const engine = global.LuminousTraitEngine || (typeof require !== "undefined" ? require("./trait-engine.js") : null);
   if (!engine) return;
 
+  const CATEGORY_ORDER = Object.freeze(["all", "racial", "class", "archetype", "background", "general", "other"]);
+  const CATEGORY_LABELS = Object.freeze({
+    all: "All",
+    racial: "Racial",
+    class: "Class",
+    archetype: "Archetype",
+    background: "Background",
+    general: "General",
+    other: "Other",
+  });
+
   function resolveHost(host) {
     if (!host) return null;
     if (typeof host === "string") return global.document?.querySelector(host) || null;
@@ -17,6 +28,69 @@
     return node;
   }
 
+  function normalizeId(value) {
+    return String(value ?? "").trim().toLowerCase().replace(/\s+/g, "_");
+  }
+
+  function titleCaseId(value) {
+    return String(value ?? "")
+      .trim()
+      .replace(/[_-]+/g, " ")
+      .replace(/\s+/g, " ")
+      .replace(/\b\w/g, (char) => char.toUpperCase());
+  }
+
+  function sourceCategory(trait = {}) {
+    const source = trait?.source || {};
+    const type = normalizeId(source.type || trait.sourceType || trait.category || trait.traitCategory);
+    if (["race", "racial", "subrace", "lineage", "ancestry"].includes(type)) return "racial";
+    if (["class"].includes(type)) return "class";
+    if (["archetype", "subclass", "class_archetype"].includes(type)) return "archetype";
+    if (["background", "origin"].includes(type)) return "background";
+    if (["general", "general_trait", "feat"].includes(type)) return "general";
+    return "other";
+  }
+
+  function sourceMeta(trait = {}) {
+    const source = trait?.source || {};
+    const category = sourceCategory(trait);
+    let rawName = "";
+    let parentName = "";
+
+    if (category === "racial") {
+      rawName = source.raceName || source.subraceName || source.lineageName || source.name || source.raceId || source.subraceId || source.lineageId || source.id;
+    } else if (category === "class") {
+      rawName = source.className || source.name || source.classId || source.id;
+    } else if (category === "archetype") {
+      rawName = source.archetypeName || source.subclassName || source.name || source.archetypeId || source.subclassId || source.id;
+      parentName = source.className || source.parentClassName || source.classId || source.parentClass || source.parentClassId || "";
+    } else if (category === "background") {
+      rawName = source.backgroundName || source.name || source.backgroundId || source.id;
+    } else if (category === "general") {
+      rawName = source.name || source.id;
+    } else {
+      rawName = source.name || source.id || trait.sourceName || "";
+    }
+
+    const sourceName = titleCaseId(rawName);
+    const parent = titleCaseId(parentName);
+    const level = [
+      source.requiredLevel,
+      source.requiredClassLevel,
+      source.unlockLevel,
+      source.milestoneLevel,
+      trait.requiredLevel,
+      trait.requiredClassLevel,
+    ].map((value) => Number(value)).find((value) => Number.isFinite(value) && value > 0) || null;
+
+    let detail = CATEGORY_LABELS[category].toUpperCase();
+    if (sourceName) detail += ` • ${sourceName.toUpperCase()}`;
+    if (category === "archetype" && parent) detail += ` · ${parent.toUpperCase()}`;
+    if (level != null) detail += ` LV.${level}`;
+
+    return { category, label: CATEGORY_LABELS[category], sourceName, parentName: parent, level, detail };
+  }
+
   function useLabel(action) {
     if (action.maximum == null) return "";
     return `${action.remaining}/${action.maximum}`;
@@ -24,6 +98,40 @@
 
   function reasonLabel(action) {
     return (action.reasons || []).join(" ") || "Unavailable";
+  }
+
+  function activationLabel(trait = {}) {
+    const type = normalizeId(trait?.activation?.type || "passive");
+    if (type === "automatic") return "AUTO";
+    if (type === "manual") return "MANUAL";
+    if (type === "choice") return "CHOICE";
+    if (type === "prompt") return "PROMPT";
+    return "PASSIVE";
+  }
+
+  function contextLabels(trait = {}) {
+    const contexts = Array.isArray(trait.contexts) ? trait.contexts : trait.contexts ? [trait.contexts] : [];
+    return [...new Set(contexts.map(normalizeId).filter(Boolean))]
+      .filter((context) => context !== "any")
+      .map((context) => context === "theatre" ? "THEATRE" : context === "combat" ? "COMBAT" : context.toUpperCase());
+  }
+
+  function filterTraits(traits = [], filter = "all") {
+    const normalizedFilter = CATEGORY_ORDER.includes(normalizeId(filter)) ? normalizeId(filter) : "all";
+    const list = Array.isArray(traits) ? traits : [];
+    if (normalizedFilter === "all") return list;
+    return list.filter((trait) => sourceCategory(trait) === normalizedFilter);
+  }
+
+  function ensureStyles() {
+    const doc = global.document;
+    if (!doc || doc.getElementById("player-trait-tabs-stylesheet")) return;
+    const link = doc.createElement("link");
+    link.id = "player-trait-tabs-stylesheet";
+    link.rel = "stylesheet";
+    link.href = "css/player-trait-tabs.css";
+    link.dataset.ui = "player-trait-tabs";
+    doc.head?.appendChild(link);
   }
 
   class TraitPlayerTray {
@@ -38,21 +146,47 @@
       this.resolveInputs = typeof options.resolveInputs === "function" ? options.resolveInputs : null;
       this.title = options.title || "TRAITS";
       this.expanded = options.expanded !== false;
+      this.filter = "all";
       this.root = null;
+      this.statsConsole = null;
+      ensureStyles();
       if (this.host && global.document) this.mount();
     }
 
     mount() {
       if (!this.host || this.root) return this.root;
-      this.root = createElement("section", "luminous-trait-tray");
-      this.root.dataset.expanded = this.expanded ? "true" : "false";
+      this.setupStatsTabs();
+      this.root = createElement("section", "luminous-trait-tray player-traits-catalog");
+      this.root.setAttribute("aria-label", "Character Traits");
       this.host.appendChild(this.root);
       this.render();
       return this.root;
     }
 
+    normalizedTraits() {
+      const seen = new Set();
+      return (this.getTraits() || [])
+        .map((trait) => engine.normalizeTrait(trait))
+        .filter((trait) => {
+          const id = normalizeId(trait?.id || trait?.name);
+          if (!id || seen.has(id)) return false;
+          seen.add(id);
+          return true;
+        })
+        .sort((a, b) => {
+          const ca = CATEGORY_ORDER.indexOf(sourceCategory(a));
+          const cb = CATEGORY_ORDER.indexOf(sourceCategory(b));
+          if (ca !== cb) return ca - cb;
+          return String(a.name || "").localeCompare(String(b.name || ""));
+        });
+    }
+
     actions() {
       return engine.listAvailableTraitActions(this.getTraits() || [], this.getRuntime() || {}, this.state);
+    }
+
+    actionMap() {
+      return new Map(this.actions().map((action) => [normalizeId(action.traitId), action]));
     }
 
     async activate(action) {
@@ -82,49 +216,172 @@
       return result;
     }
 
-    render() {
-      if (!this.root) return;
-      this.root.replaceChildren();
-      const header = createElement("button", "luminous-trait-tray__toggle", this.title);
-      header.type = "button";
-      header.setAttribute("aria-expanded", this.expanded ? "true" : "false");
-      header.addEventListener("click", () => {
-        this.expanded = !this.expanded;
-        this.root.dataset.expanded = this.expanded ? "true" : "false";
-        this.render();
-      });
-      this.root.appendChild(header);
-      if (!this.expanded) return;
+    setStatsView(view) {
+      const consoleRoot = this.statsConsole || global.document?.querySelector("#stats-modal .player-ability-console");
+      if (!consoleRoot) return false;
+      const nextView = view === "traits" ? "traits" : "stats";
+      consoleRoot.dataset.playerStatsView = nextView;
 
-      const list = createElement("div", "luminous-trait-tray__list");
-      const actions = this.actions();
-      if (!actions.length) {
-        list.appendChild(createElement("div", "luminous-trait-tray__empty", "NO ACTIVE TRAIT ACTIONS"));
-        this.root.appendChild(list);
-        return;
+      const abilityBar = consoleRoot.querySelector(":scope .player-ability-bar");
+      const statContent = consoleRoot.querySelector(":scope .player-stat-content");
+      if (abilityBar) abilityBar.hidden = nextView === "traits";
+      if (statContent) statContent.hidden = nextView === "traits";
+      if (this.host) this.host.hidden = nextView !== "traits";
+
+      consoleRoot.querySelectorAll("[data-player-stats-view]").forEach((button) => {
+        const active = button.dataset.playerStatsView === nextView;
+        button.classList.toggle("active", active);
+        button.classList.toggle("is-active", active);
+        button.setAttribute("aria-selected", active ? "true" : "false");
+        button.tabIndex = active ? 0 : -1;
+      });
+      return true;
+    }
+
+    setupStatsTabs() {
+      const doc = global.document;
+      if (!doc || !this.host) return false;
+      const consoleRoot = doc.querySelector("#stats-modal .player-ability-console");
+      const infoPanel = consoleRoot?.querySelector(".player-stats-information-panel");
+      const tabline = infoPanel?.querySelector(".player-stats-tabline");
+      if (!consoleRoot || !infoPanel || !tabline) return false;
+      this.statsConsole = consoleRoot;
+
+      let tabs = tabline.querySelector(".player-stats-view-tabs");
+      if (!tabs) {
+        tabline.querySelector(":scope > .player-stats-tab")?.remove();
+        tabs = createElement("div", "player-stats-view-tabs");
+        tabs.setAttribute("role", "tablist");
+        tabs.setAttribute("aria-label", "Character information view");
+        [
+          ["stats", "Stats"],
+          ["traits", "Traits"],
+        ].forEach(([view, label], index) => {
+          const button = createElement("button", `player-stats-tab player-stats-view-tab${index === 0 ? " active is-active" : ""}`, label);
+          button.type = "button";
+          button.dataset.playerStatsView = view;
+          button.setAttribute("role", "tab");
+          button.setAttribute("aria-selected", index === 0 ? "true" : "false");
+          button.tabIndex = index === 0 ? 0 : -1;
+          button.addEventListener("click", () => this.setStatsView(view));
+          button.addEventListener("keydown", (event) => {
+            if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) return;
+            event.preventDefault();
+            const targetView = event.key === "ArrowLeft" || event.key === "Home" ? "stats" : "traits";
+            this.setStatsView(targetView);
+            tabs.querySelector(`[data-player-stats-view="${targetView}"]`)?.focus();
+          });
+          tabs.appendChild(button);
+        });
+        tabline.prepend(tabs);
       }
 
-      actions.forEach((action) => {
-        const row = createElement("div", `luminous-trait-tray__row${action.available ? "" : " is-disabled"}`);
-        const button = createElement("button", "luminous-trait-tray__action");
+      if (this.host.parentElement !== infoPanel) infoPanel.appendChild(this.host);
+      this.host.classList.add("player-traits-panel");
+      const current = consoleRoot.dataset.playerStatsView === "traits" ? "traits" : "stats";
+      this.setStatsView(current);
+      return true;
+    }
+
+    renderFilterBar(container, traits) {
+      const counts = Object.fromEntries(CATEGORY_ORDER.map((category) => [category, 0]));
+      counts.all = traits.length;
+      traits.forEach((trait) => { counts[sourceCategory(trait)] += 1; });
+      if (this.filter !== "all" && !counts[this.filter]) this.filter = "all";
+
+      CATEGORY_ORDER.forEach((category) => {
+        const button = createElement("button", `player-trait-filter${this.filter === category ? " is-active" : ""}`);
+        button.type = "button";
+        button.dataset.traitFilter = category;
+        button.disabled = category !== "all" && counts[category] === 0;
+        button.setAttribute("aria-pressed", this.filter === category ? "true" : "false");
+        button.append(
+          createElement("span", "player-trait-filter__label", CATEGORY_LABELS[category]),
+          createElement("b", "player-trait-filter__count", counts[category]),
+        );
+        button.addEventListener("click", () => {
+          this.filter = category;
+          this.render();
+        });
+        container.appendChild(button);
+      });
+    }
+
+    renderTraitCard(trait, action) {
+      const meta = sourceMeta(trait);
+      const card = createElement("article", "player-trait-card");
+      card.dataset.traitId = trait.id;
+      card.dataset.traitCategory = meta.category;
+
+      const header = createElement("div", "player-trait-card__header");
+      const source = createElement("span", `player-trait-source player-trait-source--${meta.category}`, meta.detail);
+      const activation = createElement("span", "player-trait-activation", activationLabel(trait));
+      header.append(source, activation);
+
+      const name = createElement("h3", "player-trait-card__name", trait.name || trait.id || "Unnamed Trait");
+      const description = createElement("p", "player-trait-card__description", trait.description || "No description available.");
+      const metaRow = createElement("div", "player-trait-card__meta");
+      contextLabels(trait).forEach((context) => metaRow.appendChild(createElement("span", "player-trait-context", context)));
+      if (meta.level != null) metaRow.appendChild(createElement("span", "player-trait-context", `LEVEL ${meta.level}`));
+
+      const footer = createElement("div", "player-trait-card__footer");
+      if (action) {
+        const button = createElement("button", `luminous-trait-tray__action player-trait-use${action.available ? "" : " is-disabled"}`);
         button.type = "button";
         button.disabled = !action.available;
-        button.title = action.available ? `${action.name} · ${action.actionCost}` : reasonLabel(action);
-
-        const copy = createElement("span", "luminous-trait-tray__copy");
-        copy.append(
-          createElement("strong", "luminous-trait-tray__name", action.name),
-          createElement("small", "luminous-trait-tray__cost", action.actionCost.replaceAll("_", " ").toUpperCase()),
-        );
-        button.appendChild(copy);
-        const uses = useLabel(action);
-        if (uses) button.appendChild(createElement("b", "luminous-trait-tray__uses", uses));
+        const cost = String(action.actionCost || "special").replaceAll("_", " ").toUpperCase();
+        button.textContent = action.available ? `USE · ${cost}` : "UNAVAILABLE";
+        button.title = action.available ? `${action.name} · ${cost}` : reasonLabel(action);
         button.addEventListener("click", () => this.activate(action));
-        row.appendChild(button);
-        if (!action.available) row.appendChild(createElement("small", "luminous-trait-tray__reason", reasonLabel(action)));
-        list.appendChild(row);
-      });
-      this.root.appendChild(list);
+        footer.appendChild(button);
+        const uses = useLabel(action);
+        if (uses) footer.appendChild(createElement("b", "luminous-trait-tray__uses", uses));
+        if (!action.available) footer.appendChild(createElement("small", "luminous-trait-tray__reason", reasonLabel(action)));
+      } else {
+        const passiveCopy = activationLabel(trait) === "PASSIVE"
+          ? "Always applied when its conditions are met."
+          : activationLabel(trait) === "AUTO"
+            ? "Activates automatically when its trigger is met."
+            : "No manual action is currently available.";
+        footer.appendChild(createElement("small", "player-trait-card__passive", passiveCopy));
+      }
+
+      card.append(header, name, description);
+      if (metaRow.childElementCount) card.appendChild(metaRow);
+      card.appendChild(footer);
+      return card;
+    }
+
+    render() {
+      if (!this.root) return;
+      this.setupStatsTabs();
+      this.root.replaceChildren();
+
+      const traits = this.normalizedTraits();
+      const actions = this.actionMap();
+      const header = createElement("header", "player-traits-catalog__header");
+      const titleWrap = createElement("div", "player-traits-catalog__title");
+      titleWrap.append(
+        createElement("h2", "", this.title),
+        createElement("p", "", "Racial, Class, Archetype, Background and General Traits assigned to this character."),
+      );
+      const total = createElement("div", "player-traits-catalog__total");
+      total.append(createElement("strong", "", traits.length), createElement("span", "", "TOTAL"));
+      header.append(titleWrap, total);
+
+      const filters = createElement("nav", "player-trait-filters");
+      filters.setAttribute("aria-label", "Filter Traits by source");
+      this.renderFilterBar(filters, traits);
+
+      const list = createElement("div", "luminous-trait-tray__list player-trait-card-list");
+      const visible = filterTraits(traits, this.filter);
+      if (!visible.length) {
+        list.appendChild(createElement("div", "luminous-trait-tray__empty player-traits-empty", traits.length ? "NO TRAITS IN THIS CATEGORY" : "NO TRAITS ASSIGNED"));
+      } else {
+        visible.forEach((trait) => list.appendChild(this.renderTraitCard(trait, actions.get(normalizeId(trait.id)))));
+      }
+
+      this.root.append(header, filters, list);
     }
 
     refresh() { this.render(); }
@@ -134,7 +391,16 @@
     return new TraitPlayerTray(options);
   }
 
-  const api = Object.freeze({ TraitPlayerTray, mount });
+  ensureStyles();
+  const api = Object.freeze({
+    TraitPlayerTray,
+    mount,
+    sourceCategory,
+    sourceMeta,
+    filterTraits,
+    CATEGORY_ORDER,
+    CATEGORY_LABELS,
+  });
   global.LuminousTraitPlayerTray = api;
   if (typeof module !== "undefined" && module.exports) module.exports = api;
 })(typeof window !== "undefined" ? window : globalThis);

--- a/js/trait-player-tray.js
+++ b/js/trait-player-tray.js
@@ -1,8 +1,48 @@
 (function (global) {
   "use strict";
 
-  const engine = global.LuminousTraitEngine || (typeof require !== "undefined" ? require("./trait-engine.js") : null);
+  let engine = global.LuminousTraitEngine || (typeof require !== "undefined" ? require("./trait-engine.js") : null);
   if (!engine) return;
+
+  function preserveGrantMetadata(engineApi) {
+    if (!engineApi?.resolveTraitGrants || engineApi.__grantMetadataPreserved) return engineApi;
+    const originalResolveTraitGrants = engineApi.resolveTraitGrants.bind(engineApi);
+    return Object.freeze({
+      ...engineApi,
+      __grantMetadataPreserved: true,
+      resolveTraitGrants(character = {}, grants = [], catalog = {}) {
+        const grantList = Array.isArray(grants) ? grants : Object.values(grants || {});
+        return originalResolveTraitGrants(character, grants, catalog).map((trait) => {
+          const traitId = normalizeId(trait?.id || trait?.name);
+          const source = trait?.source || {};
+          const sourceType = normalizeId(source.type || trait?.sourceType);
+          const sourceId = normalizeId(source.id || source.classId || trait?.sourceId);
+          const grant = grantList.find((entry) => {
+            const grantTraitId = normalizeId(entry?.traitId || entry?.id);
+            const grantSourceType = normalizeId(entry?.sourceType || entry?.source?.type);
+            const grantSourceId = normalizeId(entry?.sourceId || entry?.source?.id || entry?.source?.classId);
+            return grantTraitId === traitId && grantSourceType === sourceType && grantSourceId === sourceId;
+          });
+          const atLevel = Number(grant?.atLevel ?? grant?.level);
+          if (!Number.isFinite(atLevel) || atLevel <= 0) return trait;
+
+          const next = {
+            ...trait,
+            source: {
+              ...source,
+              atLevel,
+            },
+          };
+          if (sourceType === "class") next.source.requiredClassLevel = atLevel;
+          else next.source.requiredLevel = atLevel;
+          return next;
+        });
+      },
+    });
+  }
+
+  engine = preserveGrantMetadata(engine);
+  global.LuminousTraitEngine = engine;
 
   const CATEGORY_ORDER = Object.freeze(["all", "racial", "class", "archetype", "background", "general", "other"]);
   const CATEGORY_LABELS = Object.freeze({
@@ -42,7 +82,14 @@
 
   function sourceCategory(trait = {}) {
     const source = trait?.source || {};
-    const type = normalizeId(source.type || trait.sourceType || trait.category || trait.traitCategory);
+    const sourceType = normalizeId(source.type);
+    const legacySourceType = normalizeId(trait.sourceType);
+    const categoryType = normalizeId(trait.category || trait.traitCategory);
+    const type = sourceType && sourceType !== "special"
+      ? sourceType
+      : legacySourceType && legacySourceType !== "special"
+        ? legacySourceType
+        : categoryType || sourceType || legacySourceType;
     if (["race", "racial", "subrace", "lineage", "ancestry"].includes(type)) return "racial";
     if (["class"].includes(type)) return "class";
     if (["archetype", "subclass", "class_archetype"].includes(type)) return "archetype";
@@ -79,8 +126,10 @@
       source.requiredClassLevel,
       source.unlockLevel,
       source.milestoneLevel,
+      source.atLevel,
       trait.requiredLevel,
       trait.requiredClassLevel,
+      trait.atLevel,
     ].map((value) => Number(value)).find((value) => Number.isFinite(value) && value > 0) || null;
 
     let detail = CATEGORY_LABELS[category].toUpperCase();
@@ -395,6 +444,7 @@
   const api = Object.freeze({
     TraitPlayerTray,
     mount,
+    preserveGrantMetadata,
     sourceCategory,
     sourceMeta,
     filterTraits,

--- a/tests/player_trait_tabs.spec.js
+++ b/tests/player_trait_tabs.spec.js
@@ -2,6 +2,7 @@ const { test, expect } = require("@playwright/test");
 const fs = require("node:fs");
 const path = require("node:path");
 
+const engine = require(path.join(__dirname, "..", "js", "trait-engine.js"));
 const tray = require(path.join(__dirname, "..", "js", "trait-player-tray.js"));
 const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
 
@@ -12,10 +13,23 @@ test("Traits se clasifican por origen para la pestaña del jugador", () => {
     [{ source: { type: "archetype", id: "berserker", classId: "barbarian" } }, "archetype"],
     [{ source: { type: "background", id: "soldier" } }, "background"],
     [{ source: { type: "general", id: "alert" } }, "general"],
+    [{ category: "general", source: { type: "special", id: "alert" } }, "general"],
     [{ source: { type: "special", id: "campaign" } }, "other"],
   ];
 
   cases.forEach(([trait, expected]) => expect(tray.sourceCategory(trait)).toBe(expected));
+});
+
+test("Traits Generales por category sobreviven normalizeTrait", () => {
+  const normalized = engine.normalizeTrait({
+    id: "alert",
+    name: "Alert",
+    category: "general",
+    activation: { type: "passive", actionCost: "none" },
+  });
+
+  expect(normalized.source.type).toBe("special");
+  expect(tray.sourceCategory(normalized)).toBe("general");
 });
 
 test("la etiqueta conserva origen, clase padre y nivel cuando existen", () => {
@@ -24,6 +38,33 @@ test("la etiqueta conserva origen, clase padre y nivel cuando existen", () => {
 
   expect(tray.sourceMeta({ source: { type: "archetype", id: "berserker", classId: "barbarian", requiredClassLevel: 15 } }).detail)
     .toBe("ARCHETYPE • BERSERKER · BARBARIAN LV.15");
+});
+
+test("el resolver preserva atLevel para metadata de Traits de Clase", () => {
+  const patchedEngine = tray.preserveGrantMetadata(engine);
+  const [trait] = patchedEngine.resolveTraitGrants(
+    { classes: [{ classId: "barbarian", levels: 45 }] },
+    [{
+      id: "core_class_barbarian_l45_brutal_critical",
+      sourceType: "class",
+      sourceId: "barbarian",
+      atLevel: 45,
+      traitId: "brutal_critical",
+      grantType: "trait",
+    }],
+    {
+      brutal_critical: {
+        id: "brutal_critical",
+        name: "Brutal Critical",
+        source: { type: "class", id: "barbarian", classId: "barbarian" },
+        activation: { type: "passive", actionCost: "none" },
+      },
+    },
+  );
+
+  expect(trait.source.atLevel).toBe(45);
+  expect(trait.source.requiredClassLevel).toBe(45);
+  expect(tray.sourceMeta(trait).detail).toBe("CLASS • BARBARIAN LV.45");
 });
 
 test("los filtros no eliminan Traits pasivas de la colección", () => {
@@ -46,6 +87,7 @@ test("la UI declara Stats y Traits y carga su stylesheet dedicado", () => {
   expect(js).toContain('["traits", "Traits"]');
   expect(js).toContain('css/player-trait-tabs.css');
   expect(js).toContain('player-trait-filter');
+  expect(js).toContain('requiredClassLevel');
   expect(css).toContain('.player-stats-view-tab');
   expect(css).toContain('.player-trait-card[data-trait-category="racial"]');
   expect(css).toContain('.player-trait-card[data-trait-category="class"]');

--- a/tests/player_trait_tabs.spec.js
+++ b/tests/player_trait_tabs.spec.js
@@ -1,0 +1,53 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const tray = require(path.join(__dirname, "..", "js", "trait-player-tray.js"));
+const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
+
+test("Traits se clasifican por origen para la pestaña del jugador", () => {
+  const cases = [
+    [{ source: { type: "race", id: "lizalin" } }, "racial"],
+    [{ source: { type: "class", id: "barbarian" } }, "class"],
+    [{ source: { type: "archetype", id: "berserker", classId: "barbarian" } }, "archetype"],
+    [{ source: { type: "background", id: "soldier" } }, "background"],
+    [{ source: { type: "general", id: "alert" } }, "general"],
+    [{ source: { type: "special", id: "campaign" } }, "other"],
+  ];
+
+  cases.forEach(([trait, expected]) => expect(tray.sourceCategory(trait)).toBe(expected));
+});
+
+test("la etiqueta conserva origen, clase padre y nivel cuando existen", () => {
+  expect(tray.sourceMeta({ source: { type: "class", id: "barbarian", requiredLevel: 45 } }).detail)
+    .toBe("CLASS • BARBARIAN LV.45");
+
+  expect(tray.sourceMeta({ source: { type: "archetype", id: "berserker", classId: "barbarian", requiredClassLevel: 15 } }).detail)
+    .toBe("ARCHETYPE • BERSERKER · BARBARIAN LV.15");
+});
+
+test("los filtros no eliminan Traits pasivas de la colección", () => {
+  const traits = [
+    { id: "racial", source: { type: "race", id: "lizalin" }, activation: { type: "passive" } },
+    { id: "class", source: { type: "class", id: "barbarian" }, activation: { type: "manual" } },
+    { id: "general", source: { type: "general", id: "alert" }, activation: { type: "passive" } },
+  ];
+
+  expect(tray.filterTraits(traits, "all")).toHaveLength(3);
+  expect(tray.filterTraits(traits, "racial").map((trait) => trait.id)).toEqual(["racial"]);
+  expect(tray.filterTraits(traits, "general").map((trait) => trait.id)).toEqual(["general"]);
+});
+
+test("la UI declara Stats y Traits y carga su stylesheet dedicado", () => {
+  const js = read("js/trait-player-tray.js");
+  const css = read("css/player-trait-tabs.css");
+
+  expect(js).toContain('["stats", "Stats"]');
+  expect(js).toContain('["traits", "Traits"]');
+  expect(js).toContain('css/player-trait-tabs.css');
+  expect(js).toContain('player-trait-filter');
+  expect(css).toContain('.player-stats-view-tab');
+  expect(css).toContain('.player-trait-card[data-trait-category="racial"]');
+  expect(css).toContain('.player-trait-card[data-trait-category="class"]');
+  expect(css).toContain('.player-trait-card[data-trait-category="general"]');
+});


### PR DESCRIPTION
## Summary
- adds a dedicated **Traits** tab beside **Stats** in the player character sheet
- lists every resolved Trait, including passive and automatic Traits, instead of only manual actions
- groups and filters Traits by source: Racial, Class, Archetype, Background, General, and Other
- shows source metadata, activation type, contexts, optional unlock level, usage counters, and manual activation controls
- keeps the existing Trait runtime/engine as the single source of truth

## Implementation
- extends `js/trait-player-tray.js` to mount the Stats/Traits tab switcher and full Trait catalog
- adds `css/player-trait-tabs.css` scoped to the player Stats modal
- adds regression tests for source classification, labels, filtering, and UI assets

## Checks
- `node --check` passes for the updated tray and new spec
- helper checks pass for Racial/Class/Archetype/Background/General/Other classification and filtering
- CSS brace balance checked locally

This is intentionally scoped to presentation and organization; existing Trait grant resolution and activation rules are reused rather than duplicated.