### PR TITLE
feat: add Environment context and trigger contract

### DIFF
--- a/.github/workflows/weather-engine.yml
+++ b/.github/workflows/weather-engine.yml
@@ -5,10 +5,12 @@ on:
     paths:
       - "js/weather-engine.js"
       - "js/environment-engine.js"
+      - "js/environment-runtime.js"
       - "js/weather-readonly-engine.js"
       - "js/weather-post-merge-hotfix.js"
       - "js/weather-player-widget.js"
       - "js/weather-fx.js"
+      - "js/universal-action-economy.js"
       - "js/utils.js"
       - "css/weather-player.css"
       - "css/weather-fx.css"
@@ -44,10 +46,12 @@ jobs:
         run: |
           node --check js/weather-engine.js
           node --check js/environment-engine.js
+          node --check js/environment-runtime.js
           node --check js/weather-readonly-engine.js
           node --check js/weather-post-merge-hotfix.js
           node --check js/weather-player-widget.js
           node --check js/weather-fx.js
+          node --check js/universal-action-economy.js
           node --check js/utils.js
           node --check tests/weather_engine.spec.js
           node --check tests/environment_engine.spec.js

--- a/.github/workflows/weather-engine.yml
+++ b/.github/workflows/weather-engine.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "js/weather-engine.js"
+      - "js/environment-engine.js"
       - "js/weather-readonly-engine.js"
       - "js/weather-post-merge-hotfix.js"
       - "js/weather-player-widget.js"
@@ -13,7 +14,9 @@ on:
       - "css/weather-fx.css"
       - "hoja_de_DM.html"
       - "tests/weather_engine.spec.js"
+      - "tests/environment_engine.spec.js"
       - "tests/weather_post_merge_hotfix.spec.js"
+      - "docs/environment-context.md"
       - ".github/workflows/weather-engine.yml"
   workflow_dispatch:
 
@@ -40,13 +43,15 @@ jobs:
       - name: Syntax check Weather JavaScript
         run: |
           node --check js/weather-engine.js
+          node --check js/environment-engine.js
           node --check js/weather-readonly-engine.js
           node --check js/weather-post-merge-hotfix.js
           node --check js/weather-player-widget.js
           node --check js/weather-fx.js
           node --check js/utils.js
           node --check tests/weather_engine.spec.js
+          node --check tests/environment_engine.spec.js
           node --check tests/weather_post_merge_hotfix.spec.js
 
       - name: Verify Weather contracts
-        run: npx playwright test tests/weather_engine.spec.js tests/weather_post_merge_hotfix.spec.js --workers=1
+        run: npx playwright test tests/weather_engine.spec.js tests/environment_engine.spec.js tests/weather_post_merge_hotfix.spec.js --workers=1

--- a/docs/environment-context.md
+++ b/docs/environment-context.md
@@ -1,0 +1,243 @@
+# Environment Context Contract
+
+## Goal
+
+Environment is contextual state for encounters, zones, and actors. It is **not** a second Status Effect engine and it does not apply blanket combat penalties.
+
+Weather, time, encounter type, local cover, water, terrain, and magical/artificial sources are resolved into one `Effective Environment`. Races, classes, archetypes, equipment, spells, and existing rules inspect that context through normal Trait Engine conditions.
+
+## Resolution flow
+
+```text
+Weather / Time / Encounter Type
+              ↓
+      Environment Resolver
+              ↓
+       Encounter / Zone
+              ↓
+       Actor-local context
+              ↓
+      Effective Environment
+              ↓
+Traits / Vision / Movement / other specialized resolvers
+```
+
+Weather never directly edits an actor's attack, defense, saves, HP, SP, or Status Effects.
+
+## Encounter Type
+
+Supported canonical values:
+
+- `outdoor`: exterior weather and sunlight are exposed normally.
+- `covered`: exterior light remains, direct sunlight becomes diffuse, and direct precipitation is blocked.
+- `indoor`: exterior weather and natural sunlight are blocked. Local light can override the default.
+- `underground`: exterior weather and sunlight are blocked; unconfigured natural light defaults to Darkness.
+- `underwater`: exterior weather is blocked and the encounter exposes the `Submerged` water context.
+- `special`: reserved for encounters driven primarily by explicit overrides.
+
+## Environment State
+
+These are mutually exclusive state values, not stackable effects.
+
+### Light
+
+- `bright`
+- `dim`
+- `darkness`
+
+`Darkness` describes the objective light state. Darkvision or another sense interprets it later. Magical darkness is represented by `light: "darkness"` with a `magical` state origin rather than a second light level.
+
+### Sunlight
+
+- `direct`
+- `diffuse`
+- `none`
+
+Sunlight is independent from Light. Bright artificial lighting can therefore coexist with `sunlight: "none"`.
+
+### Visibility
+
+- `clear`
+- `obscured`
+- `heavily_obscured`
+
+Visibility is independent from Light. Dense fog may be Heavily Obscured in Bright Light; a clear unlit cave can be Darkness with otherwise Clear visibility.
+
+## Environment Effects
+
+Environment effects are triggerable context. Severity documents which downstream resolver may care about them; it does not add a generic modifier.
+
+### Water
+
+| Effect | Purpose |
+| --- | --- |
+| `near_water` | Relevant accessible water is nearby. Trigger only. |
+| `in_water` | Actor is physically in water. Swimming rules may inspect it. Implies `near_water`. |
+| `submerged` | Actor is fully underwater. Underwater movement, breathing, combat, and traits may inspect it. Implies `in_water` and `near_water`. |
+
+`Retreat - Submerged` is the canonical naming. Legacy `Sink` / `Retreat - Sink` identifiers normalize to `submerged` for compatibility.
+
+### Exposure
+
+| Effect | Purpose |
+| --- | --- |
+| `exposed` | Actor receives zone exposure normally. |
+| `under_cover` | Blocks direct precipitation and reduces Direct Sunlight to Diffuse Sunlight. |
+| `indoors` | Blocks exterior weather and natural sunlight. |
+
+### Weather
+
+| Effect | Purpose |
+| --- | --- |
+| `rain` | Context trigger; no blanket penalty. |
+| `heavy_rain` | Severe rain; implies `rain` and may make visibility Obscured. |
+| `snow` | Context trigger; no blanket penalty. |
+| `heavy_snow` | Severe snow; implies `snow` and may make visibility Obscured. Accumulated terrain is separate. |
+| `fog` | Makes visibility Obscured. |
+| `dense_fog` | Makes visibility Heavily Obscured and implies `fog`. |
+| `hail` | Preserves the existing Granizo weather as triggerable context. |
+| `strong_wind` | Trigger for flight, projectiles, light objects, and mechanics that explicitly care about wind. |
+| `storm` | Composite severe weather; implies Heavy Rain and Strong Wind. No additional blanket Storm penalty is added. |
+
+### Temperature
+
+- `extreme_heat`
+- `extreme_cold`
+
+They are severe exposure triggers. This change intentionally does **not** invent numeric temperature thresholds or new saves; a dedicated exposure rule can consume them later.
+
+### Terrain
+
+- `difficult_terrain`: movement resolver may increase movement cost.
+- `hazardous_terrain`: a specific hazard defines its own consequence.
+- `slippery`: actions that care about footing may inspect it.
+
+## Origin tags
+
+Every effect or state source may declare:
+
+- `natural`
+- `artificial`
+- `magical`
+
+`Natural Environment Effect` is therefore an origin query, not a separate status.
+
+Examples:
+
+```js
+{ id: "difficult_terrain", origin: "natural" }
+{ id: "difficult_terrain", origin: "artificial" }
+{ id: "dense_fog", origin: "magical" }
+```
+
+All three can produce similar physical context while remaining distinguishable to Traits.
+
+## Scope
+
+Effects support:
+
+- `encounter`
+- `zone`
+- `actor`
+
+Weather normally resolves at Encounter scope. Terrain and nearby water commonly resolve at Zone scope. `In Water`, `Submerged`, and exposure relationships commonly resolve at Actor scope. An Underwater Encounter may promote `Submerged` to Encounter scope because every participant shares the medium.
+
+## Weather mapping
+
+The resolver keeps the weather vocabulary already used by `weather-engine.js`:
+
+| Weather | Daylight environment |
+| --- | --- |
+| `soleado` | Bright Light + Direct Sunlight + Clear |
+| `parcialmente_nublado` | Bright Light + Direct Sunlight + Clear |
+| `nublado` | Bright Light + Diffuse Sunlight + Clear |
+| `llovizna` | Diffuse Sunlight + Rain |
+| `lluvia` | Diffuse Sunlight + Rain |
+| `tormenta` | Diffuse Sunlight + Storm + Heavy Rain + Strong Wind + Obscured |
+| `niebla` | Diffuse Sunlight + Fog + Obscured |
+| `nieve` | Diffuse Sunlight + Snow |
+| `nevada` | Diffuse Sunlight + Heavy Snow + Obscured |
+| `granizo` | Diffuse Sunlight + Hail + Strong Wind + Obscured |
+
+At night the natural Light state becomes `darkness` and Sunlight becomes `none`.
+
+## Trait Engine triggers
+
+No new Trait Engine trigger type is required. The current condition system can already read arbitrary runtime paths. Put the resolved snapshot at `runtime.environment`.
+
+```js
+const environment = LuminousEnvironmentEngine.resolveEnvironment({
+  weatherId: "nublado",
+  encounterType: "outdoor",
+  isDay: true,
+  water: { nearby: true, origin: "natural" },
+});
+
+const runtime = LuminousEnvironmentEngine.withEnvironment(existingRuntime, environment);
+```
+
+Traits can then use ordinary conditions.
+
+### Direct Sunlight
+
+```js
+{
+  path: "environment.state.sunlight",
+  operator: "eq",
+  value: "direct"
+}
+```
+
+### Near Water
+
+```js
+{
+  path: "environment.effectIds",
+  operator: "contains",
+  value: "near_water"
+}
+```
+
+### Submerged
+
+```js
+{
+  path: "environment.effectIds",
+  operator: "contains",
+  value: "submerged"
+}
+```
+
+### Natural Environment Effect
+
+```js
+{
+  path: "environment.origins",
+  operator: "contains",
+  value: "natural"
+}
+```
+
+### Weather-category context
+
+```js
+{
+  path: "environment.categories",
+  operator: "contains",
+  value: "weather"
+}
+```
+
+## Mechanical boundary
+
+This contract deliberately does not create generic `-2`, Disadvantage, damage, saves, or Status Effects from normal Environment context.
+
+Downstream systems remain responsible for their own rules:
+
+- Darkness / Heavily Obscured → Vision resolver.
+- Difficult Terrain → Movement resolver.
+- Submerged → underwater movement, breathing, combat, and trait rules.
+- Extreme Heat / Extreme Cold → exposure resolver.
+- Strong Wind → only mechanics that explicitly care about wind.
+
+This keeps Environment extensible without duplicating the Status or Trait engines.

--- a/js/environment-engine.js
+++ b/js/environment-engine.js
@@ -16,42 +16,12 @@
     UNDERWATER: "underwater",
     SPECIAL: "special",
   });
-
-  const LIGHT_LEVELS = Object.freeze({
-    BRIGHT: "bright",
-    DIM: "dim",
-    DARKNESS: "darkness",
-  });
-
-  const SUNLIGHT_LEVELS = Object.freeze({
-    DIRECT: "direct",
-    DIFFUSE: "diffuse",
-    NONE: "none",
-  });
-
-  const VISIBILITY_LEVELS = Object.freeze({
-    CLEAR: "clear",
-    OBSCURED: "obscured",
-    HEAVILY_OBSCURED: "heavily_obscured",
-  });
-
-  const ORIGINS = Object.freeze({
-    NATURAL: "natural",
-    ARTIFICIAL: "artificial",
-    MAGICAL: "magical",
-  });
-
-  const SCOPES = Object.freeze({
-    ENCOUNTER: "encounter",
-    ZONE: "zone",
-    ACTOR: "actor",
-  });
-
-  const SEVERITIES = Object.freeze({
-    CONTEXT: "context",
-    MODERATE: "moderate",
-    SEVERE: "severe",
-  });
+  const LIGHT_LEVELS = Object.freeze({ BRIGHT: "bright", DIM: "dim", DARKNESS: "darkness" });
+  const SUNLIGHT_LEVELS = Object.freeze({ DIRECT: "direct", DIFFUSE: "diffuse", NONE: "none" });
+  const VISIBILITY_LEVELS = Object.freeze({ CLEAR: "clear", OBSCURED: "obscured", HEAVILY_OBSCURED: "heavily_obscured" });
+  const ORIGINS = Object.freeze({ NATURAL: "natural", ARTIFICIAL: "artificial", MAGICAL: "magical" });
+  const SCOPES = Object.freeze({ ENCOUNTER: "encounter", ZONE: "zone", ACTOR: "actor" });
+  const SEVERITIES = Object.freeze({ CONTEXT: "context", MODERATE: "moderate", SEVERE: "severe" });
 
   const normalizeId = (value) => String(value ?? "")
     .trim()
@@ -68,271 +38,79 @@
     return Object.freeze(value);
   }
 
-  const EFFECT_ALIASES = Object.freeze({
-    sink: "submerged",
-    retreat_sink: "submerged",
-  });
+  const EFFECT_ALIASES = Object.freeze({ sink: "submerged", retreat_sink: "submerged" });
 
   const EFFECTS = deepFreeze({
-    near_water: {
-      label: "Near Water",
-      category: "water",
-      defaultScope: SCOPES.ZONE,
-      severity: SEVERITIES.CONTEXT,
-      description: "Relevant, accessible water is nearby.",
-      implies: [],
-    },
-    in_water: {
-      label: "In Water",
-      category: "water",
-      defaultScope: SCOPES.ACTOR,
-      severity: SEVERITIES.MODERATE,
-      description: "The actor is physically in water; swimming rules may inspect this context.",
-      implies: ["near_water"],
-    },
-    submerged: {
-      label: "Submerged",
-      category: "water",
-      defaultScope: SCOPES.ACTOR,
-      severity: SEVERITIES.SEVERE,
-      description: "The actor is fully underwater; underwater movement, breathing, combat, and traits may inspect this context.",
-      implies: ["in_water", "near_water"],
-    },
-
-    exposed: {
-      label: "Exposed",
-      category: "exposure",
-      defaultScope: SCOPES.ACTOR,
-      severity: SEVERITIES.CONTEXT,
-      description: "The actor receives the zone's environmental exposure normally.",
-      implies: [],
-    },
-    under_cover: {
-      label: "Under Cover",
-      category: "exposure",
-      defaultScope: SCOPES.ACTOR,
-      severity: SEVERITIES.CONTEXT,
-      description: "Direct precipitation is blocked and direct sunlight is reduced to diffuse sunlight.",
-      implies: [],
-    },
-    indoors: {
-      label: "Indoors",
-      category: "exposure",
-      defaultScope: SCOPES.ACTOR,
-      severity: SEVERITIES.CONTEXT,
-      description: "Exterior weather and natural sunlight are normally blocked.",
-      implies: [],
-    },
-
-    rain: {
-      label: "Rain",
-      category: "weather",
-      defaultScope: SCOPES.ENCOUNTER,
-      severity: SEVERITIES.CONTEXT,
-      description: "Rain is present. It is a trigger and does not impose a generic penalty by itself.",
-      implies: [],
-    },
-    heavy_rain: {
-      label: "Heavy Rain",
-      category: "weather",
-      defaultScope: SCOPES.ENCOUNTER,
-      severity: SEVERITIES.SEVERE,
-      description: "Severe rain; the resolver may reduce visibility without adding a blanket combat penalty.",
-      implies: ["rain"],
-    },
-    snow: {
-      label: "Snow",
-      category: "weather",
-      defaultScope: SCOPES.ENCOUNTER,
-      severity: SEVERITIES.CONTEXT,
-      description: "Snow is falling. It is primarily a trigger unless another resolver creates terrain or visibility consequences.",
-      implies: [],
-    },
-    heavy_snow: {
-      label: "Heavy Snow",
-      category: "weather",
-      defaultScope: SCOPES.ENCOUNTER,
-      severity: SEVERITIES.SEVERE,
-      description: "Severe snowfall; visibility and accumulated terrain may be resolved separately.",
-      implies: ["snow"],
-    },
-    fog: {
-      label: "Fog",
-      category: "weather",
-      defaultScope: SCOPES.ENCOUNTER,
-      severity: SEVERITIES.MODERATE,
-      description: "Fog is present and can make visibility Obscured.",
-      implies: [],
-    },
-    dense_fog: {
-      label: "Dense Fog",
-      category: "weather",
-      defaultScope: SCOPES.ENCOUNTER,
-      severity: SEVERITIES.SEVERE,
-      description: "Dense fog can make visibility Heavily Obscured.",
-      implies: ["fog"],
-    },
-    hail: {
-      label: "Hail",
-      category: "weather",
-      defaultScope: SCOPES.ENCOUNTER,
-      severity: SEVERITIES.MODERATE,
-      description: "Hail is present. It remains contextual unless a specific mechanic reacts to it.",
-      implies: [],
-    },
-    strong_wind: {
-      label: "Strong Wind",
-      category: "weather",
-      defaultScope: SCOPES.ENCOUNTER,
-      severity: SEVERITIES.SEVERE,
-      description: "Strong wind is available to flight, projectile, object, or trait resolvers; it has no blanket penalty here.",
-      implies: [],
-    },
-    storm: {
-      label: "Storm",
-      category: "weather",
-      defaultScope: SCOPES.ENCOUNTER,
-      severity: SEVERITIES.SEVERE,
-      description: "Composite severe weather. Its component effects carry the mechanical context.",
-      implies: ["heavy_rain", "strong_wind"],
-    },
-
-    extreme_heat: {
-      label: "Extreme Heat",
-      category: "temperature",
-      defaultScope: SCOPES.ENCOUNTER,
-      severity: SEVERITIES.SEVERE,
-      description: "Extreme heat exposure is active. Thresholds and consequences belong to the exposure resolver.",
-      implies: [],
-    },
-    extreme_cold: {
-      label: "Extreme Cold",
-      category: "temperature",
-      defaultScope: SCOPES.ENCOUNTER,
-      severity: SEVERITIES.SEVERE,
-      description: "Extreme cold exposure is active. Thresholds and consequences belong to the exposure resolver.",
-      implies: [],
-    },
-
-    difficult_terrain: {
-      label: "Difficult Terrain",
-      category: "terrain",
-      defaultScope: SCOPES.ZONE,
-      severity: SEVERITIES.MODERATE,
-      description: "Movement resolvers may increase movement cost in this terrain.",
-      implies: [],
-    },
-    hazardous_terrain: {
-      label: "Hazardous Terrain",
-      category: "terrain",
-      defaultScope: SCOPES.ZONE,
-      severity: SEVERITIES.CONTEXT,
-      description: "The terrain contains a hazard whose specific rule defines the consequence.",
-      implies: [],
-    },
-    slippery: {
-      label: "Slippery",
-      category: "terrain",
-      defaultScope: SCOPES.ZONE,
-      severity: SEVERITIES.CONTEXT,
-      description: "Actions that care about footing may inspect this trigger; no permanent generic penalty is applied.",
-      implies: [],
-    },
+    near_water: { label: "Near Water", category: "water", defaultScope: SCOPES.ZONE, severity: SEVERITIES.CONTEXT, description: "Relevant, accessible water is nearby.", implies: [] },
+    in_water: { label: "In Water", category: "water", defaultScope: SCOPES.ACTOR, severity: SEVERITIES.MODERATE, description: "The actor is physically in water; swimming rules may inspect this context.", implies: ["near_water"] },
+    submerged: { label: "Submerged", category: "water", defaultScope: SCOPES.ACTOR, severity: SEVERITIES.SEVERE, description: "The actor is fully underwater; underwater movement, breathing, combat, and traits may inspect this context.", implies: ["in_water", "near_water"] },
+    exposed: { label: "Exposed", category: "exposure", defaultScope: SCOPES.ACTOR, severity: SEVERITIES.CONTEXT, description: "The actor receives the zone's environmental exposure normally.", implies: [] },
+    under_cover: { label: "Under Cover", category: "exposure", defaultScope: SCOPES.ACTOR, severity: SEVERITIES.CONTEXT, description: "Direct precipitation is blocked and direct sunlight is reduced to diffuse sunlight.", implies: [] },
+    indoors: { label: "Indoors", category: "exposure", defaultScope: SCOPES.ACTOR, severity: SEVERITIES.CONTEXT, description: "Exterior weather and natural sunlight are normally blocked.", implies: [] },
+    rain: { label: "Rain", category: "weather", defaultScope: SCOPES.ENCOUNTER, severity: SEVERITIES.CONTEXT, description: "Rain is present. It is a trigger and does not impose a generic penalty by itself.", implies: [] },
+    heavy_rain: { label: "Heavy Rain", category: "weather", defaultScope: SCOPES.ENCOUNTER, severity: SEVERITIES.SEVERE, description: "Severe rain; the resolver may reduce visibility without adding a blanket combat penalty.", implies: ["rain"] },
+    snow: { label: "Snow", category: "weather", defaultScope: SCOPES.ENCOUNTER, severity: SEVERITIES.CONTEXT, description: "Snow is falling. It is primarily a trigger unless another resolver creates terrain or visibility consequences.", implies: [] },
+    heavy_snow: { label: "Heavy Snow", category: "weather", defaultScope: SCOPES.ENCOUNTER, severity: SEVERITIES.SEVERE, description: "Severe snowfall; visibility and accumulated terrain may be resolved separately.", implies: ["snow"] },
+    fog: { label: "Fog", category: "weather", defaultScope: SCOPES.ENCOUNTER, severity: SEVERITIES.MODERATE, description: "Fog is present and can make visibility Obscured.", implies: [] },
+    dense_fog: { label: "Dense Fog", category: "weather", defaultScope: SCOPES.ENCOUNTER, severity: SEVERITIES.SEVERE, description: "Dense fog can make visibility Heavily Obscured.", implies: ["fog"] },
+    hail: { label: "Hail", category: "weather", defaultScope: SCOPES.ENCOUNTER, severity: SEVERITIES.MODERATE, description: "Hail is present. It remains contextual unless a specific mechanic reacts to it.", implies: [] },
+    strong_wind: { label: "Strong Wind", category: "weather", defaultScope: SCOPES.ENCOUNTER, severity: SEVERITIES.SEVERE, description: "Strong wind is available to flight, projectile, object, or trait resolvers; it has no blanket penalty here.", implies: [] },
+    storm: { label: "Storm", category: "weather", defaultScope: SCOPES.ENCOUNTER, severity: SEVERITIES.SEVERE, description: "Composite severe weather. Its component effects carry the mechanical context.", implies: ["heavy_rain", "strong_wind"] },
+    extreme_heat: { label: "Extreme Heat", category: "temperature", defaultScope: SCOPES.ENCOUNTER, severity: SEVERITIES.SEVERE, description: "Extreme heat exposure is active. Thresholds and consequences belong to the exposure resolver.", implies: [] },
+    extreme_cold: { label: "Extreme Cold", category: "temperature", defaultScope: SCOPES.ENCOUNTER, severity: SEVERITIES.SEVERE, description: "Extreme cold exposure is active. Thresholds and consequences belong to the exposure resolver.", implies: [] },
+    difficult_terrain: { label: "Difficult Terrain", category: "terrain", defaultScope: SCOPES.ZONE, severity: SEVERITIES.MODERATE, description: "Movement resolvers may increase movement cost in this terrain.", implies: [] },
+    hazardous_terrain: { label: "Hazardous Terrain", category: "terrain", defaultScope: SCOPES.ZONE, severity: SEVERITIES.CONTEXT, description: "The terrain contains a hazard whose specific rule defines the consequence.", implies: [] },
+    slippery: { label: "Slippery", category: "terrain", defaultScope: SCOPES.ZONE, severity: SEVERITIES.CONTEXT, description: "Actions that care about footing may inspect this trigger; no permanent generic penalty is applied.", implies: [] },
   });
 
   const WEATHER_PRESETS = deepFreeze({
-    soleado: {
-      sunlight: SUNLIGHT_LEVELS.DIRECT,
-      visibility: VISIBILITY_LEVELS.CLEAR,
-      effects: [],
-    },
-    parcialmente_nublado: {
-      sunlight: SUNLIGHT_LEVELS.DIRECT,
-      visibility: VISIBILITY_LEVELS.CLEAR,
-      effects: [],
-    },
-    nublado: {
-      sunlight: SUNLIGHT_LEVELS.DIFFUSE,
-      visibility: VISIBILITY_LEVELS.CLEAR,
-      effects: [],
-    },
-    llovizna: {
-      sunlight: SUNLIGHT_LEVELS.DIFFUSE,
-      visibility: VISIBILITY_LEVELS.CLEAR,
-      effects: ["rain"],
-    },
-    lluvia: {
-      sunlight: SUNLIGHT_LEVELS.DIFFUSE,
-      visibility: VISIBILITY_LEVELS.CLEAR,
-      effects: ["rain"],
-    },
-    tormenta: {
-      sunlight: SUNLIGHT_LEVELS.DIFFUSE,
-      visibility: VISIBILITY_LEVELS.OBSCURED,
-      effects: ["storm"],
-    },
-    niebla: {
-      sunlight: SUNLIGHT_LEVELS.DIFFUSE,
-      visibility: VISIBILITY_LEVELS.OBSCURED,
-      effects: ["fog"],
-    },
-    nieve: {
-      sunlight: SUNLIGHT_LEVELS.DIFFUSE,
-      visibility: VISIBILITY_LEVELS.CLEAR,
-      effects: ["snow"],
-    },
-    nevada: {
-      sunlight: SUNLIGHT_LEVELS.DIFFUSE,
-      visibility: VISIBILITY_LEVELS.OBSCURED,
-      effects: ["heavy_snow"],
-    },
-    granizo: {
-      sunlight: SUNLIGHT_LEVELS.DIFFUSE,
-      visibility: VISIBILITY_LEVELS.OBSCURED,
-      effects: ["hail", "strong_wind"],
-    },
+    soleado: { sunlight: SUNLIGHT_LEVELS.DIRECT, visibility: VISIBILITY_LEVELS.CLEAR, effects: [] },
+    parcialmente_nublado: { sunlight: SUNLIGHT_LEVELS.DIRECT, visibility: VISIBILITY_LEVELS.CLEAR, effects: [] },
+    nublado: { sunlight: SUNLIGHT_LEVELS.DIFFUSE, visibility: VISIBILITY_LEVELS.CLEAR, effects: [] },
+    llovizna: { sunlight: SUNLIGHT_LEVELS.DIFFUSE, visibility: VISIBILITY_LEVELS.CLEAR, effects: ["rain"] },
+    lluvia: { sunlight: SUNLIGHT_LEVELS.DIFFUSE, visibility: VISIBILITY_LEVELS.CLEAR, effects: ["rain"] },
+    tormenta: { sunlight: SUNLIGHT_LEVELS.DIFFUSE, visibility: VISIBILITY_LEVELS.OBSCURED, effects: ["storm"] },
+    niebla: { sunlight: SUNLIGHT_LEVELS.DIFFUSE, visibility: VISIBILITY_LEVELS.OBSCURED, effects: ["fog"] },
+    nieve: { sunlight: SUNLIGHT_LEVELS.DIFFUSE, visibility: VISIBILITY_LEVELS.CLEAR, effects: ["snow"] },
+    nevada: { sunlight: SUNLIGHT_LEVELS.DIFFUSE, visibility: VISIBILITY_LEVELS.OBSCURED, effects: ["heavy_snow"] },
+    granizo: { sunlight: SUNLIGHT_LEVELS.DIFFUSE, visibility: VISIBILITY_LEVELS.OBSCURED, effects: ["hail", "strong_wind"] },
   });
 
   const PRECIPITATION_EFFECTS = new Set(["rain", "heavy_rain", "snow", "heavy_snow", "hail"]);
-  const EXTERIOR_WEATHER_EFFECTS = new Set([
-    "rain", "heavy_rain", "snow", "heavy_snow", "fog", "dense_fog", "hail", "strong_wind", "storm",
-  ]);
+  const EXTERIOR_WEATHER_EFFECTS = new Set(["rain", "heavy_rain", "snow", "heavy_snow", "fog", "dense_fog", "hail", "strong_wind", "storm"]);
 
-  function clone(value) {
-    return value == null ? value : JSON.parse(JSON.stringify(value));
-  }
-
+  function clone(value) { return value == null ? value : JSON.parse(JSON.stringify(value)); }
   function normalizeEncounterType(value) {
     const id = normalizeId(value || ENCOUNTER_TYPES.OUTDOOR);
     return Object.values(ENCOUNTER_TYPES).includes(id) ? id : ENCOUNTER_TYPES.SPECIAL;
   }
-
   function normalizeOrigin(value) {
     const id = normalizeId(value);
     return Object.values(ORIGINS).includes(id) ? id : null;
   }
-
+  function normalizeOrigins(value, fallback) {
+    const list = Array.isArray(value) ? value : value ? [value] : fallback ? (Array.isArray(fallback) ? fallback : [fallback]) : [];
+    return [...new Set(list.map(normalizeOrigin).filter(Boolean))].sort();
+  }
   function normalizeScope(value, fallback) {
     const id = normalizeId(value);
     return Object.values(SCOPES).includes(id) ? id : fallback;
   }
-
-  function canonicalEffectId(value) {
-    const id = normalizeId(value);
-    return EFFECT_ALIASES[id] || id;
-  }
+  function canonicalEffectId(value) { const id = normalizeId(value); return EFFECT_ALIASES[id] || id; }
 
   function normalizeEffect(input, defaults = {}) {
     const raw = typeof input === "string" ? { id: input } : (input && typeof input === "object" ? input : {});
     const id = canonicalEffectId(raw.id || raw.name);
     if (!id) return null;
     const definition = EFFECTS[id] || {};
+    const origins = normalizeOrigins(raw.origins ?? raw.origin, defaults.origins ?? defaults.origin);
     return {
       id,
       label: String(raw.label || definition.label || raw.name || id),
       category: normalizeId(raw.category || definition.category || defaults.category || "special") || "special",
       scope: normalizeScope(raw.scope || defaults.scope, definition.defaultScope || SCOPES.ZONE),
-      origin: normalizeOrigin(raw.origin ?? defaults.origin),
+      origin: origins[0] || null,
+      origins,
       severity: normalizeId(raw.severity || definition.severity || defaults.severity || SEVERITIES.CONTEXT),
     };
   }
@@ -344,46 +122,27 @@
     const existing = store.get(effect.id);
     if (!existing) store.set(effect.id, effect);
     else {
-      if (!existing.origin && effect.origin) existing.origin = effect.origin;
+      existing.origins = [...new Set([...(existing.origins || []), ...(effect.origins || [])])].sort();
+      existing.origin = existing.origins[0] || null;
       if (existing.scope === SCOPES.ZONE && effect.scope !== SCOPES.ZONE) existing.scope = effect.scope;
     }
+    const stored = store.get(effect.id) || effect;
     const definition = EFFECTS[effect.id];
     (definition?.implies || []).forEach((impliedId) => addEffect(store, impliedId, {
       ...defaults,
-      origin: effect.origin || defaults.origin,
-      scope: effect.scope || defaults.scope,
+      origins: stored.origins,
+      scope: stored.scope || defaults.scope,
     }, visited));
   }
 
   function removeEffects(store, predicate) {
-    [...store.entries()].forEach(([id, effect]) => {
-      if (predicate(id, effect)) store.delete(id);
-    });
+    [...store.entries()].forEach(([id, effect]) => { if (predicate(id, effect)) store.delete(id); });
   }
-
-  function normalizeLight(value, fallback) {
-    const id = normalizeId(value);
-    return Object.values(LIGHT_LEVELS).includes(id) ? id : fallback;
-  }
-
-  function normalizeSunlight(value, fallback) {
-    const id = normalizeId(value);
-    return Object.values(SUNLIGHT_LEVELS).includes(id) ? id : fallback;
-  }
-
-  function normalizeVisibility(value, fallback) {
-    const id = normalizeId(value);
-    return Object.values(VISIBILITY_LEVELS).includes(id) ? id : fallback;
-  }
-
+  function normalizeLight(value, fallback) { const id = normalizeId(value); return Object.values(LIGHT_LEVELS).includes(id) ? id : fallback; }
+  function normalizeSunlight(value, fallback) { const id = normalizeId(value); return Object.values(SUNLIGHT_LEVELS).includes(id) ? id : fallback; }
+  function normalizeVisibility(value, fallback) { const id = normalizeId(value); return Object.values(VISIBILITY_LEVELS).includes(id) ? id : fallback; }
   function weatherIdFrom(input) {
-    return normalizeId(
-      input?.weatherId
-      ?? input?.weather?.actual?.tipo
-      ?? input?.weather?.tipo
-      ?? input?.weather
-      ?? "soleado"
-    ) || "soleado";
+    return normalizeId(input?.weatherId ?? input?.weather?.actual?.tipo ?? input?.weather?.tipo ?? input?.weather ?? "soleado") || "soleado";
   }
 
   function applyExposure(exposure, state, stateOrigins, effects) {
@@ -406,10 +165,10 @@
     const source = water && typeof water === "object" ? water : {};
     const immersion = normalizeId(source.immersion || source.state || "none");
     if (source.nearby || source.nearWater || ["in_water", "submerged"].includes(immersion)) {
-      addEffect(effects, { id: "near_water", origin: source.origin, scope: source.scope || SCOPES.ZONE });
+      addEffect(effects, { id: "near_water", origin: source.origin, origins: source.origins, scope: source.scope || SCOPES.ZONE });
     }
     if (["in_water", "submerged"].includes(immersion)) {
-      addEffect(effects, { id: immersion, origin: source.origin, scope: source.scope || SCOPES.ACTOR });
+      addEffect(effects, { id: immersion, origin: source.origin, origins: source.origins, scope: source.scope || SCOPES.ACTOR });
     }
   }
 
@@ -419,7 +178,6 @@
     const preset = WEATHER_PRESETS[weatherId] || WEATHER_PRESETS.soleado;
     const isDay = input.isDay == null ? true : Boolean(input.isDay);
     const effects = new Map();
-
     const state = {
       light: isDay ? LIGHT_LEVELS.BRIGHT : LIGHT_LEVELS.DARKNESS,
       sunlight: isDay ? preset.sunlight : SUNLIGHT_LEVELS.NONE,
@@ -431,10 +189,7 @@
       visibility: state.visibility === VISIBILITY_LEVELS.CLEAR ? null : ORIGINS.NATURAL,
     };
 
-    preset.effects.forEach((effectId) => addEffect(effects, effectId, {
-      origin: ORIGINS.NATURAL,
-      scope: SCOPES.ENCOUNTER,
-    }));
+    preset.effects.forEach((effectId) => addEffect(effects, effectId, { origin: ORIGINS.NATURAL, scope: SCOPES.ENCOUNTER }));
 
     if (encounterType === ENCOUNTER_TYPES.COVERED) {
       if (state.sunlight === SUNLIGHT_LEVELS.DIRECT) state.sunlight = SUNLIGHT_LEVELS.DIFFUSE;
@@ -464,9 +219,7 @@
 
     applyExposure(input.exposure, state, stateOrigins, effects);
     applyWater(input.water, effects);
-
-    (Array.isArray(input.effects) ? input.effects : input.effects ? [input.effects] : [])
-      .forEach((effect) => addEffect(effects, effect));
+    (Array.isArray(input.effects) ? input.effects : input.effects ? [input.effects] : []).forEach((effect) => addEffect(effects, effect));
 
     const explicitState = input.state && typeof input.state === "object" ? input.state : {};
     const explicitOrigins = input.stateOrigins && typeof input.stateOrigins === "object" ? input.stateOrigins : {};
@@ -492,15 +245,10 @@
 
     const effectList = [...effects.values()].sort((a, b) => a.id.localeCompare(b.id));
     const origins = [...new Set([
-      ...effectList.map((effect) => effect.origin),
+      ...effectList.flatMap((effect) => effect.origins || (effect.origin ? [effect.origin] : [])),
       ...Object.values(stateOrigins),
     ].filter(Boolean))].sort();
-    const categories = [...new Set([
-      "light",
-      "sunlight",
-      "visibility",
-      ...effectList.map((effect) => effect.category),
-    ])].sort();
+    const categories = [...new Set(["light", "sunlight", "visibility", ...effectList.map((effect) => effect.category)])].sort();
 
     return {
       version: VERSION,
@@ -516,39 +264,12 @@
     };
   }
 
-  function fromWeatherState(weatherState, options = {}) {
-    return resolveEnvironment({
-      ...options,
-      weather: weatherState,
-    });
-  }
-
-  function hasEffect(environment, effectId) {
-    const id = canonicalEffectId(effectId);
-    return Boolean(id && environment?.effectIds?.includes(id));
-  }
-
-  function hasState(environment, key, value) {
-    const stateKey = normalizeId(key);
-    return normalizeId(environment?.state?.[stateKey]) === normalizeId(value);
-  }
-
-  function hasOrigin(environment, origin) {
-    const id = normalizeOrigin(origin);
-    return Boolean(id && environment?.origins?.includes(id));
-  }
-
-  function hasCategory(environment, category) {
-    const id = normalizeId(category);
-    return Boolean(id && environment?.categories?.includes(id));
-  }
-
-  function withEnvironment(runtime = {}, environment) {
-    return {
-      ...runtime,
-      environment: clone(environment || resolveEnvironment()),
-    };
-  }
+  function fromWeatherState(weatherState, options = {}) { return resolveEnvironment({ ...options, weather: weatherState }); }
+  function hasEffect(environment, effectId) { const id = canonicalEffectId(effectId); return Boolean(id && environment?.effectIds?.includes(id)); }
+  function hasState(environment, key, value) { return normalizeId(environment?.state?.[normalizeId(key)]) === normalizeId(value); }
+  function hasOrigin(environment, origin) { const id = normalizeOrigin(origin); return Boolean(id && environment?.origins?.includes(id)); }
+  function hasCategory(environment, category) { const id = normalizeId(category); return Boolean(id && environment?.categories?.includes(id)); }
+  function withEnvironment(runtime = {}, environment) { return { ...runtime, environment: clone(environment || resolveEnvironment()) }; }
 
   const api = Object.freeze({
     VERSION,

--- a/js/environment-engine.js
+++ b/js/environment-engine.js
@@ -1,0 +1,580 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousEnvironmentEngine) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousEnvironmentEngine;
+    return;
+  }
+
+  const VERSION = 1;
+
+  const ENCOUNTER_TYPES = Object.freeze({
+    OUTDOOR: "outdoor",
+    COVERED: "covered",
+    INDOOR: "indoor",
+    UNDERGROUND: "underground",
+    UNDERWATER: "underwater",
+    SPECIAL: "special",
+  });
+
+  const LIGHT_LEVELS = Object.freeze({
+    BRIGHT: "bright",
+    DIM: "dim",
+    DARKNESS: "darkness",
+  });
+
+  const SUNLIGHT_LEVELS = Object.freeze({
+    DIRECT: "direct",
+    DIFFUSE: "diffuse",
+    NONE: "none",
+  });
+
+  const VISIBILITY_LEVELS = Object.freeze({
+    CLEAR: "clear",
+    OBSCURED: "obscured",
+    HEAVILY_OBSCURED: "heavily_obscured",
+  });
+
+  const ORIGINS = Object.freeze({
+    NATURAL: "natural",
+    ARTIFICIAL: "artificial",
+    MAGICAL: "magical",
+  });
+
+  const SCOPES = Object.freeze({
+    ENCOUNTER: "encounter",
+    ZONE: "zone",
+    ACTOR: "actor",
+  });
+
+  const SEVERITIES = Object.freeze({
+    CONTEXT: "context",
+    MODERATE: "moderate",
+    SEVERE: "severe",
+  });
+
+  const normalizeId = (value) => String(value ?? "")
+    .trim()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
+  function deepFreeze(value, seen = new WeakSet()) {
+    if (!value || typeof value !== "object" || seen.has(value)) return value;
+    seen.add(value);
+    Reflect.ownKeys(value).forEach((key) => deepFreeze(value[key], seen));
+    return Object.freeze(value);
+  }
+
+  const EFFECT_ALIASES = Object.freeze({
+    sink: "submerged",
+    retreat_sink: "submerged",
+  });
+
+  const EFFECTS = deepFreeze({
+    near_water: {
+      label: "Near Water",
+      category: "water",
+      defaultScope: SCOPES.ZONE,
+      severity: SEVERITIES.CONTEXT,
+      description: "Relevant, accessible water is nearby.",
+      implies: [],
+    },
+    in_water: {
+      label: "In Water",
+      category: "water",
+      defaultScope: SCOPES.ACTOR,
+      severity: SEVERITIES.MODERATE,
+      description: "The actor is physically in water; swimming rules may inspect this context.",
+      implies: ["near_water"],
+    },
+    submerged: {
+      label: "Submerged",
+      category: "water",
+      defaultScope: SCOPES.ACTOR,
+      severity: SEVERITIES.SEVERE,
+      description: "The actor is fully underwater; underwater movement, breathing, combat, and traits may inspect this context.",
+      implies: ["in_water", "near_water"],
+    },
+
+    exposed: {
+      label: "Exposed",
+      category: "exposure",
+      defaultScope: SCOPES.ACTOR,
+      severity: SEVERITIES.CONTEXT,
+      description: "The actor receives the zone's environmental exposure normally.",
+      implies: [],
+    },
+    under_cover: {
+      label: "Under Cover",
+      category: "exposure",
+      defaultScope: SCOPES.ACTOR,
+      severity: SEVERITIES.CONTEXT,
+      description: "Direct precipitation is blocked and direct sunlight is reduced to diffuse sunlight.",
+      implies: [],
+    },
+    indoors: {
+      label: "Indoors",
+      category: "exposure",
+      defaultScope: SCOPES.ACTOR,
+      severity: SEVERITIES.CONTEXT,
+      description: "Exterior weather and natural sunlight are normally blocked.",
+      implies: [],
+    },
+
+    rain: {
+      label: "Rain",
+      category: "weather",
+      defaultScope: SCOPES.ENCOUNTER,
+      severity: SEVERITIES.CONTEXT,
+      description: "Rain is present. It is a trigger and does not impose a generic penalty by itself.",
+      implies: [],
+    },
+    heavy_rain: {
+      label: "Heavy Rain",
+      category: "weather",
+      defaultScope: SCOPES.ENCOUNTER,
+      severity: SEVERITIES.SEVERE,
+      description: "Severe rain; the resolver may reduce visibility without adding a blanket combat penalty.",
+      implies: ["rain"],
+    },
+    snow: {
+      label: "Snow",
+      category: "weather",
+      defaultScope: SCOPES.ENCOUNTER,
+      severity: SEVERITIES.CONTEXT,
+      description: "Snow is falling. It is primarily a trigger unless another resolver creates terrain or visibility consequences.",
+      implies: [],
+    },
+    heavy_snow: {
+      label: "Heavy Snow",
+      category: "weather",
+      defaultScope: SCOPES.ENCOUNTER,
+      severity: SEVERITIES.SEVERE,
+      description: "Severe snowfall; visibility and accumulated terrain may be resolved separately.",
+      implies: ["snow"],
+    },
+    fog: {
+      label: "Fog",
+      category: "weather",
+      defaultScope: SCOPES.ENCOUNTER,
+      severity: SEVERITIES.MODERATE,
+      description: "Fog is present and can make visibility Obscured.",
+      implies: [],
+    },
+    dense_fog: {
+      label: "Dense Fog",
+      category: "weather",
+      defaultScope: SCOPES.ENCOUNTER,
+      severity: SEVERITIES.SEVERE,
+      description: "Dense fog can make visibility Heavily Obscured.",
+      implies: ["fog"],
+    },
+    hail: {
+      label: "Hail",
+      category: "weather",
+      defaultScope: SCOPES.ENCOUNTER,
+      severity: SEVERITIES.MODERATE,
+      description: "Hail is present. It remains contextual unless a specific mechanic reacts to it.",
+      implies: [],
+    },
+    strong_wind: {
+      label: "Strong Wind",
+      category: "weather",
+      defaultScope: SCOPES.ENCOUNTER,
+      severity: SEVERITIES.SEVERE,
+      description: "Strong wind is available to flight, projectile, object, or trait resolvers; it has no blanket penalty here.",
+      implies: [],
+    },
+    storm: {
+      label: "Storm",
+      category: "weather",
+      defaultScope: SCOPES.ENCOUNTER,
+      severity: SEVERITIES.SEVERE,
+      description: "Composite severe weather. Its component effects carry the mechanical context.",
+      implies: ["heavy_rain", "strong_wind"],
+    },
+
+    extreme_heat: {
+      label: "Extreme Heat",
+      category: "temperature",
+      defaultScope: SCOPES.ENCOUNTER,
+      severity: SEVERITIES.SEVERE,
+      description: "Extreme heat exposure is active. Thresholds and consequences belong to the exposure resolver.",
+      implies: [],
+    },
+    extreme_cold: {
+      label: "Extreme Cold",
+      category: "temperature",
+      defaultScope: SCOPES.ENCOUNTER,
+      severity: SEVERITIES.SEVERE,
+      description: "Extreme cold exposure is active. Thresholds and consequences belong to the exposure resolver.",
+      implies: [],
+    },
+
+    difficult_terrain: {
+      label: "Difficult Terrain",
+      category: "terrain",
+      defaultScope: SCOPES.ZONE,
+      severity: SEVERITIES.MODERATE,
+      description: "Movement resolvers may increase movement cost in this terrain.",
+      implies: [],
+    },
+    hazardous_terrain: {
+      label: "Hazardous Terrain",
+      category: "terrain",
+      defaultScope: SCOPES.ZONE,
+      severity: SEVERITIES.CONTEXT,
+      description: "The terrain contains a hazard whose specific rule defines the consequence.",
+      implies: [],
+    },
+    slippery: {
+      label: "Slippery",
+      category: "terrain",
+      defaultScope: SCOPES.ZONE,
+      severity: SEVERITIES.CONTEXT,
+      description: "Actions that care about footing may inspect this trigger; no permanent generic penalty is applied.",
+      implies: [],
+    },
+  });
+
+  const WEATHER_PRESETS = deepFreeze({
+    soleado: {
+      sunlight: SUNLIGHT_LEVELS.DIRECT,
+      visibility: VISIBILITY_LEVELS.CLEAR,
+      effects: [],
+    },
+    parcialmente_nublado: {
+      sunlight: SUNLIGHT_LEVELS.DIRECT,
+      visibility: VISIBILITY_LEVELS.CLEAR,
+      effects: [],
+    },
+    nublado: {
+      sunlight: SUNLIGHT_LEVELS.DIFFUSE,
+      visibility: VISIBILITY_LEVELS.CLEAR,
+      effects: [],
+    },
+    llovizna: {
+      sunlight: SUNLIGHT_LEVELS.DIFFUSE,
+      visibility: VISIBILITY_LEVELS.CLEAR,
+      effects: ["rain"],
+    },
+    lluvia: {
+      sunlight: SUNLIGHT_LEVELS.DIFFUSE,
+      visibility: VISIBILITY_LEVELS.CLEAR,
+      effects: ["rain"],
+    },
+    tormenta: {
+      sunlight: SUNLIGHT_LEVELS.DIFFUSE,
+      visibility: VISIBILITY_LEVELS.OBSCURED,
+      effects: ["storm"],
+    },
+    niebla: {
+      sunlight: SUNLIGHT_LEVELS.DIFFUSE,
+      visibility: VISIBILITY_LEVELS.OBSCURED,
+      effects: ["fog"],
+    },
+    nieve: {
+      sunlight: SUNLIGHT_LEVELS.DIFFUSE,
+      visibility: VISIBILITY_LEVELS.CLEAR,
+      effects: ["snow"],
+    },
+    nevada: {
+      sunlight: SUNLIGHT_LEVELS.DIFFUSE,
+      visibility: VISIBILITY_LEVELS.OBSCURED,
+      effects: ["heavy_snow"],
+    },
+    granizo: {
+      sunlight: SUNLIGHT_LEVELS.DIFFUSE,
+      visibility: VISIBILITY_LEVELS.OBSCURED,
+      effects: ["hail", "strong_wind"],
+    },
+  });
+
+  const PRECIPITATION_EFFECTS = new Set(["rain", "heavy_rain", "snow", "heavy_snow", "hail"]);
+  const EXTERIOR_WEATHER_EFFECTS = new Set([
+    "rain", "heavy_rain", "snow", "heavy_snow", "fog", "dense_fog", "hail", "strong_wind", "storm",
+  ]);
+
+  function clone(value) {
+    return value == null ? value : JSON.parse(JSON.stringify(value));
+  }
+
+  function normalizeEncounterType(value) {
+    const id = normalizeId(value || ENCOUNTER_TYPES.OUTDOOR);
+    return Object.values(ENCOUNTER_TYPES).includes(id) ? id : ENCOUNTER_TYPES.SPECIAL;
+  }
+
+  function normalizeOrigin(value) {
+    const id = normalizeId(value);
+    return Object.values(ORIGINS).includes(id) ? id : null;
+  }
+
+  function normalizeScope(value, fallback) {
+    const id = normalizeId(value);
+    return Object.values(SCOPES).includes(id) ? id : fallback;
+  }
+
+  function canonicalEffectId(value) {
+    const id = normalizeId(value);
+    return EFFECT_ALIASES[id] || id;
+  }
+
+  function normalizeEffect(input, defaults = {}) {
+    const raw = typeof input === "string" ? { id: input } : (input && typeof input === "object" ? input : {});
+    const id = canonicalEffectId(raw.id || raw.name);
+    if (!id) return null;
+    const definition = EFFECTS[id] || {};
+    return {
+      id,
+      label: String(raw.label || definition.label || raw.name || id),
+      category: normalizeId(raw.category || definition.category || defaults.category || "special") || "special",
+      scope: normalizeScope(raw.scope || defaults.scope, definition.defaultScope || SCOPES.ZONE),
+      origin: normalizeOrigin(raw.origin ?? defaults.origin),
+      severity: normalizeId(raw.severity || definition.severity || defaults.severity || SEVERITIES.CONTEXT),
+    };
+  }
+
+  function addEffect(store, input, defaults = {}, visited = new Set()) {
+    const effect = normalizeEffect(input, defaults);
+    if (!effect || visited.has(effect.id)) return;
+    visited.add(effect.id);
+    const existing = store.get(effect.id);
+    if (!existing) store.set(effect.id, effect);
+    else {
+      if (!existing.origin && effect.origin) existing.origin = effect.origin;
+      if (existing.scope === SCOPES.ZONE && effect.scope !== SCOPES.ZONE) existing.scope = effect.scope;
+    }
+    const definition = EFFECTS[effect.id];
+    (definition?.implies || []).forEach((impliedId) => addEffect(store, impliedId, {
+      ...defaults,
+      origin: effect.origin || defaults.origin,
+      scope: effect.scope || defaults.scope,
+    }, visited));
+  }
+
+  function removeEffects(store, predicate) {
+    [...store.entries()].forEach(([id, effect]) => {
+      if (predicate(id, effect)) store.delete(id);
+    });
+  }
+
+  function normalizeLight(value, fallback) {
+    const id = normalizeId(value);
+    return Object.values(LIGHT_LEVELS).includes(id) ? id : fallback;
+  }
+
+  function normalizeSunlight(value, fallback) {
+    const id = normalizeId(value);
+    return Object.values(SUNLIGHT_LEVELS).includes(id) ? id : fallback;
+  }
+
+  function normalizeVisibility(value, fallback) {
+    const id = normalizeId(value);
+    return Object.values(VISIBILITY_LEVELS).includes(id) ? id : fallback;
+  }
+
+  function weatherIdFrom(input) {
+    return normalizeId(
+      input?.weatherId
+      ?? input?.weather?.actual?.tipo
+      ?? input?.weather?.tipo
+      ?? input?.weather
+      ?? "soleado"
+    ) || "soleado";
+  }
+
+  function applyExposure(exposure, state, stateOrigins, effects) {
+    const id = normalizeId(exposure);
+    if (!id) return;
+    addEffect(effects, id, { scope: SCOPES.ACTOR });
+    if (id === "under_cover") {
+      if (state.sunlight === SUNLIGHT_LEVELS.DIRECT) state.sunlight = SUNLIGHT_LEVELS.DIFFUSE;
+      removeEffects(effects, (effectId) => PRECIPITATION_EFFECTS.has(effectId));
+    } else if (id === "indoors") {
+      state.sunlight = SUNLIGHT_LEVELS.NONE;
+      stateOrigins.sunlight = null;
+      state.visibility = VISIBILITY_LEVELS.CLEAR;
+      stateOrigins.visibility = null;
+      removeEffects(effects, (effectId) => EXTERIOR_WEATHER_EFFECTS.has(effectId));
+    }
+  }
+
+  function applyWater(water, effects) {
+    const source = water && typeof water === "object" ? water : {};
+    const immersion = normalizeId(source.immersion || source.state || "none");
+    if (source.nearby || source.nearWater || ["in_water", "submerged"].includes(immersion)) {
+      addEffect(effects, { id: "near_water", origin: source.origin, scope: source.scope || SCOPES.ZONE });
+    }
+    if (["in_water", "submerged"].includes(immersion)) {
+      addEffect(effects, { id: immersion, origin: source.origin, scope: source.scope || SCOPES.ACTOR });
+    }
+  }
+
+  function resolveEnvironment(input = {}) {
+    const encounterType = normalizeEncounterType(input.encounterType);
+    const weatherId = weatherIdFrom(input);
+    const preset = WEATHER_PRESETS[weatherId] || WEATHER_PRESETS.soleado;
+    const isDay = input.isDay == null ? true : Boolean(input.isDay);
+    const effects = new Map();
+
+    const state = {
+      light: isDay ? LIGHT_LEVELS.BRIGHT : LIGHT_LEVELS.DARKNESS,
+      sunlight: isDay ? preset.sunlight : SUNLIGHT_LEVELS.NONE,
+      visibility: preset.visibility,
+    };
+    const stateOrigins = {
+      light: ORIGINS.NATURAL,
+      sunlight: isDay && state.sunlight !== SUNLIGHT_LEVELS.NONE ? ORIGINS.NATURAL : null,
+      visibility: state.visibility === VISIBILITY_LEVELS.CLEAR ? null : ORIGINS.NATURAL,
+    };
+
+    preset.effects.forEach((effectId) => addEffect(effects, effectId, {
+      origin: ORIGINS.NATURAL,
+      scope: SCOPES.ENCOUNTER,
+    }));
+
+    if (encounterType === ENCOUNTER_TYPES.COVERED) {
+      if (state.sunlight === SUNLIGHT_LEVELS.DIRECT) state.sunlight = SUNLIGHT_LEVELS.DIFFUSE;
+      removeEffects(effects, (effectId) => PRECIPITATION_EFFECTS.has(effectId));
+    } else if (encounterType === ENCOUNTER_TYPES.INDOOR) {
+      state.light = LIGHT_LEVELS.DIM;
+      state.sunlight = SUNLIGHT_LEVELS.NONE;
+      state.visibility = VISIBILITY_LEVELS.CLEAR;
+      stateOrigins.light = null;
+      stateOrigins.sunlight = null;
+      stateOrigins.visibility = null;
+      removeEffects(effects, (effectId) => EXTERIOR_WEATHER_EFFECTS.has(effectId));
+    } else if (encounterType === ENCOUNTER_TYPES.UNDERGROUND) {
+      state.light = LIGHT_LEVELS.DARKNESS;
+      state.sunlight = SUNLIGHT_LEVELS.NONE;
+      state.visibility = VISIBILITY_LEVELS.CLEAR;
+      stateOrigins.light = ORIGINS.NATURAL;
+      stateOrigins.sunlight = null;
+      stateOrigins.visibility = null;
+      removeEffects(effects, (effectId) => EXTERIOR_WEATHER_EFFECTS.has(effectId));
+    } else if (encounterType === ENCOUNTER_TYPES.UNDERWATER) {
+      state.sunlight = isDay ? SUNLIGHT_LEVELS.DIFFUSE : SUNLIGHT_LEVELS.NONE;
+      stateOrigins.sunlight = isDay ? ORIGINS.NATURAL : null;
+      removeEffects(effects, (effectId) => EXTERIOR_WEATHER_EFFECTS.has(effectId));
+      addEffect(effects, { id: "submerged", scope: SCOPES.ENCOUNTER });
+    }
+
+    applyExposure(input.exposure, state, stateOrigins, effects);
+    applyWater(input.water, effects);
+
+    (Array.isArray(input.effects) ? input.effects : input.effects ? [input.effects] : [])
+      .forEach((effect) => addEffect(effects, effect));
+
+    const explicitState = input.state && typeof input.state === "object" ? input.state : {};
+    const explicitOrigins = input.stateOrigins && typeof input.stateOrigins === "object" ? input.stateOrigins : {};
+    ["light", "sunlight", "visibility"].forEach((key) => {
+      if (explicitState[key] === undefined && input[key] === undefined) return;
+      const raw = explicitState[key] ?? input[key];
+      if (key === "light") state.light = normalizeLight(raw, state.light);
+      if (key === "sunlight") state.sunlight = normalizeSunlight(raw, state.sunlight);
+      if (key === "visibility") state.visibility = normalizeVisibility(raw, state.visibility);
+      stateOrigins[key] = normalizeOrigin(explicitOrigins[key]);
+    });
+
+    if (effects.has("dense_fog")) {
+      state.visibility = VISIBILITY_LEVELS.HEAVILY_OBSCURED;
+      stateOrigins.visibility = effects.get("dense_fog").origin;
+    } else if (effects.has("heavy_rain") || effects.has("heavy_snow") || effects.has("fog") || effects.has("hail")) {
+      if (state.visibility === VISIBILITY_LEVELS.CLEAR) state.visibility = VISIBILITY_LEVELS.OBSCURED;
+      if (!stateOrigins.visibility) {
+        const source = effects.get("heavy_rain") || effects.get("heavy_snow") || effects.get("fog") || effects.get("hail");
+        stateOrigins.visibility = source?.origin || null;
+      }
+    }
+
+    const effectList = [...effects.values()].sort((a, b) => a.id.localeCompare(b.id));
+    const origins = [...new Set([
+      ...effectList.map((effect) => effect.origin),
+      ...Object.values(stateOrigins),
+    ].filter(Boolean))].sort();
+    const categories = [...new Set([
+      "light",
+      "sunlight",
+      "visibility",
+      ...effectList.map((effect) => effect.category),
+    ])].sort();
+
+    return {
+      version: VERSION,
+      encounterType,
+      weatherId,
+      isDay,
+      state,
+      stateOrigins,
+      effects: effectList,
+      effectIds: effectList.map((effect) => effect.id),
+      origins,
+      categories,
+    };
+  }
+
+  function fromWeatherState(weatherState, options = {}) {
+    return resolveEnvironment({
+      ...options,
+      weather: weatherState,
+    });
+  }
+
+  function hasEffect(environment, effectId) {
+    const id = canonicalEffectId(effectId);
+    return Boolean(id && environment?.effectIds?.includes(id));
+  }
+
+  function hasState(environment, key, value) {
+    const stateKey = normalizeId(key);
+    return normalizeId(environment?.state?.[stateKey]) === normalizeId(value);
+  }
+
+  function hasOrigin(environment, origin) {
+    const id = normalizeOrigin(origin);
+    return Boolean(id && environment?.origins?.includes(id));
+  }
+
+  function hasCategory(environment, category) {
+    const id = normalizeId(category);
+    return Boolean(id && environment?.categories?.includes(id));
+  }
+
+  function withEnvironment(runtime = {}, environment) {
+    return {
+      ...runtime,
+      environment: clone(environment || resolveEnvironment()),
+    };
+  }
+
+  const api = Object.freeze({
+    VERSION,
+    ENCOUNTER_TYPES,
+    LIGHT_LEVELS,
+    SUNLIGHT_LEVELS,
+    VISIBILITY_LEVELS,
+    ORIGINS,
+    SCOPES,
+    SEVERITIES,
+    EFFECTS,
+    WEATHER_PRESETS,
+    EFFECT_ALIASES,
+    normalizeId,
+    normalizeEncounterType,
+    canonicalEffectId,
+    normalizeEffect,
+    resolveEnvironment,
+    fromWeatherState,
+    hasEffect,
+    hasState,
+    hasOrigin,
+    hasCategory,
+    withEnvironment,
+  });
+
+  global.LuminousEnvironmentEngine = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/environment-runtime.js
+++ b/js/environment-runtime.js
@@ -1,0 +1,145 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousEnvironmentRuntime) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousEnvironmentRuntime;
+    return;
+  }
+
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  let bridgedSource = null;
+
+  function environmentEngine() {
+    if (global.LuminousEnvironmentEngine) return global.LuminousEnvironmentEngine;
+    if (typeof require === "function") {
+      try { return require("./environment-engine.js"); } catch (_) { return null; }
+    }
+    return null;
+  }
+
+  function weatherEngine() {
+    return global.LuminousWeatherEngine || null;
+  }
+
+  function calendarIsDay(calendar) {
+    const source = calendar && typeof calendar === "object" ? calendar : {};
+    if (!source.timestamp) return null;
+    const date = new Date(source.timestamp);
+    if (Number.isNaN(date.getTime())) return null;
+    const hour = date.getHours();
+    return hour >= 6 && hour < 18;
+  }
+
+  function overridesFromRuntime(runtime = {}) {
+    const context = runtime.environmentContext && typeof runtime.environmentContext === "object"
+      ? runtime.environmentContext
+      : {};
+    const overrides = { ...context };
+    ["encounterType", "exposure", "water", "effects", "state", "stateOrigins", "isDay"].forEach((key) => {
+      if (runtime[key] !== undefined && overrides[key] === undefined) overrides[key] = runtime[key];
+    });
+    return overrides;
+  }
+
+  function currentEnvironment(options = {}) {
+    const environment = environmentEngine();
+    if (!environment?.resolveEnvironment) return null;
+    const weather = weatherEngine();
+    const weatherState = options.weather ?? weather?.getState?.() ?? null;
+    const calendar = options.calendar ?? weather?.getCalendar?.() ?? null;
+    const isDay = options.isDay !== undefined ? options.isDay : calendarIsDay(calendar);
+    if (!weatherState && options.weatherId === undefined && options.weather === undefined) return null;
+    return environment.resolveEnvironment({
+      ...options,
+      ...(weatherState ? { weather: weatherState } : {}),
+      ...(isDay == null ? {} : { isDay }),
+    });
+  }
+
+  function augmentRuntime(runtime = {}) {
+    if (!runtime || typeof runtime !== "object") return runtime;
+    if (runtime.environment) return runtime;
+    const resolved = currentEnvironment(overridesFromRuntime(runtime));
+    if (resolved) runtime.environment = resolved;
+    return runtime;
+  }
+
+  function wrapTheatreCheck(source, payload = {}) {
+    const character = payload.character || {};
+    const traits = payload.traits || [];
+    const state = payload.state || source.createState();
+    const runtime = augmentRuntime({
+      context: "theatre",
+      character,
+      self: character,
+      check: Object.assign({ difficulty: 0, abilityPower: 0, finalPower: 0 }, clone(payload.check || {})),
+      ...(payload.environment ? { environment: clone(payload.environment) } : {}),
+      ...(payload.environmentContext ? { environmentContext: clone(payload.environmentContext) } : {}),
+      ...(payload.encounterType !== undefined ? { encounterType: payload.encounterType } : {}),
+      ...(payload.exposure !== undefined ? { exposure: payload.exposure } : {}),
+      ...(payload.water !== undefined ? { water: clone(payload.water) } : {}),
+    });
+    source.dispatchTraits(traits, "passive", runtime, state);
+    const result = source.dispatchTraits(traits, "before_check", runtime, state);
+    return { check: runtime.check, state: result.state, outcomes: result.outcomes };
+  }
+
+  function installTraitBridge() {
+    const source = global.LuminousTraitEngine;
+    if (!source || source.__environmentRuntimeBridge) return Boolean(source);
+    if (source === bridgedSource) return true;
+
+    const wrapped = Object.freeze({
+      ...source,
+      __environmentRuntimeBridge: true,
+      dispatchTrait(input, trigger, runtime = {}, state) {
+        return source.dispatchTrait(input, trigger, augmentRuntime(runtime), state);
+      },
+      dispatchTraits(traits, trigger, runtime = {}, state) {
+        return source.dispatchTraits(traits, trigger, augmentRuntime(runtime), state);
+      },
+      canActivateTrait(input, runtime = {}, state) {
+        return source.canActivateTrait(input, augmentRuntime(runtime), state);
+      },
+      activateTrait(input, runtime = {}, state) {
+        return source.activateTrait(input, augmentRuntime(runtime), state);
+      },
+      listAvailableTraitActions(traits, runtime = {}, state) {
+        return source.listAvailableTraitActions(traits, augmentRuntime(runtime), state);
+      },
+      resolveTheatreCheck(payload = {}) {
+        return wrapTheatreCheck(source, payload);
+      },
+      dispatchCombatEvent(trigger, payload = {}) {
+        const next = { ...payload };
+        if (!next.environment) {
+          const resolved = currentEnvironment(overridesFromRuntime(next));
+          if (resolved) next.environment = resolved;
+        }
+        return source.dispatchCombatEvent(trigger, next);
+      },
+    });
+
+    bridgedSource = source;
+    global.LuminousTraitEngine = wrapped;
+    return true;
+  }
+
+  const api = Object.freeze({
+    currentEnvironment,
+    augmentRuntime,
+    installTraitBridge,
+  });
+
+  global.LuminousEnvironmentRuntime = api;
+
+  if (!installTraitBridge() && global.document) {
+    let attempts = 0;
+    const timer = global.setInterval(() => {
+      attempts += 1;
+      if (installTraitBridge() || attempts >= 100) global.clearInterval(timer);
+    }, 50);
+  }
+
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/universal-action-economy.js
+++ b/js/universal-action-economy.js
@@ -174,7 +174,7 @@
   function getPlannedAction(unit, slotIndex) {
     const state = ensureState(unit);
     const entry = state?.plannedActions?.[slotIndex];
-    return entry ? { ...entry, data: { ...(entry.data || {}) } : null;
+    return entry ? { ...entry, data: { ...(entry.data || {}) } } : null;
   }
 
   function takePlannedAction(unit, slotIndex, options = {}) {

--- a/js/universal-action-economy.js
+++ b/js/universal-action-economy.js
@@ -17,6 +17,16 @@
   const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/\s+/g, "_");
   const finiteInt = (value, fallback = 0) => Number.isFinite(Number(value)) ? Math.max(0, Math.trunc(Number(value))) : fallback;
 
+  function ensureEnvironmentRuntime() {
+    if (!global.document || global.LuminousEnvironmentRuntime) return;
+    if (global.document.getElementById("luminous-weather-environment-bootstrap")) return;
+    const script = global.document.createElement("script");
+    script.id = "luminous-weather-environment-bootstrap";
+    script.src = "js/weather-readonly-engine.js";
+    script.async = false;
+    global.document.head?.appendChild(script);
+  }
+
   function normalizePhase(value) {
     const id = normalizeId(value);
     if (["pre_combat_planning", "planning", "planning_phase", "before_combat", "before_combat_phase"].includes(id)) return PHASES.PLANNING;
@@ -119,7 +129,6 @@
       state.reactionRemaining = Math.max(0, finiteInt(state.reactionRemaining, 0) - 1);
       return true;
     }
-    // Actions are never consumed as an immediate resource. They must be assigned to an Action Slot.
     return id !== ACTION_COSTS.ACTION;
   }
 
@@ -165,7 +174,7 @@
   function getPlannedAction(unit, slotIndex) {
     const state = ensureState(unit);
     const entry = state?.plannedActions?.[slotIndex];
-    return entry ? { ...entry, data: { ...(entry.data || {}) } } : null;
+    return entry ? { ...entry, data: { ...(entry.data || {}) } : null;
   }
 
   function takePlannedAction(unit, slotIndex, options = {}) {
@@ -265,5 +274,6 @@
   });
 
   global.LuminousActionEconomy = api;
+  ensureEnvironmentRuntime();
   if (typeof module !== "undefined" && module.exports) module.exports = api;
 })(typeof window !== "undefined" ? window : globalThis);

--- a/js/weather-readonly-engine.js
+++ b/js/weather-readonly-engine.js
@@ -1,7 +1,41 @@
 (function (global) {
   "use strict";
 
-  if (global.LuminousWeatherEngine) return;
+  function ensureEnvironmentRuntime() {
+    if (!global.document) return;
+
+    const loadRuntime = () => {
+      if (global.LuminousEnvironmentRuntime || global.document.getElementById("luminous-environment-runtime-script")) return;
+      const runtimeScript = global.document.createElement("script");
+      runtimeScript.id = "luminous-environment-runtime-script";
+      runtimeScript.src = "js/environment-runtime.js";
+      runtimeScript.async = false;
+      global.document.head?.appendChild(runtimeScript);
+    };
+
+    if (global.LuminousEnvironmentEngine) {
+      loadRuntime();
+      return;
+    }
+
+    const existing = global.document.getElementById("luminous-environment-engine-script");
+    if (existing) {
+      existing.addEventListener("load", loadRuntime, { once: true });
+      return;
+    }
+
+    const engineScript = global.document.createElement("script");
+    engineScript.id = "luminous-environment-engine-script";
+    engineScript.src = "js/environment-engine.js";
+    engineScript.async = false;
+    engineScript.addEventListener("load", loadRuntime, { once: true });
+    global.document.head?.appendChild(engineScript);
+  }
+
+  if (global.LuminousWeatherEngine) {
+    ensureEnvironmentRuntime();
+    return;
+  }
 
   const ROOT = "campaña/clima";
   const LEGACY_WORLD_ROOT = "campaña/estado_mundo";
@@ -217,5 +251,8 @@
     bind();
   }
 
-  if (global.document) boot();
+  if (global.document) {
+    ensureEnvironmentRuntime();
+    boot();
+  }
 })(window);

--- a/tests/environment_engine.spec.js
+++ b/tests/environment_engine.spec.js
@@ -1,4 +1,6 @@
 const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
 const Environment = require("../js/environment-engine.js");
 const TraitEngine = require("../js/trait-engine.js");
 
@@ -15,7 +17,6 @@ test.describe("Environment context resolver", () => {
   test("clear and overcast weather expose different sunlight states without generic penalties", () => {
     const clear = Environment.resolveEnvironment({ weatherId: "soleado", encounterType: "outdoor", isDay: true });
     const overcast = Environment.resolveEnvironment({ weatherId: "nublado", encounterType: "outdoor", isDay: true });
-
     expect(clear.state).toEqual({ light: "bright", sunlight: "direct", visibility: "clear" });
     expect(overcast.state).toEqual({ light: "bright", sunlight: "diffuse", visibility: "clear" });
     expect(clear.effectIds).toEqual([]);
@@ -24,7 +25,6 @@ test.describe("Environment context resolver", () => {
 
   test("night is natural Darkness with no sunlight", () => {
     const environment = Environment.resolveEnvironment({ weatherId: "soleado", encounterType: "outdoor", isDay: false });
-
     expect(environment.state.light).toBe("darkness");
     expect(environment.state.sunlight).toBe("none");
     expect(environment.stateOrigins.light).toBe("natural");
@@ -33,7 +33,6 @@ test.describe("Environment context resolver", () => {
 
   test("storm composes severe context instead of adding a blanket modifier", () => {
     const environment = Environment.resolveEnvironment({ weatherId: "tormenta", encounterType: "outdoor", isDay: true });
-
     expect(environment.state.visibility).toBe("obscured");
     expect(Environment.hasEffect(environment, "storm")).toBe(true);
     expect(Environment.hasEffect(environment, "heavy_rain")).toBe(true);
@@ -44,14 +43,12 @@ test.describe("Environment context resolver", () => {
 
   test("covered encounters block precipitation and reduce direct sunlight to diffuse", () => {
     const environment = Environment.resolveEnvironment({ weatherId: "lluvia", encounterType: "covered", isDay: true });
-
     expect(environment.state.sunlight).toBe("diffuse");
     expect(Environment.hasEffect(environment, "rain")).toBe(false);
   });
 
   test("indoors blocks exterior weather and natural sunlight", () => {
     const environment = Environment.resolveEnvironment({ weatherId: "tormenta", encounterType: "indoor", isDay: true });
-
     expect(environment.state.sunlight).toBe("none");
     expect(environment.state.visibility).toBe("clear");
     expect(Environment.hasCategory(environment, "weather")).toBe(false);
@@ -62,14 +59,11 @@ test.describe("Environment context resolver", () => {
     const near = Environment.resolveEnvironment({ water: { nearby: true } });
     const swimming = Environment.resolveEnvironment({ water: { immersion: "in_water" } });
     const submerged = Environment.resolveEnvironment({ water: { immersion: "submerged" } });
-
     expect(Environment.hasEffect(near, "near_water")).toBe(true);
     expect(Environment.hasEffect(near, "in_water")).toBe(false);
-
     expect(Environment.hasEffect(swimming, "near_water")).toBe(true);
     expect(Environment.hasEffect(swimming, "in_water")).toBe(true);
     expect(Environment.hasEffect(swimming, "submerged")).toBe(false);
-
     expect(Environment.hasEffect(submerged, "near_water")).toBe(true);
     expect(Environment.hasEffect(submerged, "in_water")).toBe(true);
     expect(Environment.hasEffect(submerged, "submerged")).toBe(true);
@@ -82,9 +76,7 @@ test.describe("Environment context resolver", () => {
   });
 
   test("Natural, Artificial, and Magical remain origin tags instead of status effects", () => {
-    const natural = Environment.resolveEnvironment({
-      effects: [{ id: "difficult_terrain", origin: "natural" }],
-    });
+    const natural = Environment.resolveEnvironment({ effects: [{ id: "difficult_terrain", origin: "natural" }] });
     const artificial = Environment.resolveEnvironment({
       encounterType: "indoor",
       effects: [{ id: "difficult_terrain", origin: "artificial" }],
@@ -94,11 +86,28 @@ test.describe("Environment context resolver", () => {
       state: { light: "darkness" },
       stateOrigins: { light: "magical" },
     });
-
     expect(Environment.hasOrigin(natural, "natural")).toBe(true);
     expect(Environment.hasOrigin(artificial, "artificial")).toBe(true);
     expect(Environment.hasOrigin(magical, "magical")).toBe(true);
     expect(Environment.hasState(magical, "light", "darkness")).toBe(true);
+  });
+
+  test("overlapping copies of one effect preserve every valid origin", () => {
+    const environment = Environment.resolveEnvironment({
+      weatherId: "lluvia",
+      encounterType: "outdoor",
+      isDay: true,
+      effects: [
+        { id: "rain", origin: "magical" },
+        { id: "rain", origin: "artificial" },
+      ],
+    });
+    const rain = environment.effects.find((effect) => effect.id === "rain");
+    expect(rain.origin).toBe("artificial");
+    expect(rain.origins).toEqual(["artificial", "magical", "natural"]);
+    expect(Environment.hasOrigin(environment, "natural")).toBe(true);
+    expect(Environment.hasOrigin(environment, "magical")).toBe(true);
+    expect(Environment.hasOrigin(environment, "artificial")).toBe(true);
   });
 
   test("existing Trait Engine path conditions can consume Environment without a new trigger type", () => {
@@ -109,31 +118,78 @@ test.describe("Environment context resolver", () => {
       water: { nearby: true, origin: "natural" },
     });
     const env = traitConditionEnv(environment);
-
     expect(TraitEngine.conditionMatches({
-      path: "environment.state.sunlight",
-      operator: "eq",
-      value: "diffuse",
+      path: "environment.state.sunlight", operator: "eq", value: "diffuse",
     }, env)).toBe(true);
-
     expect(TraitEngine.conditionMatches({
-      path: "environment.effectIds",
-      operator: "contains",
-      value: "near_water",
+      path: "environment.effectIds", operator: "contains", value: "near_water",
     }, env)).toBe(true);
-
     expect(TraitEngine.conditionMatches({
-      path: "environment.origins",
-      operator: "contains",
-      value: "natural",
+      path: "environment.origins", operator: "contains", value: "natural",
     }, env)).toBe(true);
+  });
+
+  test("production Trait runtime resolves the active Weather snapshot automatically", () => {
+    const previousWeather = global.LuminousWeatherEngine;
+    const previousTrait = global.LuminousTraitEngine;
+    const previousRuntime = global.LuminousEnvironmentRuntime;
+    const runtimeModule = require.resolve("../js/environment-runtime.js");
+
+    try {
+      global.LuminousWeatherEngine = {
+        getState: () => ({ actual: { tipo: "lluvia" } }),
+        getCalendar: () => ({ timestamp: "2026-08-25T12:00:00Z" }),
+      };
+      global.LuminousTraitEngine = TraitEngine;
+      delete global.LuminousEnvironmentRuntime;
+      delete require.cache[runtimeModule];
+      require("../js/environment-runtime.js");
+
+      const state = TraitEngine.createState();
+      const runtime = { context: "combat", character: {}, self: {} };
+      const trait = {
+        schemaVersion: 1,
+        id: "rain_listener",
+        name: "Rain Listener",
+        contexts: ["combat"],
+        activation: { type: "passive", actionCost: "none" },
+        effects: [{
+          id: "rain_listener_effect",
+          contexts: ["combat"],
+          trigger: "passive",
+          conditions: [{ path: "environment.effectIds", operator: "contains", value: "rain" }],
+          operations: [{ type: "set_flag", flagId: "rain_seen" }],
+        }],
+        rules: [],
+      };
+
+      global.LuminousTraitEngine.dispatchTrait(trait, "passive", runtime, state);
+      expect(runtime.environment?.effectIds).toContain("rain");
+      expect(state.flags.rain_seen).toBe(true);
+    } finally {
+      if (previousWeather === undefined) delete global.LuminousWeatherEngine;
+      else global.LuminousWeatherEngine = previousWeather;
+      if (previousTrait === undefined) delete global.LuminousTraitEngine;
+      else global.LuminousTraitEngine = previousTrait;
+      if (previousRuntime === undefined) delete global.LuminousEnvironmentRuntime;
+      else global.LuminousEnvironmentRuntime = previousRuntime;
+      delete require.cache[runtimeModule];
+    }
+  });
+
+  test("production entry paths bootstrap the Environment runtime", () => {
+    const root = path.resolve(__dirname, "..");
+    const weatherReader = fs.readFileSync(path.join(root, "js/weather-readonly-engine.js"), "utf8");
+    const actionEconomy = fs.readFileSync(path.join(root, "js/universal-action-economy.js"), "utf8");
+    expect(weatherReader).toContain("js/environment-engine.js");
+    expect(weatherReader).toContain("js/environment-runtime.js");
+    expect(actionEconomy).toContain("js/weather-readonly-engine.js");
   });
 
   test("dense fog can explicitly escalate visibility to Heavily Obscured", () => {
     const environment = Environment.resolveEnvironment({
       effects: [{ id: "dense_fog", origin: "magical", scope: "zone" }],
     });
-
     expect(environment.state.visibility).toBe("heavily_obscured");
     expect(Environment.hasEffect(environment, "fog")).toBe(true);
     expect(Environment.hasOrigin(environment, "magical")).toBe(true);

--- a/tests/environment_engine.spec.js
+++ b/tests/environment_engine.spec.js
@@ -1,0 +1,141 @@
+const { test, expect } = require("@playwright/test");
+const Environment = require("../js/environment-engine.js");
+const TraitEngine = require("../js/trait-engine.js");
+
+function traitConditionEnv(environment) {
+  return {
+    runtime: { environment },
+    variables: {},
+    state: TraitEngine.createState(),
+    trait: { id: "environment_test" },
+  };
+}
+
+test.describe("Environment context resolver", () => {
+  test("clear and overcast weather expose different sunlight states without generic penalties", () => {
+    const clear = Environment.resolveEnvironment({ weatherId: "soleado", encounterType: "outdoor", isDay: true });
+    const overcast = Environment.resolveEnvironment({ weatherId: "nublado", encounterType: "outdoor", isDay: true });
+
+    expect(clear.state).toEqual({ light: "bright", sunlight: "direct", visibility: "clear" });
+    expect(overcast.state).toEqual({ light: "bright", sunlight: "diffuse", visibility: "clear" });
+    expect(clear.effectIds).toEqual([]);
+    expect(overcast.effectIds).toEqual([]);
+  });
+
+  test("night is natural Darkness with no sunlight", () => {
+    const environment = Environment.resolveEnvironment({ weatherId: "soleado", encounterType: "outdoor", isDay: false });
+
+    expect(environment.state.light).toBe("darkness");
+    expect(environment.state.sunlight).toBe("none");
+    expect(environment.stateOrigins.light).toBe("natural");
+    expect(Environment.hasOrigin(environment, "natural")).toBe(true);
+  });
+
+  test("storm composes severe context instead of adding a blanket modifier", () => {
+    const environment = Environment.resolveEnvironment({ weatherId: "tormenta", encounterType: "outdoor", isDay: true });
+
+    expect(environment.state.visibility).toBe("obscured");
+    expect(Environment.hasEffect(environment, "storm")).toBe(true);
+    expect(Environment.hasEffect(environment, "heavy_rain")).toBe(true);
+    expect(Environment.hasEffect(environment, "rain")).toBe(true);
+    expect(Environment.hasEffect(environment, "strong_wind")).toBe(true);
+    expect(environment.effects.every((effect) => effect.origin === "natural")).toBe(true);
+  });
+
+  test("covered encounters block precipitation and reduce direct sunlight to diffuse", () => {
+    const environment = Environment.resolveEnvironment({ weatherId: "lluvia", encounterType: "covered", isDay: true });
+
+    expect(environment.state.sunlight).toBe("diffuse");
+    expect(Environment.hasEffect(environment, "rain")).toBe(false);
+  });
+
+  test("indoors blocks exterior weather and natural sunlight", () => {
+    const environment = Environment.resolveEnvironment({ weatherId: "tormenta", encounterType: "indoor", isDay: true });
+
+    expect(environment.state.sunlight).toBe("none");
+    expect(environment.state.visibility).toBe("clear");
+    expect(Environment.hasCategory(environment, "weather")).toBe(false);
+    expect(Environment.hasEffect(environment, "storm")).toBe(false);
+  });
+
+  test("water context expands In Water and Submerged relationships", () => {
+    const near = Environment.resolveEnvironment({ water: { nearby: true } });
+    const swimming = Environment.resolveEnvironment({ water: { immersion: "in_water" } });
+    const submerged = Environment.resolveEnvironment({ water: { immersion: "submerged" } });
+
+    expect(Environment.hasEffect(near, "near_water")).toBe(true);
+    expect(Environment.hasEffect(near, "in_water")).toBe(false);
+
+    expect(Environment.hasEffect(swimming, "near_water")).toBe(true);
+    expect(Environment.hasEffect(swimming, "in_water")).toBe(true);
+    expect(Environment.hasEffect(swimming, "submerged")).toBe(false);
+
+    expect(Environment.hasEffect(submerged, "near_water")).toBe(true);
+    expect(Environment.hasEffect(submerged, "in_water")).toBe(true);
+    expect(Environment.hasEffect(submerged, "submerged")).toBe(true);
+  });
+
+  test("Retreat - Sink normalizes to the canonical Submerged environment effect", () => {
+    expect(Environment.canonicalEffectId("Retreat - Sink")).toBe("submerged");
+    expect(Environment.canonicalEffectId("Sink")).toBe("submerged");
+    expect(Environment.canonicalEffectId("Submerged")).toBe("submerged");
+  });
+
+  test("Natural, Artificial, and Magical remain origin tags instead of status effects", () => {
+    const natural = Environment.resolveEnvironment({
+      effects: [{ id: "difficult_terrain", origin: "natural" }],
+    });
+    const artificial = Environment.resolveEnvironment({
+      encounterType: "indoor",
+      effects: [{ id: "difficult_terrain", origin: "artificial" }],
+    });
+    const magical = Environment.resolveEnvironment({
+      encounterType: "indoor",
+      state: { light: "darkness" },
+      stateOrigins: { light: "magical" },
+    });
+
+    expect(Environment.hasOrigin(natural, "natural")).toBe(true);
+    expect(Environment.hasOrigin(artificial, "artificial")).toBe(true);
+    expect(Environment.hasOrigin(magical, "magical")).toBe(true);
+    expect(Environment.hasState(magical, "light", "darkness")).toBe(true);
+  });
+
+  test("existing Trait Engine path conditions can consume Environment without a new trigger type", () => {
+    const environment = Environment.resolveEnvironment({
+      weatherId: "nublado",
+      encounterType: "outdoor",
+      isDay: true,
+      water: { nearby: true, origin: "natural" },
+    });
+    const env = traitConditionEnv(environment);
+
+    expect(TraitEngine.conditionMatches({
+      path: "environment.state.sunlight",
+      operator: "eq",
+      value: "diffuse",
+    }, env)).toBe(true);
+
+    expect(TraitEngine.conditionMatches({
+      path: "environment.effectIds",
+      operator: "contains",
+      value: "near_water",
+    }, env)).toBe(true);
+
+    expect(TraitEngine.conditionMatches({
+      path: "environment.origins",
+      operator: "contains",
+      value: "natural",
+    }, env)).toBe(true);
+  });
+
+  test("dense fog can explicitly escalate visibility to Heavily Obscured", () => {
+    const environment = Environment.resolveEnvironment({
+      effects: [{ id: "dense_fog", origin: "magical", scope: "zone" }],
+    });
+
+    expect(environment.state.visibility).toBe("heavily_obscured");
+    expect(Environment.hasEffect(environment, "fog")).toBe(true);
+    expect(Environment.hasOrigin(environment, "magical")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the first Environment contract for encounter context without creating a second Status Effect/debuff engine.

### Environment state
- `light`: `bright | dim | darkness`
- `sunlight`: `direct | diffuse | none`
- `visibility`: `clear | obscured | heavily_obscured`

### Encounter types
- `outdoor`
- `covered`
- `indoor`
- `underground`
- `underwater`
- `special`

### Environment effects
- Water: `near_water`, `in_water`, `submerged`
- Exposure: `exposed`, `under_cover`, `indoors`
- Weather: `rain`, `heavy_rain`, `snow`, `heavy_snow`, `fog`, `dense_fog`, `hail`, `strong_wind`, `storm`
- Temperature: `extreme_heat`, `extreme_cold`
- Terrain: `difficult_terrain`, `hazardous_terrain`, `slippery`

Each effect carries `category`, `scope`, `severity`, and optional origin (`natural | artificial | magical`). `Natural Environment Effect` is therefore a queryable origin, not a new Status Effect.

## Weather → Environment

The resolver consumes the weather vocabulary already used by `weather-engine.js` (`soleado`, `parcialmente_nublado`, `nublado`, `llovizna`, `lluvia`, `tormenta`, `niebla`, `nieve`, `nevada`, `granizo`) and produces the effective contextual state.

Examples:
- Sunny daytime outdoor → Bright + Direct Sunlight + Clear
- Overcast daytime outdoor → Bright + Diffuse Sunlight + Clear
- Night → Darkness + No Sunlight
- Storm → Obscured + Storm + Heavy Rain + Strong Wind
- Covered → blocks direct precipitation and reduces Direct Sunlight to Diffuse
- Indoor → blocks exterior weather and natural Sunlight

No generic attack/save/defense modifiers are introduced.

## Trait triggers

No new Trait Engine trigger type is required. The existing path-condition system already supports this cleanly by placing the snapshot at `runtime.environment`.

Examples:

```js
{ path: "environment.state.sunlight", operator: "eq", value: "direct" }
{ path: "environment.effectIds", operator: "contains", value: "near_water" }
{ path: "environment.effectIds", operator: "contains", value: "submerged" }
{ path: "environment.origins", operator: "contains", value: "natural" }
```

`LuminousEnvironmentEngine.withEnvironment(runtime, environment)` provides the bridge.

## Retreat naming

Canonical Environment naming is now `Submerged`. Legacy `Sink` and `Retreat - Sink` normalize to `submerged`, preserving compatibility while moving to `Retreat - Submerged` terminology.

## Mechanical boundary

Environment remains context/triggers. Specialized systems own consequences:
- Darkness / Heavily Obscured → Vision
- Difficult Terrain → Movement
- Submerged → underwater movement/breathing/combat
- Extreme Heat / Cold → exposure rules
- Strong Wind → only mechanics that explicitly inspect wind

## Tests

Adds `tests/environment_engine.spec.js` covering:
- Direct vs Diffuse Sunlight
- natural nighttime Darkness
- Storm composition
- Covered and Indoor filtering
- Near Water / In Water / Submerged hierarchy
- legacy Sink → Submerged normalization
- Natural / Artificial / Magical origin tags
- direct consumption by existing Trait Engine conditions
- Dense Fog → Heavily Obscured

The Weather Engine workflow now syntax-checks and executes the Environment contract tests.
