### PR TITLE
feat: integrate racial Natural Weapons and Breath Weapons

### DIFF
--- a/.github/workflows/racial-skills.yml
+++ b/.github/workflows/racial-skills.yml
@@ -1,0 +1,31 @@
+name: Racial Skills
+
+on:
+  push:
+    paths:
+      - 'js/racial-skill-runtime.js'
+      - 'js/racial-trait-runtime-bridge.js'
+      - 'tests/racial_skill_runtime.spec.js'
+      - '.github/workflows/racial-skills.yml'
+  pull_request:
+    paths:
+      - 'js/racial-skill-runtime.js'
+      - 'js/racial-trait-runtime-bridge.js'
+      - 'tests/racial_skill_runtime.spec.js'
+      - '.github/workflows/racial-skills.yml'
+
+jobs:
+  racial-skills:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Syntax check
+        run: |
+          node --check js/racial-skill-runtime.js
+          node --check js/racial-trait-runtime-bridge.js
+          node --check tests/racial_skill_runtime.spec.js
+      - name: Racial skill regression tests
+        run: node tests/racial_skill_runtime.spec.js

--- a/js/racial-skill-runtime.js
+++ b/js/racial-skill-runtime.js
@@ -1,0 +1,485 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousRacialSkillRuntime) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousRacialSkillRuntime;
+    return;
+  }
+
+  const SIN_TYPES = Object.freeze(["Wrath", "Lust", "Sloth", "Gluttony", "Gloom", "Pride", "Envy"]);
+  const ABILITY_KEYS = Object.freeze({
+    STR: Object.freeze(["STR", "str", "strength", "fuerza"]),
+    DEX: Object.freeze(["DEX", "dex", "dexterity", "destreza"]),
+    CON: Object.freeze(["CON", "con", "constitution", "constitucion", "constitución"]),
+  });
+
+  const ELEMENTS = Object.freeze({
+    fire: Object.freeze({ sin: "Wrath", statusId: "burn", statusValue: "potency" }),
+    cold: Object.freeze({ sin: "Gloom", statusId: "chill", statusValue: "count" }),
+    lightning: Object.freeze({ sin: "Envy", statusId: "shock", statusValue: "count" }),
+    acid: Object.freeze({ sin: "Gluttony", statusId: "corrosion", statusValue: "count" }),
+    poison: Object.freeze({ sin: "Gluttony", statusId: "poison", statusValue: "potency" }),
+    necrotic: Object.freeze({ sin: "Gloom", statusId: "decay", statusValue: "count" }),
+    radiant: Object.freeze({ sin: "Pride", statusId: "radiance", statusValue: "count" }),
+    psychic: Object.freeze({ sin: "Lust", statusId: "sinking", statusValue: "potency" }),
+    thunder: Object.freeze({ sin: "Wrath", statusId: "tremor", statusValue: "potency" }),
+    force: Object.freeze({ sin: "Sloth", statusId: "force", statusValue: "count" }),
+  });
+
+  const HALF_DRAGON_BREATHS = Object.freeze({
+    red: "fire",
+    black: "acid",
+    green: "poison",
+    white: "cold",
+    blue: "lightning",
+    gold: "radiant",
+    brass: "fire",
+    copper: "acid",
+    bronze: "lightning",
+    silver: "cold",
+  });
+
+  const NATURAL_SKILLS = Object.freeze({
+    lizalin: Object.freeze({
+      key: "lizalin_bite", id: "bite", name: "Bite", statPolicy: "STR", attackType: "Pierce",
+      statusId: "ruptured", statusValue: "potency", naturalWeapon: "bite",
+    }),
+    felinae: Object.freeze({
+      key: "felinae_claws", id: "claws", name: "Claws", statPolicy: "BEST_STR_DEX", attackType: "Slash",
+      statusId: "bleed", statusValue: "potency", naturalWeapon: "claws",
+    }),
+    lupae: Object.freeze({
+      key: "lupae_bite", id: "bite", name: "Bite", statPolicy: "STR", attackType: "Pierce",
+      statusId: "ruptured", statusValue: "potency", naturalWeapon: "bite",
+    }),
+    centaur: Object.freeze({
+      key: "centaur_hooves", id: "hooves", name: "Hooves", statPolicy: "STR", attackType: "Blunt",
+      statusId: "tremor", statusValue: "potency", naturalWeapon: "hooves",
+    }),
+    lanae: Object.freeze({
+      key: "lanae_horns", id: "horns", name: "Horns", statPolicy: "STR", attackType: "Blunt",
+      statusId: "tremor", statusValue: "potency", naturalWeapon: "horns",
+    }),
+  });
+
+  const BODY_SKILLS = Object.freeze({
+    warforged: Object.freeze({
+      subtype: "juggernaut", key: "warforged_iron_fists", id: "iron_fists", name: "Iron Fists",
+      statPolicy: "STR", attackType: "Blunt", statusId: "tremor", statusValue: "potency", bodyWeapon: "iron_fists",
+    }),
+  });
+
+  const state = {
+    combatEngineSource: null,
+    patchedTriggerEvent: null,
+    patchedEncounterStart: null,
+    patchedInitialize: null,
+  };
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const clampLevel = (value) => Math.max(1, Math.trunc(numberOr(value, 1)));
+  const dndModifier = (score) => Math.floor((numberOr(score, 10) - 10) / 2);
+
+  function buildOf(unit = {}) {
+    return unit.characterBuild && typeof unit.characterBuild === "object"
+      ? unit.characterBuild
+      : (unit.actor?.characterBuild && typeof unit.actor.characterBuild === "object" ? unit.actor.characterBuild : {});
+  }
+
+  function levelOf(unit = {}) {
+    const build = buildOf(unit);
+    return clampLevel(build.calculatedAtLevel ?? build.level ?? unit.level ?? unit.nivel ?? unit.actor?.level ?? 1);
+  }
+
+  function proficiencyBonus(unit = {}) {
+    const level = levelOf(unit);
+    const candidates = [
+      unit.proficiencyBonus,
+      unit.dndProficiencyBonus,
+      unit.dndStats?.proficiencyBonus,
+      unit.dnd?.proficiencyBonus,
+      unit.actor?.proficiencyBonus,
+      unit.actor?.dndStats?.proficiencyBonus,
+    ];
+    const explicit = candidates.find((value) => Number.isFinite(Number(value)));
+    return explicit == null ? Math.ceil(level / 20) : Math.max(0, numberOr(explicit, 0));
+  }
+
+  function statContainers(unit = {}) {
+    return [
+      unit.stats,
+      unit.dndStats,
+      unit.abilities,
+      unit.actor?.stats,
+      unit.actor?.dndStats,
+      unit.actor?.abilities,
+    ].filter((value) => value && typeof value === "object");
+  }
+
+  function abilityScore(unit, ability) {
+    const aliases = ABILITY_KEYS[ability] || [ability];
+    for (const source of statContainers(unit)) {
+      for (const key of aliases) {
+        if (Number.isFinite(Number(source[key]))) return Number(source[key]);
+      }
+    }
+    return 10;
+  }
+
+  function abilityModifier(unit, ability) {
+    return dndModifier(abilityScore(unit, ability));
+  }
+
+  function resolveStat(unit, policy) {
+    if (policy === "BEST_STR_DEX") {
+      const str = abilityModifier(unit, "STR");
+      const dex = abilityModifier(unit, "DEX");
+      return dex > str ? { stat: "DEX", modifier: dex } : { stat: "STR", modifier: str };
+    }
+    const stat = policy || "STR";
+    return { stat, modifier: abilityModifier(unit, stat) };
+  }
+
+  function levelTwentyStep(unit) {
+    return Math.floor(levelOf(unit) / 20);
+  }
+
+  function statusAmount(unit) {
+    return Math.max(1, Math.floor(levelOf(unit) / 5));
+  }
+
+  function canonicalSin(value) {
+    const normalized = normalizeId(value);
+    return SIN_TYPES.find((sin) => normalizeId(sin) === normalized) || null;
+  }
+
+  function naturalWeaponSin(unit = {}) {
+    const build = buildOf(unit);
+    const candidates = [
+      build.naturalWeaponSin,
+      build.racialNaturalWeaponSin,
+      build.racialSkillSin,
+      unit.naturalWeaponSin,
+      unit.racialNaturalWeaponSin,
+      unit.racialSkillSin,
+    ];
+    return candidates.map(canonicalSin).find(Boolean) || null;
+  }
+
+  function setNaturalWeaponSin(unit, sin) {
+    if (!unit || typeof unit !== "object") return false;
+    const canonical = canonicalSin(sin);
+    if (!canonical) return false;
+    if (!unit.characterBuild || typeof unit.characterBuild !== "object") unit.characterBuild = {};
+    unit.characterBuild.naturalWeaponSin = canonical;
+    refreshRacialSkills(unit);
+    return true;
+  }
+
+  function raceIdentity(unit = {}) {
+    const build = buildOf(unit);
+    return {
+      raceId: normalizeId(build.raceId ?? unit.raceId ?? unit.race?.id ?? unit.actor?.raceId ?? unit.actor?.race?.id),
+      subtypeId: normalizeId(build.raceSubtypeId ?? unit.raceSubtypeId ?? unit.race?.subtypeId ?? unit.actor?.raceSubtypeId ?? unit.actor?.race?.subtypeId),
+    };
+  }
+
+  function isNpc(unit = {}) {
+    if (unit.isPlayer === true || unit.actor?.isPlayer === true) return false;
+    if (unit.playerId || unit.player_id || unit.vinculo_jugador || unit.actor?.playerId || unit.actor?.vinculo_jugador) return false;
+    if (unit.isPlayer === false || unit.actor?.isPlayer === false) return true;
+    const explicitType = normalizeId(unit.characterType ?? unit.character_type ?? unit.tipo ?? unit.type ?? unit.actor?.tipo ?? unit.actor?.type);
+    if (["npc", "enemy", "enemigo", "abnormality", "captain", "boss"].includes(explicitType)) return true;
+    const faction = normalizeId(unit.faction ?? unit.faccion ?? unit.actor?.faction ?? unit.actor?.faccion);
+    return ["enemy", "enemigo", "hostile", "hostil"].includes(faction);
+  }
+
+  function randomSin(rng = Math.random) {
+    const raw = Math.max(0, Math.min(0.999999999, numberOr(rng(), 0)));
+    return SIN_TYPES[Math.floor(raw * SIN_TYPES.length)];
+  }
+
+  function baseSkillConfig(unit, template, options = {}) {
+    const resolved = resolveStat(unit, template.statPolicy);
+    const step = levelTwentyStep(unit);
+    const coinPowerBase = options.coinPowerBase ?? 15;
+    return {
+      basePower: proficiencyBonus(unit) + resolved.modifier + step,
+      coinPower: coinPowerBase + resolved.modifier + step,
+      coinAmount: 1,
+      coinType: options.coinType || "standard",
+      attackType: template.attackType,
+      sinAffinity: options.sinAffinity ?? null,
+      type: "Normal",
+      statUsed: resolved.stat,
+      skillFamily: "attack",
+      attackMode: options.attackMode || "melee",
+    };
+  }
+
+  function decorateSkill(skill, unit, template, options = {}) {
+    const resolved = resolveStat(unit, template.statPolicy);
+    skill.id = template.id;
+    skill.name = template.name;
+    skill.racialSkill = true;
+    skill.racialSkillKey = template.key;
+    skill.racialSkillKind = options.kind || "natural_weapon";
+    skill.affinity = skill.sinAffinity ?? null;
+    skill.pecado = skill.sinAffinity ?? null;
+    skill.statUsed = resolved.stat;
+    skill.skillFamily = "attack";
+    skill.attackMode = options.attackMode || "melee";
+    skill.tags = Array.from(new Set([...(skill.tags || []), "racial_skill", template.id, ...(options.tags || [])]));
+    skill.damageType = options.damageType || template.attackType;
+    if (template.naturalWeapon) skill.naturalWeapon = template.naturalWeapon;
+    if (template.bodyWeapon) skill.bodyWeapon = template.bodyWeapon;
+    skill.racialStatusOnHit = {
+      statusId: options.statusId || template.statusId,
+      valueMode: options.statusValue || template.statusValue || "count",
+      amountFormula: "max(1, floor(Level / 5))",
+    };
+    skill.racialPowerFormula = {
+      basePower: "Proficiency + StatMod + floor(Level / 20)",
+      coinPower: `${options.coinPowerBase ?? 15} + StatMod + floor(Level / 20)`,
+    };
+    return skill;
+  }
+
+  function createSkill(engine, config) {
+    if (engine?.createSkill) return engine.createSkill(config);
+    const coinAmount = Math.max(1, config.coinAmount || 1);
+    return {
+      ...config,
+      coins: Array.from({ length: coinAmount }, () => ({ type: config.coinType || "standard", status: "active", effects: [] })),
+    };
+  }
+
+  function naturalTemplateFor(unit) {
+    const { raceId, subtypeId } = raceIdentity(unit);
+    if (NATURAL_SKILLS[raceId]) {
+      const template = NATURAL_SKILLS[raceId];
+      return { template, coinPowerBase: raceId === "felinae" && subtypeId === "large" ? 19 : 15 };
+    }
+    const body = BODY_SKILLS[raceId];
+    if (body && (!body.subtype || body.subtype === subtypeId)) return { template: body, coinPowerBase: 15, kind: "body_weapon" };
+    return null;
+  }
+
+  function breathTemplateFor(unit) {
+    const { raceId, subtypeId } = raceIdentity(unit);
+    if (raceId !== "half_dragon") return null;
+    const elementId = HALF_DRAGON_BREATHS[subtypeId];
+    const element = ELEMENTS[elementId];
+    if (!element) return null;
+    return {
+      template: {
+        key: `half_dragon_${subtypeId}_breath`,
+        id: "dragon_breath",
+        name: `${subtypeId === "gold" ? "Gold" : subtypeId.charAt(0).toUpperCase() + subtypeId.slice(1)} Dragon Breath`,
+        statPolicy: "CON",
+        attackType: elementId.charAt(0).toUpperCase() + elementId.slice(1),
+        statusId: element.statusId,
+        statusValue: element.statusValue,
+      },
+      elementId,
+      element,
+    };
+  }
+
+  function buildNaturalWeaponSkill(unit, engine = global.CombatEngine) {
+    const resolved = naturalTemplateFor(unit);
+    if (!resolved) return null;
+    const selectedSin = isNpc(unit) ? (unit.__racialSkillEncounterSin || null) : naturalWeaponSin(unit);
+    const config = baseSkillConfig(unit, resolved.template, {
+      coinPowerBase: resolved.coinPowerBase,
+      sinAffinity: selectedSin,
+      coinType: "standard",
+      attackMode: "melee",
+    });
+    const skill = createSkill(engine, config);
+    skill.requiresSinSelection = !selectedSin && !isNpc(unit);
+    return decorateSkill(skill, unit, resolved.template, {
+      kind: resolved.kind || "natural_weapon",
+      coinPowerBase: resolved.coinPowerBase,
+      tags: [resolved.kind === "body_weapon" ? "body_weapon" : "natural_weapon"],
+    });
+  }
+
+  function buildBreathWeaponSkill(unit, engine = global.CombatEngine) {
+    const resolved = breathTemplateFor(unit);
+    if (!resolved) return null;
+    const config = baseSkillConfig(unit, resolved.template, {
+      coinPowerBase: 15,
+      sinAffinity: resolved.element.sin,
+      coinType: "unbreakable",
+      attackMode: "ranged",
+    });
+    const skill = createSkill(engine, config);
+    decorateSkill(skill, unit, resolved.template, {
+      kind: "breath_weapon",
+      coinPowerBase: 15,
+      statusId: resolved.element.statusId,
+      statusValue: resolved.element.statusValue,
+      tags: ["breath_weapon", "dragon_breath", resolved.elementId],
+      attackMode: "ranged",
+    });
+    skill.breathWeapon = true;
+    skill.breathElement = resolved.elementId;
+    skill.damageType = resolved.elementId;
+    return skill;
+  }
+
+  function allSequenceSkills(unit = {}) {
+    return [1, 2, 3].flatMap((tier) => Array.isArray(unit[`attack_tier_${tier}_sequence`]) ? unit[`attack_tier_${tier}_sequence`] : []);
+  }
+
+  function mergeSkill(target, source) {
+    if (!target || !source) return target;
+    const oldCoins = target.coins;
+    Object.assign(target, source);
+    if (Array.isArray(oldCoins) && oldCoins.length === source.coinAmount) {
+      target.coins = oldCoins.map((coin, index) => ({ ...source.coins?.[index], ...coin, type: source.coinType || coin.type }));
+    }
+    return target;
+  }
+
+  function upsertTierOne(unit, skill) {
+    if (!skill) return null;
+    if (!Array.isArray(unit.attack_tier_1_sequence)) unit.attack_tier_1_sequence = [];
+    const existing = allSequenceSkills(unit).find((entry) => entry?.racialSkillKey === skill.racialSkillKey);
+    if (existing) return mergeSkill(existing, skill);
+    unit.attack_tier_1_sequence.push(skill);
+    return skill;
+  }
+
+  function attachRacialSkills(unit, engine = global.CombatEngine) {
+    if (!unit || typeof unit !== "object") return [];
+    const attached = [];
+    const natural = buildNaturalWeaponSkill(unit, engine);
+    const breath = buildBreathWeaponSkill(unit, engine);
+    if (natural) attached.push(upsertTierOne(unit, natural));
+    if (breath) attached.push(upsertTierOne(unit, breath));
+    return attached.filter(Boolean);
+  }
+
+  function refreshRacialSkills(unit, engine = global.CombatEngine) {
+    return attachRacialSkills(unit, engine);
+  }
+
+  function prepareEncounter(allUnits = [], options = {}) {
+    const rng = typeof options.rng === "function" ? options.rng : Math.random;
+    const engine = options.engine || global.CombatEngine;
+    const units = Array.isArray(allUnits) ? allUnits : Object.values(allUnits || {});
+    units.forEach((unit) => {
+      if (!unit || typeof unit !== "object") return;
+      if (naturalTemplateFor(unit) && isNpc(unit)) unit.__racialSkillEncounterSin = randomSin(rng);
+      attachRacialSkills(unit, engine);
+    });
+    return units;
+  }
+
+  function statusInputFor(skill, unit) {
+    const effect = skill?.racialStatusOnHit;
+    if (!effect?.statusId) return null;
+    const amount = statusAmount(unit);
+    const input = { mode: "inflict", sourceUnitId: unit?.id || unit?.unitId || null };
+    if (normalizeId(effect.valueMode) === "potency") input.potency = amount;
+    else input.count = amount;
+    return { statusId: effect.statusId, amount, input };
+  }
+
+  function applyRacialOnHit(context = {}, targets = []) {
+    const skill = context.skill;
+    if (!skill?.racialStatusOnHit) return [];
+    const attacker = context.attacker || context.unitAttacker || context.self || null;
+    const engine = global.LuminousStatusEngine;
+    if (!engine?.applyStatus || !attacker) return [];
+    const resolved = statusInputFor(skill, attacker);
+    if (!resolved) return [];
+    const contextTargets = Array.isArray(context.targetsHit) ? context.targetsHit.filter(Boolean) : [];
+    const executionTargets = (contextTargets.length ? contextTargets : (targets && targets.length ? targets : [context.currentTarget || context.defender])).filter(Boolean);
+    return executionTargets.map((target) => ({
+      target,
+      status: engine.applyStatus(target, resolved.statusId, resolved.input),
+      statusId: resolved.statusId,
+      amount: resolved.amount,
+    }));
+  }
+
+  function installCombatBridge() {
+    const engine = global.CombatEngine;
+    if (!engine) return false;
+    state.combatEngineSource = engine;
+
+    if (typeof engine.initializeUnitData === "function" && !engine.initializeUnitData.__racialSkillRuntime) {
+      const source = engine.initializeUnitData;
+      const wrapped = function (unit, ...rest) {
+        attachRacialSkills(unit, this);
+        return source.call(this, unit, ...rest);
+      };
+      Object.defineProperty(wrapped, "__racialSkillRuntime", { value: true });
+      engine.initializeUnitData = wrapped;
+      state.patchedInitialize = wrapped;
+    }
+
+    if (typeof engine.triggerEncounterStart === "function" && !engine.triggerEncounterStart.__racialSkillRuntime) {
+      const source = engine.triggerEncounterStart;
+      const wrapped = function (allUnits = [], ...rest) {
+        prepareEncounter(allUnits, { engine: this });
+        return source.call(this, allUnits, ...rest);
+      };
+      Object.defineProperty(wrapped, "__racialSkillRuntime", { value: true });
+      engine.triggerEncounterStart = wrapped;
+      state.patchedEncounterStart = wrapped;
+    }
+
+    if (typeof engine.triggerEvent === "function" && !engine.triggerEvent.__racialSkillRuntime) {
+      const source = engine.triggerEvent;
+      const wrapped = function (tag, context, targets = []) {
+        const result = source.call(this, tag, context, targets);
+        if (String(tag) === "[On Hit]") applyRacialOnHit(context, targets);
+        return result;
+      };
+      Object.defineProperty(wrapped, "__racialSkillRuntime", { value: true });
+      engine.triggerEvent = wrapped;
+      state.patchedTriggerEvent = wrapped;
+    }
+    return true;
+  }
+
+  const api = Object.freeze({
+    SIN_TYPES,
+    ELEMENTS,
+    HALF_DRAGON_BREATHS,
+    NATURAL_SKILLS,
+    BODY_SKILLS,
+    levelOf,
+    proficiencyBonus,
+    abilityScore,
+    abilityModifier,
+    resolveStat,
+    statusAmount,
+    canonicalSin,
+    naturalWeaponSin,
+    setNaturalWeaponSin,
+    raceIdentity,
+    isNpc,
+    randomSin,
+    naturalTemplateFor,
+    breathTemplateFor,
+    buildNaturalWeaponSkill,
+    buildBreathWeaponSkill,
+    attachRacialSkills,
+    refreshRacialSkills,
+    prepareEncounter,
+    statusInputFor,
+    applyRacialOnHit,
+    installCombatBridge,
+  });
+
+  global.LuminousRacialSkillRuntime = api;
+  installCombatBridge();
+  if (global.document && typeof global.setInterval === "function") global.setInterval(installCombatBridge, 400);
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/racial-trait-runtime-bridge.js
+++ b/js/racial-trait-runtime-bridge.js
@@ -10,7 +10,37 @@
     traitEngineSource: null,
     combatDamageSource: null,
     pendingDamageOverride: null,
+    racialSkillScriptRequested: false,
   };
+
+  function ensureRacialSkillRuntime() {
+    if (global.LuminousRacialSkillRuntime) {
+      global.LuminousRacialSkillRuntime.installCombatBridge?.();
+      return true;
+    }
+
+    if (typeof require === "function") {
+      try {
+        require("./racial-skill-runtime.js");
+        if (global.LuminousRacialSkillRuntime) {
+          global.LuminousRacialSkillRuntime.installCombatBridge?.();
+          return true;
+        }
+      } catch (_) {}
+    }
+
+    if (!global.document || state.racialSkillScriptRequested) return false;
+    state.racialSkillScriptRequested = true;
+    const existing = global.document.getElementById("racial-skill-runtime-script");
+    if (existing) return false;
+    const script = global.document.createElement("script");
+    script.id = "racial-skill-runtime-script";
+    script.src = "js/racial-skill-runtime.js";
+    script.async = false;
+    script.addEventListener("load", () => global.LuminousRacialSkillRuntime?.installCombatBridge?.(), { once: true });
+    global.document.head?.appendChild(script);
+    return false;
+  }
 
   function installTraitDamageContextBridge() {
     const source = global.LuminousTraitEngine;
@@ -89,12 +119,14 @@
   }
 
   function installAll() {
+    ensureRacialSkillRuntime();
     installTraitDamageContextBridge();
     installCombatDamageReturnBridge();
   }
 
   const api = Object.freeze({
     installAll,
+    ensureRacialSkillRuntime,
     installTraitDamageContextBridge,
     installCombatDamageReturnBridge,
     getPendingDamageOverride: () => state.pendingDamageOverride ? { ...state.pendingDamageOverride } : null,

--- a/tests/racial_skill_runtime.spec.js
+++ b/tests/racial_skill_runtime.spec.js
@@ -1,0 +1,183 @@
+const assert = require('assert');
+
+function freshRuntime() {
+  delete global.LuminousRacialSkillRuntime;
+  delete require.cache[require.resolve('../js/racial-skill-runtime.js')];
+  return require('../js/racial-skill-runtime.js');
+}
+
+function unit(raceId, subtypeId, options = {}) {
+  return {
+    id: options.id || raceId,
+    level: options.level ?? 1,
+    stats: {
+      fuerza: options.str ?? 10,
+      destreza: options.dex ?? 10,
+      constitucion: options.con ?? 10,
+    },
+    characterBuild: {
+      raceId,
+      ...(subtypeId ? { raceSubtypeId: subtypeId } : {}),
+      ...(options.sin ? { naturalWeaponSin: options.sin } : {}),
+    },
+    ...(options.npc ? { isPlayer: false, faction: 'enemy' } : { isPlayer: true, playerId: 'player-1' }),
+  };
+}
+
+(function run() {
+  const runtime = freshRuntime();
+
+  assert.deepStrictEqual(runtime.SIN_TYPES, ['Wrath', 'Lust', 'Sloth', 'Gluttony', 'Gloom', 'Pride', 'Envy']);
+  assert.strictEqual(runtime.statusAmount(unit('lanae', null, { level: 1 })), 1);
+  assert.strictEqual(runtime.statusAmount(unit('lanae', null, { level: 9 })), 1);
+  assert.strictEqual(runtime.statusAmount(unit('lanae', null, { level: 10 })), 2);
+  assert.strictEqual(runtime.statusAmount(unit('lanae', null, { level: 20 })), 4);
+
+  const lizalin = runtime.buildNaturalWeaponSkill(unit('lizalin', null, { level: 20, str: 16, sin: 'Wrath' }));
+  assert.strictEqual(lizalin.coinAmount, 1);
+  assert.strictEqual(lizalin.coinType, 'standard');
+  assert.strictEqual(lizalin.attackType, 'Pierce');
+  assert.strictEqual(lizalin.sinAffinity, 'Wrath');
+  assert.strictEqual(lizalin.affinity, 'Wrath');
+  assert.strictEqual(lizalin.damageType, 'Pierce');
+  assert.strictEqual(lizalin.basePower, 5); // PB 1 + STR 3 + floor(20/20) 1
+  assert.strictEqual(lizalin.coinPower, 19); // 15 + STR 3 + 1
+  assert.strictEqual(lizalin.racialStatusOnHit.statusId, 'ruptured');
+
+  const felinae = runtime.buildNaturalWeaponSkill(unit('felinae', 'ordinary', { level: 1, str: 12, dex: 18, sin: 'Pride' }));
+  assert.strictEqual(felinae.statUsed, 'DEX');
+  assert.strictEqual(felinae.coinPower, 19); // 15 + DEX 4
+  assert.strictEqual(felinae.racialStatusOnHit.statusId, 'bleed');
+
+  const felinaeLarge = runtime.buildNaturalWeaponSkill(unit('felinae', 'large', { level: 1, str: 12, dex: 18, sin: 'Pride' }));
+  assert.strictEqual(felinaeLarge.coinPower, 23); // 19 + DEX 4
+  assert.strictEqual(felinaeLarge.racialPowerFormula.coinPower, '19 + StatMod + floor(Level / 20)');
+
+  const lupae = runtime.buildNaturalWeaponSkill(unit('lupae', null, { str: 14, sin: 'Gloom' }));
+  assert.strictEqual(lupae.attackType, 'Pierce');
+  assert.strictEqual(lupae.racialStatusOnHit.statusId, 'ruptured');
+
+  const centaur = runtime.buildNaturalWeaponSkill(unit('centaur', null, { str: 14, sin: 'Sloth' }));
+  assert.strictEqual(centaur.attackType, 'Blunt');
+  assert.strictEqual(centaur.racialStatusOnHit.statusId, 'tremor');
+
+  const lanae = runtime.buildNaturalWeaponSkill(unit('lanae', null, { str: 14, sin: 'Envy' }));
+  assert.strictEqual(lanae.attackType, 'Blunt');
+  assert.strictEqual(lanae.racialStatusOnHit.statusId, 'tremor');
+
+  const warforged = runtime.buildNaturalWeaponSkill(unit('warforged', 'juggernaut', { str: 16, sin: 'Wrath' }));
+  assert.strictEqual(warforged.racialSkillKind, 'body_weapon');
+  assert.strictEqual(warforged.bodyWeapon, 'iron_fists');
+  assert.strictEqual(warforged.racialStatusOnHit.statusId, 'tremor');
+  assert.strictEqual(runtime.buildNaturalWeaponSkill(unit('warforged', 'envoy', { sin: 'Wrath' })), null);
+  const noSinPc = runtime.buildNaturalWeaponSkill(unit('lanae', null, {}));
+  assert.strictEqual(noSinPc.requiresSinSelection, true);
+  assert.strictEqual(noSinPc.sinAffinity, null);
+
+  const expectedBreaths = {
+    red: ['fire', 'Wrath', 'burn'],
+    black: ['acid', 'Gluttony', 'corrosion'],
+    green: ['poison', 'Gluttony', 'poison'],
+    white: ['cold', 'Gloom', 'chill'],
+    blue: ['lightning', 'Envy', 'shock'],
+    gold: ['radiant', 'Pride', 'radiance'],
+    brass: ['fire', 'Wrath', 'burn'],
+    copper: ['acid', 'Gluttony', 'corrosion'],
+    bronze: ['lightning', 'Envy', 'shock'],
+    silver: ['cold', 'Gloom', 'chill'],
+  };
+  for (const [subtype, [element, sin, status]] of Object.entries(expectedBreaths)) {
+    const breath = runtime.buildBreathWeaponSkill(unit('half_dragon', subtype, { level: 20, con: 16 }));
+    assert.ok(breath, subtype);
+    assert.strictEqual(breath.coinAmount, 1, subtype);
+    assert.strictEqual(breath.coinType, 'unbreakable', subtype);
+    assert.strictEqual(breath.statUsed, 'CON', subtype);
+    assert.strictEqual(breath.breathElement, element, subtype);
+    assert.strictEqual(breath.sinAffinity, sin, subtype);
+    assert.strictEqual(breath.racialStatusOnHit.statusId, status, subtype);
+    assert.strictEqual(breath.basePower, 5, subtype);
+    assert.strictEqual(breath.coinPower, 19, subtype);
+  }
+
+  // Gold is always Radiance in this racial skill; never Burn.
+  const gold = runtime.buildBreathWeaponSkill(unit('half_dragon', 'gold', { con: 16 }));
+  assert.strictEqual(gold.damageType, 'radiant');
+  assert.strictEqual(gold.sinAffinity, 'Pride');
+  assert.strictEqual(gold.racialStatusOnHit.statusId, 'radiance');
+
+  // General Breath infrastructure still covers all agreed mappings.
+  assert.strictEqual(runtime.ELEMENTS.necrotic.statusId, 'decay');
+  assert.strictEqual(runtime.ELEMENTS.psychic.statusId, 'sinking');
+  assert.strictEqual(runtime.ELEMENTS.thunder.statusId, 'tremor');
+  assert.strictEqual(runtime.ELEMENTS.force.statusId, 'force');
+
+  // PC choice is persistent and never rerolled at Encounter Start.
+  const pc = unit('felinae', 'ordinary', { sin: 'Lust' });
+  runtime.prepareEncounter([pc], { rng: () => 0.99, engine: null });
+  assert.strictEqual(pc.attack_tier_1_sequence[0].sinAffinity, 'Lust');
+  assert.strictEqual(pc.__racialSkillEncounterSin, undefined);
+
+  // NPC rolls exactly on Encounter Start, then keeps that Sin until the next start.
+  const npc = unit('lupae', null, { npc: true });
+  runtime.prepareEncounter([npc], { rng: () => 0.0, engine: null });
+  assert.strictEqual(npc.__racialSkillEncounterSin, 'Wrath');
+  assert.strictEqual(npc.attack_tier_1_sequence[0].sinAffinity, 'Wrath');
+  runtime.refreshRacialSkills(npc, null);
+  assert.strictEqual(npc.attack_tier_1_sequence[0].sinAffinity, 'Wrath');
+  runtime.prepareEncounter([npc], { rng: () => 0.999, engine: null });
+  assert.strictEqual(npc.__racialSkillEncounterSin, 'Envy');
+  assert.strictEqual(npc.attack_tier_1_sequence[0].sinAffinity, 'Envy');
+
+  // Racial On Hit uses the canonical Status Engine; double statuses receive Potency, single statuses Count.
+  const applied = [];
+  global.LuminousStatusEngine = {
+    applyStatus(target, statusId, input) {
+      applied.push({ target, statusId, input });
+      return { id: statusId, ...input };
+    },
+  };
+  const target = { id: 'target' };
+  runtime.applyRacialOnHit({ attacker: unit('felinae', 'ordinary', { level: 15, sin: 'Wrath' }), skill: runtime.buildNaturalWeaponSkill(unit('felinae', 'ordinary', { level: 15, sin: 'Wrath' })) }, [target]);
+  assert.strictEqual(applied[0].statusId, 'bleed');
+  assert.strictEqual(applied[0].input.potency, 3);
+
+  const coldAttacker = unit('half_dragon', 'white', { level: 15, con: 14 });
+  runtime.applyRacialOnHit({ attacker: coldAttacker, skill: runtime.buildBreathWeaponSkill(coldAttacker) }, [target]);
+  assert.strictEqual(applied[1].statusId, 'chill');
+  assert.strictEqual(applied[1].input.count, 3);
+
+  // Combat bridge attaches before the engine initializer, rerolls NPC Sin at Encounter Start, and applies On Hit Statuses.
+  const bridgeNpc = unit('centaur', null, { npc: true, level: 10, str: 14 });
+  let initializeSawSkill = false;
+  let encounterCalls = 0;
+  let eventCalls = 0;
+  global.CombatEngine = {
+    createSkill(config) { return { ...config, coins: [{ type: config.coinType, status: 'active', effects: [] }] }; },
+    initializeUnitData(received) { initializeSawSkill = received.attack_tier_1_sequence?.some(skill => skill.racialSkillKey === 'centaur_hooves'); },
+    triggerEncounterStart() { encounterCalls += 1; },
+    triggerEvent() { eventCalls += 1; },
+  };
+  runtime.installCombatBridge();
+  global.CombatEngine.initializeUnitData(bridgeNpc);
+  assert.strictEqual(initializeSawSkill, true);
+  const oldRandom = Math.random;
+  Math.random = () => 0;
+  global.CombatEngine.triggerEncounterStart([bridgeNpc]);
+  Math.random = oldRandom;
+  assert.strictEqual(encounterCalls, 1);
+  assert.strictEqual(bridgeNpc.__racialSkillEncounterSin, 'Wrath');
+  const beforeBridgeHit = applied.length;
+  global.CombatEngine.triggerEvent('[On Hit]', { attacker: bridgeNpc, skill: bridgeNpc.attack_tier_1_sequence[0], targetsHit: [target] }, [target]);
+  assert.strictEqual(eventCalls, 1);
+  assert.strictEqual(applied.length, beforeBridgeHit + 1);
+  assert.strictEqual(applied.at(-1).statusId, 'tremor');
+  assert.strictEqual(applied.at(-1).input.potency, 2);
+
+  // Re-attaching never duplicates the racial skill.
+  const repeated = unit('lanae', null, { sin: 'Wrath' });
+  runtime.attachRacialSkills(repeated, null);
+  runtime.attachRacialSkills(repeated, null);
+  assert.strictEqual(repeated.attack_tier_1_sequence.length, 1);
+
+  console.log('racial_skill_runtime.spec.js: all assertions passed');
+})();


### PR DESCRIPTION
## Summary
- adds automatic Dynamic Skills for racial Natural Weapons / Body Weapons
- adds Semi Dragon Breath Weapons with fixed elemental Sin/status mappings
- hooks the skills into the existing CombatEngine lifecycle without duplicating racial Trait logic
- applies racial On Hit statuses through the canonical `LuminousStatusEngine`

## Natural / Body Weapons
All are 1-Coin Attack Skills.

- Lizalin Bite: STR / Pierce / Ruptured
- Felinae Claws: best STR or DEX / Slash / Bleed
- Felinae Grande Claws: same, with +4 Coin Power
- Lupae Bite: STR / Pierce / Ruptured
- Centaur Hooves: STR / Blunt / Tremor
- Lanae Horns: STR / Blunt / Tremor
- Warforged Juggernaut Iron Fists: STR / Blunt / Tremor

Power formulas:
- Base Power = Proficiency + Stat Mod + floor(Level / 20)
- Coin Power = 15 + Stat Mod + floor(Level / 20)
- Felinae Grande Coin Power = 19 + Stat Mod + floor(Level / 20)

Natural-weapon status formula is explicit to these racial Skills only:
- `[On Hit] Inflict max(1, floor(Level / 5)) Status`
- Slash -> Bleed
- Pierce -> Ruptured
- Blunt -> Tremor

PC Natural Weapon Sin is read from the persisted Character Build choice and is never rerolled. NPC Natural Weapon Sin is rolled once at Encounter Start and remains fixed for that Encounter.

## Breath Weapons
Breath Weapons use 1 Unbreakable Coin and CON for the Semi Dragon racial Skill.

- Fire -> Wrath -> Burn
- Cold -> Gloom -> Chill
- Lightning -> Envy -> Shock
- Acid -> Gluttony -> Corrosion
- Poison -> Gluttony -> Poison
- Necrotic -> Gloom -> Decay
- Radiant -> Pride -> Radiance
- Psychic -> Lust -> Sinking
- Thunder -> Wrath -> Tremor
- Force -> Sloth -> Force

The runtime retains all 10 mappings as generic Breath infrastructure. Current Semi Dragon ancestry generation uses the race's 10 subtypes. Gold is intentionally `Radiant / Pride / Radiance` only, per the latest design decision.

Breath On Hit uses the same scaling:
- `[On Hit] Inflict max(1, floor(Level / 5)) Elemental Status`

## Integration boundaries
- existing racial Traits continue to own Charge, Pack Tactics, Hungry Jaws/Shields, Grappled and other special behavior
- this PR does not recreate D&D Saving Throws; their Unbreakable-Coin conversion remains owned by the existing/current Save adaptation
- status application goes through `LuminousStatusEngine`

## Validation
- `node --check js/racial-skill-runtime.js`
- `node --check js/racial-trait-runtime-bridge.js`
- `node --check tests/racial_skill_runtime.spec.js`
- `node tests/racial_skill_runtime.spec.js`
- dedicated `Racial Skills` GitHub Actions workflow added

Local regression suite passes all assertions, including Encounter-start NPC Sin behavior, PC Sin persistence, Gold Radiance-only behavior, Felinae Grande +4 Coin Power, On Hit status scaling, and duplicate-skill prevention.