### PR TITLE
Stats: tooltips de desglose del modificador

### DIFF
--- a/js/player-splash-framing.js
+++ b/js/player-splash-framing.js
@@ -17,6 +17,18 @@
   const clamp = (value, min, max) => Math.min(max, Math.max(min, Number(value)));
   const numberOr = (value, fallback) => Number.isFinite(Number(value)) ? Number(value) : fallback;
 
+  function ensureStatModifierTooltipRuntime() {
+    let script = doc.getElementById("player-stat-tooltip-runtime-script");
+    if (script) return script;
+    script = doc.createElement("script");
+    script.id = "player-stat-tooltip-runtime-script";
+    script.src = "js/player-stat-tooltip-runtime.js";
+    script.async = false;
+    script.dataset.ui = "player-stat-tooltip-runtime";
+    doc.head?.appendChild(script);
+    return script;
+  }
+
   function normalizeFrame(source) {
     const raw = source || {};
     return {
@@ -298,6 +310,7 @@
   }
 
   function boot() {
+    ensureStatModifierTooltipRuntime();
     const tick = () => {
       if (doc.getElementById("dashboard-jugadores")) {
         mountDmControls();
@@ -326,5 +339,6 @@
     openLightbox,
     closeLightbox,
     syncPlayerFrame,
+    ensureStatModifierTooltipRuntime,
   });
 })(window);

--- a/js/player-stat-tooltip-runtime.js
+++ b/js/player-stat-tooltip-runtime.js
@@ -73,7 +73,7 @@
   function buildModifierTooltip(parts = {}) {
     const values = Object.fromEntries(SOURCE_ORDER.map(({ key }) => [key, numberOr(parts?.[key], 0)]));
     const total = SOURCE_ORDER.reduce((sum, { key }) => sum + values[key], 0);
-    const lines = [`Mod actual: ${formatSigned(total)}`];
+    const lines = [`Mod actual: ${total === 0 ? "0" : formatSigned(total)}`];
     SOURCE_ORDER.forEach(({ key, label }) => {
       const value = values[key];
       if (value === 0) return;

--- a/js/player-stat-tooltip-runtime.js
+++ b/js/player-stat-tooltip-runtime.js
@@ -92,11 +92,19 @@
     const racialRuntime = global.LuminousRacialStatRuntime;
     const normalized = normalizeAbility(ability);
     const runtimeBase = racialRuntime?.baseStats?.(data)?.[normalized.key];
-    let baseScore = Number.isFinite(Number(runtimeBase)) ? Number(runtimeBase) : numberOr(actualScore, 10);
-    let racialScoreBonus = mapAbilityValue(racialRuntime?.resolveBonuses?.(data) || data?.characterBuild?.breakdown?.racialStatBonuses, normalized);
+    const hasModernBase = Boolean(racialRuntime?.hasBaseStats?.(data));
+    const hasStoredRacialBreakdown = Boolean(racialRuntime?.hasStoredRacialBreakdown?.(data));
+    const storedRacialBonuses = data?.characterBuild?.breakdown?.racialStatBonuses;
+    let racialScoreBonus = mapAbilityValue(
+      (!hasModernBase && hasStoredRacialBreakdown ? storedRacialBonuses : null) || racialRuntime?.resolveBonuses?.(data) || storedRacialBonuses,
+      normalized,
+    );
+    const actual = numberOr(actualScore, 10);
+    let baseScore = hasModernBase && Number.isFinite(Number(runtimeBase))
+      ? Number(runtimeBase)
+      : (!hasModernBase && hasStoredRacialBreakdown ? actual - racialScoreBonus : (Number.isFinite(Number(runtimeBase)) ? Number(runtimeBase) : actual));
     let backgroundScoreBonus = optionalScoreBonus(data, "background", normalized);
     let traitsScoreBonus = optionalScoreBonus(data, "trait", normalized) || optionalScoreBonus(data, "traits", normalized);
-    const actual = numberOr(actualScore, baseScore + racialScoreBonus + backgroundScoreBonus + traitsScoreBonus);
 
     if (baseScore + racialScoreBonus + backgroundScoreBonus + traitsScoreBonus !== actual) {
       if (baseScore + racialScoreBonus + backgroundScoreBonus === actual) {

--- a/js/player-stat-tooltip-runtime.js
+++ b/js/player-stat-tooltip-runtime.js
@@ -1,0 +1,229 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousPlayerStatTooltipRuntime) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousPlayerStatTooltipRuntime;
+    return;
+  }
+
+  const doc = global.document || null;
+  const ABILITY_KEYS = Object.freeze({ str: "fuerza", dex: "destreza", con: "constitucion", int: "inteligencia", wis: "sabiduria", cha: "carisma" });
+  const PROFICIENCY_MULTIPLIERS = Object.freeze({ none: 0, half: 0.5, proficient: 1, expertise: 2 });
+  const SOURCE_ORDER = Object.freeze([
+    Object.freeze({ key: "baseModifier", label: "Mod" }),
+    Object.freeze({ key: "proficiency", label: "Proficiency" }),
+    Object.freeze({ key: "racial", label: "Racial" }),
+    Object.freeze({ key: "background", label: "Background" }),
+    Object.freeze({ key: "traits", label: "Traits" }),
+  ]);
+
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const integerOr = (value, fallback = 0) => Number.isFinite(Number.parseInt(value, 10)) ? Number.parseInt(value, 10) : fallback;
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/\s+/g, "_");
+  const abilityModifier = (score) => Math.floor((numberOr(score, 10) - 10) / 2);
+  const formatSigned = (value) => numberOr(value, 0) >= 0 ? `+${numberOr(value, 0)}` : String(numberOr(value, 0));
+
+  function normalizeAbility(ability = {}) {
+    const id = normalizeId(ability.id || ability.code);
+    const key = ability.key || ABILITY_KEYS[id] || id;
+    return { ...ability, id, key };
+  }
+
+  function mapAbilityValue(map, ability) {
+    if (!map || typeof map !== "object") return 0;
+    const normalized = normalizeAbility(ability);
+    return numberOr(map?.[normalized.id] ?? map?.[normalized.key], 0);
+  }
+
+  function proficiencyBonus(level) {
+    return Math.ceil(Math.max(0, numberOr(level, 0)) / 20);
+  }
+
+  function proficiencyContribution(level, state) {
+    const multiplier = PROFICIENCY_MULTIPLIERS[normalizeId(state)] ?? 0;
+    return Math.floor(proficiencyBonus(level) * multiplier);
+  }
+
+  function modifierContributions({ baseScore = 10, racialScoreBonus = 0, backgroundScoreBonus = 0, traitsScoreBonus = 0, proficiency = 0 } = {}) {
+    const startScore = numberOr(baseScore, 10);
+    const racialScore = numberOr(racialScoreBonus, 0);
+    const backgroundScore = numberOr(backgroundScoreBonus, 0);
+    const traitsScore = numberOr(traitsScoreBonus, 0);
+
+    const baseModifier = abilityModifier(startScore);
+    const afterRacial = startScore + racialScore;
+    const racial = abilityModifier(afterRacial) - baseModifier;
+    const afterBackground = afterRacial + backgroundScore;
+    const background = abilityModifier(afterBackground) - abilityModifier(afterRacial);
+    const afterTraits = afterBackground + traitsScore;
+    const traits = abilityModifier(afterTraits) - abilityModifier(afterBackground);
+
+    return {
+      score: afterTraits,
+      baseScore: startScore,
+      baseModifier,
+      proficiency: numberOr(proficiency, 0),
+      racial,
+      background,
+      traits,
+      total: abilityModifier(afterTraits) + numberOr(proficiency, 0),
+    };
+  }
+
+  function buildModifierTooltip(parts = {}) {
+    const values = Object.fromEntries(SOURCE_ORDER.map(({ key }) => [key, numberOr(parts?.[key], 0)]));
+    const total = SOURCE_ORDER.reduce((sum, { key }) => sum + values[key], 0);
+    const lines = [`Mod actual: ${formatSigned(total)}`];
+    SOURCE_ORDER.forEach(({ key, label }) => {
+      const value = values[key];
+      if (value === 0) return;
+      lines.push(`${formatSigned(value)} ${label}`);
+    });
+    return lines.join("\n");
+  }
+
+  function optionalScoreBonus(data, source, ability) {
+    const breakdown = data?.characterBuild?.breakdown || {};
+    const map = breakdown?.[`${source}StatBonuses`] || data?.[`${source}StatBonuses`] || null;
+    return mapAbilityValue(map, ability);
+  }
+
+  function reconciledPlayerScores(ability, data, actualScore) {
+    const racialRuntime = global.LuminousRacialStatRuntime;
+    const normalized = normalizeAbility(ability);
+    const runtimeBase = racialRuntime?.baseStats?.(data)?.[normalized.key];
+    let baseScore = Number.isFinite(Number(runtimeBase)) ? Number(runtimeBase) : numberOr(actualScore, 10);
+    let racialScoreBonus = mapAbilityValue(racialRuntime?.resolveBonuses?.(data) || data?.characterBuild?.breakdown?.racialStatBonuses, normalized);
+    let backgroundScoreBonus = optionalScoreBonus(data, "background", normalized);
+    let traitsScoreBonus = optionalScoreBonus(data, "trait", normalized) || optionalScoreBonus(data, "traits", normalized);
+    const actual = numberOr(actualScore, baseScore + racialScoreBonus + backgroundScoreBonus + traitsScoreBonus);
+
+    if (baseScore + racialScoreBonus + backgroundScoreBonus + traitsScoreBonus !== actual) {
+      if (baseScore + racialScoreBonus + backgroundScoreBonus === actual) {
+        traitsScoreBonus = 0;
+      } else if (baseScore + racialScoreBonus === actual) {
+        backgroundScoreBonus = 0;
+        traitsScoreBonus = 0;
+      } else {
+        baseScore = actual;
+        racialScoreBonus = 0;
+        backgroundScoreBonus = 0;
+        traitsScoreBonus = 0;
+      }
+    }
+
+    return { baseScore, racialScoreBonus, backgroundScoreBonus, traitsScoreBonus };
+  }
+
+  function playerAbilityBreakdown(ability, data = global.datosJugador || {}) {
+    const playerStats = global.LuminousPlayerStats;
+    const racialRuntime = global.LuminousRacialStatRuntime;
+    const normalized = normalizeAbility(ability);
+    const math = playerStats?.abilityRollMath?.(normalized, data);
+    const actualScore = numberOr(math?.score ?? playerStats?.abilityScore?.(normalized, data) ?? racialRuntime?.abilityScore?.(normalized.id, data), 10);
+    const sources = reconciledPlayerScores(normalized, data, actualScore);
+    const proficiency = numberOr(math?.proficiencyValue, 0);
+    return modifierContributions({ ...sources, proficiency });
+  }
+
+  function playerAbilityTooltip(ability, data = global.datosJugador || {}) {
+    return buildModifierTooltip(playerAbilityBreakdown(ability, data));
+  }
+
+  function selectedPlayerAbility(panel, playerStats) {
+    const activeId = normalizeId(panel?.dataset?.activeStat || "str");
+    return (playerStats?.ABILITIES || []).find((entry) => normalizeId(entry?.id) === activeId) || playerStats?.ABILITIES?.[0] || null;
+  }
+
+  function setTooltip(node, text) {
+    if (!node || !text) return false;
+    if (node.title !== text) node.title = text;
+    node.dataset.modifierBreakdownTooltip = "true";
+    return true;
+  }
+
+  function syncPlayerTooltip() {
+    if (!doc) return false;
+    const playerStats = global.LuminousPlayerStats;
+    const panel = doc.querySelector("#stats-modal .player-ability-console");
+    if (!playerStats || !panel) return false;
+    const ability = selectedPlayerAbility(panel, playerStats);
+    if (!ability) return false;
+    const tooltip = playerAbilityTooltip(ability, global.datosJugador || {});
+    const main = panel.querySelector(".player-stat-main");
+    setTooltip(main, tooltip);
+    setTooltip(panel.querySelector("[data-stat-score]"), tooltip);
+    setTooltip(panel.querySelector("[data-stat-modifier]"), tooltip);
+    setTooltip(panel.querySelector(".player-stat-save"), tooltip);
+    setTooltip(panel.querySelector("[data-stat-save]"), tooltip);
+    return true;
+  }
+
+  function dmLevel(studio) {
+    const xp = Math.max(0, integerOr(doc?.getElementById("dm-player-dnd-xp")?.value, 0));
+    return studio?.levelDataFromXp?.(xp)?.level || 1;
+  }
+
+  function dmAbilityBreakdown(ability, studio) {
+    const normalized = normalizeAbility(ability);
+    const baseStats = studio?.baseStatsFromForm?.() || {};
+    const baseScore = numberOr(baseStats?.[normalized.key], 10);
+    const racialScoreBonus = mapAbilityValue(studio?.resolveRacialStatBonuses?.(studio?.racialStatInput?.()) || {}, normalized);
+    const state = doc?.getElementById(`dm-player-prof-${normalized.id}`)?.value || "none";
+    const level = dmLevel(studio);
+    const proficiency = studio?.proficiencyContribution
+      ? numberOr(studio.proficiencyContribution(level, state), 0)
+      : proficiencyContribution(level, state);
+    return modifierContributions({ baseScore, racialScoreBonus, proficiency });
+  }
+
+  function syncDmTooltips() {
+    if (!doc) return false;
+    const studio = global.LuminousDmPlayerDndStudio;
+    if (!studio?.ABILITIES || !doc.getElementById("dashboard-jugadores")) return false;
+    studio.ABILITIES.forEach((ability) => {
+      const tooltip = buildModifierTooltip(dmAbilityBreakdown(ability, studio));
+      const input = doc.getElementById(`dm-player-stat-${ability.id}`);
+      const select = doc.getElementById(`dm-player-prof-${ability.id}`);
+      const label = input?.closest?.(".dm-player-dnd-ability");
+      setTooltip(label, tooltip);
+      setTooltip(input, tooltip);
+      setTooltip(select, tooltip);
+    });
+    return true;
+  }
+
+  function sync() {
+    const player = syncPlayerTooltip();
+    const dm = syncDmTooltips();
+    return player || dm;
+  }
+
+  function boot() {
+    sync();
+    global.setInterval?.(sync, 500);
+  }
+
+  const api = Object.freeze({
+    SOURCE_ORDER,
+    abilityModifier,
+    proficiencyBonus,
+    proficiencyContribution,
+    modifierContributions,
+    buildModifierTooltip,
+    playerAbilityBreakdown,
+    playerAbilityTooltip,
+    dmAbilityBreakdown,
+    syncPlayerTooltip,
+    syncDmTooltips,
+    sync,
+  });
+
+  global.LuminousPlayerStatTooltipRuntime = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+
+  if (doc) {
+    if (doc.readyState === "loading") doc.addEventListener("DOMContentLoaded", boot, { once: true });
+    else boot();
+  }
+})(typeof window !== "undefined" ? window : globalThis);

--- a/tests/player_stat_modifier_tooltip.spec.js
+++ b/tests/player_stat_modifier_tooltip.spec.js
@@ -1,0 +1,61 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const tooltipRuntime = require("../js/player-stat-tooltip-runtime.js");
+const splashRuntime = fs.readFileSync(path.join(__dirname, "..", "js/player-splash-framing.js"), "utf8");
+
+test("tooltip del Mod muestra solo fuentes distintas de cero", () => {
+  const parts = tooltipRuntime.modifierContributions({
+    baseScore: 14,
+    proficiency: 2,
+    racialScoreBonus: 2,
+    backgroundScoreBonus: 0,
+    traitsScoreBonus: -2,
+  });
+
+  expect(tooltipRuntime.buildModifierTooltip(parts)).toBe([
+    "Mod actual: +4",
+    "+2 Mod",
+    "+2 Proficiency",
+    "+1 Racial",
+    "-1 Traits",
+  ].join("\n"));
+});
+
+test("tooltip conserva Mod actual 0 pero oculta todas las fuentes en 0", () => {
+  const parts = tooltipRuntime.modifierContributions({ baseScore: 10 });
+  expect(tooltipRuntime.buildModifierTooltip(parts)).toBe("Mod actual: +0");
+});
+
+test("bonos de Score se convierten a aporte real del Mod sin doble conteo", () => {
+  const parts = tooltipRuntime.modifierContributions({
+    baseScore: 11,
+    racialScoreBonus: 1,
+    backgroundScoreBonus: 1,
+    traitsScoreBonus: 1,
+  });
+
+  expect(parts.baseModifier).toBe(0);
+  expect(parts.racial).toBe(1);
+  expect(parts.background).toBe(0);
+  expect(parts.traits).toBe(1);
+  expect(parts.total).toBe(2);
+  expect(tooltipRuntime.buildModifierTooltip(parts)).not.toContain("+0 Mod");
+  expect(tooltipRuntime.buildModifierTooltip(parts)).not.toContain("Background");
+});
+
+test("runtime se carga tanto en Player como DM desde el bridge compartido", () => {
+  expect(splashRuntime).toContain('script.id = "player-stat-tooltip-runtime-script"');
+  expect(splashRuntime).toContain('script.src = "js/player-stat-tooltip-runtime.js"');
+  expect(splashRuntime).toContain("ensureStatModifierTooltipRuntime();");
+});
+
+test("runtime aplica el mismo desglose al HUD del jugador y al editor del DM", () => {
+  const source = fs.readFileSync(path.join(__dirname, "..", "js/player-stat-tooltip-runtime.js"), "utf8");
+  expect(source).toContain("function syncPlayerTooltip()");
+  expect(source).toContain("function syncDmTooltips()");
+  expect(source).toContain('panel.querySelector("[data-stat-modifier]")');
+  expect(source).toContain('doc.getElementById(`dm-player-stat-${ability.id}`)');
+  expect(source).toContain("if (value === 0) return;");
+});

--- a/tests/player_stat_modifier_tooltip.spec.js
+++ b/tests/player_stat_modifier_tooltip.spec.js
@@ -45,6 +45,38 @@ test("bonos de Score se convierten a aporte real del Mod sin doble conteo", () =
   expect(tooltipRuntime.buildModifierTooltip(parts)).not.toContain("Background");
 });
 
+test("personajes legacy conservan el desglose racial cuando stats ya guarda el Score efectivo", () => {
+  const previousRacialRuntime = global.LuminousRacialStatRuntime;
+  const previousPlayerStats = global.LuminousPlayerStats;
+  try {
+    global.LuminousRacialStatRuntime = {
+      baseStats: () => ({ fuerza: 14 }),
+      hasBaseStats: () => false,
+      hasStoredRacialBreakdown: () => true,
+      resolveBonuses: () => ({ str: 2 }),
+      abilityScore: () => 14,
+    };
+    global.LuminousPlayerStats = {
+      abilityRollMath: () => ({ score: 14, proficiencyValue: 0 }),
+      abilityScore: () => 14,
+    };
+    const data = {
+      stats: { fuerza: 14 },
+      characterBuild: { breakdown: { racialStatBonuses: { str: 2 } } },
+    };
+    const parts = tooltipRuntime.playerAbilityBreakdown({ id: "str", key: "fuerza" }, data);
+    expect(parts.baseScore).toBe(12);
+    expect(parts.racial).toBe(1);
+    expect(parts.total).toBe(2);
+    expect(tooltipRuntime.buildModifierTooltip(parts)).toContain("+1 Racial");
+  } finally {
+    if (previousRacialRuntime === undefined) delete global.LuminousRacialStatRuntime;
+    else global.LuminousRacialStatRuntime = previousRacialRuntime;
+    if (previousPlayerStats === undefined) delete global.LuminousPlayerStats;
+    else global.LuminousPlayerStats = previousPlayerStats;
+  }
+});
+
 test("runtime se carga tanto en Player como DM desde el bridge compartido", () => {
   expect(splashRuntime).toContain('script.id = "player-stat-tooltip-runtime-script"');
   expect(splashRuntime).toContain('script.src = "js/player-stat-tooltip-runtime.js"');

--- a/tests/player_stat_modifier_tooltip.spec.js
+++ b/tests/player_stat_modifier_tooltip.spec.js
@@ -25,7 +25,7 @@ test("tooltip del Mod muestra solo fuentes distintas de cero", () => {
 
 test("tooltip conserva Mod actual 0 pero oculta todas las fuentes en 0", () => {
   const parts = tooltipRuntime.modifierContributions({ baseScore: 10 });
-  expect(tooltipRuntime.buildModifierTooltip(parts)).toBe("Mod actual: +0");
+  expect(tooltipRuntime.buildModifierTooltip(parts)).toBe("Mod actual: 0");
 });
 
 test("bonos de Score se convierten a aporte real del Mod sin doble conteo", () => {


### PR DESCRIPTION
## Qué cambia
- Añade un runtime compartido para mostrar el desglose del Mod al dejar el mouse sobre Score/Mod.
- El tooltip usa el formato `Mod actual` + fuentes: `Mod`, `Proficiency`, `Racial`, `Background`, `Traits`.
- Cualquier fuente con aporte exacto `0` se omite; valores positivos usan `+` y negativos conservan `-`.
- Cuando el Mod actual es cero, el encabezado muestra `Mod actual: 0` (sin `+0`).
- Convierte bonos al Score en su aporte **real** al modificador para no contar dos veces los bonos raciales ni mostrar un bono al Mod cuando el Score no cruza un umbral.
- Aplica el mismo comportamiento al HUD del jugador y al editor D&D del DM.

## Compatibilidad
- No cambia la fórmula existente de Ability Score, Proficiency ni las tiradas del Coin Engine.
- Background y Traits sólo aparecen cuando su aporte forma parte del Score efectivo; las fuentes no aplicadas permanecen ocultas.
- El runtime se carga desde el bridge compartido de Splash Framing, que ya existe tanto en Player como en DM.

## Pruebas
- Se añadió `tests/player_stat_modifier_tooltip.spec.js` para cubrir:
  - filtrado de fuentes `0`;
  - positivos y negativos;
  - `Mod actual: 0` sin filas `+0`;
  - conversión de bonos de Score a aporte real del Mod;
  - carga en Player/DM.