### PR TITLE
Fix Armorless Defense and Shield durations

### DIFF
--- a/.github/workflows/milestone-trait-modifier-patch.yml
+++ b/.github/workflows/milestone-trait-modifier-patch.yml
@@ -8,8 +8,15 @@ on:
       - "js/trait-formula-view-patch.js"
       - "js/skill-trait-breakdown-patch.js"
       - "js/milestone-revert-patch.js"
+      - "js/barbarian-class-runtime.js"
+      - "js/shield-duration-runtime.js"
+      - "js/trait-catalog-core.js"
       - "tests/milestone_trait_modifier_patch.spec.js"
       - "tests/milestone_revert_race.spec.js"
+      - "tests/barbarian_classlevel_patch.spec.js"
+      - "tests/barbarian_trait_rules_runtime.spec.js"
+      - "tests/shield_duration_runtime.spec.js"
+      - "tests/trait_formula_sign_rendering.spec.js"
       - ".github/workflows/milestone-trait-modifier-patch.yml"
 
 permissions:
@@ -41,8 +48,15 @@ jobs:
           node --check js/trait-formula-view-patch.js
           node --check js/skill-trait-breakdown-patch.js
           node --check js/milestone-revert-patch.js
+          node --check js/barbarian-class-runtime.js
+          node --check js/shield-duration-runtime.js
+          node --check js/trait-catalog-core.js
           node --check tests/milestone_trait_modifier_patch.spec.js
           node --check tests/milestone_revert_race.spec.js
+          node --check tests/barbarian_classlevel_patch.spec.js
+          node --check tests/barbarian_trait_rules_runtime.spec.js
+          node --check tests/shield_duration_runtime.spec.js
+          node --check tests/trait_formula_sign_rendering.spec.js
 
       - name: Run focused regressions
         run: >-
@@ -56,6 +70,10 @@ jobs:
           tests/class_milestone_ui.spec.js
           tests/trait_engine.spec.js
           tests/trait_standardization_review_fixes.spec.js
+          tests/barbarian_classlevel_patch.spec.js
+          tests/barbarian_trait_rules_runtime.spec.js
+          tests/shield_duration_runtime.spec.js
+          tests/trait_formula_sign_rendering.spec.js
           --workers=1
 
       - name: Run full regression suite

--- a/js/barbarian-class-runtime.js
+++ b/js/barbarian-class-runtime.js
@@ -1,9 +1,11 @@
 (function (global) {
   "use strict";
 
-  if (global.LuminousBarbarianClassRuntime) return;
+  if (global.LuminousBarbarianClassRuntime) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousBarbarianClassRuntime;
+    return;
+  }
 
-  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
   const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[_\s-]+/g, "");
 
   function isGuardSkill(skill = {}) {
@@ -12,43 +14,12 @@
     return subtype === "guard" || subtype === "clashableguard";
   }
 
-  function guardState(unit = {}) {
-    return unit?.guard && typeof unit.guard === "object" ? unit.guard : {};
-  }
-
   function installCombatBridge(engine = global.CombatEngine) {
-    if (!engine || engine.__barbarianClassLevelGuardPatched) return Boolean(engine);
+    if (!engine) return false;
+    if (engine.__barbarianClassLevelGuardPatched) return true;
 
-    const originalCalculateFinalPower = engine.calculateFinalPower;
-    const originalResolveGuard = engine.resolveGuard;
-    if (typeof originalCalculateFinalPower !== "function" || typeof originalResolveGuard !== "function") return false;
-
-    engine.calculateFinalPower = function (skill, headsFlipped, unit = null) {
-      const result = originalCalculateFinalPower.call(this, skill, headsFlipped, unit);
-      if (!unit || !isGuardSkill(skill)) return result;
-      return result + numberOr(guardState(unit).powerBonus, 0);
-    };
-
-    engine.resolveGuard = function (unitDefender, guardSkill) {
-      const shieldBefore = numberOr(unitDefender?.shield, 0);
-      const result = originalResolveGuard.call(this, unitDefender, guardSkill);
-      if (!result || !unitDefender) return result;
-
-      const shieldPercent = Math.max(0, numberOr(guardState(unitDefender).shieldPercent, 0));
-      if (shieldPercent <= 0) return result;
-
-      const baseShieldGain = Math.max(0, numberOr(unitDefender.shield, shieldBefore) - shieldBefore);
-      const shieldBonus = baseShieldGain * shieldPercent / 100;
-      unitDefender.shield = numberOr(unitDefender.shield, shieldBefore) + shieldBonus;
-
-      return {
-        ...result,
-        shieldPercentBonus: shieldPercent,
-        shieldBonus,
-        newShieldAmount: unitDefender.shield,
-      };
-    };
-
+    // Armorless Defense no longer modifies Guard Power or Guard Shield.
+    // Keep this compatibility marker/API so older loaders and tests can call the bridge safely.
     Object.defineProperty(engine, "__barbarianClassLevelGuardPatched", {
       value: true,
       enumerable: false,

--- a/js/shield-duration-runtime.js
+++ b/js/shield-duration-runtime.js
@@ -1,0 +1,221 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousShieldDurationRuntime) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousShieldDurationRuntime;
+    return;
+  }
+
+  const SHIELD_TYPES = Object.freeze({
+    EPHEMERAL: "ephemeral",
+    ENCOUNTER: "encounter",
+    PERSISTENT: "persistent",
+  });
+  const CONSUMPTION_ORDER = Object.freeze([
+    SHIELD_TYPES.EPHEMERAL,
+    SHIELD_TYPES.ENCOUNTER,
+    SHIELD_TYPES.PERSISTENT,
+  ]);
+
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const normalizeType = (value, fallback = SHIELD_TYPES.PERSISTENT) => {
+    const type = String(value || "").trim().toLowerCase();
+    return Object.values(SHIELD_TYPES).includes(type) ? type : fallback;
+  };
+  const totalPools = (pools = {}) => CONSUMPTION_ORDER.reduce((sum, type) => sum + Math.max(0, numberOr(pools[type], 0)), 0);
+
+  function consumePoolsRaw(pools, amount) {
+    let remaining = Math.max(0, numberOr(amount, 0));
+    let consumed = 0;
+    CONSUMPTION_ORDER.forEach((type) => {
+      if (remaining <= 0) return;
+      const available = Math.max(0, numberOr(pools[type], 0));
+      const used = Math.min(available, remaining);
+      pools[type] = available - used;
+      remaining -= used;
+      consumed += used;
+    });
+    return { consumed, remaining };
+  }
+
+  function ensurePools(unit = {}) {
+    if (!unit || typeof unit !== "object") return { ephemeral: 0, encounter: 0, persistent: 0 };
+    const raw = unit.shieldPools && typeof unit.shieldPools === "object" ? unit.shieldPools : {};
+    const pools = {
+      ephemeral: Math.max(0, numberOr(raw.ephemeral, 0)),
+      encounter: Math.max(0, numberOr(raw.encounter, 0)),
+      persistent: Math.max(0, numberOr(raw.persistent, 0)),
+    };
+
+    const tracked = totalPools(pools);
+    const visible = Math.max(0, numberOr(unit.shield, tracked));
+    if (visible > tracked) {
+      // Backward compatibility: old or untyped Shield is the safest when preserved between encounters.
+      pools.persistent += visible - tracked;
+    } else if (visible < tracked) {
+      // If legacy code reduced the aggregate directly, mirror that reduction into the typed pools.
+      consumePoolsRaw(pools, tracked - visible);
+    }
+
+    unit.shieldPools = pools;
+    unit.shield = totalPools(pools);
+    return pools;
+  }
+
+  function syncShield(unit = {}) {
+    const pools = ensurePools(unit);
+    unit.shield = totalPools(pools);
+    return unit.shield;
+  }
+
+  function gainShield(unit = {}, amount = 0, type = SHIELD_TYPES.PERSISTENT) {
+    if (!unit || typeof unit !== "object") return 0;
+    const pools = ensurePools(unit);
+    const shieldType = normalizeType(type);
+    const gain = Math.max(0, numberOr(amount, 0));
+    pools[shieldType] += gain;
+    unit.shield = totalPools(pools);
+    return gain;
+  }
+
+  function consumeShield(unit = {}, amount = 0) {
+    if (!unit || typeof unit !== "object") return { consumed: 0, remaining: Math.max(0, numberOr(amount, 0)), shield: 0 };
+    const pools = ensurePools(unit);
+    const result = consumePoolsRaw(pools, amount);
+    unit.shield = totalPools(pools);
+    return { ...result, shield: unit.shield };
+  }
+
+  function expireShield(unit = {}, type) {
+    if (!unit || typeof unit !== "object") return 0;
+    const pools = ensurePools(unit);
+    const shieldType = normalizeType(type, null);
+    if (!shieldType) return unit.shield;
+    pools[shieldType] = 0;
+    unit.shield = totalPools(pools);
+    return unit.shield;
+  }
+
+  function shieldBreakdown(unit = {}) {
+    const pools = ensurePools(unit);
+    return Object.freeze({
+      ephemeral: pools.ephemeral,
+      encounter: pools.encounter,
+      persistent: pools.persistent,
+      total: unit.shield,
+    });
+  }
+
+  function installCombatBridge(engine = global.CombatEngine) {
+    if (!engine || typeof engine !== "object") return false;
+    if (engine.__shieldDurationRuntimePatched) return true;
+
+    const originalInitializeUnitData = engine.initializeUnitData;
+    const originalResolveGuard = engine.resolveGuard;
+    const originalApplyDamage = engine.applyDamage;
+    const originalTriggerPhase = engine.triggerPhase;
+    const originalTriggerEncounterStart = engine.triggerEncounterStart;
+
+    if (typeof originalInitializeUnitData === "function") {
+      engine.initializeUnitData = function (unit) {
+        const result = originalInitializeUnitData.call(this, unit);
+        ensurePools(unit);
+        return result;
+      };
+    }
+
+    if (typeof originalResolveGuard === "function") {
+      engine.resolveGuard = function (unitDefender, guardSkill) {
+        const pools = ensurePools(unitDefender);
+        const before = totalPools(pools);
+        const result = originalResolveGuard.call(this, unitDefender, guardSkill);
+        const afterLegacy = Math.max(0, numberOr(unitDefender?.shield, before));
+        const gained = Math.max(0, afterLegacy - before);
+        pools.ephemeral += gained;
+        unitDefender.shield = totalPools(pools);
+        return result && typeof result === "object"
+          ? { ...result, newShieldAmount: unitDefender.shield, shieldType: SHIELD_TYPES.EPHEMERAL }
+          : result;
+      };
+    }
+
+    if (typeof originalApplyDamage === "function") {
+      engine.applyDamage = function (unit, damage, tipoDaño, isCritical, skillUsed) {
+        const pools = ensurePools(unit);
+        const before = totalPools(pools);
+        const result = originalApplyDamage.call(this, unit, damage, tipoDaño, isCritical, skillUsed);
+        const afterLegacy = Math.max(0, numberOr(unit?.shield, before));
+        const absorbed = Math.max(0, before - afterLegacy);
+        if (absorbed > 0) consumePoolsRaw(pools, absorbed);
+        unit.shield = totalPools(pools);
+        return result && typeof result === "object" ? { ...result, shield: unit.shield } : result;
+      };
+    }
+
+    if (typeof originalTriggerPhase === "function") {
+      engine.triggerPhase = function (phaseTag, allUnits) {
+        if (Array.isArray(allUnits)) {
+          if (phaseTag === "[Round Start]") {
+            allUnits.forEach((unit) => expireShield(unit, SHIELD_TYPES.EPHEMERAL));
+          } else if (phaseTag === "[Encounter End]") {
+            allUnits.forEach((unit) => {
+              expireShield(unit, SHIELD_TYPES.EPHEMERAL);
+              expireShield(unit, SHIELD_TYPES.ENCOUNTER);
+            });
+          }
+        }
+        return originalTriggerPhase.call(this, phaseTag, allUnits);
+      };
+    }
+
+    if (typeof originalTriggerEncounterStart === "function") {
+      engine.triggerEncounterStart = function (allUnits) {
+        if (Array.isArray(allUnits)) {
+          allUnits.forEach((unit) => {
+            // Safety cleanup for a previous encounter that ended without an explicit Encounter End hook.
+            expireShield(unit, SHIELD_TYPES.EPHEMERAL);
+            expireShield(unit, SHIELD_TYPES.ENCOUNTER);
+          });
+        }
+        return originalTriggerEncounterStart.call(this, allUnits);
+      };
+    }
+
+    engine.gainShield = gainShield;
+    engine.consumeShield = consumeShield;
+    engine.expireShield = expireShield;
+    engine.shieldBreakdown = shieldBreakdown;
+
+    Object.defineProperty(engine, "__shieldDurationRuntimePatched", {
+      value: true,
+      enumerable: false,
+      configurable: true,
+    });
+    return true;
+  }
+
+  function boot() {
+    if (installCombatBridge()) return;
+    let attempts = 0;
+    const timer = global.setInterval?.(() => {
+      attempts += 1;
+      if (installCombatBridge() || attempts >= 40) global.clearInterval?.(timer);
+    }, 250);
+  }
+
+  const api = Object.freeze({
+    SHIELD_TYPES,
+    CONSUMPTION_ORDER,
+    ensurePools,
+    syncShield,
+    gainShield,
+    consumeShield,
+    expireShield,
+    shieldBreakdown,
+    installCombatBridge,
+  });
+
+  global.LuminousShieldDurationRuntime = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+  if (typeof document !== "undefined") boot();
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/trait-catalog-core.js
+++ b/js/trait-catalog-core.js
@@ -2,7 +2,7 @@
   "use strict";
 
   const engine = global.LuminousTraitEngine || (typeof require === "function" ? require("./trait-engine.js") : null);
-  const CATALOG_VERSION = 4;
+  const CATALOG_VERSION = 5;
 
   const RULE_TYPES = Object.freeze([
     "modifier",
@@ -51,55 +51,34 @@
       schemaVersion: 1,
       id: "armorless_defense",
       name: "Armorless Defense",
-      description: "Without Armor, at Encounter Start gain (CON Mod + Barbarian Class Level) Guard. Guard gains +(Barbarian Class Level / 2)% Shield for the encounter. Remove 1 Stagger Threshold.",
-      display: {
-        playerDescription: "Without Armor, at Encounter Start gain {guardBonus}. Guard gains {shieldBonus} Shield for the encounter. Remove 1 Stagger Threshold.",
-        resolvedValues: [
-          { id: "guardBonus", label: "Guard", formula: "ConstitutionMod + ClassLevel", suffix: " Guard" },
-          { id: "shieldBonus", label: "Guard Shield Bonus", formula: "ClassLevel / 2", unit: "percent", signed: true },
-        ],
-      },
+      description: "Without Armor:\nGain +(1, Constitution Mod) Defensive Level.\n\n[On Encounter Start] Without Armor:\nGain (Class Level)% Max HP as Shield for encounter\n\nRemove 1 Stagger Threshold.",
       source: classSource,
       contexts: ["combat"],
       activation: { type: "passive", actionCost: "none" },
-      effects: [],
+      mechanics: {
+        defensiveLevelFormula: "max(1, ConstitutionMod)",
+        encounterShieldPercentFormula: "ClassLevel",
+        encounterShieldAmountFormula: "MaxHP * ClassLevel / 100",
+        encounterShieldType: "encounter",
+      },
+      effects: [{
+        id: "armorless_defense_encounter_shield",
+        contexts: ["combat"],
+        trigger: "encounter_start",
+        conditions: [{ path: "equipment.armorEquipped", operator: "falsy" }],
+        operations: [
+          { type: "modify", path: "self.shieldPools.encounter", mode: "add", formula: "MaxHP * ClassLevel / 100" },
+          { type: "modify", path: "self.shield", mode: "add", formula: "MaxHP * ClassLevel / 100" },
+        ],
+      }],
       rules: [
         {
           type: "modifier",
-          trigger: "encounter_start",
+          trigger: "passive",
           target: "self",
-          path: "guard.powerBonus",
-          mode: "set",
-          value: 0,
-          duration: "encounter",
-        },
-        {
-          type: "modifier",
-          trigger: "encounter_start",
-          target: "self",
-          path: "guard.shieldPercent",
-          mode: "set",
-          value: 0,
-          duration: "encounter",
-        },
-        {
-          type: "modifier",
-          trigger: "encounter_start",
-          target: "self",
-          path: "guard.powerBonus",
-          mode: "set",
-          formula: "ConstitutionMod + ClassLevel",
-          duration: "encounter",
-          conditions: [{ path: "equipment.armorEquipped", operator: "falsy" }],
-        },
-        {
-          type: "modifier",
-          trigger: "encounter_start",
-          target: "self",
-          path: "guard.shieldPercent",
-          mode: "set",
-          formula: "ClassLevel / 2",
-          duration: "encounter",
+          channel: "defensive_level",
+          mode: "add",
+          formula: "max(1, ConstitutionMod)",
           conditions: [{ path: "equipment.armorEquipped", operator: "falsy" }],
         },
         {
@@ -592,6 +571,14 @@
     const script = document.createElement("script");
     script.id = "trait-standardization-runtime-script";
     script.src = "js/trait-standardization-runtime.js";
+    script.async = false;
+    document.head?.appendChild(script);
+  }
+
+  if (typeof document !== "undefined" && !global.LuminousShieldDurationRuntime && !document.getElementById("shield-duration-runtime-script")) {
+    const script = document.createElement("script");
+    script.id = "shield-duration-runtime-script";
+    script.src = "js/shield-duration-runtime.js";
     script.async = false;
     document.head?.appendChild(script);
   }

--- a/js/trait-formula-view-patch.js
+++ b/js/trait-formula-view-patch.js
@@ -126,30 +126,49 @@
     const aliases = canonical ? VARIABLE_ALIASES[canonical] : [identifier];
     return `(?:${aliases.map((alias) => escapeRegExp(alias).replace(/\\ /g, "\\s+")).join("|")})`;
   }
+  function tokenPattern(token) {
+    if (token === "*") return "(?:\\*|×|[xX])";
+    if (/^[A-Za-z_]/.test(token)) return FORMULA_FUNCTIONS.has(token.toLowerCase()) ? escapeRegExp(token) : aliasPattern(token);
+    return escapeRegExp(token);
+  }
+  function maxShorthandPattern(tokens) {
+    if (!tokens || tokens.length !== 6) return null;
+    if (String(tokens[0]).toLowerCase() !== "max" || tokens[1] !== "(" || tokens[3] !== "," || tokens[5] !== ")") return null;
+    return `\\(\\s*${tokenPattern(tokens[2])}\\s*,\\s*${tokenPattern(tokens[4])}\\s*\\)`;
+  }
   function formulaPattern(formula) {
     const tokens = tokenizeFormula(formula);
     if (!tokens) return null;
-    const body = tokens.map((token) => {
-      if (token === "*") return "(?:\\*|×|[xX])";
-      if (/^[A-Za-z_]/.test(token)) return FORMULA_FUNCTIONS.has(token.toLowerCase()) ? escapeRegExp(token) : aliasPattern(token);
-      return escapeRegExp(token);
-    }).join("\\s*");
-    return `(?:\\(\\s*${body}\\s*\\)|${body})`;
+    const body = tokens.map(tokenPattern).join("\\s*");
+    const exact = `(?:\\(\\s*${body}\\s*\\)|${body})`;
+    const shorthand = maxShorthandPattern(tokens);
+    return shorthand ? `(?:${exact}|${shorthand})` : exact;
   }
   function formulaRegex(formula) {
     const pattern = formulaPattern(formula);
     if (!pattern) return null;
-    try { return new RegExp(pattern, "gi"); } catch (_) { return null; }
+    try { return new RegExp(`(?:([+-])\\s*)?(${pattern})`, "gi"); } catch (_) { return null; }
+  }
+  function displayForSignedFormula(resolved, sign = "") {
+    const base = Number(resolved?.value);
+    if (!sign || !Number.isFinite(base)) return resolved?.display ?? "";
+    const value = sign === "-" ? -base : base;
+    const formatted = formatNumber(value);
+    if (sign === "+" && value >= 0) return `+${formatted}`;
+    if (sign === "-" && value === 0) return "-0";
+    return formatted;
   }
 
-  function createFormulaControl(trait, resolved) {
+  function createFormulaControl(trait, resolved, sign = "") {
     const control = doc.createElement("button");
+    const display = displayForSignedFormula(resolved, sign);
     control.type = "button";
     control.className = "player-trait-live-formula-value";
-    control.textContent = resolved.display;
+    control.textContent = display;
     control.dataset.traitFormula = resolved.formula;
+    if (sign) control.dataset.traitFormulaSign = sign;
     control.setAttribute("aria-expanded", "false");
-    control.setAttribute("aria-label", `${trait?.name || trait?.id || "Trait"}: resultado ${resolved.display}. Ver cálculo.`);
+    control.setAttribute("aria-label", `${trait?.name || trait?.id || "Trait"}: resultado ${display}. Ver cálculo.`);
     const tooltip = doc.createElement("span");
     tooltip.className = "player-trait-live-formula-tooltip";
     tooltip.setAttribute("role", "tooltip");
@@ -157,7 +176,7 @@
     const original = doc.createElement("code"); original.textContent = ensureParentheses(resolved.humanFormula); tooltip.appendChild(original);
     const substituted = doc.createElement("code"); substituted.textContent = ensureParentheses(resolved.substitutedFormula); tooltip.appendChild(substituted);
     resolved.breakdown.forEach((row) => { const line = doc.createElement("span"); line.className = "player-trait-live-formula-row"; line.textContent = `${row.label}: ${row.display}`; tooltip.appendChild(line); });
-    const total = doc.createElement("b"); total.className = "player-trait-live-formula-total"; total.textContent = `Resultado: ${resolved.display}`; tooltip.appendChild(total);
+    const total = doc.createElement("b"); total.className = "player-trait-live-formula-total"; total.textContent = `Resultado: ${display}`; tooltip.appendChild(total);
     control.appendChild(tooltip);
     const setOpen = (open) => { control.classList.toggle("is-open", Boolean(open)); control.setAttribute("aria-expanded", open ? "true" : "false"); };
     control.addEventListener("click", (event) => { event.stopPropagation(); setOpen(!control.classList.contains("is-open")); });
@@ -177,7 +196,7 @@
     let replaced = 0;
     nodes.forEach((textNode) => {
       if (!textNode.parentElement || textNode.parentElement.closest(".player-trait-resolved-value, .player-trait-live-formula-value, .player-trait-formula-tooltip, .player-trait-live-formula-tooltip")) return;
-      let segments = [{ text: textNode.nodeValue || "", resolved: null }];
+      let segments = [{ text: textNode.nodeValue || "", resolved: null, sign: "" }];
       formulas.forEach((entry) => {
         const next = [];
         segments.forEach((segment) => {
@@ -185,19 +204,19 @@
           entry.regex.lastIndex = 0; let cursor = 0; let match; let matched = false;
           while ((match = entry.regex.exec(segment.text))) {
             matched = true;
-            if (match.index > cursor) next.push({ text: segment.text.slice(cursor, match.index), resolved: null });
-            next.push({ text: "", resolved: entry.resolved });
+            if (match.index > cursor) next.push({ text: segment.text.slice(cursor, match.index), resolved: null, sign: "" });
+            next.push({ text: "", resolved: entry.resolved, sign: match[1] || "" });
             cursor = match.index + match[0].length;
             if (!match[0].length) entry.regex.lastIndex += 1;
           }
           if (!matched) next.push(segment);
-          else if (cursor < segment.text.length) next.push({ text: segment.text.slice(cursor), resolved: null });
+          else if (cursor < segment.text.length) next.push({ text: segment.text.slice(cursor), resolved: null, sign: "" });
         });
         segments = next;
       });
       if (!segments.some((segment) => segment.resolved)) return;
       const fragment = doc.createDocumentFragment();
-      segments.forEach((segment) => { if (segment.resolved) { fragment.appendChild(createFormulaControl(trait, segment.resolved)); replaced += 1; } else if (segment.text) fragment.appendChild(doc.createTextNode(segment.text)); });
+      segments.forEach((segment) => { if (segment.resolved) { fragment.appendChild(createFormulaControl(trait, segment.resolved, segment.sign)); replaced += 1; } else if (segment.text) fragment.appendChild(doc.createTextNode(segment.text)); });
       textNode.replaceWith(fragment);
     });
     return replaced;
@@ -206,7 +225,7 @@
   function ensureStyles() {
     if (!doc || doc.getElementById("trait-formula-view-patch-style")) return;
     const style = doc.createElement("style"); style.id = "trait-formula-view-patch-style";
-    style.textContent = `.player-trait-live-formula-value{position:relative;display:inline-flex;align-items:center;justify-content:center;min-width:1.6em;margin:0 .12em;padding:.02em .25em;border:0;background:transparent;color:#fff27a;font:inherit;font-weight:900;line-height:1;text-shadow:0 0 5px rgba(255,242,122,.95),0 0 12px rgba(255,215,80,.68);cursor:help;vertical-align:baseline}.player-trait-live-formula-value:hover,.player-trait-live-formula-value:focus,.player-trait-live-formula-value.is-open{outline:none;color:#fffbd0;text-shadow:0 0 7px #fff,0 0 16px rgba(255,220,80,.95)}.player-trait-live-formula-tooltip{position:absolute;z-index:220000;left:50%;bottom:calc(100% + 10px);transform:translateX(-50%);display:none;min-width:240px;max-width:360px;padding:10px 12px;border:1px solid rgba(255,235,130,.8);background:rgba(8,10,13,.97);box-shadow:0 8px 30px rgba(0,0,0,.55),0 0 16px rgba(255,220,80,.22);color:#f4f1dd;text-align:left;white-space:normal;font:600 12px/1.35 monospace}.player-trait-live-formula-value:hover .player-trait-live-formula-tooltip,.player-trait-live-formula-value:focus .player-trait-live-formula-tooltip,.player-trait-live-formula-value.is-open .player-trait-live-formula-tooltip{display:grid;gap:5px}.player-trait-live-formula-tooltip strong{color:#fff27a;letter-spacing:.04em}.player-trait-live-formula-tooltip code{display:block;padding:3px 5px;background:rgba(255,255,255,.05);color:#fff}.player-trait-live-formula-row{display:block;color:#d8d5c6}.player-trait-live-formula-total{display:block;margin-top:2px;padding-top:5px;border-top:1px solid rgba(255,255,255,.14);color:#fff27a}`;
+    style.textContent = `.player-trait-live-formula-value{position:relative;display:inline-flex;align-items:center;justify-content:center;min-width:0;margin:0;padding:.02em .08em;border:0;background:transparent;color:#fff27a;font:inherit;font-weight:900;line-height:1;text-shadow:0 0 5px rgba(255,242,122,.95),0 0 12px rgba(255,215,80,.68);cursor:help;vertical-align:baseline}.player-trait-live-formula-value:hover,.player-trait-live-formula-value:focus,.player-trait-live-formula-value.is-open{outline:none;color:#fffbd0;text-shadow:0 0 7px #fff,0 0 16px rgba(255,220,80,.95)}.player-trait-live-formula-tooltip{position:absolute;z-index:220000;left:50%;bottom:calc(100% + 10px);transform:translateX(-50%);display:none;min-width:240px;max-width:360px;padding:10px 12px;border:1px solid rgba(255,235,130,.8);background:rgba(8,10,13,.97);box-shadow:0 8px 30px rgba(0,0,0,.55),0 0 16px rgba(255,220,80,.22);color:#f4f1dd;text-align:left;white-space:normal;font:600 12px/1.35 monospace}.player-trait-live-formula-value:hover .player-trait-live-formula-tooltip,.player-trait-live-formula-value:focus .player-trait-live-formula-tooltip,.player-trait-live-formula-value.is-open .player-trait-live-formula-tooltip{display:grid;gap:5px}.player-trait-live-formula-tooltip strong{color:#fff27a;letter-spacing:.04em}.player-trait-live-formula-tooltip code{display:block;padding:3px 5px;background:rgba(255,255,255,.05);color:#fff}.player-trait-live-formula-row{display:block;color:#d8d5c6}.player-trait-live-formula-total{display:block;margin-top:2px;padding-top:5px;border-top:1px solid rgba(255,255,255,.14);color:#fff27a}`;
     doc.head?.appendChild(style);
   }
   function patchTraitTray() {
@@ -227,7 +246,7 @@
   function tick() { ensureStyles(); patchTraitTray(); }
   function boot() { tick(); global.setInterval?.(tick, 500); }
 
-  const api = Object.freeze({ VARIABLE_LABELS, formulaIdentifiers, tokenizeFormula, humanizeFormula, substituteFormula, collectTraitFormulas, resolveFormula, formulaPattern, decorateTraitFormulaDescription, patchTraitTray, tick });
+  const api = Object.freeze({ VARIABLE_LABELS, formulaIdentifiers, tokenizeFormula, humanizeFormula, substituteFormula, collectTraitFormulas, resolveFormula, formulaPattern, formulaRegex, displayForSignedFormula, decorateTraitFormulaDescription, patchTraitTray, tick });
   global.LuminousTraitFormulaViewPatch = api;
   if (typeof module !== "undefined" && module.exports) module.exports = api;
   if (doc) { if (doc.readyState === "loading") doc.addEventListener("DOMContentLoaded", boot, { once: true }); else boot(); }

--- a/tests/barbarian_classlevel_patch.spec.js
+++ b/tests/barbarian_classlevel_patch.spec.js
@@ -2,10 +2,13 @@ const { test, expect } = require("@playwright/test");
 const engine = require("../js/trait-engine.js");
 const catalog = require("../js/trait-catalog-core.js");
 const tray = require("../js/trait-player-tray.js");
+const modifiers = require("../js/universal-modifier-engine.js");
 const CombatEngine = require("../js/combatEngine.js");
 const barbarianRuntime = require("../js/barbarian-class-runtime.js");
+const shieldRuntime = require("../js/shield-duration-runtime.js");
 
 barbarianRuntime.installCombatBridge(CombatEngine);
+shieldRuntime.installCombatBridge(CombatEngine);
 
 function multiclassBarbarian(barbarianLevel, otherLevel = 0, constitution = 16) {
   return {
@@ -27,28 +30,38 @@ function multiclassBarbarian(barbarianLevel, otherLevel = 0, constitution = 16) 
       offensiveLevel: barbarianLevel + otherLevel,
       defensiveLevel: barbarianLevel + otherLevel,
     },
+    hp: 200,
+    maxHp: 200,
     sp: 0,
     shield: 0,
+    statusEffects: {},
   };
 }
 
-test("Armorless Defense display resolves Barbarian ClassLevel instead of Character Level", () => {
+test("Armorless Defense uses Barbarian ClassLevel for Shield and Constitution Mod for Defensive Level", () => {
   const trait = catalog.getDefinition("armorless_defense");
   const character = multiclassBarbarian(30, 70, 16);
-  const resolved = tray.resolveTraitDisplay(trait, { character });
+  const variables = engine.buildVariables(character, {}, trait);
+  const defensiveRule = trait.rules.find((rule) => rule.channel === "defensive_level");
 
-  expect(resolved.values.guardBonus.display).toBe("33 Guard");
-  expect(resolved.values.shieldBonus.display).toBe("+15%");
-  expect(resolved.values.guardBonus.breakdown).toEqual(expect.arrayContaining([
-    expect.objectContaining({ label: "CON Mod", display: "+3" }),
-    expect.objectContaining({ label: "Class Level", display: "30" }),
-  ]));
-  expect(resolved.values.shieldBonus.breakdown).toEqual(expect.arrayContaining([
-    expect.objectContaining({ label: "Class Level", display: "30" }),
-  ]));
+  expect(trait.description).toContain("Gain +(1, Constitution Mod) Defensive Level.");
+  expect(trait.description).toContain("Gain (Class Level)% Max HP as Shield for encounter");
+  expect(variables.ClassLevel).toBe(30);
+  expect(engine.evaluateFormula(defensiveRule.formula, variables)).toBe(3);
+  expect(engine.evaluateFormula(trait.mechanics.encounterShieldPercentFormula, variables)).toBe(30);
+  expect(engine.evaluateFormula(trait.mechanics.encounterShieldAmountFormula, variables)).toBe(60);
+  expect(tray.resolveTraitDisplay(trait, { character })).toBeNull();
+
+  const snapshot = modifiers.resolveCharacterSnapshot({
+    unit: character,
+    character,
+    traits: [trait],
+    context: "combat",
+  });
+  expect(snapshot.defensiveLevel).toBe(103);
 });
 
-test("Armorless encounter state increases Guard Power and Guard Shield without using other class levels", () => {
+test("Armorless Encounter Shield is separate from normal Guard Ephemeral Shield", () => {
   const trait = catalog.getDefinition("armorless_defense");
   const character = multiclassBarbarian(30, 70, 16);
   const state = engine.createState();
@@ -61,7 +74,13 @@ test("Armorless encounter state increases Guard Power and Guard Shield without u
     equipment: { armorEquipped: false },
   });
 
-  expect(character.guard).toMatchObject({ powerBonus: 33, shieldPercent: 15 });
+  expect(character.shield).toBe(60);
+  expect(shieldRuntime.shieldBreakdown(character)).toEqual({
+    ephemeral: 0,
+    encounter: 60,
+    persistent: 0,
+    total: 60,
+  });
 
   const guardSkill = {
     type: "Guard",
@@ -74,12 +93,22 @@ test("Armorless encounter state increases Guard Power and Guard Shield without u
   };
   const result = CombatEngine.resolveGuard(character, guardSkill);
 
-  // Native Guard uses CON Mod (+3) as base. Armorless adds 33 Guard, for 36 total.
-  expect(result.guardPower).toBe(36);
-  expect(result.shieldPercentBonus).toBe(15);
-  expect(result.shieldBonus).toBeCloseTo(5.4, 6);
-  expect(result.newShieldAmount).toBeCloseTo(41.4, 6);
-  expect(character.shield).toBeCloseTo(41.4, 6);
+  expect(result.guardPower).toBe(3);
+  expect(result.shieldType).toBe("ephemeral");
+  expect(result.newShieldAmount).toBe(63);
+  expect(shieldRuntime.shieldBreakdown(character)).toEqual({
+    ephemeral: 3,
+    encounter: 60,
+    persistent: 0,
+    total: 63,
+  });
+
+  CombatEngine.triggerPhase("[Round Start]", [character]);
+  expect(character.shield).toBe(60);
+  expect(shieldRuntime.shieldBreakdown(character).encounter).toBe(60);
+
+  CombatEngine.triggerPhase("[Encounter End]", [character]);
+  expect(character.shield).toBe(0);
 });
 
 test("Brutal Critical and Unstoppable Rage previews stay tied to Barbarian ClassLevel", () => {

--- a/tests/barbarian_trait_rules_runtime.spec.js
+++ b/tests/barbarian_trait_rules_runtime.spec.js
@@ -25,26 +25,20 @@ function barbarian(level = 100) {
   };
 }
 
-test("Armorless Defense snapshots Guard from Barbarian Class Level and no longer modifies Defensive Level", () => {
+test("Armorless Defense grants CON-based Defensive Level and Class Level percent Max HP Encounter Shield", () => {
   const character = barbarian(30);
   character.level = 100;
   character.classes = [
     { classId: "barbarian", levels: 30 },
     { classId: "wizard", levels: 70 },
   ];
+  character.maxHp = 200;
+  character.shield = 0;
   character.staggerThresholds = [70, 40];
   const trait = catalog.getDefinition("armorless_defense");
   const state = engine.createState();
 
-  engine.dispatchCombatEvent("encounter_start", {
-    character,
-    self: character,
-    traits: [trait],
-    state,
-    equipment: { armorEquipped: false },
-  });
-
-  expect(character.guard).toMatchObject({ powerBonus: 34, shieldPercent: 15 });
+  expect(trait.description).toBe("Without Armor:\nGain +(1, Constitution Mod) Defensive Level.\n\n[On Encounter Start] Without Armor:\nGain (Class Level)% Max HP as Shield for encounter\n\nRemove 1 Stagger Threshold.");
 
   const firstSnapshot = modifiers.resolveCharacterSnapshot({
     unit: character,
@@ -58,8 +52,8 @@ test("Armorless Defense snapshots Guard from Barbarian Class Level and no longer
     traits: [trait],
     context: "combat",
   });
-  expect(firstSnapshot.defensiveLevel).toBe(60);
-  expect(secondSnapshot.defensiveLevel).toBe(60);
+  expect(firstSnapshot.defensiveLevel).toBe(64);
+  expect(secondSnapshot.defensiveLevel).toBe(64);
   expect(character.combatStats.defensiveLevel).toBe(60);
 
   engine.dispatchCombatEvent("encounter_start", {
@@ -69,7 +63,9 @@ test("Armorless Defense snapshots Guard from Barbarian Class Level and no longer
     state,
     equipment: { armorEquipped: false },
   });
-  expect(character.guard).toMatchObject({ powerBonus: 34, shieldPercent: 15 });
+  expect(character.shield).toBe(60);
+  expect(character.shieldPools).toMatchObject({ encounter: 60 });
+  expect(character.guard).toBeUndefined();
 
   engine.dispatchTrait(trait, "passive", {
     context: "combat",
@@ -86,15 +82,29 @@ test("Armorless Defense snapshots Guard from Barbarian Class Level and no longer
     equipment: { armorEquipped: false },
   }, state);
   expect(character.staggerThresholds).toEqual([70]);
+
+  const armored = {
+    ...character,
+    shield: 0,
+    shieldPools: undefined,
+    equipment: { armor: { itemId: "armor_test", category: "medium" } },
+  };
+  const armoredSnapshot = modifiers.resolveCharacterSnapshot({
+    unit: armored,
+    character: armored,
+    traits: [trait],
+    context: "combat",
+  });
+  expect(armoredSnapshot.defensiveLevel).toBe(60);
 
   engine.dispatchCombatEvent("encounter_start", {
-    character,
-    self: character,
+    character: armored,
+    self: armored,
     traits: [trait],
-    state,
+    state: engine.createState(),
     equipment: { armorEquipped: true },
   });
-  expect(character.guard).toMatchObject({ powerBonus: 0, shieldPercent: 0 });
+  expect(armored.shield).toBe(0);
 });
 
 test("Barbarian class scaling ignores total Character Level and Offensive Level", () => {

--- a/tests/shield_duration_runtime.spec.js
+++ b/tests/shield_duration_runtime.spec.js
@@ -1,0 +1,97 @@
+const { test, expect } = require("@playwright/test");
+const CombatEngine = require("../js/combatEngine.js");
+const shieldRuntime = require("../js/shield-duration-runtime.js");
+
+shieldRuntime.installCombatBridge(CombatEngine);
+
+function unit(overrides = {}) {
+  return {
+    id: "shield_duration_test",
+    hp: 100,
+    maxHp: 100,
+    sp: 0,
+    shield: 0,
+    stats: { constitucion: 14 },
+    statusEffects: {},
+    ...overrides,
+  };
+}
+
+test("Guard Shield is Ephemeral and is lost at the next Round Start", () => {
+  const character = unit();
+  const guardSkill = {
+    type: "Guard",
+    isDefense: true,
+    defenseSubtype: "Guard",
+    basePower: 0,
+    coinPower: 0,
+    coinAmount: 0,
+    coins: [],
+  };
+
+  const result = CombatEngine.resolveGuard(character, guardSkill);
+  expect(result.guardPower).toBe(2);
+  expect(result.shieldType).toBe("ephemeral");
+  expect(shieldRuntime.shieldBreakdown(character)).toEqual({
+    ephemeral: 2,
+    encounter: 0,
+    persistent: 0,
+    total: 2,
+  });
+
+  CombatEngine.triggerPhase("[Round Start]", [character]);
+  expect(character.shield).toBe(0);
+});
+
+test("Encounter Shield survives rounds and is lost at Encounter End", () => {
+  const character = unit();
+  shieldRuntime.gainShield(character, 25, "encounter");
+
+  CombatEngine.triggerPhase("[Round Start]", [character]);
+  expect(character.shield).toBe(25);
+  expect(shieldRuntime.shieldBreakdown(character).encounter).toBe(25);
+
+  CombatEngine.triggerPhase("[Encounter End]", [character]);
+  expect(character.shield).toBe(0);
+  expect(shieldRuntime.shieldBreakdown(character).encounter).toBe(0);
+});
+
+test("Persistent Shield survives Round Start and Encounter End until consumed", () => {
+  const character = unit();
+  shieldRuntime.gainShield(character, 30, "persistent");
+
+  CombatEngine.triggerPhase("[Round Start]", [character]);
+  CombatEngine.triggerPhase("[Encounter End]", [character]);
+  expect(character.shield).toBe(30);
+  expect(shieldRuntime.shieldBreakdown(character).persistent).toBe(30);
+});
+
+test("Shield damage consumption uses Ephemeral then Encounter then Persistent", () => {
+  const character = unit();
+  shieldRuntime.gainShield(character, 5, "ephemeral");
+  shieldRuntime.gainShield(character, 7, "encounter");
+  shieldRuntime.gainShield(character, 11, "persistent");
+
+  const result = CombatEngine.applyDamage(character, 9, "directo", false, null);
+  expect(result.hp).toBe(100);
+  expect(result.shield).toBe(14);
+  expect(shieldRuntime.shieldBreakdown(character)).toEqual({
+    ephemeral: 0,
+    encounter: 3,
+    persistent: 11,
+    total: 14,
+  });
+});
+
+test("legacy untyped Shield is preserved as Persistent Shield", () => {
+  const character = unit({ shield: 12 });
+  expect(shieldRuntime.shieldBreakdown(character)).toEqual({
+    ephemeral: 0,
+    encounter: 0,
+    persistent: 12,
+    total: 12,
+  });
+
+  CombatEngine.triggerPhase("[Encounter End]", [character]);
+  expect(character.shield).toBe(12);
+});

--- a/tests/trait_catalog_core.spec.js
+++ b/tests/trait_catalog_core.spec.js
@@ -35,7 +35,7 @@ test("core Trait catalog validates every declarative definition and rule contrac
   const validation = catalog.validateAll(engine);
   expect(validation.valid).toBe(true);
   expect(validation.errors).toEqual([]);
-  expect(catalog.CATALOG_VERSION).toBe(4);
+  expect(catalog.CATALOG_VERSION).toBe(5);
   expect(Object.keys(catalog.DEFINITIONS).sort()).toEqual([
     "additional_attack",
     "armorless_defense",

--- a/tests/trait_formula_sign_rendering.spec.js
+++ b/tests/trait_formula_sign_rendering.spec.js
@@ -1,0 +1,41 @@
+const { test, expect } = require("@playwright/test");
+const engine = require("../js/trait-engine.js");
+const catalog = require("../js/trait-catalog-core.js");
+const formulaView = require("../js/trait-formula-view-patch.js");
+
+test("max formula shorthand matches the authored (1, Constitution Mod) text", () => {
+  const pattern = formulaView.formulaPattern("max(1, ConstitutionMod)");
+  const regex = new RegExp(pattern, "i");
+  expect(regex.test("(1, Constitution Mod)")).toBe(true);
+  expect(regex.test("max(1, ConstitutionMod)")).toBe(true);
+});
+
+test("formula regex absorbs an authored plus or minus sign", () => {
+  const plus = formulaView.formulaRegex("max(1, ConstitutionMod)").exec("Gain +(1, Constitution Mod) Defensive Level.");
+  const minus = formulaView.formulaRegex("ConstitutionMod").exec("Gain -(Constitution Mod) Defensive Level.");
+
+  expect(plus[1]).toBe("+");
+  expect(plus[0]).toBe("+(1, Constitution Mod)");
+  expect(minus[1]).toBe("-");
+  expect(minus[0]).toBe("-(Constitution Mod)");
+});
+
+test("signed dynamic formula display keeps the sign attached to the number", () => {
+  expect(formulaView.displayForSignedFormula({ value: 3, display: "3" }, "+")).toBe("+3");
+  expect(formulaView.displayForSignedFormula({ value: 3, display: "3" }, "-")).toBe("-3");
+});
+
+test("Armorless Defense resolves its authored minimum shorthand without changing source text", () => {
+  const trait = catalog.getDefinition("armorless_defense");
+  const character = {
+    level: 30,
+    classes: [{ classId: "barbarian", levels: 30 }],
+    stats: { constitucion: 10 },
+    maxHp: 200,
+  };
+  const resolved = formulaView.resolveFormula(engine, trait, trait.mechanics.defensiveLevelFormula, { character });
+
+  expect(trait.description).toContain("+(1, Constitution Mod) Defensive Level");
+  expect(resolved.value).toBe(1);
+  expect(formulaView.displayForSignedFormula(resolved, "+")).toBe("+1");
+});

--- a/tests/universal_modifier_engine.spec.js
+++ b/tests/universal_modifier_engine.spec.js
@@ -44,7 +44,7 @@ test("equipment contract recognizes legacy armorType and future equipment armor 
   expect(modifiers.resolveEquipment({})).toMatchObject({ armorEquipped: false, armorCategory: "none" });
 });
 
-test("Armorless Defense no longer modifies the universal defensive level", () => {
+test("Armorless Defense adds Constitution Mod to universal Defensive Level only while unarmored", () => {
   const trait = catalog.getDefinition("armorless_defense");
   const unarmored = barbarian(100);
   const armored = { ...barbarian(100), armorType: "medium" };
@@ -62,7 +62,7 @@ test("Armorless Defense no longer modifies the universal defensive level", () =>
     context: "combat",
   });
 
-  expect(freeMods.defensive_level).toBe(0);
+  expect(freeMods.defensive_level).toBe(4);
   expect(armoredMods.defensive_level).toBe(0);
 });
 
@@ -127,7 +127,7 @@ test("Rage, Brutal Critical and Fast Movement feed canonical modifier channels",
   expect(resolved.min_speed).toBe(1);
 });
 
-test("universal snapshot preserves pre-combat Off/Def levels and layers trait modifiers on top", () => {
+test("universal snapshot preserves pre-combat Off/Def levels and layers Armorless/Fast Movement modifiers on top", () => {
   const character = barbarian(100);
   const snapshot = modifiers.resolveCharacterSnapshot({
     unit: character,
@@ -137,7 +137,7 @@ test("universal snapshot preserves pre-combat Off/Def levels and layers trait mo
   });
 
   expect(snapshot.offensiveLevel).toBe(90);
-  expect(snapshot.defensiveLevel).toBe(60);
+  expect(snapshot.defensiveLevel).toBe(64);
   expect(snapshot.minSpeed).toBe(3);
   expect(snapshot.maxSpeed).toBe(6);
 });


### PR DESCRIPTION
## Summary

This patch corrects Armorless Defense to the current design contract and introduces Shield duration semantics without changing the visible Shield name.

- Armorless Defense now grants `+(1, Constitution Mod)` Defensive Level while unarmored.
- At Encounter Start while unarmored, it grants `(Class Level)% Max HP` as Encounter Shield.
- The old Guard Power / ClassLevel÷2 Shield behavior is removed.
- Trait formula rendering treats adjacent `+` / `-` as part of the bright dynamic value and recognizes the `(1, Ability Mod)` design notation while preserving stored Trait wording.
- Shield now supports Ephemeral, Encounter, and Persistent duration buckets behind one visible `Shield` total.
- Guard-generated Shield is Ephemeral and expires at the next Round Start.
- Encounter Shield expires at encounter end; Persistent Shield survives encounters until consumed.
- Legacy untyped Shield is preserved as Persistent for compatibility.
- Shield damage consumption prioritizes Ephemeral → Encounter → Persistent.
- Demonic Resistance is intentionally unchanged.

## Tests

The patch workflow performs syntax checks, focused regressions for Armorless Defense, Barbarian runtime, Shield duration/consumption and signed formula rendering, then runs the full Playwright regression suite with one worker.