### PR TITLE
Fix racial Score visibility for player and DM

### DIFF
--- a/.github/workflows/racial-stat-integration.yml
+++ b/.github/workflows/racial-stat-integration.yml
@@ -6,6 +6,8 @@ on:
       - "js/character-build-rules.js"
       - "js/canonical-race-integration.js"
       - "js/existing-racial-stat-integration.js"
+      - "js/racial-stat-runtime.js"
+      - "js/player-stats-ability-bar.js"
       - "js/dm-player-dnd-studio.js"
       - "js/dm-player-dnd-studio-hotfix.js"
       - "js/trait-engine.js"
@@ -19,6 +21,7 @@ on:
       - "tests/racial_trait_catalog.spec.js"
       - "tests/racial_trait_engine_regressions.spec.js"
       - "tests/racial_stat_integration.spec.js"
+      - "tests/racial_stat_visibility.spec.js"
       - "tests/half_demon_traits.spec.js"
       - ".github/workflows/racial-stat-integration.yml"
 
@@ -48,6 +51,8 @@ jobs:
         run: |
           node --check js/canonical-race-integration.js
           node --check js/existing-racial-stat-integration.js
+          node --check js/racial-stat-runtime.js
+          node --check js/player-stats-ability-bar.js
           node --check js/canonical-racial-traits.js
           node --check js/half-demon-racial-traits.js
           node --check js/half-demon-combat-runtime.js
@@ -55,6 +60,7 @@ jobs:
           node --check js/dm-player-dnd-studio.js
           node --check js/dm-player-dnd-studio-hotfix.js
           node --check tests/racial_stat_integration.spec.js
+          node --check tests/racial_stat_visibility.spec.js
           node --check tests/half_demon_traits.spec.js
 
       - name: Run racial and regression matrix
@@ -62,6 +68,7 @@ jobs:
           npx playwright test
           tests/character_build_rules.spec.js
           tests/racial_stat_integration.spec.js
+          tests/racial_stat_visibility.spec.js
           tests/half_demon_traits.spec.js
           tests/racial_trait_catalog.spec.js
           tests/racial_trait_engine_regressions.spec.js

--- a/js/dm-player-dnd-studio-hotfix.js
+++ b/js/dm-player-dnd-studio-hotfix.js
@@ -92,9 +92,60 @@
     global.LuminousDmPlayerProxyMilestoneSync = true;
   }
 
+  const DM_ABILITIES = Object.freeze(["str", "dex", "con", "int", "wis", "cha"]);
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const signed = (value) => numberOr(value, 0) >= 0 ? `+${numberOr(value, 0)}` : String(numberOr(value, 0));
+
+  function syncDmRacialStatBadges() {
+    const studio = global.LuminousDmPlayerDndStudio;
+    if (!doc || !studio?.effectiveAbilityScore || !studio?.resolveRacialStatBonuses) return false;
+    const bonuses = studio.resolveRacialStatBonuses() || {};
+    let found = false;
+
+    DM_ABILITIES.forEach((abilityId) => {
+      const input = doc.getElementById(`dm-player-stat-${abilityId}`);
+      if (!input) return;
+      found = true;
+      const host = input.closest?.(".dm-player-dnd-ability") || input.parentElement;
+      if (!host) return;
+      let badge = host.querySelector?.(`[data-racial-effective-stat="${abilityId}"]`);
+      if (!badge) {
+        badge = doc.createElement("small");
+        badge.dataset.racialEffectiveStat = abilityId;
+        badge.style.cssText = "display:block;grid-column:1/-1;margin-top:2px;font-size:10px;letter-spacing:.06em;color:#d6b56d;opacity:.95;";
+        host.appendChild(badge);
+      }
+      const base = Number.parseInt(input.value, 10);
+      const effective = Number(studio.effectiveAbilityScore(abilityId));
+      const bonus = numberOr(bonuses?.[abilityId], 0);
+      const baseText = Number.isFinite(base) ? base : 10;
+      const effectiveText = Number.isFinite(effective) ? effective : baseText + bonus;
+      badge.textContent = `BASE ${baseText} → EFFECTIVE ${effectiveText} · RACE ${signed(bonus)}`;
+      input.dataset.effectiveScore = String(effectiveText);
+      input.dataset.racialBonus = String(bonus);
+      input.title = `Base ${baseText} · Racial ${signed(bonus)} · Effective ${effectiveText}`;
+    });
+    return found;
+  }
+
+  function installDmRacialStatVisibility() {
+    if (!doc || global.LuminousDmRacialStatVisibility) return;
+    const refresh = () => global.setTimeout?.(syncDmRacialStatBadges, 0);
+    doc.addEventListener("input", (event) => {
+      if (event.target?.id?.startsWith?.("dm-player-stat-")) refresh();
+    }, true);
+    doc.addEventListener("change", (event) => {
+      const id = String(event.target?.id || "");
+      if (id.startsWith("dm-player-stat-") || ["dm-player-build-race", "dm-player-build-subrace", "canonical-racial-stat-choice-1", "canonical-racial-stat-choice-2", "existing-racial-stat-choice-1", "existing-racial-stat-choice-2", "dm-player-dnd-select"].includes(id)) refresh();
+    }, true);
+    global.setInterval?.(syncDmRacialStatBadges, 500);
+    global.LuminousDmRacialStatVisibility = Object.freeze({ sync: syncDmRacialStatBadges });
+  }
+
   ensureRacialIntegrationAssets();
   ensureClassMilestoneAssets();
   installPlayerProxyMilestoneSync();
+  installDmRacialStatVisibility();
 
   if (!global?.Node || global.LuminousDmPlayerDndObserverHotfix) return;
 

--- a/js/player-stats-ability-bar.js
+++ b/js/player-stats-ability-bar.js
@@ -28,7 +28,7 @@
       { id: "deception", name: "Deception", spanish: "Engaño" },
       { id: "intimidation", name: "Intimidation", spanish: "Intimidación" },
       { id: "performance", name: "Performance", spanish: "Interpretación" },
-      { id: "persuasion", name: "Persuasion", spanish: "Persuasión" },
+      { id: "persuasion", name: "Persuasión", spanish: "Persuasión" },
     ] },
   ]);
   const PROFICIENCY_STATES = Object.freeze({
@@ -50,6 +50,19 @@
   const playerData = () => global.datosJugador || {};
   const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
   const integerOr = (value, fallback = 0) => Number.isFinite(Number.parseInt(value, 10)) ? Number.parseInt(value, 10) : fallback;
+  function ensureRacialStatRuntime() {
+    if (global.LuminousRacialStatRuntime) {
+      global.LuminousRacialStatRuntime.ensureDependencies?.();
+      return true;
+    }
+    if (!doc?.head || doc.getElementById("racial-stat-runtime-script")) return false;
+    const script = doc.createElement("script");
+    script.id = "racial-stat-runtime-script";
+    script.src = "js/racial-stat-runtime.js";
+    script.async = false;
+    doc.head.appendChild(script);
+    return false;
+  }
   const currentLevel = (data = playerData()) => Math.max(1, Math.trunc(numberOr(data?.level, 1)));
   function proficiencyBonus(level) {
     return Math.ceil(Math.max(0, numberOr(level, 0)) / 20);
@@ -72,6 +85,8 @@
     return Math.floor(proficiencyBonus(level) * definition.multiplier);
   }
   function abilityScore(ability, data = playerData()) {
+    const effective = global.LuminousRacialStatRuntime?.abilityScore?.(ability?.id, data);
+    if (Number.isFinite(Number(effective))) return Number(effective);
     const fromData = Number.parseInt(data?.stats?.[ability.key], 10);
     if (Number.isFinite(fromData)) return fromData;
     const fromInput = Number.parseInt(doc.getElementById(`stat-${ability.key}`)?.value, 10);
@@ -458,9 +473,11 @@
     return true;
   }
   function boot() {
+    ensureRacialStatRuntime();
     buildPanel();
     installCoinResultAdjustment();
     global.setInterval(() => {
+      ensureRacialStatRuntime();
       buildPanel();
       syncPanel();
       installCoinResultAdjustment();
@@ -471,6 +488,8 @@
   global.LuminousPlayerStats = Object.freeze({
     ABILITIES,
     PROFICIENCY_STATES,
+    abilityScore,
+    abilityRollMath,
     abilityModifier,
     proficiencyBonus,
     proficiencyContribution,

--- a/js/player-stats-ability-bar.js
+++ b/js/player-stats-ability-bar.js
@@ -28,7 +28,7 @@
       { id: "deception", name: "Deception", spanish: "Engaño" },
       { id: "intimidation", name: "Intimidation", spanish: "Intimidación" },
       { id: "performance", name: "Performance", spanish: "Interpretación" },
-      { id: "persuasion", name: "Persuasión", spanish: "Persuasión" },
+      { id: "persuasion", name: "Persuasion", spanish: "Persuasión" },
     ] },
   ]);
   const PROFICIENCY_STATES = Object.freeze({

--- a/js/racial-stat-runtime.js
+++ b/js/racial-stat-runtime.js
@@ -1,0 +1,135 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousRacialStatRuntime) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousRacialStatRuntime;
+    return;
+  }
+
+  const ABILITY_IDS = Object.freeze(["str", "dex", "con", "int", "wis", "cha"]);
+  const ABILITY_KEYS = Object.freeze({ str: "fuerza", dex: "destreza", con: "constitucion", int: "inteligencia", wis: "sabiduria", cha: "carisma" });
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/\s+/g, "_");
+  const integerOr = (value, fallback = 0) => Number.isFinite(Number.parseInt(value, 10)) ? Number.parseInt(value, 10) : fallback;
+  const zeroBonuses = () => Object.fromEntries(ABILITY_IDS.map((id) => [id, 0]));
+  let dependencyPromise = null;
+
+  function characterInput(character = {}) {
+    const build = character?.characterBuild && typeof character.characterBuild === "object" ? character.characterBuild : {};
+    return {
+      raceId: normalizeId(build.raceId ?? character.raceId ?? character.race?.id ?? "human") || "human",
+      raceSubtypeId: normalizeId(build.raceSubtypeId ?? character.raceSubtypeId ?? character.race?.subtypeId ?? "") || null,
+      racialStatChoices: Array.isArray(build.racialStatChoices)
+        ? build.racialStatChoices
+        : Array.isArray(character.racialStatChoices) ? character.racialStatChoices : [],
+    };
+  }
+
+  function rules() {
+    return global.LuminousCharacterBuildRules || null;
+  }
+
+  function resolveBonuses(character = {}) {
+    const api = rules();
+    if (!api) return zeroBonuses();
+    const input = characterInput(character);
+    if (api.EXISTING_RACIAL_STAT_RULES?.[input.raceId] && typeof api.resolveExistingRacialStatBonuses === "function") {
+      return api.resolveExistingRacialStatBonuses(input);
+    }
+    if (api.RACIAL_STAT_RULES?.[input.raceId] && typeof api.resolveRacialStatBonuses === "function") {
+      return api.resolveRacialStatBonuses(input);
+    }
+    return zeroBonuses();
+  }
+
+  function hasStoredRacialBreakdown(character = {}) {
+    const saved = character?.characterBuild?.breakdown?.racialStatBonuses;
+    return Boolean(saved && typeof saved === "object" && !Array.isArray(saved));
+  }
+
+  function hasBaseStats(character = {}) {
+    return Boolean(character?.baseStats && typeof character.baseStats === "object" && ABILITY_IDS.some((id) => {
+      const key = ABILITY_KEYS[id];
+      return Number.isFinite(Number.parseInt(character.baseStats?.[key] ?? character.baseStats?.[id], 10));
+    }));
+  }
+
+  function baseStats(character = {}) {
+    const modernBase = hasBaseStats(character);
+    return Object.fromEntries(ABILITY_IDS.map((id) => {
+      const key = ABILITY_KEYS[id];
+      const storedBase = Number.parseInt(character?.baseStats?.[key] ?? character?.baseStats?.[id], 10);
+      if (modernBase && Number.isFinite(storedBase)) return [key, storedBase];
+      const storedStat = Number.parseInt(character?.stats?.[key] ?? character?.stats?.[id], 10);
+      return [key, Number.isFinite(storedStat) ? storedStat : 10];
+    }));
+  }
+
+  function effectiveStats(character = {}) {
+    const bonuses = resolveBonuses(character);
+    const modernBase = hasBaseStats(character);
+    const alreadyEffective = !modernBase && hasStoredRacialBreakdown(character);
+    return Object.fromEntries(ABILITY_IDS.map((id) => {
+      const key = ABILITY_KEYS[id];
+      if (alreadyEffective) {
+        const storedEffective = Number.parseInt(character?.stats?.[key] ?? character?.stats?.[id], 10);
+        if (Number.isFinite(storedEffective)) return [key, storedEffective];
+      }
+      const base = Number.parseInt(baseStats(character)?.[key], 10);
+      return [key, integerOr(base, 10) + Number(bonuses?.[id] || 0)];
+    }));
+  }
+
+  function abilityScore(abilityId, character = {}) {
+    const id = normalizeId(abilityId);
+    const key = ABILITY_KEYS[id];
+    if (!key) return null;
+    return integerOr(effectiveStats(character)?.[key], 10);
+  }
+
+  function ensureScript(id, src, ready) {
+    if (ready?.()) return Promise.resolve(true);
+    const doc = global.document;
+    if (!doc?.head) return Promise.resolve(false);
+    let script = doc.getElementById(id);
+    if (!script) {
+      script = doc.createElement("script");
+      script.id = id;
+      script.src = src;
+      script.async = false;
+      doc.head.appendChild(script);
+    }
+    if (ready?.()) return Promise.resolve(true);
+    return new Promise((resolve) => {
+      const finish = () => resolve(Boolean(ready?.()));
+      script.addEventListener("load", finish, { once: true });
+      script.addEventListener("error", () => resolve(false), { once: true });
+    });
+  }
+
+  function ensureDependencies() {
+    if (dependencyPromise) return dependencyPromise;
+    dependencyPromise = Promise.resolve()
+      .then(() => ensureScript("character-build-rules-script", "js/character-build-rules.js", () => Boolean(global.LuminousCharacterBuildRules)))
+      .then(() => ensureScript("canonical-race-integration-script", "js/canonical-race-integration.js", () => Boolean(global.LuminousCharacterBuildRules?.__canonicalRaceIntegration)))
+      .then(() => ensureScript("existing-racial-stat-integration-script", "js/existing-racial-stat-integration.js", () => Boolean(global.LuminousCharacterBuildRules?.__existingRacialStatIntegration)))
+      .then(() => Boolean(global.LuminousCharacterBuildRules?.__existingRacialStatIntegration));
+    return dependencyPromise;
+  }
+
+  const api = Object.freeze({
+    ABILITY_IDS,
+    ABILITY_KEYS,
+    characterInput,
+    resolveBonuses,
+    hasBaseStats,
+    hasStoredRacialBreakdown,
+    baseStats,
+    effectiveStats,
+    abilityScore,
+    ensureDependencies,
+  });
+
+  global.LuminousRacialStatRuntime = api;
+  ensureDependencies();
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/tests/racial_stat_visibility.spec.js
+++ b/tests/racial_stat_visibility.spec.js
@@ -1,0 +1,116 @@
+const { test, expect } = require("@playwright/test");
+const path = require("node:path");
+
+const baseRules = require("../js/character-build-rules.js");
+const canonicalIntegration = require("../js/canonical-race-integration.js");
+const existingIntegration = require("../js/existing-racial-stat-integration.js");
+const rules = existingIntegration.installRules(canonicalIntegration.installRules(baseRules));
+global.LuminousCharacterBuildRules = rules;
+const racialRuntime = require("../js/racial-stat-runtime.js");
+
+const ALL_10 = { fuerza: 10, destreza: 10, constitucion: 10, inteligencia: 10, sabiduria: 10, carisma: 10 };
+
+test("legacy Human 10 resolves to effective 11 without requiring a resave", () => {
+  const legacy = { stats: { ...ALL_10 } };
+  expect(racialRuntime.characterInput(legacy).raceId).toBe("human");
+  expect(racialRuntime.effectiveStats(legacy)).toEqual({
+    fuerza: 11, destreza: 11, constitucion: 11, inteligencia: 11, sabiduria: 11, carisma: 11,
+  });
+});
+
+test("modern effective Stats are not double-counted", () => {
+  const modern = {
+    baseStats: { ...ALL_10 },
+    stats: { fuerza: 11, destreza: 11, constitucion: 11, inteligencia: 11, sabiduria: 11, carisma: 11 },
+    characterBuild: {
+      raceId: "human",
+      breakdown: { racialStatBonuses: { str: 1, dex: 1, con: 1, int: 1, wis: 1, cha: 1 } },
+    },
+  };
+  expect(racialRuntime.abilityScore("str", modern)).toBe(11);
+  expect(racialRuntime.effectiveStats(modern).fuerza).toBe(11);
+
+  const transitional = {
+    stats: { fuerza: 11, destreza: 11, constitucion: 11, inteligencia: 11, sabiduria: 11, carisma: 11 },
+    characterBuild: {
+      raceId: "human",
+      breakdown: { racialStatBonuses: { str: 1, dex: 1, con: 1, int: 1, wis: 1, cha: 1 } },
+    },
+  };
+  expect(racialRuntime.effectiveStats(transitional).fuerza).toBe(11);
+});
+
+test("runtime uses existing racial rules and Variant Human choices", () => {
+  expect(racialRuntime.effectiveStats({
+    stats: { ...ALL_10 },
+    characterBuild: { raceId: "lizalin" },
+  })).toMatchObject({ constitucion: 12, sabiduria: 11 });
+
+  expect(racialRuntime.effectiveStats({
+    stats: { ...ALL_10 },
+    characterBuild: { raceId: "human", raceSubtypeId: "variant", racialStatChoices: ["str", "dex"] },
+  })).toEqual({ fuerza: 11, destreza: 11, constitucion: 10, inteligencia: 10, sabiduria: 10, carisma: 10 });
+});
+
+test("player Stats HUD displays and rolls from the effective racial Score", async ({ page }) => {
+  await page.setContent('<div id="stats-modal"><div id="stats-container"></div></div>');
+  await page.evaluate(() => {
+    window.datosJugador = {
+      level: 1,
+      stats: { fuerza: 10, destreza: 10, constitucion: 10, inteligencia: 10, sabiduria: 10, carisma: 10 },
+    };
+  });
+
+  const root = path.join(__dirname, "..");
+  for (const file of ["character-build-rules.js", "canonical-race-integration.js", "existing-racial-stat-integration.js", "racial-stat-runtime.js", "player-stats-ability-bar.js"]) {
+    await page.addScriptTag({ path: path.join(root, "js", file) });
+  }
+
+  await expect(page.locator("[data-stat-score]")).toHaveText("11");
+  await expect(page.locator("[data-stat-modifier]")).toHaveText("+0");
+  await expect(page.locator("[data-stat-save]")).toHaveText("+0");
+
+  const humanRoll = await page.evaluate(() => window.LuminousPlayerStats.abilityRollMath(window.LuminousPlayerStats.ABILITIES[0], window.datosJugador));
+  expect(humanRoll).toMatchObject({ score: 11, modifier: 0, base: 0 });
+
+  await page.evaluate(() => { window.datosJugador.stats.fuerza = 11; });
+  await expect(page.locator("[data-stat-score]")).toHaveText("12", { timeout: 2500 });
+  await expect(page.locator("[data-stat-modifier]")).toHaveText("+1");
+});
+
+test("DM Studio keeps Base editable and shows Effective racial Score", async ({ page }) => {
+  await page.setContent('<section id="dashboard-jugadores"><div class="panel-cyber"><div id="grid-jugadores"></div></div></section>');
+  await page.evaluate(() => {
+    window.calculateLevelData = () => ({ level: 1, xpPercent: 0, xpMissing: 0 });
+    const players = {
+      p1: {
+        characterName: "Human Test",
+        xp: 0,
+        stats: { fuerza: 10, destreza: 10, constitucion: 10, inteligencia: 10, sabiduria: 10, carisma: 10 },
+        characterBuild: { raceId: "human", classes: [], backgroundId: "" },
+      },
+    };
+    const db = {
+      ref(path) {
+        return {
+          on(event, callback) {
+            if (path === "campaña/jugadores" && event === "value") callback({ val: () => players });
+          },
+          update() { return Promise.resolve(); },
+        };
+      },
+    };
+    window.firebase = { apps: [{}], database: () => db };
+  });
+
+  const root = path.join(__dirname, "..");
+  for (const file of ["character-build-rules.js", "canonical-race-integration.js", "existing-racial-stat-integration.js", "dm-player-dnd-studio.js", "dm-player-dnd-studio-hotfix.js"]) {
+    await page.addScriptTag({ path: path.join(root, "js", file) });
+  }
+
+  await expect(page.locator("#dm-player-dnd-select option[value='p1']")).toHaveCount(1);
+  await page.selectOption("#dm-player-dnd-select", "p1");
+  await expect(page.locator("#dm-player-stat-str")).toHaveValue("10");
+  await expect(page.locator('[data-racial-effective-stat="str"]')).toHaveText("BASE 10 → EFFECTIVE 11 · RACE +1", { timeout: 2500 });
+  expect(await page.locator("#dm-player-stat-str").getAttribute("data-effective-score")).toBe("11");
+});


### PR DESCRIPTION
## Summary
- Add a shared racial Stat runtime for effective ability scores.
- Fix the player Stats HUD so racial bonuses affect the visible SCORE and roll math, including legacy characters.
- Preserve base vs effective Stat layers to avoid double-applying racial bonuses.
- Show the DM an explicit Base → Effective racial Stat breakdown instead of making the racial bonus look missing.
- Add regression coverage for standard Human 10 → 11, modern saved characters, Variant Human, existing races, player HUD, and DM presentation.

## Expected behavior
- Standard Human with base 10 displays SCORE 11.
- A modern Human already stored as base 10 / effective 11 remains 11, never 12.
- DM continues editing base Stats while seeing the effective racial result.
- Existing racial Traits/features remain unchanged.

## Validation
This PR should not be merged until CI for Character Build / Racial Stats / Trait regressions is green.