### PR TITLE
feat: integrate core Conditions and Exhaustion (clean snapshot)

### DIFF
--- a/.github/workflows/trait-engine.yml
+++ b/.github/workflows/trait-engine.yml
@@ -24,6 +24,10 @@ on:
       - "js/universal-modifier-engine.js"
       - "js/universal-speed-runtime.js"
       - "js/universal-action-economy.js"
+      - "js/core-condition-runtime.js"
+      - "js/core-condition-combat-bridge.js"
+      - "js/core-condition-theatre-bridge.js"
+      - "js/exhaustion-engine.js"
       - "js/trait-standardization-runtime.js"
       - "js/player-trait-runtime.js"
       - "js/trait-player-tray.js"
@@ -48,6 +52,9 @@ on:
       - "tests/universal_modifier_engine.spec.js"
       - "tests/universal_speed_runtime.spec.js"
       - "tests/universal_action_economy.spec.js"
+      - "tests/core_conditions.spec.js"
+      - "tests/core_condition_integration.spec.js"
+      - "tests/exhaustion_engine.spec.js"
       - "tests/trait_standardization_review_fixes.spec.js"
       - "tests/firebase_shared_trait_rules.spec.js"
       - "tests/status_builder.spec.js"
@@ -97,6 +104,10 @@ jobs:
           node --check js/universal-modifier-engine.js
           node --check js/universal-speed-runtime.js
           node --check js/universal-action-economy.js
+          node --check js/core-condition-runtime.js
+          node --check js/core-condition-combat-bridge.js
+          node --check js/core-condition-theatre-bridge.js
+          node --check js/exhaustion-engine.js
           node --check js/trait-standardization-runtime.js
           node --check js/player-trait-runtime.js
           node --check js/trait-player-tray.js
@@ -119,6 +130,9 @@ jobs:
           node --check tests/universal_modifier_engine.spec.js
           node --check tests/universal_speed_runtime.spec.js
           node --check tests/universal_action_economy.spec.js
+          node --check tests/core_conditions.spec.js
+          node --check tests/core_condition_integration.spec.js
+          node --check tests/exhaustion_engine.spec.js
           node --check tests/trait_standardization_review_fixes.spec.js
           node --check tests/firebase_shared_trait_rules.spec.js
           node --check tests/status_builder.spec.js
@@ -144,6 +158,9 @@ jobs:
           tests/universal_modifier_engine.spec.js
           tests/universal_speed_runtime.spec.js
           tests/universal_action_economy.spec.js
+          tests/core_conditions.spec.js
+          tests/core_condition_integration.spec.js
+          tests/exhaustion_engine.spec.js
           tests/trait_standardization_review_fixes.spec.js
           tests/firebase_shared_trait_rules.spec.js
           tests/status_builder.spec.js

--- a/js/core-condition-combat-bridge.js
+++ b/js/core-condition-combat-bridge.js
@@ -1,0 +1,392 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousConditionCombatBridge) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousConditionCombatBridge;
+    return;
+  }
+
+  const PATCH_INTERVAL_MS = 250;
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const conditionRuntime = () => global.LuminousConditionRuntime || null;
+
+  const POISON_TYPES = new Set(["poison", "poison_damage", "venom", "veneno", "toxic", "toxico"]);
+  const ABILITY_KEYS = Object.freeze({
+    str: ["fuerza", "strength", "str"],
+    dex: ["destreza", "dexterity", "dex"],
+    con: ["constitucion", "constitution", "con"],
+    int: ["inteligencia", "intelligence", "int"],
+    wis: ["sabiduria", "wisdom", "wis"],
+    cha: ["carisma", "charisma", "cha"],
+  });
+  const ABILITY_CODES = Object.freeze({ str: "STR", dex: "DEX", con: "CON", int: "INT", wis: "WIS", cha: "CHA" });
+
+  function emit(name, detail) {
+    try {
+      if (typeof global.dispatchEvent === "function" && typeof global.CustomEvent === "function") {
+        global.dispatchEvent(new global.CustomEvent(name, { detail }));
+      }
+    } catch (_) {}
+    return detail;
+  }
+
+  function isPoisonDamage(type, skill = null) {
+    const values = [type, skill?.damageType, skill?.damage_type, skill?.attackType, skill?.attack_type]
+      .map(normalizeId)
+      .filter(Boolean);
+    return values.some((value) => POISON_TYPES.has(value));
+  }
+
+  function unitIds(unit = {}) {
+    return [
+      unit.combatId, unit.combat_id, unit.id, unit.unitId, unit.unit_id,
+      unit.characterId, unit.character_id, unit.playerId, unit.player_id,
+      unit.actorId, unit.actor_id, unit.uid, unit.vinculo_jugador,
+    ].filter((value) => value != null && String(value).trim() !== "").map((value) => String(value).trim());
+  }
+
+  function findUnitById(units, id) {
+    if (id == null || String(id).trim() === "") return null;
+    const wanted = String(id).trim();
+    return (units || []).find((unit) => unitIds(unit).includes(wanted)) || null;
+  }
+
+  function scoreFor(unit, abilityId) {
+    const id = normalizeId(abilityId);
+    const keys = ABILITY_KEYS[id] || [id];
+    const roots = [unit?.stats, unit?.dndStats, unit];
+    for (const root of roots) {
+      if (!root || typeof root !== "object") continue;
+      for (const key of keys) {
+        if (Number.isFinite(Number(root[key]))) return Number(root[key]);
+        const upper = String(key).toUpperCase();
+        if (Number.isFinite(Number(root[upper]))) return Number(root[upper]);
+      }
+    }
+    return 10;
+  }
+
+  function proficiencyBonus(unit = {}) {
+    const explicit = unit?.dndStats?.proficiencyBonus ?? unit?.proficiencyBonus ?? unit?.proficiency_bonus ?? unit?.proficiency;
+    if (Number.isFinite(Number(explicit))) return Number(explicit);
+    return Math.ceil(Math.max(0, numberOr(unit?.level ?? unit?.characterBuild?.calculatedAtLevel, 1)) / 20);
+  }
+
+  function proficiencyMultiplier(value) {
+    const id = normalizeId(value || "none");
+    if (id === "expertise") return 2;
+    if (id === "proficient") return 1;
+    if (id === "half") return 0.5;
+    return 0;
+  }
+
+  function legacyProficiencies(unit = {}) {
+    return Array.isArray(unit?.dndStats?.proficiencies)
+      ? unit.dndStats.proficiencies.map((value) => String(value).toUpperCase())
+      : [];
+  }
+
+  function fallbackCheckBonus(unit, check = {}) {
+    const abilityId = normalizeId(check.abilityId || check.ability || "str");
+    const score = scoreFor(unit, abilityId);
+    let bonus = Math.floor((score - 10) / 2);
+    const kind = normalizeId(check.kind || check.checkType || "ability");
+    const skillId = normalizeId(check.skillId || check.skill || "");
+    const pb = proficiencyBonus(unit);
+    const legacy = legacyProficiencies(unit);
+    if (kind === "skill" && skillId) {
+      const stored = unit?.dndSkills?.[skillId]?.value;
+      if (Number.isFinite(Number(stored))) return Number(stored);
+      const prof = unit?.skillProficiency?.[skillId] ?? unit?.dndSkills?.[skillId]?.proficiency ?? unit?.dndSkills?.[skillId]?.proficiencyState;
+      if (legacy.includes(skillId.toUpperCase())) bonus += pb;
+      else bonus += Math.floor(pb * proficiencyMultiplier(prof));
+    } else if (["save", "saving_throw", "savingthrow"].includes(kind)) {
+      const code = ABILITY_CODES[abilityId] || String(abilityId).toUpperCase();
+      if (legacy.includes(`${code}_SAVE`)) bonus += pb;
+      else {
+        const prof = unit?.saveProficiency?.[abilityId] ?? unit?.savingThrowProficiency?.[abilityId];
+        bonus += Math.floor(pb * proficiencyMultiplier(prof));
+      }
+    } else {
+      const prof = unit?.abilityProficiency?.[abilityId] ?? unit?.abilityProficiency?.[ABILITY_KEYS[abilityId]?.[0]];
+      bonus += Math.floor(pb * proficiencyMultiplier(prof));
+    }
+    return bonus;
+  }
+
+  function checkBonus(_engine, unit, check = {}) {
+    return fallbackCheckBonus(unit, check);
+  }
+
+  function sourceSpellDc(source = {}) {
+    const direct = [
+      source.spellDC, source.spellDc, source.spellSaveDC, source.spell_save_dc,
+      source.spellcasting?.spellDC, source.spellcasting?.spellDc, source.spellcasting?.saveDC,
+      source.combatStats?.spellDC, source.dndStats?.spellDC, source.dndStats?.spellSaveDC,
+    ].map(Number).find(Number.isFinite);
+    if (Number.isFinite(direct)) return direct;
+
+    const spellcasting = global.LuminousSpellcastingRuntime;
+    const classes = Array.isArray(source.classes)
+      ? source.classes
+      : (Array.isArray(source.characterBuild?.classes) ? source.characterBuild.classes : []);
+    if (spellcasting?.resolveSpellcasting) {
+      for (const entry of classes) {
+        const classId = normalizeId(entry?.id || entry?.classId || entry?.class_id || entry?.name || entry);
+        if (!classId) continue;
+        try {
+          const resolved = spellcasting.resolveSpellcasting(source, classId, {}, {});
+          if (Number.isFinite(Number(resolved?.spellDC))) return Number(resolved.spellDC);
+        } catch (_) {}
+      }
+    }
+    return NaN;
+  }
+
+  function rollCheck(engine, unit, check = {}, options = {}) {
+    if (!unit) return { pending: true, reason: "missing_unit" };
+    const rng = typeof options.rng === "function" ? options.rng : Math.random;
+    const coinAmount = Math.max(1, Math.trunc(numberOr(check.coinAmount, 5)));
+    const coinPower = numberOr(check.coinPower, 4);
+    const headsChance = typeof engine?.getCoinProbability === "function"
+      ? Math.max(5, Math.min(95, numberOr(engine.getCoinProbability(unit.sp || 0), 50)))
+      : Math.max(5, Math.min(95, 50 + numberOr(unit.sp, 0)));
+    const tosses = Array.from({ length: coinAmount }, () => (rng() * 100) < headsChance);
+    const heads = tosses.filter(Boolean).length;
+    const base = checkBonus(engine, unit, check);
+    const total = base + (heads * coinPower);
+    const threshold = Number(check.threshold ?? check.difficulty ?? check.thresholdRaw);
+    const result = { total, base, heads, tosses, headsChance, coinAmount, coinPower };
+    if (Number.isFinite(threshold)) {
+      result.threshold = threshold;
+      result.passed = total >= threshold;
+    }
+    return result;
+  }
+
+  function resolveConditionCheck(engine, request, units, options = {}) {
+    if (!request || typeof request !== "object") return { pending: true, reason: "invalid_request" };
+    if (request.type === "save_check") {
+      const source = findUnitById(units, request.sourceUnitId);
+      const check = { ...(request.check || {}) };
+      let threshold = Number(check.threshold);
+      if (!Number.isFinite(threshold) && source) threshold = sourceSpellDc(source);
+      if (!Number.isFinite(threshold)) return { pending: true, reason: "missing_threshold", source };
+      check.threshold = threshold;
+      return { ...rollCheck(engine, request.unit, check, options), source };
+    }
+    if (request.type === "opposed_check") {
+      const source = findUnitById(units, request.sourceUnitId);
+      if (!source) return { pending: true, reason: "missing_opposed_source" };
+      const unitRoll = rollCheck(engine, request.unit, request.check || { kind: "ability", abilityId: "str" }, options);
+      const rivalRoll = rollCheck(engine, source, request.rivalCheck || { kind: "ability", abilityId: "str" }, options);
+      return {
+        passed: numberOr(unitRoll.total, 0) >= numberOr(rivalRoll.total, 0),
+        unitTotal: unitRoll.total,
+        rivalTotal: rivalRoll.total,
+        unitRoll,
+        rivalRoll,
+        source,
+      };
+    }
+    return { pending: true, reason: "unsupported_condition_check" };
+  }
+
+  function resolvePerceptionChecks(engine, request, units, options = {}) {
+    const initiator = request?.initiator;
+    if (!initiator) return { pending: true, reason: "missing_invisible_unit", results: [] };
+    const stealth = rollCheck(engine, initiator, request.initiatorCheck || { kind: "skill", abilityId: "dex", skillId: "stealth" }, options);
+    const candidates = (request.targets || units || []).filter((unit) => unit && unit !== initiator && numberOr(unit.hp, 1) > 0);
+    const results = candidates.map((unit) => {
+      const perception = rollCheck(engine, unit, request.rivalCheck || { kind: "skill", abilityId: "wis", skillId: "perception" }, options);
+      return { unit, perception, stealth, passed: numberOr(perception.total, 0) >= numberOr(stealth.total, 0) };
+    });
+    return { pending: false, stealth, results };
+  }
+
+  function conditionGateForSkill(unit, target, skill, options = {}) {
+    const runtime = conditionRuntime();
+    if (!runtime) return { allowed: true, reason: null };
+    const action = runtime.actionAvailability?.(unit, "action", options);
+    if (action?.available === false) return { allowed: false, reason: action.reason || "condition_blocks_action" };
+    return runtime.canTarget?.(unit, target, skill, options) || { allowed: true, reason: null };
+  }
+
+  function blockedAttackResult(reason) {
+    return {
+      attackLogs: [{ message: `Action blocked by Condition (${reason || "condition"}).`, class: "error" }],
+      pendingActions: [],
+      damageTaken: 0,
+      conditionBlocked: true,
+      reason: reason || "condition_blocks_action",
+    };
+  }
+
+  function install() {
+    const engine = global.CombatEngine;
+    const runtime = conditionRuntime();
+    if (!engine || !runtime) return false;
+    if (engine.__luminousCoreConditionCombatBridge) return true;
+
+    const originalTriggerPhase = typeof engine.triggerPhase === "function" ? engine.triggerPhase : null;
+    const originalApplyDamage = typeof engine.applyDamage === "function" ? engine.applyDamage : null;
+    const originalAutoTarget = typeof engine.autoTarget === "function" ? engine.autoTarget : null;
+    const originalAoE = typeof engine.calculateAoETargets === "function" ? engine.calculateAoETargets : null;
+    const originalUnilateral = typeof engine.resolveUnilateralWithCounter === "function" ? engine.resolveUnilateralWithCounter : null;
+    const originalClash = typeof engine.resolveStandardClash === "function" ? engine.resolveStandardClash : null;
+    const originalResolveActionSlot = typeof engine.resolveActionSlot === "function" ? engine.resolveActionSlot : null;
+
+    if (originalTriggerPhase) {
+      engine.triggerPhase = function (phaseTag, allUnits, ...rest) {
+        const units = Array.isArray(allUnits) ? allUnits.filter(Boolean) : [];
+        const normalized = normalizeId(phaseTag).replace(/^\[+|\]+$/g, "").replace(/^_+|_+$/g, "");
+        if (normalized === "round_start") {
+          units.forEach((unit) => {
+            const outcomes = runtime.turnStart?.(unit, {
+              units,
+              combatants: units,
+              engine: this,
+              resolvePerceptionChecks: (request) => resolvePerceptionChecks(this, request, units),
+            }) || [];
+            if (outcomes.length) emit("luminous:condition-turn-start-resolved", { unit, outcomes, units });
+          });
+        }
+        const result = originalTriggerPhase.call(this, phaseTag, allUnits, ...rest);
+        if (normalized === "round_end") {
+          units.forEach((unit) => {
+            const outcomes = runtime.turnEnd?.(unit, {
+              units,
+              combatants: units,
+              engine: this,
+              resolveCheck: (request) => resolveConditionCheck(this, request, units),
+            }) || [];
+            global.LuminousStatusEngine?.advanceDurations?.(unit, "round_end");
+            if (outcomes.length) emit("luminous:condition-turn-end-resolved", { unit, outcomes, units });
+          });
+        }
+        return result;
+      };
+    }
+
+    if (originalApplyDamage) {
+      engine.applyDamage = function (unit, damage, type = "directo", isCritical = false, skillUsed = null, ...rest) {
+        const multiplier = isPoisonDamage(type, skillUsed) ? numberOr(runtime.poisonDamageMultiplier?.(unit), 1) : 1;
+        const adjusted = Math.max(0, numberOr(damage, 0) * multiplier);
+        const result = originalApplyDamage.call(this, unit, adjusted, type, isCritical, skillUsed, ...rest);
+        if (result && typeof result === "object" && multiplier !== 1) {
+          return { ...result, conditionDamageMultiplier: multiplier, incomingDamage: numberOr(damage, 0), adjustedDamage: adjusted };
+        }
+        return result;
+      };
+    }
+
+    if (originalAutoTarget) {
+      engine.autoTarget = function (attacker, skill, enemies, ...rest) {
+        const list = (enemies || []).filter((target) => conditionGateForSkill(attacker, target, skill).allowed);
+        if (!list.length) return null;
+        return originalAutoTarget.call(this, attacker, skill, list, ...rest);
+      };
+    }
+
+    if (originalAoE) {
+      engine.calculateAoETargets = function (skill, primaryTarget, allPossibleTargets, unitAttacker, ...rest) {
+        if (!conditionGateForSkill(unitAttacker, primaryTarget, skill).allowed) return [];
+        const allowed = (allPossibleTargets || []).filter((target) => conditionGateForSkill(unitAttacker, target, skill).allowed);
+        return originalAoE.call(this, skill, primaryTarget, allowed, unitAttacker, ...rest);
+      };
+    }
+
+    if (originalUnilateral) {
+      engine.resolveUnilateralWithCounter = function (attacker, attackSkill, defender, counterSkill, options, ...rest) {
+        const gate = conditionGateForSkill(attacker, defender, attackSkill, options || {});
+        if (!gate.allowed) return blockedAttackResult(gate.reason);
+        return originalUnilateral.call(this, attacker, attackSkill, defender, counterSkill, options, ...rest);
+      };
+    }
+
+    if (originalClash) {
+      engine.resolveStandardClash = function (unitA, skillA, unitB, skillB, ...rest) {
+        const gateA = conditionGateForSkill(unitA, unitB, skillA);
+        const gateB = conditionGateForSkill(unitB, unitA, skillB);
+        if (!gateA.allowed || !gateB.allowed) {
+          return {
+            winner: null,
+            clashWinner: null,
+            clashLogs: [{ note: "Clash blocked by Condition.", blockedA: !gateA.allowed, blockedB: !gateB.allowed }],
+            pendingActions: [],
+            conditionBlocked: true,
+            blockedA: !gateA.allowed,
+            blockedB: !gateB.allowed,
+            reasons: { A: gateA.reason || null, B: gateB.reason || null },
+          };
+        }
+        return originalClash.call(this, unitA, skillA, unitB, skillB, ...rest);
+      };
+    }
+
+    if (originalResolveActionSlot) {
+      engine.resolveActionSlot = function (unit, slotIndex, context = {}, ...rest) {
+        const gate = runtime.actionAvailability?.(unit, "action", { ...context, phase: this.currentState });
+        if (gate?.available === false) {
+          return { handled: true, conditionBlocked: true, reason: gate.reason || "condition_blocks_action", planned: context?.plannedAction || null };
+        }
+
+        const localPlanned = context?.plannedAction || global.LuminousActionEconomy?.getPlannedAction?.(unit, slotIndex) || null;
+        if (normalizeId(localPlanned?.kind) === "universal_action") {
+          const actionId = normalizeId(localPlanned?.data?.actionId || localPlanned?.sourceId);
+          if (actionId !== "grapple") {
+            return { handled: true, planned: localPlanned, result: { applied: false, reason: "unknown_universal_action", actionId } };
+          }
+          const units = Object.values(context?.combatData || {}).filter(Boolean);
+          if (!units.some((candidate) => candidate === unit)) units.push(unit);
+          const target = findUnitById(units, localPlanned?.targetId);
+          if (!target) {
+            return { handled: true, planned: localPlanned, result: { applied: false, reason: "grapple_target_unavailable" } };
+          }
+          runtime.onActionUsed?.(unit, { ...context, combatants: units, units });
+          const unitARoll = rollCheck(this, unit, { kind: "ability", abilityId: "str" }, context);
+          const unitBRoll = rollCheck(this, target, { kind: "ability", abilityId: "str" }, context);
+          const opposed = {
+            unitATotal: unitARoll.total,
+            unitBTotal: unitBRoll.total,
+            unitBPassed: numberOr(unitBRoll.total, 0) >= numberOr(unitARoll.total, 0),
+            unitARoll,
+            unitBRoll,
+          };
+          const grappleResult = runtime.grapple?.(unit, target, {
+            ...context,
+            combatants: units,
+            units,
+            resolveOpposedCheck: () => opposed,
+          }) || { applied: false, reason: "condition_runtime_unavailable" };
+          if (!context?.plannedAction) global.LuminousActionEconomy?.cancelAction?.(unit, slotIndex);
+          return { handled: true, planned: localPlanned, result: grappleResult, opposed };
+        }
+
+        return originalResolveActionSlot.call(this, unit, slotIndex, context, ...rest);
+      };
+    }
+
+    try { Object.defineProperty(engine, "__luminousCoreConditionCombatBridge", { value: true, configurable: true }); }
+    catch (_) { engine.__luminousCoreConditionCombatBridge = true; }
+    return true;
+  }
+
+  const api = Object.freeze({
+    POISON_TYPES,
+    isPoisonDamage,
+    fallbackCheckBonus,
+    sourceSpellDc,
+    rollCheck,
+    resolveConditionCheck,
+    resolvePerceptionChecks,
+    conditionGateForSkill,
+    install,
+  });
+
+  global.LuminousConditionCombatBridge = api;
+  install();
+  if (global.document) global.setInterval?.(install, PATCH_INTERVAL_MS);
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/core-condition-runtime.js
+++ b/js/core-condition-runtime.js
@@ -1,0 +1,455 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousConditionRuntime) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousConditionRuntime;
+    return;
+  }
+
+  const statusEngine = () => global.LuminousStatusEngine || null;
+  const exhaustion = global.LuminousExhaustionEngine || (typeof require === "function" ? require("./exhaustion-engine.js") : null);
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const PATCH_INTERVAL_MS = 250;
+
+  const DEFINITIONS = Object.freeze({
+    blinded: {
+      name: "Blinded", type: "negative", mode: "single", maxCount: 1, icon: null,
+      description: "Conditional Check, Raises Perception Checks Threshold by 99\n-5 Clash Power\nOn Turn end make a [Unit A Spell DC] CON Save Check, on Pass Remove Effect.",
+      rules: [{ trigger: "passive", cond_type: "count", cond_input: 1, operation: "sub", affectation: "clash_power", aff_input: 5 }],
+    },
+    charmed: {
+      name: "Charmed", type: "negative", mode: "single", maxCount: 1, icon: null,
+      description: "Cannot target Unit A with Attack Skills or harmful effects.\nConditional Check, Unit A lowers CHA Checks Threshold by 3 against this Unit.\nOn Turn End make a [Unit A Spell DC] WIS Save Check, on Pass Remove Effect.", rules: [],
+    },
+    deafened: {
+      name: "Deafened", type: "negative", mode: "single", maxCount: 1, icon: null,
+      description: "Conditional Check, Raises Hearing-based Perception Checks Threshold by 99\nOn Turn end make a [Unit A Spell DC] CON Save Check, on Pass Remove Effect.", rules: [],
+    },
+    frightened: {
+      name: "Frightened", type: "negative", mode: "single", maxCount: 5, defaultCount: 5, icon: null,
+      description: "Count 5\n-3 Clash Power, if target is Unit A -3 additional Clash Power\nCan't Target Unit A\nOn Turn end make a [Unit A Spell DC] WIS Save Check, on Pass Remove Effect, on fail lose 1 Count\nWith 0 Count on turn start Retreat from encounter.", rules: [],
+    },
+    grappled: {
+      name: "Grappled", type: "negative", mode: "single", maxCount: 1, icon: null,
+      description: "Grappled by [Unit A Name]\nSpeed is Fixed to 1\nUnit B Can't use any Actions\nOn Turn end make a STR Opposed Check against [Unit A Name], on Pass Remove Effect\nIf Unit A uses an Action, Remove this Effect", rules: [],
+    },
+    incapacitated: {
+      name: "Incapacitated", type: "negative", mode: "single", maxCount: 1, icon: null,
+      description: "Can't use Actions, Quick Actions or Reactions\nCan't use Universal Actions\nUntil Trigger is Removed.", rules: [],
+    },
+    invisible: {
+      name: "Invisible - [Variant]", type: "positive", mode: "single", maxCount: 1, icon: null, variant: true,
+      description: "Can't be Targeted by Skills with Weight 3 or less\nGain +5 Final Power & Defense Power\n[On Turn Start] all Units automatically make a Perception Check vs your Stealth Check\n[On Trigger] Remove this Effect",
+      rules: [
+        { trigger: "passive", cond_type: "count", cond_input: 1, operation: "add", affectation: "final_power", aff_input: 5 },
+        { trigger: "passive", cond_type: "count", cond_input: 1, operation: "add", affectation: "defense_power", aff_input: 5 },
+      ],
+    },
+    paralyzed: {
+      name: "Paralyzed", type: "negative", mode: "single", maxCount: 1, icon: null,
+      description: "Speed is Fixed to 1\nCan't use Actions, Quick Actions, Reactions.\n[On Trigger] Remove this Effect", rules: [],
+    },
+    petrified: {
+      name: "Petrified", type: "negative", mode: "single", maxCount: 1, icon: null,
+      description: "Speed is Fixed to 1\nCan't use Actions, Quick Actions, Reactions.\nOn Turn Start Gain 5 Protection\nImmune to Poisoned\nPoison deals 0 Damage\n[On Trigger] Remove this Effect", rules: [],
+    },
+    poisoned: {
+      name: "Poisoned", type: "negative", mode: "single", maxCount: 1, icon: null,
+      description: "Raises Ability and Skill Checks Threshold by 2\n-2 Clash Power\nPoison deals +50% Damage\nOn Turn end make a [Unit A Spell DC] CON Save Check, on Pass Remove Effect.",
+      rules: [{ trigger: "passive", cond_type: "count", cond_input: 1, operation: "sub", affectation: "clash_power", aff_input: 2 }],
+    },
+    prone: {
+      name: "Prone", type: "negative", mode: "single", maxCount: 1, icon: null,
+      description: "Speed is Fixed to 1\n-15 Evasion Power\n-15 Counter Power\nSkills targeting this Unit gain +2 Final Power\nOn Turn Start Remove this Effect",
+      rules: [
+        { trigger: "passive", cond_type: "count", cond_input: 1, operation: "sub", affectation: "evade_power", aff_input: 15 },
+        { trigger: "passive", cond_type: "count", cond_input: 1, operation: "sub", affectation: "counter_power", aff_input: 15 },
+      ],
+    },
+    restrained: {
+      name: "Restrained", type: "negative", mode: "single", maxCount: 1, icon: null,
+      description: "Speed is Fixed to 1\n-5 Clash Power\n-10 Evasion Power\nSkills targeting this Unit gain +2 Final Power\nRaises DEX Save Checks Threshold by 3\n[On Trigger] Remove this Effect",
+      rules: [
+        { trigger: "passive", cond_type: "count", cond_input: 1, operation: "sub", affectation: "clash_power", aff_input: 5 },
+        { trigger: "passive", cond_type: "count", cond_input: 1, operation: "sub", affectation: "evade_power", aff_input: 10 },
+      ],
+    },
+  });
+
+  const TRIGGER_REMOVAL_STATUSES = Object.freeze(["incapacitated", "invisible", "paralyzed", "petrified", "restrained"]);
+  const FIXED_SPEED_STATUSES = Object.freeze(["grappled", "paralyzed", "petrified", "prone", "restrained"]);
+  const bridgeState = { modifierSource: null };
+
+  function emit(name, detail) {
+    try {
+      if (typeof global.dispatchEvent === "function" && typeof global.CustomEvent === "function") global.dispatchEvent(new global.CustomEvent(name, { detail }));
+    } catch (_) {}
+    return detail;
+  }
+
+  function installRegistry() {
+    if (!global.STATUS_REGISTRY || typeof global.STATUS_REGISTRY !== "object") global.STATUS_REGISTRY = {};
+    Object.entries(DEFINITIONS).forEach(([id, definition]) => { global.STATUS_REGISTRY[id] = { id, ...clone(definition) }; });
+    return global.STATUS_REGISTRY;
+  }
+
+  function getDefinition(statusId) {
+    const id = normalizeId(statusId);
+    return DEFINITIONS[id] ? { id, ...clone(DEFINITIONS[id]) } : null;
+  }
+
+  function normalizeStatusInput(statusId, input = {}) {
+    const id = normalizeId(statusId);
+    if (id === "frightened" && !Object.prototype.hasOwnProperty.call(input, "count")) return { ...input, count: 5 };
+    return input;
+  }
+
+  function has(unit, statusId) {
+    return Boolean(statusEngine()?.hasStatus?.(unit, statusId) || unit?.statusEffects?.[normalizeId(statusId)]);
+  }
+
+  function status(unit, statusId) {
+    return statusEngine()?.getStatus?.(unit, statusId) || clone(unit?.statusEffects?.[normalizeId(statusId)] || null);
+  }
+
+  function unitIds(unit = {}) {
+    return [unit.combatId, unit.combat_id, unit.id, unit.unitId, unit.unit_id, unit.characterId, unit.character_id, unit.playerId, unit.player_id, unit.actorId, unit.actor_id, unit.uid, unit.vinculo_jugador]
+      .filter((value) => value != null && String(value).trim() !== "").map((value) => String(value).trim());
+  }
+
+  function primaryUnitId(unit = {}) {
+    return unitIds(unit)[0] || normalizeId(unit.characterName || unit.character_name || unit.nombre || unit.name) || null;
+  }
+
+  function sameUnit(a, b) {
+    if (!a || !b) return false;
+    if (a === b) return true;
+    const ids = new Set(unitIds(a));
+    if (unitIds(b).some((id) => ids.has(id))) return true;
+    const aName = normalizeId(a.characterName || a.character_name || a.nombre || a.name);
+    const bName = normalizeId(b.characterName || b.character_name || b.nombre || b.name);
+    return Boolean(aName && bName && aName === bName);
+  }
+
+  function statusSourceMatches(entry, sourceUnit) {
+    if (!entry || !sourceUnit) return false;
+    const sourceId = String(entry.sourceUnitId || entry.data?.sourceUnitId || "").trim();
+    if (sourceId && unitIds(sourceUnit).includes(sourceId)) return true;
+    const sourceName = normalizeId(entry.data?.sourceUnitName || "");
+    const unitName = normalizeId(sourceUnit.characterName || sourceUnit.character_name || sourceUnit.nombre || sourceUnit.name);
+    return Boolean(sourceName && sourceName === unitName);
+  }
+
+  function canApplyStatus(unit, statusId) {
+    if (normalizeId(statusId) === "poisoned" && has(unit, "petrified")) return { allowed: false, reason: "petrified_poisoned_immunity" };
+    return { allowed: true, reason: null };
+  }
+
+  function actionAvailability(unit, cost, options = {}) {
+    const id = normalizeId(cost);
+    if (has(unit, "incapacitated") && (options.universalAction === true || ["action", "quick_action", "reaction"].includes(id))) {
+      return { available: false, reason: options.universalAction === true ? "incapacitated_universal_action" : `incapacitated_${id}` };
+    }
+    if ((has(unit, "paralyzed") || has(unit, "petrified")) && ["action", "quick_action", "reaction"].includes(id)) {
+      return { available: false, reason: has(unit, "petrified") ? `petrified_${id}` : `paralyzed_${id}` };
+    }
+    if (id === "action" && status(unit, "grappled")?.data?.role === "held") return { available: false, reason: "grappled_action" };
+    return { available: true, reason: null };
+  }
+
+  function canUseUniversalAction(unit, options = {}) {
+    return actionAvailability(unit, normalizeId(options.cost || "action"), { ...options, universalAction: true });
+  }
+
+  function skillFamily(skill = {}) {
+    return normalizeId(skill.skillFamily || skill.skill_family || skill.type || "attack");
+  }
+
+  function isHarmfulSkill(skill = {}) {
+    return skill.harmful === true || skill.isHarmful === true || skill.dealsDamage === true || ["attack", "normal", "melee", "ranged", "damage", "harmful"].includes(skillFamily(skill));
+  }
+
+  function canTarget(unit, target, skill = {}, options = {}) {
+    if (!unit || !target) return { allowed: true, reason: null };
+    const charmed = status(unit, "charmed");
+    if (charmed && statusSourceMatches(charmed, target) && isHarmfulSkill(skill)) return { allowed: false, reason: "charmed_source_protected" };
+    const frightened = status(unit, "frightened");
+    if (frightened && statusSourceMatches(frightened, target)) return { allowed: false, reason: "frightened_source_untargetable" };
+    if (has(target, "invisible")) {
+      const weight = Math.max(1, numberOr(skill.weight ?? skill.skillWeight ?? skill.skill_weight ?? skill.attackWeight ?? skill.attack_weight, 1));
+      if (weight <= 3 && options.ignoreInvisible !== true) return { allowed: false, reason: "invisible_weight_3_or_less", weight };
+    }
+    return { allowed: true, reason: null };
+  }
+
+  function checkKind(check = {}) {
+    return normalizeId(check.kind || check.checkType || check.type || (check.skillId ? "skill" : "ability"));
+  }
+
+  function checkAbility(check = {}) {
+    return normalizeId(check.abilityId || check.ability || check.stat || "");
+  }
+
+  function thresholdModifier(unit, check = {}, options = {}) {
+    let value = exhaustion?.thresholdModifier?.(unit, check) || 0;
+    const kind = checkKind(check);
+    const skillId = normalizeId(check.skillId || check.skill || "");
+    const senses = Array.isArray(check.senses) ? check.senses.map(normalizeId) : [normalizeId(check.sense || "")].filter(Boolean);
+    if (has(unit, "blinded") && skillId === "perception") value += 99;
+    if (has(unit, "deafened") && skillId === "perception" && (check.hearingBased === true || senses.includes("hearing"))) value += 99;
+    if (has(unit, "poisoned") && ["ability", "ability_check", "skill", "skill_check", "check"].includes(kind)) value += 2;
+    if (has(unit, "restrained") && ["save", "saving_throw", "savingthrow"].includes(kind) && checkAbility(check) === "dex") value += 3;
+    const target = options.target || check.target || null;
+    const targetCharmed = target ? status(target, "charmed") : null;
+    if (targetCharmed && statusSourceMatches(targetCharmed, unit) && checkAbility(check) === "cha") value -= 3;
+    return value;
+  }
+
+  function applyCheckThreshold(unit, check = {}, options = {}) {
+    const modifier = thresholdModifier(unit, check, options);
+    if (!modifier) return { check, modifier: 0 };
+    if (Number.isFinite(Number(check.difficulty))) check.difficulty = Number(check.difficulty) + modifier;
+    else if (Number.isFinite(Number(check.thresholdRaw))) check.thresholdRaw = Number(check.thresholdRaw) + modifier;
+    else if (Number.isFinite(Number(check.threshold))) check.threshold = Number(check.threshold) + modifier;
+    else check.conditionThresholdModifier = numberOr(check.conditionThresholdModifier, 0) + modifier;
+    return { check, modifier };
+  }
+
+  function emptyModifiers() {
+    return { final_power: 0, defense_power: 0, clash_power: 0, counter_power: 0, evade_power: 0, min_speed: 0, max_speed: 0, speed: 0 };
+  }
+
+  function contextualModifiers(options = {}) {
+    const unit = options.unit || options.character || {};
+    const target = options.target || null;
+    const output = emptyModifiers();
+    const frightened = status(unit, "frightened");
+    if (frightened) {
+      output.clash_power -= 3;
+      if (target && statusSourceMatches(frightened, target)) output.clash_power -= 3;
+    }
+    if (target && (has(target, "prone") || has(target, "restrained"))) output.final_power += 2;
+    const fatigue = exhaustion?.combatModifiers?.(unit) || {};
+    output.clash_power += numberOr(fatigue.clash_power, 0);
+    output.max_speed += numberOr(fatigue.max_speed, 0);
+    return output;
+  }
+
+  function fixedSpeedFor(unit) {
+    if (FIXED_SPEED_STATUSES.some((id) => has(unit, id))) return 1;
+    return exhaustion?.fixedSpeed?.(unit) ?? null;
+  }
+
+  function poisonDamageMultiplier(unit) {
+    if (has(unit, "petrified")) return 0;
+    return has(unit, "poisoned") ? 1.5 : 1;
+  }
+
+  function retreat(unit, reason) {
+    unit.lifeState = "retreated";
+    unit.isRetreated = true;
+    unit.isDowned = false;
+    unit.actionQueue = [];
+    emit("luminous:condition-retreat", { unit, reason });
+    return unit;
+  }
+
+  function turnStart(unit, options = {}) {
+    const outcomes = [];
+    const frightened = status(unit, "frightened");
+    if (frightened && numberOr(frightened.count, 0) <= 0) {
+      retreat(unit, "frightened_count_0");
+      outcomes.push({ type: "retreat", statusId: "frightened" });
+    }
+    if (has(unit, "petrified")) {
+      const protection = statusEngine()?.applyStatus?.(unit, "protection", { mode: "gain", count: 5, duration: "until_removed", data: { sourceCondition: "petrified" } });
+      outcomes.push({ type: "gain_status", statusId: "protection", count: 5, status: protection });
+    }
+    if (has(unit, "prone")) {
+      const removed = statusEngine()?.removeStatus?.(unit, "prone", { from: "self", ignoreProtection: true });
+      outcomes.push({ type: "remove_status", statusId: "prone", removed: Boolean(removed?.removed) });
+    }
+    if (has(unit, "invisible")) {
+      const request = { type: "opposed_check_all", statusId: "invisible", initiator: unit, initiatorCheck: { kind: "skill", abilityId: "dex", skillId: "stealth" }, rivalCheck: { kind: "skill", abilityId: "wis", skillId: "perception" }, targets: options.units || options.combatants || null };
+      outcomes.push(request);
+      if (typeof options.resolvePerceptionChecks === "function") request.result = options.resolvePerceptionChecks(request);
+      else emit("luminous:condition-check-requested", request);
+    }
+    return outcomes;
+  }
+
+  function sourceSpellDc(entry) {
+    return numberOr(entry?.data?.spellDC ?? entry?.data?.spellDc ?? entry?.data?.sourceSpellDC ?? entry?.data?.sourceSaveDC ?? entry?.data?.saveDC, NaN);
+  }
+
+  function saveRequest(unit, statusId, abilityId, entry) {
+    return { type: "save_check", statusId, unit, sourceUnitId: entry?.sourceUnitId || null, check: { kind: "save", abilityId, threshold: sourceSpellDc(entry), source: statusId } };
+  }
+
+  function combatantsFor(unit, options = {}) {
+    const values = [unit, ...(options.combatants || options.units || Object.values(global.combatData || {}))].filter(Boolean);
+    return values.filter((candidate, index) => values.findIndex((other) => sameUnit(other, candidate)) === index);
+  }
+
+  function breakGrapple(unit, options = {}) {
+    const own = status(unit, "grappled");
+    if (!own) return [];
+    const grappleId = own.data?.grappleId || null;
+    const results = [];
+    combatantsFor(unit, options).forEach((candidate) => {
+      const linked = status(candidate, "grappled");
+      if (!linked || (grappleId && linked.data?.grappleId !== grappleId)) return;
+      const removed = statusEngine()?.removeStatus?.(candidate, "grappled", { from: "self", ignoreProtection: true });
+      if (removed?.removed) results.push(candidate);
+    });
+    emit("luminous:grapple-broken", { unit, grappleId, units: results });
+    return results;
+  }
+
+  function turnEnd(unit, options = {}) {
+    const outcomes = [];
+    const resolver = typeof options.resolveCheck === "function" ? options.resolveCheck : null;
+    [["blinded", "con"], ["charmed", "wis"], ["deafened", "con"], ["poisoned", "con"]].forEach(([statusId, abilityId]) => {
+      const entry = status(unit, statusId);
+      if (!entry) return;
+      const request = saveRequest(unit, statusId, abilityId, entry);
+      const result = resolver ? resolver(request) : null;
+      request.result = result;
+      if (result?.passed === true || result === true) statusEngine()?.removeStatus?.(unit, statusId, { from: "self", ignoreProtection: true });
+      outcomes.push(request);
+      if (!resolver) emit("luminous:condition-check-requested", request);
+    });
+
+    const frightened = status(unit, "frightened");
+    if (frightened) {
+      const request = saveRequest(unit, "frightened", "wis", frightened);
+      const result = resolver ? resolver(request) : null;
+      request.result = result;
+      if (result?.passed === true || result === true) statusEngine()?.removeStatus?.(unit, "frightened", { from: "self", ignoreProtection: true });
+      else if (result?.passed === false || result === false) statusEngine()?.applyStatus?.(unit, "frightened", { mode: "set", count: Math.max(0, numberOr(frightened.count, 5) - 1), duration: frightened.duration, sourceUnitId: frightened.sourceUnitId, data: frightened.data });
+      outcomes.push(request);
+      if (!resolver) emit("luminous:condition-check-requested", request);
+    }
+
+    const grappled = status(unit, "grappled");
+    if (grappled?.data?.role === "held") {
+      const request = { type: "opposed_check", statusId: "grappled", unit, sourceUnitId: grappled.sourceUnitId, check: { kind: "ability", abilityId: "str" }, rivalCheck: { kind: "ability", abilityId: "str" } };
+      const result = resolver ? resolver(request) : null;
+      request.result = result;
+      if (result?.passed === true || result === true) breakGrapple(unit, options);
+      outcomes.push(request);
+      if (!resolver) emit("luminous:condition-check-requested", request);
+    }
+    return outcomes;
+  }
+
+  function resolveTrigger(unit, triggerId, options = {}) {
+    const trigger = normalizeId(triggerId);
+    const removed = [];
+    TRIGGER_REMOVAL_STATUSES.forEach((statusId) => {
+      const entry = status(unit, statusId);
+      if (!entry) return;
+      const expected = normalizeId(entry.data?.removeTrigger || entry.data?.trigger || entry.data?.triggerId || "");
+      if (!expected || expected !== trigger) return;
+      const result = statusEngine()?.removeStatus?.(unit, statusId, { from: "self", ignoreProtection: true, ...options });
+      if (result?.removed) removed.push(statusId);
+    });
+    return removed;
+  }
+
+  function onActionUsed(unit, options = {}) {
+    return status(unit, "grappled")?.data?.role === "grappler" ? breakGrapple(unit, options) : [];
+  }
+
+  function grapple(unitA, unitB, options = {}) {
+    if (!unitA || !unitB || sameUnit(unitA, unitB)) return { applied: false, reason: "invalid_units" };
+    const gate = canUseUniversalAction(unitA, { cost: "action" });
+    if (!gate.available) return { applied: false, reason: gate.reason };
+    const request = { type: "opposed_check", actionId: "grapple", initiator: unitA, rival: unitB, initiatorCheck: { kind: "ability", abilityId: "str" }, rivalCheck: { kind: "ability", abilityId: "str" } };
+    let result = typeof options.resolveOpposedCheck === "function" ? options.resolveOpposedCheck(request) : null;
+    if (!result && Number.isFinite(Number(options.unitATotal)) && Number.isFinite(Number(options.unitBTotal))) {
+      result = { unitATotal: Number(options.unitATotal), unitBTotal: Number(options.unitBTotal), unitBPassed: Number(options.unitBTotal) >= Number(options.unitATotal) };
+    }
+    if (!result) {
+      emit("luminous:condition-check-requested", request);
+      return { applied: false, pending: true, request };
+    }
+    const unitBFailed = result.unitBFailed === true || result.failed === true || result.unitBPassed === false || (Number.isFinite(Number(result.unitATotal)) && Number.isFinite(Number(result.unitBTotal)) && Number(result.unitBTotal) < Number(result.unitATotal));
+    if (!unitBFailed) return { applied: false, resisted: true, request, result };
+
+    const grappleId = `grapple_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    const aId = primaryUnitId(unitA);
+    const bId = primaryUnitId(unitB);
+    const aName = String(unitA.characterName || unitA.character_name || unitA.nombre || unitA.name || aId || "Unit A");
+    const bName = String(unitB.characterName || unitB.character_name || unitB.nombre || unitB.name || bId || "Unit B");
+    const aStatus = statusEngine()?.applyStatus?.(unitA, "grappled", { mode: "set", count: 1, sourceUnitId: aId, name: `Grappled with ${bName}`, data: { grappleId, role: "grappler", partnerUnitId: bId, sourceUnitName: aName } });
+    const bStatus = statusEngine()?.applyStatus?.(unitB, "grappled", { mode: "set", count: 1, sourceUnitId: aId, name: `Grappled by ${aName}`, data: { grappleId, role: "held", partnerUnitId: aId, sourceUnitName: aName } });
+    const applied = { applied: true, grappleId, unitA: aStatus, unitB: bStatus, request, result };
+    emit("luminous:grapple-applied", { unitA, unitB, ...applied });
+    return applied;
+  }
+
+  function mergeModifiers(source, ...parts) {
+    if (source?.mergeModifiers) return source.mergeModifiers(...parts);
+    const output = {};
+    parts.forEach((part) => Object.entries(part || {}).forEach(([key, value]) => { output[key] = numberOr(output[key], 0) + numberOr(value, 0); }));
+    return output;
+  }
+
+  function installModifierBridge() {
+    const source = global.LuminousUniversalModifiers;
+    if (!source) return false;
+    if (source.__luminousCoreConditionsWrapped) { bridgeState.modifierSource = source; return true; }
+    if (bridgeState.modifierSource === source) return true;
+    const wrapped = { ...source, __luminousCoreConditionsWrapped: true };
+    if (typeof source.resolveCharacterSnapshot === "function") {
+      wrapped.resolveCharacterSnapshot = function (options = {}) {
+        const base = source.resolveCharacterSnapshot.call(source, options);
+        const extra = contextualModifiers(options);
+        return {
+          ...base,
+          modifiers: mergeModifiers(source, base?.modifiers || {}, extra),
+          maxSpeed: numberOr(base?.maxSpeed, 0) + numberOr(extra.max_speed, 0) + numberOr(extra.speed, 0),
+          minSpeed: numberOr(base?.minSpeed, 0) + numberOr(extra.min_speed, 0) + numberOr(extra.speed, 0),
+          statusModifiers: mergeModifiers(source, base?.statusModifiers || {}, { final_power: extra.final_power, clash_power: extra.clash_power }),
+        };
+      };
+    }
+    if (typeof source.canUseSkill === "function") {
+      wrapped.canUseSkill = function (unit, skill, options = {}) {
+        const base = source.canUseSkill.call(source, unit, skill);
+        if (!base?.usable) return base;
+        const target = options.target || skill?.target || null;
+        const gate = target ? canTarget(unit, target, skill, options) : { allowed: true };
+        return gate.allowed ? base : { ...base, usable: false, reason: gate.reason, restriction: "condition" };
+      };
+    }
+    global.LuminousUniversalModifiers = Object.freeze(wrapped);
+    bridgeState.modifierSource = global.LuminousUniversalModifiers;
+    return true;
+  }
+
+  function install() {
+    installRegistry();
+    exhaustion?.bindRestListener?.();
+    installModifierBridge();
+    return true;
+  }
+
+  const api = Object.freeze({
+    DEFINITIONS, TRIGGER_REMOVAL_STATUSES, FIXED_SPEED_STATUSES,
+    installRegistry, getDefinition, normalizeStatusInput,
+    hasStatus: has, getStatus: status, sameUnit, statusSourceMatches,
+    canApplyStatus, actionAvailability, canUseUniversalAction, canTarget,
+    thresholdModifier, applyCheckThreshold, contextualModifiers, fixedSpeedFor, poisonDamageMultiplier,
+    turnStart, turnEnd, resolveTrigger, breakGrapple, onActionUsed, grapple,
+    installModifierBridge, install,
+  });
+
+  global.LuminousConditionRuntime = api;
+  install();
+  if (global.document) global.setInterval?.(install, PATCH_INTERVAL_MS);
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/core-condition-theatre-bridge.js
+++ b/js/core-condition-theatre-bridge.js
@@ -1,0 +1,120 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousConditionTheatreBridge) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousConditionTheatreBridge;
+    return;
+  }
+
+  const PATCH_INTERVAL_MS = 250;
+  const state = { rollsSource: null };
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  const conditionRuntime = () => global.LuminousConditionRuntime || null;
+
+  function currentCharacter() {
+    try {
+      return global.LuminousPlayerTraitRuntime?.getCharacter?.() || global.datosJugador || null;
+    } catch (_) {
+      return global.datosJugador || null;
+    }
+  }
+
+  function currentConditionUnit() {
+    const runtime = conditionRuntime();
+    const character = currentCharacter();
+    const combatants = Object.values(global.combatData || {}).filter(Boolean);
+    if (character && runtime?.sameUnit) {
+      const combatUnit = combatants.find((unit) => runtime.sameUnit(unit, character));
+      if (combatUnit) return combatUnit;
+    }
+    return character || combatants[0] || null;
+  }
+
+  function abilities() {
+    return global.LuminousTheatreCheckCoordinator?.ABILITIES || [];
+  }
+
+  function inferRollSpec(input = {}) {
+    const explicit = input.rollSpec || input.roll_spec || null;
+    if (explicit && (explicit.kind || explicit.abilityId || explicit.skillId)) {
+      return {
+        kind: normalizeId(explicit.kind || (explicit.skillId ? "skill" : "ability")),
+        abilityId: normalizeId(explicit.abilityId || explicit.ability || ""),
+        skillId: explicit.skillId ? normalizeId(explicit.skillId) : null,
+        label: explicit.label || null,
+      };
+    }
+
+    const doc = global.document;
+    if (!doc) return null;
+    const panel = doc.querySelector?.("#stats-modal .player-ability-console") || doc.querySelector?.(".player-ability-console");
+    const abilityId = normalizeId(panel?.dataset?.activeStat || "");
+    const ability = abilities().find((entry) => normalizeId(entry.id) === abilityId) || null;
+    if (!ability) return abilityId ? { kind: "ability", abilityId, skillId: null, label: null } : null;
+
+    const promptTitle = String(doc.querySelector?.("#theatre-check-command-prompt strong")?.textContent || "").trim();
+    if (promptTitle) {
+      if (promptTitle.toLowerCase() === String(ability.name || "").toLowerCase()) {
+        return { kind: "ability", abilityId: ability.id, skillId: null, label: promptTitle };
+      }
+      if (promptTitle.toLowerCase() === `${String(ability.name || "").toLowerCase()} saving throw`) {
+        return { kind: "save", abilityId: ability.id, skillId: null, label: promptTitle };
+      }
+      const skill = (ability.skills || []).find((entry) => String(entry.name || "").toLowerCase() === promptTitle.toLowerCase());
+      if (skill) return { kind: "skill", abilityId: ability.id, skillId: skill.id, label: promptTitle };
+    }
+
+    return { kind: "ability", abilityId: ability.id, skillId: null, label: ability.name || null };
+  }
+
+  function applyConditionThreshold(checkInput = {}, options = {}) {
+    const runtime = conditionRuntime();
+    const unit = options.unit || currentConditionUnit();
+    const spec = options.rollSpec || inferRollSpec(checkInput) || {};
+    const check = {
+      ...(checkInput || {}),
+      kind: normalizeId(checkInput.kind || spec.kind || (spec.skillId ? "skill" : "ability")),
+      abilityId: normalizeId(checkInput.abilityId || spec.abilityId || ""),
+      skillId: checkInput.skillId || spec.skillId || null,
+    };
+    if (!runtime?.applyCheckThreshold || !unit) return { check, modifier: 0, unit, spec };
+    const result = runtime.applyCheckThreshold(unit, check, { target: options.target || checkInput.target || null });
+    return { ...result, unit, spec };
+  }
+
+  function install() {
+    const source = global.LuminousTheatreRolls;
+    if (!source || !conditionRuntime()) return false;
+    if (source.__luminousConditionThresholdWrapped) {
+      state.rollsSource = source;
+      return true;
+    }
+    if (state.rollsSource === source) return true;
+    if (typeof source.armCheck !== "function") return false;
+
+    const wrapped = {
+      ...source,
+      __luminousConditionThresholdWrapped: true,
+      armCheck(options = {}) {
+        const resolved = applyConditionThreshold(options);
+        return source.armCheck.call(source, resolved.check);
+      },
+    };
+    global.LuminousTheatreRolls = Object.freeze(wrapped);
+    state.rollsSource = global.LuminousTheatreRolls;
+    return true;
+  }
+
+  const api = Object.freeze({
+    currentCharacter,
+    currentConditionUnit,
+    inferRollSpec,
+    applyConditionThreshold,
+    install,
+  });
+
+  global.LuminousConditionTheatreBridge = api;
+  install();
+  if (global.document) global.setInterval?.(install, PATCH_INTERVAL_MS);
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/exhaustion-engine.js
+++ b/js/exhaustion-engine.js
@@ -1,0 +1,226 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousExhaustionEngine) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousExhaustionEngine;
+    return;
+  }
+
+  const STATE_KEY = "exhaustion";
+  const MAX_LEVEL = 6;
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+  function ensureState(unit) {
+    if (!unit || typeof unit !== "object") return null;
+    const legacy = Number.isFinite(Number(unit[STATE_KEY])) ? Number(unit[STATE_KEY]) : null;
+    if (!unit[STATE_KEY] || typeof unit[STATE_KEY] !== "object" || Array.isArray(unit[STATE_KEY])) {
+      unit[STATE_KEY] = { level: legacy == null ? 0 : legacy, baseMaxHp: null, lastLongRestAt: null, lastDailyResolutionKey: null };
+    }
+    const state = unit[STATE_KEY];
+    state.level = clamp(Math.trunc(numberOr(state.level, 0)), 0, MAX_LEVEL);
+    if (!Object.prototype.hasOwnProperty.call(state, "baseMaxHp")) state.baseMaxHp = null;
+    if (!Object.prototype.hasOwnProperty.call(state, "lastLongRestAt")) state.lastLongRestAt = null;
+    if (!Object.prototype.hasOwnProperty.call(state, "lastDailyResolutionKey")) state.lastDailyResolutionKey = null;
+    return state;
+  }
+
+  function getLevel(unit) {
+    return ensureState(unit)?.level || 0;
+  }
+
+  function maxHpSlot(unit) {
+    if (!unit || typeof unit !== "object") return null;
+    const slots = [
+      [unit, "maxHp"], [unit, "maxHP"], [unit, "hp_max"],
+      [unit.combatStats, "hp_max"], [unit.combatStats, "maxHp"],
+    ];
+    return slots.find(([root, key]) => root && Number.isFinite(Number(root[key]))) || null;
+  }
+
+  function currentHpSlots(unit) {
+    if (!unit || typeof unit !== "object") return [];
+    return [
+      [unit, "hp"], [unit, "currentHp"], [unit, "currentHP"], [unit, "hp_actual"],
+      [unit.combatStats, "hp_actual"], [unit.combatStats, "currentHp"],
+    ].filter(([root, key]) => root && Number.isFinite(Number(root[key])));
+  }
+
+  function syncMaxHp(unit) {
+    const state = ensureState(unit);
+    const slot = maxHpSlot(unit);
+    if (!state || !slot) return null;
+    const [root, key] = slot;
+    const level = state.level;
+
+    if (level >= 4) {
+      if (state.baseMaxHp == null || !Number.isFinite(Number(state.baseMaxHp))) state.baseMaxHp = Math.max(0, Number(root[key]));
+      const effective = Math.max(0, Math.floor(Number(state.baseMaxHp) * 0.5));
+      root[key] = effective;
+      currentHpSlots(unit).forEach(([hpRoot, hpKey]) => { hpRoot[hpKey] = Math.min(Number(hpRoot[hpKey]), effective); });
+      return effective;
+    }
+
+    if (state.baseMaxHp != null && Number.isFinite(Number(state.baseMaxHp))) {
+      root[key] = Math.max(0, Number(state.baseMaxHp));
+      state.baseMaxHp = null;
+    }
+    return Math.max(0, numberOr(root[key], 0));
+  }
+
+  function emit(name, detail) {
+    try {
+      if (typeof global.dispatchEvent === "function" && typeof global.CustomEvent === "function") {
+        global.dispatchEvent(new global.CustomEvent(name, { detail }));
+      }
+    } catch (_) {}
+    return detail;
+  }
+
+  function resolveDeath(unit, options = {}) {
+    if (getLevel(unit) < MAX_LEVEL) return null;
+    const deathRuntime = global.LuminousDeathSaveRuntime;
+    if (deathRuntime?.resolveDeath) return deathRuntime.resolveDeath(unit, { reason: "exhaustion_level_6", ...options });
+    unit.hp = 0;
+    unit.lifeState = "dead";
+    unit.isDead = true;
+    unit.isDowned = false;
+    unit.isRetreated = false;
+    unit.actionQueue = [];
+    return { died: true, unit, reason: "exhaustion_level_6" };
+  }
+
+  function setLevel(unit, nextLevel, options = {}) {
+    const state = ensureState(unit);
+    if (!state) return { changed: false, level: 0, reason: "missing_unit" };
+    const before = state.level;
+    state.level = clamp(Math.trunc(numberOr(nextLevel, before)), 0, MAX_LEVEL);
+    const maxHp = syncMaxHp(unit);
+    const death = state.level >= MAX_LEVEL ? resolveDeath(unit, options) : null;
+    const result = { changed: state.level !== before, before, level: state.level, maxHp, death, reason: options.reason || null };
+    if (result.changed) emit("luminous:exhaustion-changed", { unit, ...result });
+    return result;
+  }
+
+  function gainLevel(unit, amount = 1, options = {}) {
+    return setLevel(unit, getLevel(unit) + Math.max(0, Math.trunc(numberOr(amount, 1))), options);
+  }
+
+  function removeLevel(unit, amount = 1, options = {}) {
+    return setLevel(unit, getLevel(unit) - Math.max(0, Math.trunc(numberOr(amount, 1))), options);
+  }
+
+  function thresholdModifier(unit, check = {}) {
+    const level = getLevel(unit);
+    const kind = normalizeId(check.kind || check.checkType || check.type);
+    let value = 0;
+    if (level >= 1 && ["ability", "ability_check", "skill", "skill_check", "check"].includes(kind)) value += 2;
+    if (level >= 3 && ["save", "saving_throw", "savingthrow"].includes(kind)) value += 2;
+    return value;
+  }
+
+  function combatModifiers(unit) {
+    const level = getLevel(unit);
+    return {
+      clash_power: level >= 3 ? -2 : 0,
+      max_speed: level >= 2 ? -2 : 0,
+    };
+  }
+
+  function fixedSpeed(unit) {
+    return getLevel(unit) >= 5 ? 1 : null;
+  }
+
+  function traitsFor(unit, options = {}) {
+    if (Array.isArray(options.traits)) return options.traits;
+    if (Array.isArray(unit?.traitDefinitions)) return unit.traitDefinitions;
+    if (Array.isArray(unit?.traits) && unit.traits.every((entry) => entry && typeof entry === "object")) return unit.traits;
+    return global.LuminousPlayerTraitRuntime?.getTraits?.() || [];
+  }
+
+  function longRestRequirement(unit, options = {}) {
+    if (typeof options.requiresLongRest === "boolean") return { required: options.requiresLongRest, source: "explicit" };
+    const traits = traitsFor(unit, options);
+    for (const trait of traits) {
+      const mechanics = trait?.mechanics || {};
+      const rest = trait?.rest || {};
+      const value = mechanics.dailyLongRestRequirement ?? mechanics.longRestRequirement ?? rest.dailyLongRestRequirement ?? rest.longRest?.required;
+      const normalized = normalizeId(value);
+      if (value === false || ["none", "ignore", "ignored", "exempt"].includes(normalized) || mechanics.ignoreDailyLongRest === true) {
+        return { required: false, source: normalizeId(trait?.id || trait?.name) || "racial_trait" };
+      }
+      if (value === true || ["required", "normal", "long_rest"].includes(normalized)) {
+        return { required: true, source: normalizeId(trait?.id || trait?.name) || "racial_trait" };
+      }
+    }
+    return { required: true, source: "default" };
+  }
+
+  function completedLongRest(unit, options = {}) {
+    if (typeof options.completedLongRest === "boolean") return options.completedLongRest;
+    if (options.completedAlternateRest === true) return true;
+    const start = Number.isFinite(Number(options.dayStart)) ? Number(options.dayStart) : Number.NEGATIVE_INFINITY;
+    const end = Number.isFinite(Number(options.dayEnd)) ? Number(options.dayEnd) : Number.POSITIVE_INFINITY;
+    const history = unit?.restResources?.history;
+    return Array.isArray(history) && history.some((entry) => normalizeId(entry?.type) === "long_rest" && numberOr(entry?.at, 0) >= start && numberOr(entry?.at, 0) <= end);
+  }
+
+  function resolveDailyRestRequirement(unit, options = {}) {
+    const state = ensureState(unit);
+    if (!state) return { resolved: false, gained: 0, reason: "missing_unit" };
+    const dayKey = options.dayKey == null ? null : String(options.dayKey);
+    if (dayKey && state.lastDailyResolutionKey === dayKey) return { resolved: false, gained: 0, reason: "already_resolved", level: state.level };
+
+    const requirement = longRestRequirement(unit, options);
+    const completed = completedLongRest(unit, options);
+    if (dayKey) state.lastDailyResolutionKey = dayKey;
+    if (!requirement.required || completed) {
+      return { resolved: true, gained: 0, requirement, completedLongRest: completed, level: state.level };
+    }
+    const change = gainLevel(unit, 1, { reason: "missed_daily_long_rest" });
+    return { resolved: true, gained: change.changed ? 1 : 0, requirement, completedLongRest: false, ...change };
+  }
+
+  function onLongRest(unit, options = {}) {
+    const state = ensureState(unit);
+    if (!state) return { changed: false, reason: "missing_unit" };
+    state.lastLongRestAt = Number.isFinite(Number(options.at)) ? Number(options.at) : Date.now();
+    return removeLevel(unit, 1, { reason: "long_rest" });
+  }
+
+  let restListenerBound = false;
+  function bindRestListener() {
+    if (restListenerBound || typeof global.addEventListener !== "function") return false;
+    restListenerBound = true;
+    global.addEventListener("luminous:rest-completed", (event) => {
+      const detail = event?.detail || {};
+      if (normalizeId(detail.type) !== "long_rest" || !detail.character) return;
+      onLongRest(detail.character, { at: Date.now() });
+    });
+    return true;
+  }
+
+  const api = Object.freeze({
+    STATE_KEY,
+    MAX_LEVEL,
+    ensureState,
+    getLevel,
+    setLevel,
+    gainLevel,
+    removeLevel,
+    syncMaxHp,
+    thresholdModifier,
+    combatModifiers,
+    fixedSpeed,
+    longRestRequirement,
+    completedLongRest,
+    resolveDailyRestRequirement,
+    onLongRest,
+    bindRestListener,
+  });
+
+  global.LuminousExhaustionEngine = api;
+  bindRestListener();
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/status-engine.js
+++ b/js/status-engine.js
@@ -13,7 +13,7 @@
 
   function getDefinition(statusId) {
     const id = normalizeId(statusId);
-    const found = registry()[id];
+    const found = registry()[id] || global.LuminousConditionRuntime?.getDefinition?.(id);
     if (found) return { id, icon: null, rules: [], ...clone(found) };
     return {
       id,
@@ -45,7 +45,7 @@
   function normalizeInstance(statusId, input = {}, existing = null) {
     const id = normalizeId(statusId);
     const definition = getDefinition(id);
-    const count = Math.max(0, numberOr(input.count, existing?.count ?? 1));
+    const count = Math.max(0, numberOr(input.count, existing?.count ?? definition.defaultCount ?? 1));
     const potency = numberOr(input.potency, existing?.potency ?? 0);
     const duration = normalizeId(input.duration || existing?.duration || "until_removed");
     const data = { ...(existing?.data || {}), ...(input.data || {}) };
@@ -67,16 +67,21 @@
   function applyStatus(unit, statusId, input = {}) {
     const id = normalizeId(statusId);
     if (!id) return null;
+    const conditionGate = global.LuminousConditionRuntime?.canApplyStatus?.(unit, id, input);
+    if (conditionGate?.allowed === false) return null;
     const store = ensureStore(unit);
     if (!store) return null;
     const existing = store[id] && typeof store[id] === "object" ? store[id] : null;
     const mode = normalizeId(input.mode || input.action || "gain");
     const definition = getDefinition(id);
-    let next = normalizeInstance(id, input, existing);
+    const normalizedInput = !existing && mode !== "set" && Number.isFinite(Number(definition.defaultCount))
+      ? { ...input, count: Number(definition.defaultCount) }
+      : input;
+    let next = normalizeInstance(id, normalizedInput, existing);
 
     if (existing && ["gain", "add", "inflict", "apply"].includes(mode)) {
-      next.count = numberOr(existing.count, 0) + Math.max(0, numberOr(input.count, 1));
-      next.potency = numberOr(existing.potency, 0) + numberOr(input.potency, 0);
+      next.count = numberOr(existing.count, 0) + Math.max(0, numberOr(normalizedInput.count, 1));
+      next.potency = numberOr(existing.potency, 0) + numberOr(normalizedInput.potency, 0);
     }
     if (Number.isFinite(Number(definition.maxCount))) next.count = Math.min(Number(definition.maxCount), next.count);
     store[id] = next;
@@ -164,6 +169,13 @@
   global.LuminousStatusEngine = api;
   if (typeof module !== "undefined" && module.exports) module.exports = api;
 
+  if (typeof require === "function") {
+    try { if (!global.LuminousExhaustionEngine) require("./exhaustion-engine.js"); } catch (_) {}
+    try { if (!global.LuminousConditionRuntime) require("./core-condition-runtime.js"); } catch (_) {}
+    try { if (!global.LuminousConditionCombatBridge) require("./core-condition-combat-bridge.js"); } catch (_) {}
+    try { if (!global.LuminousConditionTheatreBridge) require("./core-condition-theatre-bridge.js"); } catch (_) {}
+  }
+
   function loadScript(id, src) {
     if (!global.document || global.document.getElementById(id)) return null;
     const script = global.document.createElement("script");
@@ -174,6 +186,19 @@
     return script;
   }
 
+  function ensureCoreConditionRuntime() {
+    if (!global.document || global.LuminousConditionRuntime) return;
+    const loadConditions = () => {
+      if (!global.LuminousConditionRuntime) loadScript("core-condition-runtime-script", "js/core-condition-runtime.js");
+    };
+    if (global.LuminousExhaustionEngine) return loadConditions();
+    const exhaustion = loadScript("exhaustion-engine-script", "js/exhaustion-engine.js");
+    exhaustion?.addEventListener?.("load", loadConditions, { once: true });
+  }
+
+  ensureCoreConditionRuntime();
+  if (global.document && !global.LuminousConditionCombatBridge) loadScript("core-condition-combat-bridge-script", "js/core-condition-combat-bridge.js");
+  if (global.document && !global.LuminousConditionTheatreBridge) loadScript("core-condition-theatre-bridge-script", "js/core-condition-theatre-bridge.js");
   if (global.document && !global.LuminousCharacterBuildRules) loadScript("character-build-rules-script", "js/character-build-rules.js");
   if (global.document && !global.LuminousRestEngine) loadScript("rest-engine-script", "js/rest-engine.js");
   if (global.document && !global.LuminousRestRuntime) loadScript("rest-runtime-integration-script", "js/rest-runtime-integration.js");

--- a/js/universal-action-economy.js
+++ b/js/universal-action-economy.js
@@ -7,6 +7,10 @@
     REACTION: "reaction",
   });
 
+  const UNIVERSAL_ACTIONS = Object.freeze({
+    GRAPPLE: "grapple",
+  });
+
   const PHASES = Object.freeze({
     PLANNING: "planning",
     COMBAT: "combat",
@@ -97,6 +101,8 @@
 
   function availability(unit, cost, options = {}) {
     const id = normalizeId(cost);
+    const conditionGate = global.LuminousConditionRuntime?.actionAvailability?.(unit, id, options);
+    if (conditionGate?.available === false) return { available: false, reason: conditionGate.reason || "condition_blocks_action", remaining: 0, condition: true };
     const current = snapshot(unit, options);
     if (id === ACTION_COSTS.ACTION) {
       if (current.phase !== PHASES.PLANNING) return { available: false, reason: "action_requires_planning_phase", remaining: 0 };
@@ -183,6 +189,7 @@
     const entry = state?.plannedActions?.[slotIndex];
     if (!entry) return null;
     delete state.plannedActions[slotIndex];
+    global.LuminousConditionRuntime?.onActionUsed?.(unit, options);
     return { ...entry, data: { ...(entry.data || {}) } };
   }
 
@@ -223,6 +230,40 @@
     return consume(unit, ACTION_COSTS.REACTION, options);
   }
 
+  function canUseUniversalAction(unit, actionId, options = {}) {
+    const id = normalizeId(actionId);
+    if (!Object.values(UNIVERSAL_ACTIONS).includes(id)) return { available: false, reason: "unknown_universal_action", actionId: id };
+    const conditionGate = global.LuminousConditionRuntime?.canUseUniversalAction?.(unit, { ...options, actionId: id, cost: ACTION_COSTS.ACTION });
+    if (conditionGate?.available === false) return { ...conditionGate, actionId: id };
+    const gate = availability(unit, ACTION_COSTS.ACTION, { ...options, universalAction: true });
+    return { ...gate, actionId: id };
+  }
+
+  function scheduleUniversalAction(unit, actionId, target = null, options = {}) {
+    const id = normalizeId(actionId);
+    const gate = canUseUniversalAction(unit, id, options);
+    if (!gate.available) return { scheduled: false, reason: gate.reason || "universal_action_unavailable", actionId: id };
+    return scheduleAction(unit, {
+      kind: "universal_action",
+      sourceId: id,
+      targetId: target?.id || target?.unitId || target?.characterId || options.targetId || null,
+      data: { ...(options.data || {}), actionId: id },
+    }, { ...options, universalAction: true });
+  }
+
+  function scheduleGrapple(unitA, unitB, options = {}) {
+    if (!unitB || unitA === unitB) return { scheduled: false, reason: "invalid_grapple_target", actionId: UNIVERSAL_ACTIONS.GRAPPLE };
+    return scheduleUniversalAction(unitA, UNIVERSAL_ACTIONS.GRAPPLE, unitB, options);
+  }
+
+  function performGrapple(unitA, unitB, options = {}) {
+    if (options.resolveImmediately === true) {
+      if (!global.LuminousConditionRuntime?.grapple) return { applied: false, reason: "condition_runtime_unavailable" };
+      return global.LuminousConditionRuntime.grapple(unitA, unitB, options);
+    }
+    return scheduleGrapple(unitA, unitB, options);
+  }
+
   function runtimeFor(unit, options = {}) {
     const phase = phaseFor(options);
     const runtime = {
@@ -232,6 +273,9 @@
       availability(cost) { return availability(unit, cost, { ...options, phase }); },
       consume(cost) { return consume(unit, cost, { ...options, phase }); },
       schedule(payload, scheduleOptions = {}) { return scheduleAction(unit, payload, { ...options, ...scheduleOptions, phase }); },
+      canUseUniversalAction(actionId) { return canUseUniversalAction(unit, actionId, { ...options, phase }); },
+      scheduleUniversalAction(actionId, target, scheduleOptions = {}) { return scheduleUniversalAction(unit, actionId, target, { ...options, ...scheduleOptions, phase }); },
+      scheduleGrapple(target, scheduleOptions = {}) { return scheduleGrapple(unit, target, { ...options, ...scheduleOptions, phase }); },
     };
     Object.defineProperties(runtime, {
       action: { enumerable: true, get: () => snapshot(unit, { ...options, phase }).action },
@@ -251,6 +295,7 @@
 
   const api = Object.freeze({
     ACTION_COSTS,
+    UNIVERSAL_ACTIONS,
     PHASES,
     normalizePhase,
     phaseFor,
@@ -270,6 +315,10 @@
     resetTurnResources,
     isCounterSkill,
     consumeCounterReaction,
+    canUseUniversalAction,
+    scheduleUniversalAction,
+    scheduleGrapple,
+    performGrapple,
     runtimeFor,
   });
 

--- a/js/universal-speed-runtime.js
+++ b/js/universal-speed-runtime.js
@@ -65,6 +65,8 @@
   }
 
   function effectiveSpeed(unit, options = {}) {
+    const fixed = global.LuminousConditionRuntime?.fixedSpeedFor?.(unit);
+    if (fixed != null && Number.isFinite(Number(fixed))) return Number(fixed);
     const modifiers = options.modifierEngine || global.LuminousUniversalModifiers;
     const character = options.character || (isCurrentPlayerUnit(unit) ? currentPlayerCharacter() : unit) || unit || {};
     const traits = options.traits || traitsForUnit(unit);

--- a/tests/core_condition_integration.spec.js
+++ b/tests/core_condition_integration.spec.js
@@ -1,0 +1,180 @@
+const { test, expect } = require('@playwright/test');
+
+function snapshotGlobals(keys) {
+  return Object.fromEntries(keys.map((key) => [key, global[key]]));
+}
+
+function restoreGlobals(snapshot) {
+  Object.entries(snapshot).forEach(([key, value]) => {
+    if (value === undefined) delete global[key];
+    else global[key] = value;
+  });
+}
+
+test('condition combat bridge enforces phases, saves, poison damage, targeting, action gates, and Grapple slots', () => {
+  const keys = ['CombatEngine', 'LuminousConditionRuntime', 'LuminousConditionCombatBridge', 'LuminousStatusEngine', 'LuminousActionEconomy', 'CustomEvent', 'dispatchEvent', 'LuminousSpellcastingRuntime'];
+  const previous = snapshotGlobals(keys);
+  const events = [];
+  const phases = [];
+  try {
+    delete require.cache[require.resolve('../js/core-condition-combat-bridge.js')];
+    delete require.cache[require.resolve('../js/universal-action-economy.js')];
+    delete global.LuminousConditionCombatBridge;
+    delete global.LuminousActionEconomy;
+    global.CustomEvent = class CustomEvent { constructor(name, init) { this.type = name; this.detail = init?.detail; } };
+    global.dispatchEvent = (event) => { events.push(event); return true; };
+    global.LuminousStatusEngine = { advanceDurations: () => [] };
+    global.LuminousConditionRuntime = {
+      turnStart(unit, options) {
+        phases.push(`start:${unit.id}`);
+        if (unit.invisible) options.resolvePerceptionChecks({ initiator: unit, targets: options.units });
+        return [{ type: 'start' }];
+      },
+      turnEnd(unit, options) {
+        phases.push(`end:${unit.id}`);
+        const result = options.resolveCheck({ type: 'save_check', unit, check: { kind: 'save', abilityId: 'con', threshold: 10 } });
+        return [{ type: 'save', result }];
+      },
+      poisonDamageMultiplier(unit) { return unit.petrified ? 0 : (unit.poisoned ? 1.5 : 1); },
+      actionAvailability(unit) { return unit.actionBlocked ? { available: false, reason: 'blocked_action' } : { available: true }; },
+      canTarget(unit, target) { return target?.conditionBlocked ? { allowed: false, reason: 'blocked_target' } : { allowed: true }; },
+      canUseUniversalAction(unit) { return unit.actionBlocked ? { available: false, reason: 'blocked_action' } : { available: true }; },
+      onActionUsed() { return []; },
+      grapple(unitA, unitB, options) {
+        const opposed = options.resolveOpposedCheck();
+        return { applied: opposed.unitBPassed === false, unitA: unitA.id, unitB: unitB.id, opposed };
+      },
+    };
+    global.CombatEngine = {
+      currentState: 'COMBAT_ACTIVE',
+      triggerPhase(tag) { return tag; },
+      applyDamage(unit, damage) { unit.hp -= damage; return { hp: unit.hp, shield: unit.shield || 0 }; },
+      autoTarget(attacker, skill, enemies) { return enemies[0] || null; },
+      calculateAoETargets(skill, primary, all) { return [primary, ...all.filter((unit) => unit !== primary)]; },
+      resolveUnilateralWithCounter() { return { resolved: true }; },
+      resolveStandardClash() { return { resolved: true }; },
+      resolveActionSlot() { return { handled: false }; },
+      getCoinProbability() { return 100; },
+    };
+
+    const economy = require('../js/universal-action-economy.js');
+    const bridge = require('../js/core-condition-combat-bridge.js');
+    expect(bridge.install()).toBe(true);
+
+    const source = { id: 'source', spellDC: 14 };
+    const victim = { id: 'victim', stats: { constitucion: 10 }, hp: 20 };
+    const sourceDcSave = bridge.resolveConditionCheck(global.CombatEngine, {
+      type: 'save_check', unit: victim, sourceUnitId: 'source', check: { kind: 'save', abilityId: 'con', threshold: NaN },
+    }, [source, victim], { rng: () => 0 });
+    expect(sourceDcSave.threshold).toBe(14);
+    expect(sourceDcSave.passed).toBe(true);
+
+    const units = [{ id: 'a', hp: 20, invisible: true }, { id: 'b', hp: 20 }];
+    expect(global.CombatEngine.triggerPhase('[Round Start]', units)).toBe('[Round Start]');
+    global.CombatEngine.triggerPhase('[Round End]', units);
+    expect(phases).toEqual(['start:a', 'start:b', 'end:a', 'end:b']);
+    expect(events.some((event) => event.type === 'luminous:condition-turn-start-resolved')).toBe(true);
+    expect(events.some((event) => event.type === 'luminous:condition-turn-end-resolved')).toBe(true);
+
+    const poisoned = { hp: 30, poisoned: true };
+    const poisonResult = global.CombatEngine.applyDamage(poisoned, 10, 'poison');
+    expect(poisoned.hp).toBe(15);
+    expect(poisonResult.conditionDamageMultiplier).toBe(1.5);
+
+    const petrified = { hp: 30, petrified: true };
+    const immuneResult = global.CombatEngine.applyDamage(petrified, 10, 'directo', false, { damageType: 'Poison' });
+    expect(petrified.hp).toBe(30);
+    expect(immuneResult.conditionDamageMultiplier).toBe(0);
+
+    const blocked = { id: 'blocked', conditionBlocked: true, hp: 10, actionSlots: 1 };
+    const allowed = { id: 'allowed', hp: 10, actionSlots: 1 };
+    expect(global.CombatEngine.autoTarget({}, {}, [blocked, allowed])).toBe(allowed);
+    expect(global.CombatEngine.calculateAoETargets({}, blocked, [blocked, allowed], {})).toEqual([]);
+    expect(global.CombatEngine.calculateAoETargets({}, allowed, [blocked, allowed], {})).toEqual([allowed]);
+
+    const blockedAttack = global.CombatEngine.resolveUnilateralWithCounter({}, {}, blocked, null, {});
+    expect(blockedAttack.conditionBlocked).toBe(true);
+    expect(blockedAttack.reason).toBe('blocked_target');
+
+    const actionBlocked = { id: 'actor', actionBlocked: true };
+    const slot = global.CombatEngine.resolveActionSlot(actionBlocked, 0, {});
+    expect(slot.conditionBlocked).toBe(true);
+    expect(slot.reason).toBe('blocked_action');
+
+    const grappler = { id: 'grappler', actionSlots: 1, stats: { fuerza: 14 }, hp: 20 };
+    const held = { id: 'held', actionSlots: 1, stats: { fuerza: 10 }, hp: 20 };
+    economy.beginPlanning(grappler);
+    const scheduled = economy.scheduleGrapple(grappler, held, { phase: 'planning' });
+    expect(scheduled.scheduled).toBe(true);
+    expect(scheduled.slotIndex).toBe(0);
+    expect(scheduled.entry.kind).toBe('universal_action');
+    expect(scheduled.entry.sourceId).toBe('grapple');
+    expect(scheduled.entry.targetId).toBe('held');
+    expect(economy.snapshot(grappler, { phase: 'planning' }).action).toBe(0);
+
+    const resolvedGrapple = global.CombatEngine.resolveActionSlot(grappler, 0, {
+      plannedAction: scheduled.entry,
+      combatData: { grappler, held },
+    });
+    expect(resolvedGrapple.handled).toBe(true);
+    expect(resolvedGrapple.result.applied).toBe(true);
+    expect(resolvedGrapple.opposed.unitATotal).toBeGreaterThan(resolvedGrapple.opposed.unitBTotal);
+  } finally {
+    restoreGlobals(previous);
+    delete require.cache[require.resolve('../js/core-condition-combat-bridge.js')];
+    delete require.cache[require.resolve('../js/universal-action-economy.js')];
+  }
+});
+
+test('condition theatre bridge injects the real roll spec before arming a Check', () => {
+  const keys = ['document', 'datosJugador', 'combatData', 'LuminousPlayerTraitRuntime', 'LuminousConditionRuntime', 'LuminousConditionTheatreBridge', 'LuminousTheatreCheckCoordinator', 'LuminousTheatreRolls'];
+  const previous = snapshotGlobals(keys);
+  let captured = null;
+  try {
+    delete require.cache[require.resolve('../js/core-condition-theatre-bridge.js')];
+    delete global.LuminousConditionTheatreBridge;
+    global.datosJugador = { id: 'player', statusEffects: { blinded: { count: 1 } } };
+    global.combatData = {};
+    global.LuminousConditionRuntime = {
+      sameUnit(a, b) { return a === b || a?.id === b?.id; },
+      applyCheckThreshold(unit, check) {
+        const modifier = check.skillId === 'perception' ? 99 : 0;
+        check.thresholdRaw = Number(check.thresholdRaw) + modifier;
+        return { check, modifier };
+      },
+    };
+    global.LuminousTheatreCheckCoordinator = {
+      ABILITIES: [{ id: 'wis', name: 'WISDOM', skills: [{ id: 'perception', name: 'Perception' }] }],
+    };
+    global.document = {
+      querySelector(selector) {
+        if (selector.includes('player-ability-console')) return { dataset: { activeStat: 'wis' } };
+        if (selector === '#theatre-check-command-prompt strong') return { textContent: 'Perception' };
+        return null;
+      },
+    };
+    global.LuminousTheatreRolls = Object.freeze({
+      armCheck(check) { captured = { ...check }; return { ...check }; },
+      clearArmedCheck() {},
+    });
+
+    const bridge = require('../js/core-condition-theatre-bridge.js');
+    expect(bridge.install()).toBe(true);
+    const result = global.LuminousTheatreRolls.armCheck({ thresholdRaw: 10, hiddenThreshold: false });
+    expect(captured.kind).toBe('skill');
+    expect(captured.abilityId).toBe('wis');
+    expect(captured.skillId).toBe('perception');
+    expect(captured.thresholdRaw).toBe(109);
+    expect(result.thresholdRaw).toBe(109);
+  } finally {
+    restoreGlobals(previous);
+    delete require.cache[require.resolve('../js/core-condition-theatre-bridge.js')];
+  }
+});
+
+test('status engine loads both condition integration bridges', () => {
+  const fs = require('fs');
+  const source = fs.readFileSync(require.resolve('../js/status-engine.js'), 'utf8');
+  expect(source).toContain('core-condition-combat-bridge.js');
+  expect(source).toContain('core-condition-theatre-bridge.js');
+});

--- a/tests/core_conditions.spec.js
+++ b/tests/core_conditions.spec.js
@@ -1,0 +1,198 @@
+const { test, expect } = require('@playwright/test');
+
+const statusEngine = require('../js/status-engine.js');
+const conditionRuntime = global.LuminousConditionRuntime;
+const exhaustionEngine = global.LuminousExhaustionEngine;
+require('../js/universal-modifier-engine.js');
+conditionRuntime.install();
+const actionEconomy = require('../js/universal-action-economy.js');
+const speedRuntime = require('../js/universal-speed-runtime.js');
+
+function unit(id, overrides = {}) {
+  return {
+    id,
+    name: id,
+    hp: 100,
+    maxHp: 100,
+    speed: 5,
+    combatStats: { minSpeed: 3, maxSpeed: 6, offensiveLevel: 1, defensiveLevel: 1 },
+    statusEffects: {},
+    ...overrides,
+  };
+}
+
+test('registers only the approved core Conditions', () => {
+  const expected = [
+    'blinded', 'charmed', 'deafened', 'frightened', 'grappled', 'incapacitated',
+    'invisible', 'paralyzed', 'petrified', 'poisoned', 'prone', 'restrained',
+  ];
+  expect(Object.keys(conditionRuntime.DEFINITIONS).sort()).toEqual(expected.sort());
+  expect(conditionRuntime.DEFINITIONS.stunned).toBeUndefined();
+  expect(conditionRuntime.DEFINITIONS.unconscious).toBeUndefined();
+  expect(conditionRuntime.DEFINITIONS.exhaustion).toBeUndefined();
+});
+
+test('Frightened starts at Count 5 and applies -3 Clash, -6 against Unit A', () => {
+  const victim = unit('victim');
+  const source = unit('source');
+  const other = unit('other');
+  const applied = statusEngine.applyStatus(victim, 'frightened', { sourceUnitId: 'source', data: { spellDC: 14 } });
+  expect(applied.count).toBe(5);
+
+  const modifiers = global.LuminousUniversalModifiers;
+  const normal = modifiers.resolveCharacterSnapshot({ unit: victim, character: victim, target: other, traits: [] });
+  const versusSource = modifiers.resolveCharacterSnapshot({ unit: victim, character: victim, target: source, traits: [] });
+  expect(normal.modifiers.clash_power).toBe(-3);
+  expect(versusSource.modifiers.clash_power).toBe(-6);
+  expect(conditionRuntime.canTarget(victim, source, { type: 'attack' }).allowed).toBe(false);
+});
+
+test('core numeric Conditions feed the universal modifier engine', () => {
+  const actor = unit('actor');
+  statusEngine.applyStatus(actor, 'blinded');
+  statusEngine.applyStatus(actor, 'invisible');
+  statusEngine.applyStatus(actor, 'prone');
+  const snapshot = global.LuminousUniversalModifiers.resolveCharacterSnapshot({ unit: actor, character: actor, traits: [] });
+  expect(snapshot.modifiers.clash_power).toBe(-5);
+  expect(snapshot.modifiers.final_power).toBe(5);
+  expect(snapshot.modifiers.defense_power).toBe(5);
+  expect(snapshot.modifiers.evade_power).toBe(-15);
+  expect(snapshot.modifiers.counter_power).toBe(-15);
+});
+
+test('Prone and Restrained grant +2 Final Power to Skills targeting the Unit', () => {
+  const attacker = unit('attacker');
+  const target = unit('target');
+  statusEngine.applyStatus(target, 'restrained');
+  const snapshot = global.LuminousUniversalModifiers.resolveCharacterSnapshot({ unit: attacker, character: attacker, target, traits: [] });
+  expect(snapshot.modifiers.final_power).toBe(2);
+});
+
+test('Condition Threshold modifiers use the approved Check rules', () => {
+  const actor = unit('actor');
+  statusEngine.applyStatus(actor, 'blinded');
+  expect(conditionRuntime.thresholdModifier(actor, { kind: 'skill', abilityId: 'wis', skillId: 'perception' })).toBe(99);
+
+  statusEngine.applyStatus(actor, 'deafened');
+  expect(conditionRuntime.thresholdModifier(actor, { kind: 'skill', abilityId: 'wis', skillId: 'perception', senses: ['hearing'] })).toBe(198);
+
+  const poisoned = unit('poisoned');
+  statusEngine.applyStatus(poisoned, 'poisoned');
+  expect(conditionRuntime.thresholdModifier(poisoned, { kind: 'ability', abilityId: 'str' })).toBe(2);
+  expect(conditionRuntime.thresholdModifier(poisoned, { kind: 'save', abilityId: 'con' })).toBe(0);
+
+  const restrained = unit('restrained');
+  statusEngine.applyStatus(restrained, 'restrained');
+  expect(conditionRuntime.thresholdModifier(restrained, { kind: 'save', abilityId: 'dex' })).toBe(3);
+  expect(conditionRuntime.thresholdModifier(restrained, { kind: 'save', abilityId: 'wis' })).toBe(0);
+});
+
+test('Charmed lowers Unit A CHA Threshold and blocks harmful targeting of the charmer', () => {
+  const source = unit('source');
+  const charmed = unit('charmed');
+  statusEngine.applyStatus(charmed, 'charmed', { sourceUnitId: 'source' });
+  expect(conditionRuntime.thresholdModifier(source, { kind: 'skill', abilityId: 'cha', skillId: 'persuasion' }, { target: charmed })).toBe(-3);
+  expect(conditionRuntime.canTarget(charmed, source, { type: 'attack' }).allowed).toBe(false);
+  expect(conditionRuntime.canTarget(charmed, source, { type: 'Normal' }).allowed).toBe(false);
+  expect(conditionRuntime.canTarget(charmed, source, { type: 'skill', harmful: false }).allowed).toBe(true);
+});
+
+test('Invisible blocks CombatEngine attackWeight 3 or less and allows Weight 4+', () => {
+  const attacker = unit('attacker');
+  const target = unit('target');
+  statusEngine.applyStatus(target, 'invisible');
+  expect(conditionRuntime.canTarget(attacker, target, { type: 'attack', attackWeight: 3 }).allowed).toBe(false);
+  expect(conditionRuntime.canTarget(attacker, target, { type: 'attack', attackWeight: 4 }).allowed).toBe(true);
+  expect(conditionRuntime.canTarget(attacker, target, { type: 'attack', weight: 4 }).allowed).toBe(true);
+});
+
+test('Paralyzed, Petrified and Incapacitated gate the action economy', () => {
+  const paralyzed = unit('paralyzed');
+  statusEngine.applyStatus(paralyzed, 'paralyzed');
+  expect(actionEconomy.availability(paralyzed, 'action', { phase: 'planning' }).available).toBe(false);
+  expect(actionEconomy.availability(paralyzed, 'quick_action', { phase: 'planning' }).available).toBe(false);
+  expect(actionEconomy.availability(paralyzed, 'reaction', { phase: 'combat' }).available).toBe(false);
+
+  const incapacitated = unit('incapacitated');
+  statusEngine.applyStatus(incapacitated, 'incapacitated');
+  expect(actionEconomy.canUseUniversalAction(incapacitated, 'grapple', { phase: 'planning' }).available).toBe(false);
+});
+
+test('fixed-speed Conditions resolve Speed to 1', () => {
+  for (const id of ['paralyzed', 'petrified', 'prone', 'restrained']) {
+    const actor = unit(id);
+    statusEngine.applyStatus(actor, id);
+    expect(speedRuntime.effectiveSpeed(actor)).toBe(1);
+  }
+});
+
+test('Petrified gains Protection at Turn Start, rejects Poisoned, and poison deals zero', () => {
+  const actor = unit('actor');
+  statusEngine.applyStatus(actor, 'petrified');
+  expect(statusEngine.applyStatus(actor, 'poisoned')).toBeNull();
+  conditionRuntime.turnStart(actor);
+  expect(statusEngine.getStatus(actor, 'protection').count).toBe(5);
+  expect(conditionRuntime.poisonDamageMultiplier(actor)).toBe(0);
+});
+
+test('Poisoned makes poison deal +50 percent damage', () => {
+  const actor = unit('actor');
+  statusEngine.applyStatus(actor, 'poisoned');
+  expect(conditionRuntime.poisonDamageMultiplier(actor)).toBe(1.5);
+});
+
+test('Prone removes itself on Turn Start', () => {
+  const actor = unit('actor');
+  statusEngine.applyStatus(actor, 'prone');
+  conditionRuntime.turnStart(actor);
+  expect(statusEngine.hasStatus(actor, 'prone')).toBe(false);
+});
+
+test('Frightened loses Count only on a resolved failed Turn End save', () => {
+  const actor = unit('actor');
+  statusEngine.applyStatus(actor, 'frightened', { sourceUnitId: 'source', data: { spellDC: 15 } });
+  conditionRuntime.turnEnd(actor, { resolveCheck: () => ({ pending: true, reason: 'missing_threshold' }) });
+  expect(statusEngine.getStatus(actor, 'frightened').count).toBe(5);
+  conditionRuntime.turnEnd(actor, { resolveCheck: () => ({ passed: false }) });
+  expect(statusEngine.getStatus(actor, 'frightened').count).toBe(4);
+  statusEngine.applyStatus(actor, 'frightened', { mode: 'set', count: 0, sourceUnitId: 'source' });
+  conditionRuntime.turnStart(actor);
+  expect(actor.lifeState).toBe('retreated');
+});
+
+test('Turn End saves remove Blinded, Charmed, Deafened and Poisoned on pass', () => {
+  const actor = unit('actor');
+  for (const id of ['blinded', 'charmed', 'deafened', 'poisoned']) statusEngine.applyStatus(actor, id, { sourceUnitId: 'source', data: { spellDC: 13 } });
+  conditionRuntime.turnEnd(actor, { resolveCheck: () => ({ passed: true }) });
+  for (const id of ['blinded', 'charmed', 'deafened', 'poisoned']) expect(statusEngine.hasStatus(actor, id)).toBe(false);
+});
+
+test('Variant trigger removal only removes the configured trigger Status', () => {
+  const actor = unit('actor');
+  statusEngine.applyStatus(actor, 'invisible', { data: { removeTrigger: 'attack' } });
+  expect(conditionRuntime.resolveTrigger(actor, 'spell_cast')).toEqual([]);
+  expect(conditionRuntime.resolveTrigger(actor, 'attack')).toEqual(['invisible']);
+});
+
+test('Grapple applies linked Grappled to both Units, blocks Unit B Actions and breaks when Unit A acts', () => {
+  const grappler = unit('a');
+  const held = unit('b');
+  const result = conditionRuntime.grapple(grappler, held, { unitATotal: 15, unitBTotal: 10 });
+  expect(result.applied).toBe(true);
+  expect(statusEngine.getStatus(grappler, 'grappled').data.role).toBe('grappler');
+  expect(statusEngine.getStatus(held, 'grappled').data.role).toBe('held');
+  expect(speedRuntime.effectiveSpeed(grappler)).toBe(1);
+  expect(speedRuntime.effectiveSpeed(held)).toBe(1);
+  expect(actionEconomy.availability(held, 'action', { phase: 'planning' }).available).toBe(false);
+
+  conditionRuntime.onActionUsed(grappler, { combatants: [grappler, held] });
+  expect(statusEngine.hasStatus(grappler, 'grappled')).toBe(false);
+  expect(statusEngine.hasStatus(held, 'grappled')).toBe(false);
+});
+
+test('Exhaustion remains outside the Status store', () => {
+  const actor = unit('actor');
+  exhaustionEngine.setLevel(actor, 2);
+  expect(exhaustionEngine.getLevel(actor)).toBe(2);
+  expect(statusEngine.hasStatus(actor, 'exhaustion')).toBe(false);
+});

--- a/tests/exhaustion_engine.spec.js
+++ b/tests/exhaustion_engine.spec.js
@@ -1,0 +1,120 @@
+const { test, expect } = require('@playwright/test');
+
+const statusEngine = require('../js/status-engine.js');
+const exhaustion = global.LuminousExhaustionEngine;
+const conditions = global.LuminousConditionRuntime;
+require('../js/universal-modifier-engine.js');
+conditions.install();
+const speedRuntime = require('../js/universal-speed-runtime.js');
+
+function unit(overrides = {}) {
+  return {
+    id: 'unit',
+    hp: 100,
+    maxHp: 100,
+    speed: 5,
+    combatStats: { minSpeed: 3, maxSpeed: 6, offensiveLevel: 1, defensiveLevel: 1 },
+    statusEffects: {},
+    ...overrides,
+  };
+}
+
+test('Exhaustion is clamped from Level 0 to 6', () => {
+  const actor = unit();
+  exhaustion.setLevel(actor, -10);
+  expect(exhaustion.getLevel(actor)).toBe(0);
+  exhaustion.setLevel(actor, 99);
+  expect(exhaustion.getLevel(actor)).toBe(6);
+});
+
+test('Level 1 raises Ability and Skill Check Threshold by 2', () => {
+  const actor = unit();
+  exhaustion.setLevel(actor, 1);
+  expect(exhaustion.thresholdModifier(actor, { kind: 'ability', abilityId: 'str' })).toBe(2);
+  expect(exhaustion.thresholdModifier(actor, { kind: 'skill', abilityId: 'dex', skillId: 'stealth' })).toBe(2);
+  expect(exhaustion.thresholdModifier(actor, { kind: 'save', abilityId: 'wis' })).toBe(0);
+});
+
+test('Level 2 reduces Max Speed by 2', () => {
+  const actor = unit();
+  exhaustion.setLevel(actor, 2);
+  expect(exhaustion.combatModifiers(actor).max_speed).toBe(-2);
+  expect(speedRuntime.effectiveSpeed(actor)).toBe(4);
+});
+
+test('Level 3 raises Save Threshold by 2 and gives -2 Clash Power', () => {
+  const actor = unit();
+  exhaustion.setLevel(actor, 3);
+  expect(exhaustion.thresholdModifier(actor, { kind: 'save', abilityId: 'con' })).toBe(2);
+  const snapshot = global.LuminousUniversalModifiers.resolveCharacterSnapshot({ unit: actor, character: actor, traits: [] });
+  expect(snapshot.modifiers.clash_power).toBe(-2);
+});
+
+test('Level 4 halves Max HP and restores Max HP after recovery below Level 4', () => {
+  const actor = unit();
+  exhaustion.setLevel(actor, 4);
+  expect(actor.maxHp).toBe(50);
+  expect(actor.hp).toBe(50);
+  exhaustion.setLevel(actor, 3);
+  expect(actor.maxHp).toBe(100);
+  expect(actor.hp).toBe(50);
+});
+
+test('Level 5 fixes Speed to 1', () => {
+  const actor = unit();
+  exhaustion.setLevel(actor, 5);
+  expect(speedRuntime.effectiveSpeed(actor)).toBe(1);
+});
+
+test('Level 6 causes Death', () => {
+  const actor = unit();
+  exhaustion.setLevel(actor, 6);
+  expect(actor.lifeState).toBe('dead');
+  expect(actor.isDead).toBe(true);
+  expect(actor.hp).toBe(0);
+});
+
+test('Long Rest removes exactly 1 Exhaustion Level', () => {
+  const actor = unit();
+  exhaustion.setLevel(actor, 3);
+  exhaustion.onLongRest(actor, { at: 1234 });
+  expect(exhaustion.getLevel(actor)).toBe(2);
+  expect(actor.exhaustion.lastLongRestAt).toBe(1234);
+});
+
+test('missing the required daily Long Rest gains 1 Level only once per day key', () => {
+  const actor = unit();
+  const first = exhaustion.resolveDailyRestRequirement(actor, { dayKey: 'day-1', completedLongRest: false });
+  const duplicate = exhaustion.resolveDailyRestRequirement(actor, { dayKey: 'day-1', completedLongRest: false });
+  expect(first.gained).toBe(1);
+  expect(exhaustion.getLevel(actor)).toBe(1);
+  expect(duplicate.reason).toBe('already_resolved');
+  expect(exhaustion.getLevel(actor)).toBe(1);
+});
+
+test('a completed valid Long Rest prevents daily Exhaustion', () => {
+  const actor = unit();
+  const result = exhaustion.resolveDailyRestRequirement(actor, { dayKey: 'day-1', completedLongRest: true });
+  expect(result.gained).toBe(0);
+  expect(exhaustion.getLevel(actor)).toBe(0);
+});
+
+test('racial Traits may ignore the normal Long Rest requirement explicitly', () => {
+  const actor = unit({ traitDefinitions: [{ id: 'restless_race', mechanics: { longRestRequirement: 'ignore' } }] });
+  const requirement = exhaustion.longRestRequirement(actor);
+  expect(requirement.required).toBe(false);
+  const result = exhaustion.resolveDailyRestRequirement(actor, { dayKey: 'day-1', completedLongRest: false });
+  expect(result.gained).toBe(0);
+});
+
+test("Warforged Sentry's Rest changes Long Rest behavior but does not remove the Long Rest requirement", () => {
+  const actor = unit({ traitDefinitions: [{ id: 'warforged_sentry_rest', mechanics: {} }] });
+  expect(exhaustion.longRestRequirement(actor).required).toBe(true);
+});
+
+test('Exhaustion cannot be removed by Status Effect removal', () => {
+  const actor = unit();
+  exhaustion.setLevel(actor, 2);
+  statusEngine.removeStatus(actor, 'exhaustion', { from: 'effects' });
+  expect(exhaustion.getLevel(actor)).toBe(2);
+});


### PR DESCRIPTION
Clean replacement for #572. This PR starts from current main and contains one commit with the final Core Conditions and Exhaustion implementation, including the combat/theatre bridges, targeting and damage integration, Grapple Action Slot flow, and dedicated regression tests. It preserves the Elemental Status and Environment work already present on main.