### PR TITLE
Add Bard College of Whispers archetype

### DIFF
--- a/.github/workflows/archetype-engine.yml
+++ b/.github/workflows/archetype-engine.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "Battle-viewer.html"
       - "js/status-engine.js"
+      - "js/spellcasting-runtime.js"
       - "js/fixed-damage-runtime.js"
       - "js/death-save-runtime.js"
       - "js/anatomy-equipment-engine.js"
@@ -16,6 +17,7 @@ on:
       - "js/player-archetype-runtime.js"
       - "js/archetype-combat-event-runtime.js"
       - "js/devil-lineage-runtime.js"
+      - "js/college-of-whispers-runtime.js"
       - "js/rest-engine.js"
       - "js/rest-runtime-integration.js"
       - "css/player-archetype-runtime.css"
@@ -31,6 +33,8 @@ on:
       - "tests/archetype_runtime_contract.spec.js"
       - "tests/archetype_review_regressions.spec.js"
       - "tests/devil_lineage_completion.spec.js"
+      - "tests/spellcasting_runtime.spec.js"
+      - "tests/college_of_whispers_runtime.spec.js"
       - "tests/rest_engine.spec.js"
       - "tests/rest_runtime_contract.spec.js"
       - "tests/fixed_damage_runtime.test.js"
@@ -39,6 +43,7 @@ on:
     paths:
       - "Battle-viewer.html"
       - "js/status-engine.js"
+      - "js/spellcasting-runtime.js"
       - "js/fixed-damage-runtime.js"
       - "js/death-save-runtime.js"
       - "js/anatomy-equipment-engine.js"
@@ -48,6 +53,7 @@ on:
       - "js/player-archetype-runtime.js"
       - "js/archetype-combat-event-runtime.js"
       - "js/devil-lineage-runtime.js"
+      - "js/college-of-whispers-runtime.js"
       - "js/rest-engine.js"
       - "js/rest-runtime-integration.js"
       - "css/player-archetype-runtime.css"
@@ -63,6 +69,8 @@ on:
       - "tests/archetype_runtime_contract.spec.js"
       - "tests/archetype_review_regressions.spec.js"
       - "tests/devil_lineage_completion.spec.js"
+      - "tests/spellcasting_runtime.spec.js"
+      - "tests/college_of_whispers_runtime.spec.js"
       - "tests/rest_engine.spec.js"
       - "tests/rest_runtime_contract.spec.js"
       - "tests/fixed_damage_runtime.test.js"
@@ -90,6 +98,7 @@ jobs:
       - name: Check syntax
         run: |
           node --check js/status-engine.js
+          node --check js/spellcasting-runtime.js
           node --check js/fixed-damage-runtime.js
           node --check js/death-save-runtime.js
           node --check js/anatomy-equipment-engine.js
@@ -99,6 +108,7 @@ jobs:
           node --check js/player-archetype-runtime.js
           node --check js/archetype-combat-event-runtime.js
           node --check js/devil-lineage-runtime.js
+          node --check js/college-of-whispers-runtime.js
           node --check js/rest-engine.js
           node --check js/rest-runtime-integration.js
           node --check js/utils.js
@@ -110,6 +120,8 @@ jobs:
           node --check tests/archetype_runtime_contract.spec.js
           node --check tests/archetype_review_regressions.spec.js
           node --check tests/devil_lineage_completion.spec.js
+          node --check tests/spellcasting_runtime.spec.js
+          node --check tests/college_of_whispers_runtime.spec.js
           node --check tests/rest_engine.spec.js
           node --check tests/rest_runtime_contract.spec.js
           node --check tests/fixed_damage_runtime.test.js
@@ -128,6 +140,8 @@ jobs:
           tests/archetype_runtime_contract.spec.js
           tests/archetype_review_regressions.spec.js
           tests/devil_lineage_completion.spec.js
+          tests/spellcasting_runtime.spec.js
+          tests/college_of_whispers_runtime.spec.js
           tests/rest_engine.spec.js
           tests/rest_runtime_contract.spec.js
           tests/trait_engine.spec.js

--- a/.github/workflows/trait-engine.yml
+++ b/.github/workflows/trait-engine.yml
@@ -10,7 +10,10 @@ on:
       - "database.rules.json"
       - "js/trait-engine.js"
       - "js/trait-catalog-core.js"
+      - "js/spellcasting-runtime.js"
       - "js/bard-class-runtime.js"
+      - "js/archetype-trait-catalog.js"
+      - "js/college-of-whispers-runtime.js"
       - "js/racial-trait-catalog.js"
       - "js/racial-trait-runtime-bridge.js"
       - "js/status-engine.js"
@@ -32,7 +35,9 @@ on:
       - "tests/trait_engine.spec.js"
       - "tests/trait_engine_codex_regressions.spec.js"
       - "tests/trait_catalog_core.spec.js"
+      - "tests/spellcasting_runtime.spec.js"
       - "tests/bard_class_runtime.spec.js"
+      - "tests/college_of_whispers_runtime.spec.js"
       - "tests/racial_trait_catalog.spec.js"
       - "tests/racial_trait_engine_regressions.spec.js"
       - "tests/player_trait_tabs.spec.js"
@@ -68,7 +73,10 @@ jobs:
         run: |
           node --check js/trait-engine.js
           node --check js/trait-catalog-core.js
+          node --check js/spellcasting-runtime.js
           node --check js/bard-class-runtime.js
+          node --check js/archetype-trait-catalog.js
+          node --check js/college-of-whispers-runtime.js
           node --check js/racial-trait-catalog.js
           node --check js/racial-trait-runtime-bridge.js
           node --check js/status-engine.js
@@ -88,7 +96,9 @@ jobs:
           node --check tests/trait_engine.spec.js
           node --check tests/trait_engine_codex_regressions.spec.js
           node --check tests/trait_catalog_core.spec.js
+          node --check tests/spellcasting_runtime.spec.js
           node --check tests/bard_class_runtime.spec.js
+          node --check tests/college_of_whispers_runtime.spec.js
           node --check tests/racial_trait_catalog.spec.js
           node --check tests/racial_trait_engine_regressions.spec.js
           node --check tests/player_trait_tabs.spec.js
@@ -106,7 +116,9 @@ jobs:
           tests/trait_engine.spec.js
           tests/trait_engine_codex_regressions.spec.js
           tests/trait_catalog_core.spec.js
+          tests/spellcasting_runtime.spec.js
           tests/bard_class_runtime.spec.js
+          tests/college_of_whispers_runtime.spec.js
           tests/racial_trait_catalog.spec.js
           tests/racial_trait_engine_regressions.spec.js
           tests/player_trait_tabs.spec.js

--- a/js/archetype-trait-catalog.js
+++ b/js/archetype-trait-catalog.js
@@ -5,8 +5,11 @@
   const traitEngine = global.LuminousTraitEngine || (typeof require === "function" ? require("./trait-engine.js") : null);
   if (!archetypeEngine) return;
 
+  // Kept for backwards compatibility with the original single-Archetype catalog API.
   const ARCHETYPE_ID = "path_of_the_devil_lineage";
   const CLASS_ID = "barbarian";
+  const COLLEGE_OF_WHISPERS_ID = "college_of_whispers";
+  const COLLEGE_OF_WHISPERS_CLASS_ID = "bard";
 
   function deepFreeze(value, seen = new WeakSet()) {
     if (!value || typeof value !== "object" || seen.has(value)) return value;
@@ -24,6 +27,14 @@
       unlockLevel: 15,
       traitLevels: [15, 30, 50, 70],
     },
+    [COLLEGE_OF_WHISPERS_ID]: {
+      id: COLLEGE_OF_WHISPERS_ID,
+      name: "College of Whispers",
+      classId: COLLEGE_OF_WHISPERS_CLASS_ID,
+      className: "Bard",
+      unlockLevel: 15,
+      traitLevels: [15, 30, 70],
+    },
   });
 
   const source = Object.freeze({
@@ -33,6 +44,15 @@
     archetypeName: "Path of the Devil Lineage",
     classId: CLASS_ID,
     className: "Barbarian",
+  });
+
+  const whispersSource = Object.freeze({
+    type: "archetype",
+    id: COLLEGE_OF_WHISPERS_ID,
+    archetypeId: COLLEGE_OF_WHISPERS_ID,
+    archetypeName: "College of Whispers",
+    classId: COLLEGE_OF_WHISPERS_CLASS_ID,
+    className: "Bard",
   });
 
   const DEFINITIONS = deepFreeze({
@@ -277,31 +297,114 @@
         pendingRecoveryPersistsAfterHealing: true,
       },
     },
+
+    psychic_blade: {
+      schemaVersion: 1,
+      id: "psychic_blade",
+      name: "Psychic Blade",
+      description: "[On Use] Consume 1 Bardic Inspiration to Gain ((CHA Mod)+(Bard Level/20)) Psychic Blade. [On Hit] Reduce SP by ((CHA Mod/2)+(Bard Level/25)), then reduce Count by 1.",
+      source: whispersSource,
+      contexts: ["combat"],
+      activation: { type: "manual", actionCost: "none" },
+      effects: [],
+      rules: [],
+      mechanics: {
+        consumeTraitUse: { traitId: "bardic_inspiration", amount: 1 },
+        gainCountFormula: "CharismaMod + ClassLevel / 20",
+        onHitSpReductionFormula: "CharismaMod / 2 + ClassLevel / 25",
+      },
+    },
+
+    words_of_terror: {
+      schemaVersion: 1,
+      id: "words_of_terror",
+      name: "Words of Terror",
+      description: "[On Use] Target makes a WIS Save against your Spell DC. On Fail, Inflict Frightened.",
+      source: whispersSource,
+      contexts: ["any"],
+      activation: { type: "manual", actionCost: "none" },
+      effects: [],
+      rules: [],
+      mechanics: {
+        save: { abilityId: "wis", dc: "SpellDC", onFailStatusId: "frightened" },
+      },
+    },
+
+    mantle_of_whispers: {
+      schemaVersion: 1,
+      id: "mantle_of_whispers",
+      name: "Mantle of Whispers",
+      description: "[On Encounter] When a Humanoid dies, choose to absorb its Shadow to Gain Shadow of [Unit or Character Name]. (Once Per Long Rest) Shadow of [Unit or Character Name]: [On Use] Consume Stored Shadow to assume its Identity for 1 Hour. [While Disguised] Gain +5 Deception Power against Insight Checks. [On Long Rest] If Stored Shadow was not consumed, lose it.",
+      source: whispersSource,
+      contexts: ["any"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [],
+      mechanics: {
+        trigger: "humanoid_death",
+        acquireScope: "long_rest",
+        dynamicEffectName: "Shadow of [Unit or Character Name]",
+        storedShadowMax: 1,
+        assumedIdentityHours: 1,
+        deceptionPowerAgainstInsight: 5,
+        unusedShadowExpiresOnLongRest: true,
+      },
+    },
+
+    shadow_lore: {
+      schemaVersion: 1,
+      id: "shadow_lore",
+      name: "Shadow Lore",
+      description: "[On Use] Target makes a WIS Save against your Spell DC. On Fail, Inflict Charmed for 8 Hours. (Once Per Long Rest) While Charmed by Shadow Lore, the Target believes you know its darkest secret and treats you as a trusted ally out of fear of exposure. The Target will not willingly risk its life unless it was already inclined to do so. Shadow Lore ends if you or your Allies attack or damage the Target. You do not learn the Target's secret.",
+      source: whispersSource,
+      contexts: ["any"],
+      activation: { type: "manual", actionCost: "none", uses: { max: 1, reset: "long_rest" } },
+      effects: [],
+      rules: [],
+      mechanics: {
+        save: { abilityId: "wis", dc: "SpellDC", onFailStatusId: "charmed" },
+        durationHours: 8,
+        believesDarkestSecretKnown: true,
+        treatsCasterAsTrustedAlly: true,
+        willNotRiskLifeUnlessAlreadyInclined: true,
+        endsIfCasterOrAlliesDamageTarget: true,
+        casterLearnsSecret: false,
+      },
+    },
   });
 
+  function archetypeGrant(atLevel, traitId, archetypeId, classId, traitSource) {
+    return {
+      sourceType: "archetype",
+      sourceId: archetypeId,
+      archetypeId,
+      classId,
+      atLevel,
+      traitId,
+      source: { ...traitSource, atLevel, requiredClassLevel: atLevel },
+    };
+  }
+
   const GRANTS = deepFreeze([
-    [15, "devil_lineage_devil_strength"],
-    [15, "devil_lineage_infernal_speed"],
-    [15, "devil_lineage_demonic_resistance"],
-    [15, "devil_lineage_jackpot"],
-    [30, "devil_lineage_infernal_touch"],
-    [50, "devil_lineage_supernatural_endurance"],
-    [50, "devil_lineage_demon_wing"],
-    [50, "devil_lineage_improved_devil_strength"],
-    [50, "devil_lineage_improved_demonic_resistance"],
-    [70, "devil_lineage_demonic_regeneration"],
-    [70, "devil_lineage_demon_wings"],
-    [70, "devil_lineage_power_of_the_nine_hells"],
-    [70, "devil_lineage_cursed_juggernaut"],
-  ].map(([atLevel, traitId]) => ({
-    sourceType: "archetype",
-    sourceId: ARCHETYPE_ID,
-    archetypeId: ARCHETYPE_ID,
-    classId: CLASS_ID,
-    atLevel,
-    traitId,
-    source: { ...source, atLevel, requiredClassLevel: atLevel },
-  })));
+    archetypeGrant(15, "devil_lineage_devil_strength", ARCHETYPE_ID, CLASS_ID, source),
+    archetypeGrant(15, "devil_lineage_infernal_speed", ARCHETYPE_ID, CLASS_ID, source),
+    archetypeGrant(15, "devil_lineage_demonic_resistance", ARCHETYPE_ID, CLASS_ID, source),
+    archetypeGrant(15, "devil_lineage_jackpot", ARCHETYPE_ID, CLASS_ID, source),
+    archetypeGrant(30, "devil_lineage_infernal_touch", ARCHETYPE_ID, CLASS_ID, source),
+    archetypeGrant(50, "devil_lineage_supernatural_endurance", ARCHETYPE_ID, CLASS_ID, source),
+    archetypeGrant(50, "devil_lineage_demon_wing", ARCHETYPE_ID, CLASS_ID, source),
+    archetypeGrant(50, "devil_lineage_improved_devil_strength", ARCHETYPE_ID, CLASS_ID, source),
+    archetypeGrant(50, "devil_lineage_improved_demonic_resistance", ARCHETYPE_ID, CLASS_ID, source),
+    archetypeGrant(70, "devil_lineage_demonic_regeneration", ARCHETYPE_ID, CLASS_ID, source),
+    archetypeGrant(70, "devil_lineage_demon_wings", ARCHETYPE_ID, CLASS_ID, source),
+    archetypeGrant(70, "devil_lineage_power_of_the_nine_hells", ARCHETYPE_ID, CLASS_ID, source),
+    archetypeGrant(70, "devil_lineage_cursed_juggernaut", ARCHETYPE_ID, CLASS_ID, source),
+
+    archetypeGrant(15, "psychic_blade", COLLEGE_OF_WHISPERS_ID, COLLEGE_OF_WHISPERS_CLASS_ID, whispersSource),
+    archetypeGrant(15, "words_of_terror", COLLEGE_OF_WHISPERS_ID, COLLEGE_OF_WHISPERS_CLASS_ID, whispersSource),
+    archetypeGrant(30, "mantle_of_whispers", COLLEGE_OF_WHISPERS_ID, COLLEGE_OF_WHISPERS_CLASS_ID, whispersSource),
+    archetypeGrant(70, "shadow_lore", COLLEGE_OF_WHISPERS_ID, COLLEGE_OF_WHISPERS_CLASS_ID, whispersSource),
+  ]);
 
   function allDefinitions() {
     return { ...DEFINITIONS };
@@ -324,20 +427,30 @@
     return archetypeEngine.resolveTraitGrants(character, GRANTS, definitions, ARCHETYPES, global.LuminousTraitEngine || traitEngine);
   }
 
-  function ensureDevilLineageRuntime() {
+  function ensureRuntime(id, src, ready) {
     const doc = global.document;
-    if (!doc || global.LuminousDevilLineageRuntime || doc.getElementById?.("devil-lineage-runtime-script")) return null;
+    if (!doc || ready?.() || doc.getElementById?.(id)) return null;
     const script = doc.createElement("script");
-    script.id = "devil-lineage-runtime-script";
-    script.src = "js/devil-lineage-runtime.js";
+    script.id = id;
+    script.src = src;
     script.async = false;
     doc.head?.appendChild(script);
     return script;
   }
 
+  function ensureDevilLineageRuntime() {
+    return ensureRuntime("devil-lineage-runtime-script", "js/devil-lineage-runtime.js", () => Boolean(global.LuminousDevilLineageRuntime));
+  }
+
+  function ensureCollegeOfWhispersRuntime() {
+    return ensureRuntime("college-of-whispers-runtime-script", "js/college-of-whispers-runtime.js", () => Boolean(global.LuminousCollegeOfWhispersRuntime));
+  }
+
   const api = Object.freeze({
     ARCHETYPE_ID,
     CLASS_ID,
+    COLLEGE_OF_WHISPERS_ID,
+    COLLEGE_OF_WHISPERS_CLASS_ID,
     ARCHETYPES,
     DEFINITIONS,
     GRANTS,
@@ -347,9 +460,11 @@
     getDefinition,
     resolveTraitGrants,
     ensureDevilLineageRuntime,
+    ensureCollegeOfWhispersRuntime,
   });
 
   global.LuminousArchetypeTraitCatalog = api;
   ensureDevilLineageRuntime();
+  ensureCollegeOfWhispersRuntime();
   if (typeof module !== "undefined" && module.exports) module.exports = api;
 })(typeof window !== "undefined" ? window : globalThis);

--- a/js/college-of-whispers-runtime.js
+++ b/js/college-of-whispers-runtime.js
@@ -1,0 +1,687 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousCollegeOfWhispersRuntime) return;
+
+  const ARCHETYPE_ID = "college_of_whispers";
+  const CLASS_ID = "bard";
+  const PATCH_INTERVAL_MS = 500;
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9_]+/g, "_").replace(/^_+|_+$/g, "");
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const intOr = (value, fallback = 0) => Number.isFinite(Number.parseInt(value, 10)) ? Number.parseInt(value, 10) : fallback;
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+  const runtimeStateByKey = new Map();
+  const runtimeStateByObject = typeof WeakMap === "function" ? new WeakMap() : null;
+  const stateRecords = new Set();
+  const pendingSaves = new Map();
+  let nextSaveRequestId = 1;
+  let listenersBound = false;
+
+  function identityValues(entity = {}) {
+    return [
+      entity.combatId, entity.combat_id, entity.unitId, entity.unit_id,
+      entity.id, entity.playerId, entity.player_id, entity.characterId, entity.character_id,
+      entity.actorId, entity.actor_id, entity.uid, entity.vinculo_jugador,
+    ].filter((value) => value != null && String(value).trim() !== "").map((value) => String(value).trim());
+  }
+
+  function entityName(entity = {}) {
+    return String(entity.characterName || entity.character_name || entity.nombre || entity.name || "Unknown").trim() || "Unknown";
+  }
+
+  function sameEntity(a, b) {
+    if (!a || !b) return false;
+    if (a === b) return true;
+    const ids = new Set(identityValues(a));
+    if (identityValues(b).some((id) => ids.has(id))) return true;
+    const aName = normalizeId(entityName(a));
+    const bName = normalizeId(entityName(b));
+    return Boolean(aName && bName && aName === bName);
+  }
+
+  function characterKey(character = {}) {
+    return identityValues(character)[0] || normalizeId(entityName(character)) || null;
+  }
+
+  function createRuntimeState(owner) {
+    const record = {
+      owner,
+      mantleUsedSinceLongRest: false,
+      pendingShadow: null,
+      storedShadow: null,
+      assumedIdentity: null,
+      activeShadowLore: [],
+    };
+    stateRecords.add(record);
+    return record;
+  }
+
+  function whispersState(character = {}) {
+    const key = characterKey(character);
+    if (key) {
+      if (!runtimeStateByKey.has(key)) runtimeStateByKey.set(key, createRuntimeState(character));
+      const record = runtimeStateByKey.get(key);
+      record.owner = character;
+      return record;
+    }
+    if (runtimeStateByObject && character && typeof character === "object") {
+      if (!runtimeStateByObject.has(character)) runtimeStateByObject.set(character, createRuntimeState(character));
+      return runtimeStateByObject.get(character);
+    }
+    return createRuntimeState(character);
+  }
+
+  function normalizedCharacter(character = {}) {
+    if (Array.isArray(character.classes)) return character;
+    if (Array.isArray(character.characterBuild?.classes)) return { ...character, classes: character.characterBuild.classes };
+    return character;
+  }
+
+  function currentCharacter() {
+    return global.LuminousPlayerTraitRuntime?.getCharacter?.() || global.datosJugador || null;
+  }
+
+  function bardLevel(character = {}) {
+    const normalized = normalizedCharacter(character);
+    const engine = global.LuminousArchetypeEngine;
+    if (engine?.getClassLevel) return Math.max(0, intOr(engine.getClassLevel(normalized, CLASS_ID), 0));
+    const classes = Array.isArray(normalized.classes) ? normalized.classes : [];
+    const found = classes.find((entry) => normalizeId(entry?.classId || entry?.id || entry?.name) === CLASS_ID);
+    return Math.max(0, intOr(found?.levels ?? found?.level, 0));
+  }
+
+  function selectedCollege(character = {}) {
+    const engine = global.LuminousArchetypeEngine;
+    if (engine?.isSelected) return Boolean(engine.isSelected(character, ARCHETYPE_ID, CLASS_ID));
+    const selections = Array.isArray(character.characterBuild?.archetypes) ? character.characterBuild.archetypes : [];
+    return selections.some((entry) => normalizeId(entry?.classId || entry?.parentClassId) === CLASS_ID && normalizeId(entry?.archetypeId || entry?.subclassId || entry?.id) === ARCHETYPE_ID);
+  }
+
+  function hasCollegeLevel(character, level) {
+    return selectedCollege(character) && bardLevel(character) >= Number(level || 0);
+  }
+
+  function traitId(trait = {}) {
+    return normalizeId(trait.baseTraitId || trait.id || trait.name);
+  }
+
+  function hasTrait(traits = [], id) {
+    const wanted = normalizeId(id);
+    return (traits || []).some((trait) => traitId(trait) === wanted);
+  }
+
+  function statusStore(unit = {}) {
+    if (!unit || typeof unit !== "object") return null;
+    if (global.LuminousStatusEngine?.ensureStore) return global.LuminousStatusEngine.ensureStore(unit);
+    if (!unit.statusEffects || typeof unit.statusEffects !== "object" || Array.isArray(unit.statusEffects)) unit.statusEffects = {};
+    return unit.statusEffects;
+  }
+
+  function getStatus(unit, statusId) {
+    const id = normalizeId(statusId);
+    const fromEngine = global.LuminousStatusEngine?.getStatus?.(unit, id);
+    if (fromEngine) return fromEngine;
+    return clone(statusStore(unit)?.[id] || null);
+  }
+
+  function applyStatus(unit, statusId, input = {}) {
+    if (!unit) return null;
+    const id = normalizeId(statusId);
+    if (global.LuminousStatusEngine?.applyStatus) return global.LuminousStatusEngine.applyStatus(unit, id, input);
+    const store = statusStore(unit);
+    const existing = store?.[id] || null;
+    const mode = normalizeId(input.mode || input.action || "set");
+    const count = numberOr(input.count, existing?.count ?? 1);
+    const next = {
+      id,
+      name: input.name || existing?.name || id,
+      count: ["gain", "add", "inflict", "apply"].includes(mode) && existing ? numberOr(existing.count, 0) + count : count,
+      potency: numberOr(input.potency, existing?.potency ?? 0),
+      duration: normalizeId(input.duration || existing?.duration || "until_removed"),
+      sourceTraitId: input.sourceTraitId || existing?.sourceTraitId || null,
+      sourceUnitId: input.sourceUnitId || existing?.sourceUnitId || null,
+      data: { ...(existing?.data || {}), ...(input.data || {}) },
+    };
+    store[id] = next;
+    return clone(next);
+  }
+
+  function removeStatus(unit, statusId) {
+    if (!unit) return false;
+    const id = normalizeId(statusId);
+    if (global.LuminousStatusEngine?.removeStatus) return global.LuminousStatusEngine.removeStatus(unit, id, { from: "self", ignoreProtection: true })?.removed === true;
+    const store = statusStore(unit);
+    const removed = Boolean(store && Object.prototype.hasOwnProperty.call(store, id));
+    if (removed) delete store[id];
+    return removed;
+  }
+
+  function readSp(unit = {}) {
+    const value = unit.sp ?? unit.currentSp ?? unit.sp_actual ?? unit.combatStats?.sp_actual;
+    return numberOr(value, 0);
+  }
+
+  function writeSp(unit = {}, value) {
+    const next = Math.max(0, numberOr(value, 0));
+    if (Object.prototype.hasOwnProperty.call(unit, "sp")) unit.sp = next;
+    else if (Object.prototype.hasOwnProperty.call(unit, "currentSp")) unit.currentSp = next;
+    else if (Object.prototype.hasOwnProperty.call(unit, "sp_actual")) unit.sp_actual = next;
+    else if (unit.combatStats && Object.prototype.hasOwnProperty.call(unit.combatStats, "sp_actual")) unit.combatStats.sp_actual = next;
+    else unit.sp = next;
+    return next;
+  }
+
+  function formulaValue(trait, runtime = {}, formula) {
+    const engine = global.LuminousTraitEngine;
+    const character = normalizedCharacter(runtime.character || runtime.self || {});
+    if (!engine?.evaluateFormula || !engine?.buildVariables) return numberOr(formula, 0);
+    const variables = engine.buildVariables(character, { ...runtime, sourceClassId: CLASS_ID }, trait || {});
+    variables.ClassLevel = bardLevel(character);
+    return numberOr(engine.evaluateFormula(formula, variables), 0);
+  }
+
+  function bardicInspirationInfo(character = {}, runtime = {}, traitState = {}) {
+    const engine = global.LuminousTraitEngine;
+    const catalog = global.LuminousTraitCatalogCore;
+    const definition = catalog?.getDefinition?.("bardic_inspiration") || null;
+    const normalized = normalizedCharacter(character);
+    const vars = engine?.buildVariables ? engine.buildVariables(normalized, { ...runtime, sourceClassId: CLASS_ID }, definition || {}) : {};
+    vars.ClassLevel = bardLevel(normalized);
+    const formula = definition?.activation?.uses?.formula || "max(1, CharismaMod) + min(1, floor(ClassLevel / 25))";
+    const maximum = engine?.evaluateFormula ? Math.max(0, Math.floor(engine.evaluateFormula(formula, vars))) : Math.max(1, numberOr(vars.CharismaMod, 0)) + (vars.ClassLevel >= 25 ? 1 : 0);
+    if (!traitState.usages) traitState.usages = {};
+    const record = traitState.usages.bardic_inspiration || (traitState.usages.bardic_inspiration = { used: 0, reset: "long_rest" });
+    const used = Math.max(0, intOr(record.used, 0));
+    return { maximum, used, remaining: Math.max(0, maximum - used), record };
+  }
+
+  function consumeBardicInspiration(character = {}, runtime = {}, traitState = {}) {
+    const info = bardicInspirationInfo(character, runtime, traitState);
+    if (info.remaining <= 0) return { consumed: false, ...info };
+    info.record.used = info.used + 1;
+    return { consumed: true, ...info, usedAfter: info.record.used, remainingAfter: Math.max(0, info.maximum - info.record.used) };
+  }
+
+  function applyPsychicBlade(trait, runtime = {}, traitState = {}) {
+    const self = runtime.self || runtime.character;
+    if (!self) return null;
+    const formula = trait?.mechanics?.gainCountFormula || "CharismaMod + ClassLevel / 20";
+    const count = formulaValue(trait, runtime, formula);
+    const status = applyStatus(self, "psychic_blade", {
+      mode: "gain",
+      name: "Psychic Blade",
+      count,
+      potency: 0,
+      duration: "until_removed",
+      sourceTraitId: trait?.id || "psychic_blade",
+      sourceUnitId: identityValues(self)[0] || null,
+      data: { onHitSpReductionFormula: trait?.mechanics?.onHitSpReductionFormula || "CharismaMod / 2 + ClassLevel / 25" },
+    });
+    return { type: "psychic_blade_gained", traitId: trait?.id || "psychic_blade", count, status };
+  }
+
+  function applyPsychicBladeOnHit(trait, runtime = {}) {
+    const self = runtime.self || runtime.character;
+    const target = runtime.target || runtime.defender || runtime.targetsHit?.[0];
+    if (!self || !target) return null;
+    const status = getStatus(self, "psychic_blade");
+    if (!status || numberOr(status.count, 0) <= 0) return null;
+    const formula = status.data?.onHitSpReductionFormula || trait?.mechanics?.onHitSpReductionFormula || "CharismaMod / 2 + ClassLevel / 25";
+    const amount = Math.max(0, formulaValue(trait, runtime, formula));
+    const before = readSp(target);
+    const after = writeSp(target, before - amount);
+    const remaining = numberOr(status.count, 0) - 1;
+    if (remaining <= 0) removeStatus(self, "psychic_blade");
+    else applyStatus(self, "psychic_blade", { mode: "set", name: status.name || "Psychic Blade", count: remaining, potency: status.potency || 0, duration: status.duration || "until_removed", sourceTraitId: status.sourceTraitId || trait?.id, data: status.data || {} });
+    return { type: "psychic_blade_on_hit", traitId: trait?.id || "psychic_blade", target, spReduced: before - after, spBefore: before, spAfter: after, countBefore: status.count, countAfter: Math.max(0, remaining) };
+  }
+
+  function spellDCFor(trait, runtime = {}) {
+    const character = normalizedCharacter(runtime.character || runtime.self || {});
+    const engine = global.LuminousTraitEngine;
+    const variables = engine?.buildVariables?.(character, { ...runtime, sourceClassId: CLASS_ID }, trait || {}) || {};
+    if (Number.isFinite(Number(variables.SpellDC))) return Number(variables.SpellDC);
+    const resolved = global.LuminousSpellcastingRuntime?.resolveForTrait?.(character, trait || {}, { ...runtime, sourceClassId: CLASS_ID }, variables);
+    return numberOr(resolved?.spellDC, 8 + numberOr(variables.CharismaMod, 0) + numberOr(variables.Proficiency, 0));
+  }
+
+  function savePassedFromRuntime(runtime = {}) {
+    for (const value of [runtime.savePassed, runtime.save?.passed, runtime.check?.passed]) {
+      if (typeof value === "boolean") return value;
+    }
+    return null;
+  }
+
+  function applyFailedSave(request) {
+    if (!request?.target) return null;
+    if (request.traitId === "words_of_terror") {
+      const status = applyStatus(request.target, "frightened", {
+        mode: "set",
+        name: "Frightened",
+        count: 1,
+        potency: 0,
+        duration: "until_removed",
+        sourceTraitId: "words_of_terror",
+        sourceUnitId: identityValues(request.owner)[0] || null,
+      });
+      return { type: "spell_save_failed", traitId: request.traitId, abilityId: "wis", dc: request.dc, statusId: "frightened", status };
+    }
+    if (request.traitId === "shadow_lore") {
+      const status = applyStatus(request.target, "charmed", {
+        mode: "set",
+        name: "Charmed",
+        count: 1,
+        potency: 0,
+        duration: "until_removed",
+        sourceTraitId: "shadow_lore",
+        sourceUnitId: identityValues(request.owner)[0] || null,
+        data: {
+          durationHours: 8,
+          believesDarkestSecretKnown: true,
+          treatsCasterAsTrustedAlly: true,
+          willNotRiskLifeUnlessAlreadyInclined: true,
+          casterLearnsSecret: false,
+          endsIfCasterOrAlliesDamageTarget: true,
+        },
+      });
+      const ownerState = whispersState(request.owner || {});
+      ownerState.activeShadowLore = ownerState.activeShadowLore.filter((entry) => !sameEntity(entry.target, request.target));
+      ownerState.activeShadowLore.push({ target: request.target, remainingHours: 8 });
+      return { type: "spell_save_failed", traitId: request.traitId, abilityId: "wis", dc: request.dc, statusId: "charmed", durationHours: 8, status };
+    }
+    return null;
+  }
+
+  function requestWisSave(trait, runtime = {}) {
+    const target = runtime.target || runtime.defender || null;
+    if (!target) return { requested: false, reason: "Target required." };
+    const owner = runtime.self || runtime.character || {};
+    const request = {
+      requestId: `college_whispers_save_${nextSaveRequestId++}`,
+      traitId: traitId(trait),
+      abilityId: "wis",
+      dc: spellDCFor(trait, runtime),
+      owner,
+      target,
+    };
+    const passed = savePassedFromRuntime(runtime);
+    if (passed === false) return { requested: false, resolved: true, passed: false, request, outcome: applyFailedSave(request) };
+    if (passed === true) return { requested: false, resolved: true, passed: true, request, outcome: null };
+    pendingSaves.set(request.requestId, request);
+    emit("luminous:spell-save-requested", clone({ requestId: request.requestId, traitId: request.traitId, abilityId: request.abilityId, dc: request.dc, targetId: identityValues(target)[0] || null, targetName: entityName(target) }));
+    return { requested: true, resolved: false, request };
+  }
+
+  function resolvePendingSave(requestId, passed) {
+    const id = String(requestId || "");
+    const request = pendingSaves.get(id);
+    if (!request) return { resolved: false, reason: "Unknown save request." };
+    pendingSaves.delete(id);
+    if (passed === true) return { resolved: true, passed: true, request: clone({ ...request, owner: undefined, target: undefined }), outcome: null };
+    return { resolved: true, passed: false, request: clone({ ...request, owner: undefined, target: undefined }), outcome: applyFailedSave(request) };
+  }
+
+  function isHumanoid(unit = {}) {
+    const values = [];
+    [unit.tags, unit.unitTags, unit.labels, unit.markers, unit.race?.tags].forEach((list) => { if (Array.isArray(list)) values.push(...list); });
+    values.push(unit.creatureType, unit.creature_type, unit.type, unit.unitType, unit.raceType, unit.race?.type);
+    return values.filter(Boolean).some((value) => normalizeId(value?.id || value?.name || value) === "humanoid");
+  }
+
+  function shadowIdentity(unit = {}) {
+    return {
+      id: identityValues(unit)[0] || null,
+      name: entityName(unit),
+      actorId: unit.actorId || unit.actor_id || null,
+      characterId: unit.characterId || unit.character_id || null,
+      appearance: clone({
+        sprite: unit.current_sprite || unit.sprite || null,
+        defaultSprite: unit.default_sprite || unit.defaultSprite || null,
+        portrait: unit.portrait || unit.avatar || null,
+      }),
+    };
+  }
+
+  function shadowStatusId(shadow) {
+    return `shadow_of_${normalizeId(shadow?.name || "unknown") || "unknown"}`;
+  }
+
+  function captureShadow(deadUnit, character = currentCharacter()) {
+    if (!character || !hasCollegeLevel(character, 30)) return { captured: false, reason: "Mantle of Whispers is not available." };
+    if (!deadUnit || !isHumanoid(deadUnit)) return { captured: false, reason: "Target is not a Humanoid." };
+    const state = whispersState(character);
+    if (state.mantleUsedSinceLongRest) return { captured: false, reason: "Mantle of Whispers is Once Per Long Rest." };
+    const shadow = shadowIdentity(deadUnit);
+    state.mantleUsedSinceLongRest = true;
+    state.pendingShadow = null;
+    state.storedShadow = shadow;
+    const statusId = shadowStatusId(shadow);
+    applyStatus(character, statusId, {
+      mode: "set",
+      name: `Shadow of ${shadow.name}`,
+      count: 1,
+      potency: 0,
+      duration: "until_removed",
+      sourceTraitId: "mantle_of_whispers",
+      data: { shadow: clone(shadow), activatable: true, expiresOnLongRestIfUnused: true },
+    });
+    const result = { captured: true, shadow: clone(shadow), statusId, effectName: `Shadow of ${shadow.name}` };
+    emit("luminous:mantle-of-whispers-shadow-gained", result);
+    return result;
+  }
+
+  function declinePendingShadow(character = currentCharacter()) {
+    if (!character) return false;
+    const state = whispersState(character);
+    const hadPending = Boolean(state.pendingShadow);
+    state.pendingShadow = null;
+    return hadPending;
+  }
+
+  function useStoredShadow(character = currentCharacter()) {
+    if (!character) return { used: false, reason: "No character available." };
+    const state = whispersState(character);
+    if (!state.storedShadow) return { used: false, reason: "No Stored Shadow." };
+    const shadow = state.storedShadow;
+    removeStatus(character, shadowStatusId(shadow));
+    state.storedShadow = null;
+    state.assumedIdentity = { shadow: clone(shadow), remainingHours: 1 };
+    character.assumedIdentity = { source: "mantle_of_whispers", ...clone(shadow), remainingHours: 1 };
+    applyStatus(character, "mantle_of_whispers_disguise", {
+      mode: "set",
+      name: `Identity: ${shadow.name}`,
+      count: 1,
+      potency: 0,
+      duration: "until_removed",
+      sourceTraitId: "mantle_of_whispers",
+      data: { identity: clone(shadow), durationHours: 1, deceptionPowerAgainstInsight: 5 },
+    });
+    const result = { used: true, identity: clone(shadow), durationHours: 1, deceptionPowerAgainstInsight: 5 };
+    emit("luminous:mantle-of-whispers-identity-assumed", result);
+    return result;
+  }
+
+  function clearAssumedIdentity(state) {
+    if (!state?.assumedIdentity) return false;
+    const owner = state.owner;
+    state.assumedIdentity = null;
+    if (owner && owner.assumedIdentity?.source === "mantle_of_whispers") delete owner.assumedIdentity;
+    removeStatus(owner, "mantle_of_whispers_disguise");
+    emit("luminous:mantle-of-whispers-identity-ended", { characterId: identityValues(owner)[0] || null });
+    return true;
+  }
+
+  function resetMantleOnLongRest(character) {
+    if (!character) return false;
+    const state = whispersState(character);
+    if (state.storedShadow) removeStatus(character, shadowStatusId(state.storedShadow));
+    state.storedShadow = null;
+    state.pendingShadow = null;
+    state.mantleUsedSinceLongRest = false;
+    clearAssumedIdentity(state);
+    return true;
+  }
+
+  function identityDeceptionCheck(check = {}) {
+    const skill = normalizeId(check.skillId || check.skill || check.actionId);
+    if (!["deception", "engano", "enga_o"].includes(skill)) return false;
+    const context = [
+      check.opposedBy, check.opposedSkillId, check.against, check.saveAgainst,
+      check.condition, check.label, ...(Array.isArray(check.tags) ? check.tags : []),
+    ].filter(Boolean).map(normalizeId).join(" ");
+    return context.includes("insight") || context.includes("perspicacia") || context.includes("identity") || context.includes("disguise");
+  }
+
+  function applyDisguiseDeceptionBonus(character, check = {}) {
+    const state = whispersState(character || {});
+    if (!state.assumedIdentity || check.__mantleOfWhispersDeceptionApplied || !identityDeceptionCheck(check)) return null;
+    check.finalPower = numberOr(check.finalPower, 0) + 5;
+    check.__mantleOfWhispersDeceptionApplied = true;
+    return { type: "mantle_of_whispers_deception", bonus: 5 };
+  }
+
+  function advanceWorldHours(hours) {
+    const elapsed = Math.max(0, numberOr(hours, 0));
+    if (!elapsed) return 0;
+    let changed = 0;
+    stateRecords.forEach((state) => {
+      if (state.assumedIdentity) {
+        state.assumedIdentity.remainingHours -= elapsed;
+        if (state.owner?.assumedIdentity?.source === "mantle_of_whispers") state.owner.assumedIdentity.remainingHours = Math.max(0, state.assumedIdentity.remainingHours);
+        if (state.assumedIdentity.remainingHours <= 0 && clearAssumedIdentity(state)) changed += 1;
+      }
+      state.activeShadowLore = state.activeShadowLore.filter((entry) => {
+        entry.remainingHours -= elapsed;
+        if (entry.remainingHours > 0) return true;
+        const charmed = getStatus(entry.target, "charmed");
+        if (normalizeId(charmed?.sourceTraitId) === "shadow_lore") removeStatus(entry.target, "charmed");
+        changed += 1;
+        return false;
+      });
+    });
+    return changed;
+  }
+
+  function sameFaction(a = {}, b = {}) {
+    const aFaction = a.faction ?? a.faccion;
+    const bFaction = b.faction ?? b.faccion;
+    return aFaction != null && bFaction != null && String(aFaction) === String(bFaction);
+  }
+
+  function breakShadowLoreFromDamage(detail = {}) {
+    const attacker = detail.attacker || detail.source || detail.unitAttacker || null;
+    const target = detail.target || detail.defender || detail.unit || detail.unitDefender || null;
+    if (!attacker || !target) return 0;
+    let broken = 0;
+    stateRecords.forEach((state) => {
+      state.activeShadowLore = state.activeShadowLore.filter((entry) => {
+        if (!sameEntity(entry.target, target)) return true;
+        if (!sameEntity(attacker, state.owner) && !sameFaction(attacker, state.owner)) return true;
+        const charmed = getStatus(entry.target, "charmed");
+        if (normalizeId(charmed?.sourceTraitId) === "shadow_lore") removeStatus(entry.target, "charmed");
+        broken += 1;
+        return false;
+      });
+    });
+    return broken;
+  }
+
+  function emit(name, detail) {
+    try {
+      if (typeof global.dispatchEvent === "function" && typeof global.CustomEvent === "function") global.dispatchEvent(new global.CustomEvent(name, { detail }));
+    } catch (_) {}
+  }
+
+  function onHumanoidDeath(detail = {}) {
+    const character = currentCharacter();
+    const deadUnit = detail.unit || detail.target || null;
+    if (!character || !deadUnit || !hasCollegeLevel(character, 30) || !isHumanoid(deadUnit)) return null;
+    const state = whispersState(character);
+    if (state.mantleUsedSinceLongRest) return null;
+    state.pendingShadow = shadowIdentity(deadUnit);
+    const choice = {
+      traitId: "mantle_of_whispers",
+      archetypeId: ARCHETYPE_ID,
+      characterId: identityValues(character)[0] || null,
+      targetId: identityValues(deadUnit)[0] || null,
+      targetName: entityName(deadUnit),
+      effectName: `Shadow of ${entityName(deadUnit)}`,
+    };
+    emit("luminous:mantle-of-whispers-choice", choice);
+    return choice;
+  }
+
+  function applyPsychicAfterTrigger(traits, trigger, runtime, outcomes) {
+    if (normalizeId(trigger) !== "on_hit" || !hasTrait(traits, "psychic_blade")) return;
+    const trait = (traits || []).find((entry) => traitId(entry) === "psychic_blade");
+    const outcome = applyPsychicBladeOnHit(trait, runtime);
+    if (outcome) outcomes.push(outcome);
+  }
+
+  function extraActivationAvailability(source, trait, runtime, traitState) {
+    const id = traitId(trait);
+    if (["words_of_terror", "shadow_lore"].includes(id) && !(runtime.target || runtime.defender)) return "Target required.";
+    if (id === "psychic_blade") {
+      const character = runtime.character || runtime.self || {};
+      const info = bardicInspirationInfo(character, runtime, traitState);
+      if (info.remaining <= 0) return "No Bardic Inspiration Uses remaining.";
+    }
+    return null;
+  }
+
+  function patchTraitEngine() {
+    const source = global.LuminousTraitEngine;
+    if (!source?.activateTrait || !source?.dispatchTrait) return false;
+    if (source.__collegeOfWhispersRuntimeWrapped) return true;
+
+    const wrapped = Object.freeze({
+      ...source,
+      __collegeOfWhispersRuntimeWrapped: true,
+      canActivateTrait(trait, runtime = {}, traitState) {
+        const state = traitState || source.createState?.();
+        const base = source.canActivateTrait(trait, runtime, state);
+        if (!base?.available) return base;
+        const reason = extraActivationAvailability(source, base.trait || trait, runtime, state);
+        return reason ? { ...base, available: false, reasons: [...(base.reasons || []), reason] } : base;
+      },
+      activateTrait(trait, runtime = {}, traitState) {
+        const state = traitState || source.createState?.();
+        const normalized = source.normalizeTrait?.(trait) || trait;
+        const reason = extraActivationAvailability(source, normalized, runtime, state);
+        if (reason) return { available: false, reasons: [reason], trait: normalized, state, runtime, outcomes: [] };
+        const result = source.activateTrait(trait, runtime, state);
+        if (!result?.available || result?.scheduled) return result;
+        const id = traitId(result.trait || trait);
+        const outcomes = [...(result.outcomes || [])];
+        if (id === "psychic_blade") {
+          const consumption = consumeBardicInspiration(runtime.character || runtime.self || {}, runtime, result.state || state);
+          if (!consumption.consumed) return { ...result, available: false, reasons: ["No Bardic Inspiration Uses remaining."], outcomes: [] };
+          const gained = applyPsychicBlade(result.trait || trait, result.runtime || runtime, result.state || state);
+          outcomes.push({ type: "bardic_inspiration_spent", traitId: "psychic_blade", usedAfter: consumption.usedAfter, remainingAfter: consumption.remainingAfter });
+          if (gained) outcomes.push(gained);
+        } else if (["words_of_terror", "shadow_lore"].includes(id)) {
+          const save = requestWisSave(result.trait || trait, result.runtime || runtime);
+          if (save.outcome) outcomes.push(save.outcome);
+          else if (save.requested) outcomes.push({ type: "spell_save_requested", traitId: id, requestId: save.request.requestId, abilityId: "wis", dc: save.request.dc });
+        }
+        return { ...result, outcomes };
+      },
+      dispatchTrait(trait, trigger, runtime = {}, traitState) {
+        const result = source.dispatchTrait(trait, trigger, runtime, traitState);
+        if (traitId(result?.trait || trait) !== "psychic_blade" || normalizeId(trigger) !== "on_hit") return result;
+        const outcomes = [...(result.outcomes || [])];
+        const extra = applyPsychicBladeOnHit(result.trait || trait, result.runtime || runtime);
+        if (extra) outcomes.push(extra);
+        return { ...result, outcomes };
+      },
+      dispatchTraits(traits = [], trigger, runtime = {}, traitState) {
+        const result = source.dispatchTraits(traits, trigger, runtime, traitState);
+        const outcomes = [...(result.outcomes || [])];
+        applyPsychicAfterTrigger(traits, trigger, result.runtime || runtime, outcomes);
+        return { ...result, outcomes };
+      },
+      dispatchCombatEvent(trigger, input = {}) {
+        const result = source.dispatchCombatEvent(trigger, input);
+        const outcomes = [...(result?.outcomes || [])];
+        applyPsychicAfterTrigger(input.traits || [], trigger, result?.runtime || input, outcomes);
+        return result ? { ...result, outcomes } : result;
+      },
+      resolveTheatreCheck(input = {}) {
+        const result = source.resolveTheatreCheck(input);
+        if (!result?.check) return result;
+        const extra = applyDisguiseDeceptionBonus(input.character || {}, result.check);
+        return extra ? { ...result, outcomes: [...(result.outcomes || []), extra] } : result;
+      },
+    });
+    global.LuminousTraitEngine = wrapped;
+    return true;
+  }
+
+  function isCollegeTrait(trait = {}) {
+    const source = trait.source || {};
+    return ["archetype", "subclass", "class_archetype"].includes(normalizeId(source.type || trait.sourceType)) && normalizeId(source.archetypeId || source.id) === ARCHETYPE_ID;
+  }
+
+  function patchArchetypeRuntime() {
+    const source = global.LuminousArchetypeRuntime;
+    if (!source?.syncArchetypeTraitsForUnit) return false;
+    if (source.__collegeOfWhispersRuntimeWrapped) return true;
+    const originalSync = source.syncArchetypeTraitsForUnit.bind(source);
+    const wrapped = Object.freeze({
+      ...source,
+      __collegeOfWhispersRuntimeWrapped: true,
+      syncArchetypeTraitsForUnit(unit = {}) {
+        const result = originalSync(unit) || [];
+        const catalog = global.LuminousArchetypeTraitCatalog;
+        if (!catalog?.resolveTraitGrants || !unit) return result;
+        const character = normalizedCharacter(unit);
+        const granted = catalog.resolveTraitGrants(character) || [];
+        const collegeGranted = granted.filter(isCollegeTrait);
+        const existing = Array.isArray(unit.traitDefinitions) ? unit.traitDefinitions : [];
+        const byId = new Map();
+        [...existing.filter((trait) => !isCollegeTrait(trait)), ...collegeGranted].forEach((trait) => {
+          const id = normalizeId(trait?.id || trait?.name);
+          if (id && !byId.has(id)) byId.set(id, trait);
+        });
+        unit.traitDefinitions = [...byId.values()];
+        return granted;
+      },
+    });
+    global.LuminousArchetypeRuntime = wrapped;
+    return true;
+  }
+
+  function bindListeners() {
+    if (listenersBound || typeof global.addEventListener !== "function") return false;
+    listenersBound = true;
+    global.addEventListener("luminous:unit-dead", (event) => onHumanoidDeath(event?.detail || {}));
+    global.addEventListener("luminous:rest-completed", (event) => {
+      const detail = event?.detail || {};
+      if (normalizeId(detail.type) === "long_rest") resetMantleOnLongRest(detail.character || currentCharacter());
+    });
+    global.addEventListener("luminous:world-time-advance-requested", (event) => advanceWorldHours(event?.detail?.hours));
+    ["luminous:damage-taken", "luminous:damage-dealt", "luminous:unit-damaged"].forEach((name) => global.addEventListener(name, (event) => breakShadowLoreFromDamage(event?.detail || {})));
+    return true;
+  }
+
+  function install() {
+    bindListeners();
+    patchTraitEngine();
+    patchArchetypeRuntime();
+    return true;
+  }
+
+  const api = Object.freeze({
+    ARCHETYPE_ID,
+    CLASS_ID,
+    bardLevel,
+    selectedCollege,
+    hasCollegeLevel,
+    whispersState,
+    bardicInspirationInfo,
+    consumeBardicInspiration,
+    applyPsychicBlade,
+    applyPsychicBladeOnHit,
+    spellDCFor,
+    requestWisSave,
+    resolvePendingSave,
+    isHumanoid,
+    captureShadow,
+    declinePendingShadow,
+    useStoredShadow,
+    resetMantleOnLongRest,
+    applyDisguiseDeceptionBonus,
+    advanceWorldHours,
+    breakShadowLoreFromDamage,
+    onHumanoidDeath,
+    patchTraitEngine,
+    patchArchetypeRuntime,
+    install,
+  });
+
+  global.LuminousCollegeOfWhispersRuntime = api;
+  install();
+  if (global.document && global.setInterval) global.setInterval(install, PATCH_INTERVAL_MS);
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/spellcasting-runtime.js
+++ b/js/spellcasting-runtime.js
@@ -1,0 +1,143 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousSpellcastingRuntime) return;
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const intOr = (value, fallback = 0) => Number.isFinite(Number.parseInt(value, 10)) ? Number.parseInt(value, 10) : fallback;
+
+  const ABILITY_VARIABLES = Object.freeze({
+    str: "StrengthMod",
+    dex: "DexterityMod",
+    con: "ConstitutionMod",
+    int: "IntelligenceMod",
+    wis: "WisdomMod",
+    cha: "CharismaMod",
+  });
+
+  const ABILITY_ALIASES = Object.freeze({
+    str: ["fuerza", "strength", "str"],
+    dex: ["destreza", "dexterity", "dex"],
+    con: ["constitucion", "constitution", "con"],
+    int: ["inteligencia", "intelligence", "int"],
+    wis: ["sabiduria", "wisdom", "wis"],
+    cha: ["carisma", "charisma", "cha"],
+  });
+
+  // Class spellcasting is declared once here and consumed everywhere through SpellMod / SpellDC.
+  // Add future Classes to this registry instead of repeating an Ability Mod on every Spell/Trait.
+  const classAbilities = new Map([
+    ["bard", "cha"],
+  ]);
+
+  function registerClassSpellcastingAbility(classId, abilityId) {
+    const classKey = normalizeId(classId);
+    const abilityKey = normalizeId(abilityId).slice(0, 3);
+    if (!classKey) throw new Error("Spellcasting Class id is required.");
+    if (!ABILITY_VARIABLES[abilityKey]) throw new Error(`Unsupported Spellcasting Ability: ${abilityId}`);
+    classAbilities.set(classKey, abilityKey);
+    return { classId: classKey, abilityId: abilityKey };
+  }
+
+  function getClassSpellcastingAbility(classId) {
+    return classAbilities.get(normalizeId(classId)) || null;
+  }
+
+  function totalLevel(character = {}, runtime = {}) {
+    const explicit = runtime.Level ?? runtime.level ?? character.level ?? character.characterBuild?.calculatedAtLevel;
+    if (Number.isFinite(Number(explicit))) return Math.max(0, intOr(explicit, 0));
+    const classes = Array.isArray(character.classes)
+      ? character.classes
+      : (Array.isArray(character.characterBuild?.classes) ? character.characterBuild.classes : []);
+    return classes.reduce((sum, entry) => sum + Math.max(0, intOr(entry?.levels ?? entry?.level, 0)), 0);
+  }
+
+  function statModifier(character = {}, abilityId) {
+    const ability = normalizeId(abilityId).slice(0, 3);
+    const stats = character.stats || character.dndStats || {};
+    const aliases = ABILITY_ALIASES[ability] || [ability];
+    const score = aliases
+      .map((alias) => stats?.[alias] ?? character?.[alias])
+      .find((value) => Number.isFinite(Number(value)));
+    return Math.floor((numberOr(score, 10) - 10) / 2);
+  }
+
+  function classIdForTrait(trait = {}, runtime = {}) {
+    const source = trait.source || {};
+    return normalizeId(
+      runtime.sourceClassId
+      || runtime.classId
+      || source.classId
+      || (normalizeId(source.type) === "class" ? source.id : "")
+    );
+  }
+
+  function resolveSpellcasting(character = {}, classId, runtime = {}, variables = {}) {
+    const normalizedClassId = normalizeId(classId);
+    const abilityId = getClassSpellcastingAbility(normalizedClassId);
+    if (!abilityId) return null;
+    const variableName = ABILITY_VARIABLES[abilityId];
+    const spellMod = Number.isFinite(Number(variables?.[variableName]))
+      ? Number(variables[variableName])
+      : (Number.isFinite(Number(runtime?.[variableName])) ? Number(runtime[variableName]) : statModifier(character, abilityId));
+    const proficiency = Number.isFinite(Number(variables?.Proficiency))
+      ? Number(variables.Proficiency)
+      : numberOr(runtime.Proficiency ?? character.proficiency, Math.ceil(totalLevel(character, runtime) / 20));
+    return {
+      classId: normalizedClassId,
+      abilityId,
+      spellMod,
+      proficiency,
+      spellDC: 8 + spellMod + proficiency,
+    };
+  }
+
+  function resolveForTrait(character = {}, trait = {}, runtime = {}, variables = {}) {
+    return resolveSpellcasting(character, classIdForTrait(trait, runtime), runtime, variables);
+  }
+
+  function wrapTraitEngine() {
+    const source = global.LuminousTraitEngine || (typeof require === "function" ? require("./trait-engine.js") : null);
+    if (!source?.buildVariables) return false;
+    if (source.__spellcastingRuntimeWrapped) return true;
+
+    const originalBuildVariables = source.buildVariables.bind(source);
+    const wrapped = Object.freeze({
+      ...source,
+      __spellcastingRuntimeWrapped: true,
+      buildVariables(character = {}, runtime = {}, trait = {}) {
+        const variables = originalBuildVariables(character, runtime, trait);
+        const spellcasting = resolveForTrait(character, trait, runtime, variables);
+        if (!spellcasting) return variables;
+        return {
+          ...variables,
+          SpellMod: spellcasting.spellMod,
+          SpellDC: spellcasting.spellDC,
+        };
+      },
+    });
+    global.LuminousTraitEngine = wrapped;
+    return true;
+  }
+
+  function install() {
+    return wrapTraitEngine();
+  }
+
+  const api = Object.freeze({
+    ABILITY_VARIABLES,
+    registerClassSpellcastingAbility,
+    getClassSpellcastingAbility,
+    classIdForTrait,
+    resolveSpellcasting,
+    resolveForTrait,
+    wrapTraitEngine,
+    install,
+  });
+
+  global.LuminousSpellcastingRuntime = api;
+  install();
+  if (global.document && global.setInterval) global.setInterval(install, 800);
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/status-engine.js
+++ b/js/status-engine.js
@@ -180,6 +180,7 @@
   if (global.document && !global.LuminousUniversalSpeedRuntime) loadScript("universal-speed-runtime-script", "js/universal-speed-runtime.js");
   if (global.document && !global.LuminousFixedDamageRuntime) loadScript("fixed-damage-runtime-script", "js/fixed-damage-runtime.js");
   if (global.document && !global.LuminousRacialTraitRuntimeBridge) loadScript("racial-trait-runtime-bridge-script", "js/racial-trait-runtime-bridge.js");
+  if (global.document && !global.LuminousSpellcastingRuntime) loadScript("spellcasting-runtime-script", "js/spellcasting-runtime.js");
   if (global.document && !global.LuminousBardClassRuntime) loadScript("bard-class-runtime-script", "js/bard-class-runtime.js");
 
   if (global.document && !global.LuminousArchetypeRuntime) loadScript("player-archetype-runtime-script", "js/player-archetype-runtime.js");

--- a/tests/college_of_whispers_runtime.spec.js
+++ b/tests/college_of_whispers_runtime.spec.js
@@ -5,10 +5,12 @@ global.LuminousTraitEngine = baseTraitEngine;
 global.LuminousStatusEngine = require("../js/status-engine.js");
 global.LuminousArchetypeEngine = require("../js/archetype-engine.js");
 delete global.LuminousSpellcastingRuntime;
+delete require.cache[require.resolve("../js/spellcasting-runtime.js")];
 require("../js/spellcasting-runtime.js");
 const catalog = require("../js/archetype-trait-catalog.js");
 global.LuminousArchetypeTraitCatalog = catalog;
 delete global.LuminousCollegeOfWhispersRuntime;
+delete require.cache[require.resolve("../js/college-of-whispers-runtime.js")];
 const whispers = require("../js/college-of-whispers-runtime.js");
 
 function character(level = 30) {

--- a/tests/college_of_whispers_runtime.spec.js
+++ b/tests/college_of_whispers_runtime.spec.js
@@ -1,0 +1,133 @@
+const { test, expect } = require("@playwright/test");
+
+const baseTraitEngine = require("../js/trait-engine.js");
+global.LuminousTraitEngine = baseTraitEngine;
+global.LuminousStatusEngine = require("../js/status-engine.js");
+global.LuminousArchetypeEngine = require("../js/archetype-engine.js");
+delete global.LuminousSpellcastingRuntime;
+require("../js/spellcasting-runtime.js");
+const catalog = require("../js/archetype-trait-catalog.js");
+global.LuminousArchetypeTraitCatalog = catalog;
+delete global.LuminousCollegeOfWhispersRuntime;
+const whispers = require("../js/college-of-whispers-runtime.js");
+
+function character(level = 30) {
+  return {
+    id: `bard-${level}`,
+    name: "Whisper Bard",
+    level,
+    proficiency: Math.ceil(level / 20),
+    classes: [{ classId: "bard", levels: level }],
+    characterBuild: {
+      classes: [{ classId: "bard", level }],
+      archetypes: [{ classId: "bard", archetypeId: "college_of_whispers", selectedAtClassLevel: 15 }],
+      calculatedAtLevel: level,
+    },
+    stats: { carisma: 20, sabiduria: 14 },
+  };
+}
+
+test("College of Whispers grants Traits at Bard Class Levels 15/30/70", () => {
+  const l15 = catalog.resolveTraitGrants(character(15)).map((trait) => trait.id);
+  const l30 = catalog.resolveTraitGrants(character(30)).map((trait) => trait.id);
+  const l70 = catalog.resolveTraitGrants(character(70)).map((trait) => trait.id);
+
+  expect(l15).toEqual(expect.arrayContaining(["psychic_blade", "words_of_terror"]));
+  expect(l15).toHaveLength(2);
+  expect(l30).toEqual(expect.arrayContaining(["psychic_blade", "words_of_terror", "mantle_of_whispers"]));
+  expect(l30).toHaveLength(3);
+  expect(l70).toEqual(expect.arrayContaining(["psychic_blade", "words_of_terror", "mantle_of_whispers", "shadow_lore"]));
+  expect(l70).toHaveLength(4);
+});
+
+test("Psychic Blade spends Bardic Inspiration, gains Count, reduces SP and loses 1 Count On Hit", () => {
+  const bard = character(30);
+  const self = { id: bard.id, name: bard.name, statusEffects: {} };
+  const target = { id: "target", name: "Target", sp: 20, statusEffects: {} };
+  const psychicBlade = catalog.getDefinition("psychic_blade");
+  const engine = global.LuminousTraitEngine;
+  const state = engine.createState();
+
+  const activation = engine.activateTrait(psychicBlade, { context: "combat", character: bard, self }, state);
+  expect(activation.available).toBe(true);
+  expect(state.usages.bardic_inspiration.used).toBe(1);
+  expect(self.statusEffects.psychic_blade.count).toBeCloseTo(6.5, 5);
+
+  const hit = global.LuminousTraitEngine.dispatchTrait(psychicBlade, "on_hit", { context: "combat", character: bard, self, target }, state);
+  expect(hit.outcomes.some((outcome) => outcome.type === "psychic_blade_on_hit")).toBe(true);
+  expect(target.sp).toBeCloseTo(16.3, 5);
+  expect(self.statusEffects.psychic_blade.count).toBeCloseTo(5.5, 5);
+});
+
+test("Words of Terror uses Bard Spell DC and only applies Frightened on a failed WIS Save", () => {
+  const bard = character(30);
+  const target = { id: "victim", name: "Victim", statusEffects: {} };
+  const words = catalog.getDefinition("words_of_terror");
+  const state = global.LuminousTraitEngine.createState();
+
+  const failed = global.LuminousTraitEngine.activateTrait(words, { context: "theatre", character: bard, self: bard, target, savePassed: false }, state);
+  expect(failed.available).toBe(true);
+  const outcome = failed.outcomes.find((entry) => entry.type === "spell_save_failed");
+  expect(outcome?.abilityId).toBe("wis");
+  expect(outcome?.dc).toBe(15);
+  expect(target.statusEffects.frightened).toBeTruthy();
+
+  const secondTarget = { id: "victim-2", statusEffects: {} };
+  const passed = global.LuminousTraitEngine.activateTrait(words, { context: "theatre", character: bard, self: bard, target: secondTarget, savePassed: true }, state);
+  expect(passed.available).toBe(true);
+  expect(secondTarget.statusEffects.frightened).toBeFalsy();
+  expect(passed.outcomes.some((entry) => entry.type === "spell_save_failed")).toBe(false);
+});
+
+test("Mantle of Whispers stores one named Shadow per Long Rest and consumes it into a 1 Hour identity", () => {
+  const bard = character(30);
+  const deadHumanoid = { id: "npc-gregor", name: "Gregor", tags: ["humanoid"], current_sprite: "gregor.png" };
+
+  const captured = whispers.captureShadow(deadHumanoid, bard);
+  expect(captured.captured).toBe(true);
+  expect(captured.effectName).toBe("Shadow of Gregor");
+  expect(bard.statusEffects.shadow_of_gregor.name).toBe("Shadow of Gregor");
+
+  const blocked = whispers.captureShadow({ id: "npc-2", name: "Second", tags: ["humanoid"] }, bard);
+  expect(blocked.captured).toBe(false);
+
+  const assumed = whispers.useStoredShadow(bard);
+  expect(assumed.used).toBe(true);
+  expect(assumed.durationHours).toBe(1);
+  expect(bard.assumedIdentity.name).toBe("Gregor");
+  expect(bard.statusEffects.shadow_of_gregor).toBeFalsy();
+
+  whispers.advanceWorldHours(1);
+  expect(bard.assumedIdentity).toBeFalsy();
+  whispers.resetMantleOnLongRest(bard);
+  const afterRest = whispers.captureShadow({ id: "npc-3", name: "Third", tags: ["humanoid"] }, bard);
+  expect(afterRest.captured).toBe(true);
+});
+
+test("Mantle disguise gives +5 Deception Power only against Insight identity checks", () => {
+  const bard = character(30);
+  whispers.resetMantleOnLongRest(bard);
+  whispers.captureShadow({ id: "npc-mask", name: "Mask", tags: ["humanoid"] }, bard);
+  whispers.useStoredShadow(bard);
+  const check = { skillId: "deception", opposedSkillId: "insight", finalPower: 2 };
+  const outcome = whispers.applyDisguiseDeceptionBonus(bard, check);
+  expect(outcome?.bonus).toBe(5);
+  expect(check.finalPower).toBe(7);
+});
+
+test("Shadow Lore is Once Per Long Rest and applies an 8 Hour Charmed effect on failed WIS Save", () => {
+  const bard = character(70);
+  const target = { id: "secret-holder", name: "Secret Holder", statusEffects: {} };
+  const shadowLore = catalog.getDefinition("shadow_lore");
+  const state = global.LuminousTraitEngine.createState();
+
+  const first = global.LuminousTraitEngine.activateTrait(shadowLore, { context: "theatre", character: bard, self: bard, target, savePassed: false }, state);
+  expect(first.available).toBe(true);
+  expect(target.statusEffects.charmed).toBeTruthy();
+  expect(target.statusEffects.charmed.data.durationHours).toBe(8);
+  expect(target.statusEffects.charmed.data.casterLearnsSecret).toBe(false);
+
+  const second = global.LuminousTraitEngine.activateTrait(shadowLore, { context: "theatre", character: bard, self: bard, target, savePassed: false }, state);
+  expect(second.available).toBe(false);
+  expect(second.reasons.some((reason) => reason.includes("No uses remaining"))).toBe(true);
+});

--- a/tests/spellcasting_runtime.spec.js
+++ b/tests/spellcasting_runtime.spec.js
@@ -1,0 +1,61 @@
+const { test, expect } = require("@playwright/test");
+
+const baseTraitEngine = require("../js/trait-engine.js");
+global.LuminousTraitEngine = baseTraitEngine;
+delete global.LuminousSpellcastingRuntime;
+const spellcasting = require("../js/spellcasting-runtime.js");
+
+function bardCharacter() {
+  return {
+    level: 40,
+    proficiency: 4,
+    classes: [{ classId: "bard", levels: 40 }],
+    stats: { carisma: 20, inteligencia: 16 },
+  };
+}
+
+test("Bard resolves Spell Mod and Spell DC from the Class once", () => {
+  const trait = {
+    id: "bard_spell_test",
+    name: "Bard Spell Test",
+    source: { type: "class", id: "bard", classId: "bard" },
+    contexts: ["any"],
+    activation: { type: "passive", actionCost: "none" },
+    effects: [],
+    rules: [],
+  };
+  const variables = global.LuminousTraitEngine.buildVariables(bardCharacter(), {}, trait);
+  expect(spellcasting.getClassSpellcastingAbility("bard")).toBe("cha");
+  expect(variables.SpellMod).toBe(5);
+  expect(variables.SpellDC).toBe(17);
+});
+
+test("Archetype Traits inherit their parent Class Spellcasting Ability", () => {
+  const trait = {
+    id: "words_of_terror",
+    name: "Words of Terror",
+    source: { type: "archetype", id: "college_of_whispers", archetypeId: "college_of_whispers", classId: "bard" },
+    contexts: ["any"],
+    activation: { type: "manual", actionCost: "none" },
+    effects: [],
+    rules: [],
+  };
+  const variables = global.LuminousTraitEngine.buildVariables(bardCharacter(), {}, trait);
+  expect(variables.SpellMod).toBe(5);
+  expect(variables.SpellDC).toBe(17);
+});
+
+test("Spellcasting registry is reusable for future Classes", () => {
+  spellcasting.registerClassSpellcastingAbility("wizard", "int");
+  const trait = {
+    id: "wizard_spell_test",
+    source: { type: "class", id: "wizard", classId: "wizard" },
+    contexts: ["any"],
+    activation: { type: "passive", actionCost: "none" },
+    effects: [],
+    rules: [],
+  };
+  const variables = global.LuminousTraitEngine.buildVariables(bardCharacter(), {}, trait);
+  expect(variables.SpellMod).toBe(3);
+  expect(variables.SpellDC).toBe(15);
+});

--- a/tests/spellcasting_runtime.spec.js
+++ b/tests/spellcasting_runtime.spec.js
@@ -3,6 +3,7 @@ const { test, expect } = require("@playwright/test");
 const baseTraitEngine = require("../js/trait-engine.js");
 global.LuminousTraitEngine = baseTraitEngine;
 delete global.LuminousSpellcastingRuntime;
+delete require.cache[require.resolve("../js/spellcasting-runtime.js")];
 const spellcasting = require("../js/spellcasting-runtime.js");
 
 function bardCharacter() {


### PR DESCRIPTION
## Summary
- Adds **College of Whispers** as a Bard Archetype unlocked at Bard Class Level 15.
- Grants the agreed progression strictly by **Bard Class Level**:
  - Lv15: `Psychic Blade`, `Words of Terror`
  - Lv30: `Mantle of Whispers`
  - Lv70: `Shadow Lore`
- Adds a reusable class-aware Spellcasting resolver so class spells/Traits can use `Spell Mod` and `Spell DC` without repeating a stat modifier in every definition.
- Bard is registered once as `Spellcasting Ability = CHA`, with `Spell DC = 8 + Spell Mod + Proficiency`.

## College of Whispers rules

### Psychic Blade
- `[On Use]` consumes 1 real Bardic Inspiration use.
- Gains `((CHA Mod) + (Bard Level / 20)) Psychic Blade` Count.
- `[On Hit]` reduces target SP by `((CHA Mod / 2) + (Bard Level / 25))`, then reduces Psychic Blade Count by 1.
- Uses the existing Bardic Inspiration usage state instead of creating a duplicate resource.

### Words of Terror
- `[On Use]` target makes a WIS Save against the Bard's class-resolved Spell DC.
- On failure, inflicts `Frightened`.
- A successful save simply negates the effect; no redundant success effect is authored.

### Mantle of Whispers
- Hooks the real `luminous:unit-dead` lifecycle event rather than D&D distance or `[On Kill]` semantics.
- When a Humanoid dies during an Encounter, exposes the choice to absorb its Shadow.
- Once Per Long Rest, the Bard may gain a dynamic `Shadow of [Unit or Character Name]` effect.
- Consuming the Stored Shadow assumes that Identity for 1 Hour.
- While disguised, Deception Checks defending that Identity gain +5 Power against Insight Checks.
- An unused Stored Shadow is lost on Long Rest.
- Identity duration advances through the existing world-time event contract.

### Shadow Lore
- `[On Use]` target makes a WIS Save against Spell DC.
- On failure, inflicts `Charmed` for 8 Hours.
- Once Per Long Rest.
- Stores the agreed behavior: target believes the Bard knows its darkest secret, treats the Bard as a trusted ally out of fear of exposure, will not willingly risk its life unless already inclined, and the Bard does not actually learn the secret.
- Charm ends if the Bard or an ally damages the target.

## Shared Spellcasting contract
- Adds `js/spellcasting-runtime.js`.
- Class spellcasting ability is registered once per Class.
- Bard currently registers `CHA`.
- Trait Engine variables receive `SpellMod` and `SpellDC` for class and parent-Archetype Traits.
- The registry is reusable for future spellcasting Classes instead of repeating modifier selection per Spell.

## Runtime integration
- Adds `js/college-of-whispers-runtime.js`.
- Uses the canonical Status store for Psychic Blade, Frightened, Charmed, Stored Shadow and disguise state.
- Uses the existing actual-death event, Long Rest event, world-time event and Bardic Inspiration Trait state.
- Adds a spell-save request contract (`luminous:spell-save-requested`) when a save result is not supplied directly by the caller.

## Tests
Adds focused regressions for:
- Bard CHA → Spell Mod → Spell DC resolution.
- Parent Archetype inheritance of the Bard Spellcasting Ability.
- College of Whispers Class-Level grants at 15/30/70.
- Psychic Blade Bardic Inspiration consumption, Count, SP reduction and Count loss.
- Words of Terror failed/successful WIS Save behavior.
- Mantle named Shadow storage, Once Per Long Rest gate, identity consumption, 1-Hour expiry and +5 Deception vs Insight.
- Shadow Lore Long-Rest usage and 8-Hour Charmed state.

Both **Trait Engine** and **Archetype Engine** workflows now syntax-check and run the new runtime/test files.