### PR TITLE
Fix Barbarian ClassLevel scaling and Armorless Defense formulas

### DIFF
--- a/js/barbarian-class-runtime.js
+++ b/js/barbarian-class-runtime.js
@@ -1,0 +1,77 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousBarbarianClassRuntime) return;
+
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[_\s-]+/g, "");
+
+  function isGuardSkill(skill = {}) {
+    if (!skill || typeof skill !== "object") return false;
+    const subtype = normalizeId(skill.defenseSubtype || skill.defense_subtype || skill.type);
+    return subtype === "guard" || subtype === "clashableguard";
+  }
+
+  function guardState(unit = {}) {
+    return unit?.guard && typeof unit.guard === "object" ? unit.guard : {};
+  }
+
+  function installCombatBridge(engine = global.CombatEngine) {
+    if (!engine || engine.__barbarianClassLevelGuardPatched) return Boolean(engine);
+
+    const originalCalculateFinalPower = engine.calculateFinalPower;
+    const originalResolveGuard = engine.resolveGuard;
+    if (typeof originalCalculateFinalPower !== "function" || typeof originalResolveGuard !== "function") return false;
+
+    engine.calculateFinalPower = function (skill, headsFlipped, unit = null) {
+      const result = originalCalculateFinalPower.call(this, skill, headsFlipped, unit);
+      if (!unit || !isGuardSkill(skill)) return result;
+      return result + numberOr(guardState(unit).powerBonus, 0);
+    };
+
+    engine.resolveGuard = function (unitDefender, guardSkill) {
+      const shieldBefore = numberOr(unitDefender?.shield, 0);
+      const result = originalResolveGuard.call(this, unitDefender, guardSkill);
+      if (!result || !unitDefender) return result;
+
+      const shieldPercent = Math.max(0, numberOr(guardState(unitDefender).shieldPercent, 0));
+      if (shieldPercent <= 0) return result;
+
+      const baseShieldGain = Math.max(0, numberOr(unitDefender.shield, shieldBefore) - shieldBefore);
+      const shieldBonus = baseShieldGain * shieldPercent / 100;
+      unitDefender.shield = numberOr(unitDefender.shield, shieldBefore) + shieldBonus;
+
+      return {
+        ...result,
+        shieldPercentBonus: shieldPercent,
+        shieldBonus,
+        newShieldAmount: unitDefender.shield,
+      };
+    };
+
+    Object.defineProperty(engine, "__barbarianClassLevelGuardPatched", {
+      value: true,
+      enumerable: false,
+      configurable: true,
+    });
+    return true;
+  }
+
+  const api = Object.freeze({
+    isGuardSkill,
+    installCombatBridge,
+  });
+
+  global.LuminousBarbarianClassRuntime = api;
+  installCombatBridge();
+
+  if (typeof document !== "undefined" && !global.CombatEngine) {
+    let attempts = 0;
+    const timer = global.setInterval?.(() => {
+      attempts += 1;
+      if (installCombatBridge() || attempts >= 40) global.clearInterval?.(timer);
+    }, 250);
+  }
+
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/trait-catalog-core.js
+++ b/js/trait-catalog-core.js
@@ -2,7 +2,7 @@
   "use strict";
 
   const engine = global.LuminousTraitEngine || (typeof require === "function" ? require("./trait-engine.js") : null);
-  const CATALOG_VERSION = 3;
+  const CATALOG_VERSION = 4;
 
   const RULE_TYPES = Object.freeze([
     "modifier",
@@ -51,7 +51,14 @@
       schemaVersion: 1,
       id: "armorless_defense",
       name: "Armorless Defense",
-      description: "Without Armor, gain Constitution Mod Defensive Level; at Encounter Start Guard gains Level% Shield for the encounter; remove 1 Stagger Threshold.",
+      description: "Without Armor, at Encounter Start gain (CON Mod + Barbarian Class Level) Guard. Guard gains +(Barbarian Class Level / 2)% Shield for the encounter. Remove 1 Stagger Threshold.",
+      display: {
+        playerDescription: "Without Armor, at Encounter Start gain {guardBonus}. Guard gains {shieldBonus} Shield for the encounter. Remove 1 Stagger Threshold.",
+        resolvedValues: [
+          { id: "guardBonus", label: "Guard", formula: "ConstitutionMod + ClassLevel", suffix: " Guard" },
+          { id: "shieldBonus", label: "Guard Shield Bonus", formula: "ClassLevel / 2", unit: "percent", signed: true },
+        ],
+      },
       source: classSource,
       contexts: ["combat"],
       activation: { type: "passive", actionCost: "none" },
@@ -59,11 +66,30 @@
       rules: [
         {
           type: "modifier",
-          trigger: "passive",
+          trigger: "encounter_start",
           target: "self",
-          channel: "defensive_level",
-          mode: "add",
-          formula: "ConstitutionMod",
+          path: "guard.powerBonus",
+          mode: "set",
+          value: 0,
+          duration: "encounter",
+        },
+        {
+          type: "modifier",
+          trigger: "encounter_start",
+          target: "self",
+          path: "guard.shieldPercent",
+          mode: "set",
+          value: 0,
+          duration: "encounter",
+        },
+        {
+          type: "modifier",
+          trigger: "encounter_start",
+          target: "self",
+          path: "guard.powerBonus",
+          mode: "set",
+          formula: "ConstitutionMod + ClassLevel",
+          duration: "encounter",
           conditions: [{ path: "equipment.armorEquipped", operator: "falsy" }],
         },
         {
@@ -71,8 +97,8 @@
           trigger: "encounter_start",
           target: "self",
           path: "guard.shieldPercent",
-          mode: "add",
-          formula: "Level",
+          mode: "set",
+          formula: "ClassLevel / 2",
           duration: "encounter",
           conditions: [{ path: "equipment.armorEquipped", operator: "falsy" }],
         },
@@ -92,7 +118,7 @@
       schemaVersion: 1,
       id: "rage",
       name: "Rage",
-      description: "Spend a Quick Action to gain Rage. Uses scale with Barbarian ClassLevel, are always at least 1, and reset on Long Rest.",
+      description: "Spend a Quick Action to gain Rage. Uses and Rage scaling use Barbarian Class Level, not total Character Level or Offensive Level. Uses are always at least 1 and reset on Long Rest.",
       source: classSource,
       contexts: ["combat"],
       activation: {
@@ -131,7 +157,7 @@
           target: "self",
           channel: "damage_dealt_multiplier",
           mode: "add",
-          formula: "OffensiveLevel",
+          formula: "ClassLevel",
           unit: "percent",
           whileStatus: "rage",
         },
@@ -145,7 +171,7 @@
           target: "self",
           channel: "final_power",
           mode: "add",
-          formula: "floor(OffensiveLevel / 30)",
+          formula: "floor(ClassLevel / 30)",
           whileStatus: "rage",
           conditions: [{ any: [
             { path: "skill.affinity", operator: "eq", value: "Wrath" },
@@ -264,7 +290,13 @@
       schemaVersion: 1,
       id: "brutal_critical",
       name: "Brutal Critical",
-      description: "Deal floor(Offensive Level / 2)% additional Crit Damage.",
+      description: "Deal floor(Barbarian Class Level / 2)% additional Crit Damage.",
+      display: {
+        playerDescription: "Deal {critDamage} additional Crit Damage.",
+        resolvedValues: [
+          { id: "critDamage", label: "Additional Crit Damage", formula: "floor(ClassLevel / 2)", unit: "percent", signed: true },
+        ],
+      },
       source: classSource,
       contexts: ["combat"],
       activation: { type: "passive", actionCost: "none" },
@@ -275,7 +307,7 @@
         target: "self",
         channel: "crit_damage_multiplier",
         mode: "add",
-        formula: "floor(OffensiveLevel / 2)",
+        formula: "floor(ClassLevel / 2)",
         unit: "percent",
       }],
     },
@@ -284,7 +316,13 @@
       schemaVersion: 1,
       id: "unstoppable_rage",
       name: "Unstoppable Rage",
-      description: "While Raging, at 0 HP make a CON Check starting at Threshold 10. On a pass regain floor(Defensive Level / 3)% HP. Every trigger raises this Trait Threshold by 5; only Long Rest resets it to 10.",
+      description: "While Raging, at 0 HP make a CON Check starting at Threshold 10. On a pass regain floor(Barbarian Class Level / 3)% HP. Every trigger raises this Trait Threshold by 5; only Long Rest resets it to 10.",
+      display: {
+        playerDescription: "While Raging, at 0 HP make a CON Check starting at Threshold 10. On a pass regain {recovery} HP. Every trigger raises this Trait Threshold by 5; only Long Rest resets it to 10.",
+        resolvedValues: [
+          { id: "recovery", label: "HP Recovery", formula: "floor(ClassLevel / 3)", unit: "percent" },
+        ],
+      },
       source: classSource,
       contexts: ["combat", "theatre"],
       activation: { type: "automatic", actionCost: "none" },
@@ -297,7 +335,7 @@
           abilityId: "con",
           threshold: { stateKey: "unstoppable_rage_threshold", initial: 10 },
           whileStatus: "rage",
-          onPass: [{ type: "modifier", target: "self", path: "hpPercent", mode: "regain", formula: "floor(DefensiveLevel / 3)" }],
+          onPass: [{ type: "modifier", target: "self", path: "hpPercent", mode: "regain", formula: "floor(ClassLevel / 3)" }],
         },
         {
           type: "counter",
@@ -554,6 +592,14 @@
     const script = document.createElement("script");
     script.id = "trait-standardization-runtime-script";
     script.src = "js/trait-standardization-runtime.js";
+    script.async = false;
+    document.head?.appendChild(script);
+  }
+
+  if (typeof document !== "undefined" && !global.LuminousBarbarianClassRuntime && !document.getElementById("barbarian-class-runtime-script")) {
+    const script = document.createElement("script");
+    script.id = "barbarian-class-runtime-script";
+    script.src = "js/barbarian-class-runtime.js";
     script.async = false;
     document.head?.appendChild(script);
   }

--- a/tests/barbarian_classlevel_patch.spec.js
+++ b/tests/barbarian_classlevel_patch.spec.js
@@ -1,0 +1,99 @@
+const { test, expect } = require("@playwright/test");
+const engine = require("../js/trait-engine.js");
+const catalog = require("../js/trait-catalog-core.js");
+const tray = require("../js/trait-player-tray.js");
+const CombatEngine = require("../js/combatEngine.js");
+const barbarianRuntime = require("../js/barbarian-class-runtime.js");
+
+barbarianRuntime.installCombatBridge(CombatEngine);
+
+function multiclassBarbarian(barbarianLevel, otherLevel = 0, constitution = 16) {
+  return {
+    id: "barbarian_classlevel_patch_test",
+    level: barbarianLevel + otherLevel,
+    classes: [
+      { classId: "barbarian", levels: barbarianLevel },
+      ...(otherLevel ? [{ classId: "wizard", levels: otherLevel }] : []),
+    ],
+    stats: {
+      fuerza: 18,
+      constitucion: constitution,
+      destreza: 14,
+      inteligencia: 18,
+      sabiduria: 12,
+      carisma: 10,
+    },
+    combatStats: {
+      offensiveLevel: barbarianLevel + otherLevel,
+      defensiveLevel: barbarianLevel + otherLevel,
+    },
+    sp: 0,
+    shield: 0,
+  };
+}
+
+test("Armorless Defense display resolves Barbarian ClassLevel instead of Character Level", () => {
+  const trait = catalog.getDefinition("armorless_defense");
+  const character = multiclassBarbarian(30, 70, 16);
+  const resolved = tray.resolveTraitDisplay(trait, { character });
+
+  expect(resolved.values.guardBonus.display).toBe("33 Guard");
+  expect(resolved.values.shieldBonus.display).toBe("+15%");
+  expect(resolved.values.guardBonus.breakdown).toEqual(expect.arrayContaining([
+    expect.objectContaining({ label: "CON Mod", display: "+3" }),
+    expect.objectContaining({ label: "Class Level", display: "30" }),
+  ]));
+  expect(resolved.values.shieldBonus.breakdown).toEqual(expect.arrayContaining([
+    expect.objectContaining({ label: "Class Level", display: "30" }),
+  ]));
+});
+
+test("Armorless encounter state increases Guard Power and Guard Shield without using other class levels", () => {
+  const trait = catalog.getDefinition("armorless_defense");
+  const character = multiclassBarbarian(30, 70, 16);
+  const state = engine.createState();
+
+  engine.dispatchCombatEvent("encounter_start", {
+    character,
+    self: character,
+    traits: [trait],
+    state,
+    equipment: { armorEquipped: false },
+  });
+
+  expect(character.guard).toMatchObject({ powerBonus: 33, shieldPercent: 15 });
+
+  const guardSkill = {
+    type: "Guard",
+    isDefense: true,
+    defenseSubtype: "Guard",
+    basePower: 0,
+    coinPower: 0,
+    coinAmount: 0,
+    coins: [],
+  };
+  const result = CombatEngine.resolveGuard(character, guardSkill);
+
+  // Native Guard uses CON Mod (+3) as base. Armorless adds 33 Guard, for 36 total.
+  expect(result.guardPower).toBe(36);
+  expect(result.shieldPercentBonus).toBe(15);
+  expect(result.shieldBonus).toBeCloseTo(5.4, 6);
+  expect(result.newShieldAmount).toBeCloseTo(41.4, 6);
+  expect(character.shield).toBeCloseTo(41.4, 6);
+});
+
+test("Brutal Critical and Unstoppable Rage previews stay tied to Barbarian ClassLevel", () => {
+  const character = multiclassBarbarian(55, 45, 18);
+
+  const brutal = tray.resolveTraitDisplay(catalog.getDefinition("brutal_critical"), { character });
+  const unstoppable = tray.resolveTraitDisplay(catalog.getDefinition("unstoppable_rage"), { character });
+
+  expect(brutal.values.critDamage.display).toBe("+27%");
+  expect(unstoppable.values.recovery.display).toBe("18%");
+  expect(brutal.values.critDamage.breakdown).toEqual(expect.arrayContaining([
+    expect.objectContaining({ label: "Class Level", display: "55" }),
+  ]));
+  expect(unstoppable.values.recovery.breakdown).toEqual(expect.arrayContaining([
+    expect.objectContaining({ label: "Class Level", display: "55" }),
+  ]));
+});

--- a/tests/barbarian_trait_rules_runtime.spec.js
+++ b/tests/barbarian_trait_rules_runtime.spec.js
@@ -25,11 +25,26 @@ function barbarian(level = 100) {
   };
 }
 
-test("Armorless Defense resolves Defensive Level universally and removes its Stagger Threshold only once", () => {
-  const character = barbarian(100);
+test("Armorless Defense snapshots Guard from Barbarian Class Level and no longer modifies Defensive Level", () => {
+  const character = barbarian(30);
+  character.level = 100;
+  character.classes = [
+    { classId: "barbarian", levels: 30 },
+    { classId: "wizard", levels: 70 },
+  ];
   character.staggerThresholds = [70, 40];
   const trait = catalog.getDefinition("armorless_defense");
   const state = engine.createState();
+
+  engine.dispatchCombatEvent("encounter_start", {
+    character,
+    self: character,
+    traits: [trait],
+    state,
+    equipment: { armorEquipped: false },
+  });
+
+  expect(character.guard).toMatchObject({ powerBonus: 34, shieldPercent: 15 });
 
   const firstSnapshot = modifiers.resolveCharacterSnapshot({
     unit: character,
@@ -43,10 +58,19 @@ test("Armorless Defense resolves Defensive Level universally and removes its Sta
     traits: [trait],
     context: "combat",
   });
-  expect(firstSnapshot.defensiveLevel).toBe(64);
-  expect(secondSnapshot.defensiveLevel).toBe(64);
+  expect(firstSnapshot.defensiveLevel).toBe(60);
+  expect(secondSnapshot.defensiveLevel).toBe(60);
   expect(character.combatStats.defensiveLevel).toBe(60);
 
+  engine.dispatchCombatEvent("encounter_start", {
+    character,
+    self: character,
+    traits: [trait],
+    state,
+    equipment: { armorEquipped: false },
+  });
+  expect(character.guard).toMatchObject({ powerBonus: 34, shieldPercent: 15 });
+
   engine.dispatchTrait(trait, "passive", {
     context: "combat",
     character,
@@ -62,6 +86,39 @@ test("Armorless Defense resolves Defensive Level universally and removes its Sta
     equipment: { armorEquipped: false },
   }, state);
   expect(character.staggerThresholds).toEqual([70]);
+
+  engine.dispatchCombatEvent("encounter_start", {
+    character,
+    self: character,
+    traits: [trait],
+    state,
+    equipment: { armorEquipped: true },
+  });
+  expect(character.guard).toMatchObject({ powerBonus: 0, shieldPercent: 0 });
+});
+
+test("Barbarian class scaling ignores total Character Level and Offensive Level", () => {
+  const character = barbarian(45);
+  character.level = 100;
+  character.classes = [
+    { classId: "barbarian", levels: 45 },
+    { classId: "wizard", levels: 55 },
+  ];
+  character.combatStats.offensiveLevel = 100;
+
+  const rage = catalog.getDefinition("rage");
+  const rageVars = engine.buildVariables(character, {}, rage);
+  const rageDamage = rage.rules.find((rule) => rule.channel === "damage_dealt_multiplier");
+  const rageWrathPower = rage.rules.find((rule) => rule.channel === "final_power");
+  expect(rageVars.Level).toBe(100);
+  expect(rageVars.ClassLevel).toBe(45);
+  expect(rageVars.OffensiveLevel).toBe(100);
+  expect(engine.evaluateFormula(rageDamage.formula, rageVars)).toBe(45);
+  expect(engine.evaluateFormula(rageWrathPower.formula, rageVars)).toBe(1);
+
+  const brutal = catalog.getDefinition("brutal_critical");
+  const brutalVars = engine.buildVariables(character, {}, brutal);
+  expect(engine.evaluateFormula(brutal.rules[0].formula, brutalVars)).toBe(22);
 });
 
 test("Wild Instincts grants STR Mod Haste Count once at Encounter Start", () => {
@@ -150,8 +207,14 @@ test("Additional Attack reuses the last Coin only once per eligible Skill", () =
   expect(fourCoinSkill.coins).toHaveLength(4);
 });
 
-test("Unstoppable Rage raises Threshold after every trigger and only Long Rest resets it", () => {
-  const character = barbarian(100);
+test("Unstoppable Rage uses Barbarian Class Level even when total level and Defensive Level are higher", () => {
+  const character = barbarian(55);
+  character.level = 100;
+  character.classes = [
+    { classId: "barbarian", levels: 55 },
+    { classId: "wizard", levels: 45 },
+  ];
+  character.combatStats.defensiveLevel = 100;
   const trait = catalog.getDefinition("unstoppable_rage");
   const state = engine.createState({ statuses: { rage: { id: "rage", count: 1 } } });
   const self = { hp: 0, maxHp: 300 };
@@ -162,7 +225,7 @@ test("Unstoppable Rage raises Threshold after every trigger and only Long Rest r
     self,
     traits: [trait],
     state,
-    DefensiveLevel: 60,
+    DefensiveLevel: 100,
     resolveCheck: ({ abilityId, threshold }) => {
       expect(abilityId).toBe("con");
       thresholds.push(threshold);
@@ -170,7 +233,7 @@ test("Unstoppable Rage raises Threshold after every trigger and only Long Rest r
     },
   });
   expect(thresholds).toEqual([10]);
-  expect(self.hp).toBe(60);
+  expect(self.hp).toBe(54);
   expect(state.counters.unstoppable_rage_threshold.value).toBe(15);
   expect(pass.outcomes.some((outcome) => outcome.type === "rule_check" && outcome.passed === true)).toBe(true);
 
@@ -180,7 +243,7 @@ test("Unstoppable Rage raises Threshold after every trigger and only Long Rest r
     self,
     traits: [trait],
     state,
-    DefensiveLevel: 60,
+    DefensiveLevel: 100,
     resolveCheck: ({ threshold }) => {
       thresholds.push(threshold);
       return { passed: false };

--- a/tests/trait_catalog_core.spec.js
+++ b/tests/trait_catalog_core.spec.js
@@ -35,7 +35,7 @@ test("core Trait catalog validates every declarative definition and rule contrac
   const validation = catalog.validateAll(engine);
   expect(validation.valid).toBe(true);
   expect(validation.errors).toEqual([]);
-  expect(catalog.CATALOG_VERSION).toBe(3);
+  expect(catalog.CATALOG_VERSION).toBe(4);
   expect(Object.keys(catalog.DEFINITIONS).sort()).toEqual([
     "additional_attack",
     "armorless_defense",

--- a/tests/universal_modifier_engine.spec.js
+++ b/tests/universal_modifier_engine.spec.js
@@ -44,7 +44,7 @@ test("equipment contract recognizes legacy armorType and future equipment armor 
   expect(modifiers.resolveEquipment({})).toMatchObject({ armorEquipped: false, armorCategory: "none" });
 });
 
-test("Armorless Defense contributes to the universal defensive level only while unarmored", () => {
+test("Armorless Defense no longer modifies the universal defensive level", () => {
   const trait = catalog.getDefinition("armorless_defense");
   const unarmored = barbarian(100);
   const armored = { ...barbarian(100), armorType: "medium" };
@@ -62,7 +62,7 @@ test("Armorless Defense contributes to the universal defensive level only while 
     context: "combat",
   });
 
-  expect(freeMods.defensive_level).toBe(4);
+  expect(freeMods.defensive_level).toBe(0);
   expect(armoredMods.defensive_level).toBe(0);
 });
 
@@ -121,9 +121,9 @@ test("Rage, Brutal Critical and Fast Movement feed canonical modifier channels",
   const resolved = modifiers.resolveTraitModifiers({ unit: character, character, traits, skill, context: "combat" });
 
   expect(resolved.damage_taken_multiplier).toBe(5); // +5 means 50% reduction in CombatEngine's 10%-step channel.
-  expect(resolved.damage_dealt_multiplier).toBe(9); // Offensive Level 90 => +90% damage.
-  expect(resolved.final_power).toBe(3); // floor(90 / 30)
-  expect(resolved.crit_damage_multiplier).toBe(4.5); // floor(90 / 2)=45% => 4.5 x 10% steps.
+  expect(resolved.damage_dealt_multiplier).toBe(10); // Barbarian ClassLevel 100 => +100% damage.
+  expect(resolved.final_power).toBe(3); // floor(Barbarian ClassLevel 100 / 30)
+  expect(resolved.crit_damage_multiplier).toBe(5); // floor(Barbarian ClassLevel 100 / 2)=50% => 5 x 10% steps.
   expect(resolved.min_speed).toBe(1);
 });
 
@@ -137,7 +137,7 @@ test("universal snapshot preserves pre-combat Off/Def levels and layers trait mo
   });
 
   expect(snapshot.offensiveLevel).toBe(90);
-  expect(snapshot.defensiveLevel).toBe(64);
+  expect(snapshot.defensiveLevel).toBe(60);
   expect(snapshot.minSpeed).toBe(3);
   expect(snapshot.maxSpeed).toBe(6);
 });


### PR DESCRIPTION
## Draft — consulta de balance e implementación

Este PR queda **intencionalmente en Draft**. No está marcado Ready for Review.

### Qué corrige

- Corrige **Armorless Defense** para usar Barbarian `ClassLevel`:
  - Sin armadura, al inicio del Encounter: `Guard = ConstitutionMod + ClassLevel`.
  - Guard obtiene `+(ClassLevel / 2)% Shield` durante el Encounter.
  - Mantiene la eliminación de 1 Stagger Threshold.
- Elimina el viejo bonus de `ConstitutionMod` a `DefensiveLevel` de Armorless Defense.
- Hace que el estado de Guard se reinicie en cada Encounter para evitar stacking entre encuentros o valores residuales al llevar armadura.
- Conecta `guard.powerBonus` y `guard.shieldPercent` con el cálculo real de Guard/Shield de `CombatEngine`.
- Migra escalado viejo de Bárbaro a **Barbarian ClassLevel** donde estaba funcionando como progresión de clase:
  - Rage Damage: `ClassLevel` en lugar de `OffensiveLevel`.
  - Rage Wrath Final Power: `floor(ClassLevel / 30)`.
  - Brutal Critical: `floor(ClassLevel / 2)%`.
  - Unstoppable Rage: `floor(ClassLevel / 3)% HP`.
- Añade metadata `display` para que Armorless Defense, Brutal Critical y Unstoppable Rage muestren números resueltos y usen el tooltip de fórmula existente en Traits.

### Multiclass

Las regresiones cubren personajes con total Character Level 100 pero solo parte de sus niveles en Bárbaro, para comprobar que Wizard/u otra clase no infle los beneficios de Bárbaro.

### Arquetipos y Bardo

Se auditó **Path of the Devil Lineage**: sus runtimes ya resuelven nivel desde Barbarian Class Level, por lo que no se hizo un reemplazo innecesario.

También se verificó **Bard** y **College of Whispers**: ya usan `ClassLevel` correctamente y quedan fuera de este parche.

### Pruebas incluidas

- Armorless Defense no modifica Defensive Level.
- Armorless usa Barbarian ClassLevel aunque Character Level sea mayor.
- Guard Power y Shield bonus se aplican al resolver Guard.
- Encounter Start no acumula los bonus de Armorless.
- Llevar armadura limpia los bonus de Guard de Armorless al iniciar el Encounter.
- Rage, Brutal Critical y Unstoppable Rage ignoran niveles de otras clases para su escalado.
- Los valores visibles de Traits muestran `Class Level` en su breakdown.

### Estado

Draft para consulta. Las pruebas de regresión están añadidas; revisar los checks de CI antes de considerar cualquier cambio de estado.