### PR TITLE
Hotfix: sincronizar la Trait Library con todos los catálogos

### DIFF
--- a/js/dm-trait-catalog-importer.js
+++ b/js/dm-trait-catalog-importer.js
@@ -3,13 +3,106 @@
 
   const doc = global.document || null;
   const engine = global.LuminousTraitEngine || (typeof require === "function" ? require("./trait-engine.js") : null);
-  const catalog = global.LuminousTraitCatalogCore || (typeof require === "function" ? require("./trait-catalog-core.js") : null);
+
+  function optionalRequire(path) {
+    if (typeof require !== "function") return null;
+    try { return require(path); } catch (_) { return null; }
+  }
+
+  const initialCoreCatalog = global.LuminousTraitCatalogCore || optionalRequire("./trait-catalog-core.js");
+  const initialBardRuntime = global.LuminousBardClassRuntime || optionalRequire("./bard-class-runtime.js");
+  initialBardRuntime?.wrapCatalog?.();
+  const initialRacialCatalog = global.LuminousRacialTraitCatalog || optionalRequire("./racial-trait-catalog.js");
+  const initialArchetypeCatalog = global.LuminousArchetypeTraitCatalog || optionalRequire("./archetype-trait-catalog.js");
+
   const TRAITS_ROOT = "campaña/config/traits";
   const DEFINITIONS_ROOT = `${TRAITS_ROOT}/definitions`;
   const GRANTS_ROOT = `${TRAITS_ROOT}/grants`;
 
   function asRecord(value) {
     return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+  }
+
+  function stableValue(value) {
+    if (Array.isArray(value)) return value.map(stableValue);
+    if (!value || typeof value !== "object") return value;
+    return Object.keys(value).sort().reduce((out, key) => {
+      out[key] = stableValue(value[key]);
+      return out;
+    }, {});
+  }
+
+  function comparableDefinition(value = {}) {
+    const copy = { ...(value || {}) };
+    delete copy.createdAt;
+    delete copy.updatedAt;
+    delete copy.catalogSource;
+    delete copy.catalogVersion;
+    return stableValue(copy);
+  }
+
+  function definitionsEqual(left, right) {
+    return JSON.stringify(comparableDefinition(left)) === JSON.stringify(comparableDefinition(right));
+  }
+
+  function providerVersion(catalog) {
+    const value = Number(catalog?.CATALOG_VERSION || 1);
+    return Number.isFinite(value) && value > 0 ? value : 1;
+  }
+
+  function catalogProviders() {
+    const core = global.LuminousTraitCatalogCore || initialCoreCatalog;
+    const racial = global.LuminousRacialTraitCatalog || initialRacialCatalog;
+    const archetype = global.LuminousArchetypeTraitCatalog || initialArchetypeCatalog;
+    return [
+      { key: "core", catalog: core, includeGrants: true },
+      { key: "racial", catalog: racial, includeGrants: false },
+      { key: "archetype", catalog: archetype, includeGrants: false },
+    ].filter((entry) => entry.catalog?.allDefinitions);
+  }
+
+  function collectCatalog() {
+    const definitions = {};
+    const grants = [];
+    const errors = [];
+    const providers = catalogProviders();
+
+    providers.forEach(({ key, catalog, includeGrants }) => {
+      const version = providerVersion(catalog);
+      Object.entries(catalog.allDefinitions?.() || {}).forEach(([rawId, definition]) => {
+        const id = engine?.normalizeId ? engine.normalizeId(rawId) : String(rawId || "").trim().toLowerCase();
+        if (!id) {
+          errors.push(`${key}: Trait definition is missing an id.`);
+          return;
+        }
+
+        if (definitions[id]) {
+          if (!definitionsEqual(definitions[id].definition, definition)) {
+            errors.push(`${id}: conflicting Trait definitions from ${definitions[id].catalogSource} and ${key}.`);
+          }
+          return;
+        }
+
+        definitions[id] = {
+          id,
+          definition,
+          catalogSource: key,
+          catalogVersion: version,
+        };
+      });
+
+      if (!includeGrants) return;
+      (catalog.allGrants?.() || []).forEach((grant) => {
+        grants.push({
+          id: grant?.id,
+          grant,
+          catalogSource: key,
+          catalogVersion: version,
+        });
+      });
+    });
+
+    return { definitions, grants, providers, errors };
   }
 
   function grantIdentity(grant = {}) {
@@ -21,14 +114,13 @@
   }
 
   function buildImportPlan(existingDefinitions = {}, existingGrants = [], helpers = {}) {
-    const definitions = catalog?.allDefinitions?.() || {};
-    const grants = catalog?.allGrants?.() || [];
-    const errors = [];
+    const collected = collectCatalog();
+    const errors = [...collected.errors];
     const definitionWrites = [];
     const grantWrites = [];
     const existingIdentities = new Set((existingGrants || []).map(grantIdentity));
 
-    Object.entries(definitions).forEach(([id, definition]) => {
+    Object.values(collected.definitions).forEach(({ id, definition, catalogSource, catalogVersion }) => {
       const validation = helpers.validateDefinitionForPersistence
         ? helpers.validateDefinitionForPersistence(definition)
         : engine?.validateTrait?.(definition);
@@ -38,9 +130,14 @@
       }
 
       const existing = existingDefinitions?.[id];
+      const existingSource = String(existing?.catalogSource || "").trim().toLowerCase();
       const existingCatalogVersion = Number(existing?.catalogVersion || 0);
-      const isManagedCoreDefinition = existingCatalogVersion > 0;
-      const needsCatalogUpgrade = isManagedCoreDefinition && existingCatalogVersion < Number(catalog.CATALOG_VERSION || 0);
+      const legacyCoreManaged = !existingSource && catalogSource === "core" && existingCatalogVersion > 0;
+      const managedByProvider = existingSource === catalogSource || legacyCoreManaged;
+      const needsCatalogUpgrade = Boolean(existing && managedByProvider && (
+        existingCatalogVersion < catalogVersion ||
+        !definitionsEqual(existing, validation.trait)
+      ));
 
       if (!existing || needsCatalogUpgrade) {
         definitionWrites.push({
@@ -48,24 +145,26 @@
           definition: validation.trait,
           replace: Boolean(existing),
           previous: existing || null,
+          catalogSource,
+          catalogVersion,
         });
       }
     });
 
-    grants.forEach((grant) => {
-      const idValidation = helpers.validateFirebaseKey ? helpers.validateFirebaseKey(grant.id) : { valid: Boolean(grant.id), errors: [] };
+    collected.grants.forEach(({ id, grant, catalogSource, catalogVersion }) => {
+      const idValidation = helpers.validateFirebaseKey ? helpers.validateFirebaseKey(id) : { valid: Boolean(id), errors: [] };
       const validation = helpers.validateGrant ? helpers.validateGrant(grant) : { valid: true, grant };
       if (!idValidation.valid) {
-        (idValidation.errors || ["Invalid Firebase key."]).forEach((message) => errors.push(`${grant.id || "<grant>"}: ${message}`));
+        (idValidation.errors || ["Invalid Firebase key."]).forEach((message) => errors.push(`${id || "<grant>"}: ${message}`));
         return;
       }
       if (!validation.valid) {
-        (validation.errors || ["Invalid Grant."]).forEach((message) => errors.push(`${grant.id}: ${message}`));
+        (validation.errors || ["Invalid Grant."]).forEach((message) => errors.push(`${id}: ${message}`));
         return;
       }
       const identity = grantIdentity(validation.grant);
       if (!existingIdentities.has(identity)) {
-        grantWrites.push({ id: grant.id, grant: validation.grant });
+        grantWrites.push({ id, grant: validation.grant, catalogSource, catalogVersion });
         existingIdentities.add(identity);
       }
     });
@@ -75,8 +174,9 @@
       errors,
       definitionWrites,
       grantWrites,
-      skippedDefinitions: Math.max(0, Object.keys(definitions).length - definitionWrites.length),
-      skippedGrants: Math.max(0, grants.length - grantWrites.length),
+      skippedDefinitions: Math.max(0, Object.keys(collected.definitions).length - definitionWrites.length),
+      skippedGrants: Math.max(0, collected.grants.length - grantWrites.length),
+      providerKeys: collected.providers.map((entry) => entry.key),
     };
   }
 
@@ -97,20 +197,22 @@
     const nextDefinitions = { ...definitions };
     const nextGrants = { ...grantMap };
 
-    plan.definitionWrites.forEach(({ id, definition, previous }) => {
+    plan.definitionWrites.forEach(({ id, definition, previous, catalogSource, catalogVersion }) => {
       nextDefinitions[id] = {
         ...definition,
         createdAt: previous?.createdAt ?? stamp,
         updatedAt: stamp,
-        catalogVersion: catalog.CATALOG_VERSION,
+        catalogSource,
+        catalogVersion,
       };
     });
-    plan.grantWrites.forEach(({ id, grant }) => {
+    plan.grantWrites.forEach(({ id, grant, catalogSource, catalogVersion }) => {
       nextGrants[id] = {
         ...grant,
         createdAt: stamp,
         updatedAt: stamp,
-        catalogVersion: catalog.CATALOG_VERSION,
+        catalogSource,
+        catalogVersion,
       };
     });
 
@@ -157,19 +259,60 @@
     return { ...lastMutation.plan, committed: true };
   }
 
+  function ensureScript(id, src, ready) {
+    if (!doc || ready?.()) return Promise.resolve();
+    const existing = doc.getElementById(id);
+    if (existing) {
+      if (ready?.()) return Promise.resolve();
+      return new Promise((resolve, reject) => {
+        existing.addEventListener("load", resolve, { once: true });
+        existing.addEventListener("error", reject, { once: true });
+      });
+    }
+
+    return new Promise((resolve, reject) => {
+      const script = doc.createElement("script");
+      script.id = id;
+      script.src = src;
+      script.async = false;
+      script.addEventListener("load", resolve, { once: true });
+      script.addEventListener("error", reject, { once: true });
+      doc.head?.appendChild(script);
+    });
+  }
+
+  async function ensureBuiltInCatalogs() {
+    initialBardRuntime?.wrapCatalog?.();
+    if (!doc) return catalogProviders();
+
+    await ensureScript("bard-class-runtime-script", "js/bard-class-runtime.js", () => Boolean(global.LuminousBardClassRuntime));
+    global.LuminousBardClassRuntime?.wrapCatalog?.();
+
+    await Promise.all([
+      ensureScript("racial-trait-catalog-script", "js/racial-trait-catalog.js", () => Boolean(global.LuminousRacialTraitCatalog)),
+      ensureScript("archetype-engine-script", "js/archetype-engine.js", () => Boolean(global.LuminousArchetypeEngine)),
+    ]);
+    await ensureScript("archetype-trait-catalog-script", "js/archetype-trait-catalog.js", () => Boolean(global.LuminousArchetypeTraitCatalog));
+
+    return catalogProviders();
+  }
+
   if (typeof module !== "undefined" && module.exports) {
     module.exports = {
       TRAITS_ROOT,
       DEFINITIONS_ROOT,
       GRANTS_ROOT,
       grantIdentity,
+      catalogProviders,
+      collectCatalog,
       buildImportPlan,
       buildAtomicImportMutation,
       runAtomicImport,
+      ensureBuiltInCatalogs,
     };
   }
 
-  if (!doc || !engine || !catalog || global.LuminousTraitCatalogImporter) return;
+  if (!doc || !engine || global.LuminousTraitCatalogImporter) return;
 
   function timestamp() {
     return global.firebase?.database?.ServerValue?.TIMESTAMP || Date.now();
@@ -191,8 +334,16 @@
     if (!lib) throw new Error("Trait Library no está lista.");
     if (!global.firebase?.database || !global.firebase?.apps?.length) throw new Error("Firebase no está disponible.");
 
-    const catalogValidation = catalog.validateAll(engine);
-    if (!catalogValidation.valid) throw new Error(catalogValidation.errors.join(" · "));
+    const providers = await ensureBuiltInCatalogs();
+    const validationErrors = [];
+    providers.forEach(({ key, catalog }) => {
+      if (!catalog?.validateAll) return;
+      const validation = catalog.validateAll(engine);
+      if (!validation?.valid) {
+        (validation?.errors || ["Invalid catalog."]).forEach((message) => validationErrors.push(`${key}: ${message}`));
+      }
+    });
+    if (validationErrors.length) throw new Error(validationErrors.join(" · "));
 
     const plan = await runAtomicImport(
       global.firebase.database(),
@@ -205,13 +356,13 @@
     );
 
     if (!plan.definitionWrites.length && !plan.grantWrites.length) {
-      feedback("El catálogo base ya está importado. No hay cambios.", "success");
+      feedback("Los catálogos integrados ya están sincronizados. No hay cambios.", "success");
       return plan;
     }
 
     const upgraded = plan.definitionWrites.filter((entry) => entry.replace).length;
     const created = plan.definitionWrites.length - upgraded;
-    feedback(`Catálogo base importado: ${created} Traits nuevos · ${upgraded} actualizados · ${plan.grantWrites.length} Grants.`, "success");
+    feedback(`Catálogos sincronizados: ${created} Traits nuevos · ${upgraded} actualizados · ${plan.grantWrites.length} Grants genéricos.`, "success");
     return plan;
   }
 
@@ -224,16 +375,16 @@
     button.id = "dm-trait-import-core";
     button.className = "btn-cyber";
     button.type = "button";
-    button.textContent = "IMPORTAR CATÁLOGO BASE";
+    button.textContent = "SINCRONIZAR CATÁLOGOS";
     button.addEventListener("click", async () => {
       button.disabled = true;
       const oldText = button.textContent;
-      button.textContent = "IMPORTANDO...";
+      button.textContent = "SINCRONIZANDO...";
       try {
         await importCatalog();
       } catch (error) {
-        console.error("Core Trait Catalog Import:", error);
-        feedback(error.message || "No se pudo importar el catálogo base.", "error");
+        console.error("Trait Catalog Sync:", error);
+        feedback(error.message || "No se pudieron sincronizar los catálogos.", "error");
       } finally {
         button.disabled = false;
         button.textContent = oldText;
@@ -257,9 +408,12 @@
     DEFINITIONS_ROOT,
     GRANTS_ROOT,
     grantIdentity,
+    catalogProviders,
+    collectCatalog,
     buildImportPlan,
     buildAtomicImportMutation,
     runAtomicImport,
+    ensureBuiltInCatalogs,
     importCatalog,
     mountButton,
   });

--- a/tests/dm_trait_catalog_importer.spec.js
+++ b/tests/dm_trait_catalog_importer.spec.js
@@ -2,8 +2,11 @@ const { test, expect } = require("@playwright/test");
 const fs = require("node:fs");
 const path = require("node:path");
 const studio = require("../js/dm-trait-library-studio.js");
-const catalog = require("../js/trait-catalog-core.js");
+require("../js/trait-catalog-core.js");
 const importer = require("../js/dm-trait-catalog-importer.js");
+const catalog = global.LuminousTraitCatalogCore;
+const racialCatalog = global.LuminousRacialTraitCatalog;
+const archetypeCatalog = global.LuminousArchetypeTraitCatalog;
 
 const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
 
@@ -14,16 +17,41 @@ const helpers = {
 };
 
 const barbarianGrantCount = () => catalog.GRANTS.filter((grant) => grant.sourceType === "class" && grant.sourceId === "barbarian").length;
+const allBuiltInDefinitions = () => Object.fromEntries(
+  Object.values(importer.collectCatalog().definitions).map(({ id, definition }) => [id, definition]),
+);
 
-test("empty Trait Library imports all known core definitions and confirmed Grants", () => {
+test("empty Trait Library imports every built-in definition and only generic Grants", () => {
   const plan = importer.buildImportPlan({}, [], helpers);
+  const collected = importer.collectCatalog();
+
   expect(plan.valid).toBe(true);
   expect(plan.errors).toEqual([]);
-  expect(plan.definitionWrites.map((entry) => entry.id).sort()).toEqual(Object.keys(catalog.DEFINITIONS).sort());
-  expect(plan.grantWrites.map((entry) => entry.id).sort()).toEqual(catalog.GRANTS.map((entry) => entry.id).sort());
-  expect(plan.definitionWrites).toHaveLength(Object.keys(catalog.DEFINITIONS).length);
-  expect(plan.grantWrites).toHaveLength(catalog.GRANTS.length);
+  expect(plan.providerKeys).toEqual(expect.arrayContaining(["core", "racial", "archetype"]));
+  expect(plan.definitionWrites.map((entry) => entry.id).sort()).toEqual(Object.keys(collected.definitions).sort());
+  expect(plan.grantWrites.map((entry) => entry.id).sort()).toEqual(collected.grants.map((entry) => entry.id).sort());
+  expect(plan.definitionWrites).toHaveLength(Object.keys(collected.definitions).length);
+  expect(plan.grantWrites).toHaveLength(collected.grants.length);
   expect(barbarianGrantCount()).toBe(12);
+
+  const definitionIds = new Set(plan.definitionWrites.map((entry) => entry.id));
+  expect(definitionIds.has("bardic_inspiration")).toBe(true);
+  expect(definitionIds.has("yuan_ti_magic_resistance")).toBe(true);
+  expect(definitionIds.has("psychic_blade")).toBe(true);
+
+  expect(plan.grantWrites.some((entry) => entry.grant.sourceType === "race")).toBe(false);
+  expect(plan.grantWrites.some((entry) => entry.grant.sourceType === "archetype")).toBe(false);
+  expect(plan.grantWrites.some((entry) => entry.grant.traitId === "bardic_inspiration")).toBe(true);
+});
+
+test("catalog providers expose the specialized catalogs without importing their automatic Grants", () => {
+  expect(racialCatalog?.allDefinitions?.().yuan_ti_magic_resistance).toBeTruthy();
+  expect(archetypeCatalog?.allDefinitions?.().psychic_blade).toBeTruthy();
+
+  const collected = importer.collectCatalog();
+  expect(collected.definitions.yuan_ti_magic_resistance.catalogSource).toBe("racial");
+  expect(collected.definitions.psychic_blade.catalogSource).toBe("archetype");
+  expect(collected.grants.every((entry) => entry.catalogSource === "core")).toBe(true);
 });
 
 test("core import never overwrites an existing DM Trait definition without catalog ownership", () => {
@@ -39,7 +67,7 @@ test("core import never overwrites an existing DM Trait definition without catal
   const plan = importer.buildImportPlan(existing, [], helpers);
   expect(plan.valid).toBe(true);
   expect(plan.definitionWrites.some((entry) => entry.id === "rage")).toBe(false);
-  expect(plan.skippedDefinitions).toBe(1);
+  expect(plan.skippedDefinitions).toBeGreaterThanOrEqual(1);
 });
 
 test("managed core definitions upgrade when their catalogVersion is older", () => {
@@ -53,13 +81,48 @@ test("managed core definitions upgrade when their catalogVersion is older", () =
   const plan = importer.buildImportPlan({ rage: oldManagedRage }, [], helpers);
   const rageWrite = plan.definitionWrites.find((entry) => entry.id === "rage");
   expect(plan.valid).toBe(true);
-  expect(rageWrite).toMatchObject({ id: "rage", replace: true });
+  expect(rageWrite).toMatchObject({ id: "rage", replace: true, catalogSource: "core" });
 
   const mutation = importer.buildAtomicImportMutation({ definitions: { rage: oldManagedRage }, grants: {} }, helpers, 222);
   expect(mutation.next.definitions.rage.name).toBe("Rage");
+  expect(mutation.next.definitions.rage.catalogSource).toBe("core");
   expect(mutation.next.definitions.rage.catalogVersion).toBe(catalog.CATALOG_VERSION);
   expect(mutation.next.definitions.rage.createdAt).toBe(111);
   expect(mutation.next.definitions.rage.updatedAt).toBe(222);
+});
+
+test("managed specialized definitions refresh on content changes without leaking specialized Grants", () => {
+  const racial = importer.collectCatalog().definitions.yuan_ti_magic_resistance;
+  const stale = {
+    ...racial.definition,
+    description: "STALE RACIAL COPY",
+    catalogSource: "racial",
+    catalogVersion: racial.catalogVersion,
+    createdAt: 333,
+    updatedAt: 333,
+  };
+
+  const mutation = importer.buildAtomicImportMutation({ definitions: { yuan_ti_magic_resistance: stale }, grants: {} }, helpers, 444);
+  expect(mutation.valid).toBe(true);
+  expect(mutation.next.definitions.yuan_ti_magic_resistance.description).toBe(racial.definition.description);
+  expect(mutation.next.definitions.yuan_ti_magic_resistance.catalogSource).toBe("racial");
+  expect(mutation.next.definitions.yuan_ti_magic_resistance.createdAt).toBe(333);
+  expect(mutation.plan.grantWrites.some((entry) => entry.grant.sourceType === "race")).toBe(false);
+});
+
+test("custom definition with a built-in archetype id remains DM-owned", () => {
+  const custom = {
+    id: "psychic_blade",
+    name: "Psychic Blade - DM Custom",
+    description: "Custom definition.",
+    contexts: ["combat"],
+    activation: { type: "passive", actionCost: "none" },
+    effects: [],
+    rules: [],
+  };
+  const plan = importer.buildImportPlan({ psychic_blade: custom }, [], helpers);
+  expect(plan.valid).toBe(true);
+  expect(plan.definitionWrites.some((entry) => entry.id === "psychic_blade")).toBe(false);
 });
 
 test("core import deduplicates confirmed Grants by semantic identity even with another Firebase push id", () => {
@@ -72,7 +135,7 @@ test("core import deduplicates confirmed Grants by semantic identity even with a
   const plan = importer.buildImportPlan({}, existingGrants, helpers);
   expect(plan.valid).toBe(true);
   expect(plan.grantWrites.some((entry) => entry.grant.traitId === "devil_body")).toBe(false);
-  expect(plan.grantWrites).toHaveLength(barbarianGrantCount());
+  expect(plan.grantWrites).toHaveLength(catalog.GRANTS.length - 1);
 });
 
 test("atomic mutation preserves concurrent custom definitions and semantic Grants", () => {
@@ -94,11 +157,13 @@ test("atomic mutation preserves concurrent custom definitions and semantic Grant
   expect(mutation.valid).toBe(true);
   expect(mutation.changed).toBe(true);
   expect(mutation.plan.definitionWrites.some((entry) => entry.id === "rage")).toBe(false);
-  expect(mutation.plan.grantWrites).toHaveLength(barbarianGrantCount());
+  expect(mutation.plan.grantWrites).toHaveLength(catalog.GRANTS.length - 1);
   expect(mutation.next.definitions.rage.name).toBe("Rage - Concurrent DM Version");
   expect(mutation.next.grants.custom_push_id.traitId).toBe("devil_body");
   expect(mutation.next.unrelated).toEqual({ keep: true });
   expect(mutation.next.definitions.danger_senses.createdAt).toBe(1234);
+  expect(mutation.next.definitions.yuan_ti_magic_resistance.catalogSource).toBe("racial");
+  expect(mutation.next.definitions.psychic_blade.catalogSource).toBe("archetype");
   expect(mutation.next.grants.core_class_barbarian_l100_primordial_champion.atLevel).toBe(100);
 });
 
@@ -139,22 +204,25 @@ test("Firebase transaction retry replans against a concurrent DM write before co
   expect(attempts).toBe(2);
   expect(result.committed).toBe(true);
   expect(result.definitionWrites.some((entry) => entry.id === "rage")).toBe(false);
-  expect(result.grantWrites).toHaveLength(barbarianGrantCount());
+  expect(result.grantWrites).toHaveLength(catalog.GRANTS.length - 1);
   expect(committedTree.definitions.rage.name).toBe("Rage - Saved During Import");
   expect(committedTree.grants.another_dm_grant.traitId).toBe("devil_body");
   expect(Object.keys(committedTree.definitions)).toEqual(expect.arrayContaining([
     "additional_attack",
     "armorless_defense",
+    "bardic_inspiration",
     "danger_senses",
     "devil_body",
     "devil_trigger",
+    "psychic_blade",
     "rage",
+    "yuan_ti_magic_resistance",
   ]));
 });
 
 test("no-op cache is server-confirmed and retries when the server lost a catalog definition", async () => {
   const completeTree = {
-    definitions: catalog.allDefinitions(),
+    definitions: allBuiltInDefinitions(),
     grants: Object.fromEntries(catalog.allGrants().map(({ id, ...grant }) => [id, grant])),
   };
   const serverTree = JSON.parse(JSON.stringify(completeTree));
@@ -185,10 +253,11 @@ test("no-op cache is server-confirmed and retries when the server lost a catalog
   expect(result.definitionWrites.map((entry) => entry.id)).toEqual(["rage"]);
   expect(result.grantWrites).toHaveLength(0);
   expect(committedTree.definitions.rage.name).toBe("Rage");
+  expect(committedTree.definitions.rage.catalogSource).toBe("core");
   expect(committedTree.definitions.rage.createdAt).toBe(9012);
 });
 
-test("core Grant ids are Firebase-safe and deterministic", () => {
+test("generic catalog Grant ids are Firebase-safe and deterministic", () => {
   catalog.GRANTS.forEach((grant) => {
     expect(studio.validateFirebaseKey(grant.id).valid).toBe(true);
     expect(importer.grantIdentity(grant)).toBe(studio.grantIdentity(grant));


### PR DESCRIPTION
## Problema

La Trait Library del DM solo sincronizaba `LuminousTraitCatalogCore`. Después de separar Traits en catálogos/runtimes especializados, la biblioteca podía quedar incompleta: Bard, Traits raciales y Traits de Arquetipo como College of Whispers no aparecían al importar el catálogo.

Importar también sus Grants automáticos por el resolver genérico no es seguro: los Grants raciales dependen de subraza y los de Arquetipo de la selección/nivel del Arquetipo, condiciones que `resolveTraitGrants()` genérico no resuelve.

## Hotfix

- sincroniza definiciones desde los proveedores integrados `core`, `racial` y `archetype`;
- carga Bard antes de recolectar el core para incluir su progresión de clase;
- mantiene en Firebase únicamente los Grants genéricos del core (Class/Lineage, incluido Bard cuando extiende el core);
- NO importa Grants raciales ni de Arquetipo, que continúan en sus resolvers especializados;
- marca definiciones administradas con `catalogSource` + `catalogVersion`;
- actualiza una definición administrada si cambió su contenido, incluso cuando el catálogo especializado no incrementó versión;
- conserva definiciones DM custom que coincidan en ID pero no tengan ownership de catálogo;
- cambia el CTA a `SINCRONIZAR CATÁLOGOS` para reflejar el comportamiento real.

## Cobertura

`tests/dm_trait_catalog_importer.spec.js` ahora verifica:

- Bardic Inspiration, Yuan-ti Magic Resistance y Psychic Blade en una biblioteca vacía;
- ausencia de Grants `race`/`archetype` en la mutación Firebase;
- actualización segura de definiciones administradas;
- preservación de definiciones custom del DM;
- transacciones/reintentos y deduplicación de Grants existentes.

## Alcance

No cambia `trait-engine.js`, no cambia el resolver de Traits y no modifica reglas de Firebase. El parche queda limitado al sincronizador de la Trait Library y sus regresiones.