### PR TITLE
Archetypes: Path of the Devil Lineage + lifecycle/rest foundation

### DIFF
--- a/.github/workflows/archetype-engine.yml
+++ b/.github/workflows/archetype-engine.yml
@@ -8,6 +8,8 @@ on:
       - "Battle-viewer.html"
       - "js/status-engine.js"
       - "js/death-save-runtime.js"
+      - "js/anatomy-equipment-engine.js"
+      - "js/injury-engine.js"
       - "js/archetype-engine.js"
       - "js/archetype-trait-catalog.js"
       - "js/player-archetype-runtime.js"
@@ -17,8 +19,11 @@ on:
       - "css/player-archetype-runtime.css"
       - "js/utils.js"
       - "docs/rest-system.md"
+      - "docs/injury-equipment-system.md"
       - "tests/death_save_runtime.spec.js"
       - "tests/death_save_trait_modifiers.spec.js"
+      - "tests/anatomy_equipment_engine.spec.js"
+      - "tests/injury_engine.spec.js"
       - "tests/archetype_engine.spec.js"
       - "tests/archetype_runtime_contract.spec.js"
       - "tests/archetype_review_regressions.spec.js"
@@ -30,6 +35,8 @@ on:
       - "Battle-viewer.html"
       - "js/status-engine.js"
       - "js/death-save-runtime.js"
+      - "js/anatomy-equipment-engine.js"
+      - "js/injury-engine.js"
       - "js/archetype-engine.js"
       - "js/archetype-trait-catalog.js"
       - "js/player-archetype-runtime.js"
@@ -39,8 +46,11 @@ on:
       - "css/player-archetype-runtime.css"
       - "js/utils.js"
       - "docs/rest-system.md"
+      - "docs/injury-equipment-system.md"
       - "tests/death_save_runtime.spec.js"
       - "tests/death_save_trait_modifiers.spec.js"
+      - "tests/anatomy_equipment_engine.spec.js"
+      - "tests/injury_engine.spec.js"
       - "tests/archetype_engine.spec.js"
       - "tests/archetype_runtime_contract.spec.js"
       - "tests/archetype_review_regressions.spec.js"
@@ -71,6 +81,8 @@ jobs:
         run: |
           node --check js/status-engine.js
           node --check js/death-save-runtime.js
+          node --check js/anatomy-equipment-engine.js
+          node --check js/injury-engine.js
           node --check js/archetype-engine.js
           node --check js/archetype-trait-catalog.js
           node --check js/player-archetype-runtime.js
@@ -80,6 +92,8 @@ jobs:
           node --check js/utils.js
           node --check tests/death_save_runtime.spec.js
           node --check tests/death_save_trait_modifiers.spec.js
+          node --check tests/anatomy_equipment_engine.spec.js
+          node --check tests/injury_engine.spec.js
           node --check tests/archetype_engine.spec.js
           node --check tests/archetype_runtime_contract.spec.js
           node --check tests/archetype_review_regressions.spec.js
@@ -91,6 +105,8 @@ jobs:
           npx playwright test
           tests/death_save_runtime.spec.js
           tests/death_save_trait_modifiers.spec.js
+          tests/anatomy_equipment_engine.spec.js
+          tests/injury_engine.spec.js
           tests/archetype_engine.spec.js
           tests/archetype_runtime_contract.spec.js
           tests/archetype_review_regressions.spec.js

--- a/.github/workflows/archetype-engine.yml
+++ b/.github/workflows/archetype-engine.yml
@@ -10,6 +10,7 @@ on:
       - "js/archetype-engine.js"
       - "js/archetype-trait-catalog.js"
       - "js/player-archetype-runtime.js"
+      - "js/archetype-combat-event-runtime.js"
       - "css/player-archetype-runtime.css"
       - "js/utils.js"
       - "tests/archetype_engine.spec.js"
@@ -23,6 +24,7 @@ on:
       - "js/archetype-engine.js"
       - "js/archetype-trait-catalog.js"
       - "js/player-archetype-runtime.js"
+      - "js/archetype-combat-event-runtime.js"
       - "css/player-archetype-runtime.css"
       - "js/utils.js"
       - "tests/archetype_engine.spec.js"
@@ -55,6 +57,7 @@ jobs:
           node --check js/archetype-engine.js
           node --check js/archetype-trait-catalog.js
           node --check js/player-archetype-runtime.js
+          node --check js/archetype-combat-event-runtime.js
           node --check js/utils.js
           node --check tests/archetype_engine.spec.js
           node --check tests/archetype_runtime_contract.spec.js

--- a/.github/workflows/archetype-engine.yml
+++ b/.github/workflows/archetype-engine.yml
@@ -18,6 +18,7 @@ on:
       - "js/utils.js"
       - "docs/rest-system.md"
       - "tests/death_save_runtime.spec.js"
+      - "tests/death_save_trait_modifiers.spec.js"
       - "tests/archetype_engine.spec.js"
       - "tests/archetype_runtime_contract.spec.js"
       - "tests/archetype_review_regressions.spec.js"
@@ -39,6 +40,7 @@ on:
       - "js/utils.js"
       - "docs/rest-system.md"
       - "tests/death_save_runtime.spec.js"
+      - "tests/death_save_trait_modifiers.spec.js"
       - "tests/archetype_engine.spec.js"
       - "tests/archetype_runtime_contract.spec.js"
       - "tests/archetype_review_regressions.spec.js"
@@ -77,6 +79,7 @@ jobs:
           node --check js/rest-runtime-integration.js
           node --check js/utils.js
           node --check tests/death_save_runtime.spec.js
+          node --check tests/death_save_trait_modifiers.spec.js
           node --check tests/archetype_engine.spec.js
           node --check tests/archetype_runtime_contract.spec.js
           node --check tests/archetype_review_regressions.spec.js
@@ -87,6 +90,7 @@ jobs:
         run: >-
           npx playwright test
           tests/death_save_runtime.spec.js
+          tests/death_save_trait_modifiers.spec.js
           tests/archetype_engine.spec.js
           tests/archetype_runtime_contract.spec.js
           tests/archetype_review_regressions.spec.js

--- a/.github/workflows/archetype-engine.yml
+++ b/.github/workflows/archetype-engine.yml
@@ -12,12 +12,17 @@ on:
       - "js/archetype-trait-catalog.js"
       - "js/player-archetype-runtime.js"
       - "js/archetype-combat-event-runtime.js"
+      - "js/rest-engine.js"
+      - "js/rest-runtime-integration.js"
       - "css/player-archetype-runtime.css"
       - "js/utils.js"
+      - "docs/rest-system.md"
       - "tests/death_save_runtime.spec.js"
       - "tests/archetype_engine.spec.js"
       - "tests/archetype_runtime_contract.spec.js"
       - "tests/archetype_review_regressions.spec.js"
+      - "tests/rest_engine.spec.js"
+      - "tests/rest_runtime_contract.spec.js"
       - ".github/workflows/archetype-engine.yml"
   pull_request:
     paths:
@@ -28,12 +33,17 @@ on:
       - "js/archetype-trait-catalog.js"
       - "js/player-archetype-runtime.js"
       - "js/archetype-combat-event-runtime.js"
+      - "js/rest-engine.js"
+      - "js/rest-runtime-integration.js"
       - "css/player-archetype-runtime.css"
       - "js/utils.js"
+      - "docs/rest-system.md"
       - "tests/death_save_runtime.spec.js"
       - "tests/archetype_engine.spec.js"
       - "tests/archetype_runtime_contract.spec.js"
       - "tests/archetype_review_regressions.spec.js"
+      - "tests/rest_engine.spec.js"
+      - "tests/rest_runtime_contract.spec.js"
       - ".github/workflows/archetype-engine.yml"
 
 permissions:
@@ -63,11 +73,15 @@ jobs:
           node --check js/archetype-trait-catalog.js
           node --check js/player-archetype-runtime.js
           node --check js/archetype-combat-event-runtime.js
+          node --check js/rest-engine.js
+          node --check js/rest-runtime-integration.js
           node --check js/utils.js
           node --check tests/death_save_runtime.spec.js
           node --check tests/archetype_engine.spec.js
           node --check tests/archetype_runtime_contract.spec.js
           node --check tests/archetype_review_regressions.spec.js
+          node --check tests/rest_engine.spec.js
+          node --check tests/rest_runtime_contract.spec.js
 
       - name: Run Archetype regressions
         run: >-
@@ -76,6 +90,8 @@ jobs:
           tests/archetype_engine.spec.js
           tests/archetype_runtime_contract.spec.js
           tests/archetype_review_regressions.spec.js
+          tests/rest_engine.spec.js
+          tests/rest_runtime_contract.spec.js
           tests/trait_engine.spec.js
           tests/player_trait_tabs.spec.js
           tests/barbarian_trait_rules_runtime.spec.js

--- a/.github/workflows/archetype-engine.yml
+++ b/.github/workflows/archetype-engine.yml
@@ -7,12 +7,14 @@ on:
     paths:
       - "Battle-viewer.html"
       - "js/status-engine.js"
+      - "js/death-save-runtime.js"
       - "js/archetype-engine.js"
       - "js/archetype-trait-catalog.js"
       - "js/player-archetype-runtime.js"
       - "js/archetype-combat-event-runtime.js"
       - "css/player-archetype-runtime.css"
       - "js/utils.js"
+      - "tests/death_save_runtime.spec.js"
       - "tests/archetype_engine.spec.js"
       - "tests/archetype_runtime_contract.spec.js"
       - "tests/archetype_review_regressions.spec.js"
@@ -21,12 +23,14 @@ on:
     paths:
       - "Battle-viewer.html"
       - "js/status-engine.js"
+      - "js/death-save-runtime.js"
       - "js/archetype-engine.js"
       - "js/archetype-trait-catalog.js"
       - "js/player-archetype-runtime.js"
       - "js/archetype-combat-event-runtime.js"
       - "css/player-archetype-runtime.css"
       - "js/utils.js"
+      - "tests/death_save_runtime.spec.js"
       - "tests/archetype_engine.spec.js"
       - "tests/archetype_runtime_contract.spec.js"
       - "tests/archetype_review_regressions.spec.js"
@@ -54,11 +58,13 @@ jobs:
       - name: Check syntax
         run: |
           node --check js/status-engine.js
+          node --check js/death-save-runtime.js
           node --check js/archetype-engine.js
           node --check js/archetype-trait-catalog.js
           node --check js/player-archetype-runtime.js
           node --check js/archetype-combat-event-runtime.js
           node --check js/utils.js
+          node --check tests/death_save_runtime.spec.js
           node --check tests/archetype_engine.spec.js
           node --check tests/archetype_runtime_contract.spec.js
           node --check tests/archetype_review_regressions.spec.js
@@ -66,6 +72,7 @@ jobs:
       - name: Run Archetype regressions
         run: >-
           npx playwright test
+          tests/death_save_runtime.spec.js
           tests/archetype_engine.spec.js
           tests/archetype_runtime_contract.spec.js
           tests/archetype_review_regressions.spec.js

--- a/.github/workflows/archetype-engine.yml
+++ b/.github/workflows/archetype-engine.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - feature/archetypes-devil-lineage
     paths:
+      - "Battle-viewer.html"
+      - "js/status-engine.js"
       - "js/archetype-engine.js"
       - "js/archetype-trait-catalog.js"
       - "js/player-archetype-runtime.js"
@@ -12,9 +14,12 @@ on:
       - "js/utils.js"
       - "tests/archetype_engine.spec.js"
       - "tests/archetype_runtime_contract.spec.js"
+      - "tests/archetype_review_regressions.spec.js"
       - ".github/workflows/archetype-engine.yml"
   pull_request:
     paths:
+      - "Battle-viewer.html"
+      - "js/status-engine.js"
       - "js/archetype-engine.js"
       - "js/archetype-trait-catalog.js"
       - "js/player-archetype-runtime.js"
@@ -22,6 +27,7 @@ on:
       - "js/utils.js"
       - "tests/archetype_engine.spec.js"
       - "tests/archetype_runtime_contract.spec.js"
+      - "tests/archetype_review_regressions.spec.js"
       - ".github/workflows/archetype-engine.yml"
 
 permissions:
@@ -45,18 +51,25 @@ jobs:
 
       - name: Check syntax
         run: |
+          node --check js/status-engine.js
           node --check js/archetype-engine.js
           node --check js/archetype-trait-catalog.js
           node --check js/player-archetype-runtime.js
           node --check js/utils.js
           node --check tests/archetype_engine.spec.js
           node --check tests/archetype_runtime_contract.spec.js
+          node --check tests/archetype_review_regressions.spec.js
 
       - name: Run Archetype regressions
         run: >-
           npx playwright test
           tests/archetype_engine.spec.js
           tests/archetype_runtime_contract.spec.js
+          tests/archetype_review_regressions.spec.js
           tests/trait_engine.spec.js
           tests/player_trait_tabs.spec.js
+          tests/barbarian_trait_rules_runtime.spec.js
+          tests/universal_modifier_engine.spec.js
+          tests/universal_speed_runtime.spec.js
+          tests/trait_standardization_review_fixes.spec.js
           --workers=1

--- a/.github/workflows/archetype-engine.yml
+++ b/.github/workflows/archetype-engine.yml
@@ -1,0 +1,62 @@
+name: Archetype Engine
+
+on:
+  push:
+    branches:
+      - feature/archetypes-devil-lineage
+    paths:
+      - "js/archetype-engine.js"
+      - "js/archetype-trait-catalog.js"
+      - "js/player-archetype-runtime.js"
+      - "css/player-archetype-runtime.css"
+      - "js/utils.js"
+      - "tests/archetype_engine.spec.js"
+      - "tests/archetype_runtime_contract.spec.js"
+      - ".github/workflows/archetype-engine.yml"
+  pull_request:
+    paths:
+      - "js/archetype-engine.js"
+      - "js/archetype-trait-catalog.js"
+      - "js/player-archetype-runtime.js"
+      - "css/player-archetype-runtime.css"
+      - "js/utils.js"
+      - "tests/archetype_engine.spec.js"
+      - "tests/archetype_runtime_contract.spec.js"
+      - ".github/workflows/archetype-engine.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  archetype-regressions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check syntax
+        run: |
+          node --check js/archetype-engine.js
+          node --check js/archetype-trait-catalog.js
+          node --check js/player-archetype-runtime.js
+          node --check js/utils.js
+          node --check tests/archetype_engine.spec.js
+          node --check tests/archetype_runtime_contract.spec.js
+
+      - name: Run Archetype regressions
+        run: >-
+          npx playwright test
+          tests/archetype_engine.spec.js
+          tests/archetype_runtime_contract.spec.js
+          tests/trait_engine.spec.js
+          tests/player_trait_tabs.spec.js
+          --workers=1

--- a/.github/workflows/archetype-engine.yml
+++ b/.github/workflows/archetype-engine.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "Battle-viewer.html"
       - "js/status-engine.js"
+      - "js/fixed-damage-runtime.js"
       - "js/death-save-runtime.js"
       - "js/anatomy-equipment-engine.js"
       - "js/injury-engine.js"
@@ -21,6 +22,7 @@ on:
       - "js/utils.js"
       - "docs/rest-system.md"
       - "docs/injury-equipment-system.md"
+      - "docs/fixed-damage.md"
       - "tests/death_save_runtime.spec.js"
       - "tests/death_save_trait_modifiers.spec.js"
       - "tests/anatomy_equipment_engine.spec.js"
@@ -31,11 +33,13 @@ on:
       - "tests/devil_lineage_completion.spec.js"
       - "tests/rest_engine.spec.js"
       - "tests/rest_runtime_contract.spec.js"
+      - "tests/fixed_damage_runtime.test.js"
       - ".github/workflows/archetype-engine.yml"
   pull_request:
     paths:
       - "Battle-viewer.html"
       - "js/status-engine.js"
+      - "js/fixed-damage-runtime.js"
       - "js/death-save-runtime.js"
       - "js/anatomy-equipment-engine.js"
       - "js/injury-engine.js"
@@ -50,6 +54,7 @@ on:
       - "js/utils.js"
       - "docs/rest-system.md"
       - "docs/injury-equipment-system.md"
+      - "docs/fixed-damage.md"
       - "tests/death_save_runtime.spec.js"
       - "tests/death_save_trait_modifiers.spec.js"
       - "tests/anatomy_equipment_engine.spec.js"
@@ -60,6 +65,7 @@ on:
       - "tests/devil_lineage_completion.spec.js"
       - "tests/rest_engine.spec.js"
       - "tests/rest_runtime_contract.spec.js"
+      - "tests/fixed_damage_runtime.test.js"
       - ".github/workflows/archetype-engine.yml"
 
 permissions:
@@ -84,6 +90,7 @@ jobs:
       - name: Check syntax
         run: |
           node --check js/status-engine.js
+          node --check js/fixed-damage-runtime.js
           node --check js/death-save-runtime.js
           node --check js/anatomy-equipment-engine.js
           node --check js/injury-engine.js
@@ -105,6 +112,10 @@ jobs:
           node --check tests/devil_lineage_completion.spec.js
           node --check tests/rest_engine.spec.js
           node --check tests/rest_runtime_contract.spec.js
+          node --check tests/fixed_damage_runtime.test.js
+
+      - name: Run Fixed Damage contract
+        run: node tests/fixed_damage_runtime.test.js
 
       - name: Run Archetype regressions
         run: >-

--- a/.github/workflows/archetype-engine.yml
+++ b/.github/workflows/archetype-engine.yml
@@ -14,6 +14,7 @@ on:
       - "js/archetype-trait-catalog.js"
       - "js/player-archetype-runtime.js"
       - "js/archetype-combat-event-runtime.js"
+      - "js/devil-lineage-runtime.js"
       - "js/rest-engine.js"
       - "js/rest-runtime-integration.js"
       - "css/player-archetype-runtime.css"
@@ -27,6 +28,7 @@ on:
       - "tests/archetype_engine.spec.js"
       - "tests/archetype_runtime_contract.spec.js"
       - "tests/archetype_review_regressions.spec.js"
+      - "tests/devil_lineage_completion.spec.js"
       - "tests/rest_engine.spec.js"
       - "tests/rest_runtime_contract.spec.js"
       - ".github/workflows/archetype-engine.yml"
@@ -41,6 +43,7 @@ on:
       - "js/archetype-trait-catalog.js"
       - "js/player-archetype-runtime.js"
       - "js/archetype-combat-event-runtime.js"
+      - "js/devil-lineage-runtime.js"
       - "js/rest-engine.js"
       - "js/rest-runtime-integration.js"
       - "css/player-archetype-runtime.css"
@@ -54,6 +57,7 @@ on:
       - "tests/archetype_engine.spec.js"
       - "tests/archetype_runtime_contract.spec.js"
       - "tests/archetype_review_regressions.spec.js"
+      - "tests/devil_lineage_completion.spec.js"
       - "tests/rest_engine.spec.js"
       - "tests/rest_runtime_contract.spec.js"
       - ".github/workflows/archetype-engine.yml"
@@ -87,6 +91,7 @@ jobs:
           node --check js/archetype-trait-catalog.js
           node --check js/player-archetype-runtime.js
           node --check js/archetype-combat-event-runtime.js
+          node --check js/devil-lineage-runtime.js
           node --check js/rest-engine.js
           node --check js/rest-runtime-integration.js
           node --check js/utils.js
@@ -97,6 +102,7 @@ jobs:
           node --check tests/archetype_engine.spec.js
           node --check tests/archetype_runtime_contract.spec.js
           node --check tests/archetype_review_regressions.spec.js
+          node --check tests/devil_lineage_completion.spec.js
           node --check tests/rest_engine.spec.js
           node --check tests/rest_runtime_contract.spec.js
 
@@ -110,6 +116,7 @@ jobs:
           tests/archetype_engine.spec.js
           tests/archetype_runtime_contract.spec.js
           tests/archetype_review_regressions.spec.js
+          tests/devil_lineage_completion.spec.js
           tests/rest_engine.spec.js
           tests/rest_runtime_contract.spec.js
           tests/trait_engine.spec.js

--- a/css/player-archetype-runtime.css
+++ b/css/player-archetype-runtime.css
@@ -1,0 +1,21 @@
+.player-archetype-selector{display:grid;gap:10px;margin:0 0 14px;padding:12px;border:1px solid rgba(255,255,255,.12);background:rgba(7,9,12,.72)}
+.player-archetype-selector__head{display:flex;align-items:flex-end;justify-content:space-between;gap:12px;padding-bottom:8px;border-bottom:1px solid rgba(255,255,255,.1)}
+.player-archetype-selector__head strong{font-size:13px;letter-spacing:.12em;text-transform:uppercase}
+.player-archetype-selector__head span{font-size:11px;opacity:.68;text-align:right}
+.player-archetype-selector__row{display:grid;grid-template-columns:minmax(130px,.7fr) minmax(0,1.3fr);gap:12px;align-items:center;padding:9px 10px;border:1px solid rgba(255,255,255,.08);background:rgba(255,255,255,.025)}
+.player-archetype-selector__class{display:grid;gap:2px}
+.player-archetype-selector__class b{font-size:12px;text-transform:uppercase;letter-spacing:.08em}
+.player-archetype-selector__class span{font-size:10px;opacity:.62}
+.player-archetype-selector__choices{display:flex;flex-wrap:wrap;gap:7px;justify-content:flex-end}
+.player-archetype-selector__choice,.player-archetype-subtab{appearance:none;border:1px solid rgba(255,255,255,.16);background:rgba(255,255,255,.045);color:inherit;font:inherit;cursor:pointer;transition:border-color .15s ease,background .15s ease,transform .15s ease}
+.player-archetype-selector__choice{padding:7px 10px;font-size:11px;letter-spacing:.04em}
+.player-archetype-selector__choice:hover:not(:disabled),.player-archetype-subtab:hover{border-color:rgba(255,255,255,.34);background:rgba(255,255,255,.08)}
+.player-archetype-selector__choice:active:not(:disabled),.player-archetype-subtab:active{transform:translateY(1px)}
+.player-archetype-selector__choice:disabled{cursor:not-allowed;opacity:.45}
+.player-archetype-selector__selected{display:inline-flex;align-items:center;min-height:30px;padding:5px 10px;border:1px solid rgba(255,255,255,.22);background:rgba(255,255,255,.07);font-size:11px;font-weight:700;letter-spacing:.05em;text-transform:uppercase}
+.player-archetype-subtabs{display:flex;flex-wrap:wrap;gap:7px;margin:8px 0 12px;padding:8px;border:1px solid rgba(255,255,255,.09);background:rgba(0,0,0,.18)}
+.player-archetype-subtab{display:inline-flex;align-items:center;gap:8px;padding:7px 10px;font-size:11px;text-transform:uppercase;letter-spacing:.05em}
+.player-archetype-subtab b{display:inline-grid;place-items:center;min-width:20px;height:20px;padding:0 5px;border-radius:10px;background:rgba(255,255,255,.1);font-size:10px}
+.player-archetype-subtab.is-active{border-color:currentColor;background:rgba(255,255,255,.1);font-weight:700}
+.player-trait-card[hidden]{display:none!important}
+@media(max-width:700px){.player-archetype-selector__head{align-items:flex-start;flex-direction:column}.player-archetype-selector__head span{text-align:left}.player-archetype-selector__row{grid-template-columns:1fr}.player-archetype-selector__choices{justify-content:flex-start}.player-archetype-subtabs{overflow-x:auto;flex-wrap:nowrap}.player-archetype-subtab{flex:0 0 auto}}

--- a/docs/fixed-damage.md
+++ b/docs/fixed-damage.md
@@ -1,0 +1,54 @@
+# Fixed Damage
+
+## Canonical contract
+
+Luminous has two damage modes. The mode is independent from kinetic damage type (`tipo_dano`) and Sin affinity.
+
+- `damageMode: "normal"` is the default and keeps the existing damage calculation unchanged.
+- `damageMode: "fixed"` is still ordinary damage, but defensive mechanics cannot reduce its amount.
+
+Fixed Damage is **not** direct HP loss, soul damage, or a Shield bypass. After its amount is calculated it continues through the same `applyDamage` path as Normal Damage.
+
+## Defensive reductions
+
+For Fixed Damage, defender-originated reductions are neutralized instead of being allowed to lower the hit:
+
+- Physical Resistance below neutral cannot reduce it.
+- Sin Resistance below neutral cannot reduce it.
+- A higher Defensive Level cannot reduce it below the attacker-side result.
+- positive `damage_taken_multiplier` reduction cannot reduce it.
+
+Vulnerabilities and other effects that increase damage are still allowed to increase Fixed Damage. Offensive bonuses, Crit, Clash and other attacker-side damage logic continue to work normally.
+
+## Shield, HP and combat events
+
+Fixed Damage keeps the normal damage application path:
+
+1. Shield absorbs as much of the damage as it can.
+2. Remaining damage is applied to HP.
+3. Direct-damage/Stagger handling remains active.
+4. Existing Hit/Damage lifecycle and combat bookkeeping remain applicable.
+
+Example: 50 Fixed Damage against 30 Shield and 100 HP leaves 0 Shield and 80 HP. Resistances cannot turn the 50 into a lower value before the Shield receives it.
+
+## Skill schema
+
+```js
+{
+  tipo_dano: "cortante",
+  pecado: "wrath",
+  damageMode: "fixed"
+}
+```
+
+`tipo_dano` continues to describe Cortante/Perforante/Contundente. `damageMode` describes whether defender-side reductions may mitigate the damage.
+
+Skills without `damageMode` are treated as `normal` for backward compatibility.
+
+## Path of the Devil Lineage
+
+`Power of the Nine Hells` uses the same Fixed Damage contract for its existing mechanic:
+
+`On Hit, STR Skills deal (STR Mod × 2)% Fixed Damage.`
+
+The additional component is Fixed Damage, but it is still absorbed by Shield before it reaches HP.

--- a/docs/rest-system.md
+++ b/docs/rest-system.md
@@ -1,0 +1,106 @@
+# Rest & Recover System
+
+This document is the canonical implementation contract for Luminous rests.
+
+## Recover Slots
+
+Recover Slots belong to a **Class**, not to total Character Level.
+
+```text
+Max Recover Slots = floor(Class Level / 5)
+```
+
+Multiclass characters therefore maintain one independent pool per Class. The Class Base HP used by Recover is the existing `hpPer5` value from `js/character-build-rules.js` (for example, Barbarian = 12).
+
+A normal spent Recover Slot is restored by a Long Rest. A Trait may explicitly Block a spent Recover Slot for more than one Long Rest; blocked slots remain unavailable until their Long-Rest counter reaches zero.
+
+## Recover action
+
+Each Recover action chooses one Class and spends one or more available Recover Slots from that Class.
+
+```text
+Recovered HP = 5 + (Class Base HP × Recover Slots spent in this Recover action)
+```
+
+The flat `+5` is applied **once per Recover action**, not once per slot. Two separate 1-slot Recover actions therefore receive the `+5` twice.
+
+Healing can never raise the unit above Max HP.
+
+## Short Rest
+
+Duration: **1–2 in-world hours**. The DM and players decide the exact duration within that range.
+
+A Short Rest does not restore Recover Slots by itself. Players may spend their remaining Recover Slots during the rest.
+
+Traits do not automatically regain uses during a Short Rest. A Trait must explicitly opt in:
+
+```text
+[On Short Rest] Recover X Uses.
+[On Short Rest] Recover All Uses.
+```
+
+The canonical data representations are:
+
+```js
+activation: { uses: { recoverOnShortRest: X } }
+```
+
+or, for all uses, the existing reset declaration:
+
+```js
+activation: { uses: { reset: "short_rest" } }
+```
+
+Short-Rest-triggered Trait effects still use the existing `short_rest` Trait trigger.
+
+### Augmentation recovery
+
+Only Augments may add Max-HP-based recovery to a Short Rest. An Augment declares:
+
+```js
+mechanics: { shortRestRecoveryPercent: X }
+```
+
+All applicable Augment percentages are added together, then globally capped:
+
+```text
+Combined Short Rest Augment Bonus <= 5% Max HP
+```
+
+The cap is global, not per Augment. This bonus applies only to a Recover made in `short_rest` context. A Trait that performs a Recover during combat does not receive the Short Rest Augment bonus.
+
+## Long Rest
+
+Duration: **6–8 in-world hours**. The DM and players decide the exact duration within that range.
+
+A completed Long Rest:
+
+- restores HP to Max HP;
+- restores all normally spent Recover Slots;
+- advances multi-Long-Rest Blocked Recover Slot counters;
+- restores all Trait uses;
+- executes effects/counters explicitly bound to the `long_rest` Trait trigger/reset scope.
+
+There is intentionally **no daily cooldown or once-per-24-hours restriction**. Players may Long Rest repeatedly. The balancing cost is world time: each rest consumes its full 6–8 hours while the campaign world, factions, opportunities, EXP sources and resources may continue changing.
+
+## World-time integration
+
+`LuminousRestRuntime` emits:
+
+```text
+luminous:rest-completed
+luminous:world-time-advance-requested
+```
+
+The world-time event includes the rest type and exact number of hours. The Rest system does not invent or directly mutate a campaign calendar; the world/time subsystem owns that state and can consume this event.
+
+## Improved Demonic Resistance
+
+`Path of the Devil Lineage` already defines:
+
+```text
+Quick Action: Spend 1 Recover Slot and perform that Recover immediately.
+The used Recover Slot becomes Blocked until 2 Long Rests are completed.
+```
+
+`js/rest-runtime-integration.js` connects that Trait to the real Recover resource. Activation is rejected before spending the Quick Action if the source Class has no available Recover Slot. On success it performs a normal 1-slot Recover using the Class Base HP and blocks that slot for exactly two completed Long Rests.

--- a/js/anatomy-equipment-engine.js
+++ b/js/anatomy-equipment-engine.js
@@ -1,0 +1,489 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousAnatomyEquipmentEngine) return;
+
+  const VALID_STATES = new Set(["available", "disabled", "missing", "replaced"]);
+  const VALID_SUBSTRATES = new Set(["biological", "mechanical"]);
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const asArray = (value) => value == null ? [] : (Array.isArray(value) ? value : [value]);
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+  function emit(name, detail) {
+    try {
+      if (typeof global.dispatchEvent === "function" && typeof global.CustomEvent === "function") {
+        global.dispatchEvent(new global.CustomEvent(name, { detail }));
+      }
+    } catch (_) {}
+    return detail;
+  }
+
+  function createAnatomy() {
+    return { version: 1, parts: {}, order: [] };
+  }
+
+  function uniquePartId(anatomy, wanted) {
+    const base = normalizeId(wanted || "part") || "part";
+    if (!anatomy.parts[base]) return base;
+    let index = 2;
+    while (anatomy.parts[`${base}_${index}`]) index += 1;
+    return `${base}_${index}`;
+  }
+
+  function addPart(anatomy, spec = {}) {
+    if (!anatomy || typeof anatomy !== "object") anatomy = createAnatomy();
+    if (!anatomy.parts || typeof anatomy.parts !== "object") anatomy.parts = {};
+    if (!Array.isArray(anatomy.order)) anatomy.order = [];
+
+    const type = normalizeId(spec.type || spec.slotType || spec.id || "part");
+    const side = normalizeId(spec.side || "none");
+    const suggested = spec.id || [side !== "none" ? side : null, type].filter(Boolean).join("_");
+    const id = uniquePartId(anatomy, suggested);
+    const parentId = spec.parentId ? normalizeId(spec.parentId) : null;
+    const state = VALID_STATES.has(normalizeId(spec.state)) ? normalizeId(spec.state) : "available";
+    const substrate = VALID_SUBSTRATES.has(normalizeId(spec.substrate)) ? normalizeId(spec.substrate) : "biological";
+
+    anatomy.parts[id] = {
+      id,
+      type,
+      side,
+      parentId,
+      state,
+      substrate,
+      canHoldItem: spec.canHoldItem === true || type === "hand",
+      handEquivalent: spec.handEquivalent === true || type === "hand",
+      tags: asArray(spec.tags).map(normalizeId).filter(Boolean),
+      source: normalizeId(spec.source || "base"),
+      metadata: clone(spec.metadata || {}),
+    };
+    anatomy.order.push(id);
+    return anatomy.parts[id];
+  }
+
+  function addFingerSet(anatomy, handId, side, count = 5, options = {}) {
+    const total = Math.max(0, Math.trunc(numberOr(count, 5)));
+    const result = [];
+    for (let index = 1; index <= total; index += 1) {
+      result.push(addPart(anatomy, {
+        id: `${side || "extra"}_finger_${index}`,
+        type: "finger",
+        side: side || "none",
+        parentId: handId,
+        substrate: options.substrate || "biological",
+        source: options.source || "base",
+      }));
+    }
+    return result;
+  }
+
+  function addArmBranch(anatomy, spec = {}) {
+    const side = normalizeId(spec.side || "extra");
+    const source = spec.source || "extra";
+    const substrate = spec.substrate || "biological";
+    const arm = addPart(anatomy, {
+      id: spec.id || `${side}_arm`, type: "arm", side, parentId: spec.parentId || "torso", substrate, source,
+    });
+    if (spec.withHand === false) return { arm, hand: null, fingers: [] };
+    const hand = addPart(anatomy, {
+      id: spec.handId || `${side}_hand`, type: "hand", side, parentId: arm.id, substrate, source, canHoldItem: true, handEquivalent: true,
+    });
+    const fingers = addFingerSet(anatomy, hand.id, side, spec.fingers ?? 5, { substrate, source });
+    return { arm, hand, fingers };
+  }
+
+  function addLegBranch(anatomy, spec = {}) {
+    const side = normalizeId(spec.side || "extra");
+    const source = spec.source || "extra";
+    const substrate = spec.substrate || "biological";
+    const leg = addPart(anatomy, {
+      id: spec.id || `${side}_leg`, type: "leg", side, parentId: spec.parentId || "torso", substrate, source,
+    });
+    if (spec.withFoot === false) return { leg, foot: null };
+    const foot = addPart(anatomy, {
+      id: spec.footId || `${side}_foot`, type: "foot", side, parentId: leg.id, substrate, source,
+    });
+    return { leg, foot };
+  }
+
+  function createHumanoidAnatomy(options = {}) {
+    const anatomy = createAnatomy();
+    addPart(anatomy, { id: "torso", type: "torso", source: "base" });
+    const head = addPart(anatomy, { id: "head", type: "head", parentId: "torso", source: "base" });
+    addPart(anatomy, { id: "left_eye", type: "eye", side: "left", parentId: head.id, source: "base" });
+    addPart(anatomy, { id: "right_eye", type: "eye", side: "right", parentId: head.id, source: "base" });
+    addArmBranch(anatomy, { side: "left", source: "base", fingers: options.fingersPerHand ?? 5 });
+    addArmBranch(anatomy, { side: "right", source: "base", fingers: options.fingersPerHand ?? 5 });
+    addLegBranch(anatomy, { side: "left", source: "base" });
+    addLegBranch(anatomy, { side: "right", source: "base" });
+    return anatomy;
+  }
+
+  function descendantsOf(anatomy, partId) {
+    const root = normalizeId(partId);
+    const found = [];
+    const visit = (parentId) => {
+      anatomy.order.forEach((id) => {
+        const part = anatomy.parts[id];
+        if (part?.parentId === parentId) {
+          found.push(id);
+          visit(id);
+        }
+      });
+    };
+    visit(root);
+    return found;
+  }
+
+  function setPartState(anatomy, partId, nextState, options = {}) {
+    const id = normalizeId(partId);
+    const state = normalizeId(nextState);
+    if (!anatomy?.parts?.[id] || !VALID_STATES.has(state)) return null;
+    const targets = [id, ...(options.cascade === false ? [] : descendantsOf(anatomy, id))];
+    targets.forEach((targetId) => {
+      const part = anatomy.parts[targetId];
+      if (!part) return;
+      part.state = state;
+      if (options.substrate && VALID_SUBSTRATES.has(normalizeId(options.substrate))) part.substrate = normalizeId(options.substrate);
+      if (options.source) part.stateSource = normalizeId(options.source);
+    });
+    return anatomy.parts[id];
+  }
+
+  function replaceBranch(anatomy, partId, options = {}) {
+    const substrate = normalizeId(options.substrate || "mechanical");
+    const root = setPartState(anatomy, partId, "replaced", { cascade: true, substrate, source: options.source || "augmentation" });
+    return root;
+  }
+
+  function restoreBranch(anatomy, partId, options = {}) {
+    const id = normalizeId(partId);
+    const root = anatomy?.parts?.[id];
+    if (!root) return { restored: false, reason: "missing_part" };
+    const method = normalizeId(options.method || "biological");
+    if (root.substrate === "mechanical" && ["biological", "regeneration", "healing"].includes(method)) {
+      return { restored: false, reason: "biological_healing_cannot_repair_mechanical", part: root };
+    }
+    if (root.substrate === "biological" && ["mechanical_repair", "repair"].includes(method) && options.allowReplacement !== true) {
+      return { restored: false, reason: "mechanical_repair_cannot_regrow_biological", part: root };
+    }
+    const substrate = options.substrate || (method === "replacement" ? "mechanical" : root.substrate);
+    const state = method === "replacement" ? "replaced" : "available";
+    setPartState(anatomy, id, state, { cascade: true, substrate, source: options.source || method });
+    return { restored: true, part: anatomy.parts[id] };
+  }
+
+  function isPartUsable(part) {
+    return Boolean(part) && ["available", "replaced"].includes(normalizeId(part.state));
+  }
+
+  function partsByType(anatomy, type, options = {}) {
+    const wanted = normalizeId(type);
+    return (anatomy?.order || []).map((id) => anatomy.parts[id]).filter((part) => {
+      if (!part || part.type !== wanted) return false;
+      return options.usableOnly === false ? true : isPartUsable(part);
+    });
+  }
+
+  function addBodyGrant(anatomy, rawGrant, options = {}) {
+    if (!rawGrant) return [];
+    const grant = typeof rawGrant === "string" ? { type: rawGrant } : rawGrant;
+    const type = normalizeId(grant.type || grant.bodyPart || grant.partType || grant.slot);
+    const source = grant.source || options.source || "grant";
+    const count = Math.max(1, Math.trunc(numberOr(grant.count, 1)));
+    const added = [];
+
+    for (let index = 0; index < count; index += 1) {
+      if (type === "arm") {
+        const side = grant.side || `extra_${partsByType(anatomy, "arm", { usableOnly: false }).length + 1}`;
+        added.push(addArmBranch(anatomy, { ...grant, side, source }));
+      } else if (type === "leg") {
+        const side = grant.side || `extra_${partsByType(anatomy, "leg", { usableOnly: false }).length + 1}`;
+        added.push(addLegBranch(anatomy, { ...grant, side, source }));
+      } else {
+        added.push(addPart(anatomy, {
+          ...grant,
+          id: grant.id || `${grant.side ? `${grant.side}_` : ""}${type || "part"}`,
+          type: type || "part",
+          parentId: grant.parentId || (type === "tail" || type === "wing" ? "torso" : grant.parentId),
+          source,
+          canHoldItem: grant.canHoldItem === true,
+          handEquivalent: grant.handEquivalent === true,
+        }));
+      }
+    }
+    return added;
+  }
+
+  function augmentationMechanics(augmentation = {}) {
+    return augmentation.mechanics || augmentation.anatomy || augmentation.bodyModification || augmentation;
+  }
+
+  function applyAugmentation(anatomy, augmentation = {}) {
+    const mechanics = augmentationMechanics(augmentation);
+    const source = augmentation.id || augmentation.name || "augmentation";
+    asArray(mechanics.addBodyParts || mechanics.addBodyPart || mechanics.addsBodyParts).forEach((grant) => addBodyGrant(anatomy, grant, { source }));
+
+    asArray(mechanics.replaceBodyPart || mechanics.replacesBodyPart || mechanics.replaces).forEach((replacement) => {
+      if (!replacement) return;
+      const partId = typeof replacement === "string" ? replacement : (replacement.partId || replacement.id || replacement.target);
+      if (!partId) return;
+      replaceBranch(anatomy, partId, {
+        substrate: typeof replacement === "object" ? (replacement.substrate || "mechanical") : "mechanical",
+        source,
+      });
+    });
+    return anatomy;
+  }
+
+  function applyInjury(anatomy, injury = {}) {
+    if (injury.active === false) return anatomy;
+    const state = normalizeId(injury.slotEffect || injury.anatomyState || (injury.structural ? "missing" : ""));
+    if (!VALID_STATES.has(state) || state === "available" || state === "replaced") return anatomy;
+    const targets = asArray(injury.affectedParts || injury.bodyPart || injury.partId).filter(Boolean);
+    targets.forEach((partId) => setPartState(anatomy, partId, state, { cascade: true, source: injury.id || injury.name || "injury" }));
+    return anatomy;
+  }
+
+  function resolveCharacterAnatomy(character = {}, options = {}) {
+    const anatomy = options.baseAnatomy ? clone(options.baseAnatomy) : createHumanoidAnatomy(options);
+    const grants = [
+      ...asArray(character.raceBodyParts),
+      ...asArray(character.extraBodyParts),
+      ...asArray(character.bodyPartsAdded),
+      ...asArray(character.anatomyGrants),
+    ];
+    grants.forEach((grant) => addBodyGrant(anatomy, grant, { source: "character" }));
+    asArray(character.augmentations || character.augments || character.bodyAugmentations).forEach((augmentation) => applyAugmentation(anatomy, augmentation));
+    asArray(character.injuries).forEach((injury) => applyInjury(anatomy, injury));
+    return anatomy;
+  }
+
+  function itemKind(item = {}) {
+    const explicit = normalizeId(item.equipment?.kind || item.equipmentSchema?.kind || item.kind || item.category || item.itemType || item.tipo || item.type || item.tag);
+    if (["weapon", "arma"].includes(explicit)) return "weapon";
+    if (["shield", "escudo"].includes(explicit)) return "shield";
+    if (["armor", "armadura"].includes(explicit)) return "armor";
+    if (["accessory", "accessories", "accesorio"].includes(explicit)) return "accessory";
+    if (["augmentation", "augment", "aumento", "alteracion_corporal"].includes(explicit)) return "augmentation";
+    return explicit || "item";
+  }
+
+  function normalizeBlocker(raw) {
+    if (typeof raw === "string") return { type: normalizeId(raw), count: Infinity };
+    return {
+      type: normalizeId(raw?.type || raw?.slot || raw?.bodyPart),
+      count: raw?.count == null ? Infinity : Math.max(0, Math.trunc(numberOr(raw.count, 0))),
+    };
+  }
+
+  function normalizeItemRequirements(item = {}, character = {}) {
+    const schema = item.equipment || item.equipmentSchema || {};
+    const kind = itemKind(item);
+    const blockers = asArray(schema.blocksAccessorySlots || item.blocksAccessorySlots || item.blocks || item.blockedAccessorySlots)
+      .map(normalizeBlocker).filter((entry) => entry.type);
+
+    let handCost = Math.max(0, Math.trunc(numberOr(schema.handCost ?? item.handCost ?? item.handsRequired, 0)));
+    if (!handCost && kind === "weapon") handCost = item.twoHanded === true || normalizeId(item.handedness) === "two_handed" ? 2 : 1;
+    if (!handCost && kind === "shield") handCost = 1;
+    const twoHandedAsOne = character?.equipmentRules?.twoHandedAsOneHanded === true
+      || character?.twoHandedAsOneHanded === true
+      || asArray(character?.traits).some((trait) => trait?.mechanics?.twoHandedAsOneHanded === true);
+    if (handCost === 2 && twoHandedAsOne) handCost = 1;
+
+    const accessoryType = normalizeId(schema.accessoryType || schema.bodySlot || item.accessorySlot || item.bodySlot || item.slotType || item.equipBodyPart);
+    let accessoryCost = Math.max(1, Math.trunc(numberOr(schema.slotCost ?? item.slotCost, 1)));
+    if (kind !== "accessory") accessoryCost = 0;
+
+    return {
+      kind,
+      handCost,
+      armorCost: kind === "armor" ? 1 : 0,
+      accessoryType: kind === "accessory" ? (accessoryType || "legacy_accessory") : null,
+      accessoryCost,
+      blockers,
+      legacySlot: normalizeId(item.equipped_slot || item.equippedSlot),
+    };
+  }
+
+  function isEquipped(item = {}) {
+    return item.equipped === true || Boolean(item.equipped_slot || item.equippedSlot || item.equippedPartIds || item.assignedBodyParts);
+  }
+
+  function equippedEntries(rawItems) {
+    const list = Array.isArray(rawItems) ? rawItems : Object.entries(rawItems || {}).map(([key, value]) => ({ key, ...(value || {}) }));
+    return list.filter((item) => item && isEquipped(item));
+  }
+
+  function blockedSetForArmor(anatomy, blockers) {
+    const blocked = new Set();
+    blockers.forEach((blocker) => {
+      const matches = partsByType(anatomy, blocker.type);
+      const count = Number.isFinite(blocker.count) ? blocker.count : matches.length;
+      matches.slice(0, count).forEach((part) => blocked.add(part.id));
+    });
+    return blocked;
+  }
+
+  function validateEquipment(character = {}, rawItems = [], options = {}) {
+    const anatomy = options.anatomy || resolveCharacterAnatomy(character, options);
+    const items = equippedEntries(rawItems);
+    const assignments = [];
+    const invalid = [];
+    const handPool = (anatomy.order || []).map((id) => anatomy.parts[id]).filter((part) => isPartUsable(part) && (part.type === "hand" || part.handEquivalent));
+    const usedHands = new Set();
+    const usedAccessoryParts = new Set();
+    const blockedAccessoryParts = new Set();
+    let armorUsed = false;
+
+    const rows = items.map((item) => ({ item, req: normalizeItemRequirements(item, character) }));
+    rows.filter((row) => row.req.kind === "armor").forEach((row) => {
+      if (armorUsed) invalid.push({ item: row.item, reason: "armor_slot_unavailable", requirements: row.req });
+      else {
+        armorUsed = true;
+        row.req.blockers.forEach((blocker) => blockedSetForArmor(anatomy, [blocker]).forEach((id) => blockedAccessoryParts.add(id)));
+        assignments.push({ item: row.item, kind: "armor", partIds: ["torso"] });
+      }
+    });
+
+    rows.filter((row) => ["weapon", "shield"].includes(row.req.kind)).forEach((row) => {
+      const free = handPool.filter((part) => !usedHands.has(part.id));
+      if (free.length < row.req.handCost) {
+        invalid.push({ item: row.item, reason: "not_enough_functional_hands", requirements: row.req });
+        return;
+      }
+      const chosen = free.slice(0, row.req.handCost);
+      chosen.forEach((part) => usedHands.add(part.id));
+      assignments.push({ item: row.item, kind: row.req.kind, partIds: chosen.map((part) => part.id) });
+    });
+
+    const accessoryRows = rows.filter((row) => row.req.kind === "accessory")
+      .sort((a, b) => Number(b.req.blockers.length > 0) - Number(a.req.blockers.length > 0));
+    let legacyAccessoriesUsed = 0;
+    accessoryRows.forEach((row) => {
+      if (row.req.accessoryType === "legacy_accessory") {
+        if (legacyAccessoriesUsed >= 4) invalid.push({ item: row.item, reason: "legacy_accessory_capacity", requirements: row.req });
+        else {
+          legacyAccessoriesUsed += 1;
+          assignments.push({ item: row.item, kind: "accessory", partIds: [`legacy_accessory_${legacyAccessoriesUsed}`] });
+        }
+        return;
+      }
+      const candidates = partsByType(anatomy, row.req.accessoryType).filter((part) => !usedAccessoryParts.has(part.id) && !blockedAccessoryParts.has(part.id));
+      if (candidates.length < row.req.accessoryCost) {
+        invalid.push({ item: row.item, reason: "accessory_body_slot_unavailable", requirements: row.req });
+        return;
+      }
+      const chosen = candidates.slice(0, row.req.accessoryCost);
+      chosen.forEach((part) => usedAccessoryParts.add(part.id));
+      assignments.push({ item: row.item, kind: "accessory", partIds: chosen.map((part) => part.id) });
+
+      row.req.blockers.forEach((blocker) => {
+        chosen.forEach((root) => {
+          const localIds = [root.id, ...descendantsOf(anatomy, root.id)];
+          const matching = localIds.map((id) => anatomy.parts[id]).filter((part) => part?.type === blocker.type && isPartUsable(part));
+          const count = Number.isFinite(blocker.count) ? blocker.count : matching.length;
+          matching.slice(0, count).forEach((part) => blockedAccessoryParts.add(part.id));
+        });
+      });
+    });
+
+    rows.filter((row) => !["armor", "weapon", "shield", "accessory", "augmentation"].includes(row.req.kind)).forEach((row) => {
+      assignments.push({ item: row.item, kind: row.req.kind, partIds: [] });
+    });
+
+    return {
+      valid: invalid.length === 0,
+      anatomy,
+      assignments,
+      invalid,
+      capacities: {
+        hands: handPool.length,
+        freeHands: Math.max(0, handPool.length - usedHands.size),
+        armor: 1,
+        accessoryByType: anatomy.order.reduce((acc, id) => {
+          const part = anatomy.parts[id];
+          if (isPartUsable(part)) acc[part.type] = (acc[part.type] || 0) + 1;
+          return acc;
+        }, {}),
+      },
+      blockedAccessoryParts: [...blockedAccessoryParts],
+    };
+  }
+
+  function clearEquippedState(item) {
+    if (!item || typeof item !== "object") return item;
+    item.equipped = false;
+    item.equipped_slot = null;
+    item.equippedSlot = null;
+    item.equippedPartIds = [];
+    item.assignedBodyParts = [];
+    return item;
+  }
+
+  function revalidateEquipment(character = {}, rawItems = [], options = {}) {
+    const result = validateEquipment(character, rawItems, options);
+    const lootPool = Array.isArray(options.lootPool) ? options.lootPool : null;
+    result.invalid.forEach((entry) => {
+      const item = entry.item;
+      clearEquippedState(item);
+      const dropped = { item, reason: entry.reason, characterId: character.id || character.unitId || character.playerId || null };
+      if (typeof options.onDropToLoot === "function") options.onDropToLoot(dropped);
+      else if (lootPool) lootPool.push(item);
+      emit("luminous:equipment-invalidated", dropped);
+    });
+    emit("luminous:equipment-revalidated", { character, result });
+    return result;
+  }
+
+  function collectEquippedItems(character = {}) {
+    const containers = [character.equipment, character.activeInventory, character.inventory, character.inventario, character.items];
+    const result = [];
+    const seen = new Set();
+    containers.forEach((container) => {
+      equippedEntries(container).forEach((item) => {
+        const key = item.key || item.id || item.itemId || item;
+        if (seen.has(key)) return;
+        seen.add(key);
+        result.push(item);
+      });
+    });
+    return result;
+  }
+
+  function rebuildCharacter(character = {}, options = {}) {
+    const anatomy = resolveCharacterAnatomy(character, options);
+    character.anatomyRuntime = anatomy;
+    const items = options.items || collectEquippedItems(character);
+    const validation = revalidateEquipment(character, items, { ...options, anatomy });
+    return { anatomy, validation };
+  }
+
+  const api = Object.freeze({
+    VALID_STATES: Object.freeze([...VALID_STATES]),
+    VALID_SUBSTRATES: Object.freeze([...VALID_SUBSTRATES]),
+    normalizeId,
+    createAnatomy,
+    createHumanoidAnatomy,
+    addPart,
+    addBodyGrant,
+    descendantsOf,
+    setPartState,
+    replaceBranch,
+    restoreBranch,
+    isPartUsable,
+    partsByType,
+    applyAugmentation,
+    applyInjury,
+    resolveCharacterAnatomy,
+    normalizeItemRequirements,
+    collectEquippedItems,
+    validateEquipment,
+    revalidateEquipment,
+    rebuildCharacter,
+  });
+
+  global.LuminousAnatomyEquipmentEngine = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/archetype-combat-event-runtime.js
+++ b/js/archetype-combat-event-runtime.js
@@ -5,6 +5,9 @@
   if (!doc || global.LuminousArchetypeCombatEventRuntime) return;
 
   const PATCH_INTERVAL_MS = 250;
+  const DEVIL_ARCHETYPE_ID = "path_of_the_devil_lineage";
+  const DEVIL_CLASS_ID = "barbarian";
+  const LOW_HP_CRIT_STATUS_ID = "devil_lineage_low_hp_crit_bonus";
   const EVENT_MAP = Object.freeze({
     "[Before Use]": { trigger: "before_skill", timing: "before" },
     "[Before Attack]": { trigger: "before_attack", timing: "before" },
@@ -22,9 +25,13 @@
     combatSource: null,
     traitStateByKey: new Map(),
     traitStateByObject: typeof WeakMap === "function" ? new WeakMap() : null,
+    turnMechanicsByKey: new Map(),
+    turnMechanicsByObject: typeof WeakMap === "function" ? new WeakMap() : null,
+    attackStack: [],
   };
 
   const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/\s+/g, "_");
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
 
   function identityValues(entity = {}) {
     return [
@@ -65,6 +72,48 @@
     };
   }
 
+  function devilLineageLevel(unit = {}) {
+    const character = traitCharacterForUnit(unit);
+    const playerRuntime = global.LuminousArchetypeRuntime;
+    if (playerRuntime?.devilLineageLevel) {
+      try {
+        const value = numberOr(playerRuntime.devilLineageLevel(character), 0);
+        if (value > 0) return value;
+      } catch (_) {}
+    }
+
+    const engine = global.LuminousArchetypeEngine;
+    if (engine?.isSelected && engine?.getClassLevel) {
+      try {
+        if (engine.isSelected(character, DEVIL_ARCHETYPE_ID, DEVIL_CLASS_ID)) {
+          return Math.max(0, numberOr(engine.getClassLevel(character, DEVIL_CLASS_ID), 0));
+        }
+      } catch (_) {}
+    }
+
+    const selections = Array.isArray(character.characterBuild?.archetypes) ? character.characterBuild.archetypes : [];
+    const selected = selections.some((entry) =>
+      normalizeId(entry?.classId || entry?.parentClassId) === DEVIL_CLASS_ID &&
+      normalizeId(entry?.archetypeId || entry?.subclassId || entry?.id) === DEVIL_ARCHETYPE_ID
+    );
+    if (!selected) return 0;
+    const classes = Array.isArray(character.characterBuild?.classes) ? character.characterBuild.classes : character.classes || [];
+    const barbarian = classes.find((entry) => normalizeId(entry?.classId || entry?.id || entry?.name) === DEVIL_CLASS_ID);
+    return Math.max(0, numberOr(barbarian?.level ?? barbarian?.levels, 0));
+  }
+
+  function unitHp(unit = {}) {
+    return numberOr(unit.hp ?? unit.currentHp ?? unit.hp_actual ?? unit.combatStats?.hp_actual, 0);
+  }
+
+  function unitMaxHp(unit = {}) {
+    return Math.max(1, numberOr(unit.maxHp ?? unit.max_hp ?? unit.hp_max ?? unit.combatStats?.hp_max ?? unit.combatStats?.maxHp, 1));
+  }
+
+  function criticalBonusApplies(unit = {}) {
+    return devilLineageLevel(unit) >= 30 && unitHp(unit) <= unitMaxHp(unit) * 0.5;
+  }
+
   function delegatedToPlayerRuntime(unit) {
     const runtime = global.LuminousPlayerTraitRuntime;
     if (!runtime?.dispatchCombatEvent || !runtime?.getCharacter) return false;
@@ -78,6 +127,7 @@
 
   function traitsForUnit(unit = {}) {
     global.LuminousArchetypeRuntime?.syncArchetypeTraitsForUnit?.(unit);
+    global.LuminousDevilLineageRuntime?.trackUnit?.(unit);
     const definitions = Array.isArray(unit.traitDefinitions)
       ? unit.traitDefinitions
       : (Array.isArray(unit.traits) && unit.traits.every((entry) => entry && typeof entry === "object") ? unit.traits : []);
@@ -96,6 +146,29 @@
       return state.traitStateByObject.get(unit);
     }
     return engine?.createState?.() || { usages: {}, ruleScopes: {}, counters: {} };
+  }
+
+  function turnMechanicsFor(unit = {}) {
+    const key = unitKey(unit);
+    const create = () => ({ reuseLastUsed: false, reuseSkillUsed: false });
+    if (key) {
+      if (!state.turnMechanicsByKey.has(key)) state.turnMechanicsByKey.set(key, create());
+      return state.turnMechanicsByKey.get(key);
+    }
+    if (state.turnMechanicsByObject) {
+      if (!state.turnMechanicsByObject.has(unit)) state.turnMechanicsByObject.set(unit, create());
+      return state.turnMechanicsByObject.get(unit);
+    }
+    return create();
+  }
+
+  function resetTurnMechanics(units = []) {
+    const list = Array.isArray(units) ? units : [units];
+    list.filter(Boolean).forEach((unit) => {
+      const key = unitKey(unit);
+      if (key) state.turnMechanicsByKey.delete(key);
+      else if (state.turnMechanicsByObject) state.turnMechanicsByObject.delete(unit);
+    });
   }
 
   function resetScopeForTrigger(trigger, traitState) {
@@ -196,29 +269,205 @@
     })).filter(Boolean);
   }
 
+  function ensureCritRegistry() {
+    if (!global.STATUS_REGISTRY || typeof global.STATUS_REGISTRY !== "object") global.STATUS_REGISTRY = {};
+    if (!global.STATUS_REGISTRY[LOW_HP_CRIT_STATUS_ID]) {
+      global.STATUS_REGISTRY[LOW_HP_CRIT_STATUS_ID] = {
+        id: LOW_HP_CRIT_STATUS_ID,
+        name: "Devil Lineage Low HP Critical Bonus",
+        type: "neutral",
+        mode: "single",
+        icon: null,
+        rules: [],
+        crit_vulnerability_per_count: 0.10,
+        runtimeOnly: true,
+      };
+    }
+    return global.STATUS_REGISTRY[LOW_HP_CRIT_STATUS_ID];
+  }
+
+  function clearCritMarkers(context = {}) {
+    const markers = Array.isArray(context.__devilLineageCritMarkers) ? context.__devilLineageCritMarkers : [];
+    markers.forEach((entry) => {
+      const store = entry.target?.statusEffects;
+      if (!store || typeof store !== "object") return;
+      if (entry.hadOwn) store[LOW_HP_CRIT_STATUS_ID] = entry.previous;
+      else delete store[LOW_HP_CRIT_STATUS_ID];
+    });
+    context.__devilLineageCritMarkers = [];
+  }
+
+  function prepareCritMarkers(context = {}, targetsHit = []) {
+    clearCritMarkers(context);
+    const attacker = context.attacker || context.unitAttacker || null;
+    if (!attacker || !criticalBonusApplies(attacker)) return false;
+    ensureCritRegistry();
+
+    const candidates = [context.defender, ...(Array.isArray(targetsHit) ? targetsHit : []), ...(Array.isArray(context.targetsHit) ? context.targetsHit : [])];
+    const seen = new Set();
+    const markers = [];
+    candidates.filter(Boolean).forEach((target) => {
+      const key = unitKey(target) || target;
+      if (seen.has(key)) return;
+      seen.add(key);
+      if (!target.statusEffects || typeof target.statusEffects !== "object" || Array.isArray(target.statusEffects)) target.statusEffects = {};
+      const hadOwn = Object.prototype.hasOwnProperty.call(target.statusEffects, LOW_HP_CRIT_STATUS_ID);
+      const previous = target.statusEffects[LOW_HP_CRIT_STATUS_ID];
+      target.statusEffects[LOW_HP_CRIT_STATUS_ID] = {
+        id: LOW_HP_CRIT_STATUS_ID,
+        count: 1,
+        potency: 0,
+        duration: "runtime_coin",
+        data: { runtimeOnly: true },
+      };
+      markers.push({ target, hadOwn, previous });
+    });
+    context.__devilLineageCritMarkers = markers;
+    const tracker = currentAttackTracker(context);
+    if (tracker) tracker.critMarkers = markers;
+    return markers.length > 0;
+  }
+
+  function currentAttackTracker(context = {}) {
+    const attacker = context.attacker || context.unitAttacker || null;
+    const skill = context.skill || null;
+    for (let index = state.attackStack.length - 1; index >= 0; index -= 1) {
+      const tracker = state.attackStack[index];
+      if ((!attacker || sameUnit(tracker.attacker, attacker)) && (!skill || tracker.skill === skill)) return tracker;
+    }
+    return null;
+  }
+
+  function captureDevilEvent(tag, context = {}, targetsHit = []) {
+    if (tag === "[Coin Start]") prepareCritMarkers(context, targetsHit);
+    if (tag === "[Current Coin Attack End]" || tag === "[Attack End]") clearCritMarkers(context);
+
+    const tracker = currentAttackTracker(context);
+    if (!tracker || tracker.reuseCall || devilLineageLevel(tracker.attacker) < 30) return tracker;
+    const turn = turnMechanicsFor(tracker.attacker);
+    const target = (Array.isArray(targetsHit) && targetsHit[0]) || context.currentTarget || context.defender || tracker.defender || null;
+
+    if (tag === "[On Crit]" && tracker.baseCoinCount >= 2 && tracker.baseCoinCount <= 3 && !turn.reuseLastUsed) {
+      tracker.pendingReuseLast = true;
+      tracker.reuseLastTarget = target;
+    }
+    if (tag === "[On Crit Kill]" && tracker.baseCoinCount === 1 && !turn.reuseSkillUsed) {
+      tracker.pendingReuseSkill = true;
+      tracker.reuseSkillKilledTarget = target;
+    }
+    return tracker;
+  }
+
+  function cloneCoin(coin = {}, reused = false) {
+    return {
+      ...coin,
+      status: "active",
+      isReused: reused || coin.isReused === true,
+      effects: Array.isArray(coin.effects) ? [...coin.effects] : [],
+    };
+  }
+
+  function cloneSkillForReuse(skill = {}, coins = []) {
+    const clonedCoins = coins.map((coin) => cloneCoin(coin, true));
+    const next = {
+      ...skill,
+      coins: clonedCoins,
+      coinAmount: Math.max(1, clonedCoins.length),
+      effects: Array.isArray(skill.effects) ? [...skill.effects] : [],
+    };
+    delete next.__traitRuleScopes;
+    return next;
+  }
+
+  function cleanupTraitAppendedCoins(tracker) {
+    const skill = tracker?.skill;
+    const count = Math.max(0, Math.trunc(numberOr(tracker?.appendedByTrait, 0)));
+    if (!skill || !Array.isArray(skill.coins) || !count) return 0;
+    const removable = Math.min(count, Math.max(0, skill.coins.length - tracker.baseCoinCount));
+    if (removable > 0) skill.coins.splice(skill.coins.length - removable, removable);
+    skill.coinAmount = skill.coins.length || tracker.baseCoinCount || skill.coinAmount;
+    return removable;
+  }
+
+  function aliveHostiles(engine, attacker, options = {}, excluded = null) {
+    const explicit = Array.isArray(options.combatants) ? options.combatants : [];
+    const source = explicit.length ? explicit : (typeof engine.getAllAliveUnits === "function" ? engine.getAllAliveUnits() : []);
+    const faction = attacker?.faction ?? attacker?.faccion;
+    return (Array.isArray(source) ? source : []).filter((unit) => {
+      if (!unit || sameUnit(unit, attacker) || (excluded && sameUnit(unit, excluded)) || unitHp(unit) <= 0) return false;
+      const otherFaction = unit.faction ?? unit.faccion;
+      return faction == null || otherFaction == null || otherFaction !== faction;
+    });
+  }
+
+  function chooseReuseTarget(engine, tracker) {
+    const candidates = aliveHostiles(engine, tracker.attacker, tracker.options || {}, tracker.reuseSkillKilledTarget);
+    if (!candidates.length) return null;
+    if (candidates.length === 1) return candidates[0];
+    return candidates[Math.floor(Math.random() * candidates.length)];
+  }
+
+  function executeLastCoinReuse(engine, tracker) {
+    const target = tracker.reuseLastTarget || tracker.defender;
+    if (!target || unitHp(target) <= 0 || typeof engine.resolveUnilateralWithCounter !== "function") return null;
+    const template = tracker.lastCoinTemplate || { type: tracker.skill?.coinType || "standard", effects: [] };
+    const skill = cloneSkillForReuse(tracker.skill, [template]);
+    const options = { ...(tracker.options || {}), skipUseHooks: true, __devilLineageReuse: true };
+    return engine.resolveUnilateralWithCounter(tracker.attacker, skill, target, null, options);
+  }
+
+  function executeSkillReuse(engine, tracker) {
+    const target = chooseReuseTarget(engine, tracker);
+    if (!target || typeof engine.resolveUnilateralWithCounter !== "function") return null;
+    const templates = tracker.baseCoinsTemplate.length ? tracker.baseCoinsTemplate : [{ type: tracker.skill?.coinType || "standard", effects: [] }];
+    const skill = cloneSkillForReuse(tracker.skill, templates);
+    const options = { ...(tracker.options || {}), skipUseHooks: true, skill_reused: true, __devilLineageReuse: true };
+    return engine.resolveUnilateralWithCounter(tracker.attacker, skill, target, null, options);
+  }
+
+  function mergeReuseResult(base, extra, key) {
+    if (!extra) return base;
+    const result = base && typeof base === "object" ? base : {};
+    if (Array.isArray(extra.attackLogs)) {
+      if (!Array.isArray(result.attackLogs)) result.attackLogs = [];
+      result.attackLogs.push(...extra.attackLogs);
+    }
+    if (Array.isArray(extra.pendingActions)) {
+      if (!Array.isArray(result.pendingActions)) result.pendingActions = [];
+      result.pendingActions.push(...extra.pendingActions);
+    }
+    result[key] = extra;
+    return result;
+  }
+
   function clearEncounterState() {
     state.traitStateByKey.clear();
     state.traitStateByObject = typeof WeakMap === "function" ? new WeakMap() : null;
+    state.turnMechanicsByKey.clear();
+    state.turnMechanicsByObject = typeof WeakMap === "function" ? new WeakMap() : null;
+    state.attackStack.length = 0;
   }
 
   function patchCombatEngine() {
     const engine = global.CombatEngine;
     if (!engine) return false;
-    if (engine.__archetypeCombatEventRuntimeIntegrated) {
+    if (engine.__archetypeCombatEventRuntimeIntegratedV2) {
       state.combatSource = engine;
       return true;
     }
-    if (state.combatSource === engine) return true;
+    if (state.combatSource === engine && engine.__archetypeCombatEventRuntimeIntegratedV2) return true;
 
     const originalInitialize = typeof engine.initializeUnitData === "function" ? engine.initializeUnitData : null;
     const originalEncounterStart = typeof engine.triggerEncounterStart === "function" ? engine.triggerEncounterStart : null;
     const originalTriggerPhase = typeof engine.triggerPhase === "function" ? engine.triggerPhase : null;
     const originalTriggerEvent = typeof engine.triggerEvent === "function" ? engine.triggerEvent : null;
+    const originalResolveUnilateral = typeof engine.resolveUnilateralWithCounter === "function" ? engine.resolveUnilateralWithCounter : null;
 
     if (originalInitialize) {
       engine.initializeUnitData = function (unit, ...rest) {
         const result = originalInitialize.call(this, unit, ...rest);
         global.LuminousArchetypeRuntime?.syncArchetypeTraitsForUnit?.(unit);
+        global.LuminousDevilLineageRuntime?.trackUnit?.(unit);
         return result;
       };
     }
@@ -228,6 +477,7 @@
         clearEncounterState();
         const result = originalEncounterStart.call(this, allUnits, ...rest);
         (Array.isArray(allUnits) ? allUnits : []).forEach((unit) => {
+          global.LuminousDevilLineageRuntime?.trackUnit?.(unit);
           dispatchForUnit("encounter_start", unit, { units: allUnits });
         });
         return result;
@@ -236,8 +486,9 @@
 
     if (originalTriggerPhase) {
       engine.triggerPhase = function (phaseTag, allUnits, ...rest) {
-        const result = originalTriggerPhase.call(this, phaseTag, allUnits, ...rest);
         const units = Array.isArray(allUnits) ? allUnits : [];
+        if (phaseTag === "[Round Start]") resetTurnMechanics(units);
+        const result = originalTriggerPhase.call(this, phaseTag, allUnits, ...rest);
         if (phaseTag === "[Round Start]") {
           units.forEach((unit) => dispatchForUnit("turn_start", unit, { units }));
         } else if (phaseTag === "[Round End]") {
@@ -249,15 +500,69 @@
 
     if (originalTriggerEvent) {
       engine.triggerEvent = function (tag, context, targetsHit = []) {
+        captureDevilEvent(tag, context, targetsHit);
         const mapping = EVENT_MAP[tag];
         if (mapping?.timing === "before") dispatchMappedEvent(mapping, context, targetsHit);
         const result = originalTriggerEvent.call(this, tag, context, targetsHit);
+        const tracker = currentAttackTracker(context || {});
+        const beforeMappedCoins = Array.isArray(context?.skill?.coins) ? context.skill.coins.length : 0;
         if (mapping?.timing === "after") dispatchMappedEvent(mapping, context, targetsHit);
+        if (tag === "[On Crit]" && tracker && Array.isArray(context?.skill?.coins)) {
+          tracker.appendedByTrait += Math.max(0, context.skill.coins.length - beforeMappedCoins);
+        }
+        return result;
+      };
+    }
+
+    if (originalResolveUnilateral) {
+      engine.resolveUnilateralWithCounter = function (attacker, skill, defender, counterSkill, options = {}) {
+        const baseCoins = Array.isArray(skill?.coins) && skill.coins.length
+          ? skill.coins.map((coin) => cloneCoin(coin, false))
+          : Array.from({ length: Math.max(1, Math.trunc(numberOr(skill?.coinAmount, 1))) }, () => ({ type: skill?.coinType || "standard", status: "active", effects: [] }));
+        const tracker = {
+          attacker,
+          skill,
+          defender,
+          counterSkill,
+          options: options || {},
+          reuseCall: options?.__devilLineageReuse === true,
+          baseCoinCount: baseCoins.length,
+          baseCoinsTemplate: baseCoins,
+          lastCoinTemplate: baseCoins.at(-1),
+          pendingReuseLast: false,
+          pendingReuseSkill: false,
+          reuseLastTarget: null,
+          reuseSkillKilledTarget: null,
+          appendedByTrait: 0,
+        };
+        state.attackStack.push(tracker);
+        let result;
+        try {
+          result = originalResolveUnilateral.call(this, attacker, skill, defender, counterSkill, options);
+        } finally {
+          const index = state.attackStack.lastIndexOf(tracker);
+          if (index >= 0) state.attackStack.splice(index, 1);
+          clearCritMarkers({ __devilLineageCritMarkers: tracker.critMarkers || [] });
+        }
+
+        cleanupTraitAppendedCoins(tracker);
+        if (tracker.reuseCall || devilLineageLevel(attacker) < 30) return result;
+
+        const turn = turnMechanicsFor(attacker);
+        if (tracker.pendingReuseLast && !turn.reuseLastUsed) {
+          turn.reuseLastUsed = true;
+          result = mergeReuseResult(result, executeLastCoinReuse(this, tracker), "devilLineageReuseLastCoin");
+        }
+        if (tracker.pendingReuseSkill && !turn.reuseSkillUsed) {
+          turn.reuseSkillUsed = true;
+          result = mergeReuseResult(result, executeSkillReuse(this, tracker), "devilLineageReuseSkill");
+        }
         return result;
       };
     }
 
     Object.defineProperty(engine, "__archetypeCombatEventRuntimeIntegrated", { value: true, configurable: true });
+    Object.defineProperty(engine, "__archetypeCombatEventRuntimeIntegratedV2", { value: true, configurable: true });
     state.combatSource = engine;
     return true;
   }
@@ -268,14 +573,23 @@
 
   const api = Object.freeze({
     EVENT_MAP,
+    LOW_HP_CRIT_STATUS_ID,
     unitKey,
     sameUnit,
     traitCharacterForUnit,
+    devilLineageLevel,
+    criticalBonusApplies,
     traitsForUnit,
     traitStateFor,
+    turnMechanicsFor,
     delegatedToPlayerRuntime,
     dispatchForUnit,
     dispatchMappedEvent,
+    ensureCritRegistry,
+    prepareCritMarkers,
+    clearCritMarkers,
+    captureDevilEvent,
+    resetTurnMechanics,
     clearEncounterState,
     patchCombatEngine,
     install,

--- a/js/archetype-combat-event-runtime.js
+++ b/js/archetype-combat-event-runtime.js
@@ -53,6 +53,18 @@
     return Boolean(aName && aName === entityName(b));
   }
 
+  function traitCharacterForUnit(unit = {}) {
+    const build = unit.characterBuild && typeof unit.characterBuild === "object" ? unit.characterBuild : {};
+    const classes = Array.isArray(unit.classes)
+      ? unit.classes
+      : (Array.isArray(build.classes) ? build.classes : []);
+    return {
+      ...unit,
+      classes,
+      characterBuild: build,
+    };
+  }
+
   function delegatedToPlayerRuntime(unit) {
     const runtime = global.LuminousPlayerTraitRuntime;
     if (!runtime?.dispatchCombatEvent || !runtime?.getCharacter) return false;
@@ -108,16 +120,17 @@
     resetScopeForTrigger(trigger, traitState);
     const allOutcomes = [];
     const normalizedTrigger = normalizeId(trigger);
+    const character = traitCharacterForUnit(unit);
 
     traits.forEach((trait) => {
       const runtime = {
         context: "combat",
-        character: unit,
+        character,
         self: unit,
         sourceClassId: normalizeId(trait?.source?.classId || trait?.classId),
         ...(input || {}),
       };
-      runtime.character = unit;
+      runtime.character = character;
       runtime.self = unit;
 
       if (normalizedTrigger !== "passive") {
@@ -257,6 +270,7 @@
     EVENT_MAP,
     unitKey,
     sameUnit,
+    traitCharacterForUnit,
     traitsForUnit,
     traitStateFor,
     delegatedToPlayerRuntime,

--- a/js/archetype-combat-event-runtime.js
+++ b/js/archetype-combat-event-runtime.js
@@ -1,0 +1,273 @@
+(function (global) {
+  "use strict";
+
+  const doc = global.document;
+  if (!doc || global.LuminousArchetypeCombatEventRuntime) return;
+
+  const PATCH_INTERVAL_MS = 250;
+  const EVENT_MAP = Object.freeze({
+    "[Before Use]": { trigger: "before_skill", timing: "before" },
+    "[Before Attack]": { trigger: "before_attack", timing: "before" },
+    "[Before Clash]": { trigger: "before_clash", timing: "before" },
+    "[On Hit]": { trigger: "on_hit", timing: "after", perTarget: true },
+    "[On Crit]": { trigger: "on_crit", timing: "after", perTarget: true },
+    "[On Kill]": { trigger: "on_kill", timing: "after", perTarget: true },
+    "[On Clash Win]": { trigger: "clash_win", timing: "after" },
+    "[On Clash Lose]": { trigger: "clash_lose", timing: "after" },
+    "[On Evade]": { trigger: "on_evade", timing: "after" },
+    "[Attack End]": { trigger: "attack_end", timing: "after" },
+  });
+
+  const state = {
+    combatSource: null,
+    traitStateByKey: new Map(),
+    traitStateByObject: typeof WeakMap === "function" ? new WeakMap() : null,
+  };
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/\s+/g, "_");
+
+  function identityValues(entity = {}) {
+    return [
+      entity.combatId, entity.combat_id, entity.unitId, entity.unit_id,
+      entity.id, entity.playerId, entity.player_id, entity.characterId, entity.character_id,
+      entity.actorId, entity.actor_id, entity.uid, entity.vinculo_jugador,
+    ]
+      .filter((value) => value != null && String(value).trim() !== "")
+      .map((value) => String(value).trim());
+  }
+
+  function entityName(entity = {}) {
+    return normalizeId(entity.characterName || entity.character_name || entity.nombre || entity.name || "");
+  }
+
+  function unitKey(unit = {}) {
+    return identityValues(unit)[0] || entityName(unit) || null;
+  }
+
+  function sameUnit(a, b) {
+    if (!a || !b) return false;
+    if (a === b) return true;
+    const aIds = new Set(identityValues(a));
+    if (identityValues(b).some((id) => aIds.has(id))) return true;
+    const aName = entityName(a);
+    return Boolean(aName && aName === entityName(b));
+  }
+
+  function delegatedToPlayerRuntime(unit) {
+    const runtime = global.LuminousPlayerTraitRuntime;
+    if (!runtime?.dispatchCombatEvent || !runtime?.getCharacter) return false;
+    return sameUnit(unit, runtime.getCharacter());
+  }
+
+  function isArchetypeTrait(trait = {}) {
+    const source = trait.source || {};
+    return ["archetype", "subclass", "class_archetype"].includes(normalizeId(source.type || trait.sourceType));
+  }
+
+  function traitsForUnit(unit = {}) {
+    global.LuminousArchetypeRuntime?.syncArchetypeTraitsForUnit?.(unit);
+    const definitions = Array.isArray(unit.traitDefinitions)
+      ? unit.traitDefinitions
+      : (Array.isArray(unit.traits) && unit.traits.every((entry) => entry && typeof entry === "object") ? unit.traits : []);
+    return definitions.filter(isArchetypeTrait);
+  }
+
+  function traitStateFor(unit = {}) {
+    const engine = global.LuminousTraitEngine;
+    const key = unitKey(unit);
+    if (key) {
+      if (!state.traitStateByKey.has(key)) state.traitStateByKey.set(key, engine?.createState?.() || { usages: {}, ruleScopes: {}, counters: {} });
+      return state.traitStateByKey.get(key);
+    }
+    if (state.traitStateByObject) {
+      if (!state.traitStateByObject.has(unit)) state.traitStateByObject.set(unit, engine?.createState?.() || { usages: {}, ruleScopes: {}, counters: {} });
+      return state.traitStateByObject.get(unit);
+    }
+    return engine?.createState?.() || { usages: {}, ruleScopes: {}, counters: {} };
+  }
+
+  function resetScopeForTrigger(trigger, traitState) {
+    const engine = global.LuminousTraitEngine;
+    if (!engine?.resetStateScope || !traitState) return;
+    const id = normalizeId(trigger);
+    if (id === "turn_start") engine.resetStateScope(traitState, "turn");
+    else if (id === "encounter_start") engine.resetStateScope(traitState, "encounter");
+    else if (id === "short_rest" || id === "long_rest") engine.resetStateScope(traitState, id);
+    else if (id === "day_start") engine.resetStateScope(traitState, "day");
+  }
+
+  function dispatchForUnit(trigger, unit, input = {}) {
+    const engine = global.LuminousTraitEngine;
+    if (!unit || !engine?.dispatchTrait) return null;
+    if (delegatedToPlayerRuntime(unit)) return { delegated: true, unit, trigger: normalizeId(trigger), outcomes: [] };
+
+    const traits = traitsForUnit(unit);
+    if (!traits.length) return { delegated: false, unit, trigger: normalizeId(trigger), outcomes: [] };
+
+    const traitState = traitStateFor(unit);
+    resetScopeForTrigger(trigger, traitState);
+    const allOutcomes = [];
+    const normalizedTrigger = normalizeId(trigger);
+
+    traits.forEach((trait) => {
+      const runtime = {
+        context: "combat",
+        character: unit,
+        self: unit,
+        sourceClassId: normalizeId(trait?.source?.classId || trait?.classId),
+        ...(input || {}),
+      };
+      runtime.character = unit;
+      runtime.self = unit;
+
+      if (normalizedTrigger !== "passive") {
+        const passive = engine.dispatchTrait(trait, "passive", runtime, traitState);
+        if (Array.isArray(passive?.outcomes)) allOutcomes.push(...passive.outcomes);
+      }
+      const result = engine.dispatchTrait(trait, normalizedTrigger, runtime, traitState);
+      if (Array.isArray(result?.outcomes)) allOutcomes.push(...result.outcomes);
+
+      global.LuminousTraitStandardizationRuntime?.resolveTraitRuntimeResolutions?.(
+        [trait],
+        normalizedTrigger,
+        result?.runtime || runtime,
+        result,
+      );
+    });
+
+    return { delegated: false, unit, trigger: normalizedTrigger, state: traitState, outcomes: allOutcomes };
+  }
+
+  function eventTargets(mapping, context = {}, targetsHit = []) {
+    if (!mapping?.perTarget) return [context?.target || context?.currentTarget || context?.defender || null];
+    const candidates = Array.isArray(targetsHit) && targetsHit.length
+      ? targetsHit
+      : (Array.isArray(context.targetsHit) && context.targetsHit.length ? context.targetsHit : [context?.currentTarget || context?.defender || null]);
+    const seen = new Set();
+    return candidates.filter((target) => {
+      if (!target) return false;
+      const key = unitKey(target) || target;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }
+
+  function dispatchMappedEvent(mapping, context = {}, targetsHit = []) {
+    if (!mapping) return [];
+    const attacker = context?.attacker || context?.unitAttacker || null;
+    if (!attacker) return [];
+    const targets = eventTargets(mapping, context, targetsHit);
+    if (!mapping.perTarget) {
+      const target = targets[0] || null;
+      return [dispatchForUnit(mapping.trigger, attacker, {
+        attacker,
+        defender: target || context?.defender || null,
+        target,
+        targetsHit: Array.isArray(targetsHit) ? targetsHit : [],
+        skill: context?.skill || null,
+        currentCoin: context?.currentCoin || null,
+        damageDealt: context?.damageDealt,
+        isCritical: context?.isCritical,
+      })].filter(Boolean);
+    }
+    return targets.map((target) => dispatchForUnit(mapping.trigger, attacker, {
+      attacker,
+      defender: target,
+      target,
+      targetsHit: targets,
+      skill: context?.skill || null,
+      currentCoin: context?.currentCoin || null,
+      damageDealt: context?.damageDealt,
+      isCritical: mapping.trigger === "on_crit" || context?.isCritical === true,
+    })).filter(Boolean);
+  }
+
+  function clearEncounterState() {
+    state.traitStateByKey.clear();
+    state.traitStateByObject = typeof WeakMap === "function" ? new WeakMap() : null;
+  }
+
+  function patchCombatEngine() {
+    const engine = global.CombatEngine;
+    if (!engine) return false;
+    if (engine.__archetypeCombatEventRuntimeIntegrated) {
+      state.combatSource = engine;
+      return true;
+    }
+    if (state.combatSource === engine) return true;
+
+    const originalInitialize = typeof engine.initializeUnitData === "function" ? engine.initializeUnitData : null;
+    const originalEncounterStart = typeof engine.triggerEncounterStart === "function" ? engine.triggerEncounterStart : null;
+    const originalTriggerPhase = typeof engine.triggerPhase === "function" ? engine.triggerPhase : null;
+    const originalTriggerEvent = typeof engine.triggerEvent === "function" ? engine.triggerEvent : null;
+
+    if (originalInitialize) {
+      engine.initializeUnitData = function (unit, ...rest) {
+        const result = originalInitialize.call(this, unit, ...rest);
+        global.LuminousArchetypeRuntime?.syncArchetypeTraitsForUnit?.(unit);
+        return result;
+      };
+    }
+
+    if (originalEncounterStart) {
+      engine.triggerEncounterStart = function (allUnits = [], ...rest) {
+        clearEncounterState();
+        const result = originalEncounterStart.call(this, allUnits, ...rest);
+        (Array.isArray(allUnits) ? allUnits : []).forEach((unit) => {
+          dispatchForUnit("encounter_start", unit, { units: allUnits });
+        });
+        return result;
+      };
+    }
+
+    if (originalTriggerPhase) {
+      engine.triggerPhase = function (phaseTag, allUnits, ...rest) {
+        const result = originalTriggerPhase.call(this, phaseTag, allUnits, ...rest);
+        const units = Array.isArray(allUnits) ? allUnits : [];
+        if (phaseTag === "[Round Start]") {
+          units.forEach((unit) => dispatchForUnit("turn_start", unit, { units }));
+        } else if (phaseTag === "[Round End]") {
+          units.forEach((unit) => dispatchForUnit("turn_end", unit, { units }));
+        }
+        return result;
+      };
+    }
+
+    if (originalTriggerEvent) {
+      engine.triggerEvent = function (tag, context, targetsHit = []) {
+        const mapping = EVENT_MAP[tag];
+        if (mapping?.timing === "before") dispatchMappedEvent(mapping, context, targetsHit);
+        const result = originalTriggerEvent.call(this, tag, context, targetsHit);
+        if (mapping?.timing === "after") dispatchMappedEvent(mapping, context, targetsHit);
+        return result;
+      };
+    }
+
+    Object.defineProperty(engine, "__archetypeCombatEventRuntimeIntegrated", { value: true, configurable: true });
+    state.combatSource = engine;
+    return true;
+  }
+
+  function install() {
+    return patchCombatEngine();
+  }
+
+  const api = Object.freeze({
+    EVENT_MAP,
+    unitKey,
+    sameUnit,
+    traitsForUnit,
+    traitStateFor,
+    delegatedToPlayerRuntime,
+    dispatchForUnit,
+    dispatchMappedEvent,
+    clearEncounterState,
+    patchCombatEngine,
+    install,
+  });
+
+  global.LuminousArchetypeCombatEventRuntime = api;
+  install();
+  global.setInterval?.(install, PATCH_INTERVAL_MS);
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/archetype-engine.js
+++ b/js/archetype-engine.js
@@ -1,0 +1,244 @@
+(function (global) {
+  "use strict";
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/\s+/g, "_");
+  const toInt = (value, fallback = 0) => Number.isFinite(Number.parseInt(value, 10)) ? Number.parseInt(value, 10) : fallback;
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+  function classEntries(character = {}) {
+    const build = character?.characterBuild && typeof character.characterBuild === "object" ? character.characterBuild : {};
+    const list = Array.isArray(build.classes) ? build.classes : Array.isArray(character.classes) ? character.classes : null;
+    if (list) {
+      return list
+        .map((entry) => ({
+          classId: normalizeId(entry?.classId || entry?.id),
+          levels: Math.max(0, toInt(entry?.levels ?? entry?.level)),
+        }))
+        .filter((entry) => entry.classId && entry.levels > 0);
+    }
+
+    const source = build.classLevels || character.classLevels || character.classesById || {};
+    return Object.entries(source)
+      .map(([classId, levels]) => ({
+        classId: normalizeId(classId),
+        levels: Math.max(0, toInt(levels?.levels ?? levels?.level ?? levels)),
+      }))
+      .filter((entry) => entry.classId && entry.levels > 0);
+  }
+
+  function getClassLevel(character = {}, classId) {
+    const id = normalizeId(classId);
+    return classEntries(character).find((entry) => entry.classId === id)?.levels || 0;
+  }
+
+  function normalizeSelections(character = {}) {
+    const build = character?.characterBuild && typeof character.characterBuild === "object" ? character.characterBuild : {};
+    const raw = build.archetypes ?? character.archetypes ?? [];
+    const list = Array.isArray(raw)
+      ? raw
+      : Object.entries(raw || {}).map(([classId, value]) => typeof value === "string"
+        ? { classId, archetypeId: value }
+        : { classId, ...(value || {}) });
+
+    const byClass = new Map();
+    list.forEach((entry) => {
+      const classId = normalizeId(entry?.classId || entry?.parentClassId || entry?.class);
+      const archetypeId = normalizeId(entry?.archetypeId || entry?.subclassId || entry?.id || entry?.archetype);
+      if (!classId || !archetypeId || byClass.has(classId)) return;
+      byClass.set(classId, {
+        classId,
+        archetypeId,
+        selectedAtClassLevel: Math.max(0, toInt(entry?.selectedAtClassLevel ?? entry?.selectedAtLevel)),
+      });
+    });
+    return [...byClass.values()];
+  }
+
+  function catalogEntries(catalog = {}) {
+    if (Array.isArray(catalog)) return catalog.filter(Boolean);
+    return Object.values(catalog || {}).filter(Boolean);
+  }
+
+  function normalizeArchetype(entry = {}) {
+    const id = normalizeId(entry.id || entry.archetypeId || entry.name);
+    const classId = normalizeId(entry.classId || entry.parentClassId || entry.parentClass);
+    return {
+      ...clone(entry),
+      id,
+      archetypeId: id,
+      classId,
+      name: String(entry.name || entry.archetypeName || id || "Archetype"),
+      className: String(entry.className || entry.parentClassName || classId || "Class"),
+      unlockLevel: Math.max(0, toInt(entry.unlockLevel ?? entry.selectAtLevel ?? 15, 15)),
+    };
+  }
+
+  function archetypeMap(catalog = {}) {
+    return new Map(catalogEntries(catalog).map(normalizeArchetype).filter((entry) => entry.id).map((entry) => [entry.id, entry]));
+  }
+
+  function selectedForClass(character = {}, classId) {
+    const id = normalizeId(classId);
+    return normalizeSelections(character).find((entry) => entry.classId === id) || null;
+  }
+
+  function isSelected(character = {}, archetypeId, classId = null) {
+    const archetype = normalizeId(archetypeId);
+    const parent = normalizeId(classId);
+    return normalizeSelections(character).some((entry) => entry.archetypeId === archetype && (!parent || entry.classId === parent));
+  }
+
+  function eligibleArchetypes(character = {}, catalog = {}, classId = null) {
+    const parent = normalizeId(classId);
+    return [...archetypeMap(catalog).values()].filter((archetype) => {
+      if (parent && archetype.classId !== parent) return false;
+      return getClassLevel(character, archetype.classId) >= archetype.unlockLevel;
+    });
+  }
+
+  function validateSelections(character = {}, catalog = {}) {
+    const definitions = archetypeMap(catalog);
+    const raw = normalizeSelections(character);
+    const errors = [];
+    const seenClasses = new Set();
+
+    raw.forEach((selection) => {
+      if (seenClasses.has(selection.classId)) errors.push(`Only one Archetype can be selected for ${selection.classId}.`);
+      seenClasses.add(selection.classId);
+      const archetype = definitions.get(selection.archetypeId);
+      if (!archetype) {
+        errors.push(`Unknown Archetype: ${selection.archetypeId}.`);
+        return;
+      }
+      if (archetype.classId !== selection.classId) {
+        errors.push(`${archetype.name} belongs to ${archetype.classId}, not ${selection.classId}.`);
+      }
+      const classLevel = getClassLevel(character, archetype.classId);
+      if (classLevel < archetype.unlockLevel) {
+        errors.push(`${archetype.name} requires ${archetype.className} Class Level ${archetype.unlockLevel}.`);
+      }
+    });
+
+    return { valid: errors.length === 0, errors, selections: raw };
+  }
+
+  function selectArchetype(character = {}, classId, archetypeId, catalog = {}, options = {}) {
+    const parent = normalizeId(classId);
+    const id = normalizeId(archetypeId);
+    const archetype = archetypeMap(catalog).get(id);
+    if (!archetype) throw new Error(`Unknown Archetype: ${id}.`);
+    if (archetype.classId !== parent) throw new Error(`${archetype.name} cannot be selected for ${parent}.`);
+    const classLevel = getClassLevel(character, parent);
+    if (classLevel < archetype.unlockLevel) throw new Error(`${archetype.name} requires Class Level ${archetype.unlockLevel}.`);
+
+    const current = normalizeSelections(character);
+    const existing = current.find((entry) => entry.classId === parent);
+    if (existing && existing.archetypeId !== id && options.allowReplace !== true) {
+      throw new Error(`${parent} already has Archetype ${existing.archetypeId}.`);
+    }
+
+    const next = current.filter((entry) => entry.classId !== parent);
+    next.push({ classId: parent, archetypeId: id, selectedAtClassLevel: classLevel });
+    return next.sort((a, b) => a.classId.localeCompare(b.classId));
+  }
+
+  function grantSourceType(grant = {}) {
+    return normalizeId(grant.sourceType || grant.source?.type);
+  }
+
+  function grantArchetypeId(grant = {}) {
+    return normalizeId(grant.archetypeId || grant.sourceId || grant.source?.archetypeId || grant.source?.id);
+  }
+
+  function grantClassId(grant = {}, definition = {}, archetype = {}) {
+    return normalizeId(
+      grant.classId || grant.parentClassId || grant.source?.classId || grant.source?.parentClassId ||
+      definition?.source?.classId || definition?.source?.parentClassId || archetype.classId,
+    );
+  }
+
+  function resolveTraitGrants(character = {}, grants = [], catalog = {}, archetypes = {}, traitEngine = global.LuminousTraitEngine) {
+    const definitionMap = catalog instanceof Map
+      ? catalog
+      : new Map(Object.entries(catalog || {}).map(([key, value]) => [normalizeId(key), value]));
+    const archetypeDefinitions = archetypeMap(archetypes);
+    const selections = normalizeSelections(character);
+
+    return (Array.isArray(grants) ? grants : Object.values(grants || {}))
+      .filter((grant) => grantSourceType(grant) === "archetype")
+      .map((grant) => {
+        const traitId = normalizeId(grant.traitId || grant.id);
+        const definition = definitionMap.get(traitId);
+        if (!definition) return null;
+        const archetypeId = grantArchetypeId(grant) || normalizeId(definition?.source?.archetypeId || definition?.source?.id);
+        const archetype = archetypeDefinitions.get(archetypeId) || normalizeArchetype({
+          id: archetypeId,
+          classId: grantClassId(grant, definition),
+          name: definition?.source?.archetypeName || archetypeId,
+          className: definition?.source?.className || grantClassId(grant, definition),
+          unlockLevel: 0,
+        });
+        const classId = grantClassId(grant, definition, archetype);
+        const selected = selections.some((entry) => entry.classId === classId && entry.archetypeId === archetypeId);
+        const atLevel = Math.max(0, toInt(grant.atLevel ?? grant.level));
+        if (!selected || getClassLevel(character, classId) < atLevel) return null;
+
+        const normalized = traitEngine?.normalizeTrait ? traitEngine.normalizeTrait(definition) : clone(definition);
+        normalized.source = {
+          ...(normalized.source || {}),
+          ...(grant.source || {}),
+          type: "archetype",
+          id: archetypeId,
+          archetypeId,
+          archetypeName: archetype.name,
+          classId,
+          className: archetype.className,
+          atLevel,
+          requiredClassLevel: atLevel,
+        };
+        return normalized;
+      })
+      .filter(Boolean);
+  }
+
+  function groupTraitsByArchetype(traits = []) {
+    const groups = new Map();
+    (traits || []).forEach((trait) => {
+      const source = trait?.source || {};
+      const type = normalizeId(source.type || trait?.sourceType);
+      if (!["archetype", "subclass", "class_archetype"].includes(type)) return;
+      const archetypeId = normalizeId(source.archetypeId || source.subclassId || source.id);
+      if (!archetypeId) return;
+      if (!groups.has(archetypeId)) {
+        groups.set(archetypeId, {
+          archetypeId,
+          name: String(source.archetypeName || source.subclassName || source.name || archetypeId),
+          classId: normalizeId(source.classId || source.parentClassId || source.parentClass),
+          className: String(source.className || source.parentClassName || source.classId || ""),
+          traits: [],
+        });
+      }
+      groups.get(archetypeId).traits.push(trait);
+    });
+    return [...groups.values()];
+  }
+
+  const api = Object.freeze({
+    normalizeId,
+    classEntries,
+    getClassLevel,
+    normalizeSelections,
+    normalizeArchetype,
+    archetypeMap,
+    selectedForClass,
+    isSelected,
+    eligibleArchetypes,
+    validateSelections,
+    selectArchetype,
+    resolveTraitGrants,
+    groupTraitsByArchetype,
+  });
+
+  global.LuminousArchetypeEngine = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/archetype-engine.js
+++ b/js/archetype-engine.js
@@ -40,18 +40,19 @@
         ? { classId, archetypeId: value }
         : { classId, ...(value || {}) });
 
-    const byClass = new Map();
-    list.forEach((entry) => {
+    // Intentionally preserve duplicate Class entries here. Validation must see malformed
+    // persisted input instead of silently normalizing it into a valid one. Callers that
+    // select/replace an Archetype canonicalize the chosen Class by filtering and re-adding it.
+    return list.map((entry) => {
       const classId = normalizeId(entry?.classId || entry?.parentClassId || entry?.class);
       const archetypeId = normalizeId(entry?.archetypeId || entry?.subclassId || entry?.id || entry?.archetype);
-      if (!classId || !archetypeId || byClass.has(classId)) return;
-      byClass.set(classId, {
+      if (!classId || !archetypeId) return null;
+      return {
         classId,
         archetypeId,
         selectedAtClassLevel: Math.max(0, toInt(entry?.selectedAtClassLevel ?? entry?.selectedAtLevel)),
-      });
-    });
-    return [...byClass.values()];
+      };
+    }).filter(Boolean);
   }
 
   function catalogEntries(catalog = {}) {

--- a/js/archetype-trait-catalog.js
+++ b/js/archetype-trait-catalog.js
@@ -50,6 +50,7 @@
         activeInventoryBonus: 2,
         strengthCheckThreshold: -1,
         twoHandedHandSlots: 1,
+        twoHandedAsOneHanded: true,
       },
     },
 
@@ -83,7 +84,10 @@
         id: "devil_lineage_demonic_resistance_heal",
         contexts: ["combat"],
         trigger: "turn_start",
-        conditions: [],
+        conditions: [
+          { path: "self.isDowned", operator: "falsy" },
+          { path: "self.lifeState", operator: "ne", value: "downed" },
+        ],
         operations: [{ type: "heal_hp", path: "self.hp", maxPath: "self.maxHp", formula: "floor(MaxHP * (ConstitutionMod + Proficiency) / 100)" }],
       }],
       rules: [],
@@ -143,7 +147,13 @@
       source,
       contexts: ["any"],
       activation: { type: "passive", actionCost: "none" },
-      effects: [],
+      effects: [{
+        id: "devil_lineage_supernatural_endurance_death_save_power",
+        contexts: ["combat"],
+        trigger: "before_check",
+        conditions: [{ path: "check.kind", operator: "eq", value: "death_save" }],
+        operations: [{ type: "modify", path: "check.deathSavePower", mode: "add", value: 2 }],
+      }],
       rules: [],
       mechanics: { deathSavePowerBonus: 2 },
     },
@@ -167,14 +177,14 @@
       schemaVersion: 1,
       id: "devil_lineage_improved_devil_strength",
       name: "Improved Devil Strength",
-      description: "On Hit, apply 3 Burn Potency. On Critical, apply 1 Burn Count.",
+      description: "While having Rage, On Hit apply 3 Burn Potency and On Critical apply 1 Burn Count.",
       source,
       contexts: ["combat"],
       activation: { type: "automatic", actionCost: "none" },
       effects: [],
       rules: [
-        { type: "status", trigger: "on_hit", target: "target", action: "inflict", statusId: "burn", potency: 3, count: 0 },
-        { type: "status", trigger: "on_crit", target: "target", action: "inflict", statusId: "burn", potency: 0, count: 1 },
+        { type: "status", trigger: "on_hit", target: "target", action: "inflict", statusId: "burn", potency: 3, count: 0, whileStatus: "rage" },
+        { type: "status", trigger: "on_crit", target: "target", action: "inflict", statusId: "burn", potency: 0, count: 1, whileStatus: "rage" },
       ],
     },
 
@@ -207,6 +217,7 @@
       rules: [],
       mechanics: {
         bodyPartRegenerationDays: 3,
+        bodyPartRegenerationHours: 72,
         minimumHpDuringRegeneration: 1,
         restoreBlockedEquipmentSlots: true,
       },
@@ -304,8 +315,24 @@
     return { ...ARCHETYPES };
   }
 
+  function getDefinition(id) {
+    const key = String(id ?? "").trim().toLowerCase().replace(/\s+/g, "_");
+    return DEFINITIONS[key] || null;
+  }
+
   function resolveTraitGrants(character = {}, definitions = allDefinitions()) {
     return archetypeEngine.resolveTraitGrants(character, GRANTS, definitions, ARCHETYPES, global.LuminousTraitEngine || traitEngine);
+  }
+
+  function ensureDevilLineageRuntime() {
+    const doc = global.document;
+    if (!doc || global.LuminousDevilLineageRuntime || doc.getElementById?.("devil-lineage-runtime-script")) return null;
+    const script = doc.createElement("script");
+    script.id = "devil-lineage-runtime-script";
+    script.src = "js/devil-lineage-runtime.js";
+    script.async = false;
+    doc.head?.appendChild(script);
+    return script;
   }
 
   const api = Object.freeze({
@@ -317,9 +344,12 @@
     allDefinitions,
     allGrants,
     allArchetypes,
+    getDefinition,
     resolveTraitGrants,
+    ensureDevilLineageRuntime,
   });
 
   global.LuminousArchetypeTraitCatalog = api;
+  ensureDevilLineageRuntime();
   if (typeof module !== "undefined" && module.exports) module.exports = api;
 })(typeof window !== "undefined" ? window : globalThis);

--- a/js/archetype-trait-catalog.js
+++ b/js/archetype-trait-catalog.js
@@ -79,10 +79,14 @@
       source,
       contexts: ["any"],
       activation: { type: "passive", actionCost: "none" },
-      effects: [],
-      rules: [
-        { type: "modifier", trigger: "turn_start", target: "self", path: "hpPercent", mode: "regain", formula: "ConstitutionMod + Proficiency" },
-      ],
+      effects: [{
+        id: "devil_lineage_demonic_resistance_heal",
+        contexts: ["combat"],
+        trigger: "turn_start",
+        conditions: [],
+        operations: [{ type: "heal_hp", path: "self.hp", maxPath: "self.maxHp", formula: "floor(MaxHP * (ConstitutionMod + Proficiency) / 100)" }],
+      }],
+      rules: [],
       mechanics: {
         statusDamageMultipliers: { burn: 0.5, poison: 0.5 },
       },

--- a/js/archetype-trait-catalog.js
+++ b/js/archetype-trait-catalog.js
@@ -1,0 +1,321 @@
+(function (global) {
+  "use strict";
+
+  const archetypeEngine = global.LuminousArchetypeEngine || (typeof require === "function" ? require("./archetype-engine.js") : null);
+  const traitEngine = global.LuminousTraitEngine || (typeof require === "function" ? require("./trait-engine.js") : null);
+  if (!archetypeEngine) return;
+
+  const ARCHETYPE_ID = "path_of_the_devil_lineage";
+  const CLASS_ID = "barbarian";
+
+  function deepFreeze(value, seen = new WeakSet()) {
+    if (!value || typeof value !== "object" || seen.has(value)) return value;
+    seen.add(value);
+    Reflect.ownKeys(value).forEach((key) => deepFreeze(value[key], seen));
+    return Object.freeze(value);
+  }
+
+  const ARCHETYPES = deepFreeze({
+    [ARCHETYPE_ID]: {
+      id: ARCHETYPE_ID,
+      name: "Path of the Devil Lineage",
+      classId: CLASS_ID,
+      className: "Barbarian",
+      unlockLevel: 15,
+      traitLevels: [15, 30, 50, 70],
+    },
+  });
+
+  const source = Object.freeze({
+    type: "archetype",
+    id: ARCHETYPE_ID,
+    archetypeId: ARCHETYPE_ID,
+    archetypeName: "Path of the Devil Lineage",
+    classId: CLASS_ID,
+    className: "Barbarian",
+  });
+
+  const DEFINITIONS = deepFreeze({
+    devil_lineage_devil_strength: {
+      schemaVersion: 1,
+      id: "devil_lineage_devil_strength",
+      name: "Devil Strength",
+      description: "Gain +2 Active Inventory. Strength Checks have Threshold -1. Two-Handed Weapons can be equipped using only 1 Hand Equipment Slot.",
+      source,
+      contexts: ["any"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [],
+      mechanics: {
+        activeInventoryBonus: 2,
+        strengthCheckThreshold: -1,
+        twoHandedHandSlots: 1,
+      },
+    },
+
+    devil_lineage_infernal_speed: {
+      schemaVersion: 1,
+      id: "devil_lineage_infernal_speed",
+      name: "Infernal Speed",
+      description: "While having Rage, gain +2 Max Speed and halve Jump Check Thresholds.",
+      source,
+      contexts: ["any"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [
+        { type: "modifier", trigger: "passive", target: "self", channel: "max_speed", mode: "add", value: 2, whileStatus: "rage" },
+      ],
+      mechanics: {
+        whileStatus: "rage",
+        jumpThresholdMultiplier: 0.5,
+      },
+    },
+
+    devil_lineage_demonic_resistance: {
+      schemaVersion: 1,
+      id: "devil_lineage_demonic_resistance",
+      name: "Demonic Resistance",
+      description: "Take Half Damage from Burn and Poison. At Turn Start, Recover (CON Mod + Proficiency)% Max HP.",
+      source,
+      contexts: ["any"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [
+        { type: "modifier", trigger: "turn_start", target: "self", path: "hpPercent", mode: "regain", formula: "ConstitutionMod + Proficiency" },
+      ],
+      mechanics: {
+        statusDamageMultipliers: { burn: 0.5, poison: 0.5 },
+      },
+    },
+
+    devil_lineage_jackpot: {
+      schemaVersion: 1,
+      id: "devil_lineage_jackpot",
+      name: "¡JACKPOT!",
+      description: "Coins that spend Ammo deal +(10 × STR Mod)% Damage. Performance Checks gain +(STR Mod) Power.",
+      source,
+      contexts: ["any"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [],
+      mechanics: {
+        ammoCoinDamagePercentFormula: "10 * StrengthMod",
+        performancePowerFormula: "StrengthMod",
+      },
+    },
+
+    devil_lineage_infernal_touch: {
+      schemaVersion: 1,
+      id: "devil_lineage_infernal_touch",
+      name: "Infernal Touch",
+      description: "While having Rage, Slash, Pierce and Blunt Resistance is treated as Normal (x1) for you. At 50% Max HP or less gain +10% Critical Chance. On Critical with a 2-3 Coin Skill, Reuse its last Coin once per Turn. On Critical Kill with a 1 Coin Skill, Reuse that Skill once per Turn.",
+      source,
+      contexts: ["combat"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [
+        {
+          type: "coin",
+          trigger: "on_crit",
+          target: "self",
+          action: "reuse_last",
+          count: 1,
+          scope: "once_per_turn",
+          conditions: [{ variable: "SkillCoinCount", operator: "between", value: 2, max: 3 }],
+        },
+      ],
+      mechanics: {
+        resistanceToNormalWhileStatus: { statusId: "rage", damageTypes: ["slash", "pierce", "blunt"], resistance: 0.5, normal: 1 },
+        lowHpCriticalChance: { atOrBelowPercent: 50, bonusPercent: 10 },
+        oneCoinCriticalKillReuse: { scope: "once_per_turn", coinCount: 1 },
+      },
+    },
+
+    devil_lineage_supernatural_endurance: {
+      schemaVersion: 1,
+      id: "devil_lineage_supernatural_endurance",
+      name: "Supernatural Endurance",
+      description: "Gain +2 Death Save Power.",
+      source,
+      contexts: ["any"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [],
+      mechanics: { deathSavePowerBonus: 2 },
+    },
+
+    devil_lineage_demon_wing: {
+      schemaVersion: 1,
+      id: "devil_lineage_demon_wing",
+      name: "Demon Wing",
+      description: "Gain Flight and +1 Max Speed.",
+      source,
+      contexts: ["any"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [
+        { type: "modifier", trigger: "passive", target: "self", channel: "max_speed", mode: "add", value: 1 },
+      ],
+      mechanics: { capabilities: ["flight"], maxSpeedFinalBonus: 1 },
+    },
+
+    devil_lineage_improved_devil_strength: {
+      schemaVersion: 1,
+      id: "devil_lineage_improved_devil_strength",
+      name: "Improved Devil Strength",
+      description: "On Hit, apply 3 Burn Potency. On Critical, apply 1 Burn Count.",
+      source,
+      contexts: ["combat"],
+      activation: { type: "automatic", actionCost: "none" },
+      effects: [],
+      rules: [
+        { type: "status", trigger: "on_hit", target: "target", action: "inflict", statusId: "burn", potency: 3, count: 0 },
+        { type: "status", trigger: "on_crit", target: "target", action: "inflict", statusId: "burn", potency: 0, count: 1 },
+      ],
+    },
+
+    devil_lineage_improved_demonic_resistance: {
+      schemaVersion: 1,
+      id: "devil_lineage_improved_demonic_resistance",
+      name: "Improved Demonic Resistance",
+      description: "Quick Action: Spend 1 Recover Slot and perform that Recover immediately. The used Recover Slot becomes Blocked until 2 Long Rests are completed.",
+      source,
+      contexts: ["combat"],
+      activation: { type: "manual", actionCost: "quick_action" },
+      effects: [],
+      rules: [],
+      mechanics: {
+        spendRecoverSlot: 1,
+        performRecoverImmediately: true,
+        blockUsedRecoverSlotLongRests: 2,
+      },
+    },
+
+    devil_lineage_demonic_regeneration: {
+      schemaVersion: 1,
+      id: "devil_lineage_demonic_regeneration",
+      name: "Demonic Regeneration",
+      description: "Lost body parts regenerate after 3 Days if the character remains at 1 HP or higher. Restore Equipment Slots blocked by that lost body part when it regenerates.",
+      source,
+      contexts: ["any"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [],
+      mechanics: {
+        bodyPartRegenerationDays: 3,
+        minimumHpDuringRegeneration: 1,
+        restoreBlockedEquipmentSlots: true,
+      },
+    },
+
+    devil_lineage_demon_wings: {
+      schemaVersion: 1,
+      id: "devil_lineage_demon_wings",
+      name: "Demon Wings",
+      description: "Gain Flight, +3 Max Speed and +1 Min Speed.",
+      source,
+      contexts: ["any"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [
+        { type: "modifier", trigger: "passive", target: "self", channel: "max_speed", mode: "add", value: 2 },
+        { type: "modifier", trigger: "passive", target: "self", channel: "min_speed", mode: "add", value: 1 },
+      ],
+      mechanics: { capabilities: ["flight"], maxSpeedFinalBonus: 3, minSpeedFinalBonus: 1, upgradesTraitId: "devil_lineage_demon_wing" },
+    },
+
+    devil_lineage_power_of_the_nine_hells: {
+      schemaVersion: 1,
+      id: "devil_lineage_power_of_the_nine_hells",
+      name: "Power of the Nine Hells",
+      description: "Gain +6 Active Inventory. Strength Checks have Threshold -3. On Hit, STR Skills deal (STR Mod × 2)% Fixed Damage.",
+      source,
+      contexts: ["any"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [],
+      mechanics: {
+        activeInventoryBonus: 6,
+        strengthCheckThreshold: -3,
+        onHitStrengthFixedDamagePercentFormula: "StrengthMod * 2",
+        upgradesTraitId: "devil_lineage_devil_strength",
+      },
+    },
+
+    devil_lineage_cursed_juggernaut: {
+      schemaVersion: 1,
+      id: "devil_lineage_cursed_juggernaut",
+      name: "Cursed Juggernaut",
+      description: "While having Rage, HP cannot be reduced below 1. Once per Encounter, when Damage or an Effect would reduce HP to 1 or less, set HP to 1 and mark a recovery. At the next Turn Start, Recover Max(14, 14 × CON Mod)% Max HP even if other healing already raised HP.",
+      source,
+      contexts: ["combat"],
+      activation: { type: "automatic", actionCost: "none" },
+      effects: [],
+      rules: [],
+      mechanics: {
+        whileStatus: "rage",
+        minimumHp: 1,
+        triggerAtOrBelowHp: 1,
+        recoveryScope: "encounter",
+        recoveryTiming: "next_turn_start",
+        recoveryPercentFormula: "max(14, 14 * ConstitutionMod)",
+        pendingRecoveryPersistsAfterHealing: true,
+      },
+    },
+  });
+
+  const GRANTS = deepFreeze([
+    [15, "devil_lineage_devil_strength"],
+    [15, "devil_lineage_infernal_speed"],
+    [15, "devil_lineage_demonic_resistance"],
+    [15, "devil_lineage_jackpot"],
+    [30, "devil_lineage_infernal_touch"],
+    [50, "devil_lineage_supernatural_endurance"],
+    [50, "devil_lineage_demon_wing"],
+    [50, "devil_lineage_improved_devil_strength"],
+    [50, "devil_lineage_improved_demonic_resistance"],
+    [70, "devil_lineage_demonic_regeneration"],
+    [70, "devil_lineage_demon_wings"],
+    [70, "devil_lineage_power_of_the_nine_hells"],
+    [70, "devil_lineage_cursed_juggernaut"],
+  ].map(([atLevel, traitId]) => ({
+    sourceType: "archetype",
+    sourceId: ARCHETYPE_ID,
+    archetypeId: ARCHETYPE_ID,
+    classId: CLASS_ID,
+    atLevel,
+    traitId,
+    source: { ...source, atLevel, requiredClassLevel: atLevel },
+  })));
+
+  function allDefinitions() {
+    return { ...DEFINITIONS };
+  }
+
+  function allGrants() {
+    return GRANTS.map((grant) => ({ ...grant, source: { ...(grant.source || {}) } }));
+  }
+
+  function allArchetypes() {
+    return { ...ARCHETYPES };
+  }
+
+  function resolveTraitGrants(character = {}, definitions = allDefinitions()) {
+    return archetypeEngine.resolveTraitGrants(character, GRANTS, definitions, ARCHETYPES, global.LuminousTraitEngine || traitEngine);
+  }
+
+  const api = Object.freeze({
+    ARCHETYPE_ID,
+    CLASS_ID,
+    ARCHETYPES,
+    DEFINITIONS,
+    GRANTS,
+    allDefinitions,
+    allGrants,
+    allArchetypes,
+    resolveTraitGrants,
+  });
+
+  global.LuminousArchetypeTraitCatalog = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/death-save-runtime.js
+++ b/js/death-save-runtime.js
@@ -6,13 +6,32 @@
   const PATCH_INTERVAL_MS = 250;
   const MAX_DEATH_SAVES = 3;
   const DEATH_SAVE_CHECK = Object.freeze({
+    id: "death_save",
+    kind: "death_save",
+    checkType: "death_save",
+    abilityId: "death_save",
     coinAmount: 5,
     coinPower: 4,
     basePower: 0,
     threshold: 10,
+    deathSavePower: 0,
+    deathSaveThreshold: 10,
     flat: true,
     statModifiers: false,
+    proficiency: false,
     headsChance: 50,
+  });
+
+  const SINNER_TRAIT = Object.freeze({
+    schemaVersion: 1,
+    id: "sinner",
+    name: "Sinner",
+    source: { type: "special", id: "sinner" },
+    contexts: ["combat"],
+    activation: { type: "passive", actionCost: "none" },
+    description: "On actual death, use Sinner Death instead of normal permanent-death consequences. Player Sinners still use Downed and Death Saves to determine whether they remain available in the Encounter.",
+    effects: [],
+    rules: [],
   });
 
   const state = {
@@ -20,6 +39,8 @@
     retreatQueue: [],
     skillTokens: typeof WeakMap === "function" ? new WeakMap() : null,
     nextSkillToken: 1,
+    deathSaveTraitStateByKey: new Map(),
+    deathSaveTraitStateByObject: typeof WeakMap === "function" ? new WeakMap() : null,
   };
 
   const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
@@ -27,9 +48,26 @@
   const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
 
   function unitIds(unit = {}) {
-    return [unit.id, unit.unitId, unit.unit_id, unit.characterId, unit.character_id, unit.playerId, unit.player_id, unit.uid]
+    return [
+      unit.combatId, unit.combat_id, unit.id, unit.unitId, unit.unit_id,
+      unit.characterId, unit.character_id, unit.playerId, unit.player_id,
+      unit.actorId, unit.actor_id, unit.uid, unit.vinculo_jugador,
+    ]
       .filter((value) => value != null && String(value).trim() !== "")
       .map((value) => String(value).trim());
+  }
+
+  function unitName(unit = {}) {
+    return normalizeId(unit.characterName || unit.character_name || unit.nombre || unit.name || "");
+  }
+
+  function sameUnit(a, b) {
+    if (!a || !b) return false;
+    if (a === b) return true;
+    const ids = new Set(unitIds(a));
+    if (unitIds(b).some((id) => ids.has(id))) return true;
+    const name = unitName(a);
+    return Boolean(name && name === unitName(b));
   }
 
   function hasTag(unit = {}, tag) {
@@ -72,6 +110,147 @@
     return isPlayerCharacter(unit) || isCaptain(unit);
   }
 
+  function traitCharacterForUnit(unit = {}) {
+    const build = unit.characterBuild && typeof unit.characterBuild === "object" ? unit.characterBuild : {};
+    return {
+      ...unit,
+      characterBuild: build,
+      classes: Array.isArray(unit.classes) ? unit.classes : (Array.isArray(build.classes) ? build.classes : []),
+      raceId: build.raceId ?? unit.raceId ?? unit.race?.id,
+      raceSubtypeId: build.raceSubtypeId ?? unit.raceSubtypeId ?? unit.race?.subtypeId,
+      backgroundId: build.backgroundId ?? unit.backgroundId ?? unit.background?.id,
+      level: build.calculatedAtLevel ?? unit.level,
+      lineages: Array.isArray(build.lineages) ? build.lineages : unit.lineages,
+      lineageId: build.lineageId ?? unit.lineageId,
+    };
+  }
+
+  function addTraitDefinition(byId, definition) {
+    if (!definition || typeof definition !== "object") return;
+    const engine = global.LuminousTraitEngine;
+    let trait = definition;
+    try { trait = engine?.normalizeTrait ? engine.normalizeTrait(definition) : definition; } catch (_) {}
+    const id = normalizeId(trait?.id || trait?.name);
+    if (id && !byId.has(id)) byId.set(id, trait);
+  }
+
+  function traitsForDeathSaveUnit(unit = {}) {
+    const engine = global.LuminousTraitEngine;
+    if (!engine) return [];
+    const byId = new Map();
+    const character = traitCharacterForUnit(unit);
+
+    try { global.LuminousArchetypeRuntime?.syncArchetypeTraitsForUnit?.(unit); } catch (_) {}
+    [unit.traitDefinitions, unit.traits].forEach((list) => {
+      if (!Array.isArray(list)) return;
+      list.forEach((entry) => { if (entry && typeof entry === "object") addTraitDefinition(byId, entry); });
+    });
+
+    const core = global.LuminousTraitCatalogCore;
+    const racial = global.LuminousRacialTraitCatalog;
+    const archetypeCatalog = global.LuminousArchetypeTraitCatalog;
+    const coreDefinitions = core?.allDefinitions?.() || {};
+    const racialDefinitions = racial?.allDefinitions?.() || {};
+
+    try {
+      (engine.resolveTraitGrants?.(character, core?.allGrants?.() || [], coreDefinitions) || []).forEach((trait) => addTraitDefinition(byId, trait));
+    } catch (_) {}
+    try {
+      (racial?.resolveTraitGrants?.(character, { ...coreDefinitions, ...racialDefinitions }) || []).forEach((trait) => addTraitDefinition(byId, trait));
+    } catch (_) {}
+    try {
+      (global.LuminousArchetypeCombatEventRuntime?.traitsForUnit?.(unit) || []).forEach((trait) => addTraitDefinition(byId, trait));
+    } catch (_) {}
+
+    const selectedDefinitions = { ...coreDefinitions, ...racialDefinitions };
+    try {
+      (global.LuminousClassMilestones?.resolveSelectedGeneralTraits?.(unit, selectedDefinitions) || []).forEach((trait) => addTraitDefinition(byId, trait));
+    } catch (_) {}
+
+    traitIds(unit).forEach((id) => {
+      if (byId.has(id)) return;
+      let definition = null;
+      try { definition = core?.getDefinition?.(id) || null; } catch (_) {}
+      try { definition = definition || racial?.getDefinition?.(id) || null; } catch (_) {}
+      try { definition = definition || archetypeCatalog?.getDefinition?.(id) || null; } catch (_) {}
+      if (id === "sinner") definition = definition || SINNER_TRAIT;
+      addTraitDefinition(byId, definition);
+    });
+
+    return [...byId.values()];
+  }
+
+  function deathSaveTraitStateFor(unit = {}) {
+    const shared = global.LuminousArchetypeCombatEventRuntime?.traitStateFor?.(unit);
+    if (shared) return shared;
+    const engine = global.LuminousTraitEngine;
+    const key = unitIds(unit)[0] || unitName(unit) || null;
+    if (key) {
+      if (!state.deathSaveTraitStateByKey.has(key)) state.deathSaveTraitStateByKey.set(key, engine?.createState?.() || {});
+      return state.deathSaveTraitStateByKey.get(key);
+    }
+    if (state.deathSaveTraitStateByObject) {
+      if (!state.deathSaveTraitStateByObject.has(unit)) state.deathSaveTraitStateByObject.set(unit, engine?.createState?.() || {});
+      return state.deathSaveTraitStateByObject.get(unit);
+    }
+    return engine?.createState?.() || {};
+  }
+
+  function playerRuntimeOwnsUnit(unit) {
+    const runtime = global.LuminousPlayerTraitRuntime;
+    if (!runtime?.getCharacter || !runtime?.dispatchCombatEvent) return false;
+    try { return sameUnit(unit, runtime.getCharacter()); } catch (_) { return false; }
+  }
+
+  function dispatchDeathSaveTraitTrigger(trigger, unit, check, options = {}) {
+    if (!unit || !check) return { delegated: false, outcomes: [] };
+    const input = {
+      context: "combat",
+      character: traitCharacterForUnit(unit),
+      self: unit,
+      unit,
+      target: unit,
+      defender: unit,
+      check,
+      checkKind: "death_save",
+      deathSave: true,
+      source: "death_save",
+      ...(options.runtime || {}),
+    };
+    input.character = traitCharacterForUnit(unit);
+    input.self = unit;
+    input.check = check;
+
+    if (playerRuntimeOwnsUnit(unit)) {
+      try {
+        const result = global.LuminousPlayerTraitRuntime.dispatchCombatEvent(trigger, input) || null;
+        return { delegated: true, result, outcomes: result?.outcomes || [] };
+      } catch (_) {
+        return { delegated: true, result: null, outcomes: [] };
+      }
+    }
+
+    const engine = global.LuminousTraitEngine;
+    const traits = traitsForDeathSaveUnit(unit);
+    if (!engine?.dispatchTraits || !traits.length) return { delegated: false, traits, outcomes: [] };
+    const traitState = deathSaveTraitStateFor(unit);
+    const runtime = { ...input };
+    const outcomes = [];
+    try {
+      if (normalizeId(trigger) !== "passive") {
+        const passive = engine.dispatchTraits(traits, "passive", runtime, traitState);
+        if (Array.isArray(passive?.outcomes)) outcomes.push(...passive.outcomes);
+      }
+      const result = engine.dispatchTraits(traits, trigger, runtime, traitState);
+      if (Array.isArray(result?.outcomes)) outcomes.push(...result.outcomes);
+      global.LuminousTraitStandardizationRuntime?.resolveTraitRuntimeResolutions?.(traits, normalizeId(trigger), runtime, result);
+      return { delegated: false, traits, state: traitState, runtime, result, outcomes };
+    } catch (error) {
+      console.warn?.("Death Save Trait dispatch failed:", error);
+      return { delegated: false, traits, state: traitState, runtime, outcomes, error };
+    }
+  }
+
   function ensureDeathState(unit) {
     if (!unit || typeof unit !== "object") return null;
     if (!unit.deathSaves || typeof unit.deathSaves !== "object") unit.deathSaves = { successes: 0, failures: 0 };
@@ -83,6 +262,8 @@
       else if (unit.isDowned === true) unit.lifeState = "downed";
       else unit.lifeState = "alive";
     }
+    if (!Number.isFinite(Number(unit.deathSavePower))) unit.deathSavePower = DEATH_SAVE_CHECK.deathSavePower;
+    if (!Number.isFinite(Number(unit.deathSaveThreshold))) unit.deathSaveThreshold = DEATH_SAVE_CHECK.deathSaveThreshold;
     return unit.deathSaves;
   }
 
@@ -246,22 +427,100 @@
     return result;
   }
 
+  function prepareDeathSaveCheck(unit = null, options = {}) {
+    const check = {
+      ...DEATH_SAVE_CHECK,
+      id: "death_save",
+      kind: "death_save",
+      checkType: "death_save",
+      abilityId: "death_save",
+      skillId: null,
+      abilityPower: 0,
+      finalPower: 0,
+      deathSavePower: DEATH_SAVE_CHECK.deathSavePower,
+      difficulty: DEATH_SAVE_CHECK.threshold,
+      threshold: DEATH_SAVE_CHECK.threshold,
+      deathSaveThreshold: DEATH_SAVE_CHECK.deathSaveThreshold,
+      statModifier: 0,
+      proficiencyBonus: 0,
+      statModifiers: false,
+      proficiency: false,
+      source: "death_save",
+      ...(options.check || {}),
+    };
+
+    const baseThreshold = DEATH_SAVE_CHECK.threshold;
+    const traitResolution = unit ? dispatchDeathSaveTraitTrigger("before_check", unit, check, options) : { outcomes: [] };
+
+    // Death Saves never import ordinary Check bonuses. Only values written into the Check
+    // by Traits are honored. Dedicated Death Save fields and generic Check channels stack.
+    const traitPower =
+      numberOr(check.deathSavePower, DEATH_SAVE_CHECK.deathSavePower) +
+      numberOr(check.finalPower, 0) +
+      numberOr(check.abilityPower, 0);
+    const resolvedThreshold = baseThreshold
+      + (numberOr(check.deathSaveThreshold, baseThreshold) - baseThreshold)
+      + (numberOr(check.difficulty, baseThreshold) - baseThreshold)
+      + (numberOr(check.threshold, baseThreshold) - baseThreshold);
+
+    check.coinAmount = Math.max(1, Math.trunc(numberOr(check.coinAmount, DEATH_SAVE_CHECK.coinAmount)));
+    check.coinPower = numberOr(check.coinPower, DEATH_SAVE_CHECK.coinPower);
+    check.basePower = numberOr(check.basePower, DEATH_SAVE_CHECK.basePower);
+    check.headsChance = Math.max(5, Math.min(95, numberOr(check.headsChance, DEATH_SAVE_CHECK.headsChance)));
+    check.deathSavePower = traitPower;
+    check.deathSaveThreshold = resolvedThreshold;
+    check.resolvedThreshold = resolvedThreshold;
+    check.statModifier = 0;
+    check.proficiencyBonus = 0;
+    check.statModifiers = false;
+    check.proficiency = false;
+    check.traitOutcomes = clone(traitResolution?.outcomes || []);
+
+    if (unit) {
+      unit.deathSavePower = traitPower;
+      unit.deathSaveThreshold = resolvedThreshold;
+      unit.deathSaveCheck = {
+        power: traitPower,
+        threshold: resolvedThreshold,
+        coinAmount: check.coinAmount,
+        coinPower: check.coinPower,
+        basePower: check.basePower,
+      };
+    }
+
+    emit("luminous:death-save-check-prepared", { unit, check, traitResolution });
+    return { check, traitResolution };
+  }
+
   function rollDeathSave(options = {}) {
+    const unit = options.unit || null;
+    const prepared = prepareDeathSaveCheck(unit, options);
+    const check = prepared.check;
     const coin = global.LuminousCoinEngine;
     const rng = typeof options.rng === "function" ? options.rng : Math.random;
     const tosses = [];
-    for (let index = 0; index < DEATH_SAVE_CHECK.coinAmount; index += 1) {
-      const side = coin?.rollSide ? coin.rollSide(DEATH_SAVE_CHECK.headsChance, rng) : ((rng() * 100) < DEATH_SAVE_CHECK.headsChance ? "head" : "tail");
+    for (let index = 0; index < check.coinAmount; index += 1) {
+      const side = coin?.rollSide ? coin.rollSide(check.headsChance, rng) : ((rng() * 100) < check.headsChance ? "head" : "tail");
       tosses.push(side);
     }
     const heads = tosses.filter((side) => side === "head").length;
-    const total = DEATH_SAVE_CHECK.basePower + heads * DEATH_SAVE_CHECK.coinPower;
-    return { ...DEATH_SAVE_CHECK, tosses, heads, total, passed: total >= DEATH_SAVE_CHECK.threshold };
+    const rolledPower = check.basePower + heads * check.coinPower;
+    const total = rolledPower + check.deathSavePower;
+    check.tosses = tosses;
+    check.heads = heads;
+    check.rolledPower = rolledPower;
+    check.total = total;
+    check.passed = total >= check.deathSaveThreshold;
+
+    if (unit) dispatchDeathSaveTraitTrigger("after_check", unit, check, options);
+    return check;
   }
 
   function resolveDeathSave(unit, options = {}) {
     if (!isDowned(unit) || isDead(unit)) return { resolved: false, reason: "not_downed", unit };
-    const check = options.checkResult || rollDeathSave(options);
+    const check = options.checkResult
+      ? { ...DEATH_SAVE_CHECK, ...options.checkResult }
+      : rollDeathSave({ ...options, unit });
     const outcome = check.passed ? addSuccess(unit, { reason: "death_save", check }) : addFailure(unit, { reason: "death_save", check });
     const result = { resolved: true, unit, check, outcome };
     emit("luminous:death-save-resolved", result);
@@ -416,6 +675,7 @@
     engine.canUnitAct = function (unit) { return canAct(unit); };
     engine.applyHealing = function (unit, amount, options = {}) { return heal(unit, amount, options); };
     engine.reviveUnit = function (unit, amount = 1, options = {}) { return heal(unit, amount, { ...options, revive: true, source: options.source || "revival" }); };
+    engine.prepareDeathSaveCheck = function (unit, options = {}) { return prepareDeathSaveCheck(unit, options); };
     engine.resolveDeathSave = function (unit, options = {}) { return resolveDeathSave(unit, options); };
     engine.returnFromRetreat = function (unit, options = {}) { return returnFromRetreat(unit, options); };
     engine.getAllTargetableUnits = function () {
@@ -615,19 +875,11 @@
   const api = Object.freeze({
     MAX_DEATH_SAVES,
     DEATH_SAVE_CHECK,
-    SINNER_TRAIT: Object.freeze({
-      schemaVersion: 1,
-      id: "sinner",
-      name: "Sinner",
-      source: { type: "special", id: "sinner" },
-      contexts: ["combat"],
-      activation: { type: "passive", actionCost: "none" },
-      description: "On actual death, use Sinner Death instead of normal permanent-death consequences. Player Sinners still use Downed and Death Saves to determine whether they remain available in the Encounter.",
-      effects: [],
-      rules: [],
-    }),
+    SINNER_TRAIT,
     normalizeId,
     traitIds,
+    traitsForDeathSaveUnit,
+    dispatchDeathSaveTraitTrigger,
     isPlayerCharacter,
     isCaptain,
     isSinner,
@@ -643,6 +895,7 @@
     resolveDeath,
     addFailure,
     addSuccess,
+    prepareDeathSaveCheck,
     rollDeathSave,
     resolveDeathSave,
     heal,

--- a/js/death-save-runtime.js
+++ b/js/death-save-runtime.js
@@ -410,6 +410,7 @@
     const originalTriggerEvent = typeof engine.triggerEvent === "function" ? engine.triggerEvent : null;
     const originalResolveUnilateral = typeof engine.resolveUnilateralWithCounter === "function" ? engine.resolveUnilateralWithCounter : null;
     const originalCalculateAoE = typeof engine.calculateAoETargets === "function" ? engine.calculateAoETargets : null;
+    const originalGetAllAliveUnits = typeof engine.getAllAliveUnits === "function" ? engine.getAllAliveUnits : null;
 
     engine.isUnitTargetable = function (unit) { return isTargetable(unit); };
     engine.canUnitAct = function (unit) { return canAct(unit); };
@@ -417,6 +418,17 @@
     engine.reviveUnit = function (unit, amount = 1, options = {}) { return heal(unit, amount, { ...options, revive: true, source: options.source || "revival" }); };
     engine.resolveDeathSave = function (unit, options = {}) { return resolveDeathSave(unit, options); };
     engine.returnFromRetreat = function (unit, options = {}) { return returnFromRetreat(unit, options); };
+    engine.getAllTargetableUnits = function () {
+      const data = global.combatData && typeof global.combatData === "object" ? Object.values(global.combatData) : [];
+      return data.filter((unit) => isTargetable(unit));
+    };
+
+    if (originalGetAllAliveUnits) {
+      engine.getAllAliveUnits = function (...args) {
+        const units = originalGetAllAliveUnits.apply(this, args) || [];
+        return units.filter((unit) => !isDead(unit) && !isRetreated(unit));
+      };
+    }
 
     if (originalInitialize) {
       engine.initializeUnitData = function (unit, ...rest) {
@@ -523,7 +535,14 @@
 
     if (originalCalculateAoE) {
       engine.calculateAoETargets = function (skill, primaryTarget, allPossibleTargets, attacker, ...rest) {
-        const source = Array.isArray(allPossibleTargets) ? allPossibleTargets : [];
+        const supplied = Array.isArray(allPossibleTargets) ? allPossibleTargets : [];
+        const world = global.combatData && typeof global.combatData === "object" ? Object.values(global.combatData) : [];
+        const sideKey = (unit) => normalizeId(unit?.team || unit?.faction || unit?.side || (isPlayerCharacter(unit) ? "player" : "enemy"));
+        const targetSide = sideKey(primaryTarget);
+        const source = [...supplied];
+        world.forEach((unit) => {
+          if (!source.includes(unit) && isTargetable(unit) && (!targetSide || sideKey(unit) === targetSide)) source.push(unit);
+        });
         const eligible = source.filter((unit) => isTargetable(unit));
         const targets = originalCalculateAoE.call(this, skill, primaryTarget, eligible, attacker, ...rest) || [];
         let remainingWeight = Math.max(0, numberOr(skill?.atkWeight ?? skill?.weight, 1) - targets.reduce((sum, unit) => sum + Math.max(1, numberOr(unit?.slotWeight, 1)), 0));
@@ -551,21 +570,35 @@
     if (originalTriggerPhase) {
       engine.triggerPhase = function (phaseTag, allUnits, ...rest) {
         const units = Array.isArray(allUnits) ? allUnits : [];
+        units.forEach(ensureDeathState);
+
         if (phaseTag === "[Round Start]") {
-          units.forEach((unit) => {
-            ensureDeathState(unit);
-            if (isDowned(unit)) unit.actionQueue = [];
-          });
+          units.forEach((unit) => { if (isDowned(unit)) unit.actionQueue = []; });
         }
+
         if (phaseTag === "[Round End]") {
+          // Death Save resolves before Turn End. A third Success arms Retreat and Retreat
+          // immediately removes the unit before normal Turn End passives/status decay.
           units.forEach((unit) => {
             if (isDowned(unit) && !isDead(unit)) resolveDeathSave(unit);
           });
-        }
-        const result = originalTriggerPhase.call(this, phaseTag, allUnits, ...rest);
-        if (phaseTag === "[Round End]") {
           units.forEach((unit) => {
             if (unit?.retreat?.pending && !isDead(unit)) resolveRetreat(unit, { units });
+          });
+          units.forEach((unit) => {
+            if (isDowned(unit) && !isDead(unit)) unit.__luminousPausedStatusSnapshot = clone(unit.statusEffects || {});
+          });
+        }
+
+        const activeUnits = units.filter((unit) => !isDead(unit) && !isRetreated(unit));
+        const result = originalTriggerPhase.call(this, phaseTag, activeUnits, ...rest);
+
+        if (phaseTag === "[Round End]") {
+          units.forEach((unit) => {
+            if (unit.__luminousPausedStatusSnapshot) {
+              if (isDowned(unit) && !isDead(unit)) unit.statusEffects = unit.__luminousPausedStatusSnapshot;
+              delete unit.__luminousPausedStatusSnapshot;
+            }
           });
         }
         return result;

--- a/js/death-save-runtime.js
+++ b/js/death-save-runtime.js
@@ -1,0 +1,612 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousDeathSaveRuntime) return;
+
+  const PATCH_INTERVAL_MS = 250;
+  const MAX_DEATH_SAVES = 3;
+  const DEATH_SAVE_CHECK = Object.freeze({
+    coinAmount: 5,
+    coinPower: 4,
+    basePower: 0,
+    threshold: 10,
+    flat: true,
+    statModifiers: false,
+    headsChance: 50,
+  });
+
+  const state = {
+    combatSource: null,
+    retreatQueue: [],
+    skillTokens: typeof WeakMap === "function" ? new WeakMap() : null,
+    nextSkillToken: 1,
+  };
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+  function unitIds(unit = {}) {
+    return [unit.id, unit.unitId, unit.unit_id, unit.characterId, unit.character_id, unit.playerId, unit.player_id, unit.uid]
+      .filter((value) => value != null && String(value).trim() !== "")
+      .map((value) => String(value).trim());
+  }
+
+  function hasTag(unit = {}, tag) {
+    const wanted = normalizeId(tag);
+    const values = [];
+    [unit.tags, unit.unitTags, unit.labels, unit.markers].forEach((list) => {
+      if (Array.isArray(list)) values.push(...list);
+    });
+    return values.some((value) => normalizeId(value?.id || value?.name || value) === wanted);
+  }
+
+  function traitIds(unit = {}) {
+    const values = [];
+    [unit.traitIds, unit.grantedTraitIds, unit.racialTraitIds].forEach((list) => {
+      if (Array.isArray(list)) values.push(...list);
+    });
+    [unit.traits, unit.traitDefinitions].forEach((list) => {
+      if (Array.isArray(list)) values.push(...list.map((entry) => entry?.id || entry?.name || entry));
+    });
+    return new Set(values.filter(Boolean).map(normalizeId));
+  }
+
+  function isPlayerCharacter(unit = {}) {
+    if (unit.isPlayer === true || unit.isPlayerCharacter === true || unit.playerCharacter === true) return true;
+    const type = normalizeId(unit.unitType || unit.unit_type || unit.controlType || unit.control_type || unit.actorType || unit.actor_type);
+    return ["player", "player_character", "pc"].includes(type);
+  }
+
+  function isCaptain(unit = {}) {
+    if (unit.isCaptain === true || unit.captain === true || unit.enemyCaptain === true) return true;
+    const rank = normalizeId(unit.rank || unit.unitRank || unit.unit_rank || unit.enemyRank || unit.enemy_rank);
+    return rank === "captain" || hasTag(unit, "captain");
+  }
+
+  function isSinner(unit = {}) {
+    return unit.isSinner === true || traitIds(unit).has("sinner");
+  }
+
+  function usesDeathSaves(unit = {}) {
+    return isPlayerCharacter(unit) || isCaptain(unit);
+  }
+
+  function ensureDeathState(unit) {
+    if (!unit || typeof unit !== "object") return null;
+    if (!unit.deathSaves || typeof unit.deathSaves !== "object") {
+      unit.deathSaves = { successes: 0, failures: 0 };
+    }
+    unit.deathSaves.successes = Math.max(0, Math.min(MAX_DEATH_SAVES, Math.trunc(numberOr(unit.deathSaves.successes, 0))));
+    unit.deathSaves.failures = Math.max(0, Math.min(MAX_DEATH_SAVES, Math.trunc(numberOr(unit.deathSaves.failures, 0))));
+    if (!unit.lifeState) {
+      if (unit.isDead === true) unit.lifeState = "dead";
+      else if (unit.isRetreated === true) unit.lifeState = "retreated";
+      else if (unit.isDowned === true) unit.lifeState = "downed";
+      else unit.lifeState = "alive";
+    }
+    return unit.deathSaves;
+  }
+
+  function resetDeathSaves(unit) {
+    const saves = ensureDeathState(unit);
+    if (!saves) return null;
+    saves.successes = 0;
+    saves.failures = 0;
+    return saves;
+  }
+
+  function isDowned(unit = {}) {
+    ensureDeathState(unit);
+    return unit.lifeState === "downed" || unit.isDowned === true;
+  }
+
+  function isDead(unit = {}) {
+    ensureDeathState(unit);
+    return unit.lifeState === "dead" || unit.isDead === true;
+  }
+
+  function isRetreated(unit = {}) {
+    ensureDeathState(unit);
+    return unit.lifeState === "retreated" || unit.isRetreated === true;
+  }
+
+  function isTargetable(unit = {}) {
+    if (!unit || isDead(unit) || isRetreated(unit)) return false;
+    return numberOr(unit.hp, 0) > 0 || isDowned(unit);
+  }
+
+  function canAct(unit = {}) {
+    return Boolean(unit) && !isDowned(unit) && !isDead(unit) && !isRetreated(unit) && numberOr(unit.hp, 0) > 0;
+  }
+
+  function emit(name, detail) {
+    try {
+      if (typeof global.dispatchEvent === "function" && typeof global.CustomEvent === "function") {
+        global.dispatchEvent(new global.CustomEvent(name, { detail }));
+      }
+    } catch (_) {}
+    return detail;
+  }
+
+  function dispatchLifeEvent(trigger, unit, context = {}) {
+    if (!unit) return null;
+    const input = { context: "combat", self: unit, character: unit, unit, target: unit, defender: unit, ...(context || {}) };
+    let playerResult = null;
+    if (isPlayerCharacter(unit)) {
+      try { playerResult = global.LuminousPlayerTraitRuntime?.dispatchCombatEvent?.(trigger, input) || null; } catch (_) {}
+    }
+    let archetypeResult = null;
+    try { archetypeResult = global.LuminousArchetypeCombatEventRuntime?.dispatchForUnit?.(trigger, unit, input) || null; } catch (_) {}
+    emit(`luminous:${normalizeId(trigger).replace(/_/g, "-")}`, { unit, trigger, context: input });
+    return { playerResult, archetypeResult };
+  }
+
+  function markAlive(unit) {
+    if (!unit) return unit;
+    unit.lifeState = "alive";
+    unit.isDowned = false;
+    unit.isDead = false;
+    unit.isRetreated = false;
+    delete unit.deathType;
+    delete unit.sinnerDeath;
+    return unit;
+  }
+
+  function enterDowned(unit, options = {}) {
+    if (!unit || isDead(unit) || isRetreated(unit)) return { entered: false, reason: "not_available", unit };
+    if (!usesDeathSaves(unit)) return resolveDeath(unit, { ...options, reason: options.reason || "hp_zero", immediateEnemyDeath: true });
+
+    const wasDowned = isDowned(unit);
+    ensureDeathState(unit);
+    unit.hp = 0;
+    unit.lifeState = "downed";
+    unit.isDowned = true;
+    unit.isDead = false;
+    unit.isRetreated = false;
+    unit.actionQueue = [];
+    if (!wasDowned) resetDeathSaves(unit);
+
+    const sourceKind = normalizeId(options.sourceKind || options.damageType || options.reason || "other");
+    emit("luminous:downed", { unit, sourceKind, context: options.context || null });
+
+    if (!wasDowned && ["status", "status_effect", "effect_status", "efecto_estado", "dot"].includes(sourceKind)) {
+      const failure = addFailure(unit, { reason: "downed_by_status", context: options.context || null });
+      return { entered: true, unit, failure };
+    }
+    return { entered: !wasDowned, unit };
+  }
+
+  function resolveDeath(unit, options = {}) {
+    if (!unit) return { died: false, reason: "missing_unit" };
+    ensureDeathState(unit);
+    if (isDead(unit)) return { died: false, alreadyDead: true, unit };
+
+    const wasDowned = isDowned(unit);
+    unit.hp = 0;
+    unit.lifeState = "dead";
+    unit.isDead = true;
+    unit.isDowned = false;
+    unit.isRetreated = false;
+    unit.actionQueue = [];
+    unit.deathType = isSinner(unit) ? "sinner" : "normal";
+    unit.sinnerDeath = unit.deathType === "sinner";
+    unit.deleted = false;
+    resetDeathSaves(unit);
+
+    if (unit.dead_sprite) unit.current_sprite = unit.dead_sprite;
+    dispatchLifeEvent("on_death", unit, { ...options, wasDowned, deathType: unit.deathType });
+    emit("luminous:unit-dead", { unit, wasDowned, deathType: unit.deathType, reason: options.reason || "death" });
+    return { died: true, unit, deathType: unit.deathType, permanentRecordDeletion: false };
+  }
+
+  function addFailure(unit, options = {}) {
+    if (!isDowned(unit) || isDead(unit)) return { changed: false, unit, reason: "not_downed" };
+    const saves = ensureDeathState(unit);
+    saves.failures = Math.min(MAX_DEATH_SAVES, saves.failures + 1);
+    const result = { changed: true, unit, failures: saves.failures, successes: saves.successes, reason: options.reason || "failure" };
+    emit("luminous:death-save-failure", result);
+    if (saves.failures >= MAX_DEATH_SAVES) result.death = resolveDeath(unit, { reason: options.reason || "three_failed_death_saves", context: options.context || null });
+    return result;
+  }
+
+  function grantRetreat(unit, options = {}) {
+    if (!unit) return null;
+    unit.retreat = {
+      pending: true,
+      grantedAt: Date.now(),
+      reason: options.reason || "death_save_success",
+    };
+    try {
+      global.LuminousStatusEngine?.applyStatus?.(unit, "retreat", {
+        mode: "set",
+        count: 1,
+        duration: "until_removed",
+        data: { pending: true, systemStatus: true },
+      });
+    } catch (_) {}
+    emit("luminous:retreat-granted", { unit, retreat: clone(unit.retreat) });
+    return unit.retreat;
+  }
+
+  function resolveThreeSuccesses(unit) {
+    if (!unit) return { resolved: false };
+    const maxHp = Math.max(1, numberOr(unit.maxHp, 1));
+    const recoveredHp = Math.max(1, Math.ceil(maxHp * 0.05));
+    resetDeathSaves(unit);
+    markAlive(unit);
+    unit.hp = Math.min(maxHp, recoveredHp);
+    grantRetreat(unit);
+    emit("luminous:death-save-stabilized", { unit, hp: unit.hp, maxHp });
+    return { resolved: true, unit, hp: unit.hp, retreat: true };
+  }
+
+  function addSuccess(unit, options = {}) {
+    if (!isDowned(unit) || isDead(unit)) return { changed: false, unit, reason: "not_downed" };
+    const saves = ensureDeathState(unit);
+    saves.successes = Math.min(MAX_DEATH_SAVES, saves.successes + 1);
+    const result = { changed: true, unit, successes: saves.successes, failures: saves.failures };
+    emit("luminous:death-save-success", result);
+    if (saves.successes >= MAX_DEATH_SAVES) result.stabilized = resolveThreeSuccesses(unit, options);
+    return result;
+  }
+
+  function rollDeathSave(options = {}) {
+    const coin = global.LuminousCoinEngine;
+    const rng = typeof options.rng === "function" ? options.rng : Math.random;
+    const tosses = [];
+    for (let index = 0; index < DEATH_SAVE_CHECK.coinAmount; index += 1) {
+      const side = coin?.rollSide ? coin.rollSide(DEATH_SAVE_CHECK.headsChance, rng) : ((rng() * 100) < DEATH_SAVE_CHECK.headsChance ? "head" : "tail");
+      tosses.push(side);
+    }
+    const heads = tosses.filter((side) => side === "head").length;
+    const total = DEATH_SAVE_CHECK.basePower + heads * DEATH_SAVE_CHECK.coinPower;
+    return { ...DEATH_SAVE_CHECK, tosses, heads, total, passed: total >= DEATH_SAVE_CHECK.threshold };
+  }
+
+  function resolveDeathSave(unit, options = {}) {
+    if (!isDowned(unit) || isDead(unit)) return { resolved: false, reason: "not_downed", unit };
+    const check = options.checkResult || rollDeathSave(options);
+    const outcome = check.passed ? addSuccess(unit, { reason: "death_save", check }) : addFailure(unit, { reason: "death_save", check });
+    const result = { resolved: true, unit, check, outcome };
+    emit("luminous:death-save-resolved", result);
+    return result;
+  }
+
+  function heal(unit, amount, options = {}) {
+    if (!unit) return { applied: 0, reason: "missing_unit" };
+    const requested = Math.max(0, numberOr(amount, 0));
+    const source = normalizeId(options.source || options.healSource || "external");
+    const revival = options.revive === true || options.resurrection === true || ["revival", "resurrection"].includes(source);
+
+    if (isDead(unit)) {
+      if (!revival) return { applied: 0, reason: "dead_requires_revival", unit };
+      const maxHp = Math.max(1, numberOr(unit.maxHp, 1));
+      const restored = Math.min(maxHp, Math.max(1, requested || 1));
+      markAlive(unit);
+      resetDeathSaves(unit);
+      unit.hp = restored;
+      emit("luminous:unit-revived", { unit, hp: restored, source });
+      return { applied: restored, revived: true, unit };
+    }
+
+    if (isDowned(unit)) {
+      if (["self", "passive", "regen", "trait", "self_passive", "self_regen"].includes(source)) {
+        emit("luminous:downed-self-heal-negated", { unit, requested, source });
+        return { applied: 0, negated: true, reason: "downed_self_heal", unit };
+      }
+      if (requested <= 0) return { applied: 0, reason: "no_healing", unit };
+      const maxHp = Math.max(1, numberOr(unit.maxHp, 1));
+      const restored = Math.min(maxHp, requested);
+      markAlive(unit);
+      resetDeathSaves(unit);
+      unit.hp = restored;
+      emit("luminous:downed-stabilized-by-heal", { unit, hp: restored, source });
+      return { applied: restored, stabilized: true, unit };
+    }
+
+    const maxHp = Math.max(1, numberOr(unit.maxHp, numberOr(unit.hp, 1)));
+    const before = Math.max(0, numberOr(unit.hp, 0));
+    const after = Math.min(maxHp, before + requested);
+    unit.hp = after;
+    return { applied: after - before, unit };
+  }
+
+  function queueRetreat(unit) {
+    if (!unit) return;
+    const key = unitIds(unit)[0] || unit;
+    if (!state.retreatQueue.some((entry) => entry.key === key)) state.retreatQueue.push({ key, unit, at: Date.now() });
+  }
+
+  function resolveRetreat(unit, options = {}) {
+    if (!unit || !unit.retreat?.pending || isDead(unit)) return { retreated: false, unit };
+    const forcedStagger = unit.isForcedStagger === true || unit.forcedStagger === true || unit.staggerForced === true;
+    if (!forcedStagger) {
+      unit.isStaggered = false;
+      unit.staggerTurns = 0;
+    }
+    const snapshot = {
+      hp: Math.max(0, numberOr(unit.hp, 0)),
+      sp: numberOr(unit.sp, 0),
+      retreatedAt: Date.now(),
+    };
+    unit.retreatSnapshot = snapshot;
+    unit.retreat.pending = false;
+    unit.lifeState = "retreated";
+    unit.isRetreated = true;
+    unit.isDowned = false;
+    unit.actionQueue = [];
+    unit.activeSlots = 0;
+    queueRetreat(unit);
+    emit("luminous:unit-retreated", { unit, snapshot, chainBattle: options.chainBattle === true });
+    return { retreated: true, unit, snapshot };
+  }
+
+  function statusPersistsThroughRetreat(statusId, instance) {
+    if (instance?.data?.persistsThroughRetreat === true || instance?.persistsThroughRetreat === true) return true;
+    try {
+      return global.LuminousStatusEngine?.getDefinition?.(statusId)?.persistsThroughRetreat === true;
+    } catch (_) { return false; }
+  }
+
+  function clearRetreatEffects(unit) {
+    if (!unit?.statusEffects || typeof unit.statusEffects !== "object") return [];
+    const kept = [];
+    Object.keys({ ...unit.statusEffects }).forEach((statusId) => {
+      const instance = unit.statusEffects[statusId];
+      if (normalizeId(statusId) === "retreat") {
+        delete unit.statusEffects[statusId];
+        return;
+      }
+      if (statusPersistsThroughRetreat(statusId, instance)) kept.push(statusId);
+      else delete unit.statusEffects[statusId];
+    });
+    return kept;
+  }
+
+  function returnFromRetreat(unit, options = {}) {
+    if (!unit || !isRetreated(unit)) return { returned: false, unit };
+    const snapshot = unit.retreatSnapshot || { hp: numberOr(unit.hp, 0), sp: numberOr(unit.sp, 0) };
+    markAlive(unit);
+    unit.hp = Math.max(1, numberOr(snapshot.hp, 1));
+    unit.sp = numberOr(snapshot.sp, 0) < 0 ? 0 : numberOr(snapshot.sp, 0);
+    const keptStatuses = clearRetreatEffects(unit);
+    const key = unitIds(unit)[0] || unit;
+    state.retreatQueue = state.retreatQueue.filter((entry) => entry.key !== key);
+    emit("luminous:unit-returned-from-retreat", { unit, keptStatuses, options });
+    return { returned: true, unit, keptStatuses };
+  }
+
+  function noteSkillHitOnDowned(unit, skill, context = {}) {
+    if (!isDowned(unit) || isDead(unit)) return { changed: false, reason: "not_downed", unit };
+    if (!skill || (skill.type && normalizeId(skill.type) === "status")) return { changed: false, reason: "not_skill", unit };
+    let token = context.__luminousDeathSaveSkillToken || null;
+    if (!token && state.skillTokens && typeof skill === "object") {
+      token = state.skillTokens.get(skill);
+      if (!token) {
+        token = `skill_${state.nextSkillToken++}`;
+        state.skillTokens.set(skill, token);
+      }
+    }
+    token = token || `skill_${state.nextSkillToken++}`;
+    if (unit.__luminousLastDownedFailureSkillToken === token) return { changed: false, deduped: true, unit };
+    unit.__luminousLastDownedFailureSkillToken = token;
+    return addFailure(unit, { reason: "skill_hit_while_downed", context });
+  }
+
+  function clearSkillHitToken(unit) {
+    if (unit) delete unit.__luminousLastDownedFailureSkillToken;
+  }
+
+  function patchCombatEngine() {
+    const engine = global.CombatEngine;
+    if (!engine) return false;
+    if (engine.__deathSaveRuntimeIntegrated) {
+      state.combatSource = engine;
+      return true;
+    }
+
+    const originalInitialize = typeof engine.initializeUnitData === "function" ? engine.initializeUnitData : null;
+    const originalApplyDamage = typeof engine.applyDamage === "function" ? engine.applyDamage : null;
+    const originalProcessStatusEffects = typeof engine.processStatusEffects === "function" ? engine.processStatusEffects : null;
+    const originalTriggerPhase = typeof engine.triggerPhase === "function" ? engine.triggerPhase : null;
+    const originalTriggerEvent = typeof engine.triggerEvent === "function" ? engine.triggerEvent : null;
+    const originalResolveUnilateral = typeof engine.resolveUnilateralWithCounter === "function" ? engine.resolveUnilateralWithCounter : null;
+    const originalCalculateAoE = typeof engine.calculateAoETargets === "function" ? engine.calculateAoETargets : null;
+
+    engine.isUnitTargetable = function (unit) { return isTargetable(unit); };
+    engine.canUnitAct = function (unit) { return canAct(unit); };
+    engine.applyHealing = function (unit, amount, options = {}) { return heal(unit, amount, options); };
+    engine.reviveUnit = function (unit, amount = 1, options = {}) { return heal(unit, amount, { ...options, revive: true, source: options.source || "revival" }); };
+    engine.resolveDeathSave = function (unit, options = {}) { return resolveDeathSave(unit, options); };
+    engine.returnFromRetreat = function (unit, options = {}) { return returnFromRetreat(unit, options); };
+
+    if (originalInitialize) {
+      engine.initializeUnitData = function (unit, ...rest) {
+        const result = originalInitialize.call(this, unit, ...rest);
+        ensureDeathState(unit);
+        return result;
+      };
+    }
+
+    if (originalApplyDamage) {
+      engine.applyDamage = function (unit, damage, damageType = "directo", isCritical = false, skillUsed = null, ...rest) {
+        if (!unit) return originalApplyDamage.call(this, unit, damage, damageType, isCritical, skillUsed, ...rest);
+        ensureDeathState(unit);
+        const beforeHp = numberOr(unit.hp, 0);
+        const wasDowned = isDowned(unit);
+        const statusDamage = ["efecto_estado", "status", "status_effect", "dot"].includes(normalizeId(damageType));
+
+        if (wasDowned) {
+          if (statusDamage) return { hp: 0, shield: unit.shield, deathSave: addFailure(unit, { reason: "status_damage_while_downed" }) };
+          if (skillUsed) return { hp: 0, shield: unit.shield, downedHitDeferred: true };
+          return { hp: 0, shield: unit.shield };
+        }
+
+        const result = originalApplyDamage.call(this, unit, damage, damageType, isCritical, skillUsed, ...rest);
+        const reachedZero = beforeHp > 0 && numberOr(unit.hp, 0) <= 0;
+        if (!reachedZero) return result;
+
+        if (usesDeathSaves(unit)) {
+          const transition = enterDowned(unit, { sourceKind: statusDamage ? "status" : (skillUsed?.type === "Spell" ? "spell" : (skillUsed ? "skill" : normalizeId(damageType))), skill: skillUsed });
+          return { ...(result || {}), hp: unit.hp, downed: true, transition };
+        }
+        const death = resolveDeath(unit, { reason: "hp_zero", sourceKind: statusDamage ? "status" : (skillUsed ? "skill" : normalizeId(damageType)), skill: skillUsed });
+        return { ...(result || {}), hp: 0, death };
+      };
+    }
+
+    if (originalProcessStatusEffects) {
+      engine.processStatusEffects = function (unit, triggerKey, context = {}, ...rest) {
+        const downedBefore = isDowned(unit);
+        const hpBefore = numberOr(unit?.hp, 0);
+        const result = originalProcessStatusEffects.call(this, unit, triggerKey, context, ...rest);
+        if (downedBefore && !isDead(unit) && numberOr(unit?.hp, 0) > hpBefore) {
+          const healed = numberOr(unit?.hp, 0) - hpBefore;
+          unit.hp = 0;
+          emit("luminous:downed-self-heal-negated", { unit, requested: healed, source: "status_or_passive" });
+        }
+        return result;
+      };
+    }
+
+    if (originalTriggerEvent) {
+      engine.triggerEvent = function (tag, context = {}, targetsHit = [], ...rest) {
+        const targets = Array.isArray(targetsHit) && targetsHit.length ? targetsHit : [context?.defender || context?.currentTarget].filter(Boolean);
+        if (tag === "[On Kill]" && targets.some((target) => target?.__luminousDownedAttackProxy || (isDowned(target) && numberOr(target.hp, 0) <= 0))) return;
+        const result = originalTriggerEvent.call(this, tag, context, targetsHit, ...rest);
+        if (tag === "[On Hit]" && context?.skill) {
+          targets.forEach((target) => {
+            if (target?.__luminousDownedAttackProxy || isDowned(target)) noteSkillHitOnDowned(target, context.skill, context);
+          });
+        }
+        if (tag === "[Attack End]") targets.forEach(clearSkillHitToken);
+        return result;
+      };
+    }
+
+    if (originalResolveUnilateral) {
+      engine.resolveUnilateralWithCounter = function (attacker, skill, defender, counterSkill, options = {}, ...rest) {
+        if (!defender || !isDowned(defender)) return originalResolveUnilateral.call(this, attacker, skill, defender, counterSkill, options, ...rest);
+        const originalHp = defender.hp;
+        defender.__luminousDownedAttackProxy = true;
+        defender.hp = 1;
+        try {
+          const result = originalResolveUnilateral.call(this, attacker, skill, defender, counterSkill, options, ...rest);
+          defender.hp = 0;
+          return result;
+        } finally {
+          defender.hp = isDead(defender) ? 0 : originalHp;
+          delete defender.__luminousDownedAttackProxy;
+          clearSkillHitToken(defender);
+        }
+      };
+    }
+
+    if (originalCalculateAoE) {
+      engine.calculateAoETargets = function (skill, primaryTarget, allPossibleTargets, attacker, ...rest) {
+        const source = Array.isArray(allPossibleTargets) ? allPossibleTargets : [];
+        const eligible = source.filter((unit) => isTargetable(unit));
+        const targets = originalCalculateAoE.call(this, skill, primaryTarget, eligible, attacker, ...rest) || [];
+        let remainingWeight = Math.max(0, numberOr(skill?.atkWeight ?? skill?.weight, 1) - targets.reduce((sum, unit) => sum + Math.max(1, numberOr(unit?.slotWeight, 1)), 0));
+        if (remainingWeight <= 0) return targets;
+        const primaryPos = primaryTarget?.grid_pos || null;
+        const downedCandidates = eligible
+          .filter((unit) => unit !== primaryTarget && isDowned(unit) && !targets.includes(unit))
+          .sort((a, b) => {
+            if (!primaryPos || !a?.grid_pos || !b?.grid_pos) return 0;
+            const da = Math.hypot(a.grid_pos.x - primaryPos.x, a.grid_pos.y - primaryPos.y);
+            const db = Math.hypot(b.grid_pos.x - primaryPos.x, b.grid_pos.y - primaryPos.y);
+            return da - db;
+          });
+        downedCandidates.forEach((candidate) => {
+          const weight = Math.max(1, numberOr(candidate?.slotWeight, 1));
+          if (weight <= remainingWeight) {
+            targets.push(candidate);
+            remainingWeight -= weight;
+          }
+        });
+        return targets;
+      };
+    }
+
+    if (originalTriggerPhase) {
+      engine.triggerPhase = function (phaseTag, allUnits, ...rest) {
+        const units = Array.isArray(allUnits) ? allUnits : [];
+        if (phaseTag === "[Round Start]") {
+          units.forEach((unit) => {
+            ensureDeathState(unit);
+            if (isDowned(unit)) unit.actionQueue = [];
+          });
+        }
+        if (phaseTag === "[Round End]") {
+          units.forEach((unit) => {
+            if (isDowned(unit) && !isDead(unit)) resolveDeathSave(unit);
+          });
+        }
+        const result = originalTriggerPhase.call(this, phaseTag, allUnits, ...rest);
+        if (phaseTag === "[Round End]") {
+          units.forEach((unit) => {
+            if (unit?.retreat?.pending && !isDead(unit)) resolveRetreat(unit, { units });
+          });
+        }
+        return result;
+      };
+    }
+
+    Object.defineProperty(engine, "__deathSaveRuntimeIntegrated", { value: true, configurable: true });
+    state.combatSource = engine;
+    return true;
+  }
+
+  function install() { return patchCombatEngine(); }
+
+  const api = Object.freeze({
+    MAX_DEATH_SAVES,
+    DEATH_SAVE_CHECK,
+    SINNER_TRAIT: Object.freeze({
+      schemaVersion: 1,
+      id: "sinner",
+      name: "Sinner",
+      source: { type: "special", id: "sinner" },
+      contexts: ["combat"],
+      activation: { type: "passive", actionCost: "none" },
+      description: "On actual death, use Sinner Death instead of normal permanent-death consequences. Player Sinners still use Downed and Death Saves to determine whether they remain available in the Encounter.",
+      effects: [],
+      rules: [],
+    }),
+    normalizeId,
+    traitIds,
+    isPlayerCharacter,
+    isCaptain,
+    isSinner,
+    usesDeathSaves,
+    ensureDeathState,
+    resetDeathSaves,
+    isDowned,
+    isDead,
+    isRetreated,
+    isTargetable,
+    canAct,
+    enterDowned,
+    resolveDeath,
+    addFailure,
+    addSuccess,
+    rollDeathSave,
+    resolveDeathSave,
+    heal,
+    grantRetreat,
+    resolveRetreat,
+    returnFromRetreat,
+    noteSkillHitOnDowned,
+    clearRetreatEffects,
+    patchCombatEngine,
+    install,
+    getRetreatQueue: () => state.retreatQueue.slice(),
+  });
+
+  global.LuminousDeathSaveRuntime = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+  install();
+  global.setInterval?.(install, PATCH_INTERVAL_MS);
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/death-save-runtime.js
+++ b/js/death-save-runtime.js
@@ -74,9 +74,7 @@
 
   function ensureDeathState(unit) {
     if (!unit || typeof unit !== "object") return null;
-    if (!unit.deathSaves || typeof unit.deathSaves !== "object") {
-      unit.deathSaves = { successes: 0, failures: 0 };
-    }
+    if (!unit.deathSaves || typeof unit.deathSaves !== "object") unit.deathSaves = { successes: 0, failures: 0 };
     unit.deathSaves.successes = Math.max(0, Math.min(MAX_DEATH_SAVES, Math.trunc(numberOr(unit.deathSaves.successes, 0))));
     unit.deathSaves.failures = Math.max(0, Math.min(MAX_DEATH_SAVES, Math.trunc(numberOr(unit.deathSaves.failures, 0))));
     if (!unit.lifeState) {
@@ -169,7 +167,6 @@
 
     const sourceKind = normalizeId(options.sourceKind || options.damageType || options.reason || "other");
     emit("luminous:downed", { unit, sourceKind, context: options.context || null });
-
     if (!wasDowned && ["status", "status_effect", "effect_status", "efecto_estado", "dot"].includes(sourceKind)) {
       const failure = addFailure(unit, { reason: "downed_by_status", context: options.context || null });
       return { entered: true, unit, failure };
@@ -195,7 +192,9 @@
     resetDeathSaves(unit);
 
     if (unit.dead_sprite) unit.current_sprite = unit.dead_sprite;
-    dispatchLifeEvent("on_death", unit, { ...options, wasDowned, deathType: unit.deathType });
+    const deathEventContext = { ...options, wasDowned, deathType: unit.deathType };
+    if (options.deferOnDeath === true) unit.__luminousPendingDeathEvent = deathEventContext;
+    else dispatchLifeEvent("on_death", unit, deathEventContext);
     emit("luminous:unit-dead", { unit, wasDowned, deathType: unit.deathType, reason: options.reason || "death" });
     return { died: true, unit, deathType: unit.deathType, permanentRecordDeletion: false };
   }
@@ -212,11 +211,7 @@
 
   function grantRetreat(unit, options = {}) {
     if (!unit) return null;
-    unit.retreat = {
-      pending: true,
-      grantedAt: Date.now(),
-      reason: options.reason || "death_save_success",
-    };
+    unit.retreat = { pending: true, grantedAt: Date.now(), reason: options.reason || "death_save_success" };
     try {
       global.LuminousStatusEngine?.applyStatus?.(unit, "retreat", {
         mode: "set",
@@ -328,6 +323,7 @@
     const snapshot = {
       hp: Math.max(0, numberOr(unit.hp, 0)),
       sp: numberOr(unit.sp, 0),
+      releasedSlots: Math.max(0, numberOr(unit.activeSlots ?? unit.actionSlots, 0)),
       retreatedAt: Date.now(),
     };
     unit.retreatSnapshot = snapshot;
@@ -344,9 +340,8 @@
 
   function statusPersistsThroughRetreat(statusId, instance) {
     if (instance?.data?.persistsThroughRetreat === true || instance?.persistsThroughRetreat === true) return true;
-    try {
-      return global.LuminousStatusEngine?.getDefinition?.(statusId)?.persistsThroughRetreat === true;
-    } catch (_) { return false; }
+    try { return global.LuminousStatusEngine?.getDefinition?.(statusId)?.persistsThroughRetreat === true; }
+    catch (_) { return false; }
   }
 
   function clearRetreatEffects(unit) {
@@ -367,11 +362,13 @@
   function returnFromRetreat(unit, options = {}) {
     if (!unit || !isRetreated(unit)) return { returned: false, unit };
     const snapshot = unit.retreatSnapshot || { hp: numberOr(unit.hp, 0), sp: numberOr(unit.sp, 0) };
+    const key = unitIds(unit)[0] || unit;
+    const firstQueued = state.retreatQueue[0] || null;
+    if (firstQueued && firstQueued.key !== key && options.force !== true) return { returned: false, reason: "retreat_order", unit, nextUnit: firstQueued.unit };
     markAlive(unit);
     unit.hp = Math.max(1, numberOr(snapshot.hp, 1));
     unit.sp = numberOr(snapshot.sp, 0) < 0 ? 0 : numberOr(snapshot.sp, 0);
     const keptStatuses = clearRetreatEffects(unit);
-    const key = unitIds(unit)[0] || unit;
     state.retreatQueue = state.retreatQueue.filter((entry) => entry.key !== key);
     emit("luminous:unit-returned-from-retreat", { unit, keptStatuses, options });
     return { returned: true, unit, keptStatuses };
@@ -439,7 +436,10 @@
 
         if (wasDowned) {
           if (statusDamage) return { hp: 0, shield: unit.shield, deathSave: addFailure(unit, { reason: "status_damage_while_downed" }) };
-          if (skillUsed) return { hp: 0, shield: unit.shield, downedHitDeferred: true };
+          if (skillUsed) {
+            unit.__luminousDownedHitPending = true;
+            return { hp: unit.hp, shield: unit.shield, downedHitDeferred: true };
+          }
           return { hp: 0, shield: unit.shield };
         }
 
@@ -451,7 +451,12 @@
           const transition = enterDowned(unit, { sourceKind: statusDamage ? "status" : (skillUsed?.type === "Spell" ? "spell" : (skillUsed ? "skill" : normalizeId(damageType))), skill: skillUsed });
           return { ...(result || {}), hp: unit.hp, downed: true, transition };
         }
-        const death = resolveDeath(unit, { reason: "hp_zero", sourceKind: statusDamage ? "status" : (skillUsed ? "skill" : normalizeId(damageType)), skill: skillUsed });
+        const death = resolveDeath(unit, {
+          reason: "hp_zero",
+          sourceKind: statusDamage ? "status" : (skillUsed ? "skill" : normalizeId(damageType)),
+          skill: skillUsed,
+          deferOnDeath: Boolean(skillUsed && !statusDamage),
+        });
         return { ...(result || {}), hp: 0, death };
       };
     }
@@ -473,14 +478,27 @@
     if (originalTriggerEvent) {
       engine.triggerEvent = function (tag, context = {}, targetsHit = [], ...rest) {
         const targets = Array.isArray(targetsHit) && targetsHit.length ? targetsHit : [context?.defender || context?.currentTarget].filter(Boolean);
-        if (tag === "[On Kill]" && targets.some((target) => target?.__luminousDownedAttackProxy || (isDowned(target) && numberOr(target.hp, 0) <= 0))) return;
+        if (tag === "[On Kill]" && targets.some((target) => target?.__luminousDownedAttackProxy)) return;
         const result = originalTriggerEvent.call(this, tag, context, targetsHit, ...rest);
         if (tag === "[On Hit]" && context?.skill) {
           targets.forEach((target) => {
-            if (target?.__luminousDownedAttackProxy || isDowned(target)) noteSkillHitOnDowned(target, context.skill, context);
+            if (target?.__luminousDownedHitPending || target?.__luminousDownedAttackProxy) {
+              noteSkillHitOnDowned(target, context.skill, context);
+              delete target.__luminousDownedHitPending;
+            }
           });
         }
-        if (tag === "[Attack End]") targets.forEach(clearSkillHitToken);
+        if (tag === "[Attack End]") {
+          targets.forEach((target) => {
+            clearSkillHitToken(target);
+            delete target.__luminousDownedHitPending;
+            if (target?.__luminousPendingDeathEvent) {
+              const pending = target.__luminousPendingDeathEvent;
+              delete target.__luminousPendingDeathEvent;
+              dispatchLifeEvent("on_death", target, pending);
+            }
+          });
+        }
         return result;
       };
     }

--- a/js/devil-lineage-runtime.js
+++ b/js/devil-lineage-runtime.js
@@ -1,0 +1,280 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousDevilLineageRuntime) return;
+
+  const ARCHETYPE_ID = "path_of_the_devil_lineage";
+  const CLASS_ID = "barbarian";
+  const REGEN_HOURS_REQUIRED = 72;
+  const PATCH_INTERVAL_MS = 500;
+  const state = {
+    trackedUnits: new Set(),
+    listenersBound: false,
+    timer: null,
+  };
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+  function classEntries(character = {}) {
+    const build = character.characterBuild && typeof character.characterBuild === "object" ? character.characterBuild : {};
+    const source = Array.isArray(build.classes) ? build.classes : (Array.isArray(character.classes) ? character.classes : []);
+    return source.map((entry) => ({
+      classId: normalizeId(entry?.classId || entry?.id || entry?.className || entry?.name),
+      level: Math.max(0, Number.parseInt(entry?.level ?? entry?.levels ?? entry?.classLevel, 10) || 0),
+    })).filter((entry) => entry.classId);
+  }
+
+  function selections(character = {}) {
+    const build = character.characterBuild && typeof character.characterBuild === "object" ? character.characterBuild : {};
+    const source = Array.isArray(build.archetypes) ? build.archetypes : (Array.isArray(character.archetypes) ? character.archetypes : []);
+    return source.map((entry) => ({
+      classId: normalizeId(entry?.classId || entry?.parentClassId),
+      archetypeId: normalizeId(entry?.archetypeId || entry?.subclassId || entry?.id),
+    }));
+  }
+
+  function devilLineageLevel(character = {}) {
+    const runtime = global.LuminousArchetypeRuntime;
+    if (runtime?.devilLineageLevel) {
+      try {
+        const value = numberOr(runtime.devilLineageLevel(character), 0);
+        if (value > 0) return value;
+      } catch (_) {}
+    }
+
+    const engine = global.LuminousArchetypeEngine;
+    if (engine?.isSelected && engine?.getClassLevel) {
+      try {
+        if (engine.isSelected(character, ARCHETYPE_ID, CLASS_ID)) return Math.max(0, numberOr(engine.getClassLevel(character, CLASS_ID), 0));
+      } catch (_) {}
+    }
+
+    const selected = selections(character).some((entry) => entry.classId === CLASS_ID && entry.archetypeId === ARCHETYPE_ID);
+    if (!selected) return 0;
+    return classEntries(character).find((entry) => entry.classId === CLASS_ID)?.level || 0;
+  }
+
+  function identityValues(entity = {}) {
+    return [
+      entity.combatId, entity.combat_id, entity.unitId, entity.unit_id,
+      entity.id, entity.playerId, entity.player_id, entity.characterId, entity.character_id,
+      entity.actorId, entity.actor_id, entity.uid, entity.vinculo_jugador,
+    ].filter((value) => value != null && String(value).trim() !== "").map((value) => String(value).trim());
+  }
+
+  function currentCharacter() {
+    return global.LuminousPlayerTraitRuntime?.getCharacter?.() || global.datosJugador || null;
+  }
+
+  function currentHp(unit = {}) {
+    return numberOr(unit.hp ?? unit.currentHp ?? unit.hp_actual ?? unit.combatStats?.hp_actual, 0);
+  }
+
+  function markDerivedTwoHandedRule(character, active) {
+    if (!character || typeof character !== "object") return false;
+    if (active) {
+      try {
+        if (character.twoHandedAsOneHanded !== true) {
+          Object.defineProperty(character, "twoHandedAsOneHanded", {
+            value: true,
+            writable: true,
+            configurable: true,
+            enumerable: false,
+          });
+        }
+        if (character.__devilLineageTwoHandedRule !== true) {
+          Object.defineProperty(character, "__devilLineageTwoHandedRule", {
+            value: true,
+            writable: true,
+            configurable: true,
+            enumerable: false,
+          });
+        }
+      } catch (_) {
+        character.twoHandedAsOneHanded = true;
+        character.__devilLineageTwoHandedRule = true;
+      }
+      return true;
+    }
+
+    if (character.__devilLineageTwoHandedRule === true) {
+      try { delete character.twoHandedAsOneHanded; } catch (_) { character.twoHandedAsOneHanded = false; }
+      try { delete character.__devilLineageTwoHandedRule; } catch (_) { character.__devilLineageTwoHandedRule = false; }
+    }
+    return false;
+  }
+
+  function syncEquipmentRules(character = currentCharacter()) {
+    if (!character) return false;
+    const active = devilLineageLevel(character) >= 15;
+    return markDerivedTwoHandedRule(character, active);
+  }
+
+  function trackUnit(unit) {
+    if (!unit || typeof unit !== "object") return unit;
+    state.trackedUnits.add(unit);
+    syncEquipmentRules(unit);
+    return unit;
+  }
+
+  function structuralInjuries(unit = {}) {
+    return (Array.isArray(unit.injuries) ? unit.injuries : []).filter((injury) =>
+      injury && injury.active !== false && injury.structural === true &&
+      (Array.isArray(injury.affectedParts) ? injury.affectedParts.length > 0 : Boolean(injury.bodyPart || injury.partId))
+    );
+  }
+
+  function regenerationHours(injury = {}) {
+    return Math.max(0, numberOr(injury.metadata?.devilLineageRegenerationHours, 0));
+  }
+
+  function setRegenerationHours(injury, hours) {
+    if (!injury || typeof injury !== "object") return 0;
+    if (!injury.metadata || typeof injury.metadata !== "object") injury.metadata = {};
+    const next = Math.max(0, Math.min(REGEN_HOURS_REQUIRED, numberOr(hours, 0)));
+    injury.metadata.devilLineageRegenerationHours = next;
+    return next;
+  }
+
+  function persistRegenerationState(unit) {
+    const engine = global.LuminousInjuryEngine;
+    if (engine?.syncDerivedState) {
+      try { engine.syncDerivedState(unit); return true; } catch (_) {}
+    }
+    return false;
+  }
+
+  function resetRegeneration(unit, options = {}) {
+    if (!unit || devilLineageLevel(unit) < 70) return { reset: false, unit, reason: "not_eligible" };
+    let changed = false;
+    structuralInjuries(unit).forEach((injury) => {
+      if (regenerationHours(injury) > 0) {
+        setRegenerationHours(injury, 0);
+        changed = true;
+      }
+    });
+    if (changed && options.persist !== false) persistRegenerationState(unit);
+    return { reset: changed, unit, reason: options.reason || "hp_below_one" };
+  }
+
+  function advanceRegeneration(unit, hours, options = {}) {
+    if (!unit) return { eligible: false, unit, reason: "missing_unit", progressed: [], completed: [] };
+    trackUnit(unit);
+    if (devilLineageLevel(unit) < 70) return { eligible: false, unit, reason: "not_eligible", progressed: [], completed: [] };
+    const elapsed = Math.max(0, numberOr(hours, 0));
+    if (!elapsed) return { eligible: true, unit, reason: "no_time", progressed: [], completed: [] };
+
+    const injuries = structuralInjuries(unit);
+    if (!injuries.length) return { eligible: true, unit, reason: "no_structural_injuries", progressed: [], completed: [] };
+    if (currentHp(unit) < 1) {
+      const reset = resetRegeneration(unit, { reason: "hp_below_one", persist: options.persist });
+      return { eligible: true, unit, reason: "hp_below_one", reset: reset.reset, progressed: [], completed: [] };
+    }
+
+    const progressed = [];
+    const completed = [];
+    injuries.forEach((injury) => {
+      const before = regenerationHours(injury);
+      const after = setRegenerationHours(injury, before + elapsed);
+      progressed.push({ instanceId: injury.instanceId || injury.id, before, after });
+      if (after >= REGEN_HOURS_REQUIRED) completed.push(injury.instanceId || injury.id);
+    });
+
+    const engine = global.LuminousInjuryEngine;
+    const cured = [];
+    completed.forEach((injuryRef) => {
+      if (!engine?.treatInjury) return;
+      try {
+        const result = engine.treatInjury(unit, injuryRef, { cure: true, method: "regeneration" });
+        if (result?.cured) cured.push(injuryRef);
+      } catch (_) {}
+    });
+
+    if (progressed.length && !cured.length && options.persist !== false) persistRegenerationState(unit);
+    return { eligible: true, unit, hours: elapsed, progressed, completed, cured };
+  }
+
+  function matchingTrackedUnits(characterId) {
+    const wanted = String(characterId || "").trim();
+    const candidates = new Set(state.trackedUnits);
+    const current = currentCharacter();
+    if (current) candidates.add(current);
+    const combatData = global.combatData && typeof global.combatData === "object" ? Object.values(global.combatData) : [];
+    combatData.forEach((unit) => candidates.add(unit));
+    if (!wanted) return [...candidates];
+    return [...candidates].filter((unit) => identityValues(unit).includes(wanted));
+  }
+
+  function advanceWorldTime(detail = {}) {
+    const hours = Math.max(0, numberOr(detail.hours ?? detail.worldHoursAdvanced, 0));
+    if (!hours) return [];
+    const direct = detail.character && typeof detail.character === "object" ? [trackUnit(detail.character)] : [];
+    const units = direct.length ? direct : matchingTrackedUnits(detail.characterId);
+    return units.map((unit) => advanceRegeneration(unit, hours)).filter(Boolean);
+  }
+
+  function bindEvents() {
+    if (state.listenersBound || typeof global.addEventListener !== "function") return false;
+    state.listenersBound = true;
+
+    ["luminous:injury-gained", "luminous:injury-state-changed", "luminous:rest-completed", "luminous:unit-revived"].forEach((name) => {
+      global.addEventListener(name, (event) => {
+        const detail = event?.detail || {};
+        trackUnit(detail.unit || detail.character);
+      });
+    });
+
+    ["luminous:downed", "luminous:unit-dead"].forEach((name) => {
+      global.addEventListener(name, (event) => {
+        const unit = trackUnit(event?.detail?.unit);
+        if (unit) resetRegeneration(unit, { reason: name });
+      });
+    });
+
+    global.addEventListener("luminous:world-time-advance-requested", (event) => advanceWorldTime(event?.detail || {}));
+    global.addEventListener("luminous:traits-refreshed", () => trackUnit(currentCharacter()));
+    return true;
+  }
+
+  function syncKnownUnits() {
+    trackUnit(currentCharacter());
+    const combatData = global.combatData && typeof global.combatData === "object" ? Object.values(global.combatData) : [];
+    combatData.forEach(trackUnit);
+    return true;
+  }
+
+  function install() {
+    bindEvents();
+    syncKnownUnits();
+    return true;
+  }
+
+  const api = Object.freeze({
+    ARCHETYPE_ID,
+    CLASS_ID,
+    REGEN_HOURS_REQUIRED,
+    devilLineageLevel,
+    identityValues,
+    currentCharacter,
+    syncEquipmentRules,
+    trackUnit,
+    structuralInjuries,
+    regenerationHours,
+    resetRegeneration,
+    advanceRegeneration,
+    advanceWorldTime,
+    matchingTrackedUnits,
+    bindEvents,
+    syncKnownUnits,
+    install,
+  });
+
+  global.LuminousDevilLineageRuntime = api;
+  install();
+  if (typeof global.setInterval === "function") {
+    state.timer = global.setInterval(install, PATCH_INTERVAL_MS);
+    if (typeof state.timer?.unref === "function") state.timer.unref();
+  }
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/fixed-damage-runtime.js
+++ b/js/fixed-damage-runtime.js
@@ -1,0 +1,244 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousFixedDamageRuntime) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousFixedDamageRuntime;
+    return;
+  }
+
+  const PATCH_INTERVAL_MS = 250;
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+  function normalizeDamageMode(value) {
+    const id = normalizeId(value);
+    return ["fixed", "fixed_damage", "fixeddamage"].includes(id) ? "fixed" : "normal";
+  }
+
+  function damageModeForSkill(skill = {}) {
+    return normalizeDamageMode(skill.damageMode ?? skill.damage_mode ?? skill.damageModeType ?? skill.damage_mode_type);
+  }
+
+  function isFixedDamageSkill(skill = {}) {
+    return damageModeForSkill(skill) === "fixed";
+  }
+
+  function nonReducingResistance(value) {
+    return Math.max(1, numberOr(value, 1));
+  }
+
+  function nonReducingDamageTakenModifier(value) {
+    return Math.min(0, numberOr(value, 0));
+  }
+
+  function fixedDefenderView(defender = {}) {
+    return {
+      ...defender,
+      physRes: nonReducingResistance(defender.physRes),
+      sinRes: nonReducingResistance(defender.sinRes),
+    };
+  }
+
+  function patchCombatEngine() {
+    const engine = global.CombatEngine;
+    if (!engine || typeof engine.calculateCoinDamage !== "function") return false;
+    if (engine.calculateCoinDamage.__luminousFixedDamageRuntime) return true;
+
+    const originalCalculateCoinDamage = engine.calculateCoinDamage;
+    function calculateCoinDamageWithFixedMode(attacker, defender, skill, coinFinalPower, isCritical, clashCount, context = null) {
+      if (!isFixedDamageSkill(skill) || !defender || typeof defender !== "object") {
+        return originalCalculateCoinDamage.call(this, attacker, defender, skill, coinFinalPower, isCritical, clashCount, context);
+      }
+
+      const baseEngine = this || engine;
+      const defenderView = fixedDefenderView(defender);
+      const engineView = Object.create(baseEngine);
+      const originalPassiveModifiers = baseEngine.applyPassiveModifiers;
+      const originalDefensiveLevel = baseEngine.getDefensiveLevel;
+      const originalOffensiveLevel = baseEngine.getOffensiveLevel;
+
+      if (typeof originalPassiveModifiers === "function") {
+        engineView.applyPassiveModifiers = function (unit, passiveContext) {
+          const actualUnit = unit === defenderView ? defender : unit;
+          const modifiers = originalPassiveModifiers.call(this, actualUnit, passiveContext) || {};
+          if (unit !== defenderView && actualUnit !== defender) return modifiers;
+          return {
+            ...modifiers,
+            damage_taken_multiplier: nonReducingDamageTakenModifier(modifiers.damage_taken_multiplier),
+          };
+        };
+      }
+
+      if (typeof originalDefensiveLevel === "function" && typeof originalOffensiveLevel === "function") {
+        engineView.getDefensiveLevel = function (unit, defensiveContext) {
+          const actualUnit = unit === defenderView ? defender : unit;
+          const actualContext = defensiveContext === defenderView ? defender : defensiveContext;
+          const defensiveLevel = originalDefensiveLevel.call(this, actualUnit, actualContext);
+          if (unit !== defenderView && actualUnit !== defender) return defensiveLevel;
+          const offensiveLevel = originalOffensiveLevel.call(this, attacker, skill);
+          if (!Number.isFinite(Number(defensiveLevel)) || !Number.isFinite(Number(offensiveLevel))) return defensiveLevel;
+          return Math.min(Number(defensiveLevel), Number(offensiveLevel));
+        };
+      }
+
+      return originalCalculateCoinDamage.call(
+        engineView,
+        attacker,
+        defenderView,
+        skill,
+        coinFinalPower,
+        isCritical,
+        clashCount,
+        context,
+      );
+    }
+
+    Object.defineProperty(calculateCoinDamageWithFixedMode, "__luminousFixedDamageRuntime", { value: true });
+    Object.defineProperty(calculateCoinDamageWithFixedMode, "__luminousFixedDamageOriginal", { value: originalCalculateCoinDamage });
+    engine.calculateCoinDamage = calculateCoinDamageWithFixedMode;
+
+    if (typeof engine.createSkill === "function" && !engine.createSkill.__luminousDamageModeRuntime) {
+      const originalCreateSkill = engine.createSkill;
+      function createSkillWithDamageMode(config = {}) {
+        const skill = originalCreateSkill.call(this, config);
+        if (!skill || typeof skill !== "object") return skill;
+        skill.damageMode = normalizeDamageMode(config.damageMode ?? config.damage_mode);
+        return skill;
+      }
+      Object.defineProperty(createSkillWithDamageMode, "__luminousDamageModeRuntime", { value: true });
+      engine.createSkill = createSkillWithDamageMode;
+    }
+    return true;
+  }
+
+  function applyFixedDamage(unit, damage, options = {}) {
+    const engine = options.engine || global.CombatEngine;
+    const amount = Math.max(0, Math.floor(numberOr(damage, 0)));
+    if (!unit || !engine || typeof engine.applyDamage !== "function") {
+      return { applied: false, amount: 0, result: null };
+    }
+
+    const hpBefore = numberOr(unit.hp, 0);
+    const shieldBefore = numberOr(unit.shield, 0);
+    const result = engine.applyDamage(
+      unit,
+      amount,
+      options.tipoDano || options.damageKind || "directo",
+      Boolean(options.isCritical),
+      options.skillUsed ?? null,
+    );
+
+    return {
+      applied: true,
+      amount,
+      hpBefore,
+      hpAfter: numberOr(unit.hp, hpBefore),
+      shieldBefore,
+      shieldAfter: numberOr(unit.shield, shieldBefore),
+      result,
+    };
+  }
+
+  function strengthModifier(character = {}) {
+    const explicit = character.strengthMod ?? character.str_mod ?? character.strModifier;
+    if (Number.isFinite(Number(explicit))) return Number(explicit);
+    const stats = character.stats || character.dndStats || {};
+    const score = [stats.fuerza, stats.strength, stats.str, character.fuerza, character.strength, character.str]
+      .find((value) => Number.isFinite(Number(value)));
+    return Math.floor((numberOr(score, 10) - 10) / 2);
+  }
+
+  function isStrengthSkill(skill = {}) {
+    const stat = normalizeId(
+      skill.scaling_stat ?? skill.scalingStat ?? skill.scaling_stat_id ?? skill.abilityId ?? skill.ability ?? skill.stat,
+    );
+    return ["str", "strength", "fuerza"].includes(stat);
+  }
+
+  function fixedPercentCoefficient(formula) {
+    const compact = String(formula || "").replace(/\s+/g, "");
+    let match = compact.match(/^StrengthMod\*([+-]?\d+(?:\.\d+)?)$/i);
+    if (match) return numberOr(match[1], 2);
+    match = compact.match(/^([+-]?\d+(?:\.\d+)?)\*StrengthMod$/i);
+    return match ? numberOr(match[1], 2) : 2;
+  }
+
+  function resolveOnHitFixedDamage(traits = [], trigger, runtime = {}) {
+    if (normalizeId(trigger) !== "on_hit" || !isStrengthSkill(runtime.skill)) return null;
+    const target = runtime.target || runtime.defender || null;
+    const baseDamage = Math.max(0, numberOr(runtime.damageDealt, 0));
+    if (!target || baseDamage <= 0) return null;
+
+    const character = runtime.character || runtime.attacker || runtime.self || {};
+    const strengthMod = strengthModifier(character);
+    let totalFixedDamage = 0;
+    const components = [];
+
+    (Array.isArray(traits) ? traits : Object.values(traits || {})).forEach((trait) => {
+      const formula = trait?.mechanics?.onHitStrengthFixedDamagePercentFormula;
+      if (!formula) return;
+      const coefficient = fixedPercentCoefficient(formula);
+      const percent = Math.max(0, strengthMod * coefficient);
+      const amount = Math.max(0, Math.floor(baseDamage * percent / 100));
+      if (amount <= 0) return;
+      totalFixedDamage += amount;
+      components.push({ traitId: trait.id || null, formula, percent, amount });
+    });
+
+    if (totalFixedDamage <= 0) return null;
+    const applied = applyFixedDamage(target, totalFixedDamage, { damageKind: "directo", skillUsed: null });
+    runtime.fixedDamageDealt = numberOr(runtime.fixedDamageDealt, 0) + totalFixedDamage;
+    runtime.fixedDamageMode = "fixed";
+    runtime.fixedDamageComponents = [...(runtime.fixedDamageComponents || []), ...components];
+    return { ...applied, components };
+  }
+
+  function patchTraitStandardizationRuntime() {
+    const source = global.LuminousTraitStandardizationRuntime;
+    if (!source || typeof source.resolveTraitRuntimeResolutions !== "function") return false;
+    if (source.__fixedDamageRuntimeBridge) return true;
+
+    const originalResolve = source.resolveTraitRuntimeResolutions.bind(source);
+    const wrapped = Object.freeze({
+      ...source,
+      __fixedDamageRuntimeBridge: true,
+      resolveTraitRuntimeResolutions(traits = [], trigger, runtime = {}, result = null) {
+        const resolved = originalResolve(traits, trigger, runtime, result);
+        resolveOnHitFixedDamage(traits, trigger, runtime);
+        return resolved;
+      },
+    });
+    global.LuminousTraitStandardizationRuntime = wrapped;
+    return true;
+  }
+
+  function patchAll() {
+    return {
+      combat: patchCombatEngine(),
+      traits: patchTraitStandardizationRuntime(),
+    };
+  }
+
+  const api = Object.freeze({
+    normalizeDamageMode,
+    damageModeForSkill,
+    isFixedDamageSkill,
+    nonReducingResistance,
+    nonReducingDamageTakenModifier,
+    patchCombatEngine,
+    applyFixedDamage,
+    strengthModifier,
+    isStrengthSkill,
+    fixedPercentCoefficient,
+    resolveOnHitFixedDamage,
+    patchTraitStandardizationRuntime,
+    patchAll,
+  });
+
+  global.LuminousFixedDamageRuntime = api;
+  patchAll();
+  const timer = typeof global.setInterval === "function" ? global.setInterval(patchAll, PATCH_INTERVAL_MS) : null;
+  timer?.unref?.();
+
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/injury-engine.js
+++ b/js/injury-engine.js
@@ -1,0 +1,701 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousInjuryEngine) return;
+
+  const anatomyEngine = global.LuminousAnatomyEquipmentEngine || (typeof require === "function" ? require("./anatomy-equipment-engine.js") : null);
+  const PATCH_INTERVAL_MS = 250;
+  const DOWNS_PER_MODERATE = 3;
+  const SEVERE_MAX_HP_PENALTY = 0.05;
+  const MAX_SEVERE_HP_PENALTY = 0.20;
+  const PLAYER_ROOT = "campaña/jugadores";
+  const SEVERITY_RANK = Object.freeze({ light: 1, moderate: 2, severe: 3 });
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const asArray = (value) => value == null ? [] : (Array.isArray(value) ? value : [value]);
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+  const CATALOG = Object.freeze({
+    combat_bruising: Object.freeze({
+      id: "combat_bruising", name: "Combat Bruising", severity: "light", recoveryHours: 4,
+      effects: Object.freeze({ physicalCheckPenalty: -1 }),
+    }),
+    cut_hand: Object.freeze({
+      id: "cut_hand", name: "Cut Hand", severity: "light", recoveryHours: 3,
+      effects: Object.freeze({ physicalCheckPenalty: -1 }),
+    }),
+    sprained_wrist: Object.freeze({
+      id: "sprained_wrist", name: "Sprained Wrist", severity: "light", recoveryHours: 4,
+      effects: Object.freeze({ physicalCheckPenalty: -1 }),
+    }),
+    sprained_ankle: Object.freeze({
+      id: "sprained_ankle", name: "Sprained Ankle", severity: "light", recoveryHours: 6,
+      effects: Object.freeze({ speed: -1, physicalCheckPenalty: -1 }),
+    }),
+    minor_concussion: Object.freeze({
+      id: "minor_concussion", name: "Minor Concussion", severity: "light", recoveryHours: 8,
+      effects: Object.freeze({ mentalCheckPenalty: -1 }),
+    }),
+
+    accumulated_trauma: Object.freeze({
+      id: "accumulated_trauma", name: "Accumulated Trauma", severity: "moderate", recoveryHours: 24,
+      effects: Object.freeze({ physicalCheckPenalty: -2 }),
+    }),
+    deep_wound: Object.freeze({
+      id: "deep_wound", name: "Deep Wound", severity: "moderate", recoveryHours: 18,
+      effects: Object.freeze({ physicalCheckPenalty: -2 }),
+    }),
+    dislocated_shoulder: Object.freeze({
+      id: "dislocated_shoulder", name: "Dislocated Shoulder", severity: "moderate", recoveryHours: 24,
+      effects: Object.freeze({ physicalCheckPenalty: -2 }),
+    }),
+    cracked_ribs: Object.freeze({
+      id: "cracked_ribs", name: "Cracked Ribs", severity: "moderate", recoveryHours: 48,
+      effects: Object.freeze({ physicalCheckPenalty: -2 }),
+    }),
+    damaged_knee: Object.freeze({
+      id: "damaged_knee", name: "Damaged Knee", severity: "moderate", recoveryHours: 36,
+      effects: Object.freeze({ speed: -1, evade_power: -2, physicalCheckPenalty: -2 }),
+    }),
+    moderate_concussion: Object.freeze({
+      id: "moderate_concussion", name: "Moderate Concussion", severity: "moderate", recoveryHours: 24,
+      effects: Object.freeze({ mentalCheckPenalty: -2 }),
+    }),
+
+    severe_trauma: Object.freeze({
+      id: "severe_trauma", name: "Severe Body Trauma", severity: "severe", recoveryHours: 120,
+      effects: Object.freeze({ physicalCheckPenalty: -3 }),
+    }),
+    broken_arm: Object.freeze({
+      id: "broken_arm", name: "Broken Arm", severity: "severe", recoveryHours: 168, slotEffect: "disabled",
+      effects: Object.freeze({ physicalCheckPenalty: -3 }),
+    }),
+    broken_leg: Object.freeze({
+      id: "broken_leg", name: "Broken Leg", severity: "severe", recoveryHours: 240, slotEffect: "disabled",
+      effects: Object.freeze({ speed: -3, evade_power: -6, physicalCheckPenalty: -3 }),
+    }),
+    damaged_lung: Object.freeze({
+      id: "damaged_lung", name: "Damaged Lung", severity: "severe", recoveryHours: 168,
+      effects: Object.freeze({ physicalCheckPenalty: -3 }),
+    }),
+    damaged_eye: Object.freeze({
+      id: "damaged_eye", name: "Damaged Eye", severity: "severe", recoveryHours: 96, slotEffect: "disabled",
+      effects: Object.freeze({ visualCheckPenalty: -3 }),
+    }),
+    missing_eye: Object.freeze({
+      id: "missing_eye", name: "Missing Eye", severity: "severe", recoveryHours: null, structural: true, slotEffect: "missing",
+      effects: Object.freeze({ visualCheckPenalty: -2 }),
+    }),
+    missing_hand: Object.freeze({
+      id: "missing_hand", name: "Missing Hand", severity: "severe", recoveryHours: null, structural: true, slotEffect: "missing",
+      effects: Object.freeze({ physicalCheckPenalty: -3 }),
+    }),
+    missing_arm: Object.freeze({
+      id: "missing_arm", name: "Missing Arm", severity: "severe", recoveryHours: null, structural: true, slotEffect: "missing",
+      effects: Object.freeze({ physicalCheckPenalty: -3 }),
+    }),
+    missing_foot: Object.freeze({
+      id: "missing_foot", name: "Missing Foot", severity: "severe", recoveryHours: null, structural: true, slotEffect: "missing",
+      effects: Object.freeze({ speed: -1, evade_power: -2, physicalCheckPenalty: -3 }),
+    }),
+    missing_leg: Object.freeze({
+      id: "missing_leg", name: "Missing Leg", severity: "severe", recoveryHours: null, structural: true, slotEffect: "missing",
+      effects: Object.freeze({ speed: -3, evade_power: -6, physicalCheckPenalty: -3 }),
+    }),
+    missing_organ: Object.freeze({
+      id: "missing_organ", name: "Missing Organ", severity: "severe", recoveryHours: null, structural: true,
+      effects: Object.freeze({ physicalCheckPenalty: -3 }),
+    }),
+  });
+
+  const state = {
+    trackedUnits: new Set(),
+    nextInstanceId: 1,
+    listenersBound: false,
+    combatSource: null,
+    patchTimer: null,
+  };
+
+  function emit(name, detail) {
+    try {
+      if (typeof global.dispatchEvent === "function" && typeof global.CustomEvent === "function") {
+        global.dispatchEvent(new global.CustomEvent(name, { detail }));
+      }
+    } catch (_) {}
+    return detail;
+  }
+
+  function unitIds(unit = {}) {
+    return [unit.id, unit.unitId, unit.unit_id, unit.characterId, unit.character_id, unit.playerId, unit.player_id, unit.uid]
+      .filter((value) => value != null && String(value).trim() !== "").map((value) => String(value).trim());
+  }
+
+  function sameUnitId(unit, wanted) {
+    if (!wanted) return true;
+    return unitIds(unit).includes(String(wanted).trim());
+  }
+
+  function ensureEncounterState(unit) {
+    const injuryState = ensureState(unit);
+    if (!injuryState.encounter || typeof injuryState.encounter !== "object") {
+      injuryState.encounter = { active: false, naturalStaggerCrossed: false, highestAutoRank: 0, autoInjuryIds: [] };
+    }
+    if (!Array.isArray(injuryState.encounter.autoInjuryIds)) injuryState.encounter.autoInjuryIds = [];
+    return injuryState.encounter;
+  }
+
+  function ensureState(unit) {
+    if (!unit || typeof unit !== "object") return null;
+    if (!Array.isArray(unit.injuries)) unit.injuries = [];
+    if (!unit.injuryState || typeof unit.injuryState !== "object") unit.injuryState = {};
+    unit.injuryState.downCount = Math.max(0, Math.trunc(numberOr(unit.injuryState.downCount, 0)));
+    unit.injuryState.currentlyDownedCounted = unit.injuryState.currentlyDownedCounted === true;
+    state.trackedUnits.add(unit);
+    return unit.injuryState;
+  }
+
+  function definition(injuryId) {
+    const id = normalizeId(injuryId);
+    return CATALOG[id] ? clone(CATALOG[id]) : null;
+  }
+
+  function activeInjuries(unit) {
+    ensureState(unit);
+    return unit.injuries.filter((injury) => injury && injury.active !== false);
+  }
+
+  function severityRank(value) {
+    return SEVERITY_RANK[normalizeId(value)] || 0;
+  }
+
+  function normalizeInjury(input, options = {}) {
+    const raw = typeof input === "string" ? (definition(input) || { id: normalizeId(input), name: String(input) }) : clone(input || {});
+    const base = definition(raw.catalogId || raw.id) || {};
+    const merged = { ...base, ...raw, ...clone(options.overrides || {}) };
+    const severity = normalizeId(merged.severity || "light");
+    const catalogId = normalizeId(base.id || merged.catalogId || merged.id || "custom_injury");
+    const recovery = merged.recoveryHours == null ? null : Math.max(0, numberOr(merged.recoveryHours, 0));
+    const instanceId = merged.instanceId || `injury_${Date.now()}_${state.nextInstanceId++}`;
+    const affectedParts = asArray(merged.affectedParts || merged.bodyPart || merged.partId).map(normalizeId).filter(Boolean);
+    return {
+      instanceId,
+      catalogId,
+      id: catalogId,
+      name: merged.name || base.name || catalogId,
+      severity: SEVERITY_RANK[severity] ? severity : "light",
+      structural: merged.structural === true,
+      slotEffect: normalizeId(merged.slotEffect || merged.anatomyState || "") || null,
+      affectedParts,
+      bodyPart: affectedParts[0] || null,
+      recoveryHours: recovery,
+      remainingRecoveryHours: recovery,
+      effects: { ...(base.effects || {}), ...(merged.effects || {}) },
+      source: normalizeId(options.source || merged.source || "system"),
+      auto: options.auto === true || merged.auto === true,
+      encounterGenerated: options.encounterGenerated === true || merged.encounterGenerated === true,
+      createdAt: options.createdAt || Date.now(),
+      active: true,
+      metadata: clone(merged.metadata || {}),
+    };
+  }
+
+  function severePenaltyPct(unit) {
+    const severeCount = activeInjuries(unit).filter((injury) => normalizeId(injury.severity) === "severe").length;
+    return Math.min(MAX_SEVERE_HP_PENALTY, severeCount * SEVERE_MAX_HP_PENALTY);
+  }
+
+  function syncMaxHp(unit) {
+    if (!unit) return { penaltyPct: 0, baseMaxHp: 0, effectiveMaxHp: 0 };
+    const penaltyPct = severePenaltyPct(unit);
+    const currentMax = Math.max(1, numberOr(unit.maxHp ?? unit.max_hp ?? unit.combatStats?.maxHp ?? unit.combatStats?.max_hp, 1));
+
+    if (penaltyPct > 0) {
+      if (!Number.isFinite(Number(unit.injuryHealthBaseMaxHp))) unit.injuryHealthBaseMaxHp = currentMax;
+      const baseMaxHp = Math.max(1, numberOr(unit.injuryHealthBaseMaxHp, currentMax));
+      const effectiveMaxHp = Math.max(1, Math.floor(baseMaxHp * (1 - penaltyPct)));
+      unit.injuryMaxHpPenaltyPct = penaltyPct;
+      unit.effectiveMaxHp = effectiveMaxHp;
+      if (Object.prototype.hasOwnProperty.call(unit, "maxHp")) unit.maxHp = effectiveMaxHp;
+      else if (Object.prototype.hasOwnProperty.call(unit, "max_hp")) unit.max_hp = effectiveMaxHp;
+      if (Number.isFinite(Number(unit.hp))) unit.hp = Math.min(Number(unit.hp), effectiveMaxHp);
+      return { penaltyPct, baseMaxHp, effectiveMaxHp };
+    }
+
+    const baseMaxHp = Math.max(1, numberOr(unit.injuryHealthBaseMaxHp, currentMax));
+    if (Number.isFinite(Number(unit.injuryHealthBaseMaxHp))) {
+      if (Object.prototype.hasOwnProperty.call(unit, "maxHp")) unit.maxHp = baseMaxHp;
+      else if (Object.prototype.hasOwnProperty.call(unit, "max_hp")) unit.max_hp = baseMaxHp;
+    }
+    unit.injuryMaxHpPenaltyPct = 0;
+    unit.effectiveMaxHp = baseMaxHp;
+    delete unit.injuryHealthBaseMaxHp;
+    return { penaltyPct: 0, baseMaxHp, effectiveMaxHp: baseMaxHp };
+  }
+
+  function defaultLootPool() {
+    if (!Array.isArray(global.LuminousCombatLootPool)) global.LuminousCombatLootPool = [];
+    return global.LuminousCombatLootPool;
+  }
+
+  function syncAnatomyAndEquipment(unit, options = {}) {
+    if (!unit || !anatomyEngine) return null;
+    const anatomy = anatomyEngine.resolveCharacterAnatomy(unit);
+    unit.anatomyRuntime = anatomy;
+    const items = options.items || anatomyEngine.collectEquippedItems(unit);
+    const validation = anatomyEngine.revalidateEquipment(unit, items, {
+      anatomy,
+      lootPool: options.lootPool || defaultLootPool(),
+      onDropToLoot: options.onDropToLoot,
+    });
+    validation.assignments.forEach((assignment) => {
+      if (assignment.item && typeof assignment.item === "object") assignment.item.equippedPartIds = [...assignment.partIds];
+    });
+    return { anatomy, validation };
+  }
+
+  function persistPlayerState(unit) {
+    try {
+      const db = global.firebase?.database?.();
+      if (!db) return null;
+      const id = String(unit?.playerId || unit?.player_id || global.localStorage?.getItem?.("playerId") || "").trim();
+      if (!id) return null;
+      const updates = {
+        injuries: clone(unit.injuries || []),
+        injuryState: clone(unit.injuryState || {}),
+        injuryMaxHpPenaltyPct: numberOr(unit.injuryMaxHpPenaltyPct, 0),
+      };
+      const promise = db.ref(`${PLAYER_ROOT}/${id}`).update(updates);
+      promise?.catch?.((error) => console.warn("Injury persistence:", error));
+      return promise;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function syncDerivedState(unit, options = {}) {
+    const health = syncMaxHp(unit);
+    const equipment = syncAnatomyAndEquipment(unit, options);
+    emit("luminous:injury-state-changed", { unit, injuries: clone(activeInjuries(unit)), health, equipment });
+    if (options.persist !== false) persistPlayerState(unit);
+    return { health, equipment };
+  }
+
+  function gainInjury(unit, input, options = {}) {
+    if (!unit) return { gained: false, reason: "missing_unit" };
+    ensureState(unit);
+    const injury = normalizeInjury(input, options);
+    unit.injuries.push(injury);
+    const derived = syncDerivedState(unit, options);
+    const result = { gained: true, unit, injury: clone(injury), derived };
+    emit("luminous:injury-gained", result);
+    return result;
+  }
+
+  function findInjuryIndex(unit, injuryRef) {
+    ensureState(unit);
+    const wanted = normalizeId(typeof injuryRef === "object" ? (injuryRef.instanceId || injuryRef.id || injuryRef.catalogId) : injuryRef);
+    return unit.injuries.findIndex((injury) => normalizeId(injury.instanceId) === wanted || normalizeId(injury.catalogId || injury.id) === wanted);
+  }
+
+  function removeInjury(unit, injuryRef, options = {}) {
+    const index = findInjuryIndex(unit, injuryRef);
+    if (index < 0) return { removed: false, reason: "not_found", unit };
+    const [removed] = unit.injuries.splice(index, 1);
+    const encounter = ensureEncounterState(unit);
+    encounter.autoInjuryIds = encounter.autoInjuryIds.filter((id) => id !== removed.instanceId);
+    const derived = syncDerivedState(unit, options);
+    const result = { removed: true, unit, injury: removed, derived, reason: options.reason || "removed" };
+    emit("luminous:injury-removed", result);
+    return result;
+  }
+
+  function replaceInjury(unit, injuryRef, replacement, options = {}) {
+    const index = findInjuryIndex(unit, injuryRef);
+    if (index < 0) return { replaced: false, reason: "not_found", unit };
+    const previous = unit.injuries[index];
+    const next = normalizeInjury(replacement, {
+      ...options,
+      source: options.source || previous.source,
+      overrides: { ...(options.overrides || {}), createdAt: previous.createdAt },
+    });
+    next.createdAt = previous.createdAt;
+    next.auto = previous.auto;
+    next.encounterGenerated = previous.encounterGenerated;
+    unit.injuries[index] = next;
+    syncDerivedState(unit, options);
+    emit("luminous:injury-replaced", { unit, previous: clone(previous), injury: clone(next) });
+    return { replaced: true, unit, previous, injury: next };
+  }
+
+  function gainAutomaticInjury(unit, severity, detail = {}) {
+    const encounter = ensureEncounterState(unit);
+    const rank = severityRank(severity);
+    if (rank <= 0) return { gained: false, reason: "invalid_severity" };
+    if (encounter.highestAutoRank >= rank) return { gained: false, reason: "equal_or_higher_auto_injury_already_generated", unit };
+
+    const lowerAuto = new Set(encounter.autoInjuryIds);
+    unit.injuries = unit.injuries.filter((injury) => !(lowerAuto.has(injury.instanceId) && severityRank(injury.severity) < rank));
+    encounter.autoInjuryIds = encounter.autoInjuryIds.filter((id) => unit.injuries.some((injury) => injury.instanceId === id));
+
+    const fallbackId = severity === "light" ? "combat_bruising" : severity === "moderate" ? "accumulated_trauma" : "severe_trauma";
+    const injuryInput = detail.injury || detail.injuryId || fallbackId;
+    const overrides = {
+      ...(typeof injuryInput === "object" ? injuryInput : {}),
+      severity,
+      affectedParts: detail.affectedParts || detail.bodyPart || (typeof injuryInput === "object" ? injuryInput.affectedParts : undefined),
+      slotEffect: detail.slotEffect || (typeof injuryInput === "object" ? injuryInput.slotEffect : undefined),
+      structural: detail.structural ?? (typeof injuryInput === "object" ? injuryInput.structural : undefined),
+      metadata: { ...(typeof injuryInput === "object" ? injuryInput.metadata : {}), trigger: detail.trigger || null },
+    };
+    const baseInput = typeof injuryInput === "string" ? { ...(definition(injuryInput) || { id: injuryInput }), ...overrides } : overrides;
+    const result = gainInjury(unit, baseInput, { source: detail.source || "automatic", auto: true, encounterGenerated: true });
+    if (result.gained) {
+      encounter.highestAutoRank = rank;
+      encounter.autoInjuryIds.push(result.injury.instanceId);
+    }
+    return result;
+  }
+
+  function beginEncounter(units = []) {
+    asArray(units).forEach((unit) => {
+      if (!unit) return;
+      const encounter = ensureEncounterState(unit);
+      encounter.active = true;
+      encounter.naturalStaggerCrossed = false;
+      encounter.highestAutoRank = 0;
+      encounter.autoInjuryIds = [];
+    });
+    return units;
+  }
+
+  function markNaturalStagger(unit, detail = {}) {
+    if (!unit) return null;
+    const encounter = ensureEncounterState(unit);
+    encounter.active = true;
+    encounter.naturalStaggerCrossed = true;
+    emit("luminous:stagger-threshold-crossed", { unit, natural: true, ...detail });
+    return encounter;
+  }
+
+  function finalizeEncounter(units = []) {
+    const results = [];
+    asArray(units).forEach((unit) => {
+      if (!unit) return;
+      const encounter = ensureEncounterState(unit);
+      let light = null;
+      if (encounter.naturalStaggerCrossed && encounter.highestAutoRank < SEVERITY_RANK.light) {
+        light = gainAutomaticInjury(unit, "light", { trigger: "stagger_threshold", source: "encounter_end" });
+      }
+      results.push({ unit, light, highestAutoRank: encounter.highestAutoRank });
+      encounter.active = false;
+      encounter.naturalStaggerCrossed = false;
+      encounter.highestAutoRank = 0;
+      encounter.autoInjuryIds = [];
+    });
+    emit("luminous:injury-encounter-finalized", { results });
+    return results;
+  }
+
+  function handleDown(unit, detail = {}) {
+    if (!unit) return { counted: false, reason: "missing_unit" };
+    const injuryState = ensureState(unit);
+    if (injuryState.currentlyDownedCounted) return { counted: false, reason: "same_down_already_counted", unit };
+    injuryState.currentlyDownedCounted = true;
+    injuryState.downCount += 1;
+    let moderate = null;
+    if (injuryState.downCount >= DOWNS_PER_MODERATE) {
+      injuryState.downCount -= DOWNS_PER_MODERATE;
+      moderate = gainAutomaticInjury(unit, "moderate", {
+        trigger: "down_count",
+        source: "downs",
+        injuryId: detail.injuryId,
+        bodyPart: detail.bodyPart,
+      });
+    }
+    persistPlayerState(unit);
+    emit("luminous:injury-down-count-changed", { unit, downCount: injuryState.downCount, moderate });
+    return { counted: true, unit, downCount: injuryState.downCount, moderate };
+  }
+
+  function clearCurrentDown(unit) {
+    const injuryState = ensureState(unit);
+    if (!injuryState) return null;
+    injuryState.currentlyDownedCounted = false;
+    return injuryState;
+  }
+
+  function handleDeath(unit, detail = {}) {
+    if (!unit) return { gained: false, reason: "missing_unit" };
+    return gainAutomaticInjury(unit, "severe", {
+      trigger: "death",
+      source: detail.reason || "death",
+      injury: detail.injury,
+      injuryId: detail.injuryId,
+      bodyPart: detail.bodyPart,
+      affectedParts: detail.affectedParts,
+      slotEffect: detail.slotEffect,
+      structural: detail.structural,
+    });
+  }
+
+  function resetDownCount(unit, options = {}) {
+    const injuryState = ensureState(unit);
+    if (!injuryState) return null;
+    injuryState.downCount = 0;
+    injuryState.currentlyDownedCounted = false;
+    if (options.persist !== false) persistPlayerState(unit);
+    emit("luminous:injury-down-count-reset", { unit, reason: options.reason || "long_rest" });
+    return injuryState;
+  }
+
+  function advanceRecovery(unit, hours, options = {}) {
+    if (!unit) return [];
+    ensureState(unit);
+    const elapsed = Math.max(0, numberOr(hours, 0));
+    if (!elapsed) return [];
+    const progressed = [];
+    const completed = [];
+
+    unit.injuries.forEach((injury) => {
+      if (!injury || injury.active === false || injury.structural === true || injury.remainingRecoveryHours == null) return;
+      const before = Math.max(0, numberOr(injury.remainingRecoveryHours, 0));
+      injury.remainingRecoveryHours = Math.max(0, before - elapsed);
+      progressed.push({ instanceId: injury.instanceId, before, after: injury.remainingRecoveryHours });
+      if (injury.remainingRecoveryHours <= 0) completed.push(injury.instanceId);
+    });
+    completed.forEach((instanceId) => removeInjury(unit, instanceId, { reason: "natural_recovery", persist: false }));
+    if (progressed.length) {
+      syncDerivedState(unit, { ...options, persist: false });
+      if (options.persist !== false) persistPlayerState(unit);
+      emit("luminous:injury-recovery-progress", { unit, hours: elapsed, progressed, completed });
+    }
+    return progressed;
+  }
+
+  function treatInjury(unit, injuryRef, treatment = {}) {
+    const index = findInjuryIndex(unit, injuryRef);
+    if (index < 0) return { treated: false, reason: "not_found", unit };
+    const injury = unit.injuries[index];
+    const method = normalizeId(treatment.method || "treatment");
+    const canCureStructural = treatment.allowStructural === true || ["regeneration", "replacement", "body_replacement", "dante_clock"].includes(method);
+
+    if (treatment.cure === true || treatment.remove === true) {
+      if (injury.structural && !canCureStructural) return { treated: false, reason: "structural_requires_regeneration_or_replacement", unit, injury };
+      const removed = removeInjury(unit, injury.instanceId, { reason: method });
+      return { treated: removed.removed, cured: removed.removed, unit, injury: removed.injury };
+    }
+    if (injury.structural) return { treated: false, reason: "structural_has_no_natural_recovery_timer", unit, injury };
+
+    const before = Math.max(0, numberOr(injury.remainingRecoveryHours, 0));
+    let after = before;
+    if (Number.isFinite(Number(treatment.reduceHours))) after -= Math.max(0, Number(treatment.reduceHours));
+    if (Number.isFinite(Number(treatment.reducePercent))) after *= Math.max(0, 1 - Number(treatment.reducePercent) / 100);
+    if (Number.isFinite(Number(treatment.multiplier))) after *= Math.max(0, Number(treatment.multiplier));
+    injury.remainingRecoveryHours = Math.max(0, after);
+    if (injury.remainingRecoveryHours <= 0) {
+      const removed = removeInjury(unit, injury.instanceId, { reason: method });
+      return { treated: true, cured: true, unit, injury: removed.injury, before, after: 0 };
+    }
+    syncDerivedState(unit);
+    const result = { treated: true, cured: false, unit, injury: clone(injury), before, after: injury.remainingRecoveryHours };
+    emit("luminous:injury-treated", result);
+    return result;
+  }
+
+  function clearForDanteClock(unit) {
+    if (!unit) return { cleared: false, reason: "missing_unit" };
+    ensureState(unit);
+    const removed = unit.injuries.splice(0, unit.injuries.length);
+    resetDownCount(unit, { persist: false, reason: "dante_clock" });
+    const encounter = ensureEncounterState(unit);
+    encounter.active = false;
+    encounter.naturalStaggerCrossed = false;
+    encounter.highestAutoRank = 0;
+    encounter.autoInjuryIds = [];
+    const derived = syncDerivedState(unit);
+    const result = { cleared: true, unit, removed, derived };
+    emit("luminous:dante-clock-injuries-cleared", result);
+    return result;
+  }
+
+  const MODIFIER_CHANNELS = Object.freeze([
+    "damage_dealt_multiplier", "damage_taken_multiplier", "healing_multiplier", "final_power", "base_power",
+    "defense_power", "counter_power", "evade_power", "guard_power", "clash_power", "offensive_level",
+    "defensive_level", "speed", "min_speed", "max_speed", "resource", "coin_power", "crit_damage_multiplier",
+  ]);
+
+  function collectModifiers(unit) {
+    const modifiers = Object.fromEntries(MODIFIER_CHANNELS.map((channel) => [channel, 0]));
+    activeInjuries(unit).forEach((injury) => {
+      MODIFIER_CHANNELS.forEach((channel) => {
+        modifiers[channel] += numberOr(injury.effects?.[channel], 0);
+      });
+    });
+    return modifiers;
+  }
+
+  function checkPenalty(unit, statUsed, skillUsed) {
+    const stat = normalizeId(statUsed);
+    const skill = normalizeId(skillUsed);
+    const physicalStats = new Set(["str", "strength", "fuerza", "dex", "dexterity", "destreza", "con", "constitution", "constitucion"]);
+    const mentalStats = new Set(["int", "intelligence", "inteligencia", "wis", "wisdom", "sabiduria", "cha", "charisma", "carisma"]);
+    let penalty = 0;
+    activeInjuries(unit).forEach((injury) => {
+      if (physicalStats.has(stat)) penalty += numberOr(injury.effects?.physicalCheckPenalty, 0);
+      if (mentalStats.has(stat)) penalty += numberOr(injury.effects?.mentalCheckPenalty, 0);
+      if (["perception", "percepcion"].includes(skill)) penalty += numberOr(injury.effects?.visualCheckPenalty, 0);
+    });
+    return penalty;
+  }
+
+  function wrapCombatEngine(source) {
+    if (!source || source.__luminousInjuryWrapped) return source;
+    if (typeof source.checkStagger === "function") {
+      const original = source.checkStagger;
+      source.checkStagger = function (unit, ...args) {
+        const before = Array.isArray(unit?.crossedThresholds) ? [...unit.crossedThresholds] : [];
+        const forced = unit?.isForcedStagger === true || unit?.forcedStagger === true || unit?.staggerForced === true;
+        const result = original.call(this, unit, ...args);
+        const after = Array.isArray(unit?.crossedThresholds) ? unit.crossedThresholds : [];
+        const crossed = after.map((value, index) => Boolean(value) && !Boolean(before[index])).filter(Boolean).length;
+        if (crossed > 0 && !forced) markNaturalStagger(unit, { crossed });
+        return result;
+      };
+    }
+    if (typeof source.triggerEncounterStart === "function") {
+      const original = source.triggerEncounterStart;
+      source.triggerEncounterStart = function (units = [], ...args) {
+        beginEncounter(units);
+        return original.call(this, units, ...args);
+      };
+    }
+    if (typeof source.initializeUnitData === "function") {
+      const original = source.initializeUnitData;
+      source.initializeUnitData = function (unit, ...args) {
+        const result = original.call(this, unit, ...args);
+        ensureState(unit);
+        syncDerivedState(unit, { persist: false });
+        return result;
+      };
+    }
+    if (typeof source.applyPassiveModifiers === "function") {
+      const original = source.applyPassiveModifiers;
+      source.applyPassiveModifiers = function (unit, contextOptions = null) {
+        const base = original.call(this, unit, contextOptions) || {};
+        const injury = collectModifiers(unit);
+        const merged = { ...base };
+        MODIFIER_CHANNELS.forEach((channel) => { merged[channel] = numberOr(base[channel], 0) + numberOr(injury[channel], 0); });
+        return merged;
+      };
+    }
+    if (typeof source.calculateDndBonus === "function") {
+      const original = source.calculateDndBonus;
+      source.calculateDndBonus = function (unit, statUsed, skillUsed) {
+        return numberOr(original.call(this, unit, statUsed, skillUsed), 0) + checkPenalty(unit, statUsed, skillUsed);
+      };
+    }
+    if (typeof source.endEncounter === "function") {
+      const original = source.endEncounter;
+      source.endEncounter = function (units = [], ...args) {
+        const result = original.call(this, units, ...args);
+        finalizeEncounter(units);
+        return result;
+      };
+    }
+    source.__luminousInjuryWrapped = true;
+    return source;
+  }
+
+  function installCombatBridge() {
+    const source = global.CombatEngine;
+    if (!source) return false;
+    if (state.combatSource === source && source.__luminousInjuryWrapped) return true;
+    state.combatSource = wrapCombatEngine(source);
+    return true;
+  }
+
+  function eventUnits(detail = {}) {
+    if (Array.isArray(detail.units)) return detail.units;
+    if (detail.combatData && typeof detail.combatData === "object") return Object.values(detail.combatData);
+    if (detail.unit) return [detail.unit];
+    return [];
+  }
+
+  function bindEvents() {
+    if (state.listenersBound || typeof global.addEventListener !== "function") return false;
+    state.listenersBound = true;
+    global.addEventListener("luminous:downed", (event) => handleDown(event?.detail?.unit, event?.detail || {}));
+    ["luminous:unit-revived", "luminous:downed-stabilized-by-heal", "luminous:death-save-stabilized"].forEach((name) => {
+      global.addEventListener(name, (event) => clearCurrentDown(event?.detail?.unit));
+    });
+    global.addEventListener("luminous:unit-dead", (event) => handleDeath(event?.detail?.unit, event?.detail || {}));
+    global.addEventListener("luminous:rest-completed", (event) => {
+      const detail = event?.detail || {};
+      if (normalizeId(detail.type || detail.restType) === "long_rest") resetDownCount(detail.character, { reason: "long_rest" });
+    });
+    global.addEventListener("luminous:world-time-advance-requested", (event) => {
+      const detail = event?.detail || {};
+      const hours = Math.max(0, numberOr(detail.hours, 0));
+      if (!hours) return;
+      if (detail.character) advanceRecovery(detail.character, hours);
+      else [...state.trackedUnits].filter((unit) => sameUnitId(unit, detail.characterId)).forEach((unit) => advanceRecovery(unit, hours));
+    });
+    ["luminous:encounter-end", "luminous:encounter-ended"].forEach((name) => {
+      global.addEventListener(name, (event) => finalizeEncounter(eventUnits(event?.detail || {})));
+    });
+    global.addEventListener("luminous:dante-clock-windup", (event) => {
+      eventUnits(event?.detail || {}).forEach((unit) => clearForDanteClock(unit));
+    });
+    return true;
+  }
+
+  function install() {
+    bindEvents();
+    installCombatBridge();
+    if (typeof global.setInterval === "function" && !state.patchTimer) {
+      state.patchTimer = global.setInterval(() => installCombatBridge(), PATCH_INTERVAL_MS);
+      if (typeof state.patchTimer?.unref === "function") state.patchTimer.unref();
+    }
+    return true;
+  }
+
+  const api = Object.freeze({
+    CATALOG,
+    DOWNS_PER_MODERATE,
+    SEVERE_MAX_HP_PENALTY,
+    MAX_SEVERE_HP_PENALTY,
+    normalizeId,
+    definition,
+    ensureState,
+    activeInjuries,
+    severePenaltyPct,
+    syncMaxHp,
+    syncAnatomyAndEquipment,
+    syncDerivedState,
+    gainInjury,
+    removeInjury,
+    replaceInjury,
+    gainAutomaticInjury,
+    beginEncounter,
+    markNaturalStagger,
+    finalizeEncounter,
+    handleDown,
+    clearCurrentDown,
+    handleDeath,
+    resetDownCount,
+    advanceRecovery,
+    treatInjury,
+    clearForDanteClock,
+    collectModifiers,
+    checkPenalty,
+    wrapCombatEngine,
+    installCombatBridge,
+    install,
+  });
+
+  global.LuminousInjuryEngine = api;
+  install();
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/injury-equipment-runtime.js
+++ b/js/injury-equipment-runtime.js
@@ -1,0 +1,220 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousInjuryEquipmentRuntime) return;
+
+  const PATCH_INTERVAL_MS = 300;
+  const COMBATANTS_PATH = "campaña/combate/combatants";
+  const state = {
+    trackedUnits: new Set(),
+    listenersBound: false,
+    firebaseBound: false,
+    combatantsSeen: null,
+    combatBonusSource: null,
+    playerSignatures: typeof WeakMap === "function" ? new WeakMap() : null,
+    timer: null,
+  };
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+  function trackUnit(unit) {
+    if (unit && typeof unit === "object") state.trackedUnits.add(unit);
+    return unit;
+  }
+
+  function activeInjuries(unit) {
+    return Array.isArray(unit?.injuries) ? unit.injuries.filter((injury) => injury && injury.active !== false) : [];
+  }
+
+  function missingEyePerceptionCompensation(unit, skillUsed) {
+    const skill = normalizeId(skillUsed);
+    if (!["perception", "percepcion"].includes(skill)) return 0;
+    return activeInjuries(unit)
+      .filter((injury) => normalizeId(injury.catalogId || injury.id) === "missing_eye")
+      .reduce((sum, injury) => sum - Math.min(0, numberOr(injury.effects?.visualCheckPenalty, 0)), 0);
+  }
+
+  function syncCombatStatsMaxHp(unit) {
+    if (!unit || !unit.combatStats || typeof unit.combatStats !== "object") return null;
+    const stats = unit.combatStats;
+    const key = Object.prototype.hasOwnProperty.call(stats, "hp_max") ? "hp_max"
+      : Object.prototype.hasOwnProperty.call(stats, "max_hp") ? "max_hp"
+        : Object.prototype.hasOwnProperty.call(stats, "maxHp") ? "maxHp" : "hp_max";
+    const current = Math.max(1, numberOr(stats[key], unit.effectiveMaxHp || unit.maxHp || 1));
+    const penalty = Math.max(0, numberOr(unit.injuryMaxHpPenaltyPct, 0));
+
+    if (penalty > 0) {
+      if (!Number.isFinite(Number(unit.injuryHealthBaseCombatStatsMaxHp))) unit.injuryHealthBaseCombatStatsMaxHp = current;
+      const base = Math.max(1, numberOr(unit.injuryHealthBaseCombatStatsMaxHp, current));
+      const effective = Math.max(1, Math.floor(base * (1 - penalty)));
+      stats[key] = effective;
+      if (Number.isFinite(Number(stats.hp_actual))) stats.hp_actual = Math.min(Number(stats.hp_actual), effective);
+      return { baseMaxHp: base, effectiveMaxHp: effective, penaltyPct: penalty, key };
+    }
+
+    if (Number.isFinite(Number(unit.injuryHealthBaseCombatStatsMaxHp))) {
+      stats[key] = Math.max(1, Number(unit.injuryHealthBaseCombatStatsMaxHp));
+      delete unit.injuryHealthBaseCombatStatsMaxHp;
+    }
+    return { baseMaxHp: Number(stats[key]), effectiveMaxHp: Number(stats[key]), penaltyPct: 0, key };
+  }
+
+  function itemIdentity(item, fallback = null) {
+    return String(item?.key || item?.id || item?.itemId || item?.item_id || fallback || "").trim();
+  }
+
+  function objectValuesWithKeys(container) {
+    if (!container) return [];
+    if (Array.isArray(container)) return container.map((item, index) => ({ key: itemIdentity(item, index), item }));
+    if (typeof container !== "object") return [];
+    return Object.entries(container).map(([key, item]) => ({ key, item }));
+  }
+
+  function clearOriginalEquippedState(unit, droppedItem) {
+    const wanted = itemIdentity(droppedItem);
+    if (!wanted || !unit) return false;
+    let changed = false;
+    [unit.equipment, unit.activeInventory, unit.inventory, unit.inventario, unit.items].forEach((container) => {
+      objectValuesWithKeys(container).forEach(({ key, item }) => {
+        if (!item || typeof item !== "object") return;
+        if (itemIdentity(item, key) !== wanted) return;
+        item.equipped = false;
+        item.equipped_slot = null;
+        item.equippedSlot = null;
+        item.equippedPartIds = [];
+        item.assignedBodyParts = [];
+        changed = true;
+      });
+    });
+    return changed;
+  }
+
+  function syncLootDropsBackToSource(unit) {
+    const pool = Array.isArray(global.LuminousCombatLootPool) ? global.LuminousCombatLootPool : [];
+    let changed = 0;
+    pool.forEach((item) => { if (clearOriginalEquippedState(unit, item)) changed += 1; });
+    return changed;
+  }
+
+  function currentPlayer() {
+    return global.LuminousPlayerTraitRuntime?.getCharacter?.() || global.datosJugador || null;
+  }
+
+  function playerSignature(unit) {
+    if (!unit) return "";
+    const injuries = activeInjuries(unit).map((injury) => [
+      injury.instanceId || injury.id,
+      injury.remainingRecoveryHours,
+      injury.severity,
+      injury.slotEffect,
+      (injury.affectedParts || []).join(","),
+    ]);
+    return JSON.stringify([injuries, unit.injuryState?.downCount || 0]);
+  }
+
+  function syncKnownPlayer() {
+    const engine = global.LuminousInjuryEngine;
+    const unit = currentPlayer();
+    if (!engine || !unit) return false;
+    trackUnit(unit);
+    const signature = playerSignature(unit);
+    if (state.playerSignatures && state.playerSignatures.get(unit) === signature) return true;
+    state.playerSignatures?.set(unit, signature);
+    engine.ensureState?.(unit);
+    engine.syncDerivedState?.(unit, { persist: false });
+    syncCombatStatsMaxHp(unit);
+    syncLootDropsBackToSource(unit);
+    return true;
+  }
+
+  function patchCombatPerception() {
+    const combat = global.CombatEngine;
+    if (!combat || !combat.__luminousInjuryWrapped || typeof combat.calculateDndBonus !== "function") return false;
+    if (combat.calculateDndBonus.__luminousMonocularCompensation) return true;
+    const source = combat.calculateDndBonus;
+    const wrapped = function (unit, statUsed, skillUsed) {
+      return numberOr(source.call(this, unit, statUsed, skillUsed), 0) + missingEyePerceptionCompensation(unit, skillUsed);
+    };
+    wrapped.__luminousMonocularCompensation = true;
+    wrapped.__luminousSource = source;
+    combat.calculateDndBonus = wrapped;
+    state.combatBonusSource = wrapped;
+    return true;
+  }
+
+  function finalizeTrackedEncounter() {
+    const engine = global.LuminousInjuryEngine;
+    if (!engine?.finalizeEncounter) return [];
+    const units = [...state.trackedUnits].filter((unit) => unit?.injuryState?.encounter?.active === true);
+    if (!units.length) return [];
+    return engine.finalizeEncounter(units);
+  }
+
+  function bindFirebaseCombatEnd() {
+    if (state.firebaseBound) return true;
+    const db = global.firebase?.database?.();
+    if (!db) return false;
+    const ref = db.ref(COMBATANTS_PATH);
+    if (!ref?.on) return false;
+    state.firebaseBound = true;
+    ref.on("value", (snapshot) => {
+      const data = snapshot?.val?.() || {};
+      const count = Object.keys(data).length;
+      if (state.combatantsSeen != null && state.combatantsSeen > 0 && count === 0) finalizeTrackedEncounter();
+      state.combatantsSeen = count;
+    });
+    return true;
+  }
+
+  function bindEvents() {
+    if (state.listenersBound || typeof global.addEventListener !== "function") return false;
+    state.listenersBound = true;
+    [
+      "luminous:stagger-threshold-crossed",
+      "luminous:downed",
+      "luminous:unit-dead",
+      "luminous:unit-revived",
+    ].forEach((name) => global.addEventListener(name, (event) => trackUnit(event?.detail?.unit)));
+
+    global.addEventListener("luminous:injury-state-changed", (event) => {
+      const unit = trackUnit(event?.detail?.unit);
+      if (!unit) return;
+      syncCombatStatsMaxHp(unit);
+      syncLootDropsBackToSource(unit);
+      state.playerSignatures?.set(unit, playerSignature(unit));
+    });
+    return true;
+  }
+
+  function install() {
+    bindEvents();
+    bindFirebaseCombatEnd();
+    patchCombatPerception();
+    syncKnownPlayer();
+    return true;
+  }
+
+  const api = Object.freeze({
+    trackUnit,
+    activeInjuries,
+    missingEyePerceptionCompensation,
+    syncCombatStatsMaxHp,
+    clearOriginalEquippedState,
+    syncLootDropsBackToSource,
+    syncKnownPlayer,
+    patchCombatPerception,
+    finalizeTrackedEncounter,
+    bindFirebaseCombatEnd,
+    bindEvents,
+    install,
+  });
+
+  global.LuminousInjuryEquipmentRuntime = api;
+  install();
+  if (typeof global.setInterval === "function") {
+    state.timer = global.setInterval(install, PATCH_INTERVAL_MS);
+    if (typeof state.timer?.unref === "function") state.timer.unref();
+  }
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/player-archetype-runtime.js
+++ b/js/player-archetype-runtime.js
@@ -46,6 +46,7 @@
   }
 
   function ensureStyles() {
+    if (!doc.querySelector?.(".sheet-phone-wrapper")) return;
     if (doc.getElementById("player-archetype-runtime-stylesheet")) return;
     const link = doc.createElement("link");
     link.id = "player-archetype-runtime-stylesheet";
@@ -138,7 +139,7 @@
   function statMod(character = {}, stat) {
     const key = normalizeId(stat);
     const aliases = key === "strength" ? ["fuerza", "strength", "str"] : key === "constitution" ? ["constitucion", "constitution", "con"] : [key];
-    const stats = character.stats || {};
+    const stats = character.stats || character.dndStats || {};
     const score = aliases.map((alias) => stats[alias] ?? character[alias]).find((value) => Number.isFinite(Number(value)));
     return Math.floor((numberOr(score, 10) - 10) / 2);
   }
@@ -174,6 +175,23 @@
   function statusDamageMultiplier(character = currentCharacter(), statusId) {
     if (devilLineageLevel(character) < 15) return 1;
     return ["burn", "poison"].includes(normalizeId(statusId)) ? 0.5 : 1;
+  }
+
+  function syncArchetypeTraitsForUnit(unit = {}) {
+    const archetypeCatalog = catalog();
+    if (!unit || !archetypeCatalog?.resolveTraitGrants) return [];
+    const character = characterForUnit(unit);
+    const granted = archetypeCatalog.resolveTraitGrants(character) || [];
+    if (!granted.length) return [];
+    const existing = Array.isArray(unit.traitDefinitions) ? unit.traitDefinitions : [];
+    const byId = new Map();
+    [...existing, ...granted].forEach((trait) => {
+      const id = normalizeId(trait?.id || trait?.name);
+      if (id && !byId.has(id)) byId.set(id, trait);
+    });
+    unit.traitDefinitions = [...byId.values()];
+    global.LuminousTraitStandardizationRuntime?.registerCombatUnit?.(unit);
+    return granted;
   }
 
   function patchTraitEngine() {
@@ -570,8 +588,9 @@
 
   function coinSpendsAmmo(skill = {}, context = {}) {
     const coin = context?.currentCoin || context?.coin || context?.coinData || null;
-    if (!coin) return false;
-    return coin.spendsAmmo === true || coin.spendAmmo === true || numberOr(coin.ammoCost ?? coin.ammo_cost ?? coin.ammo?.cost, 0) > 0;
+    const coinCost = numberOr(coin?.ammoCost ?? coin?.ammo_cost ?? coin?.ammo?.cost, 0);
+    const skillCost = numberOr(skill?.ammo?.cost ?? skill?.ammoCost ?? skill?.ammo_cost, 0);
+    return coin?.spendsAmmo === true || coin?.spendAmmo === true || coinCost > 0 || skillCost > 0;
   }
 
   function patchCombatEngine() {
@@ -582,6 +601,15 @@
       return true;
     }
     if (state.combatSource === engine) return true;
+
+    const originalInitialize = typeof engine.initializeUnitData === "function" ? engine.initializeUnitData : null;
+    if (originalInitialize) {
+      engine.initializeUnitData = function (unit, ...rest) {
+        const result = originalInitialize.call(this, unit, ...rest);
+        syncArchetypeTraitsForUnit(unit);
+        return result;
+      };
+    }
 
     const originalCoinDamage = typeof engine.calculateCoinDamage === "function" ? engine.calculateCoinDamage : null;
     if (originalCoinDamage) {
@@ -615,7 +643,7 @@
     if (originalApplyDamage) {
       engine.applyDamage = function (unit, damage, ...rest) {
         const character = characterForUnit(unit);
-        const active = isCurrentPlayerUnit(unit) && hasDevilLineageLevel(character, 70) && hasStatus(unit, "rage");
+        const active = hasDevilLineageLevel(character, 70) && hasStatus(unit, "rage");
         if (!active) return originalApplyDamage.call(this, unit, damage, ...rest);
         const hpBefore = currentHp(unit);
         const shieldBefore = Math.max(0, numberOr(unit?.shield, 0));
@@ -638,7 +666,7 @@
     if (originalProcessStatuses) {
       engine.processStatusEffects = function (unit, triggerKey, context = {}) {
         const character = characterForUnit(unit);
-        const resistant = isCurrentPlayerUnit(unit) && hasDevilLineageLevel(character, 15);
+        const resistant = hasDevilLineageLevel(character, 15);
         const store = unit?.statusEffects && typeof unit.statusEffects === "object" ? unit.statusEffects : null;
         const changed = [];
         if (resistant && store) {
@@ -657,7 +685,7 @@
         } finally {
           changed.forEach(([status, potency]) => { status.potency = potency; });
         }
-        if (isCurrentPlayerUnit(unit) && hasDevilLineageLevel(character, 70) && hasStatus(unit, "rage") && currentHp(unit) <= 1) {
+        if (hasDevilLineageLevel(character, 70) && hasStatus(unit, "rage") && currentHp(unit) <= 1) {
           if (hpBefore > 1) armCursedJuggernaut(unit);
           if (currentHp(unit) < 1) setHp(unit, 1);
         }
@@ -668,7 +696,9 @@
     const originalEncounterStart = typeof engine.triggerEncounterStart === "function" ? engine.triggerEncounterStart : null;
     if (originalEncounterStart) {
       engine.triggerEncounterStart = function (allUnits = [], ...rest) {
-        (Array.isArray(allUnits) ? allUnits : []).filter(isCurrentPlayerUnit).forEach((unit) => {
+        (Array.isArray(allUnits) ? allUnits : []).forEach((unit) => {
+          syncArchetypeTraitsForUnit(unit);
+          if (!hasDevilLineageLevel(characterForUnit(unit), 70)) return;
           const record = cursedState(unit);
           record.used = false;
           record.pending = false;
@@ -680,9 +710,11 @@
     const originalTriggerPhase = typeof engine.triggerPhase === "function" ? engine.triggerPhase : null;
     if (originalTriggerPhase) {
       engine.triggerPhase = function (phaseTag, allUnits, ...rest) {
+        const units = Array.isArray(allUnits) ? allUnits : [];
+        units.forEach(syncArchetypeTraitsForUnit);
         const result = originalTriggerPhase.call(this, phaseTag, allUnits, ...rest);
         if (phaseTag === "[Round Start]") {
-          (Array.isArray(allUnits) ? allUnits : []).filter(isCurrentPlayerUnit).forEach((unit) => {
+          units.forEach((unit) => {
             if (hasDevilLineageLevel(characterForUnit(unit), 70)) resolveCursedJuggernautRecovery(unit);
           });
         }
@@ -789,6 +821,8 @@
     deathSavePowerBonus,
     capabilities,
     statusDamageMultiplier,
+    syncArchetypeTraitsForUnit,
+    coinSpendsAmmo,
     applyTheatreCheckMechanics,
     classArchetypeOptions,
     persistArchetypeSelection,

--- a/js/player-archetype-runtime.js
+++ b/js/player-archetype-runtime.js
@@ -18,6 +18,7 @@
     theatreSource: null,
     combatSource: null,
     lastSelectionSignature: "",
+    cursedByUnit: new Map(),
   };
 
   const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/\s+/g, "_");
@@ -73,13 +74,21 @@
   }
 
   function idsFor(entity = {}) {
-    return [entity.id, entity.playerId, entity.player_id, entity.characterId, entity.character_id, entity.actorId, entity.actor_id, entity.uid]
+    return [
+      entity.combatId, entity.combat_id, entity.unitId, entity.unit_id,
+      entity.id, entity.playerId, entity.player_id, entity.characterId, entity.character_id,
+      entity.actorId, entity.actor_id, entity.uid,
+    ]
       .filter((value) => value != null && String(value).trim() !== "")
       .map((value) => String(value).trim());
   }
 
   function entityName(entity = {}) {
     return normalizeId(entity.characterName || entity.character_name || entity.nombre || entity.name || "");
+  }
+
+  function combatUnitKey(unit = {}) {
+    return idsFor(unit)[0] || entityName(unit) || null;
   }
 
   function isCurrentPlayerUnit(unit = {}) {
@@ -177,15 +186,21 @@
     return ["burn", "poison"].includes(normalizeId(statusId)) ? 0.5 : 1;
   }
 
+  function isDevilArchetypeTrait(trait = {}) {
+    const source = trait?.source || {};
+    const type = normalizeId(source.type || trait?.sourceType);
+    const archetypeId = normalizeId(source.archetypeId || source.id || trait?.archetypeId);
+    return ["archetype", "subclass", "class_archetype"].includes(type) && archetypeId === DEVIL_ARCHETYPE_ID;
+  }
+
   function syncArchetypeTraitsForUnit(unit = {}) {
     const archetypeCatalog = catalog();
     if (!unit || !archetypeCatalog?.resolveTraitGrants) return [];
     const character = characterForUnit(unit);
     const granted = archetypeCatalog.resolveTraitGrants(character) || [];
-    if (!granted.length) return [];
     const existing = Array.isArray(unit.traitDefinitions) ? unit.traitDefinitions : [];
     const byId = new Map();
-    [...existing, ...granted].forEach((trait) => {
+    [...existing.filter((trait) => !isDevilArchetypeTrait(trait)), ...granted].forEach((trait) => {
       const id = normalizeId(trait?.id || trait?.name);
       if (id && !byId.has(id)) byId.set(id, trait);
     });
@@ -554,6 +569,11 @@
   }
 
   function cursedState(unit = {}) {
+    const key = combatUnitKey(unit);
+    if (key) {
+      if (!state.cursedByUnit.has(key)) state.cursedByUnit.set(key, { used: false, pending: false });
+      return state.cursedByUnit.get(key);
+    }
     if (!unit.__devilLineageCursedJuggernaut) {
       Object.defineProperty(unit, "__devilLineageCursedJuggernaut", {
         value: { used: false, pending: false },
@@ -633,7 +653,7 @@
         }
         if (level >= 15 && coinSpendsAmmo(skill, context)) {
           const multiplier = 1 + (10 * statMod(character, "strength")) / 100;
-          if (typeof result === "number") result *= multiplier;
+          if (typeof result === "number") result = Math.max(0, Math.floor(result * multiplier));
         }
         return result;
       };
@@ -696,6 +716,7 @@
     const originalEncounterStart = typeof engine.triggerEncounterStart === "function" ? engine.triggerEncounterStart : null;
     if (originalEncounterStart) {
       engine.triggerEncounterStart = function (allUnits = [], ...rest) {
+        state.cursedByUnit.clear();
         (Array.isArray(allUnits) ? allUnits : []).forEach((unit) => {
           syncArchetypeTraitsForUnit(unit);
           if (!hasDevilLineageLevel(characterForUnit(unit), 70)) return;
@@ -727,6 +748,31 @@
     return true;
   }
 
+  function watchCombatEngineAssignment() {
+    if (global.CombatEngine || global.__luminousArchetypeCombatAssignmentWatch) return false;
+    global.__luminousArchetypeCombatAssignmentWatch = true;
+    try {
+      Object.defineProperty(global, "CombatEngine", {
+        configurable: true,
+        enumerable: true,
+        get() { return undefined; },
+        set(value) {
+          Object.defineProperty(global, "CombatEngine", {
+            value,
+            writable: true,
+            configurable: true,
+            enumerable: true,
+          });
+          state.combatSource = null;
+          patchCombatEngine();
+        },
+      });
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
   function installActiveInventoryBridge() {
     if (global.__luminousArchetypeInventoryBridge) return true;
     global.__luminousArchetypeInventoryBridge = true;
@@ -737,10 +783,11 @@
       const bonus = activeInventoryBonus(character);
       if (bonus <= 0) return;
 
-      event.stopImmediatePropagation();
       const playerId = currentPlayerId();
       const db = global.firebase?.database?.();
       if (!playerId || !db || !detail.itemKey || !detail.itemData) return;
+      event.stopImmediatePropagation();
+
       const itemKey = detail.itemKey;
       const itemData = detail.itemData;
       const sourceRef = db.ref(`${PLAYER_ROOT}/${playerId}/inventario_stash/${itemKey}`);
@@ -802,6 +849,7 @@
 
   function boot() {
     ensureStyles();
+    watchCombatEngineAssignment();
     installActiveInventoryBridge();
     installPatches();
     global.addEventListener?.("luminous:traits-refreshed", () => {
@@ -833,6 +881,7 @@
     patchTraitTray,
     patchTheatreRolls,
     patchCombatEngine,
+    watchCombatEngineAssignment,
     resolveCursedJuggernautRecovery,
   });
 

--- a/js/player-archetype-runtime.js
+++ b/js/player-archetype-runtime.js
@@ -1,0 +1,807 @@
+(function (global) {
+  "use strict";
+
+  const doc = global.document;
+  if (!doc || global.LuminousArchetypeRuntime) return;
+
+  const PLAYER_ROOT = "campaña/jugadores";
+  const PLAYER_ID_STORAGE_KEY = "playerId";
+  const PATCH_INTERVAL_MS = 500;
+  const DEVIL_ARCHETYPE_ID = "path_of_the_devil_lineage";
+
+  const state = {
+    dependencyPromise: null,
+    engineSource: null,
+    coreSource: null,
+    racialSource: null,
+    traySource: null,
+    theatreSource: null,
+    combatSource: null,
+    lastSelectionSignature: "",
+  };
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/\s+/g, "_");
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+  function ensureScript(id, src, ready) {
+    if (ready?.()) return Promise.resolve();
+    const existing = doc.getElementById(id);
+    if (existing) {
+      return new Promise((resolve, reject) => {
+        if (ready?.()) return resolve();
+        existing.addEventListener("load", resolve, { once: true });
+        existing.addEventListener("error", reject, { once: true });
+      });
+    }
+    return new Promise((resolve, reject) => {
+      const script = doc.createElement("script");
+      script.id = id;
+      script.src = src;
+      script.async = false;
+      script.addEventListener("load", resolve, { once: true });
+      script.addEventListener("error", reject, { once: true });
+      doc.head?.appendChild(script);
+    });
+  }
+
+  function ensureStyles() {
+    if (doc.getElementById("player-archetype-runtime-stylesheet")) return;
+    const link = doc.createElement("link");
+    link.id = "player-archetype-runtime-stylesheet";
+    link.rel = "stylesheet";
+    link.href = "css/player-archetype-runtime.css";
+    link.dataset.ui = "player-archetypes";
+    doc.head?.appendChild(link);
+  }
+
+  function ensureDependencies() {
+    if (state.dependencyPromise) return state.dependencyPromise;
+    state.dependencyPromise = Promise.resolve()
+      .then(() => ensureScript("archetype-engine-script", "js/archetype-engine.js", () => Boolean(global.LuminousArchetypeEngine)))
+      .then(() => ensureScript("archetype-trait-catalog-script", "js/archetype-trait-catalog.js", () => Boolean(global.LuminousArchetypeTraitCatalog)));
+    return state.dependencyPromise;
+  }
+
+  function currentCharacter() {
+    return global.LuminousPlayerTraitRuntime?.getCharacter?.() || global.datosJugador || {};
+  }
+
+  function currentPlayerId() {
+    return String(global.localStorage?.getItem?.(PLAYER_ID_STORAGE_KEY) || "").trim();
+  }
+
+  function idsFor(entity = {}) {
+    return [entity.id, entity.playerId, entity.player_id, entity.characterId, entity.character_id, entity.actorId, entity.actor_id, entity.uid]
+      .filter((value) => value != null && String(value).trim() !== "")
+      .map((value) => String(value).trim());
+  }
+
+  function entityName(entity = {}) {
+    return normalizeId(entity.characterName || entity.character_name || entity.nombre || entity.name || "");
+  }
+
+  function isCurrentPlayerUnit(unit = {}) {
+    const character = currentCharacter();
+    if (unit === character) return true;
+    const unitIds = new Set(idsFor(unit));
+    const expectedIds = new Set([currentPlayerId(), ...idsFor(character)].filter(Boolean));
+    if ([...unitIds].some((id) => expectedIds.has(id))) return true;
+    const unitName = entityName(unit);
+    return Boolean(unitName && unitName === entityName(character));
+  }
+
+  function characterForUnit(unit = {}) {
+    if (!isCurrentPlayerUnit(unit)) return unit || {};
+    const character = currentCharacter();
+    return {
+      ...(character || {}),
+      ...(unit || {}),
+      characterBuild: character?.characterBuild || unit?.characterBuild || {},
+    };
+  }
+
+  function archetypeEngine() {
+    return global.LuminousArchetypeEngine;
+  }
+
+  function catalog() {
+    return global.LuminousArchetypeTraitCatalog;
+  }
+
+  function selectedDevilLineage(character = currentCharacter()) {
+    const api = archetypeEngine();
+    return Boolean(api?.isSelected?.(character, DEVIL_ARCHETYPE_ID, "barbarian"));
+  }
+
+  function devilLineageLevel(character = currentCharacter()) {
+    const api = archetypeEngine();
+    return selectedDevilLineage(character) ? api.getClassLevel(character, "barbarian") : 0;
+  }
+
+  function hasDevilLineageLevel(character, level) {
+    return devilLineageLevel(character) >= Number(level || 0);
+  }
+
+  function statusStore(unit = {}) {
+    return unit.statusEffects || unit.status_effects || unit.statuses || {};
+  }
+
+  function hasStatus(unit = {}, statusId) {
+    const id = normalizeId(statusId);
+    const statuses = statusStore(unit);
+    if (Array.isArray(statuses)) return statuses.some((entry) => normalizeId(entry?.id || entry?.name || entry) === id);
+    if (statuses && typeof statuses === "object") return Boolean(statuses[id] || Object.values(statuses).some((entry) => normalizeId(entry?.id || entry?.name) === id));
+    return false;
+  }
+
+  function statMod(character = {}, stat) {
+    const key = normalizeId(stat);
+    const aliases = key === "strength" ? ["fuerza", "strength", "str"] : key === "constitution" ? ["constitucion", "constitution", "con"] : [key];
+    const stats = character.stats || {};
+    const score = aliases.map((alias) => stats[alias] ?? character[alias]).find((value) => Number.isFinite(Number(value)));
+    return Math.floor((numberOr(score, 10) - 10) / 2);
+  }
+
+  function activeInventoryBonus(character = currentCharacter()) {
+    const level = devilLineageLevel(character);
+    if (level >= 70) return 6;
+    if (level >= 15) return 2;
+    return 0;
+  }
+
+  function activeInventoryLimit(character = currentCharacter(), base = 10) {
+    return Math.max(0, Math.floor(numberOr(base, 10) + activeInventoryBonus(character)));
+  }
+
+  function strengthThresholdModifier(character = currentCharacter()) {
+    const level = devilLineageLevel(character);
+    if (level >= 70) return -3;
+    if (level >= 15) return -1;
+    return 0;
+  }
+
+  function deathSavePowerBonus(character = currentCharacter()) {
+    return devilLineageLevel(character) >= 50 ? 2 : 0;
+  }
+
+  function capabilities(character = currentCharacter()) {
+    return devilLineageLevel(character) >= 50
+      ? [{ archetypeId: DEVIL_ARCHETYPE_ID, classId: "barbarian", capabilityId: "flight", conditions: {} }]
+      : [];
+  }
+
+  function statusDamageMultiplier(character = currentCharacter(), statusId) {
+    if (devilLineageLevel(character) < 15) return 1;
+    return ["burn", "poison"].includes(normalizeId(statusId)) ? 0.5 : 1;
+  }
+
+  function patchTraitEngine() {
+    const api = archetypeEngine();
+    const archetypeCatalog = catalog();
+    const source = global.LuminousTraitEngine;
+    if (!api || !archetypeCatalog || !source?.resolveTraitGrants) return false;
+    if (source.__archetypeGrantResolver) {
+      state.engineSource = source;
+      return true;
+    }
+    if (state.engineSource === source) return true;
+
+    const originalResolve = source.resolveTraitGrants.bind(source);
+    const wrapped = Object.freeze({
+      ...source,
+      __archetypeGrantResolver: true,
+      resolveTraitGrants(character = {}, grants = [], definitions = {}) {
+        const list = Array.isArray(grants) ? grants : Object.values(grants || {});
+        const normal = list.filter((grant) => normalizeId(grant?.sourceType || grant?.source?.type) !== "archetype");
+        const archetypeGrants = list.filter((grant) => normalizeId(grant?.sourceType || grant?.source?.type) === "archetype");
+        const resolved = originalResolve(character, normal, definitions);
+        const selected = api.resolveTraitGrants(character, archetypeGrants, definitions, archetypeCatalog.allArchetypes(), source);
+        const byId = new Map();
+        [...resolved, ...selected].forEach((trait) => {
+          const id = normalizeId(trait?.id || trait?.name);
+          if (id && !byId.has(id)) byId.set(id, trait);
+        });
+        return [...byId.values()];
+      },
+    });
+    global.LuminousTraitEngine = wrapped;
+    state.engineSource = wrapped;
+    return true;
+  }
+
+  function patchCoreCatalog() {
+    const source = global.LuminousTraitCatalogCore;
+    const archetypeCatalog = catalog();
+    if (!source?.allDefinitions || !source?.allGrants || !archetypeCatalog) return false;
+    if (source.__archetypeCatalogIntegrated) {
+      state.coreSource = source;
+      return true;
+    }
+    if (state.coreSource === source) return true;
+
+    const originalDefinitions = source.allDefinitions.bind(source);
+    const originalGrants = source.allGrants.bind(source);
+    const originalGet = typeof source.getDefinition === "function" ? source.getDefinition.bind(source) : null;
+    const wrapped = Object.freeze({
+      ...source,
+      __archetypeCatalogIntegrated: true,
+      allDefinitions() {
+        return { ...originalDefinitions(), ...archetypeCatalog.allDefinitions() };
+      },
+      allGrants() {
+        return [...originalGrants(), ...archetypeCatalog.allGrants()];
+      },
+      getDefinition(id) {
+        const key = normalizeId(id);
+        const local = archetypeCatalog.allDefinitions()[key];
+        return local ? clone(local) : originalGet?.(id) || null;
+      },
+    });
+    global.LuminousTraitCatalogCore = wrapped;
+    state.coreSource = wrapped;
+    return true;
+  }
+
+  function patchRacialCapabilities() {
+    const source = global.LuminousRacialTraitCatalog;
+    if (!source?.resolveCapabilities) return false;
+    if (source.__archetypeCapabilitiesIntegrated) {
+      state.racialSource = source;
+      return true;
+    }
+    if (state.racialSource === source) return true;
+
+    const original = source.resolveCapabilities.bind(source);
+    const wrapped = Object.freeze({
+      ...source,
+      __archetypeCapabilitiesIntegrated: true,
+      resolveCapabilities(character = {}) {
+        const merged = [...(original(character) || []), ...capabilities(character)];
+        const seen = new Set();
+        return merged.filter((entry) => {
+          const key = `${normalizeId(entry?.capabilityId)}:${normalizeId(entry?.raceId || entry?.archetypeId || entry?.sourceId)}`;
+          if (!entry?.capabilityId || seen.has(key)) return false;
+          seen.add(key);
+          return true;
+        });
+      },
+    });
+    global.LuminousRacialTraitCatalog = wrapped;
+    state.racialSource = wrapped;
+    return true;
+  }
+
+  function archetypeIdForTrait(trait = {}) {
+    const source = trait.source || {};
+    return normalizeId(source.archetypeId || source.subclassId || source.id);
+  }
+
+  function decorateArchetypeSubtabs(tray) {
+    const api = archetypeEngine();
+    if (!tray?.root || !api) return;
+    tray.root.querySelector(".player-archetype-subtabs")?.remove();
+    if (normalizeId(tray.filter) !== "archetype") return;
+
+    const traits = tray.normalizedTraits?.() || [];
+    const groups = api.groupTraitsByArchetype(traits);
+    if (groups.length <= 1) return;
+
+    const validIds = new Set(groups.map((group) => group.archetypeId));
+    if (!validIds.has(normalizeId(tray.archetypeFilter))) tray.archetypeFilter = groups[0].archetypeId;
+    const activeId = normalizeId(tray.archetypeFilter);
+    const nav = doc.createElement("nav");
+    nav.className = "player-archetype-subtabs";
+    nav.setAttribute("aria-label", "Filter Archetype Traits");
+
+    groups.forEach((group) => {
+      const button = doc.createElement("button");
+      button.type = "button";
+      button.className = `player-archetype-subtab${activeId === group.archetypeId ? " is-active" : ""}`;
+      button.dataset.archetypeFilter = group.archetypeId;
+      button.setAttribute("aria-pressed", activeId === group.archetypeId ? "true" : "false");
+      const name = doc.createElement("span");
+      name.textContent = group.name;
+      const count = doc.createElement("b");
+      count.textContent = String(group.traits.length);
+      button.append(name, count);
+      button.addEventListener("click", () => {
+        tray.archetypeFilter = group.archetypeId;
+        tray.render();
+      });
+      nav.appendChild(button);
+    });
+
+    const filters = tray.root.querySelector(".player-trait-filters");
+    filters?.insertAdjacentElement("afterend", nav);
+    const byTraitId = new Map(traits.map((trait) => [normalizeId(trait.id), archetypeIdForTrait(trait)]));
+    tray.root.querySelectorAll(".player-trait-card").forEach((card) => {
+      const traitArchetype = byTraitId.get(normalizeId(card.dataset.traitId));
+      card.dataset.archetypeId = traitArchetype || "";
+      card.hidden = Boolean(traitArchetype && traitArchetype !== activeId);
+    });
+  }
+
+  function patchTraitTray() {
+    const source = global.LuminousTraitPlayerTray;
+    const Tray = source?.TraitPlayerTray;
+    if (!Tray?.prototype?.render) return false;
+    if (Tray.prototype.render.__archetypeSubtabsIntegrated) {
+      state.traySource = source;
+      return true;
+    }
+    if (state.traySource === source) return true;
+
+    const originalRender = Tray.prototype.render;
+    function renderWithArchetypeSubtabs(...args) {
+      const result = originalRender.apply(this, args);
+      decorateArchetypeSubtabs(this);
+      return result;
+    }
+    Object.defineProperty(renderWithArchetypeSubtabs, "__archetypeSubtabsIntegrated", { value: true });
+    Tray.prototype.render = renderWithArchetypeSubtabs;
+    state.traySource = source;
+    global.LuminousPlayerTraitRuntime?.refresh?.();
+    return true;
+  }
+
+  function classArchetypeOptions(character = currentCharacter()) {
+    const api = archetypeEngine();
+    const archetypeCatalog = catalog();
+    if (!api || !archetypeCatalog) return [];
+    const all = Object.values(archetypeCatalog.allArchetypes());
+    return api.classEntries(character).map((entry) => {
+      const options = all.filter((archetype) => normalizeId(archetype.classId) === entry.classId);
+      if (!options.length) return null;
+      return {
+        classId: entry.classId,
+        classLevel: entry.levels,
+        className: options[0]?.className || entry.classId,
+        selected: api.selectedForClass(character, entry.classId),
+        options,
+      };
+    }).filter(Boolean);
+  }
+
+  function persistArchetypeSelection(classId, archetypeId) {
+    const api = archetypeEngine();
+    const archetypeCatalog = catalog();
+    const character = currentCharacter();
+    if (!api || !archetypeCatalog) return Promise.reject(new Error("Archetype Engine is unavailable."));
+    let selections;
+    try {
+      selections = api.selectArchetype(character, classId, archetypeId, archetypeCatalog.allArchetypes());
+    } catch (error) {
+      return Promise.reject(error);
+    }
+
+    if (!character.characterBuild || typeof character.characterBuild !== "object") character.characterBuild = {};
+    character.characterBuild.archetypes = selections;
+    const playerId = currentPlayerId();
+    const db = global.firebase?.database?.();
+    if (!playerId || !db) {
+      global.LuminousPlayerTraitRuntime?.refresh?.();
+      renderArchetypeSelector();
+      return Promise.resolve(selections);
+    }
+    return db.ref(`${PLAYER_ROOT}/${playerId}/characterBuild/archetypes`).set(selections).then(() => {
+      global.LuminousPlayerTraitRuntime?.refresh?.();
+      renderArchetypeSelector();
+      return selections;
+    });
+  }
+
+  function renderArchetypeSelector() {
+    const host = doc.getElementById("player-trait-runtime-host");
+    if (!host) return false;
+    let panel = doc.getElementById("player-archetype-selector");
+    if (!panel) {
+      panel = doc.createElement("section");
+      panel.id = "player-archetype-selector";
+      panel.className = "player-archetype-selector";
+      host.prepend(panel);
+    }
+
+    const character = currentCharacter();
+    const rows = classArchetypeOptions(character);
+    const signature = JSON.stringify({ rows, selections: archetypeEngine()?.normalizeSelections?.(character) || [] });
+    if (signature === state.lastSelectionSignature && panel.childElementCount) return true;
+    state.lastSelectionSignature = signature;
+    panel.replaceChildren();
+    if (!rows.length) {
+      panel.hidden = true;
+      return false;
+    }
+    panel.hidden = false;
+
+    const head = doc.createElement("div");
+    head.className = "player-archetype-selector__head";
+    const title = doc.createElement("strong");
+    title.textContent = "ARCHETYPES";
+    const help = doc.createElement("span");
+    help.textContent = "Each Class tracks its own Archetype by Class Level.";
+    head.append(title, help);
+    panel.appendChild(head);
+
+    rows.forEach((row) => {
+      const item = doc.createElement("div");
+      item.className = "player-archetype-selector__row";
+      item.dataset.classId = row.classId;
+      const identity = doc.createElement("div");
+      identity.className = "player-archetype-selector__class";
+      const className = doc.createElement("b");
+      className.textContent = row.className;
+      const classLevel = doc.createElement("span");
+      classLevel.textContent = `CLASS LV.${row.classLevel}`;
+      identity.append(className, classLevel);
+      item.appendChild(identity);
+
+      const choices = doc.createElement("div");
+      choices.className = "player-archetype-selector__choices";
+      if (row.selected) {
+        const selected = row.options.find((entry) => normalizeId(entry.id) === row.selected.archetypeId);
+        const badge = doc.createElement("span");
+        badge.className = "player-archetype-selector__selected";
+        badge.textContent = selected?.name || row.selected.archetypeId;
+        badge.title = "Archetype selection is stored per Class.";
+        choices.appendChild(badge);
+      } else {
+        row.options.forEach((option) => {
+          const required = Math.max(0, Number(option.unlockLevel) || 0);
+          const button = doc.createElement("button");
+          button.type = "button";
+          button.className = "player-archetype-selector__choice";
+          button.dataset.archetypeId = option.id;
+          button.disabled = row.classLevel < required;
+          button.textContent = row.classLevel < required ? `${option.name} · LV.${required}` : `SELECT · ${option.name}`;
+          button.addEventListener("click", () => {
+            button.disabled = true;
+            persistArchetypeSelection(row.classId, option.id).catch((error) => {
+              button.disabled = false;
+              global.alert?.(error.message || "Could not select Archetype.");
+            });
+          });
+          choices.appendChild(button);
+        });
+      }
+      item.appendChild(choices);
+      panel.appendChild(item);
+    });
+    return true;
+  }
+
+  function numericThresholdField(check = {}) {
+    for (const key of ["difficulty", "thresholdRaw", "threshold"]) {
+      if (Number.isFinite(Number(check[key]))) return key;
+    }
+    return null;
+  }
+
+  function applyTheatreCheckMechanics(checkInput = {}) {
+    const check = { ...(checkInput || {}) };
+    if (check.__archetypeAdjusted) return check;
+    const character = currentCharacter();
+    const level = devilLineageLevel(character);
+    if (level < 15) return check;
+    const ability = normalizeId(check.abilityId || check.statId || check.ability || check.stat);
+    const skill = normalizeId(check.skillId || check.skill || check.actionId);
+    const tags = Array.isArray(check.tags) ? check.tags.map(normalizeId) : [];
+    const thresholdKey = numericThresholdField(check);
+
+    if (["str", "strength", "fuerza"].includes(ability) && thresholdKey) {
+      check[thresholdKey] = numberOr(check[thresholdKey]) + strengthThresholdModifier(character);
+    }
+    if (skill === "performance") check.finalPower = numberOr(check.finalPower) + statMod(character, "strength");
+    const jumpCheck = skill === "jump" || tags.includes("jump");
+    if (jumpCheck && thresholdKey && hasStatus(character, "rage")) check[thresholdKey] = numberOr(check[thresholdKey]) / 2;
+    Object.defineProperty(check, "__archetypeAdjusted", { value: true, enumerable: false, configurable: true });
+    return check;
+  }
+
+  function patchTheatreRolls() {
+    const source = global.LuminousTheatreRolls;
+    if (!source?.armCheck) return false;
+    if (source.__archetypeRuntimeIntegrated) {
+      state.theatreSource = source;
+      return true;
+    }
+    if (state.theatreSource === source) return true;
+    const originalArmCheck = source.armCheck.bind(source);
+    const wrapped = Object.freeze({
+      ...source,
+      __archetypeRuntimeIntegrated: true,
+      armCheck(check = {}) {
+        return originalArmCheck(applyTheatreCheckMechanics(check));
+      },
+    });
+    global.LuminousTheatreRolls = wrapped;
+    state.theatreSource = wrapped;
+    return true;
+  }
+
+  function currentHp(unit = {}) {
+    return numberOr(unit.hp ?? unit.currentHp ?? unit.current_hp, 0);
+  }
+
+  function maxHp(unit = {}) {
+    return numberOr(unit.maxHp ?? unit.max_hp ?? unit.hp_max, currentHp(unit));
+  }
+
+  function setHp(unit = {}, value) {
+    const next = Math.max(0, numberOr(value));
+    if (Object.prototype.hasOwnProperty.call(unit, "hp")) unit.hp = next;
+    else if (Object.prototype.hasOwnProperty.call(unit, "currentHp")) unit.currentHp = next;
+    else unit.hp = next;
+    return next;
+  }
+
+  function cursedState(unit = {}) {
+    if (!unit.__devilLineageCursedJuggernaut) {
+      Object.defineProperty(unit, "__devilLineageCursedJuggernaut", {
+        value: { used: false, pending: false },
+        writable: true,
+        configurable: true,
+        enumerable: false,
+      });
+    }
+    return unit.__devilLineageCursedJuggernaut;
+  }
+
+  function armCursedJuggernaut(unit = {}) {
+    const record = cursedState(unit);
+    if (!record.used) {
+      record.used = true;
+      record.pending = true;
+    }
+    return record;
+  }
+
+  function resolveCursedJuggernautRecovery(unit = {}) {
+    const record = cursedState(unit);
+    if (!record.pending) return 0;
+    record.pending = false;
+    const character = characterForUnit(unit);
+    const percent = Math.max(14, 14 * statMod(character, "constitution"));
+    const maximum = maxHp(unit);
+    const amount = Math.floor(maximum * percent / 100);
+    setHp(unit, Math.min(maximum, currentHp(unit) + amount));
+    return amount;
+  }
+
+  function coinSpendsAmmo(skill = {}, context = {}) {
+    const coin = context?.currentCoin || context?.coin || context?.coinData || null;
+    if (!coin) return false;
+    return coin.spendsAmmo === true || coin.spendAmmo === true || numberOr(coin.ammoCost ?? coin.ammo_cost ?? coin.ammo?.cost, 0) > 0;
+  }
+
+  function patchCombatEngine() {
+    const engine = global.CombatEngine;
+    if (!engine) return false;
+    if (engine.__archetypeRuntimeIntegrated) {
+      state.combatSource = engine;
+      return true;
+    }
+    if (state.combatSource === engine) return true;
+
+    const originalCoinDamage = typeof engine.calculateCoinDamage === "function" ? engine.calculateCoinDamage : null;
+    if (originalCoinDamage) {
+      engine.calculateCoinDamage = function (attacker, defender, skill, coinFinalPower, isCritical, clashCount, context = null) {
+        const character = characterForUnit(attacker);
+        const level = devilLineageLevel(character);
+        const rage = hasStatus(attacker, "rage");
+        let restorePhysRes = null;
+        if (level >= 30 && rage && defender && Number(defender.physRes) === 0.5) {
+          const damageType = normalizeId(skill?.attackType || skill?.damageType || skill?.damage_type);
+          if (["slash", "pierce", "piercing", "blunt"].includes(damageType)) {
+            restorePhysRes = defender.physRes;
+            defender.physRes = 1;
+          }
+        }
+        let result;
+        try {
+          result = originalCoinDamage.call(this, attacker, defender, skill, coinFinalPower, isCritical, clashCount, context);
+        } finally {
+          if (restorePhysRes != null) defender.physRes = restorePhysRes;
+        }
+        if (level >= 15 && coinSpendsAmmo(skill, context)) {
+          const multiplier = 1 + (10 * statMod(character, "strength")) / 100;
+          if (typeof result === "number") result *= multiplier;
+        }
+        return result;
+      };
+    }
+
+    const originalApplyDamage = typeof engine.applyDamage === "function" ? engine.applyDamage : null;
+    if (originalApplyDamage) {
+      engine.applyDamage = function (unit, damage, ...rest) {
+        const character = characterForUnit(unit);
+        const active = isCurrentPlayerUnit(unit) && hasDevilLineageLevel(character, 70) && hasStatus(unit, "rage");
+        if (!active) return originalApplyDamage.call(this, unit, damage, ...rest);
+        const hpBefore = currentHp(unit);
+        const shieldBefore = Math.max(0, numberOr(unit?.shield, 0));
+        const incoming = Math.max(0, numberOr(damage, 0));
+        const projectedHpLoss = Math.max(0, incoming - shieldBefore);
+        const reachesFloor = hpBefore - projectedHpLoss <= 1;
+        let adjustedDamage = incoming;
+        if (reachesFloor) {
+          const allowedHpLoss = Math.max(0, hpBefore - 1);
+          adjustedDamage = Math.min(incoming, shieldBefore + allowedHpLoss);
+          armCursedJuggernaut(unit);
+        }
+        const result = originalApplyDamage.call(this, unit, adjustedDamage, ...rest);
+        if (currentHp(unit) < 1) setHp(unit, 1);
+        return result;
+      };
+    }
+
+    const originalProcessStatuses = typeof engine.processStatusEffects === "function" ? engine.processStatusEffects : null;
+    if (originalProcessStatuses) {
+      engine.processStatusEffects = function (unit, triggerKey, context = {}) {
+        const character = characterForUnit(unit);
+        const resistant = isCurrentPlayerUnit(unit) && hasDevilLineageLevel(character, 15);
+        const store = unit?.statusEffects && typeof unit.statusEffects === "object" ? unit.statusEffects : null;
+        const changed = [];
+        if (resistant && store) {
+          ["burn", "poison"].forEach((id) => {
+            const status = store[id];
+            if (status && typeof status === "object" && Number.isFinite(Number(status.potency))) {
+              changed.push([status, status.potency]);
+              status.potency = Number(status.potency) * 0.5;
+            }
+          });
+        }
+        const hpBefore = currentHp(unit);
+        let result;
+        try {
+          result = originalProcessStatuses.call(this, unit, triggerKey, context);
+        } finally {
+          changed.forEach(([status, potency]) => { status.potency = potency; });
+        }
+        if (isCurrentPlayerUnit(unit) && hasDevilLineageLevel(character, 70) && hasStatus(unit, "rage") && currentHp(unit) <= 1) {
+          if (hpBefore > 1) armCursedJuggernaut(unit);
+          if (currentHp(unit) < 1) setHp(unit, 1);
+        }
+        return result;
+      };
+    }
+
+    const originalEncounterStart = typeof engine.triggerEncounterStart === "function" ? engine.triggerEncounterStart : null;
+    if (originalEncounterStart) {
+      engine.triggerEncounterStart = function (allUnits = [], ...rest) {
+        (Array.isArray(allUnits) ? allUnits : []).filter(isCurrentPlayerUnit).forEach((unit) => {
+          const record = cursedState(unit);
+          record.used = false;
+          record.pending = false;
+        });
+        return originalEncounterStart.call(this, allUnits, ...rest);
+      };
+    }
+
+    const originalTriggerPhase = typeof engine.triggerPhase === "function" ? engine.triggerPhase : null;
+    if (originalTriggerPhase) {
+      engine.triggerPhase = function (phaseTag, allUnits, ...rest) {
+        const result = originalTriggerPhase.call(this, phaseTag, allUnits, ...rest);
+        if (phaseTag === "[Round Start]") {
+          (Array.isArray(allUnits) ? allUnits : []).filter(isCurrentPlayerUnit).forEach((unit) => {
+            if (hasDevilLineageLevel(characterForUnit(unit), 70)) resolveCursedJuggernautRecovery(unit);
+          });
+        }
+        return result;
+      };
+    }
+
+    Object.defineProperty(engine, "__archetypeRuntimeIntegrated", { value: true, configurable: true });
+    state.combatSource = engine;
+    return true;
+  }
+
+  function installActiveInventoryBridge() {
+    if (global.__luminousArchetypeInventoryBridge) return true;
+    global.__luminousArchetypeInventoryBridge = true;
+    global.addEventListener("item-move-action", (event) => {
+      const detail = event?.detail || {};
+      if (!detail.fromStash) return;
+      const character = currentCharacter();
+      const bonus = activeInventoryBonus(character);
+      if (bonus <= 0) return;
+
+      event.stopImmediatePropagation();
+      const playerId = currentPlayerId();
+      const db = global.firebase?.database?.();
+      if (!playerId || !db || !detail.itemKey || !detail.itemData) return;
+      const itemKey = detail.itemKey;
+      const itemData = detail.itemData;
+      const sourceRef = db.ref(`${PLAYER_ROOT}/${playerId}/inventario_stash/${itemKey}`);
+      const targetRef = db.ref(`${PLAYER_ROOT}/${playerId}/inventario_activo`);
+      const sourceCurrentCant = Math.max(1, Number.parseInt(itemData.cantidad, 10) || 1);
+
+      targetRef.once("value", (snapshot) => {
+        const targetData = snapshot.val() || {};
+        let foundKey = null;
+        let targetCurrentCant = 0;
+        Object.entries(targetData).some(([key, targetItem]) => {
+          if (targetItem?.nombre === itemData.nombre && (targetItem?.tier || 1) == (itemData.tier || 1)) {
+            foundKey = key;
+            targetCurrentCant = targetItem.cantidad || 1;
+            return true;
+          }
+          return false;
+        });
+
+        const activeStackLimit = Number.parseInt(itemData.limite_activo, 10) || 2;
+        const maxCanMove = activeStackLimit - targetCurrentCant;
+        if (maxCanMove <= 0) {
+          global.alert?.(`No puedes equipar más de ${activeStackLimit} de este ítem a la vez.`);
+          return;
+        }
+        const limit = activeInventoryLimit(character, 10);
+        if (!foundKey && Object.keys(targetData).length >= limit) {
+          global.alert?.(`El Inventario Activo está lleno. Solo puedes llevar ${limit} espacios.`);
+          return;
+        }
+
+        const moveAmount = Math.min(sourceCurrentCant, maxCanMove);
+        const itemToMove = { ...itemData, cantidad: moveAmount };
+        delete itemToMove.key;
+        const add = foundKey
+          ? targetRef.child(foundKey).update({ cantidad: targetCurrentCant + moveAmount })
+          : targetRef.push(itemToMove);
+        Promise.resolve(add).then(() => sourceRef.once("value", (sourceSnapshot) => {
+          const sourceItem = sourceSnapshot.val();
+          if (!sourceItem) return;
+          const newSourceCant = (Number(sourceItem.cantidad) || 1) - moveAmount;
+          if (newSourceCant > 0) sourceRef.update({ cantidad: newSourceCant });
+          else sourceRef.remove();
+        }));
+      });
+    }, true);
+    return true;
+  }
+
+  function installPatches() {
+    patchTraitEngine();
+    patchCoreCatalog();
+    patchRacialCapabilities();
+    patchTraitTray();
+    patchTheatreRolls();
+    patchCombatEngine();
+    renderArchetypeSelector();
+  }
+
+  function boot() {
+    ensureStyles();
+    installActiveInventoryBridge();
+    installPatches();
+    global.addEventListener?.("luminous:traits-refreshed", () => {
+      state.lastSelectionSignature = "";
+      renderArchetypeSelector();
+    });
+    global.setInterval(installPatches, PATCH_INTERVAL_MS);
+  }
+
+  const api = Object.freeze({
+    currentCharacter,
+    selectedDevilLineage,
+    devilLineageLevel,
+    activeInventoryBonus,
+    activeInventoryLimit,
+    strengthThresholdModifier,
+    deathSavePowerBonus,
+    capabilities,
+    statusDamageMultiplier,
+    applyTheatreCheckMechanics,
+    classArchetypeOptions,
+    persistArchetypeSelection,
+    renderArchetypeSelector,
+    patchTraitEngine,
+    patchCoreCatalog,
+    patchRacialCapabilities,
+    patchTraitTray,
+    patchTheatreRolls,
+    patchCombatEngine,
+    resolveCursedJuggernautRecovery,
+  });
+
+  global.LuminousArchetypeRuntime = api;
+  ensureDependencies().then(boot).catch((error) => console.error("Player Archetype Runtime:", error));
+})(window);

--- a/js/rest-engine.js
+++ b/js/rest-engine.js
@@ -1,0 +1,508 @@
+(function (global) {
+  "use strict";
+
+  const SCHEMA_VERSION = 1;
+  const REST_STATE_KEY = "restResources";
+  const RECOVER_LEVEL_INTERVAL = 5;
+  const RECOVER_FLAT_BONUS = 5;
+  const SHORT_REST_MIN_HOURS = 1;
+  const SHORT_REST_MAX_HOURS = 2;
+  const LONG_REST_MIN_HOURS = 6;
+  const LONG_REST_MAX_HOURS = 8;
+  const SHORT_REST_AUGMENT_MAX_HP_PERCENT_CAP = 5;
+
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const integerOr = (value, fallback = 0) => Number.isFinite(Number.parseInt(value, 10)) ? Number.parseInt(value, 10) : fallback;
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/\s+/g, "_");
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+  function buildRules() {
+    if (global.LuminousCharacterBuildRules) return global.LuminousCharacterBuildRules;
+    if (typeof require === "function") {
+      try { return require("./character-build-rules.js"); } catch (_) {}
+    }
+    return null;
+  }
+
+  function traitEngine() {
+    if (global.LuminousTraitEngine) return global.LuminousTraitEngine;
+    if (typeof require === "function") {
+      try { return require("./trait-engine.js"); } catch (_) {}
+    }
+    return null;
+  }
+
+  function classEntries(character = {}) {
+    const build = character?.characterBuild && typeof character.characterBuild === "object" ? character.characterBuild : {};
+    const source = Array.isArray(character.classes)
+      ? character.classes
+      : (Array.isArray(build.classes) ? build.classes : []);
+    if (source.length) {
+      return source
+        .map((entry) => ({
+          classId: normalizeId(entry?.classId || entry?.id),
+          levels: Math.max(0, integerOr(entry?.levels ?? entry?.level, 0)),
+        }))
+        .filter((entry) => entry.classId && entry.levels > 0);
+    }
+    const map = character.classLevels || character.classesById || build.classLevels || {};
+    return Object.entries(map)
+      .map(([classId, value]) => ({
+        classId: normalizeId(classId),
+        levels: Math.max(0, integerOr(value?.levels ?? value?.level ?? value, 0)),
+      }))
+      .filter((entry) => entry.classId && entry.levels > 0);
+  }
+
+  function getClassLevel(character, classId) {
+    const id = normalizeId(classId);
+    return classEntries(character).find((entry) => entry.classId === id)?.levels || 0;
+  }
+
+  function getClassDefinition(classId) {
+    const rules = buildRules();
+    const id = normalizeId(classId);
+    if (rules?.getClass) return rules.getClass(id);
+    if (Array.isArray(rules?.CLASSES)) return rules.CLASSES.find((entry) => normalizeId(entry?.id) === id) || null;
+    return null;
+  }
+
+  function getClassBaseHp(classId) {
+    const definition = getClassDefinition(classId);
+    const value = numberOr(definition?.hpPer5, NaN);
+    return Number.isFinite(value) ? value : null;
+  }
+
+  function maxRecoverSlots(character, classId) {
+    return Math.max(0, Math.floor(getClassLevel(character, classId) / RECOVER_LEVEL_INTERVAL));
+  }
+
+  function ensureRestState(character) {
+    if (!character || typeof character !== "object") throw new Error("Rest Engine requires a character object.");
+    if (!character[REST_STATE_KEY] || typeof character[REST_STATE_KEY] !== "object" || Array.isArray(character[REST_STATE_KEY])) {
+      character[REST_STATE_KEY] = {};
+    }
+    const state = character[REST_STATE_KEY];
+    state.schemaVersion = SCHEMA_VERSION;
+    if (!state.recoverByClass || typeof state.recoverByClass !== "object" || Array.isArray(state.recoverByClass)) state.recoverByClass = {};
+    if (!Array.isArray(state.history)) state.history = [];
+    classEntries(character).forEach(({ classId }) => reconcileRecoverPool(character, classId, state));
+    return state;
+  }
+
+  function reconcileRecoverPool(character, classId, stateInput) {
+    const state = stateInput || ensureRestState(character);
+    const id = normalizeId(classId);
+    if (!id) throw new Error("Recover requires a classId.");
+    if (!state.recoverByClass[id] || typeof state.recoverByClass[id] !== "object" || Array.isArray(state.recoverByClass[id])) {
+      state.recoverByClass[id] = { spent: 0, blocked: [] };
+    }
+    const pool = state.recoverByClass[id];
+    pool.spent = Math.max(0, integerOr(pool.spent, 0));
+    if (!Array.isArray(pool.blocked)) pool.blocked = [];
+    pool.blocked = pool.blocked
+      .map((entry) => ({
+        remainingLongRests: Math.max(0, integerOr(entry?.remainingLongRests ?? entry?.longRests, 0)),
+        sourceTraitId: normalizeId(entry?.sourceTraitId) || null,
+        blockedAt: Number.isFinite(Number(entry?.blockedAt)) ? Number(entry.blockedAt) : null,
+      }))
+      .filter((entry) => entry.remainingLongRests > 0);
+    const maximum = maxRecoverSlots(character, id);
+    pool.spent = Math.min(pool.spent, Math.max(0, maximum - pool.blocked.length));
+    return pool;
+  }
+
+  function recoverPool(character, classId) {
+    const state = ensureRestState(character);
+    const id = normalizeId(classId);
+    const pool = reconcileRecoverPool(character, id, state);
+    const maximum = maxRecoverSlots(character, id);
+    const blocked = pool.blocked.length;
+    const spent = Math.min(pool.spent, Math.max(0, maximum - blocked));
+    return {
+      classId: id,
+      classLevel: getClassLevel(character, id),
+      classBaseHp: getClassBaseHp(id),
+      maximum,
+      spent,
+      blocked,
+      blockedSlots: clone(pool.blocked),
+      available: Math.max(0, maximum - spent - blocked),
+    };
+  }
+
+  function listRecoverPools(character) {
+    ensureRestState(character);
+    return classEntries(character).map(({ classId }) => recoverPool(character, classId));
+  }
+
+  function canSpendRecoverSlots(character, classId, count = 1) {
+    const requested = Math.max(0, integerOr(count, 0));
+    const pool = recoverPool(character, classId);
+    return {
+      available: requested > 0 && pool.available >= requested,
+      requested,
+      pool,
+      reason: requested <= 0
+        ? "Recover requires at least 1 slot."
+        : (pool.available < requested ? `Only ${pool.available} Recover Slot(s) available for ${pool.classId}.` : null),
+    };
+  }
+
+  function spendRecoverSlots(character, classId, count = 1, options = {}) {
+    const check = canSpendRecoverSlots(character, classId, count);
+    if (!check.available) return { ...check, spent: 0 };
+    const state = ensureRestState(character);
+    const pool = reconcileRecoverPool(character, classId, state);
+    const blockLongRests = Math.max(0, integerOr(options.blockLongRests, 0));
+    if (blockLongRests > 0) {
+      for (let index = 0; index < check.requested; index += 1) {
+        pool.blocked.push({
+          remainingLongRests: blockLongRests,
+          sourceTraitId: normalizeId(options.sourceTraitId) || null,
+          blockedAt: Date.now(),
+        });
+      }
+    } else {
+      pool.spent += check.requested;
+    }
+    return {
+      available: true,
+      spent: check.requested,
+      blockedForLongRests: blockLongRests,
+      pool: recoverPool(character, classId),
+      reason: null,
+    };
+  }
+
+  function augmentationCandidates(character = {}, extra = []) {
+    const build = character?.characterBuild && typeof character.characterBuild === "object" ? character.characterBuild : {};
+    const inventory = character?.inventory && typeof character.inventory === "object" ? character.inventory : {};
+    const sources = [character.augmentations, character.augments, build.augmentations, inventory.augmentations, extra];
+    const seenObjects = new Set();
+    const result = [];
+    sources.forEach((source) => {
+      (Array.isArray(source) ? source : []).forEach((entry) => {
+        if (!entry || typeof entry !== "object") return;
+        if (seenObjects.has(entry)) return;
+        seenObjects.add(entry);
+        result.push(entry);
+      });
+    });
+    return result;
+  }
+
+  function augmentationShortRestPercent(augmentation = {}) {
+    const mechanics = augmentation?.mechanics && typeof augmentation.mechanics === "object" ? augmentation.mechanics : {};
+    const rest = augmentation?.rest && typeof augmentation.rest === "object" ? augmentation.rest : {};
+    return Math.max(0, numberOr(
+      mechanics.shortRestRecoveryPercent
+      ?? mechanics.shortRestRecoverMaxHpPercent
+      ?? rest.shortRestRecoveryPercent
+      ?? augmentation.shortRestRecoveryPercent,
+      0,
+    ));
+  }
+
+  function shortRestAugmentPercent(character, extraAugmentations = []) {
+    const raw = augmentationCandidates(character, extraAugmentations)
+      .reduce((sum, augmentation) => sum + augmentationShortRestPercent(augmentation), 0);
+    return {
+      rawPercent: raw,
+      appliedPercent: clamp(raw, 0, SHORT_REST_AUGMENT_MAX_HP_PERCENT_CAP),
+      capPercent: SHORT_REST_AUGMENT_MAX_HP_PERCENT_CAP,
+    };
+  }
+
+  function readMaxHp(entity = {}) {
+    const combat = entity?.combatStats && typeof entity.combatStats === "object" ? entity.combatStats : {};
+    const candidates = [entity.maxHp, entity.maxHP, entity.hp_max, combat.hp_max, combat.maxHp];
+    const found = candidates.find((value) => Number.isFinite(Number(value)));
+    return found == null ? null : Math.max(0, Number(found));
+  }
+
+  function readCurrentHp(entity = {}) {
+    const combat = entity?.combatStats && typeof entity.combatStats === "object" ? entity.combatStats : {};
+    const candidates = [entity.hp, entity.currentHp, entity.currentHP, entity.hp_actual, combat.hp_actual, combat.currentHp];
+    const found = candidates.find((value) => Number.isFinite(Number(value)));
+    return found == null ? null : Math.max(0, Number(found));
+  }
+
+  function writeCurrentHp(entity, value) {
+    if (!entity || typeof entity !== "object") return null;
+    const next = Math.max(0, numberOr(value, 0));
+    let wrote = false;
+    if (Object.prototype.hasOwnProperty.call(entity, "hp")) { entity.hp = next; wrote = true; }
+    if (Object.prototype.hasOwnProperty.call(entity, "currentHp")) { entity.currentHp = next; wrote = true; }
+    if (Object.prototype.hasOwnProperty.call(entity, "currentHP")) { entity.currentHP = next; wrote = true; }
+    if (Object.prototype.hasOwnProperty.call(entity, "hp_actual")) { entity.hp_actual = next; wrote = true; }
+    if (entity.combatStats && typeof entity.combatStats === "object") {
+      if (Object.prototype.hasOwnProperty.call(entity.combatStats, "hp_actual")) { entity.combatStats.hp_actual = next; wrote = true; }
+      if (Object.prototype.hasOwnProperty.call(entity.combatStats, "currentHp")) { entity.combatStats.currentHp = next; wrote = true; }
+    }
+    if (!wrote) entity.currentHp = next;
+    return next;
+  }
+
+  function healEntity(entity, amount) {
+    const requested = Math.max(0, Math.floor(numberOr(amount, 0)));
+    const before = readCurrentHp(entity);
+    const maximum = readMaxHp(entity);
+    if (before == null) return { requested, amount: 0, before: null, after: null, maximum };
+    const after = maximum == null ? before + requested : Math.min(maximum, before + requested);
+    writeCurrentHp(entity, after);
+    return { requested, amount: Math.max(0, after - before), before, after, maximum };
+  }
+
+  function fullHeal(entity) {
+    const before = readCurrentHp(entity);
+    const maximum = readMaxHp(entity);
+    if (maximum == null) return { amount: 0, before, after: before, maximum: null };
+    writeCurrentHp(entity, maximum);
+    return { amount: before == null ? 0 : Math.max(0, maximum - before), before, after: maximum, maximum };
+  }
+
+  function performRecover(character, classId, slots = 1, options = {}) {
+    const count = Math.max(1, integerOr(slots, 1));
+    const id = normalizeId(classId);
+    const classBaseHp = getClassBaseHp(id);
+    if (classBaseHp == null) return { success: false, reason: `Unknown Class Base HP for ${id || "<missing class>"}.` };
+    const availability = canSpendRecoverSlots(character, id, count);
+    if (!availability.available) return { success: false, reason: availability.reason, pool: availability.pool };
+
+    const context = normalizeId(options.context || "recover");
+    const usesShortRestAugments = context === "short_rest" && options.includeAugments !== false;
+    const augment = usesShortRestAugments
+      ? shortRestAugmentPercent(character, options.augmentations || [])
+      : { rawPercent: 0, appliedPercent: 0, capPercent: SHORT_REST_AUGMENT_MAX_HP_PERCENT_CAP };
+    const healTarget = options.healTarget || character;
+    const maxHp = readMaxHp(healTarget) ?? readMaxHp(character) ?? 0;
+    const flatHp = RECOVER_FLAT_BONUS + (classBaseHp * count);
+    const augmentHp = Math.floor(maxHp * augment.appliedPercent / 100);
+    const totalHp = Math.max(0, Math.floor(flatHp + augmentHp));
+
+    const spent = spendRecoverSlots(character, id, count, {
+      blockLongRests: options.blockLongRests,
+      sourceTraitId: options.sourceTraitId,
+    });
+    if (!spent.available) return { success: false, reason: spent.reason, pool: spent.pool };
+    const healing = healEntity(healTarget, totalHp);
+
+    return {
+      success: true,
+      context,
+      classId: id,
+      classBaseHp,
+      slotsUsed: count,
+      flatBonus: RECOVER_FLAT_BONUS,
+      flatHp,
+      augmentPercentRaw: augment.rawPercent,
+      augmentPercentApplied: augment.appliedPercent,
+      augmentPercentCap: augment.capPercent,
+      augmentHp,
+      calculatedHp: totalHp,
+      healedHp: healing.amount,
+      hpBefore: healing.before,
+      hpAfter: healing.after,
+      maxHp: healing.maximum,
+      blockedForLongRests: spent.blockedForLongRests,
+      pool: spent.pool,
+    };
+  }
+
+  function validateRestHours(type, value) {
+    const restType = normalizeId(type);
+    const min = restType === "short_rest" ? SHORT_REST_MIN_HOURS : LONG_REST_MIN_HOURS;
+    const max = restType === "short_rest" ? SHORT_REST_MAX_HOURS : LONG_REST_MAX_HOURS;
+    const fallback = min;
+    const hours = numberOr(value, fallback);
+    if (hours < min || hours > max) return { valid: false, hours, min, max, reason: `${restType} must last between ${min} and ${max} hours.` };
+    return { valid: true, hours, min, max, reason: null };
+  }
+
+  function traitId(trait = {}) {
+    return normalizeId(trait?.id || trait?.name);
+  }
+
+  function shortRestUseRecoverySpec(trait = {}) {
+    const uses = trait?.activation?.uses || {};
+    if (normalizeId(uses.reset) === "short_rest") return "all";
+    const explicit = uses.recoverOnShortRest
+      ?? uses.shortRestRecover
+      ?? trait?.mechanics?.shortRestRecoverUses
+      ?? trait?.rest?.shortRest?.recoverUses;
+    if (normalizeId(explicit) === "all") return "all";
+    const amount = Math.max(0, integerOr(explicit, 0));
+    return amount > 0 ? amount : null;
+  }
+
+  function recoverShortRestTraitUses(traits = [], state = null) {
+    if (!state?.usages || typeof state.usages !== "object") return [];
+    const changes = [];
+    (Array.isArray(traits) ? traits : []).forEach((trait) => {
+      const id = traitId(trait);
+      const record = state.usages[id];
+      if (!id || !record || typeof record !== "object") return;
+      const spec = shortRestUseRecoverySpec(trait);
+      if (spec == null) return;
+      const before = Math.max(0, integerOr(record.used, 0));
+      record.used = spec === "all" ? 0 : Math.max(0, before - spec);
+      changes.push({ traitId: id, recovered: before - record.used, before, after: record.used, spec });
+    });
+    return changes;
+  }
+
+  function recoverAllTraitUses(state = null) {
+    if (!state?.usages || typeof state.usages !== "object") return [];
+    return Object.entries(state.usages).map(([id, record]) => {
+      const before = Math.max(0, integerOr(record?.used, 0));
+      if (record && typeof record === "object") record.used = 0;
+      return { traitId: normalizeId(id), recovered: before, before, after: 0, spec: "all" };
+    });
+  }
+
+  function dispatchRestTraits(type, character, traits, state, runtime = {}) {
+    const engine = traitEngine();
+    if (!engine || !Array.isArray(traits) || !traits.length || !state) return null;
+    const trigger = normalizeId(type);
+    engine.resetStateScope?.(state, trigger);
+    return engine.dispatchTraits?.(traits, trigger, {
+      context: "any",
+      character,
+      self: runtime.self || character,
+      ...(runtime || {}),
+    }, state) || null;
+  }
+
+  function recordRest(character, entry) {
+    const state = ensureRestState(character);
+    state.history.push({ at: Date.now(), ...clone(entry) });
+    if (state.history.length > 50) state.history.splice(0, state.history.length - 50);
+    return state.history.at(-1);
+  }
+
+  function performShortRest(character, options = {}) {
+    const duration = validateRestHours("short_rest", options.hours);
+    if (!duration.valid) return { success: false, type: "short_rest", reason: duration.reason, duration };
+    const traitState = options.traitState || null;
+    const traits = Array.isArray(options.traits) ? options.traits : [];
+    const requests = Array.isArray(options.recovers) ? options.recovers : [];
+    const requestedByClass = new Map();
+    for (const request of requests) {
+      const classId = normalizeId(request?.classId);
+      const slots = Math.max(1, integerOr(request?.slots, 1));
+      if (getClassBaseHp(classId) == null) return { success: false, type: "short_rest", reason: `Unknown Class Base HP for ${classId || "<missing class>"}.`, duration, recovers: [] };
+      requestedByClass.set(classId, (requestedByClass.get(classId) || 0) + slots);
+    }
+    for (const [classId, slots] of requestedByClass) {
+      const check = canSpendRecoverSlots(character, classId, slots);
+      if (!check.available) return { success: false, type: "short_rest", reason: check.reason, duration, recovers: [] };
+    }
+
+    const recovers = [];
+    for (const request of requests) {
+      const result = performRecover(character, request?.classId, request?.slots, {
+        context: "short_rest",
+        healTarget: options.healTarget || character,
+        augmentations: request?.augmentations || options.augmentations || [],
+        includeAugments: true,
+      });
+      recovers.push(result);
+      if (!result.success) return { success: false, type: "short_rest", reason: result.reason, duration, recovers };
+    }
+    const traitUseRecovery = recoverShortRestTraitUses(traits, traitState);
+    const traitDispatch = dispatchRestTraits("short_rest", character, traits, traitState, options.runtime || {});
+    const result = {
+      success: true,
+      type: "short_rest",
+      hours: duration.hours,
+      worldHoursAdvanced: duration.hours,
+      recovers,
+      traitUseRecovery,
+      traitDispatch,
+      pools: listRecoverPools(character),
+    };
+    recordRest(character, { type: result.type, hours: result.hours, recovers: recovers.map((entry) => ({ classId: entry.classId, slotsUsed: entry.slotsUsed, healedHp: entry.healedHp })) });
+    return result;
+  }
+
+  function restoreRecoverSlotsOnLongRest(character) {
+    const state = ensureRestState(character);
+    const changes = [];
+    Object.keys(state.recoverByClass).forEach((classId) => {
+      const pool = reconcileRecoverPool(character, classId, state);
+      const spentBefore = pool.spent;
+      const blockedBefore = clone(pool.blocked);
+      pool.spent = 0;
+      pool.blocked = pool.blocked
+        .map((entry) => ({ ...entry, remainingLongRests: Math.max(0, integerOr(entry.remainingLongRests, 0) - 1) }))
+        .filter((entry) => entry.remainingLongRests > 0);
+      changes.push({ classId, spentRestored: spentBefore, blockedBefore, blockedAfter: clone(pool.blocked), pool: recoverPool(character, classId) });
+    });
+    return changes;
+  }
+
+  function performLongRest(character, options = {}) {
+    const duration = validateRestHours("long_rest", options.hours);
+    if (!duration.valid) return { success: false, type: "long_rest", reason: duration.reason, duration };
+    const healTarget = options.healTarget || character;
+    const healing = fullHeal(healTarget);
+    if (character !== healTarget && options.fullHealCharacter !== false) fullHeal(character);
+    const recoverChanges = restoreRecoverSlotsOnLongRest(character);
+    const traitState = options.traitState || null;
+    const traits = Array.isArray(options.traits) ? options.traits : [];
+    const traitUseRecovery = recoverAllTraitUses(traitState);
+    const traitDispatch = dispatchRestTraits("long_rest", character, traits, traitState, options.runtime || {});
+    const result = {
+      success: true,
+      type: "long_rest",
+      hours: duration.hours,
+      worldHoursAdvanced: duration.hours,
+      healing,
+      recoverChanges,
+      traitUseRecovery,
+      traitDispatch,
+      pools: listRecoverPools(character),
+    };
+    recordRest(character, { type: result.type, hours: result.hours, healedHp: healing.amount, recoverSlotsRestored: recoverChanges.reduce((sum, entry) => sum + entry.spentRestored, 0) });
+    return result;
+  }
+
+  const api = Object.freeze({
+    SCHEMA_VERSION,
+    REST_STATE_KEY,
+    RECOVER_LEVEL_INTERVAL,
+    RECOVER_FLAT_BONUS,
+    SHORT_REST_MIN_HOURS,
+    SHORT_REST_MAX_HOURS,
+    LONG_REST_MIN_HOURS,
+    LONG_REST_MAX_HOURS,
+    SHORT_REST_AUGMENT_MAX_HP_PERCENT_CAP,
+    classEntries,
+    getClassLevel,
+    getClassDefinition,
+    getClassBaseHp,
+    maxRecoverSlots,
+    ensureRestState,
+    recoverPool,
+    listRecoverPools,
+    canSpendRecoverSlots,
+    spendRecoverSlots,
+    shortRestAugmentPercent,
+    readMaxHp,
+    readCurrentHp,
+    writeCurrentHp,
+    performRecover,
+    validateRestHours,
+    shortRestUseRecoverySpec,
+    recoverShortRestTraitUses,
+    recoverAllTraitUses,
+    restoreRecoverSlotsOnLongRest,
+    performShortRest,
+    performLongRest,
+  });
+
+  global.LuminousRestEngine = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/rest-runtime-integration.js
+++ b/js/rest-runtime-integration.js
@@ -1,0 +1,291 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousRestRuntime) return;
+
+  const restEngine = global.LuminousRestEngine || (typeof require === "function" ? require("./rest-engine.js") : null);
+  if (!restEngine) return;
+
+  const PATCH_INTERVAL_MS = 250;
+  const PLAYER_ROOT = "campaña/jugadores";
+  const PLAYER_ID_STORAGE_KEY = "playerId";
+  const state = {
+    traitEngineSource: null,
+    traitStateByOwner: typeof WeakMap === "function" ? new WeakMap() : null,
+    listenersBound: false,
+  };
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/\s+/g, "_");
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+  function identityValues(entity = {}) {
+    return [
+      entity?.id, entity?.playerId, entity?.player_id, entity?.characterId, entity?.character_id,
+      entity?.actorId, entity?.actor_id, entity?.uid, entity?.vinculo_jugador,
+    ].filter((value) => value != null && String(value).trim() !== "").map((value) => String(value).trim());
+  }
+
+  function sameEntity(a, b) {
+    if (!a || !b) return false;
+    if (a === b) return true;
+    const ids = new Set(identityValues(a));
+    if (identityValues(b).some((id) => ids.has(id))) return true;
+    const aName = normalizeId(a.characterName || a.character_name || a.nombre || a.name);
+    const bName = normalizeId(b.characterName || b.character_name || b.nombre || b.name);
+    return Boolean(aName && bName && aName === bName);
+  }
+
+  function currentPlayerCharacter() {
+    return global.LuminousPlayerTraitRuntime?.getCharacter?.() || global.datosJugador || null;
+  }
+
+  function resourceOwnerForRuntime(runtime = {}) {
+    const self = runtime.self || null;
+    const character = runtime.character || null;
+    const player = currentPlayerCharacter();
+    if (player && (sameEntity(player, self) || sameEntity(player, character))) return player;
+    return self || character;
+  }
+
+  function healTargetForRuntime(runtime = {}) {
+    return runtime.self || runtime.character || resourceOwnerForRuntime(runtime);
+  }
+
+  function rememberTraitState(runtime, traitState) {
+    if (!state.traitStateByOwner || !traitState || typeof traitState !== "object") return traitState;
+    const owner = resourceOwnerForRuntime(runtime || {});
+    const self = runtime?.self;
+    const character = runtime?.character;
+    [owner, self, character].filter((entry) => entry && typeof entry === "object").forEach((entry) => state.traitStateByOwner.set(entry, traitState));
+    return traitState;
+  }
+
+  function traitStateFor(character) {
+    return state.traitStateByOwner?.get(character) || null;
+  }
+
+  function recoverMechanics(trait = {}) {
+    const mechanics = trait?.mechanics || {};
+    const count = Math.max(0, Number.parseInt(mechanics.spendRecoverSlot, 10) || 0);
+    if (!count || mechanics.performRecoverImmediately !== true) return null;
+    return {
+      count,
+      classId: normalizeId(mechanics.recoverClassId || trait?.source?.classId || trait?.classId),
+      blockLongRests: Math.max(0, Number.parseInt(mechanics.blockUsedRecoverSlotLongRests, 10) || 0),
+      sourceTraitId: normalizeId(trait?.id || trait?.name),
+    };
+  }
+
+  function recoverAvailability(trait, runtime = {}) {
+    const mechanics = recoverMechanics(trait);
+    if (!mechanics) return { available: true, mechanics: null, reason: null };
+    const owner = resourceOwnerForRuntime(runtime);
+    if (!owner) return { available: false, mechanics, reason: "Recover has no character resource owner." };
+    if (!mechanics.classId) return { available: false, mechanics, reason: "Recover Trait has no source Class." };
+    const check = restEngine.canSpendRecoverSlots(owner, mechanics.classId, mechanics.count);
+    return { available: check.available, mechanics, owner, check, reason: check.reason };
+  }
+
+  function persistPlayerRestState(character, options = {}) {
+    const player = currentPlayerCharacter();
+    if (!character || !player || !sameEntity(character, player)) return null;
+    const db = global.firebase?.database?.();
+    const playerId = String(global.localStorage?.getItem?.(PLAYER_ID_STORAGE_KEY) || character.playerId || character.player_id || "").trim();
+    if (!db || !playerId) return null;
+    const updates = { restResources: clone(character.restResources || {}) };
+    if (options.includeHp !== false) {
+      if (character.combatStats && Object.prototype.hasOwnProperty.call(character.combatStats, "hp_actual")) updates["combatStats/hp_actual"] = character.combatStats.hp_actual;
+      else if (Object.prototype.hasOwnProperty.call(character, "currentHp")) updates.currentHp = character.currentHp;
+      else if (Object.prototype.hasOwnProperty.call(character, "hp_actual")) updates.hp_actual = character.hp_actual;
+      else if (Object.prototype.hasOwnProperty.call(character, "hp")) updates.hp = character.hp;
+    }
+    const promise = db.ref(`${PLAYER_ROOT}/${playerId}`).update(updates);
+    promise?.catch?.((error) => console.warn("Rest Runtime persistence:", error));
+    return promise;
+  }
+
+  function emit(name, detail) {
+    if (typeof global.CustomEvent !== "function") return;
+    global.dispatchEvent?.(new global.CustomEvent(name, { detail }));
+  }
+
+  function emitRestCompleted(result, character) {
+    if (!result?.success) return result;
+    const detail = { ...result, character };
+    emit("luminous:rest-completed", detail);
+    emit("luminous:world-time-advance-requested", {
+      source: "rest",
+      restType: result.type,
+      hours: result.worldHoursAdvanced,
+      characterId: identityValues(character)[0] || null,
+    });
+    return result;
+  }
+
+  function completeShortRest(character = currentPlayerCharacter(), options = {}) {
+    if (!character) return { success: false, type: "short_rest", reason: "No character available." };
+    const traits = options.traits || global.LuminousPlayerTraitRuntime?.getTraits?.() || [];
+    const traitState = options.traitState || traitStateFor(character);
+    const result = restEngine.performShortRest(character, { ...options, traits, traitState });
+    if (result.success) persistPlayerRestState(character, { includeHp: true });
+    return emitRestCompleted(result, character);
+  }
+
+  function completeLongRest(character = currentPlayerCharacter(), options = {}) {
+    if (!character) return { success: false, type: "long_rest", reason: "No character available." };
+    const traits = options.traits || global.LuminousPlayerTraitRuntime?.getTraits?.() || [];
+    const traitState = options.traitState || traitStateFor(character);
+    const result = restEngine.performLongRest(character, { ...options, traits, traitState });
+    if (result.success) persistPlayerRestState(character, { includeHp: true });
+    return emitRestCompleted(result, character);
+  }
+
+  function wrapTraitEngine(source) {
+    const wrapped = { ...source, __luminousRestIntegrationWrapped: true };
+
+    if (typeof source.dispatchTrait === "function") {
+      wrapped.dispatchTrait = function (trait, trigger, runtime = {}, traitState) {
+        rememberTraitState(runtime, traitState);
+        const result = source.dispatchTrait.call(source, trait, trigger, runtime, traitState);
+        rememberTraitState(result?.runtime || runtime, result?.state || traitState);
+        return result;
+      };
+    }
+
+    if (typeof source.dispatchTraits === "function") {
+      wrapped.dispatchTraits = function (traits, trigger, runtime = {}, traitState) {
+        rememberTraitState(runtime, traitState);
+        const result = source.dispatchTraits.call(source, traits, trigger, runtime, traitState);
+        rememberTraitState(result?.runtime || runtime, result?.state || traitState);
+        return result;
+      };
+    }
+
+    if (typeof source.dispatchCombatEvent === "function") {
+      wrapped.dispatchCombatEvent = function (trigger, input = {}) {
+        rememberTraitState(input, input?.state);
+        const result = source.dispatchCombatEvent.call(source, trigger, input);
+        rememberTraitState(result?.runtime || input, result?.state || input?.state);
+        return result;
+      };
+    }
+
+    if (typeof source.canActivateTrait === "function") {
+      wrapped.canActivateTrait = function (trait, runtime = {}, traitState) {
+        rememberTraitState(runtime, traitState);
+        const base = source.canActivateTrait.call(source, trait, runtime, traitState);
+        if (!base?.available) return base;
+        const recovery = recoverAvailability(base.trait || trait, runtime);
+        if (recovery.available) return base;
+        return {
+          ...base,
+          available: false,
+          reasons: [...(base.reasons || []), recovery.reason || "No Recover Slots available."],
+        };
+      };
+    }
+
+    if (typeof source.activateTrait === "function") {
+      wrapped.activateTrait = function (trait, runtime = {}, traitState) {
+        rememberTraitState(runtime, traitState);
+        const recovery = recoverAvailability(trait, runtime);
+        if (!recovery.available) {
+          const normalized = source.normalizeTrait?.(trait) || trait;
+          return {
+            available: false,
+            reasons: [recovery.reason || "No Recover Slots available."],
+            maximum: null,
+            remaining: null,
+            actionCost: normalized?.activation?.actionCost || "none",
+            trait: normalized,
+            state: traitState,
+            runtime,
+            outcomes: [],
+          };
+        }
+
+        const result = source.activateTrait.call(source, trait, runtime, traitState);
+        rememberTraitState(result?.runtime || runtime, result?.state || traitState);
+        if (!result?.available || result?.scheduled || !recovery.mechanics) return result;
+
+        const owner = recovery.owner || resourceOwnerForRuntime(result.runtime || runtime);
+        const healTarget = healTargetForRuntime(result.runtime || runtime);
+        const recoverResult = restEngine.performRecover(owner, recovery.mechanics.classId, recovery.mechanics.count, {
+          context: "combat",
+          healTarget,
+          includeAugments: false,
+          blockLongRests: recovery.mechanics.blockLongRests,
+          sourceTraitId: recovery.mechanics.sourceTraitId,
+        });
+        if (!recoverResult.success) return { ...result, available: false, reasons: [recoverResult.reason], restRecover: recoverResult };
+        persistPlayerRestState(owner, { includeHp: false });
+        const outcome = {
+          type: "recover",
+          traitId: recovery.mechanics.sourceTraitId,
+          classId: recoverResult.classId,
+          slotsUsed: recoverResult.slotsUsed,
+          healedHp: recoverResult.healedHp,
+          blockedForLongRests: recoverResult.blockedForLongRests,
+        };
+        const next = { ...result, restRecover: recoverResult, outcomes: [...(result.outcomes || []), outcome] };
+        emit("luminous:recover-performed", { character: owner, target: healTarget, result: recoverResult, trait: next.trait || trait });
+        return next;
+      };
+    }
+
+    return Object.freeze(wrapped);
+  }
+
+  function installTraitEngineBridge() {
+    const source = global.LuminousTraitEngine;
+    if (!source) return false;
+    if (source.__luminousRestIntegrationWrapped) {
+      state.traitEngineSource = source;
+      return true;
+    }
+    if (state.traitEngineSource === source) return true;
+    const wrapped = wrapTraitEngine(source);
+    global.LuminousTraitEngine = wrapped;
+    state.traitEngineSource = wrapped;
+    return true;
+  }
+
+  function bindRequestEvents() {
+    if (state.listenersBound || !global.addEventListener) return false;
+    state.listenersBound = true;
+    global.addEventListener("luminous:request-short-rest", (event) => {
+      const detail = event?.detail || {};
+      completeShortRest(detail.character || currentPlayerCharacter(), detail);
+    });
+    global.addEventListener("luminous:request-long-rest", (event) => {
+      const detail = event?.detail || {};
+      completeLongRest(detail.character || currentPlayerCharacter(), detail);
+    });
+    return true;
+  }
+
+  function install() {
+    bindRequestEvents();
+    return installTraitEngineBridge();
+  }
+
+  const api = Object.freeze({
+    sameEntity,
+    resourceOwnerForRuntime,
+    healTargetForRuntime,
+    rememberTraitState,
+    traitStateFor,
+    recoverMechanics,
+    recoverAvailability,
+    persistPlayerRestState,
+    completeShortRest,
+    completeLongRest,
+    installTraitEngineBridge,
+    install,
+  });
+
+  global.LuminousRestRuntime = api;
+  install();
+  if (global.document) global.setInterval?.(install, PATCH_INTERVAL_MS);
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/rest-runtime-integration.js
+++ b/js/rest-runtime-integration.js
@@ -272,13 +272,19 @@
       global.document.head?.appendChild(script);
       return script;
     };
+    const ensureBridge = () => {
+      if (!global.LuminousInjuryEquipmentRuntime) ensureScript("injury-equipment-runtime-script", "js/injury-equipment-runtime.js");
+    };
+    const ensureInjury = () => {
+      if (global.LuminousInjuryEngine) return ensureBridge();
+      const injury = ensureScript("injury-engine-script", "js/injury-engine.js");
+      injury?.addEventListener?.("load", ensureBridge, { once: true });
+    };
     if (global.LuminousAnatomyEquipmentEngine) {
-      return { anatomy: null, injury: global.LuminousInjuryEngine ? null : ensureScript("injury-engine-script", "js/injury-engine.js") };
+      ensureInjury();
+      return { anatomy: null };
     }
     const anatomy = ensureScript("anatomy-equipment-engine-script", "js/anatomy-equipment-engine.js");
-    const ensureInjury = () => {
-      if (!global.LuminousInjuryEngine) ensureScript("injury-engine-script", "js/injury-engine.js");
-    };
     anatomy?.addEventListener?.("load", ensureInjury, { once: true });
     return { anatomy };
   }

--- a/js/rest-runtime-integration.js
+++ b/js/rest-runtime-integration.js
@@ -177,11 +177,7 @@
         if (!base?.available) return base;
         const recovery = recoverAvailability(base.trait || trait, runtime);
         if (recovery.available) return base;
-        return {
-          ...base,
-          available: false,
-          reasons: [...(base.reasons || []), recovery.reason || "No Recover Slots available."],
-        };
+        return { ...base, available: false, reasons: [...(base.reasons || []), recovery.reason || "No Recover Slots available."] };
       };
     }
 
@@ -264,8 +260,32 @@
     return true;
   }
 
+  function ensureHealthEquipmentAssets() {
+    if (!global.document) return null;
+    const ensureScript = (id, src) => {
+      let script = global.document.getElementById(id);
+      if (script) return script;
+      script = global.document.createElement("script");
+      script.id = id;
+      script.src = src;
+      script.async = false;
+      global.document.head?.appendChild(script);
+      return script;
+    };
+    if (global.LuminousAnatomyEquipmentEngine) {
+      return { anatomy: null, injury: global.LuminousInjuryEngine ? null : ensureScript("injury-engine-script", "js/injury-engine.js") };
+    }
+    const anatomy = ensureScript("anatomy-equipment-engine-script", "js/anatomy-equipment-engine.js");
+    const ensureInjury = () => {
+      if (!global.LuminousInjuryEngine) ensureScript("injury-engine-script", "js/injury-engine.js");
+    };
+    anatomy?.addEventListener?.("load", ensureInjury, { once: true });
+    return { anatomy };
+  }
+
   function install() {
     bindRequestEvents();
+    ensureHealthEquipmentAssets();
     return installTraitEngineBridge();
   }
 
@@ -281,6 +301,7 @@
     completeShortRest,
     completeLongRest,
     installTraitEngineBridge,
+    ensureHealthEquipmentAssets,
     install,
   });
 

--- a/js/status-engine.js
+++ b/js/status-engine.js
@@ -185,6 +185,32 @@
   global.LuminousStatusEngine = api;
   if (typeof module !== "undefined" && module.exports) module.exports = api;
 
+  // Rest/Recover is a shared player + combat resource. Load the canonical Class table first,
+  // then Rest Engine, then the bridge that connects Trait activation and persistence.
+  if (global.document && !global.LuminousCharacterBuildRules && !global.document.getElementById("character-build-rules-script")) {
+    const script = global.document.createElement("script");
+    script.id = "character-build-rules-script";
+    script.src = "js/character-build-rules.js";
+    script.async = false;
+    global.document.head?.appendChild(script);
+  }
+
+  if (global.document && !global.LuminousRestEngine && !global.document.getElementById("rest-engine-script")) {
+    const script = global.document.createElement("script");
+    script.id = "rest-engine-script";
+    script.src = "js/rest-engine.js";
+    script.async = false;
+    global.document.head?.appendChild(script);
+  }
+
+  if (global.document && !global.LuminousRestRuntime && !global.document.getElementById("rest-runtime-integration-script")) {
+    const script = global.document.createElement("script");
+    script.id = "rest-runtime-integration-script";
+    script.src = "js/rest-runtime-integration.js";
+    script.async = false;
+    global.document.head?.appendChild(script);
+  }
+
   if (global.document && !global.LuminousUniversalSpeedRuntime && !global.document.getElementById("universal-speed-runtime-script")) {
     const script = global.document.createElement("script");
     script.id = "universal-speed-runtime-script";

--- a/js/status-engine.js
+++ b/js/status-engine.js
@@ -174,32 +174,30 @@
     return script;
   }
 
-  // Rest/Recover is a shared player + combat resource. Load the canonical Class table first,
-  // then Rest Engine, then the bridge that connects Trait activation and persistence.
   if (global.document && !global.LuminousCharacterBuildRules) loadScript("character-build-rules-script", "js/character-build-rules.js");
   if (global.document && !global.LuminousRestEngine) loadScript("rest-engine-script", "js/rest-engine.js");
   if (global.document && !global.LuminousRestRuntime) loadScript("rest-runtime-integration-script", "js/rest-runtime-integration.js");
   if (global.document && !global.LuminousUniversalSpeedRuntime) loadScript("universal-speed-runtime-script", "js/universal-speed-runtime.js");
   if (global.document && !global.LuminousRacialTraitRuntimeBridge) loadScript("racial-trait-runtime-bridge-script", "js/racial-trait-runtime-bridge.js");
 
-  // Status Engine is loaded by the real Battle Viewer before CombatEngine. Bootstrap the
-  // Archetype runtimes here so combat mechanics do not depend on player-sheet-only loaders.
   if (global.document && !global.LuminousArchetypeRuntime) loadScript("player-archetype-runtime-script", "js/player-archetype-runtime.js");
   if (global.document && !global.LuminousArchetypeCombatEventRuntime) loadScript("archetype-combat-event-runtime-script", "js/archetype-combat-event-runtime.js");
-
-  // Death/Downed is a combat-wide rule, not a player-sheet feature.
   if (global.document && !global.LuminousDeathSaveRuntime) loadScript("death-save-runtime-script", "js/death-save-runtime.js");
 
-  // Anatomy/Equipment and Injuries are also combat-wide rules. Anatomy must load first because
-  // Injuries can disable/miss parts and immediately invalidate held or worn equipment.
-  if (global.document && !global.LuminousAnatomyEquipmentEngine) {
-    const anatomyScript = loadScript("anatomy-equipment-engine-script", "js/anatomy-equipment-engine.js");
-    const ensureInjury = () => {
-      if (!global.LuminousInjuryEngine) loadScript("injury-engine-script", "js/injury-engine.js");
+  function ensureInjuryEquipmentRuntime() {
+    if (!global.document) return;
+    const ensureBridge = () => {
+      if (!global.LuminousInjuryEquipmentRuntime) loadScript("injury-equipment-runtime-script", "js/injury-equipment-runtime.js");
     };
-    if (global.LuminousAnatomyEquipmentEngine) ensureInjury();
-    else anatomyScript?.addEventListener?.("load", ensureInjury, { once: true });
-  } else if (global.document && !global.LuminousInjuryEngine) {
-    loadScript("injury-engine-script", "js/injury-engine.js");
+    const ensureInjury = () => {
+      if (global.LuminousInjuryEngine) return ensureBridge();
+      const injuryScript = loadScript("injury-engine-script", "js/injury-engine.js");
+      injuryScript?.addEventListener?.("load", ensureBridge, { once: true });
+    };
+    if (global.LuminousAnatomyEquipmentEngine) return ensureInjury();
+    const anatomyScript = loadScript("anatomy-equipment-engine-script", "js/anatomy-equipment-engine.js");
+    anatomyScript?.addEventListener?.("load", ensureInjury, { once: true });
   }
+
+  ensureInjuryEquipmentRuntime();
 })(typeof window !== "undefined" ? window : globalThis);

--- a/js/status-engine.js
+++ b/js/status-engine.js
@@ -200,4 +200,15 @@
     script.async = false;
     global.document.head?.appendChild(script);
   }
+
+  // Status Engine is loaded by the real Battle Viewer before CombatEngine. Bootstrap the
+  // Archetype Runtime here as a shared runtime bridge so combat mechanics do not depend on
+  // player-sheet-only loaders such as utils.js or .sheet-phone-wrapper.
+  if (global.document && !global.LuminousArchetypeRuntime && !global.document.getElementById("player-archetype-runtime-script")) {
+    const script = global.document.createElement("script");
+    script.id = "player-archetype-runtime-script";
+    script.src = "js/player-archetype-runtime.js";
+    script.async = false;
+    global.document.head?.appendChild(script);
+  }
 })(typeof window !== "undefined" ? window : globalThis);

--- a/js/status-engine.js
+++ b/js/status-engine.js
@@ -202,12 +202,19 @@
   }
 
   // Status Engine is loaded by the real Battle Viewer before CombatEngine. Bootstrap the
-  // Archetype Runtime here as a shared runtime bridge so combat mechanics do not depend on
-  // player-sheet-only loaders such as utils.js or .sheet-phone-wrapper.
+  // Archetype runtimes here so combat mechanics do not depend on player-sheet-only loaders.
   if (global.document && !global.LuminousArchetypeRuntime && !global.document.getElementById("player-archetype-runtime-script")) {
     const script = global.document.createElement("script");
     script.id = "player-archetype-runtime-script";
     script.src = "js/player-archetype-runtime.js";
+    script.async = false;
+    global.document.head?.appendChild(script);
+  }
+
+  if (global.document && !global.LuminousArchetypeCombatEventRuntime && !global.document.getElementById("archetype-combat-event-runtime-script")) {
+    const script = global.document.createElement("script");
+    script.id = "archetype-combat-event-runtime-script";
+    script.src = "js/archetype-combat-event-runtime.js";
     script.async = false;
     global.document.head?.appendChild(script);
   }

--- a/js/status-engine.js
+++ b/js/status-engine.js
@@ -78,19 +78,14 @@
       next.count = numberOr(existing.count, 0) + Math.max(0, numberOr(input.count, 1));
       next.potency = numberOr(existing.potency, 0) + numberOr(input.potency, 0);
     }
-    if (Number.isFinite(Number(definition.maxCount))) {
-      next.count = Math.min(Number(definition.maxCount), next.count);
-    }
+    if (Number.isFinite(Number(definition.maxCount))) next.count = Math.min(Number(definition.maxCount), next.count);
     store[id] = next;
     return next;
   }
 
   function protectionFor(unit, statusId, options = {}) {
     const id = normalizeId(statusId);
-    return options.protectedStatuses?.[id]
-      || unit?.statusProtections?.[id]
-      || unit?.protectedStatuses?.[id]
-      || null;
+    return options.protectedStatuses?.[id] || unit?.statusProtections?.[id] || unit?.protectedStatuses?.[id] || null;
   }
 
   function removeStatus(unit, statusId, options = {}) {
@@ -122,21 +117,14 @@
     if (!unit || typeof unit !== "object") return null;
     if (!unit.statusProtections || typeof unit.statusProtections !== "object") unit.statusProtections = {};
     const id = normalizeId(statusId);
-    unit.statusProtections[id] = {
-      from: normalizeId(protection.from || "effects"),
-      sourceTraitId: protection.sourceTraitId || null,
-    };
+    unit.statusProtections[id] = { from: normalizeId(protection.from || "effects"), sourceTraitId: protection.sourceTraitId || null };
     return clone(unit.statusProtections[id]);
   }
 
   function syncTraitState(unit, traitState = {}) {
     if (!unit) return unit;
-    Object.entries(traitState.statuses || {}).forEach(([statusId, status]) => {
-      applyStatus(unit, statusId, { ...status, mode: "set" });
-    });
-    Object.entries(traitState.protectedStatuses || {}).forEach(([statusId, protection]) => {
-      protectStatus(unit, statusId, protection);
-    });
+    Object.entries(traitState.statuses || {}).forEach(([statusId, status]) => applyStatus(unit, statusId, { ...status, mode: "set" }));
+    Object.entries(traitState.protectedStatuses || {}).forEach(([statusId, protection]) => protectStatus(unit, statusId, protection));
     return unit;
   }
 
@@ -169,89 +157,49 @@
   }
 
   const api = Object.freeze({
-    normalizeId,
-    getDefinition,
-    ensureStore,
-    applyStatus,
-    removeStatus,
-    hasStatus,
-    getStatus,
-    protectStatus,
-    syncTraitState,
-    advanceDurations,
-    listStatuses,
+    normalizeId, getDefinition, ensureStore, applyStatus, removeStatus, hasStatus, getStatus,
+    protectStatus, syncTraitState, advanceDurations, listStatuses,
   });
 
   global.LuminousStatusEngine = api;
   if (typeof module !== "undefined" && module.exports) module.exports = api;
 
+  function loadScript(id, src) {
+    if (!global.document || global.document.getElementById(id)) return null;
+    const script = global.document.createElement("script");
+    script.id = id;
+    script.src = src;
+    script.async = false;
+    global.document.head?.appendChild(script);
+    return script;
+  }
+
   // Rest/Recover is a shared player + combat resource. Load the canonical Class table first,
   // then Rest Engine, then the bridge that connects Trait activation and persistence.
-  if (global.document && !global.LuminousCharacterBuildRules && !global.document.getElementById("character-build-rules-script")) {
-    const script = global.document.createElement("script");
-    script.id = "character-build-rules-script";
-    script.src = "js/character-build-rules.js";
-    script.async = false;
-    global.document.head?.appendChild(script);
-  }
-
-  if (global.document && !global.LuminousRestEngine && !global.document.getElementById("rest-engine-script")) {
-    const script = global.document.createElement("script");
-    script.id = "rest-engine-script";
-    script.src = "js/rest-engine.js";
-    script.async = false;
-    global.document.head?.appendChild(script);
-  }
-
-  if (global.document && !global.LuminousRestRuntime && !global.document.getElementById("rest-runtime-integration-script")) {
-    const script = global.document.createElement("script");
-    script.id = "rest-runtime-integration-script";
-    script.src = "js/rest-runtime-integration.js";
-    script.async = false;
-    global.document.head?.appendChild(script);
-  }
-
-  if (global.document && !global.LuminousUniversalSpeedRuntime && !global.document.getElementById("universal-speed-runtime-script")) {
-    const script = global.document.createElement("script");
-    script.id = "universal-speed-runtime-script";
-    script.src = "js/universal-speed-runtime.js";
-    script.async = false;
-    global.document.head?.appendChild(script);
-  }
-
-  if (global.document && !global.LuminousRacialTraitRuntimeBridge && !global.document.getElementById("racial-trait-runtime-bridge-script")) {
-    const script = global.document.createElement("script");
-    script.id = "racial-trait-runtime-bridge-script";
-    script.src = "js/racial-trait-runtime-bridge.js";
-    script.async = false;
-    global.document.head?.appendChild(script);
-  }
+  if (global.document && !global.LuminousCharacterBuildRules) loadScript("character-build-rules-script", "js/character-build-rules.js");
+  if (global.document && !global.LuminousRestEngine) loadScript("rest-engine-script", "js/rest-engine.js");
+  if (global.document && !global.LuminousRestRuntime) loadScript("rest-runtime-integration-script", "js/rest-runtime-integration.js");
+  if (global.document && !global.LuminousUniversalSpeedRuntime) loadScript("universal-speed-runtime-script", "js/universal-speed-runtime.js");
+  if (global.document && !global.LuminousRacialTraitRuntimeBridge) loadScript("racial-trait-runtime-bridge-script", "js/racial-trait-runtime-bridge.js");
 
   // Status Engine is loaded by the real Battle Viewer before CombatEngine. Bootstrap the
   // Archetype runtimes here so combat mechanics do not depend on player-sheet-only loaders.
-  if (global.document && !global.LuminousArchetypeRuntime && !global.document.getElementById("player-archetype-runtime-script")) {
-    const script = global.document.createElement("script");
-    script.id = "player-archetype-runtime-script";
-    script.src = "js/player-archetype-runtime.js";
-    script.async = false;
-    global.document.head?.appendChild(script);
-  }
+  if (global.document && !global.LuminousArchetypeRuntime) loadScript("player-archetype-runtime-script", "js/player-archetype-runtime.js");
+  if (global.document && !global.LuminousArchetypeCombatEventRuntime) loadScript("archetype-combat-event-runtime-script", "js/archetype-combat-event-runtime.js");
 
-  if (global.document && !global.LuminousArchetypeCombatEventRuntime && !global.document.getElementById("archetype-combat-event-runtime-script")) {
-    const script = global.document.createElement("script");
-    script.id = "archetype-combat-event-runtime-script";
-    script.src = "js/archetype-combat-event-runtime.js";
-    script.async = false;
-    global.document.head?.appendChild(script);
-  }
+  // Death/Downed is a combat-wide rule, not a player-sheet feature.
+  if (global.document && !global.LuminousDeathSaveRuntime) loadScript("death-save-runtime-script", "js/death-save-runtime.js");
 
-  // Death/Downed is a combat-wide rule, not a player-sheet feature. Load it from the same
-  // Battle Viewer bootstrap and let it patch CombatEngine when that script becomes available.
-  if (global.document && !global.LuminousDeathSaveRuntime && !global.document.getElementById("death-save-runtime-script")) {
-    const script = global.document.createElement("script");
-    script.id = "death-save-runtime-script";
-    script.src = "js/death-save-runtime.js";
-    script.async = false;
-    global.document.head?.appendChild(script);
+  // Anatomy/Equipment and Injuries are also combat-wide rules. Anatomy must load first because
+  // Injuries can disable/miss parts and immediately invalidate held or worn equipment.
+  if (global.document && !global.LuminousAnatomyEquipmentEngine) {
+    const anatomyScript = loadScript("anatomy-equipment-engine-script", "js/anatomy-equipment-engine.js");
+    const ensureInjury = () => {
+      if (!global.LuminousInjuryEngine) loadScript("injury-engine-script", "js/injury-engine.js");
+    };
+    if (global.LuminousAnatomyEquipmentEngine) ensureInjury();
+    else anatomyScript?.addEventListener?.("load", ensureInjury, { once: true });
+  } else if (global.document && !global.LuminousInjuryEngine) {
+    loadScript("injury-engine-script", "js/injury-engine.js");
   }
 })(typeof window !== "undefined" ? window : globalThis);

--- a/js/status-engine.js
+++ b/js/status-engine.js
@@ -218,4 +218,14 @@
     script.async = false;
     global.document.head?.appendChild(script);
   }
+
+  // Death/Downed is a combat-wide rule, not a player-sheet feature. Load it from the same
+  // Battle Viewer bootstrap and let it patch CombatEngine when that script becomes available.
+  if (global.document && !global.LuminousDeathSaveRuntime && !global.document.getElementById("death-save-runtime-script")) {
+    const script = global.document.createElement("script");
+    script.id = "death-save-runtime-script";
+    script.src = "js/death-save-runtime.js";
+    script.async = false;
+    global.document.head?.appendChild(script);
+  }
 })(typeof window !== "undefined" ? window : globalThis);

--- a/js/status-engine.js
+++ b/js/status-engine.js
@@ -178,6 +178,7 @@
   if (global.document && !global.LuminousRestEngine) loadScript("rest-engine-script", "js/rest-engine.js");
   if (global.document && !global.LuminousRestRuntime) loadScript("rest-runtime-integration-script", "js/rest-runtime-integration.js");
   if (global.document && !global.LuminousUniversalSpeedRuntime) loadScript("universal-speed-runtime-script", "js/universal-speed-runtime.js");
+  if (global.document && !global.LuminousFixedDamageRuntime) loadScript("fixed-damage-runtime-script", "js/fixed-damage-runtime.js");
   if (global.document && !global.LuminousRacialTraitRuntimeBridge) loadScript("racial-trait-runtime-bridge-script", "js/racial-trait-runtime-bridge.js");
 
   if (global.document && !global.LuminousArchetypeRuntime) loadScript("player-archetype-runtime-script", "js/player-archetype-runtime.js");

--- a/js/utils.js
+++ b/js/utils.js
@@ -110,6 +110,12 @@ function ensurePlayerTraitRuntimeAssets(doc) {
     return ensureScriptAsset(documentRef, 'player-trait-runtime-script', 'js/player-trait-runtime.js', { ui: 'player-trait-runtime' });
 }
 
+function ensurePlayerArchetypeRuntimeAssets(doc) {
+    const documentRef = doc || (typeof document !== 'undefined' ? document : null);
+    if (!documentRef?.querySelector?.('.sheet-phone-wrapper')) return null;
+    return ensureScriptAsset(documentRef, 'player-archetype-runtime-script', 'js/player-archetype-runtime.js', { ui: 'player-archetype-runtime' });
+}
+
 function ensureDmPlayerDndStudioAssets(doc) {
     const documentRef = doc || (typeof document !== 'undefined' ? document : null);
     if (!documentRef?.querySelector?.('#dashboard-jugadores')) return null;
@@ -296,6 +302,7 @@ if (typeof document !== 'undefined') {
     ensurePlayerUxPolishAssets(document);
     ensurePlayerStatsAbilityBarAssets(document);
     ensurePlayerTraitRuntimeAssets(document);
+    ensurePlayerArchetypeRuntimeAssets(document);
     ensureDmPlayerDndStudioAssets(document);
     ensureDmTraitLibraryAssets(document);
     ensurePlayerSplashFramingAssets(document);
@@ -314,6 +321,7 @@ if (typeof module !== 'undefined' && module.exports) {
         ensurePlayerUxPolishAssets,
         ensurePlayerStatsAbilityBarAssets,
         ensurePlayerTraitRuntimeAssets,
+        ensurePlayerArchetypeRuntimeAssets,
         ensureDmPlayerDndStudioAssets,
         ensureDmTraitLibraryAssets,
         ensurePlayerSplashFramingAssets,

--- a/js/utils.js
+++ b/js/utils.js
@@ -110,6 +110,24 @@ function ensurePlayerTraitRuntimeAssets(doc) {
     return ensureScriptAsset(documentRef, 'player-trait-runtime-script', 'js/player-trait-runtime.js', { ui: 'player-trait-runtime' });
 }
 
+function ensurePlayerRestRuntimeAssets(doc) {
+    const documentRef = doc || (typeof document !== 'undefined' ? document : null);
+    if (!documentRef?.querySelector?.('.sheet-phone-wrapper')) return null;
+
+    const ensureRestRuntime = () => {
+        const restEngine = ensureScriptAsset(documentRef, 'rest-engine-script', 'js/rest-engine.js', { engine: 'rest-engine' });
+        const ensureBridge = () => ensureScriptAsset(documentRef, 'rest-runtime-integration-script', 'js/rest-runtime-integration.js', { engine: 'rest-runtime' });
+        if (typeof window !== 'undefined' && window.LuminousRestEngine) ensureBridge();
+        else restEngine.addEventListener('load', ensureBridge, { once: true });
+        return restEngine;
+    };
+
+    const buildRules = ensureScriptAsset(documentRef, 'character-build-rules-script', 'js/character-build-rules.js', { engine: 'character-build-rules' });
+    if (typeof window !== 'undefined' && window.LuminousCharacterBuildRules) ensureRestRuntime();
+    else buildRules.addEventListener('load', ensureRestRuntime, { once: true });
+    return { buildRules };
+}
+
 function ensurePlayerArchetypeRuntimeAssets(doc) {
     const documentRef = doc || (typeof document !== 'undefined' ? document : null);
     if (!documentRef?.querySelector?.('.sheet-phone-wrapper')) return null;
@@ -302,6 +320,7 @@ if (typeof document !== 'undefined') {
     ensurePlayerUxPolishAssets(document);
     ensurePlayerStatsAbilityBarAssets(document);
     ensurePlayerTraitRuntimeAssets(document);
+    ensurePlayerRestRuntimeAssets(document);
     ensurePlayerArchetypeRuntimeAssets(document);
     ensureDmPlayerDndStudioAssets(document);
     ensureDmTraitLibraryAssets(document);
@@ -321,6 +340,7 @@ if (typeof module !== 'undefined' && module.exports) {
         ensurePlayerUxPolishAssets,
         ensurePlayerStatsAbilityBarAssets,
         ensurePlayerTraitRuntimeAssets,
+        ensurePlayerRestRuntimeAssets,
         ensurePlayerArchetypeRuntimeAssets,
         ensureDmPlayerDndStudioAssets,
         ensureDmTraitLibraryAssets,

--- a/tests/anatomy_equipment_engine.spec.js
+++ b/tests/anatomy_equipment_engine.spec.js
@@ -1,0 +1,144 @@
+const { test, expect } = require("@playwright/test");
+
+const equipment = require("../js/anatomy-equipment-engine.js");
+
+function equippedItem(id, kind, extra = {}) {
+  return { id, equipped: true, equipment: { kind, ...(extra.equipment || {}) }, ...extra };
+}
+
+test("humanoid anatomy exposes two hands, ten fingers, two feet and one armor capacity", () => {
+  const anatomy = equipment.createHumanoidAnatomy();
+  expect(equipment.partsByType(anatomy, "hand")).toHaveLength(2);
+  expect(equipment.partsByType(anatomy, "finger")).toHaveLength(10);
+  expect(equipment.partsByType(anatomy, "foot")).toHaveLength(2);
+  const result = equipment.validateEquipment({}, [], { anatomy });
+  expect(result.capacities).toMatchObject({ hands: 2, freeHands: 2, armor: 1 });
+  expect(result.capacities.accessoryByType.finger).toBe(10);
+});
+
+test("One-Handed costs one hand, Two-Handed costs two, and two shields are legal", () => {
+  const twoShields = [
+    equippedItem("shield_a", "shield"),
+    equippedItem("shield_b", "shield"),
+  ];
+  expect(equipment.validateEquipment({}, twoShields).valid).toBe(true);
+
+  const occupied = [
+    equippedItem("greatsword", "weapon", { equipment: { kind: "weapon", handCost: 2 } }),
+    equippedItem("shield", "shield"),
+  ];
+  const result = equipment.validateEquipment({}, occupied);
+  expect(result.valid).toBe(false);
+  expect(result.invalid[0].reason).toBe("not_enough_functional_hands");
+});
+
+test("Traits or Augments may treat a Two-Handed weapon as One-Handed", () => {
+  const character = { equipmentRules: { twoHandedAsOneHanded: true } };
+  const items = [
+    equippedItem("greatsword", "weapon", { equipment: { kind: "weapon", handCost: 2 } }),
+    equippedItem("shield", "shield"),
+  ];
+  const result = equipment.validateEquipment(character, items);
+  expect(result.valid).toBe(true);
+  expect(result.capacities.freeHands).toBe(0);
+});
+
+test("extra arms automatically add hand, arm and finger capacity", () => {
+  const character = { extraBodyParts: [{ type: "arm", side: "extra_1" }] };
+  const anatomy = equipment.resolveCharacterAnatomy(character);
+  expect(equipment.partsByType(anatomy, "arm")).toHaveLength(3);
+  expect(equipment.partsByType(anatomy, "hand")).toHaveLength(3);
+  expect(equipment.partsByType(anatomy, "finger")).toHaveLength(15);
+
+  const items = [
+    equippedItem("greatsword", "weapon", { equipment: { kind: "weapon", handCost: 2 } }),
+    equippedItem("shield", "shield"),
+  ];
+  expect(equipment.validateEquipment(character, items, { anatomy }).valid).toBe(true);
+});
+
+test("Missing Arm cascades into Hand and Fingers while Missing Hand leaves the Arm", () => {
+  const missingArm = equipment.createHumanoidAnatomy();
+  equipment.setPartState(missingArm, "left_arm", "missing");
+  expect(missingArm.parts.left_arm.state).toBe("missing");
+  expect(missingArm.parts.left_hand.state).toBe("missing");
+  expect(missingArm.parts.left_finger_1.state).toBe("missing");
+  expect(equipment.partsByType(missingArm, "hand")).toHaveLength(1);
+
+  const missingHand = equipment.createHumanoidAnatomy();
+  equipment.setPartState(missingHand, "left_hand", "missing");
+  expect(missingHand.parts.left_arm.state).toBe("available");
+  expect(missingHand.parts.left_hand.state).toBe("missing");
+  expect(missingHand.parts.left_finger_5.state).toBe("missing");
+});
+
+test("Severe disabled limb invalidates held equipment and drops it to Loot Pool", () => {
+  const character = {
+    injuries: [{ id: "broken_right_arm", severity: "severe", affectedParts: ["right_arm"], slotEffect: "disabled", active: true }],
+  };
+  const sword = equippedItem("sword", "weapon");
+  const shield = equippedItem("shield", "shield");
+  const greatsword = equippedItem("greatsword", "weapon", { equipment: { kind: "weapon", handCost: 2 } });
+  const loot = [];
+
+  const oneHandEach = equipment.revalidateEquipment(character, [sword, shield], { lootPool: loot });
+  expect(oneHandEach.valid).toBe(false);
+  expect(oneHandEach.invalid).toHaveLength(1);
+  expect(loot).toHaveLength(1);
+  expect(loot[0].equipped).toBe(false);
+
+  const twoHanded = equipment.revalidateEquipment(character, [greatsword], { lootPool: loot });
+  expect(twoHanded.valid).toBe(false);
+  expect(twoHanded.invalid[0].reason).toBe("not_enough_functional_hands");
+});
+
+test("Accessories allocate real body parts instead of a fixed generic count", () => {
+  const rings = Array.from({ length: 10 }, (_, index) => equippedItem(`ring_${index}`, "accessory", {
+    equipment: { kind: "accessory", accessoryType: "finger", slotCost: 1 },
+  }));
+  expect(equipment.validateEquipment({}, rings).valid).toBe(true);
+
+  const eleventh = equippedItem("ring_11", "accessory", { equipment: { kind: "accessory", accessoryType: "finger", slotCost: 1 } });
+  const overflow = equipment.validateEquipment({}, [...rings, eleventh]);
+  expect(overflow.valid).toBe(false);
+  expect(overflow.invalid[0].reason).toBe("accessory_body_slot_unavailable");
+});
+
+test("Gloves use Hand accessory space but do not block Rings unless the item says so", () => {
+  const glove = equippedItem("glove", "accessory", { equipment: { kind: "accessory", accessoryType: "hand", slotCost: 1 } });
+  const rings = Array.from({ length: 10 }, (_, index) => equippedItem(`ring_${index}`, "accessory", {
+    equipment: { kind: "accessory", accessoryType: "finger", slotCost: 1 },
+  }));
+  expect(equipment.validateEquipment({}, [glove, ...rings]).valid).toBe(true);
+
+  const sealedGlove = equippedItem("sealed_glove", "accessory", {
+    equipment: { kind: "accessory", accessoryType: "hand", slotCost: 1, blocksAccessorySlots: ["finger"] },
+  });
+  const blocked = equipment.validateEquipment({}, [sealedGlove, ...rings]);
+  expect(blocked.valid).toBe(false);
+  expect(blocked.assignments.filter((entry) => entry.item.id.startsWith("ring_"))).toHaveLength(5);
+});
+
+test("Full Armor may block Hand, Arm and Foot accessories while leaving Finger slots free", () => {
+  const armor = equippedItem("full_armor", "armor", {
+    equipment: { kind: "armor", blocksAccessorySlots: ["hand", "arm", "foot"] },
+  });
+  const glove = equippedItem("glove", "accessory", { equipment: { kind: "accessory", accessoryType: "hand" } });
+  const bracelet = equippedItem("bracelet", "accessory", { equipment: { kind: "accessory", accessoryType: "arm" } });
+  const shoes = equippedItem("shoes", "accessory", { equipment: { kind: "accessory", accessoryType: "foot", slotCost: 2 } });
+  const ring = equippedItem("ring", "accessory", { equipment: { kind: "accessory", accessoryType: "finger" } });
+  const result = equipment.validateEquipment({}, [armor, glove, bracelet, shoes, ring]);
+  expect(result.invalid.map((entry) => entry.item.id).sort()).toEqual(["bracelet", "glove", "shoes"]);
+  expect(result.assignments.some((entry) => entry.item.id === "ring")).toBe(true);
+});
+
+test("biological regeneration does not repair a mechanical prosthesis", () => {
+  const anatomy = equipment.createHumanoidAnatomy();
+  equipment.replaceBranch(anatomy, "left_arm", { substrate: "mechanical" });
+  equipment.setPartState(anatomy, "left_arm", "disabled");
+  const biological = equipment.restoreBranch(anatomy, "left_arm", { method: "regeneration" });
+  expect(biological.restored).toBe(false);
+  expect(biological.reason).toBe("biological_healing_cannot_repair_mechanical");
+  const mechanical = equipment.restoreBranch(anatomy, "left_arm", { method: "mechanical_repair" });
+  expect(mechanical.restored).toBe(true);
+});

--- a/tests/archetype_engine.spec.js
+++ b/tests/archetype_engine.spec.js
@@ -39,6 +39,18 @@ test("multiclase conserva un Archetype separado por Class", () => {
   expect(both.find((entry) => entry.classId === "wizard")?.archetypeId).toBe("school_of_test");
 });
 
+test("validateSelections rechaza dos Archetypes persistidos para la misma Class", () => {
+  const malformed = character({ barbarian: 40 }, [
+    { classId: "barbarian", archetypeId: "path_of_the_devil_lineage", selectedAtClassLevel: 15 },
+    { classId: "barbarian", archetypeId: "path_of_the_devil_lineage", selectedAtClassLevel: 30 },
+  ]);
+  const normalized = archetypeEngine.normalizeSelections(malformed);
+  expect(normalized).toHaveLength(2);
+  const validation = archetypeEngine.validateSelections(malformed, catalog.allArchetypes());
+  expect(validation.valid).toBe(false);
+  expect(validation.errors.some((message) => message.includes("Only one Archetype can be selected for barbarian"))).toBe(true);
+});
+
 test("Path of the Devil Lineage entrega Traits por pisos 15/30/50/70", () => {
   const expected = new Map([[15, 4], [30, 5], [50, 9], [70, 13]]);
   for (const [level, count] of expected) {

--- a/tests/archetype_engine.spec.js
+++ b/tests/archetype_engine.spec.js
@@ -1,0 +1,88 @@
+const { test, expect } = require("@playwright/test");
+
+const traitEngine = require("../js/trait-engine.js");
+const archetypeEngine = require("../js/archetype-engine.js");
+const catalog = require("../js/archetype-trait-catalog.js");
+
+function character(levels, archetypes = []) {
+  return {
+    characterBuild: {
+      classes: Object.entries(levels).map(([classId, level]) => ({ classId, level })),
+      archetypes,
+      calculatedAtLevel: Object.values(levels).reduce((sum, level) => sum + level, 0),
+    },
+    stats: { fuerza: 18, constitucion: 16 },
+    combatStats: { hp_max: 200, hp_actual: 100 },
+  };
+}
+
+test("Archetype unlock usa Class Level y no Character Level", () => {
+  const highTotalLowBarbarian = character({ barbarian: 14, wizard: 60 });
+  expect(archetypeEngine.getClassLevel(highTotalLowBarbarian, "barbarian")).toBe(14);
+  expect(archetypeEngine.eligibleArchetypes(highTotalLowBarbarian, catalog.allArchetypes(), "barbarian")).toHaveLength(0);
+
+  const unlocked = character({ barbarian: 15, wizard: 60 });
+  expect(archetypeEngine.eligibleArchetypes(unlocked, catalog.allArchetypes(), "barbarian").map((entry) => entry.id)).toContain("path_of_the_devil_lineage");
+});
+
+test("multiclase conserva un Archetype separado por Class", () => {
+  const fakeCatalog = {
+    path_of_the_devil_lineage: catalog.ARCHETYPES.path_of_the_devil_lineage,
+    school_of_test: { id: "school_of_test", name: "School of Test", classId: "wizard", className: "Wizard", unlockLevel: 15 },
+  };
+  const base = character({ barbarian: 20, wizard: 20 });
+  const barbarian = archetypeEngine.selectArchetype(base, "barbarian", "path_of_the_devil_lineage", fakeCatalog);
+  const withBarbarian = character({ barbarian: 20, wizard: 20 }, barbarian);
+  const both = archetypeEngine.selectArchetype(withBarbarian, "wizard", "school_of_test", fakeCatalog);
+  expect(both).toHaveLength(2);
+  expect(both.find((entry) => entry.classId === "barbarian")?.archetypeId).toBe("path_of_the_devil_lineage");
+  expect(both.find((entry) => entry.classId === "wizard")?.archetypeId).toBe("school_of_test");
+});
+
+test("Path of the Devil Lineage entrega Traits por pisos 15/30/50/70", () => {
+  const expected = new Map([[15, 4], [30, 5], [50, 9], [70, 13]]);
+  for (const [level, count] of expected) {
+    const unit = character({ barbarian: level }, [{ classId: "barbarian", archetypeId: "path_of_the_devil_lineage", selectedAtClassLevel: 15 }]);
+    const traits = catalog.resolveTraitGrants(unit);
+    expect(traits).toHaveLength(count);
+    for (const trait of traits) {
+      expect(trait.source.type).toBe("archetype");
+      expect(trait.source.archetypeId).toBe("path_of_the_devil_lineage");
+      expect(trait.source.classId).toBe("barbarian");
+      expect(trait.source.requiredClassLevel).toBeLessThanOrEqual(level);
+    }
+  }
+});
+
+test("sin selección de Archetype no se conceden Traits de Archetype", () => {
+  expect(catalog.resolveTraitGrants(character({ barbarian: 70 }))).toEqual([]);
+});
+
+test("todas las definiciones del Archetype son válidas para Trait Engine", () => {
+  for (const [id, definition] of Object.entries(catalog.allDefinitions())) {
+    const validation = traitEngine.validateTrait(definition);
+    expect(validation.errors, `${id}: ${validation.errors.join(" | ")}`).toEqual([]);
+  }
+});
+
+test("Demonic Resistance puede ejecutar su Recover de Turn Start", () => {
+  const definition = catalog.allDefinitions().devil_lineage_demonic_resistance;
+  const state = traitEngine.createState();
+  const self = { hp: 100, maxHp: 200 };
+  const unit = character({ barbarian: 15 }, [{ classId: "barbarian", archetypeId: "path_of_the_devil_lineage" }]);
+  unit.combatStats.hp_max = 200;
+  const result = traitEngine.dispatchTrait(definition, "turn_start", { context: "combat", character: unit, self, Proficiency: 1 }, state);
+  expect(result.outcomes.some((outcome) => outcome.type === "heal_hp")).toBe(true);
+  expect(self.hp).toBeGreaterThan(100);
+});
+
+test("groupTraitsByArchetype separa visualmente varios Archetypes", () => {
+  const groups = archetypeEngine.groupTraitsByArchetype([
+    { id: "a", source: { type: "archetype", archetypeId: "devil", archetypeName: "Devil", classId: "barbarian" } },
+    { id: "b", source: { type: "archetype", archetypeId: "school", archetypeName: "School", classId: "wizard" } },
+    { id: "c", source: { type: "archetype", archetypeId: "devil", archetypeName: "Devil", classId: "barbarian" } },
+  ]);
+  expect(groups).toHaveLength(2);
+  expect(groups.find((group) => group.archetypeId === "devil")?.traits).toHaveLength(2);
+  expect(groups.find((group) => group.archetypeId === "school")?.traits).toHaveLength(1);
+});

--- a/tests/archetype_review_regressions.spec.js
+++ b/tests/archetype_review_regressions.spec.js
@@ -3,8 +3,12 @@ const fs = require("node:fs");
 const path = require("node:path");
 const vm = require("node:vm");
 
+const traitEngine = require("../js/trait-engine.js");
+const archetypeCatalog = require("../js/archetype-trait-catalog.js");
+
 const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
 const runtimeSource = read("js/player-archetype-runtime.js");
+const combatEventSource = read("js/archetype-combat-event-runtime.js");
 const statusSource = read("js/status-engine.js");
 const battleViewer = read("Battle-viewer.html");
 
@@ -45,7 +49,7 @@ function makeDocument() {
   };
 }
 
-function loadRuntime({ grantedTraits = [] } = {}) {
+function loadRuntime({ grantedTraits = [], traitEngineApi = null, playerTraitRuntime = null } = {}) {
   const document = makeDocument();
   const window = {
     document,
@@ -54,6 +58,12 @@ function loadRuntime({ grantedTraits = [] } = {}) {
     addEventListener() {},
     setInterval() {},
     alert() {},
+    LuminousTraitEngine: traitEngineApi || undefined,
+    LuminousPlayerTraitRuntime: playerTraitRuntime || undefined,
+    LuminousTraitStandardizationRuntime: {
+      registerCombatUnit() {},
+      resolveTraitRuntimeResolutions() {},
+    },
     LuminousArchetypeEngine: {
       isSelected,
       getClassLevel: classLevel,
@@ -80,15 +90,21 @@ function loadRuntime({ grantedTraits = [] } = {}) {
   return { window, document, api: window.LuminousArchetypeRuntime };
 }
 
+function loadCombatEventRuntime(window) {
+  vm.runInNewContext(combatEventSource, { window, console, WeakMap, Map }, { filename: "archetype-combat-event-runtime.js" });
+  return window.LuminousArchetypeCombatEventRuntime;
+}
+
 function devilUnit(level, extra = {}) {
   return {
+    id: extra.id,
     name: extra.name || `Devil Unit ${level}`,
     hp: extra.hp ?? 100,
     maxHp: extra.maxHp ?? 100,
     shield: extra.shield ?? 0,
     stats: { fuerza: 18, constitucion: 14, ...(extra.stats || {}) },
     statusEffects: extra.statusEffects || {},
-    characterBuild: {
+    characterBuild: extra.characterBuild || {
       classes: [{ classId: "barbarian", level }],
       archetypes: [{ classId: "barbarian", archetypeId: DEVIL, selectedAtClassLevel: 15 }],
     },
@@ -118,10 +134,11 @@ function baseCombatEngine({ coinDamage } = {}) {
     },
     triggerEncounterStart() {},
     triggerPhase() {},
+    triggerEvent() {},
   };
 }
 
-test("Battle Viewer bootstraps Archetype Runtime through Status Engine", () => {
+test("Battle Viewer bootstraps both Archetype runtimes through Status Engine", () => {
   const statusIndex = battleViewer.indexOf('src="js/status-engine.js"');
   const combatIndex = battleViewer.indexOf('src="js/combatEngine.js"');
   expect(statusIndex).toBeGreaterThan(-1);
@@ -133,6 +150,7 @@ test("Battle Viewer bootstraps Archetype Runtime through Status Engine", () => {
   vm.runInNewContext(statusSource, { window }, { filename: "status-engine.js" });
   const scripts = document.appended.map((node) => node.src).filter(Boolean);
   expect(scripts).toContain("js/player-archetype-runtime.js");
+  expect(scripts).toContain("js/archetype-combat-event-runtime.js");
 });
 
 test("JACKPOT reconoce Ammo canónico en skill.ammo.cost aunque la Coin no tenga metadata de Ammo", () => {
@@ -188,11 +206,30 @@ test("Cursed Juggernaut funciona para combatants arbitrarios y conserva la recup
   window.CombatEngine.applyDamage(unit, 100, "directo");
   expect(unit.hp).toBe(1);
 
-  // Healing between the lethal event and next Turn Start must not cancel the stored trigger.
   unit.hp = 8;
   window.CombatEngine.triggerPhase("[Round Start]", [unit]);
-  // CON 14 => Mod +2 => Max(14, 28)% Max HP = 28 HP.
   expect(unit.hp).toBe(36);
+});
+
+test("Cursed Juggernaut conserva pending y used cuando Firebase reconstruye el objeto del combatant", () => {
+  const { window, api } = loadRuntime();
+  window.CombatEngine = baseCombatEngine();
+  api.patchCombatEngine();
+
+  const firstSnapshot = devilUnit(70, { id: "ally_42", hp: 10, statusEffects: { rage: { count: 1 } } });
+  window.CombatEngine.applyDamage(firstSnapshot, 100, "directo");
+  expect(firstSnapshot.hp).toBe(1);
+
+  const secondSnapshot = devilUnit(70, { id: "ally_42", hp: 8, statusEffects: { rage: { count: 1 } } });
+  window.CombatEngine.triggerPhase("[Round Start]", [secondSnapshot]);
+  expect(secondSnapshot.hp).toBe(36);
+
+  const thirdSnapshot = devilUnit(70, { id: "ally_42", hp: 10, statusEffects: { rage: { count: 1 } } });
+  window.CombatEngine.applyDamage(thirdSnapshot, 100, "directo");
+  expect(thirdSnapshot.hp).toBe(1);
+  const fourthSnapshot = devilUnit(70, { id: "ally_42", hp: 1, statusEffects: { rage: { count: 1 } } });
+  window.CombatEngine.triggerPhase("[Round Start]", [fourthSnapshot]);
+  expect(fourthSnapshot.hp).toBe(1);
 });
 
 test("combat initialization attaches granted Archetype Traits to non-current-player units", () => {
@@ -204,4 +241,122 @@ test("combat initialization attaches granted Archetype Traits to non-current-pla
   const unit = devilUnit(15);
   window.CombatEngine.initializeUnitData(unit);
   expect(unit.traitDefinitions?.map((entry) => entry.id)).toContain("devil_lineage_infernal_speed");
+});
+
+test("universal Archetype bridge dispatches Turn Start for every arbitrary combatant", () => {
+  const definition = archetypeCatalog.DEFINITIONS.devil_lineage_demonic_resistance;
+  const { window, api } = loadRuntime({ grantedTraits: [definition], traitEngineApi: traitEngine });
+  window.CombatEngine = baseCombatEngine();
+  api.patchCombatEngine();
+  loadCombatEventRuntime(window).patchCombatEngine();
+
+  const a = devilUnit(15, { id: "ally_a", hp: 50, maxHp: 100 });
+  const b = devilUnit(15, { id: "ally_b", hp: 40, maxHp: 100 });
+  window.CombatEngine.triggerPhase("[Round Start]", [a, b]);
+  expect(a.hp).toBe(52);
+  expect(b.hp).toBe(42);
+});
+
+test("universal Archetype bridge dispatches On Hit and On Crit to the concrete target", () => {
+  const improved = archetypeCatalog.DEFINITIONS.devil_lineage_improved_devil_strength;
+  const calls = [];
+  const engine = {
+    createState: traitEngine.createState,
+    resetStateScope: traitEngine.resetStateScope,
+    dispatchTrait(trait, trigger, runtime, state) {
+      calls.push({ trait: trait.id, trigger, self: runtime.self?.id, target: runtime.target?.id, sourceClassId: runtime.sourceClassId });
+      return { trait, state, runtime, outcomes: [] };
+    },
+  };
+  const { window, api } = loadRuntime({ grantedTraits: [improved], traitEngineApi: engine });
+  window.CombatEngine = baseCombatEngine();
+  api.patchCombatEngine();
+  loadCombatEventRuntime(window).patchCombatEngine();
+
+  const attacker = devilUnit(50, { id: "attacker" });
+  const target = { id: "target", hp: 100, maxHp: 100, statusEffects: {} };
+  const context = { attacker, defender: target, skill: { coinAmount: 2 }, currentCoin: {} };
+  window.CombatEngine.triggerEvent("[On Hit]", context, [target]);
+  window.CombatEngine.triggerEvent("[On Crit]", context, [target]);
+
+  expect(calls.some((call) => call.trigger === "on_hit" && call.self === "attacker" && call.target === "target")).toBe(true);
+  expect(calls.some((call) => call.trigger === "on_crit" && call.self === "attacker" && call.target === "target")).toBe(true);
+});
+
+test("universal Archetype bridge dispatches AoE On Hit once for each unique target", () => {
+  const improved = archetypeCatalog.DEFINITIONS.devil_lineage_improved_devil_strength;
+  const hitTargets = [];
+  const engine = {
+    createState: traitEngine.createState,
+    resetStateScope: traitEngine.resetStateScope,
+    dispatchTrait(trait, trigger, runtime, state) {
+      if (trigger === "on_hit") hitTargets.push(runtime.target?.id);
+      return { trait, state, runtime, outcomes: [] };
+    },
+  };
+  const { window, api } = loadRuntime({ grantedTraits: [improved], traitEngineApi: engine });
+  window.CombatEngine = baseCombatEngine();
+  api.patchCombatEngine();
+  loadCombatEventRuntime(window).patchCombatEngine();
+
+  const attacker = devilUnit(50, { id: "aoe_attacker" });
+  const a = { id: "target_a" };
+  const b = { id: "target_b" };
+  window.CombatEngine.triggerEvent("[On Hit]", { attacker, defender: a, skill: {}, currentCoin: {} }, [a, b, a]);
+  expect(hitTargets).toEqual(["target_a", "target_b"]);
+});
+
+test("universal bridge delegates the locally managed player to PlayerTraitRuntime to prevent double dispatch", () => {
+  const local = devilUnit(50, { id: "local_player" });
+  let dispatchCount = 0;
+  const engine = {
+    createState: traitEngine.createState,
+    resetStateScope: traitEngine.resetStateScope,
+    dispatchTrait(trait, trigger, runtime, state) {
+      dispatchCount += 1;
+      return { trait, state, runtime, outcomes: [] };
+    },
+  };
+  const playerTraitRuntime = { getCharacter: () => local, dispatchCombatEvent() {} };
+  const improved = archetypeCatalog.DEFINITIONS.devil_lineage_improved_devil_strength;
+  const { window, api } = loadRuntime({ grantedTraits: [improved], traitEngineApi: engine, playerTraitRuntime });
+  window.CombatEngine = baseCombatEngine();
+  api.patchCombatEngine();
+  const bridge = loadCombatEventRuntime(window);
+  bridge.patchCombatEngine();
+
+  const target = { id: "target" };
+  window.CombatEngine.triggerEvent("[On Hit]", { attacker: local, defender: target, skill: {}, currentCoin: {} }, [target]);
+  expect(dispatchCount).toBe(0);
+});
+
+test("universal bridge passes each Archetype Trait sourceClassId for multiclass ClassLevel formulas", () => {
+  const testTrait = {
+    schemaVersion: 1,
+    id: "test_wizard_archetype_class_level",
+    name: "Class Level Test",
+    source: { type: "archetype", archetypeId: DEVIL, classId: "wizard" },
+    contexts: ["combat"],
+    activation: { type: "automatic", actionCost: "none" },
+    effects: [{
+      id: "heal_by_class_level",
+      contexts: ["combat"],
+      trigger: "turn_start",
+      conditions: [],
+      operations: [{ type: "heal_hp", path: "self.hp", maxPath: "self.maxHp", formula: "ClassLevel" }],
+    }],
+    rules: [],
+  };
+  const build = {
+    classes: [{ classId: "barbarian", level: 70 }, { classId: "wizard", level: 3 }],
+    archetypes: [{ classId: "barbarian", archetypeId: DEVIL, selectedAtClassLevel: 15 }],
+  };
+  const { window, api } = loadRuntime({ grantedTraits: [testTrait], traitEngineApi: traitEngine });
+  window.CombatEngine = baseCombatEngine();
+  api.patchCombatEngine();
+  loadCombatEventRuntime(window).patchCombatEngine();
+
+  const unit = devilUnit(70, { id: "multiclass", hp: 50, maxHp: 100, characterBuild: build });
+  window.CombatEngine.triggerPhase("[Round Start]", [unit]);
+  expect(unit.hp).toBe(53);
 });

--- a/tests/archetype_review_regressions.spec.js
+++ b/tests/archetype_review_regressions.spec.js
@@ -1,0 +1,207 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
+const runtimeSource = read("js/player-archetype-runtime.js");
+const statusSource = read("js/status-engine.js");
+const battleViewer = read("Battle-viewer.html");
+
+const DEVIL = "path_of_the_devil_lineage";
+
+function classLevel(character, classId) {
+  const build = character?.characterBuild || {};
+  const classes = Array.isArray(build.classes) ? build.classes : [];
+  const found = classes.find((entry) => String(entry.classId || entry.id).toLowerCase() === classId);
+  return Number(found?.level ?? found?.levels ?? 0) || 0;
+}
+
+function isSelected(character, archetypeId, classId) {
+  const list = character?.characterBuild?.archetypes || [];
+  return Array.isArray(list) && list.some((entry) =>
+    String(entry.classId || "").toLowerCase() === classId &&
+    String(entry.archetypeId || "").toLowerCase() === archetypeId
+  );
+}
+
+function makeDocument() {
+  const appended = [];
+  return {
+    appended,
+    querySelector() { return null; },
+    getElementById() { return null; },
+    createElement(tag) {
+      return {
+        tagName: String(tag).toUpperCase(),
+        dataset: {},
+        addEventListener() {},
+        setAttribute() {},
+      };
+    },
+    head: {
+      appendChild(node) { appended.push(node); },
+    },
+  };
+}
+
+function loadRuntime({ grantedTraits = [] } = {}) {
+  const document = makeDocument();
+  const window = {
+    document,
+    console,
+    localStorage: { getItem() { return ""; } },
+    addEventListener() {},
+    setInterval() {},
+    alert() {},
+    LuminousArchetypeEngine: {
+      isSelected,
+      getClassLevel: classLevel,
+      classEntries(character) {
+        return (character?.characterBuild?.classes || []).map((entry) => ({
+          classId: String(entry.classId || entry.id || "").toLowerCase(),
+          levels: Number(entry.level ?? entry.levels ?? 0) || 0,
+        }));
+      },
+      selectedForClass() { return null; },
+      groupTraitsByArchetype() { return []; },
+    },
+    LuminousArchetypeTraitCatalog: {
+      resolveTraitGrants(character) {
+        return isSelected(character, DEVIL, "barbarian") ? grantedTraits.map((trait) => ({ ...trait })) : [];
+      },
+      allArchetypes() { return {}; },
+      allDefinitions() { return {}; },
+      allGrants() { return []; },
+    },
+  };
+  window.window = window;
+  vm.runInNewContext(runtimeSource, { window, console, Promise }, { filename: "player-archetype-runtime.js" });
+  return { window, document, api: window.LuminousArchetypeRuntime };
+}
+
+function devilUnit(level, extra = {}) {
+  return {
+    name: extra.name || `Devil Unit ${level}`,
+    hp: extra.hp ?? 100,
+    maxHp: extra.maxHp ?? 100,
+    shield: extra.shield ?? 0,
+    stats: { fuerza: 18, constitucion: 14, ...(extra.stats || {}) },
+    statusEffects: extra.statusEffects || {},
+    characterBuild: {
+      classes: [{ classId: "barbarian", level }],
+      archetypes: [{ classId: "barbarian", archetypeId: DEVIL, selectedAtClassLevel: 15 }],
+    },
+  };
+}
+
+function baseCombatEngine({ coinDamage } = {}) {
+  return {
+    initializeUnitData(unit) { unit.initialized = true; return unit; },
+    calculateCoinDamage(attacker, defender) {
+      return typeof coinDamage === "function" ? coinDamage(attacker, defender) : 100;
+    },
+    applyDamage(unit, damage) {
+      let remaining = Number(damage) || 0;
+      if (unit.shield > 0) {
+        const blocked = Math.min(unit.shield, remaining);
+        unit.shield -= blocked;
+        remaining -= blocked;
+      }
+      unit.hp = Math.max(0, unit.hp - remaining);
+      return { hp: unit.hp, shield: unit.shield };
+    },
+    processStatusEffects(unit, triggerKey) {
+      if (triggerKey === "burn_tick" && unit.statusEffects?.burn) {
+        this.applyDamage(unit, Number(unit.statusEffects.burn.potency) || 0, "efecto_estado");
+      }
+    },
+    triggerEncounterStart() {},
+    triggerPhase() {},
+  };
+}
+
+test("Battle Viewer bootstraps Archetype Runtime through Status Engine", () => {
+  const statusIndex = battleViewer.indexOf('src="js/status-engine.js"');
+  const combatIndex = battleViewer.indexOf('src="js/combatEngine.js"');
+  expect(statusIndex).toBeGreaterThan(-1);
+  expect(combatIndex).toBeGreaterThan(statusIndex);
+
+  const document = makeDocument();
+  const window = { document };
+  window.window = window;
+  vm.runInNewContext(statusSource, { window }, { filename: "status-engine.js" });
+  const scripts = document.appended.map((node) => node.src).filter(Boolean);
+  expect(scripts).toContain("js/player-archetype-runtime.js");
+});
+
+test("JACKPOT reconoce Ammo canónico en skill.ammo.cost aunque la Coin no tenga metadata de Ammo", () => {
+  const { window, api } = loadRuntime();
+  window.CombatEngine = baseCombatEngine();
+  expect(api.patchCombatEngine()).toBe(true);
+
+  const attacker = devilUnit(15);
+  const defender = { physRes: 1, hp: 100, maxHp: 100, shield: 0, statusEffects: {} };
+  const context = { currentCoin: { type: "standard" } };
+  expect(api.coinSpendsAmmo({ ammo: { resourceId: "ammo", cost: 1 } }, context)).toBe(true);
+  const damage = window.CombatEngine.calculateCoinDamage(
+    attacker,
+    defender,
+    { ammo: { resourceId: "ammo", cost: 1 } },
+    10,
+    false,
+    0,
+    context,
+  );
+  expect(damage).toBe(140);
+});
+
+test("Infernal Touch normaliza Resistance sólo durante el cálculo y restaura al objetivo", () => {
+  const { window, api } = loadRuntime();
+  window.CombatEngine = baseCombatEngine({ coinDamage: (_attacker, defender) => defender.physRes * 100 });
+  api.patchCombatEngine();
+
+  const attacker = devilUnit(30, { statusEffects: { rage: { count: 1 } } });
+  const defender = { physRes: 0.5, hp: 100, maxHp: 100, shield: 0, statusEffects: {} };
+  const damage = window.CombatEngine.calculateCoinDamage(attacker, defender, { attackType: "Slash" }, 10, false, 0, { currentCoin: {} });
+  expect(damage).toBe(100);
+  expect(defender.physRes).toBe(0.5);
+});
+
+test("Demonic Resistance reduce Burn para cualquier combatant con el Archetype, no sólo el player sheet", () => {
+  const { window, api } = loadRuntime();
+  window.CombatEngine = baseCombatEngine();
+  api.patchCombatEngine();
+
+  const unit = devilUnit(15, { hp: 100, statusEffects: { burn: { potency: 10, count: 2 } } });
+  window.CombatEngine.processStatusEffects(unit, "burn_tick", {});
+  expect(unit.hp).toBe(95);
+  expect(unit.statusEffects.burn.potency).toBe(10);
+});
+
+test("Cursed Juggernaut funciona para combatants arbitrarios y conserva la recuperación pendiente", () => {
+  const { window, api } = loadRuntime();
+  window.CombatEngine = baseCombatEngine();
+  api.patchCombatEngine();
+
+  const unit = devilUnit(70, { hp: 10, statusEffects: { rage: { count: 1 } } });
+  window.CombatEngine.applyDamage(unit, 100, "directo");
+  expect(unit.hp).toBe(1);
+
+  // Healing between the lethal event and next Turn Start must not cancel the stored trigger.
+  unit.hp = 8;
+  window.CombatEngine.triggerPhase("[Round Start]", [unit]);
+  // CON 14 => Mod +2 => Max(14, 28)% Max HP = 28 HP.
+  expect(unit.hp).toBe(36);
+});
+
+test("combat initialization attaches granted Archetype Traits to non-current-player units", () => {
+  const trait = { id: "devil_lineage_infernal_speed", source: { type: "archetype", archetypeId: DEVIL } };
+  const { window, api } = loadRuntime({ grantedTraits: [trait] });
+  window.CombatEngine = baseCombatEngine();
+  api.patchCombatEngine();
+
+  const unit = devilUnit(15);
+  window.CombatEngine.initializeUnitData(unit);
+  expect(unit.traitDefinitions?.map((entry) => entry.id)).toContain("devil_lineage_infernal_speed");
+});

--- a/tests/archetype_runtime_contract.spec.js
+++ b/tests/archetype_runtime_contract.spec.js
@@ -4,6 +4,7 @@ const path = require("node:path");
 
 const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
 const runtime = read("js/player-archetype-runtime.js");
+const archetypeEngine = read("js/archetype-engine.js");
 const utils = read("js/utils.js");
 const css = read("css/player-archetype-runtime.css");
 const tray = read("js/trait-player-tray.js");
@@ -19,7 +20,7 @@ test("selección se persiste por Class dentro de characterBuild.archetypes", () 
   expect(runtime).toContain("character.characterBuild.archetypes = selections");
   expect(runtime).toContain("characterBuild/archetypes");
   expect(runtime).toContain("api.selectArchetype(character, classId, archetypeId");
-  expect(runtime).toContain("selectedAtClassLevel");
+  expect(archetypeEngine).toContain("selectedAtClassLevel: classLevel");
 });
 
 test("Traits mantiene categoría Archetype y agrega subtabs sólo al filtrar Archetype", () => {

--- a/tests/archetype_runtime_contract.spec.js
+++ b/tests/archetype_runtime_contract.spec.js
@@ -1,0 +1,56 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
+const runtime = read("js/player-archetype-runtime.js");
+const utils = read("js/utils.js");
+const css = read("css/player-archetype-runtime.css");
+const tray = read("js/trait-player-tray.js");
+
+test("Player loader monta el Archetype Runtime junto al Trait Runtime", () => {
+  expect(utils).toContain("function ensurePlayerArchetypeRuntimeAssets");
+  expect(utils).toContain("js/player-archetype-runtime.js");
+  expect(utils).toContain("ensurePlayerTraitRuntimeAssets(document);");
+  expect(utils).toContain("ensurePlayerArchetypeRuntimeAssets(document);");
+});
+
+test("selección se persiste por Class dentro de characterBuild.archetypes", () => {
+  expect(runtime).toContain("character.characterBuild.archetypes = selections");
+  expect(runtime).toContain("characterBuild/archetypes");
+  expect(runtime).toContain("api.selectArchetype(character, classId, archetypeId");
+  expect(runtime).toContain("selectedAtClassLevel");
+});
+
+test("Traits mantiene categoría Archetype y agrega subtabs sólo al filtrar Archetype", () => {
+  expect(tray).toContain('"archetype"');
+  expect(runtime).toContain('normalizeId(tray.filter) !== "archetype"');
+  expect(runtime).toContain("if (groups.length <= 1) return");
+  expect(runtime).toContain('className = "player-archetype-subtabs"');
+  expect(runtime).toContain("card.hidden = Boolean(traitArchetype && traitArchetype !== activeId)");
+  expect(css).toContain(".player-archetype-subtabs");
+  expect(css).toContain(".player-trait-card[hidden]");
+});
+
+test("runtime expone integración de Flight, Active Inventory y checks", () => {
+  expect(runtime).toContain('capabilityId: "flight"');
+  expect(runtime).toContain("activeInventoryLimit");
+  expect(runtime).toContain("strengthThresholdModifier");
+  expect(runtime).toContain("applyTheatreCheckMechanics");
+  expect(runtime).toContain('skill === "performance"');
+  expect(runtime).toContain('tags.includes("jump")');
+});
+
+test("runtime integra resistencia física, Ammo y Cursed Juggernaut en Combat Engine", () => {
+  expect(runtime).toContain("defender.physRes = 1");
+  expect(runtime).toContain("coinSpendsAmmo");
+  expect(runtime).toContain("originalApplyDamage");
+  expect(runtime).toContain("armCursedJuggernaut");
+  expect(runtime).toContain("resolveCursedJuggernautRecovery");
+});
+
+test("Active Inventory deja de quedar limitado al 10 legacy cuando aplica el Archetype", () => {
+  expect(runtime).toContain("const limit = activeInventoryLimit(character, 10)");
+  expect(runtime).toContain("Object.keys(targetData).length >= limit");
+  expect(runtime).toContain("event.stopImmediatePropagation()");
+});

--- a/tests/death_save_runtime.spec.js
+++ b/tests/death_save_runtime.spec.js
@@ -236,6 +236,5 @@ test("Death Save resolves before Round End and a third Success Retreats in the s
 });
 
 test("Status Engine bootstraps the Death Save runtime in the real Battle Viewer load chain", () => {
-  expect(statusSource).toContain('script.id = "death-save-runtime-script"');
-  expect(statusSource).toContain('script.src = "js/death-save-runtime.js"');
+  expect(statusSource).toContain('loadScript("death-save-runtime-script", "js/death-save-runtime.js")');
 });

--- a/tests/death_save_runtime.spec.js
+++ b/tests/death_save_runtime.spec.js
@@ -1,0 +1,241 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const runtimeSource = fs.readFileSync(path.join(__dirname, "..", "js", "death-save-runtime.js"), "utf8");
+const statusSource = fs.readFileSync(path.join(__dirname, "..", "js", "status-engine.js"), "utf8");
+
+function createSandbox({ combatEngine = null, random = () => 0.25 } = {}) {
+  const events = [];
+  const math = Object.create(Math);
+  math.random = random;
+  const sandbox = {
+    console,
+    Math: math,
+    Date,
+    JSON,
+    Object,
+    Array,
+    Set,
+    WeakMap,
+    Number,
+    String,
+    Boolean,
+    RegExp,
+    CustomEvent: class CustomEvent {
+      constructor(type, init = {}) { this.type = type; this.detail = init.detail; }
+    },
+    dispatchEvent(event) { events.push(event); return true; },
+    setInterval() { return 0; },
+    clearInterval() {},
+    CombatEngine: combatEngine,
+  };
+  sandbox.globalThis = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(runtimeSource, sandbox, { filename: "death-save-runtime.js" });
+  return { sandbox, runtime: sandbox.LuminousDeathSaveRuntime, events };
+}
+
+const player = (extra = {}) => ({ id: "pc", isPlayer: true, hp: 100, maxHp: 100, sp: 0, ...extra });
+const enemy = (extra = {}) => ({ id: "enemy", isPlayer: false, hp: 100, maxHp: 100, ...extra });
+
+test("Death Save contract is the existing flat 5-Coin check", () => {
+  const { runtime } = createSandbox();
+  expect(runtime.DEATH_SAVE_CHECK).toMatchObject({ coinAmount: 5, coinPower: 4, basePower: 0, threshold: 10, flat: true, statModifiers: false });
+  expect(runtime.SINNER_TRAIT.id).toBe("sinner");
+});
+
+test("Players and Captains use Downed; ordinary enemies die at 0 HP", () => {
+  const { runtime } = createSandbox();
+  const pc = player();
+  runtime.enterDowned(pc, { sourceKind: "skill" });
+  expect(runtime.isDowned(pc)).toBe(true);
+  expect(pc.deathSaves).toEqual({ successes: 0, failures: 0 });
+
+  const captain = enemy({ isCaptain: true });
+  runtime.enterDowned(captain, { sourceKind: "skill" });
+  expect(runtime.isDowned(captain)).toBe(true);
+
+  const minion = enemy();
+  const result = runtime.enterDowned(minion, { sourceKind: "skill" });
+  expect(result.died).toBe(true);
+  expect(runtime.isDead(minion)).toBe(true);
+  expect(minion.lifeState).toBe("dead");
+});
+
+test("Status damage that causes Downed starts with exactly one Failure", () => {
+  const { runtime } = createSandbox();
+  const pc = player();
+  runtime.enterDowned(pc, { sourceKind: "status" });
+  expect(pc.deathSaves.failures).toBe(1);
+  expect(pc.deathSaves.successes).toBe(0);
+});
+
+test("each damaging Status trigger while Downed causes one Failure and the third is immediate Death", () => {
+  const { runtime } = createSandbox();
+  const pc = player();
+  runtime.enterDowned(pc, { sourceKind: "skill" });
+  runtime.addFailure(pc, { reason: "burn_trigger" });
+  runtime.addFailure(pc, { reason: "bleed_check" });
+  const third = runtime.addFailure(pc, { reason: "burn_trigger" });
+  expect(third.death.died).toBe(true);
+  expect(runtime.isDead(pc)).toBe(true);
+  expect(pc.hp).toBe(0);
+});
+
+test("external Heal stabilizes at 0-2 Failures, self/passive healing is zero", () => {
+  const { runtime } = createSandbox();
+  const pc = player();
+  runtime.enterDowned(pc);
+  runtime.addFailure(pc);
+  runtime.addFailure(pc);
+
+  const regen = runtime.heal(pc, 20, { source: "regen" });
+  expect(regen.applied).toBe(0);
+  expect(regen.negated).toBe(true);
+  expect(pc.hp).toBe(0);
+  expect(pc.deathSaves.failures).toBe(2);
+
+  const spell = runtime.heal(pc, 17, { source: "spell" });
+  expect(spell.stabilized).toBe(true);
+  expect(pc.hp).toBe(17);
+  expect(runtime.isDowned(pc)).toBe(false);
+  expect(pc.deathSaves).toEqual({ successes: 0, failures: 0 });
+});
+
+test("Dead character records are preserved; normal Heal cannot revive but explicit Revival can", () => {
+  const { runtime } = createSandbox();
+  const pc = player();
+  runtime.enterDowned(pc);
+  runtime.addFailure(pc);
+  runtime.addFailure(pc);
+  runtime.addFailure(pc);
+
+  expect(runtime.isDead(pc)).toBe(true);
+  expect(pc.deleted).toBe(false);
+  expect(runtime.heal(pc, 30, { source: "spell" }).reason).toBe("dead_requires_revival");
+
+  const revived = runtime.heal(pc, 30, { source: "revival", revive: true });
+  expect(revived.revived).toBe(true);
+  expect(runtime.isDead(pc)).toBe(false);
+  expect(pc.hp).toBe(30);
+});
+
+test("Sinner changes actual Death to Sinner Death without bypassing Player Death Saves", () => {
+  const { runtime } = createSandbox();
+  const sinner = player({ traits: [{ id: "sinner" }] });
+  runtime.enterDowned(sinner);
+  expect(runtime.isDowned(sinner)).toBe(true);
+  runtime.addFailure(sinner);
+  runtime.addFailure(sinner);
+  const result = runtime.addFailure(sinner);
+  expect(result.death.deathType).toBe("sinner");
+  expect(sinner.sinnerDeath).toBe(true);
+  expect(sinner.deleted).toBe(false);
+});
+
+test("3 Successes immediately restore 5% Max HP and arm Retreat", () => {
+  const { runtime } = createSandbox();
+  const pc = player({ maxHp: 201 });
+  runtime.enterDowned(pc);
+  runtime.addSuccess(pc);
+  runtime.addSuccess(pc);
+  const result = runtime.addSuccess(pc);
+  expect(result.stabilized.resolved).toBe(true);
+  expect(pc.hp).toBe(11);
+  expect(pc.retreat.pending).toBe(true);
+  expect(runtime.isDowned(pc)).toBe(false);
+  expect(pc.deathSaves).toEqual({ successes: 0, failures: 0 });
+});
+
+test("Retreat snapshots HP/SP, clears normal statuses and clamps negative SP to 0 on return", () => {
+  const { runtime } = createSandbox();
+  const pc = player({ hp: 5, sp: -20, statusEffects: {
+    burn: { id: "burn", count: 2 },
+    story_mark: { id: "story_mark", count: 1, data: { persistsThroughRetreat: true } },
+  }});
+  runtime.grantRetreat(pc);
+  const retreated = runtime.resolveRetreat(pc);
+  expect(retreated.retreated).toBe(true);
+  expect(runtime.isRetreated(pc)).toBe(true);
+  const returned = runtime.returnFromRetreat(pc);
+  expect(returned.returned).toBe(true);
+  expect(pc.hp).toBe(5);
+  expect(pc.sp).toBe(0);
+  expect(pc.statusEffects.burn).toBeUndefined();
+  expect(pc.statusEffects.story_mark).toBeTruthy();
+});
+
+test("patched CombatEngine gives only one Failure per multi-hit Skill against an already Downed target", () => {
+  const eventTags = [];
+  const engine = {
+    initializeUnitData() {},
+    applyDamage(unit, damage) { unit.hp = Math.max(0, unit.hp - damage); return { hp: unit.hp }; },
+    processStatusEffects() {},
+    triggerPhase() {},
+    triggerEvent(tag) { eventTags.push(tag); },
+    calculateAoETargets(skill, primary) { return [primary]; },
+    resolveUnilateralWithCounter(attacker, skill, defender) {
+      const context = { attacker, defender, skill };
+      for (let i = 0; i < 4; i += 1) {
+        this.applyDamage(defender, 5, "directo", false, skill);
+        this.triggerEvent("[On Hit]", context, [defender]);
+      }
+      this.triggerEvent("[Attack End]", context, [defender]);
+      return {};
+    },
+  };
+  const { runtime } = createSandbox({ combatEngine: engine });
+  const pc = player();
+  runtime.enterDowned(pc);
+  engine.resolveUnilateralWithCounter(enemy(), { id: "multi", type: "Normal" }, pc, null, {});
+  expect(pc.deathSaves.failures).toBe(1);
+  expect(eventTags.filter((tag) => tag === "[On Kill]")).toHaveLength(0);
+});
+
+test("patched Status damage produces one Failure per trigger and passive/status self-heal cannot stand a Downed unit", () => {
+  const engine = {
+    initializeUnitData() {},
+    applyDamage(unit, damage) { unit.hp = Math.max(0, unit.hp - damage); return { hp: unit.hp }; },
+    processStatusEffects(unit, trigger) { if (trigger === "regen") unit.hp += 12; },
+    triggerPhase() {},
+    triggerEvent() {},
+    calculateAoETargets(skill, primary) { return [primary]; },
+    resolveUnilateralWithCounter() { return {}; },
+  };
+  const { runtime } = createSandbox({ combatEngine: engine });
+  const pc = player();
+  runtime.enterDowned(pc);
+  engine.applyDamage(pc, 50, "efecto_estado");
+  expect(pc.deathSaves.failures).toBe(1);
+  engine.processStatusEffects(pc, "regen");
+  expect(pc.hp).toBe(0);
+  expect(runtime.isDowned(pc)).toBe(true);
+});
+
+test("Death Save resolves before Round End and a third Success Retreats in the same Turn End", () => {
+  const order = [];
+  const engine = {
+    initializeUnitData() {},
+    applyDamage(unit, damage) { unit.hp = Math.max(0, unit.hp - damage); return { hp: unit.hp }; },
+    processStatusEffects() {},
+    triggerEvent() {},
+    calculateAoETargets(skill, primary) { return [primary]; },
+    resolveUnilateralWithCounter() { return {}; },
+    triggerPhase(tag) { order.push(`original:${tag}`); },
+  };
+  const { runtime } = createSandbox({ combatEngine: engine, random: () => 0 });
+  const pc = player();
+  runtime.enterDowned(pc);
+  pc.deathSaves.successes = 2;
+  engine.triggerPhase("[Round End]", [pc]);
+  expect(order).toEqual(["original:[Round End]"]);
+  expect(runtime.isRetreated(pc)).toBe(true);
+  expect(pc.retreatSnapshot.hp).toBe(5);
+});
+
+test("Status Engine bootstraps the Death Save runtime in the real Battle Viewer load chain", () => {
+  expect(statusSource).toContain('script.id = "death-save-runtime-script"');
+  expect(statusSource).toContain('script.src = "js/death-save-runtime.js"');
+});

--- a/tests/death_save_trait_modifiers.spec.js
+++ b/tests/death_save_trait_modifiers.spec.js
@@ -1,0 +1,129 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const traitEngineSource = fs.readFileSync(path.join(__dirname, "..", "js", "trait-engine.js"), "utf8");
+const deathSaveSource = fs.readFileSync(path.join(__dirname, "..", "js", "death-save-runtime.js"), "utf8");
+
+function createSandbox() {
+  const math = Object.create(Math);
+  const sandbox = {
+    console,
+    Math: math,
+    Date,
+    JSON,
+    Object,
+    Array,
+    Set,
+    Map,
+    WeakMap,
+    Number,
+    String,
+    Boolean,
+    RegExp,
+    setInterval() { return 0; },
+    clearInterval() {},
+    dispatchEvent() { return true; },
+    CustomEvent: class CustomEvent {
+      constructor(type, init = {}) { this.type = type; this.detail = init.detail; }
+    },
+  };
+  sandbox.globalThis = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(traitEngineSource, sandbox, { filename: "trait-engine.js" });
+  vm.runInContext(deathSaveSource, sandbox, { filename: "death-save-runtime.js" });
+  return sandbox;
+}
+
+const deathSaveEdgeTrait = {
+  schemaVersion: 1,
+  id: "death_save_edge",
+  name: "Death Save Edge",
+  source: { type: "special", id: "death_save_edge" },
+  contexts: ["combat"],
+  activation: { type: "passive", actionCost: "none" },
+  effects: [
+    {
+      id: "death_save_edge_power",
+      contexts: ["combat"],
+      trigger: "before_check",
+      conditions: [{ path: "check.kind", operator: "eq", value: "death_save" }],
+      operations: [
+        { type: "modify", path: "check.finalPower", mode: "add", value: 1 },
+        { type: "modify", path: "check.difficulty", mode: "add", value: -1 },
+      ],
+    },
+  ],
+  rules: [],
+};
+
+test("Death Save ignores Stats/proficiency but accepts Trait Power and Threshold modifiers", () => {
+  const sandbox = createSandbox();
+  const runtime = sandbox.LuminousDeathSaveRuntime;
+  const unit = {
+    id: "captain-trait-check",
+    isCaptain: true,
+    hp: 0,
+    maxHp: 100,
+    lifeState: "downed",
+    isDowned: true,
+    stats: { strength: 30, fuerza: 30, constitution: 30, constitucion: 30 },
+    proficiency: 99,
+    dndStats: { proficiencyBonus: 99 },
+    traits: [deathSaveEdgeTrait],
+  };
+
+  // Exactly two Heads => base roll 8. Without Traits this fails Threshold 10.
+  const rolls = [0.1, 0.1, 0.9, 0.9, 0.9];
+  const check = runtime.rollDeathSave({ unit, rng: () => rolls.shift() });
+
+  expect(check.rolledPower).toBe(8);
+  expect(check.deathSavePower).toBe(1);
+  expect(check.deathSaveThreshold).toBe(9);
+  expect(check.total).toBe(9);
+  expect(check.passed).toBe(true);
+  expect(check.statModifier).toBe(0);
+  expect(check.proficiencyBonus).toBe(0);
+  expect(check.statModifiers).toBe(false);
+  expect(unit.deathSavePower).toBe(1);
+  expect(unit.deathSaveThreshold).toBe(9);
+});
+
+test("Death Save supports dedicated Trait channels as well as generic Check channels", () => {
+  const sandbox = createSandbox();
+  const runtime = sandbox.LuminousDeathSaveRuntime;
+  const unit = {
+    id: "captain-dedicated-check",
+    isCaptain: true,
+    hp: 0,
+    maxHp: 100,
+    lifeState: "downed",
+    isDowned: true,
+    traits: [{
+      schemaVersion: 1,
+      id: "death_save_focus",
+      name: "Death Save Focus",
+      source: { type: "special", id: "death_save_focus" },
+      contexts: ["combat"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [{
+        id: "death_save_focus_before",
+        contexts: ["combat"],
+        trigger: "before_check",
+        conditions: [{ path: "check.abilityId", operator: "eq", value: "death_save" }],
+        operations: [
+          { type: "modify", path: "check.deathSavePower", mode: "add", value: 1 },
+          { type: "modify", path: "check.deathSaveThreshold", mode: "add", value: -1 },
+        ],
+      }],
+      rules: [],
+    }],
+  };
+
+  const prepared = runtime.prepareDeathSaveCheck(unit);
+  expect(prepared.check.deathSavePower).toBe(1);
+  expect(prepared.check.deathSaveThreshold).toBe(9);
+  expect(prepared.check.kind).toBe("death_save");
+  expect(prepared.check.abilityId).toBe("death_save");
+});

--- a/tests/devil_lineage_completion.spec.js
+++ b/tests/devil_lineage_completion.spec.js
@@ -1,0 +1,209 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const traitEngine = require("../js/trait-engine.js");
+const archetypeEngine = require("../js/archetype-engine.js");
+const catalog = require("../js/archetype-trait-catalog.js");
+const anatomy = require("../js/anatomy-equipment-engine.js");
+const injuries = require("../js/injury-engine.js");
+
+const runtimeSource = fs.readFileSync(path.join(__dirname, "..", "js", "archetype-combat-event-runtime.js"), "utf8");
+const DEVIL = "path_of_the_devil_lineage";
+
+function devilUnit(level, extra = {}) {
+  return {
+    id: extra.id || `devil_${level}`,
+    hp: extra.hp ?? 100,
+    maxHp: extra.maxHp ?? 100,
+    faction: extra.faction ?? "player",
+    stats: { fuerza: 18, constitucion: 14, ...(extra.stats || {}) },
+    statusEffects: extra.statusEffects || {},
+    characterBuild: extra.characterBuild || {
+      classes: [{ classId: "barbarian", level }],
+      archetypes: [{ classId: "barbarian", archetypeId: DEVIL, selectedAtClassLevel: 15 }],
+    },
+    ...extra,
+  };
+}
+
+function combatSandbox(random = () => 0) {
+  const math = Object.create(Math);
+  math.random = random;
+  const document = {};
+  const window = {
+    document,
+    console,
+    Math: math,
+    STATUS_REGISTRY: {},
+    setInterval() {},
+    LuminousArchetypeRuntime: {
+      devilLineageLevel(unit) {
+        const build = unit?.characterBuild || {};
+        const selected = (build.archetypes || []).some((entry) => entry.archetypeId === DEVIL && entry.classId === "barbarian");
+        if (!selected) return 0;
+        return Number((build.classes || []).find((entry) => entry.classId === "barbarian")?.level || 0);
+      },
+      syncArchetypeTraitsForUnit() {},
+    },
+    LuminousTraitStandardizationRuntime: { resolveTraitRuntimeResolutions() {} },
+  };
+  window.window = window;
+  window.CombatEngine = {
+    initializeUnitData() {},
+    triggerEncounterStart() {},
+    triggerPhase() {},
+    triggerEvent(tag) {
+      if (tag === "[On Crit]") window.critEvents = (window.critEvents || 0) + 1;
+    },
+    getAllAliveUnits() { return window.units || []; },
+    applyDamage(unit, damage) { unit.hp = Math.max(0, unit.hp - damage); return { hp: unit.hp }; },
+    resolveUnilateralWithCounter(attacker, skill, defender, counterSkill, options = {}) {
+      const context = { attacker, defender, skill, targetsHit: [defender] };
+      const coins = [...(skill.coins || [])];
+      for (const coin of coins) {
+        context.currentCoin = coin;
+        this.triggerEvent("[Coin Start]", context, [defender]);
+        let critRate = 0.05;
+        Object.entries(defender.statusEffects || {}).forEach(([statusId, status]) => {
+          const config = window.STATUS_REGISTRY[statusId];
+          if (config?.crit_vulnerability_per_count) critRate += config.crit_vulnerability_per_count * Number(status?.count || 1);
+        });
+        const critical = window.Math.random() < critRate;
+        this.applyDamage(defender, 1, "directo", critical, skill);
+        this.triggerEvent("[On Hit]", context, [defender]);
+        if (critical) this.triggerEvent("[On Crit]", context, [defender]);
+        if (defender.hp <= 0) {
+          this.triggerEvent("[On Kill]", context, [defender]);
+          if (critical) this.triggerEvent("[On Crit Kill]", context, [defender]);
+        }
+        this.triggerEvent("[Current Coin Attack End]", context, [defender]);
+      }
+      this.triggerEvent("[Attack End]", context, [defender]);
+      return { attackLogs: [], pendingActions: [] };
+    },
+  };
+  vm.runInNewContext(runtimeSource, { window, console, WeakMap, Map, Set, Object, Array, Math: math }, { filename: "archetype-combat-event-runtime.js" });
+  return window;
+}
+
+test("Devil Lineage catalog carries the corrected closed-rule mechanics", () => {
+  const devilStrength = catalog.DEFINITIONS.devil_lineage_devil_strength;
+  expect(devilStrength.mechanics.twoHandedAsOneHanded).toBe(true);
+
+  const improved = catalog.DEFINITIONS.devil_lineage_improved_devil_strength;
+  expect(improved.rules).toHaveLength(2);
+  expect(improved.rules.every((rule) => rule.whileStatus === "rage")).toBe(true);
+
+  const regeneration = catalog.DEFINITIONS.devil_lineage_demonic_regeneration;
+  expect(regeneration.mechanics.bodyPartRegenerationHours).toBe(72);
+
+  const endurance = catalog.DEFINITIONS.devil_lineage_supernatural_endurance;
+  expect(endurance.effects[0].trigger).toBe("before_check");
+  expect(endurance.effects[0].operations[0]).toMatchObject({ type: "modify", path: "check.deathSavePower", mode: "add", value: 2 });
+});
+
+test("Supernatural Endurance gives +2 Death Save Power through the real Trait Check channel", () => {
+  const trait = catalog.DEFINITIONS.devil_lineage_supernatural_endurance;
+  const unit = devilUnit(50, { hp: 0, lifeState: "downed", isDowned: true });
+  const runtime = {
+    context: "combat",
+    character: unit,
+    self: unit,
+    sourceClassId: "barbarian",
+    check: { kind: "death_save", deathSavePower: 0 },
+  };
+  traitEngine.dispatchTrait(trait, "before_check", runtime, traitEngine.createState());
+  expect(runtime.check.deathSavePower).toBe(2);
+});
+
+test("Demonic Resistance cannot self-heal a Downed unit but still heals a living unit", () => {
+  const trait = catalog.DEFINITIONS.devil_lineage_demonic_resistance;
+  const downed = devilUnit(15, { hp: 0, maxHp: 100, lifeState: "downed", isDowned: true, proficiency: 2 });
+  traitEngine.dispatchTrait(trait, "turn_start", { context: "combat", character: downed, self: downed, sourceClassId: "barbarian" }, traitEngine.createState());
+  expect(downed.hp).toBe(0);
+
+  const living = devilUnit(15, { hp: 50, maxHp: 100, lifeState: "alive", isDowned: false, proficiency: 2 });
+  traitEngine.dispatchTrait(trait, "turn_start", { context: "combat", character: living, self: living, sourceClassId: "barbarian" }, traitEngine.createState());
+  expect(living.hp).toBe(54);
+});
+
+test("Devil Strength bridges into the real hand-capacity engine", () => {
+  global.LuminousArchetypeEngine = archetypeEngine;
+  delete global.LuminousDevilLineageRuntime;
+  const devilRuntime = require("../js/devil-lineage-runtime.js");
+  const unit = devilUnit(15);
+  devilRuntime.syncEquipmentRules(unit);
+
+  const items = [
+    { id: "greatsword", equipped: true, equipment: { kind: "weapon", handCost: 2 } },
+    { id: "shield", equipped: true, equipment: { kind: "shield", handCost: 1 } },
+  ];
+  const result = anatomy.validateEquipment(unit, items);
+  expect(result.valid).toBe(true);
+  expect(result.assignments.find((entry) => entry.item.id === "greatsword").partIds).toHaveLength(1);
+});
+
+test("Demonic Regeneration requires 72 continuous hours at 1+ HP and restores structural loss", () => {
+  global.LuminousArchetypeEngine = archetypeEngine;
+  global.LuminousInjuryEngine = injuries;
+  delete global.LuminousDevilLineageRuntime;
+  delete require.cache[require.resolve("../js/devil-lineage-runtime.js")];
+  const devilRuntime = require("../js/devil-lineage-runtime.js");
+  const unit = devilUnit(70, { hp: 10, maxHp: 100, injuries: [] });
+  const gained = injuries.gainInjury(unit, { ...injuries.definition("missing_hand"), affectedParts: ["left_hand"] }, { persist: false });
+  const ref = gained.injury.instanceId;
+
+  devilRuntime.advanceRegeneration(unit, 48, { persist: false });
+  expect(injuries.activeInjuries(unit).find((entry) => entry.instanceId === ref).metadata.devilLineageRegenerationHours).toBe(48);
+
+  devilRuntime.resetRegeneration(unit, { persist: false, reason: "downed" });
+  devilRuntime.advanceRegeneration(unit, 24, { persist: false });
+  expect(injuries.activeInjuries(unit).find((entry) => entry.instanceId === ref).metadata.devilLineageRegenerationHours).toBe(24);
+
+  devilRuntime.advanceRegeneration(unit, 48, { persist: false });
+  expect(injuries.activeInjuries(unit).some((entry) => entry.instanceId === ref)).toBe(false);
+  expect(unit.anatomyRuntime.parts.left_hand.state).toBe("available");
+});
+
+test("Infernal Touch adds +10% Critical Chance at half HP or less", () => {
+  const window = combatSandbox(() => 0.10);
+  const attacker = devilUnit(30, { hp: 50, maxHp: 100 });
+  const defender = { id: "target", hp: 10, maxHp: 10, faction: "enemy", statusEffects: {} };
+  window.units = [attacker, defender];
+  window.CombatEngine.resolveUnilateralWithCounter(attacker, { coinAmount: 1, coinType: "standard", coins: [{ status: "active", effects: [] }] }, defender, null, { combatants: window.units });
+  expect(window.critEvents).toBe(1);
+  expect(defender.statusEffects[window.LuminousArchetypeCombatEventRuntime.LOW_HP_CRIT_STATUS_ID]).toBeUndefined();
+});
+
+test("Infernal Touch executes the reused last Coin once per Turn for 2-3 Coin Skills", () => {
+  const window = combatSandbox(() => 0);
+  const attacker = devilUnit(30, { hp: 100, maxHp: 100 });
+  const defender = { id: "target", hp: 10, maxHp: 10, faction: "enemy", statusEffects: {} };
+  window.units = [attacker, defender];
+  const skill = { coinAmount: 2, coinType: "standard", coins: [{ status: "active", effects: [] }, { status: "active", effects: [] }] };
+
+  window.CombatEngine.resolveUnilateralWithCounter(attacker, skill, defender, null, { combatants: window.units });
+  expect(defender.hp).toBe(7);
+
+  window.CombatEngine.resolveUnilateralWithCounter(attacker, skill, defender, null, { combatants: window.units });
+  expect(defender.hp).toBe(5);
+
+  window.CombatEngine.triggerPhase("[Round Start]", window.units);
+  window.CombatEngine.resolveUnilateralWithCounter(attacker, skill, defender, null, { combatants: window.units });
+  expect(defender.hp).toBe(2);
+});
+
+test("Infernal Touch reuses a 1-Coin Skill on Critical Kill once per Turn", () => {
+  const window = combatSandbox(() => 0);
+  const attacker = devilUnit(30, { hp: 100, maxHp: 100 });
+  const killed = { id: "killed", hp: 1, maxHp: 1, faction: "enemy", statusEffects: {} };
+  const next = { id: "next", hp: 3, maxHp: 3, faction: "enemy", statusEffects: {} };
+  window.units = [attacker, killed, next];
+  const skill = { coinAmount: 1, coinType: "standard", coins: [{ status: "active", effects: [] }] };
+
+  window.CombatEngine.resolveUnilateralWithCounter(attacker, skill, killed, null, { combatants: window.units });
+  expect(killed.hp).toBe(0);
+  expect(next.hp).toBe(2);
+});

--- a/tests/fixed_damage_runtime.test.js
+++ b/tests/fixed_damage_runtime.test.js
@@ -1,0 +1,136 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function resistanceModifier(value) {
+  const v = Number(value);
+  if (v <= 0) return -0.5;
+  if (v < 1) return (v - 1) / 2;
+  return v - 1;
+}
+
+function makeCombatEngine() {
+  return {
+    createSkill(config = {}) {
+      return { name: config.name || "Skill", tipo_dano: config.tipo_dano || "cortante" };
+    },
+    calculateResistanceModifier: resistanceModifier,
+    applyPassiveModifiers(unit) {
+      return { damage_taken_multiplier: Number(unit.damageTakenModifier || 0) };
+    },
+    getOffensiveLevel(unit) {
+      return Number(unit.offensiveLevel || 0);
+    },
+    getDefensiveLevel(unit) {
+      return Number(unit.defensiveLevel || 0);
+    },
+    calculateCoinDamage(attacker, defender, skill, coinFinalPower) {
+      const defenderMods = this.applyPassiveModifiers(defender, { skill });
+      const physMod = this.calculateResistanceModifier(defender.physRes || 1);
+      const sinMod = this.calculateResistanceModifier(defender.sinRes || 1);
+      const offLevel = this.getOffensiveLevel(attacker, skill);
+      const defLevel = this.getDefensiveLevel(defender, defender);
+      const levelMod = (offLevel - defLevel) / (Math.abs(offLevel - defLevel) + 25);
+      const rawDamage = coinFinalPower * (1 + physMod + sinMod + levelMod);
+      const defMult = Math.max(0, 1 - (defenderMods.damage_taken_multiplier || 0) * 0.1);
+      return Math.max(0, Math.floor(rawDamage * defMult));
+    },
+    applyDamage(unit, damage, tipoDano = "directo") {
+      let remainingDamage = Number(damage || 0);
+      if (unit.shield > 0) {
+        const absorbed = Math.min(unit.shield, remainingDamage);
+        unit.shield -= absorbed;
+        remainingDamage -= absorbed;
+      }
+      unit.hp = Math.max(0, unit.hp - remainingDamage);
+      if (tipoDano === "directo") unit.staggerChecks = Number(unit.staggerChecks || 0) + 1;
+      return { hp: unit.hp, shield: unit.shield };
+    },
+  };
+}
+
+globalThis.CombatEngine = makeCombatEngine();
+globalThis.LuminousTraitStandardizationRuntime = Object.freeze({
+  resolveTraitRuntimeResolutions() {
+    return { originalResolution: true };
+  },
+});
+
+const runtime = require(path.resolve(__dirname, "../js/fixed-damage-runtime.js"));
+runtime.patchAll();
+
+assert.equal(runtime.normalizeDamageMode(undefined), "normal");
+assert.equal(runtime.normalizeDamageMode("Fixed"), "fixed");
+assert.equal(runtime.damageModeForSkill({ damageMode: "fixed" }), "fixed");
+assert.equal(runtime.damageModeForSkill({ tipo_dano: "cortante" }), "normal", "kinetic damage type must stay independent from damage mode");
+const createdFixedSkill = globalThis.CombatEngine.createSkill({ name: "Fixed Test", tipo_dano: "cortante", damageMode: "fixed" });
+assert.equal(createdFixedSkill.damageMode, "fixed", "CombatEngine.createSkill must preserve the canonical damageMode field");
+const createdNormalSkill = globalThis.CombatEngine.createSkill({ name: "Normal Test", tipo_dano: "perforante" });
+assert.equal(createdNormalSkill.damageMode, "normal", "skills without a mode must stay backward-compatible Normal Damage");
+
+const attacker = { offensiveLevel: 10 };
+const defendedTarget = {
+  physRes: 0.5,
+  sinRes: 0.5,
+  defensiveLevel: 30,
+  damageTakenModifier: 2,
+};
+
+const normalDamage = globalThis.CombatEngine.calculateCoinDamage(attacker, defendedTarget, { damageMode: "normal" }, 100, false, 0);
+const fixedDamage = globalThis.CombatEngine.calculateCoinDamage(attacker, defendedTarget, { damageMode: "fixed" }, 100, false, 0);
+assert.ok(normalDamage < 100, "normal damage should still be reduced by defenses");
+assert.equal(fixedDamage, 100, "fixed damage must ignore resistance, Defensive Level and Damage Taken reductions");
+
+const vulnerableTarget = {
+  physRes: 1.5,
+  sinRes: 1,
+  defensiveLevel: 0,
+  damageTakenModifier: -2,
+};
+const vulnerableFixed = globalThis.CombatEngine.calculateCoinDamage(attacker, vulnerableTarget, { damageMode: "fixed" }, 100, false, 0);
+assert.ok(vulnerableFixed > 100, "fixed damage may still benefit from vulnerabilities and other increases");
+
+const shielded = { hp: 100, shield: 30, staggerChecks: 0 };
+const applied = runtime.applyFixedDamage(shielded, 50);
+assert.equal(applied.amount, 50);
+assert.equal(shielded.shield, 0, "fixed damage does not bypass Shield");
+assert.equal(shielded.hp, 80, "only damage left after Shield reaches HP");
+assert.equal(shielded.staggerChecks, 1, "fixed damage keeps the normal direct-damage/Stagger path");
+
+const traitTarget = { hp: 100, shield: 2, staggerChecks: 0 };
+const traitRuntime = {
+  character: { stats: { fuerza: 18 } },
+  attacker: { stats: { fuerza: 18 } },
+  target: traitTarget,
+  defender: traitTarget,
+  skill: { scaling_stat: "Fuerza", tipo_dano: "cortante", damageMode: "normal" },
+  damageDealt: 50,
+};
+const trait = {
+  id: "devil_lineage_power_of_the_nine_hells",
+  mechanics: { onHitStrengthFixedDamagePercentFormula: "StrengthMod * 2" },
+};
+const standardResult = globalThis.LuminousTraitStandardizationRuntime.resolveTraitRuntimeResolutions([trait], "on_hit", traitRuntime, {});
+assert.equal(standardResult.originalResolution, true, "existing Trait standardization resolution must remain intact");
+assert.equal(traitRuntime.fixedDamageDealt, 4, "STR Mod 4 × 2% of 50 damage produces 4 Fixed Damage");
+assert.equal(traitTarget.shield, 0, "Power of the Nine Hells Fixed Damage is absorbed by Shield first");
+assert.equal(traitTarget.hp, 98, "remaining Fixed Damage reaches HP normally");
+
+const nonStrengthTarget = { hp: 100, shield: 0 };
+globalThis.LuminousTraitStandardizationRuntime.resolveTraitRuntimeResolutions([trait], "on_hit", {
+  character: { stats: { fuerza: 18 } },
+  target: nonStrengthTarget,
+  skill: { scaling_stat: "Destreza" },
+  damageDealt: 50,
+}, {});
+assert.equal(nonStrengthTarget.hp, 100, "Power of the Nine Hells must only add Fixed Damage to STR Skills");
+
+const statusPath = path.resolve(__dirname, "../js/status-engine.js");
+if (fs.existsSync(statusPath)) {
+  const statusSource = fs.readFileSync(statusPath, "utf8");
+  assert.ok(statusSource.includes('loadScript("fixed-damage-runtime-script", "js/fixed-damage-runtime.js")'), "Status Engine must bootstrap the Fixed Damage runtime");
+}
+
+console.log("Fixed Damage runtime contract: OK");

--- a/tests/injury_engine.spec.js
+++ b/tests/injury_engine.spec.js
@@ -1,0 +1,201 @@
+const { test, expect } = require("@playwright/test");
+
+const equipment = require("../js/anatomy-equipment-engine.js");
+const injuries = require("../js/injury-engine.js");
+
+function unit(maxHp = 200) {
+  return {
+    id: `unit_${Math.random()}`,
+    hp: maxHp,
+    maxHp,
+    statusEffects: {},
+    dndStats: {
+      STR: 16,
+      DEX: 18,
+      CON: 14,
+      proficiencies: [],
+      proficiencyBonus: 2,
+    },
+  };
+}
+
+test("Light and Moderate Injuries do not reduce Max HP", () => {
+  const actor = unit(200);
+  injuries.gainInjury(actor, "combat_bruising", { persist: false });
+  injuries.gainInjury(actor, "accumulated_trauma", { persist: false });
+  expect(actor.maxHp).toBe(200);
+  expect(actor.injuryMaxHpPenaltyPct).toBe(0);
+});
+
+test("each Severe Injury reduces Max HP by 5% and the global injury cap is 20%", () => {
+  const actor = unit(200);
+  const refs = [];
+  for (let index = 0; index < 5; index += 1) {
+    refs.push(injuries.gainInjury(actor, { id: `severe_${index}`, name: `Severe ${index}`, severity: "severe", recoveryHours: 100 }, { persist: false }).injury.instanceId);
+  }
+  expect(actor.maxHp).toBe(160);
+  expect(actor.injuryMaxHpPenaltyPct).toBe(0.20);
+
+  injuries.removeInjury(actor, refs[0], { persist: false });
+  expect(actor.maxHp).toBe(160);
+  injuries.removeInjury(actor, refs[1], { persist: false });
+  expect(actor.maxHp).toBe(170);
+});
+
+test("three distinct Downs before reset generate one Moderate Injury and keep overflow", () => {
+  const actor = unit();
+  const first = injuries.handleDown(actor);
+  expect(first.downCount).toBe(1);
+  expect(injuries.handleDown(actor).counted).toBe(false);
+
+  injuries.clearCurrentDown(actor);
+  injuries.handleDown(actor);
+  expect(actor.injuryState.downCount).toBe(2);
+  injuries.clearCurrentDown(actor);
+  const third = injuries.handleDown(actor);
+  expect(third.downCount).toBe(0);
+  expect(third.moderate.gained).toBe(true);
+  expect(injuries.activeInjuries(actor).map((entry) => entry.severity)).toEqual(["moderate"]);
+});
+
+test("Long Rest reset is represented by clearing Down Count, not by curing existing Injuries", () => {
+  const actor = unit();
+  injuries.handleDown(actor);
+  injuries.clearCurrentDown(actor);
+  injuries.handleDown(actor);
+  injuries.gainInjury(actor, "deep_wound", { persist: false });
+  injuries.resetDownCount(actor, { persist: false, reason: "long_rest" });
+  expect(actor.injuryState.downCount).toBe(0);
+  expect(injuries.activeInjuries(actor).some((entry) => entry.catalogId === "deep_wound")).toBe(true);
+});
+
+test("natural Stagger Threshold only creates Light Injury when Encounter finalizes", () => {
+  const actor = unit();
+  injuries.beginEncounter([actor]);
+  injuries.markNaturalStagger(actor, { crossed: 1 });
+  expect(injuries.activeInjuries(actor)).toHaveLength(0);
+  const result = injuries.finalizeEncounter([actor]);
+  expect(result[0].light.gained).toBe(true);
+  expect(injuries.activeInjuries(actor)[0].severity).toBe("light");
+});
+
+test("higher automatic severity replaces lower automatic Injury from the same Encounter", () => {
+  const actor = unit();
+  injuries.beginEncounter([actor]);
+  injuries.gainAutomaticInjury(actor, "moderate", { trigger: "down_count" });
+  expect(injuries.activeInjuries(actor).map((entry) => entry.severity)).toEqual(["moderate"]);
+  injuries.handleDeath(actor, { reason: "death" });
+  expect(injuries.activeInjuries(actor).map((entry) => entry.severity)).toEqual(["severe"]);
+});
+
+test("Death records Severe Injury before revival and revival does not remove it", () => {
+  const actor = unit(200);
+  const death = injuries.handleDeath(actor, { reason: "impalement" });
+  expect(death.gained).toBe(true);
+  expect(death.injury.severity).toBe("severe");
+  expect(actor.maxHp).toBe(190);
+  injuries.clearCurrentDown(actor);
+  expect(injuries.activeInjuries(actor)).toHaveLength(1);
+});
+
+test("world hours reduce remaining recovery time without requiring a Rest type", () => {
+  const actor = unit();
+  const gained = injuries.gainInjury(actor, "cracked_ribs", { persist: false });
+  const ref = gained.injury.instanceId;
+  injuries.advanceRecovery(actor, 10, { persist: false });
+  expect(injuries.activeInjuries(actor).find((entry) => entry.instanceId === ref).remainingRecoveryHours).toBe(38);
+  injuries.advanceRecovery(actor, 38, { persist: false });
+  expect(injuries.activeInjuries(actor).some((entry) => entry.instanceId === ref)).toBe(false);
+});
+
+test("medicine and Treatment reduce hours and may cure a normal Injury in minutes", () => {
+  const actor = unit();
+  const gained = injuries.gainInjury(actor, "deep_wound", { persist: false });
+  const ref = gained.injury.instanceId;
+  const reduced = injuries.treatInjury(actor, ref, { reducePercent: 50 });
+  expect(reduced.after).toBe(9);
+  const cured = injuries.treatInjury(actor, ref, { cure: true, method: "advanced_treatment" });
+  expect(cured.cured).toBe(true);
+});
+
+test("Structural loss never heals from elapsed hours or ordinary treatment", () => {
+  const actor = unit();
+  const gained = injuries.gainInjury(actor, { ...injuries.definition("missing_hand"), affectedParts: ["left_hand"] }, { persist: false });
+  const ref = gained.injury.instanceId;
+  injuries.advanceRecovery(actor, 10000, { persist: false });
+  expect(injuries.activeInjuries(actor).some((entry) => entry.instanceId === ref)).toBe(true);
+  const normal = injuries.treatInjury(actor, ref, { cure: true, method: "medical_treatment" });
+  expect(normal.treated).toBe(false);
+  const replacement = injuries.treatInjury(actor, ref, { cure: true, method: "replacement" });
+  expect(replacement.cured).toBe(true);
+});
+
+test("Missing Arm disables the whole Arm-Hand-Finger chain and invalid equipment is sent to Loot", () => {
+  const actor = unit();
+  const sword = { id: "sword", equipped: true, equipment: { kind: "weapon", handCost: 1 } };
+  const greatsword = { id: "greatsword", equipped: true, equipment: { kind: "weapon", handCost: 2 } };
+  actor.equipment = [sword, greatsword];
+  global.LuminousCombatLootPool = [];
+
+  injuries.gainInjury(actor, { ...injuries.definition("missing_arm"), affectedParts: ["left_arm"] }, { persist: false });
+  expect(actor.anatomyRuntime.parts.left_arm.state).toBe("missing");
+  expect(actor.anatomyRuntime.parts.left_hand.state).toBe("missing");
+  expect(actor.anatomyRuntime.parts.left_finger_1.state).toBe("missing");
+  expect(global.LuminousCombatLootPool.some((item) => item.id === "greatsword")).toBe(true);
+});
+
+test("Missing Hand does not disable its parent Arm", () => {
+  const actor = unit();
+  injuries.gainInjury(actor, { ...injuries.definition("missing_hand"), affectedParts: ["left_hand"] }, { persist: false });
+  expect(actor.anatomyRuntime.parts.left_arm.state).toBe("available");
+  expect(actor.anatomyRuntime.parts.left_hand.state).toBe("missing");
+  expect(actor.anatomyRuntime.parts.left_finger_5.state).toBe("missing");
+});
+
+test("Injury modifiers feed Speed, Evade Power and D&D-style physical checks", () => {
+  const actor = unit();
+  injuries.gainInjury(actor, "damaged_knee", { persist: false });
+  const modifiers = injuries.collectModifiers(actor);
+  expect(modifiers.speed).toBe(-1);
+  expect(modifiers.evade_power).toBe(-2);
+  expect(injuries.checkPenalty(actor, "DEX", null)).toBe(-2);
+});
+
+test("CombatEngine bridge detects natural threshold crossing and merges Injury modifiers", () => {
+  const actor = unit();
+  actor.staggerThresholds = [50];
+  actor.crossedThresholds = [false];
+  actor.hp = 40;
+  const combat = {
+    checkStagger(target) {
+      const pct = (target.hp / target.maxHp) * 100;
+      if (pct <= target.staggerThresholds[0]) target.crossedThresholds[0] = true;
+    },
+    triggerEncounterStart() {},
+    initializeUnitData() {},
+    applyPassiveModifiers() { return { speed: 0, evade_power: 0 }; },
+    calculateDndBonus() { return 4; },
+  };
+  injuries.wrapCombatEngine(combat);
+  combat.triggerEncounterStart([actor]);
+  combat.checkStagger(actor);
+  expect(actor.injuryState.encounter.naturalStaggerCrossed).toBe(true);
+
+  injuries.gainInjury(actor, "damaged_knee", { persist: false });
+  expect(combat.applyPassiveModifiers(actor).speed).toBe(-1);
+  expect(combat.applyPassiveModifiers(actor).evade_power).toBe(-2);
+  expect(combat.calculateDndBonus(actor, "DEX", null)).toBe(2);
+});
+
+test("Dante Clock Windup removes Injuries, restores Max HP and resets Down Count", () => {
+  const actor = unit(200);
+  injuries.handleDown(actor);
+  injuries.gainInjury(actor, { ...injuries.definition("missing_arm"), affectedParts: ["left_arm"] }, { persist: false });
+  expect(actor.maxHp).toBe(190);
+  const result = injuries.clearForDanteClock(actor);
+  expect(result.cleared).toBe(true);
+  expect(injuries.activeInjuries(actor)).toHaveLength(0);
+  expect(actor.injuryState.downCount).toBe(0);
+  expect(actor.maxHp).toBe(200);
+  expect(actor.anatomyRuntime.parts.left_arm.state).toBe("available");
+});

--- a/tests/injury_equipment_runtime.spec.js
+++ b/tests/injury_equipment_runtime.spec.js
@@ -1,0 +1,56 @@
+const { test, expect } = require("@playwright/test");
+
+const injuries = require("../js/injury-engine.js");
+const runtime = require("../js/injury-equipment-runtime.js");
+
+test("Severe Injury also reduces player combatStats.hp_max while Light and Moderate do not", () => {
+  const actor = { id: "hp_sheet", maxHp: 200, hp: 200, combatStats: { hp_max: 200, hp_actual: 200 }, statusEffects: {} };
+  injuries.gainInjury(actor, "combat_bruising", { persist: false });
+  runtime.syncCombatStatsMaxHp(actor);
+  expect(actor.combatStats.hp_max).toBe(200);
+
+  injuries.gainInjury(actor, "accumulated_trauma", { persist: false });
+  runtime.syncCombatStatsMaxHp(actor);
+  expect(actor.combatStats.hp_max).toBe(200);
+
+  const severe = injuries.gainInjury(actor, "severe_trauma", { persist: false });
+  runtime.syncCombatStatsMaxHp(actor);
+  expect(actor.combatStats.hp_max).toBe(190);
+  expect(actor.combatStats.hp_actual).toBe(190);
+
+  injuries.removeInjury(actor, severe.injury.instanceId, { persist: false });
+  runtime.syncCombatStatsMaxHp(actor);
+  expect(actor.combatStats.hp_max).toBe(200);
+  expect(actor.combatStats.hp_actual).toBe(190);
+});
+
+test("Missing Eye has no universal Perception penalty after monocular compensation", () => {
+  const actor = { id: "one_eye", maxHp: 100, hp: 100, statusEffects: {} };
+  injuries.gainInjury(actor, { ...injuries.definition("missing_eye"), affectedParts: ["left_eye"] }, { persist: false });
+  expect(injuries.checkPenalty(actor, "DEX", "Perception")).toBe(-2);
+  expect(runtime.missingEyePerceptionCompensation(actor, "Perception")).toBe(2);
+});
+
+test("Loot bridge clears the original Firebase-shaped equipment object instead of only its validation copy", () => {
+  const actor = {
+    equipment: {
+      sword_key: { id: "sword", equipped: true, equipped_slot: "arma_principal", equipment: { kind: "weapon" } },
+    },
+  };
+  global.LuminousCombatLootPool = [{ key: "sword_key", id: "sword", equipped: false }];
+  const changed = runtime.syncLootDropsBackToSource(actor);
+  expect(changed).toBe(1);
+  expect(actor.equipment.sword_key.equipped).toBe(false);
+  expect(actor.equipment.sword_key.equipped_slot).toBeNull();
+});
+
+test("Firebase combatant transition from populated to empty finalizes tracked Encounter", () => {
+  const actor = { id: "finalize_me", maxHp: 100, hp: 40, statusEffects: {} };
+  injuries.beginEncounter([actor]);
+  injuries.markNaturalStagger(actor);
+  runtime.trackUnit(actor);
+  const result = runtime.finalizeTrackedEncounter();
+  expect(result).toHaveLength(1);
+  expect(injuries.activeInjuries(actor).some((injury) => injury.severity === "light")).toBe(true);
+  expect(actor.injuryState.encounter.active).toBe(false);
+});

--- a/tests/rest_engine.spec.js
+++ b/tests/rest_engine.spec.js
@@ -1,0 +1,194 @@
+const { test, expect } = require("@playwright/test");
+
+const traitEngine = require("../js/trait-engine.js");
+const restEngine = require("../js/rest-engine.js");
+const catalog = require("../js/archetype-trait-catalog.js");
+
+function character(levels = { barbarian: 20 }, hp = 500, currentHp = 100) {
+  return {
+    characterBuild: {
+      classes: Object.entries(levels).map(([classId, level]) => ({ classId, level })),
+      calculatedAtLevel: Object.values(levels).reduce((sum, level) => sum + level, 0),
+    },
+    combatStats: { hp_max: hp, hp_actual: currentHp },
+  };
+}
+
+test("Recover Slots escalan por Class Level cada 5 niveles y conservan pools separados", () => {
+  const unit = character({ barbarian: 20, wizard: 10 });
+  expect(restEngine.recoverPool(unit, "barbarian")).toMatchObject({ classLevel: 20, classBaseHp: 12, maximum: 4, available: 4 });
+  expect(restEngine.recoverPool(unit, "wizard")).toMatchObject({ classLevel: 10, classBaseHp: 6, maximum: 2, available: 2 });
+});
+
+test("Recover usa HP plano 5 + Class Base HP por slot", () => {
+  const unit = character({ barbarian: 20 });
+  const result = restEngine.performRecover(unit, "barbarian", 3, { context: "short_rest" });
+  expect(result.success).toBe(true);
+  expect(result.flatBonus).toBe(5);
+  expect(result.classBaseHp).toBe(12);
+  expect(result.calculatedHp).toBe(41);
+  expect(unit.combatStats.hp_actual).toBe(141);
+  expect(restEngine.recoverPool(unit, "barbarian").available).toBe(1);
+});
+
+test("el +5 se aplica por acción Recover, no por slot", () => {
+  const split = character({ barbarian: 20 });
+  const combined = character({ barbarian: 20 });
+  restEngine.performRecover(split, "barbarian", 1, { context: "short_rest" });
+  restEngine.performRecover(split, "barbarian", 1, { context: "short_rest" });
+  restEngine.performRecover(combined, "barbarian", 2, { context: "short_rest" });
+  expect(split.combatStats.hp_actual).toBe(134);
+  expect(combined.combatStats.hp_actual).toBe(129);
+});
+
+test("sólo Augments de Short Rest aportan Max HP y su suma tiene cap global de 5%", () => {
+  const unit = character({ barbarian: 20 });
+  unit.augmentations = [
+    { id: "augment_a", mechanics: { shortRestRecoveryPercent: 3 } },
+    { id: "augment_b", mechanics: { shortRestRecoveryPercent: 4 } },
+  ];
+  const result = restEngine.performRecover(unit, "barbarian", 1, { context: "short_rest" });
+  expect(result.augmentPercentRaw).toBe(7);
+  expect(result.augmentPercentApplied).toBe(5);
+  expect(result.augmentHp).toBe(25);
+  expect(result.calculatedHp).toBe(42);
+
+  const combatRecover = character({ barbarian: 20 });
+  combatRecover.augmentations = unit.augmentations;
+  const combatResult = restEngine.performRecover(combatRecover, "barbarian", 1, { context: "combat" });
+  expect(combatResult.augmentPercentApplied).toBe(0);
+  expect(combatResult.calculatedHp).toBe(17);
+});
+
+test("Short Rest dura 1-2 horas, no devuelve Recover Slots y puede ejecutar múltiples Recover", () => {
+  const unit = character({ barbarian: 20, wizard: 10 });
+  const result = restEngine.performShortRest(unit, {
+    hours: 2,
+    recovers: [
+      { classId: "barbarian", slots: 1 },
+      { classId: "wizard", slots: 1 },
+    ],
+  });
+  expect(result.success).toBe(true);
+  expect(result.worldHoursAdvanced).toBe(2);
+  expect(result.recovers).toHaveLength(2);
+  expect(restEngine.recoverPool(unit, "barbarian").available).toBe(3);
+  expect(restEngine.recoverPool(unit, "wizard").available).toBe(1);
+
+  const secondShortRest = restEngine.performShortRest(unit, { hours: 1 });
+  expect(secondShortRest.success).toBe(true);
+  expect(restEngine.recoverPool(unit, "barbarian").available).toBe(3);
+});
+
+test("Short Rest preflight evita gasto parcial cuando se solicitan más slots de los disponibles", () => {
+  const unit = character({ barbarian: 5 });
+  const result = restEngine.performShortRest(unit, {
+    hours: 1,
+    recovers: [
+      { classId: "barbarian", slots: 1 },
+      { classId: "barbarian", slots: 1 },
+    ],
+  });
+  expect(result.success).toBe(false);
+  expect(restEngine.recoverPool(unit, "barbarian").available).toBe(1);
+  expect(unit.combatStats.hp_actual).toBe(100);
+});
+
+test("Short Rest sólo recupera usos de Traits que lo declaran explícitamente", () => {
+  const unit = character({ barbarian: 20 });
+  const state = traitEngine.createState();
+  state.usages.partial = { used: 3, reset: "never" };
+  state.usages.all_short = { used: 2, reset: "short_rest" };
+  state.usages.long_only = { used: 4, reset: "never" };
+  const traits = [
+    { id: "partial", activation: { type: "manual", actionCost: "none", uses: { max: 3, recoverOnShortRest: 1 } }, contexts: ["any"], effects: [], rules: [] },
+    { id: "all_short", activation: { type: "manual", actionCost: "none", uses: { max: 2, reset: "short_rest" } }, contexts: ["any"], effects: [], rules: [] },
+    { id: "long_only", activation: { type: "manual", actionCost: "none", uses: { max: 4 } }, contexts: ["any"], effects: [], rules: [] },
+  ];
+  const result = restEngine.performShortRest(unit, { hours: 1, traits, traitState: state });
+  expect(result.success).toBe(true);
+  expect(state.usages.partial.used).toBe(2);
+  expect(state.usages.all_short.used).toBe(0);
+  expect(state.usages.long_only.used).toBe(4);
+});
+
+test("Long Rest dura 6-8 horas, cura Full HP, devuelve Recover Slots y todos los usos de Traits", () => {
+  const unit = character({ barbarian: 20 }, 500, 25);
+  restEngine.performRecover(unit, "barbarian", 3, { context: "short_rest" });
+  unit.combatStats.hp_actual = 25;
+  const state = traitEngine.createState();
+  state.usages.a = { used: 2, reset: "never" };
+  state.usages.b = { used: 1, reset: "encounter" };
+  const result = restEngine.performLongRest(unit, { hours: 7, traitState: state, traits: [] });
+  expect(result.success).toBe(true);
+  expect(result.worldHoursAdvanced).toBe(7);
+  expect(unit.combatStats.hp_actual).toBe(500);
+  expect(restEngine.recoverPool(unit, "barbarian").available).toBe(4);
+  expect(state.usages.a.used).toBe(0);
+  expect(state.usages.b.used).toBe(0);
+});
+
+test("Long Rest no tiene cooldown: el límite narrativo es el tiempo mundial consumido", () => {
+  const unit = character({ barbarian: 20 }, 500, 1);
+  const first = restEngine.performLongRest(unit, { hours: 6 });
+  unit.combatStats.hp_actual = 1;
+  const second = restEngine.performLongRest(unit, { hours: 8 });
+  expect(first.success).toBe(true);
+  expect(second.success).toBe(true);
+  expect(first.worldHoursAdvanced).toBe(6);
+  expect(second.worldHoursAdvanced).toBe(8);
+  expect(unit.combatStats.hp_actual).toBe(500);
+});
+
+test("Recover Slot bloqueado por Improved Demonic Resistance requiere 2 Long Rests completos", () => {
+  const unit = character({ barbarian: 50 });
+  const recover = restEngine.performRecover(unit, "barbarian", 1, {
+    context: "combat",
+    includeAugments: false,
+    blockLongRests: 2,
+    sourceTraitId: "devil_lineage_improved_demonic_resistance",
+  });
+  expect(recover.success).toBe(true);
+  expect(restEngine.recoverPool(unit, "barbarian")).toMatchObject({ maximum: 10, available: 9, blocked: 1 });
+
+  restEngine.performLongRest(unit, { hours: 6 });
+  expect(restEngine.recoverPool(unit, "barbarian").blockedSlots[0].remainingLongRests).toBe(1);
+  expect(restEngine.recoverPool(unit, "barbarian").available).toBe(9);
+
+  restEngine.performLongRest(unit, { hours: 6 });
+  expect(restEngine.recoverPool(unit, "barbarian")).toMatchObject({ maximum: 10, available: 10, blocked: 0 });
+});
+
+test("Improved Demonic Resistance usa el Recover Engine real y se bloquea sin slots", () => {
+  const restRuntime = require("../js/rest-runtime-integration.js");
+  restRuntime.install();
+  const integratedTraitEngine = global.LuminousTraitEngine;
+  const trait = catalog.allDefinitions().devil_lineage_improved_demonic_resistance;
+  const unit = character({ barbarian: 50 }, 200, 50);
+  const combatSelf = { hp: 50, maxHp: 200, characterBuild: unit.characterBuild };
+  global.datosJugador = unit;
+  const state = integratedTraitEngine.createState();
+  const result = integratedTraitEngine.activateTrait(trait, { context: "combat", character: unit, self: combatSelf }, state);
+  expect(result.available).toBe(true);
+  expect(result.restRecover).toMatchObject({ calculatedHp: 17, slotsUsed: 1, blockedForLongRests: 2 });
+  expect(combatSelf.hp).toBe(67);
+  expect(restEngine.recoverPool(unit, "barbarian").blocked).toBe(1);
+
+  const lowLevel = character({ barbarian: 4 }, 100, 50);
+  global.datosJugador = lowLevel;
+  const blocked = integratedTraitEngine.canActivateTrait(trait, { context: "combat", character: lowLevel, self: lowLevel }, integratedTraitEngine.createState());
+  expect(blocked.available).toBe(false);
+  expect(blocked.reasons.join(" ")).toContain("0 Recover Slot");
+  delete global.datosJugador;
+});
+
+test("duraciones fuera de rango son rechazadas", () => {
+  expect(restEngine.validateRestHours("short_rest", 0.5).valid).toBe(false);
+  expect(restEngine.validateRestHours("short_rest", 1).valid).toBe(true);
+  expect(restEngine.validateRestHours("short_rest", 2).valid).toBe(true);
+  expect(restEngine.validateRestHours("short_rest", 3).valid).toBe(false);
+  expect(restEngine.validateRestHours("long_rest", 5).valid).toBe(false);
+  expect(restEngine.validateRestHours("long_rest", 6).valid).toBe(true);
+  expect(restEngine.validateRestHours("long_rest", 8).valid).toBe(true);
+  expect(restEngine.validateRestHours("long_rest", 9).valid).toBe(false);
+});

--- a/tests/rest_runtime_contract.spec.js
+++ b/tests/rest_runtime_contract.spec.js
@@ -1,0 +1,43 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
+const statusEngine = read("js/status-engine.js");
+const restEngine = read("js/rest-engine.js");
+const restRuntime = read("js/rest-runtime-integration.js");
+const docs = read("docs/rest-system.md");
+
+test("Status Engine bootstrap carga Rest Engine e integración de runtime", () => {
+  expect(statusEngine).toContain("rest-engine-script");
+  expect(statusEngine).toContain("js/rest-engine.js");
+  expect(statusEngine).toContain("rest-runtime-integration-script");
+  expect(statusEngine).toContain("js/rest-runtime-integration.js");
+});
+
+test("Rest Engine usa hpPer5 de Character Build Rules como Class Base HP", () => {
+  expect(restEngine).toContain("definition?.hpPer5");
+  expect(restEngine).toContain("Math.floor(getClassLevel(character, classId) / RECOVER_LEVEL_INTERVAL)");
+  expect(restEngine).toContain("RECOVER_FLAT_BONUS + (classBaseHp * count)");
+});
+
+test("Augments tienen cap global 5% y sólo se aplican en short_rest", () => {
+  expect(restEngine).toContain("SHORT_REST_AUGMENT_MAX_HP_PERCENT_CAP = 5");
+  expect(restEngine).toContain('context === "short_rest"');
+  expect(restEngine).toContain("mechanics.shortRestRecoveryPercent");
+});
+
+test("Runtime conecta Traits de Recover inmediato y bloqueo multi-Long-Rest", () => {
+  expect(restRuntime).toContain("spendRecoverSlot");
+  expect(restRuntime).toContain("performRecoverImmediately");
+  expect(restRuntime).toContain("blockUsedRecoverSlotLongRests");
+  expect(restRuntime).toContain('context: "combat"');
+  expect(restRuntime).toContain("includeAugments: false");
+});
+
+test("Rest Runtime expone avance de tiempo sin imponer cooldown ni calendario propio", () => {
+  expect(restRuntime).toContain("luminous:world-time-advance-requested");
+  expect(restRuntime).toContain("worldHoursAdvanced");
+  expect(docs).toContain("no daily cooldown");
+  expect(docs).toContain("world time");
+});


### PR DESCRIPTION
## Summary
- Adds a generic Archetype engine keyed by Class Level.
- Adds per-Class Archetype selections for multiclass characters under `characterBuild.archetypes`.
- Adds Path of the Devil Lineage Trait catalog and grants at Barbarian Class Levels 15/30/50/70.
- Integrates Archetype Traits into the existing Trait runtime and Stats > Traits UI.
- Adds Archetype subtabs when more than one Archetype is present so multiclass Traits do not mix visually.
- Adds player selector UI, Flight capability bridge, Active Inventory integration, Theatre checks, and Combat hooks required by the current archetype rules.
- Adds a shared Combat lifecycle runtime for **Downed, Death Saves, Death, Sinner Death and Retreat**, loaded through the real Battle Viewer Status Engine bootstrap.
- Adds the shared **Rest / Recover runtime** for class-based Recover Slots, Short Rest, Long Rest, Short-Rest Augments and Trait-use recovery.
- Connects **Improved Demonic Resistance** to the real Recover resource, including its two-Long-Rest blocked-slot rule.
- Exposes rest-completion/world-time events so the future dynamic world/faction clock can advance without Rest Engine inventing a separate calendar schema.
- Adds dedicated regression tests and extends the Archetype Engine workflow to gate the combined patch.

## Rest / Recover rules included in this patch

### Recover Slots
- Recover Slots belong to each **Class**, not Character Level.
- `Max Recover Slots = floor(Class Level / 5)`.
- Multiclass characters maintain independent Recover pools for every Class.
- Recover uses the Class Base HP already defined as `hpPer5` in `js/character-build-rules.js`.
- A normal spent Recover Slot is restored only by Long Rest.
- Traits may explicitly block a Recover Slot across multiple completed Long Rests.

### Recover action
- Each Recover action chooses one Class and spends one or more available Recover Slots from that Class.
- `Recovered HP = 5 + (Class Base HP × Recover Slots spent in that Recover action)`.
- The flat `+5` is applied once per Recover action, not once per slot.
- Healing is capped at Max HP.

### Short Rest
- Duration: **1–2 in-world hours**; DM and players choose the exact duration within that range.
- Short Rest does **not** restore Recover Slots.
- Players may make one or more Recover actions using their remaining class pools.
- Trait uses only recover if the Trait explicitly opts in:
  - `[On Short Rest] Recover X Uses.` → `activation.uses.recoverOnShortRest: X`
  - `[On Short Rest] Recover All Uses.` → `activation.uses.reset: "short_rest"`
- Existing Trait `short_rest` triggers are dispatched when the rest completes.

### Short-Rest Augments
- Only **Augments** may add Max-HP-based healing to a Short Rest Recover.
- Canonical declaration: `mechanics.shortRestRecoveryPercent: X`.
- All applicable Augment percentages are added together, then capped globally at **5% Max HP**.
- The 5% cap is global, not per Augment.
- Augment percentage healing applies only in `short_rest` context; a combat Recover does not receive it.

### Long Rest
- Duration: **6–8 in-world hours**; DM and players choose the exact duration within that range.
- Restores HP to Max HP.
- Restores all normally spent Recover Slots.
- Restores all Trait uses.
- Executes existing `long_rest` Trait trigger/reset behavior.
- Advances blocked Recover Slot counters instead of bypassing their explicit lock duration.
- There is intentionally **no daily cooldown / once-per-24-hours restriction**. Consecutive Long Rests are allowed; their balancing cost is the 6–8 hours of world time consumed while factions, opportunities, EXP sources and resources may continue changing.

### World-time contract
- Successful rests expose `worldHoursAdvanced` and emit:
  - `luminous:rest-completed`
  - `luminous:world-time-advance-requested`
- Rest Engine does not invent or directly mutate a campaign calendar. The dynamic-world/time subsystem can consume the emitted exact duration.

### Improved Demonic Resistance
- Uses the existing Archetype metadata instead of introducing a special duplicate rule.
- Before activation, the runtime verifies that the Barbarian Recover pool has an available slot.
- On success, the Quick Action spends 1 real Recover Slot and immediately performs a normal 1-slot Recover.
- Short-Rest Augment bonuses are not applied because this Recover occurs in combat.
- The used Recover Slot remains unavailable until **2 Long Rests have been completed**.

## Death / Downed rules included in this patch
- **Player Characters** and enemy units explicitly marked **Captain** use Downed + Death Saves.
- Ordinary enemies die immediately at 0 HP.
- Downed units remain targetable but cannot act normally.
- Death Save uses the existing Check/Coin contract: **5 Coins, Coin Power 4, flat, Threshold 10, no Stat modifiers**.
- Success and Failure counters are separate and reset whenever a unit leaves Downed.
- **3 Successes:** recover 5% Max HP, gain Retreat, then Retreat resolves at Turn End.
- **3 Failures:** immediate actual Death and `on_death` dispatch.
- A Skill/Spell that reduces an eligible unit to 0 HP still allows the existing `[On Kill]` trigger for the takedown; actual Death does not create a second Kill.
- Hitting a unit that was already Downed gives **+1 Failure per Skill per target**, not per Coin/Hit. Multi-target attacks can give one Failure to each Downed target hit.
- Damaging Status triggers while Downed give **+1 Failure per trigger**. Being Downed by Status damage starts with +1 Failure. Indirect Status damage does not receive Skill/Spell `[On Kill]` credit.
- Self/passive regeneration while Downed is negated. External healing stabilizes the unit, applies the Heal amount, removes Downed and clears Death Save counters.
- Dead units cannot be restored by normal healing; explicit Revival/Resurrection is required.
- Death never deletes a character record automatically. The character remains marked Dead until revived or explicitly retired/deleted by the DM.
- The special **Sinner** identity is recognized by Trait id `sinner`: Player Sinners still make Death Saves, but actual Death resolves as Sinner Death rather than normal permanent-death consequences.
- Retreat snapshots HP/SP and released Slots, clears Stagger except forced Stagger, queues retreat order, preserves explicitly marked effects, clamps negative SP to 0 on return, and enforces FIFO return order.

## Runtime integration
- `js/death-save-runtime.js` owns the explicit `alive | downed | dead | retreated` lifecycle and exposes CombatEngine helpers for targeting, healing, revival, Death Saves and Retreat return.
- `js/rest-engine.js` owns the canonical Recover pools, Recover formula, rest durations, Augment cap, HP application, Trait-use recovery and blocked-slot counters.
- `js/rest-runtime-integration.js` bridges the Rest Engine into Trait activation, player persistence and world-time events.
- `js/status-engine.js` bootstraps Character Build Rules, Rest Engine/bridge, Archetype runtime and Death Save runtime for shared Battle Viewer/player use.
- Existing CombatEngine/TraitEngine hooks are wrapped instead of duplicating their state machines.
- Player Rest state persists under the existing player record as `restResources`.
- Full rule contract is documented in `docs/rest-system.md`.

## Test gate
The combined patch is gated by the existing PR workflows plus dedicated Death Save and Rest/Recover regression suites.

### Targeted tests
- `tests/death_save_runtime.spec.js`
- `tests/archetype_engine.spec.js`
- `tests/archetype_runtime_contract.spec.js`
- `tests/archetype_review_regressions.spec.js`
- `tests/rest_engine.spec.js`
- `tests/rest_runtime_contract.spec.js`
- `tests/trait_engine.spec.js`
- `tests/player_trait_tabs.spec.js`
- `tests/barbarian_trait_rules_runtime.spec.js`
- `tests/universal_modifier_engine.spec.js`
- `tests/universal_speed_runtime.spec.js`
- `tests/trait_standardization_review_fixes.spec.js`

### Syntax checks
- `js/status-engine.js`
- `js/death-save-runtime.js`
- `js/archetype-engine.js`
- `js/archetype-trait-catalog.js`
- `js/player-archetype-runtime.js`
- `js/archetype-combat-event-runtime.js`
- `js/rest-engine.js`
- `js/rest-runtime-integration.js`
- `js/utils.js`
- Death/Archetype/Rest test files
