### PR TITLE
Spellcasting Basic Rules v1

### DIFF
--- a/.github/workflows/spellcasting-basic-rules.yml
+++ b/.github/workflows/spellcasting-basic-rules.yml
@@ -1,0 +1,45 @@
+name: Spellcasting Basic Rules
+
+on:
+  pull_request:
+    paths:
+      - "js/spellcasting-runtime.js"
+      - "js/spellcasting-basic-rules-runtime.js"
+      - "js/scene-time-engine.js"
+      - "tests/spellcasting_runtime.spec.js"
+      - "docs/spellcasting-basic-rules.md"
+      - ".github/workflows/spellcasting-basic-rules.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  spellcasting:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Syntax checks
+        run: |
+          node --check js/spellcasting-runtime.js
+          node --check js/spellcasting-basic-rules-runtime.js
+          node --check js/scene-time-engine.js
+          node --check tests/spellcasting_runtime.spec.js
+      - name: Focused Spellcasting regressions
+        run: npx playwright test tests/spellcasting_runtime.spec.js --workers=1
+      - name: Related integration regressions
+        run: >-
+          npx playwright test
+          tests/fixed_damage_runtime.test.js
+          tests/rest_engine.spec.js
+          tests/rest_runtime_contract.spec.js
+          tests/scene_time_engine.spec.js
+          tests/bard_class_runtime.spec.js
+          --workers=1

--- a/docs/spellcasting-basic-rules.md
+++ b/docs/spellcasting-basic-rules.md
@@ -1,0 +1,98 @@
+# Spellcasting Basic Rules v1
+
+## Scope
+
+`js/spellcasting-runtime.js` remains the shared Spell Mod / Spell DC bridge. `js/spellcasting-basic-rules-runtime.js` extends it with the reusable resource and resolution contract without replacing the Trait, Combat, Fixed Damage, Rest, Action Economy, or Scene Time engines.
+
+This version intentionally does **not** invent a universal Spell Power formula. Spells may define their own Skill/Coin power, while the runtime owns the shared resources and resolution metadata below.
+
+## Spellcasting Ability and DC
+
+A Class registers one default Spellcasting Ability. Bard remains Charisma. A saved Class entry may explicitly override its Spellcasting Ability when a Class or feature requires it.
+
+- `SpellMod = Class Spellcasting Ability modifier`
+- `SpellDC = 8 + SpellMod + Proficiency`
+- Archetype Traits inherit their parent `classId` and therefore the parent Class Spellcasting Ability.
+
+## Spell Slots
+
+Slots are tracked **per Class and Slot Level** in `character.spellcastingState.slotsByClass`. The runtime does not assume a multiclass slot-merging policy. Each Class supplies its own slot table.
+
+- Cantrips (`slotLevel: 0`) spend no Slot.
+- A leveled Spell normally spends one Slot of the level used to cast it.
+- Casting with a higher Slot Level is Upcast.
+- Long Rest restores spent Spell Slots.
+
+## Overcast
+
+If the required Slot is unavailable, callers may explicitly permit Overcast.
+
+`Overcast SP Cost = Slot Level × 15 SP`
+
+SP is paid first. Any unpaid remainder becomes the same canonical **Fixed Damage** already owned by `LuminousFixedDamageRuntime`.
+
+Example: a Level 3 Spell costs 45 SP. At 20 SP, the caster goes to 0 SP and receives 25 Fixed Damage.
+
+Fixed Damage keeps its existing contract: defensive reductions cannot lower it, but Shield still absorbs it before HP.
+
+## Upcast
+
+Upcast scaling is metadata-driven and exposes four independent per-extra-level channels:
+
+- `finalPower`
+- `coinPower`
+- `atkWeight`
+- `duration`
+
+A Spell may use any subset. Missing channels are zero. The runtime returns resolved deltas and does not force every Spell to scale in every channel.
+
+## Saving Throws
+
+A Spell Save declares:
+
+- Save Ability (`str`, `dex`, `con`, `int`, `wis`, `cha`)
+- success behavior: `negates`, `half`, `reduced`, or `special`
+
+The DC always comes from the source Class Spellcasting contract. The runtime returns Save metadata; the existing Check/Save execution layer remains responsible for the actual roll and downstream effects.
+
+## Target Type
+
+The shared target categories are:
+
+`self`, `single`, `multi`, `area`, `allies`, `enemies`, `special`.
+
+Unknown/custom target descriptions normalize to `special` rather than creating engine-specific exceptions.
+
+## Casting Time and Scene Time
+
+Casting Time uses the existing Scene Time clock rather than a new timer.
+
+- normal Action cast: 6 seconds
+- Quick/Bonus Action cast: 3 seconds
+- explicit `castingTimeRounds`: rounds × 6 seconds
+- explicit `castingTimeSeconds`: exact declared seconds
+- instant/free casts create no blocking Scene Time Action Instance
+
+`buildCastingActionMessage()` produces the same `actuar` Action Instance contract used by Scene Time. During Combat, completed rounds already advance that same clock by 6 seconds, so long casts continue across rounds without double-counting time.
+
+## Concentration
+
+Only one active Concentration Spell is stored per caster. Starting another Concentration Spell replaces the previous one.
+
+When the caster takes damage from one Skill:
+
+1. collect the damaging Final Power values produced by that Skill;
+2. use the **highest Final Power** as the Constitution Check DC;
+3. create only one Concentration Check for that Skill event, even if the Skill has multiple damaging Coins/hits;
+4. success preserves Concentration;
+5. failure ends the active Concentration Spell.
+
+The runtime de-duplicates checks by `skillEventId` / event id so repeated combat bookkeeping cannot request multiple Concentration checks for the same Skill.
+
+## Integration boundaries
+
+- Trait Engine: continues to receive `SpellMod` and `SpellDC` through the existing wrapper; the V1 extension may override the Class Ability from saved Class data.
+- Fixed Damage: owns Overcast overflow damage application.
+- Scene Time: owns elapsed time and Action Instance progression.
+- Rest Runtime: emits `luminous:rest-completed`; Spellcasting listens for Long Rest, restores Slots, and persists `spellcastingState` when Firebase/player identity is available.
+- Combat/Save UI: consumes the returned casting, Save, Upcast, target, and Concentration contracts. This module does not replace Coin Engine or Check execution.

--- a/js/scene-time-engine.js
+++ b/js/scene-time-engine.js
@@ -16,6 +16,12 @@
     document.head?.appendChild(script);
   }
   const runtime = () => load('scene-time-v1-runtime', 'js/scene-time-runtime.js');
+  const spellcasting = () => {
+    const basic = () => load('luminous-spellcasting-basic-rules', 'js/spellcasting-basic-rules-runtime.js');
+    if (global.LuminousSpellcastingRuntime) basic();
+    else load('luminous-spellcasting-runtime', 'js/spellcasting-runtime.js', basic);
+  };
+  spellcasting();
   if (global.LuminousSceneTimeCore) runtime();
   else load('scene-time-v1-core', 'js/scene-time-core.js', runtime);
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/js/spellcasting-basic-rules-runtime.js
+++ b/js/spellcasting-basic-rules-runtime.js
@@ -1,0 +1,368 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousSpellcastingRuntime?.__basicRulesV1) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousSpellcastingRuntime;
+    return;
+  }
+
+  const base = global.LuminousSpellcastingRuntime || (typeof require === "function" ? require("./spellcasting-runtime.js") : null);
+  if (!base) return;
+
+  const SCHEMA_VERSION = 1;
+  const STATE_KEY = "spellcastingState";
+  const OVERCAST_SP_PER_SLOT_LEVEL = 15;
+  const VALID_TARGET_TYPES = Object.freeze(["self", "single", "multi", "area", "allies", "enemies", "special"]);
+  const ABILITY_ALIASES = Object.freeze({
+    str: ["str", "strength", "fuerza"], dex: ["dex", "dexterity", "destreza"],
+    con: ["con", "constitution", "constitucion"], int: ["int", "intelligence", "inteligencia"],
+    wis: ["wis", "wisdom", "sabiduria"], cha: ["cha", "charisma", "carisma"],
+  });
+  const ABILITY_VARIABLES = base.ABILITY_VARIABLES || Object.freeze({
+    str: "StrengthMod", dex: "DexterityMod", con: "ConstitutionMod",
+    int: "IntelligenceMod", wis: "WisdomMod", cha: "CharismaMod",
+  });
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const intOr = (value, fallback = 0) => Number.isFinite(Number.parseInt(value, 10)) ? Number.parseInt(value, 10) : fallback;
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  let restListenerBound = false;
+
+  function normalizeAbility(value) {
+    const raw = normalizeId(value);
+    for (const [abilityId, aliases] of Object.entries(ABILITY_ALIASES)) {
+      if (aliases.includes(raw)) return abilityId;
+    }
+    return null;
+  }
+
+  function classEntries(character = {}) {
+    const build = character?.characterBuild && typeof character.characterBuild === "object" ? character.characterBuild : {};
+    return (Array.isArray(character.classes) ? character.classes : (Array.isArray(build.classes) ? build.classes : []))
+      .filter((entry) => entry && typeof entry === "object");
+  }
+
+  function classEntry(character, classId) {
+    const id = normalizeId(classId);
+    return classEntries(character).find((entry) => normalizeId(entry.classId || entry.id) === id) || null;
+  }
+
+  function classSpellcastingAbility(character = {}, classId) {
+    const entry = classEntry(character, classId);
+    return normalizeAbility(
+      entry?.spellcastingAbility ?? entry?.spellcasting_ability ?? entry?.spellcasting?.abilityId
+      ?? entry?.spellcasting?.ability ?? entry?.spellcasting?.stat,
+    ) || base.getClassSpellcastingAbility(classId);
+  }
+
+  function statModifier(character = {}, abilityId) {
+    const ability = normalizeAbility(abilityId);
+    if (!ability) return 0;
+    const stats = character.stats || character.dndStats || {};
+    const score = ABILITY_ALIASES[ability].map((alias) => stats?.[alias] ?? character?.[alias])
+      .find((value) => Number.isFinite(Number(value)));
+    return Math.floor((numberOr(score, 10) - 10) / 2);
+  }
+
+  function resolveSpellcasting(character = {}, classId, runtime = {}, variables = {}) {
+    const normalizedClassId = normalizeId(classId);
+    const abilityId = classSpellcastingAbility(character, normalizedClassId);
+    if (!abilityId) return null;
+    const variableName = ABILITY_VARIABLES[abilityId];
+    const spellMod = Number.isFinite(Number(variables?.[variableName]))
+      ? Number(variables[variableName])
+      : (Number.isFinite(Number(runtime?.[variableName])) ? Number(runtime[variableName]) : statModifier(character, abilityId));
+    const baseResolved = base.resolveSpellcasting(character, normalizedClassId, runtime, variables);
+    const proficiency = numberOr(variables?.Proficiency ?? runtime?.Proficiency ?? character.proficiency ?? baseResolved?.proficiency, 0);
+    return { classId: normalizedClassId, abilityId, spellMod, proficiency, spellDC: 8 + spellMod + proficiency };
+  }
+
+  function resolveForTrait(character = {}, trait = {}, runtime = {}, variables = {}) {
+    return resolveSpellcasting(character, base.classIdForTrait(trait, runtime), runtime, variables);
+  }
+
+  function normalizeSlotTable(source = {}) {
+    const table = {};
+    Object.entries(source && typeof source === "object" ? source : {}).forEach(([rawLevel, rawValue]) => {
+      const parsed = intOr(String(rawLevel).replace(/[^0-9-]/g, ""), 0);
+      if (parsed <= 0) return;
+      const maximum = Math.max(0, intOr(rawValue?.maximum ?? rawValue?.max ?? rawValue?.total ?? rawValue, 0));
+      if (maximum > 0) table[parsed] = maximum;
+    });
+    return table;
+  }
+
+  function slotTableForClass(character = {}, classId, explicit = null) {
+    if (explicit && typeof explicit === "object") return normalizeSlotTable(explicit);
+    const id = normalizeId(classId), entry = classEntry(character, id);
+    const candidates = [entry?.spellSlots, entry?.spell_slots, entry?.spellcasting?.slots,
+      character?.spellSlotsByClass?.[id], character?.spellSlots?.[id], character?.characterBuild?.spellSlotsByClass?.[id]];
+    return normalizeSlotTable(candidates.find((value) => value && typeof value === "object" && Object.keys(value).length) || {});
+  }
+
+  function ensureSpellcastingState(character) {
+    if (!character || typeof character !== "object") throw new Error("Spellcasting Runtime requires a character object.");
+    if (!character[STATE_KEY] || typeof character[STATE_KEY] !== "object" || Array.isArray(character[STATE_KEY])) character[STATE_KEY] = {};
+    const state = character[STATE_KEY];
+    state.schemaVersion = SCHEMA_VERSION;
+    if (!state.slotsByClass || typeof state.slotsByClass !== "object" || Array.isArray(state.slotsByClass)) state.slotsByClass = {};
+    if (!state.concentration || typeof state.concentration !== "object" || Array.isArray(state.concentration)) state.concentration = {};
+    if (!state.concentrationChecks || typeof state.concentrationChecks !== "object" || Array.isArray(state.concentrationChecks)) state.concentrationChecks = {};
+    return state;
+  }
+
+  function reconcileSlotPool(character, classId, explicitTable = null) {
+    const state = ensureSpellcastingState(character), id = normalizeId(classId), maxima = slotTableForClass(character, id, explicitTable);
+    if (!id) throw new Error("Spell Slot pool requires classId.");
+    if (!state.slotsByClass[id]?.levels) state.slotsByClass[id] = { levels: {} };
+    const levels = state.slotsByClass[id].levels;
+    Object.entries(maxima).forEach(([level, maximum]) => {
+      const current = levels[level] || { spent: 0 };
+      levels[level] = { maximum, spent: Math.max(0, Math.min(maximum, intOr(current.spent, 0))) };
+    });
+    Object.keys(levels).forEach((level) => { if (!Object.prototype.hasOwnProperty.call(maxima, level)) delete levels[level]; });
+    return state.slotsByClass[id];
+  }
+
+  function spellSlotPool(character, classId, explicitTable = null) {
+    const id = normalizeId(classId), pool = reconcileSlotPool(character, id, explicitTable), levels = {};
+    Object.entries(pool.levels).forEach(([level, entry]) => {
+      const maximum = Math.max(0, intOr(entry.maximum, 0)), spent = Math.max(0, Math.min(maximum, intOr(entry.spent, 0)));
+      levels[level] = { level: Number(level), maximum, spent, available: maximum - spent };
+    });
+    return { classId: id, levels };
+  }
+
+  function canSpendSpellSlot(character, classId, slotLevel, explicitTable = null) {
+    const level = Math.max(0, intOr(slotLevel, 0));
+    if (level === 0) return { available: true, cantrip: true, classId: normalizeId(classId), slotLevel: 0 };
+    const pool = spellSlotPool(character, classId, explicitTable), levelPool = pool.levels[level] || { maximum: 0, spent: 0, available: 0 };
+    return { available: levelPool.available > 0, cantrip: false, classId: pool.classId, slotLevel: level, levelPool, pool,
+      reason: levelPool.available > 0 ? null : `No Level ${level} Spell Slots available for ${pool.classId}.` };
+  }
+
+  function spendSpellSlot(character, classId, slotLevel, explicitTable = null) {
+    const check = canSpendSpellSlot(character, classId, slotLevel, explicitTable);
+    if (!check.available || check.cantrip) return { ...check, spent: 0 };
+    ensureSpellcastingState(character).slotsByClass[check.classId].levels[String(check.slotLevel)].spent += 1;
+    return { ...check, spent: 1, pool: spellSlotPool(character, classId, explicitTable), reason: null };
+  }
+
+  function syncSpellSlotPools(character) {
+    return classEntries(character).map((entry) => {
+      const classId = normalizeId(entry.classId || entry.id), table = slotTableForClass(character, classId);
+      return classId && Object.keys(table).length ? spellSlotPool(character, classId, table) : null;
+    }).filter(Boolean);
+  }
+
+  function restoreSpellSlots(character, classId = null) {
+    syncSpellSlotPools(character);
+    const state = ensureSpellcastingState(character), ids = classId ? [normalizeId(classId)] : Object.keys(state.slotsByClass), changes = [];
+    ids.forEach((id) => {
+      if (!state.slotsByClass[id]?.levels) return;
+      Object.values(state.slotsByClass[id].levels).forEach((entry) => { entry.spent = 0; });
+      changes.push(spellSlotPool(character, id));
+    });
+    return changes;
+  }
+
+  function readCurrentSp(entity = {}) {
+    const combat = entity?.combatStats || {};
+    const found = [entity.sp, entity.currentSp, entity.currentSP, entity.sp_actual, combat.sp_actual, combat.currentSp]
+      .find((value) => Number.isFinite(Number(value)));
+    return found == null ? null : Number(found);
+  }
+
+  function writeCurrentSp(entity, value) {
+    if (!entity || typeof entity !== "object") return null;
+    const next = Number(value); let wrote = false;
+    for (const key of ["sp", "currentSp", "currentSP", "sp_actual"]) if (Object.prototype.hasOwnProperty.call(entity, key)) { entity[key] = next; wrote = true; }
+    if (entity.combatStats && typeof entity.combatStats === "object") {
+      for (const key of ["sp_actual", "currentSp"]) if (Object.prototype.hasOwnProperty.call(entity.combatStats, key)) { entity.combatStats[key] = next; wrote = true; }
+    }
+    if (!wrote) entity.currentSp = next;
+    return next;
+  }
+
+  function fixedDamageRuntime() {
+    if (global.LuminousFixedDamageRuntime) return global.LuminousFixedDamageRuntime;
+    if (typeof require === "function") { try { return require("./fixed-damage-runtime.js"); } catch (_) {} }
+    return null;
+  }
+
+  function applyOvercast(character, slotLevel, options = {}) {
+    const level = Math.max(1, intOr(slotLevel, 1)), cost = Math.max(0, intOr(options.spCost, level * OVERCAST_SP_PER_SLOT_LEVEL));
+    const current = readCurrentSp(character);
+    if (current == null) return { success: false, reason: "Overcast requires a readable SP resource.", slotLevel: level, spCost: cost };
+    const spSpent = Math.min(Math.max(0, current), cost), overflow = Math.max(0, cost - spSpent);
+    writeCurrentSp(character, current - spSpent);
+    const fixed = options.fixedDamageRuntime || fixedDamageRuntime();
+    const fixedDamage = overflow > 0 && fixed?.applyFixedDamage
+      ? fixed.applyFixedDamage(options.damageTarget || character, overflow, { engine: options.engine, damageKind: "directo", skillUsed: options.skillUsed || options.spell || null })
+      : (overflow > 0 ? { applied: false, amount: overflow, reason: "Fixed Damage Runtime unavailable." } : null);
+    return { success: true, slotLevel: level, spCost: cost, spBefore: current, spSpent, spAfter: readCurrentSp(character), overflowFixedDamage: overflow, fixedDamage };
+  }
+
+  function normalizeTargetType(value) {
+    const id = normalizeId(value || "single");
+    return VALID_TARGET_TYPES.includes(id) ? id : "special";
+  }
+
+  function normalizeSave(spell = {}) {
+    const raw = spell.save || spell.savingThrow || spell.saving_throw || {};
+    const abilityId = normalizeAbility(raw.abilityId || raw.ability || raw.stat || spell.saveAbility || spell.save_ability);
+    if (!abilityId) return null;
+    const onSuccess = normalizeId(raw.onSuccess || raw.on_success || spell.saveOnSuccess || "negates");
+    return { abilityId, onSuccess: ["negates", "half", "reduced", "special"].includes(onSuccess) ? onSuccess : "special" };
+  }
+
+  function resolveSpellSave(character, classId, spell = {}, runtime = {}, variables = {}) {
+    const save = normalizeSave(spell), casting = resolveSpellcasting(character, classId, runtime, variables);
+    return save && casting ? { ...save, dc: casting.spellDC, classId: casting.classId, spellMod: casting.spellMod } : null;
+  }
+
+  function normalizeUpcast(spell = {}) {
+    const raw = spell.upcast || spell.upcastScaling || spell.upcast_scaling || {};
+    return { finalPower: numberOr(raw.finalPower ?? raw.final_power, 0), coinPower: numberOr(raw.coinPower ?? raw.coin_power, 0),
+      atkWeight: numberOr(raw.atkWeight ?? raw.atk_weight, 0), duration: numberOr(raw.duration ?? raw.durationRounds ?? raw.duration_rounds, 0) };
+  }
+
+  function resolveUpcast(spell = {}, slotLevel = null) {
+    const baseSlotLevel = Math.max(0, intOr(spell.slotLevel ?? spell.level ?? spell.spellLevel, 0));
+    const usedSlotLevel = slotLevel == null ? baseSlotLevel : Math.max(baseSlotLevel, intOr(slotLevel, baseSlotLevel));
+    const extraLevels = Math.max(0, usedSlotLevel - baseSlotLevel), perLevel = normalizeUpcast(spell);
+    return { baseSlotLevel, slotLevel: usedSlotLevel, extraLevels, finalPower: perLevel.finalPower * extraLevels,
+      coinPower: perLevel.coinPower * extraLevels, atkWeight: perLevel.atkWeight * extraLevels, duration: perLevel.duration * extraLevels, perLevel };
+  }
+
+  function normalizeCastingTimeSeconds(spell = {}) {
+    const seconds = spell.castingTimeSeconds ?? spell.casting_time_seconds;
+    if (Number.isFinite(Number(seconds)) && Number(seconds) >= 0) return Math.ceil(Number(seconds));
+    const rounds = spell.castingTimeRounds ?? spell.casting_time_rounds;
+    if (Number.isFinite(Number(rounds)) && Number(rounds) > 0) return Math.ceil(Number(rounds) * 6);
+    const raw = normalizeId(spell.castingTime || spell.casting_time || spell.actionCost || "action");
+    if (["none", "instant", "free"].includes(raw)) return 0;
+    if (["quick_action", "bonus_action", "quick"].includes(raw)) return 3;
+    return 6;
+  }
+
+  function buildCastingActionMessage(spell = {}, actorId, options = {}) {
+    const seconds = normalizeCastingTimeSeconds(spell);
+    if (seconds <= 0) return null;
+    return { tipo_dialogo: "actuar", actorId: String(actorId || options.actorId || ""), mensaje: options.message || `Cast ${spell.name || spell.id || "Spell"}`,
+      actionDurationSeconds: seconds, actionBucket: seconds <= 2 ? "instant" : (seconds <= 3 ? "normal" : (seconds <= 6 ? "complete" : "prolonged")),
+      spellId: normalizeId(spell.id || spell.name), source: "spellcasting" };
+  }
+
+  function startConcentration(character, spell = {}, options = {}) {
+    const state = ensureSpellcastingState(character), requires = spell.concentration === true || spell.requiresConcentration === true || spell.requires_concentration === true;
+    if (!requires) return { started: false, concentration: clone(state.concentration.active || null) };
+    state.concentration.active = { spellId: normalizeId(spell.id || spell.name), spellName: String(spell.name || spell.id || "Spell"),
+      startedAt: options.startedAt ?? Date.now(), sourceClassId: normalizeId(options.classId || spell.classId || spell.sourceClassId) };
+    return { started: true, concentration: clone(state.concentration.active) };
+  }
+
+  function endConcentration(character, reason = "ended") {
+    const state = ensureSpellcastingState(character), previous = clone(state.concentration.active || null);
+    delete state.concentration.active;
+    return { ended: Boolean(previous), previous, reason: normalizeId(reason) || "ended" };
+  }
+
+  function concentrationCheckForSkill(character, input = {}) {
+    const state = ensureSpellcastingState(character);
+    if (!state.concentration.active) return { required: false, reason: "not_concentrating" };
+    const eventId = String(input.skillEventId || input.eventId || input.skillId || "").trim();
+    if (eventId && state.concentrationChecks[eventId]) return { ...clone(state.concentrationChecks[eventId]), required: false, duplicate: true };
+    const values = Array.isArray(input.finalPowers) ? input.finalPowers
+      : (Array.isArray(input.hits) ? input.hits.map((hit) => hit?.finalPower ?? hit?.final_power) : [input.finalPower ?? input.final_power]);
+    const highestFinalPower = values.reduce((max, value) => Math.max(max, numberOr(value, 0)), 0);
+    if (highestFinalPower <= 0) return { required: false, reason: "no_damaging_final_power" };
+    const check = { required: true, duplicate: false, skillEventId: eventId || null, abilityId: "con", dc: highestFinalPower,
+      highestFinalPower, concentration: clone(state.concentration.active) };
+    if (eventId) state.concentrationChecks[eventId] = clone(check);
+    const keys = Object.keys(state.concentrationChecks); if (keys.length > 100) keys.slice(0, keys.length - 100).forEach((key) => delete state.concentrationChecks[key]);
+    return check;
+  }
+
+  function resolveConcentrationCheck(character, check = {}, total) {
+    const success = numberOr(total, 0) >= numberOr(check.dc, 0);
+    if (!success) endConcentration(character, "failed_concentration_check");
+    return { success, total: numberOr(total, 0), dc: numberOr(check.dc, 0), concentrationEnded: !success };
+  }
+
+  function normalizeSpell(spell = {}, options = {}) {
+    const slotLevel = Math.max(0, intOr(spell.slotLevel ?? spell.level ?? spell.spellLevel, 0));
+    return { ...spell, id: normalizeId(spell.id || spell.name), slotLevel, cantrip: slotLevel === 0 || spell.cantrip === true,
+      sourceClassId: normalizeId(spell.sourceClassId || spell.classId || options.classId), targetType: normalizeTargetType(spell.targetType || spell.target_type),
+      save: normalizeSave(spell), concentration: spell.concentration === true || spell.requiresConcentration === true || spell.requires_concentration === true,
+      castingTimeSeconds: normalizeCastingTimeSeconds(spell), upcast: normalizeUpcast(spell) };
+  }
+
+  function castSpell(character, spellInput = {}, options = {}) {
+    const spell = normalizeSpell(spellInput, options), classId = normalizeId(options.classId || spell.sourceClassId);
+    if (!classId) return { success: false, reason: "Spell has no source Class.", spell };
+    const requestedSlotLevel = spell.cantrip ? 0 : Math.max(spell.slotLevel, intOr(options.slotLevel, spell.slotLevel));
+    let resource = { type: "cantrip", spent: 0 };
+    if (!spell.cantrip) {
+      const slot = spendSpellSlot(character, classId, requestedSlotLevel, options.slotTable);
+      if (slot.available) resource = { type: "slot", spent: slot.spent, slotLevel: requestedSlotLevel, pool: slot.pool };
+      else if (options.overcast === true) {
+        const overcast = applyOvercast(character, requestedSlotLevel, { ...options, spell });
+        if (!overcast.success) return { success: false, reason: overcast.reason, spell, slot, overcast };
+        resource = { type: "overcast", slotLevel: requestedSlotLevel, overcast };
+      } else return { success: false, reason: slot.reason, spell, slot };
+    }
+    const casting = resolveSpellcasting(character, classId, options.runtime || {}, options.variables || {});
+    return { success: true, spell, classId, casting, save: resolveSpellSave(character, classId, spell, options.runtime || {}, options.variables || {}),
+      resource, upcast: resolveUpcast(spell, requestedSlotLevel), concentration: startConcentration(character, spell, { classId, startedAt: options.startedAt }),
+      castingAction: buildCastingActionMessage(spell, options.actorId || character.actorId || character.id, options) };
+  }
+
+  function persistSpellcastingState(character) {
+    const db = global.firebase?.database?.(), playerId = String(global.localStorage?.getItem?.("playerId") || character?.playerId || character?.player_id || "").trim();
+    if (!db || !playerId || !character) return null;
+    const promise = db.ref(`campaña/jugadores/${playerId}`).update({ spellcastingState: clone(character[STATE_KEY] || {}) });
+    promise?.catch?.((error) => console.warn("Spellcasting state persistence:", error));
+    return promise;
+  }
+
+  function handleRestCompleted(event) {
+    const detail = event?.detail || {};
+    if (normalizeId(detail.type) !== "long_rest") return null;
+    const character = detail.character || global.LuminousPlayerTraitRuntime?.getCharacter?.() || global.datosJugador || null;
+    if (!character) return null;
+    const restored = restoreSpellSlots(character); persistSpellcastingState(character); return restored;
+  }
+
+  function bindRestIntegration() {
+    if (restListenerBound || !global.addEventListener) return false;
+    global.addEventListener("luminous:rest-completed", handleRestCompleted); restListenerBound = true; return true;
+  }
+
+  function wrapTraitEngine() {
+    const source = global.LuminousTraitEngine;
+    if (!source?.buildVariables || source.__spellcastingBasicRulesWrapped) return Boolean(source?.__spellcastingBasicRulesWrapped);
+    const original = source.buildVariables.bind(source);
+    global.LuminousTraitEngine = Object.freeze({ ...source, __spellcastingBasicRulesWrapped: true,
+      buildVariables(character = {}, runtime = {}, trait = {}) {
+        const variables = original(character, runtime, trait), resolved = resolveForTrait(character, trait, runtime, variables);
+        return resolved ? { ...variables, SpellMod: resolved.spellMod, SpellDC: resolved.spellDC } : variables;
+      } });
+    return true;
+  }
+
+  function install() { bindRestIntegration(); return wrapTraitEngine(); }
+
+  const api = Object.freeze({ ...base, __basicRulesV1: true, SCHEMA_VERSION, STATE_KEY, OVERCAST_SP_PER_SLOT_LEVEL, VALID_TARGET_TYPES,
+    normalizeAbility, classSpellcastingAbility, resolveSpellcasting, resolveForTrait, normalizeSlotTable, slotTableForClass, ensureSpellcastingState,
+    reconcileSlotPool, spellSlotPool, canSpendSpellSlot, spendSpellSlot, syncSpellSlotPools, restoreSpellSlots, readCurrentSp, writeCurrentSp,
+    applyOvercast, normalizeTargetType, normalizeSave, resolveSpellSave, normalizeUpcast, resolveUpcast, normalizeCastingTimeSeconds,
+    buildCastingActionMessage, startConcentration, endConcentration, concentrationCheckForSkill, resolveConcentrationCheck, normalizeSpell, castSpell,
+    persistSpellcastingState, handleRestCompleted, bindRestIntegration, wrapTraitEngine, install });
+
+  global.LuminousSpellcastingRuntime = api;
+  install();
+  if (global.document && global.setInterval) { const timer = global.setInterval(install, 800); timer?.unref?.(); }
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/spellcasting-basic-rules-runtime.js
+++ b/js/spellcasting-basic-rules-runtime.js
@@ -196,11 +196,14 @@
     const current = readCurrentSp(character);
     if (current == null) return { success: false, reason: "Overcast requires a readable SP resource.", slotLevel: level, spCost: cost };
     const spSpent = Math.min(Math.max(0, current), cost), overflow = Math.max(0, cost - spSpent);
+    const fixed = overflow > 0 ? (options.fixedDamageRuntime || fixedDamageRuntime()) : null;
+    if (overflow > 0 && !fixed?.applyFixedDamage) {
+      return { success: false, reason: "Fixed Damage Runtime is required for Overcast overflow.", slotLevel: level, spCost: cost, spBefore: current, overflowFixedDamage: overflow };
+    }
     writeCurrentSp(character, current - spSpent);
-    const fixed = options.fixedDamageRuntime || fixedDamageRuntime();
-    const fixedDamage = overflow > 0 && fixed?.applyFixedDamage
+    const fixedDamage = overflow > 0
       ? fixed.applyFixedDamage(options.damageTarget || character, overflow, { engine: options.engine, damageKind: "directo", skillUsed: options.skillUsed || options.spell || null })
-      : (overflow > 0 ? { applied: false, amount: overflow, reason: "Fixed Damage Runtime unavailable." } : null);
+      : null;
     return { success: true, slotLevel: level, spCost: cost, spBefore: current, spSpent, spAfter: readCurrentSp(character), overflowFixedDamage: overflow, fixedDamage };
   }
 
@@ -340,6 +343,18 @@
     global.addEventListener("luminous:rest-completed", handleRestCompleted); restListenerBound = true; return true;
   }
 
+  function ensureFixedDamageAsset() {
+    if (global.LuminousFixedDamageRuntime || !global.document) return global.LuminousFixedDamageRuntime || null;
+    let script = global.document.getElementById("luminous-fixed-damage-runtime");
+    if (script) return script;
+    script = global.document.createElement("script");
+    script.id = "luminous-fixed-damage-runtime";
+    script.src = "js/fixed-damage-runtime.js";
+    script.async = false;
+    global.document.head?.appendChild(script);
+    return script;
+  }
+
   function wrapTraitEngine() {
     const source = global.LuminousTraitEngine;
     if (!source?.buildVariables || source.__spellcastingBasicRulesWrapped) return Boolean(source?.__spellcastingBasicRulesWrapped);
@@ -352,14 +367,14 @@
     return true;
   }
 
-  function install() { bindRestIntegration(); return wrapTraitEngine(); }
+  function install() { ensureFixedDamageAsset(); bindRestIntegration(); return wrapTraitEngine(); }
 
   const api = Object.freeze({ ...base, __basicRulesV1: true, SCHEMA_VERSION, STATE_KEY, OVERCAST_SP_PER_SLOT_LEVEL, VALID_TARGET_TYPES,
     normalizeAbility, classSpellcastingAbility, resolveSpellcasting, resolveForTrait, normalizeSlotTable, slotTableForClass, ensureSpellcastingState,
     reconcileSlotPool, spellSlotPool, canSpendSpellSlot, spendSpellSlot, syncSpellSlotPools, restoreSpellSlots, readCurrentSp, writeCurrentSp,
     applyOvercast, normalizeTargetType, normalizeSave, resolveSpellSave, normalizeUpcast, resolveUpcast, normalizeCastingTimeSeconds,
     buildCastingActionMessage, startConcentration, endConcentration, concentrationCheckForSkill, resolveConcentrationCheck, normalizeSpell, castSpell,
-    persistSpellcastingState, handleRestCompleted, bindRestIntegration, wrapTraitEngine, install });
+    persistSpellcastingState, handleRestCompleted, bindRestIntegration, ensureFixedDamageAsset, wrapTraitEngine, install });
 
   global.LuminousSpellcastingRuntime = api;
   install();

--- a/tests/spellcasting_runtime.spec.js
+++ b/tests/spellcasting_runtime.spec.js
@@ -117,6 +117,14 @@ test("Overcast costs 15 SP per Slot Level and overflow becomes Fixed Damage", ()
   expect(fixedDamageCalls[0].amount).toBe(25);
 });
 
+test("Overcast overflow never mutates SP when Fixed Damage is unavailable", () => {
+  const character = bardCharacter({ currentSp: 5 });
+  const result = spellcasting.applyOvercast(character, 2, { fixedDamageRuntime: {} });
+  expect(result.success).toBe(false);
+  expect(result.reason).toContain("Fixed Damage Runtime");
+  expect(character.currentSp).toBe(5);
+});
+
 test("Upcast exposes Final Power, Coin Power, ATK Weight and Duration as independent channels", () => {
   const result = spellcasting.resolveUpcast({
     slotLevel: 2,

--- a/tests/spellcasting_runtime.spec.js
+++ b/tests/spellcasting_runtime.spec.js
@@ -4,59 +4,187 @@ const baseTraitEngine = require("../js/trait-engine.js");
 global.LuminousTraitEngine = baseTraitEngine;
 delete global.LuminousSpellcastingRuntime;
 delete require.cache[require.resolve("../js/spellcasting-runtime.js")];
-const spellcasting = require("../js/spellcasting-runtime.js");
+delete require.cache[require.resolve("../js/spellcasting-basic-rules-runtime.js")];
+require("../js/spellcasting-runtime.js");
+const spellcasting = require("../js/spellcasting-basic-rules-runtime.js");
 
-function bardCharacter() {
+function bardCharacter(overrides = {}) {
   return {
+    id: "bard_pc",
     level: 40,
     proficiency: 4,
-    classes: [{ classId: "bard", levels: 40 }],
-    stats: { carisma: 20, inteligencia: 16 },
+    classes: [{
+      classId: "bard",
+      levels: 40,
+      spellcasting: { slots: { 1: 4, 2: 3, 3: 2, 4: 1, 5: 1 } },
+    }],
+    stats: { carisma: 20, inteligencia: 16, constitucion: 14 },
+    currentSp: 20,
+    hp: 100,
+    ...overrides,
   };
 }
 
-test("Bard resolves Spell Mod and Spell DC from the Class once", () => {
-  const trait = {
+function bardTrait(source = { type: "class", id: "bard", classId: "bard" }) {
+  return {
     id: "bard_spell_test",
     name: "Bard Spell Test",
-    source: { type: "class", id: "bard", classId: "bard" },
+    source,
     contexts: ["any"],
     activation: { type: "passive", actionCost: "none" },
     effects: [],
     rules: [],
   };
-  const variables = global.LuminousTraitEngine.buildVariables(bardCharacter(), {}, trait);
+}
+
+test("Bard resolves Spell Mod and Spell DC from the Class once", () => {
+  const variables = global.LuminousTraitEngine.buildVariables(bardCharacter(), {}, bardTrait());
   expect(spellcasting.getClassSpellcastingAbility("bard")).toBe("cha");
   expect(variables.SpellMod).toBe(5);
   expect(variables.SpellDC).toBe(17);
 });
 
 test("Archetype Traits inherit their parent Class Spellcasting Ability", () => {
-  const trait = {
-    id: "words_of_terror",
-    name: "Words of Terror",
-    source: { type: "archetype", id: "college_of_whispers", archetypeId: "college_of_whispers", classId: "bard" },
-    contexts: ["any"],
-    activation: { type: "manual", actionCost: "none" },
-    effects: [],
-    rules: [],
-  };
+  const trait = bardTrait({ type: "archetype", id: "college_of_whispers", archetypeId: "college_of_whispers", classId: "bard" });
   const variables = global.LuminousTraitEngine.buildVariables(bardCharacter(), {}, trait);
   expect(variables.SpellMod).toBe(5);
   expect(variables.SpellDC).toBe(17);
 });
 
-test("Spellcasting registry is reusable for future Classes", () => {
+test("Spellcasting registry is reusable and saved Class data may override its Ability", () => {
   spellcasting.registerClassSpellcastingAbility("wizard", "int");
-  const trait = {
-    id: "wizard_spell_test",
-    source: { type: "class", id: "wizard", classId: "wizard" },
-    contexts: ["any"],
-    activation: { type: "passive", actionCost: "none" },
-    effects: [],
-    rules: [],
-  };
-  const variables = global.LuminousTraitEngine.buildVariables(bardCharacter(), {}, trait);
+  const wizardTrait = bardTrait({ type: "class", id: "wizard", classId: "wizard" });
+  const wizard = bardCharacter({ classes: [{ classId: "wizard", levels: 40, spellcastingAbility: "cha" }] });
+  let variables = global.LuminousTraitEngine.buildVariables(wizard, {}, wizardTrait);
+  expect(spellcasting.getClassSpellcastingAbility("wizard")).toBe("int");
+  expect(spellcasting.classSpellcastingAbility(wizard, "wizard")).toBe("cha");
+  expect(variables.SpellMod).toBe(5);
+
+  delete wizard.classes[0].spellcastingAbility;
+  variables = global.LuminousTraitEngine.buildVariables(wizard, {}, wizardTrait);
   expect(variables.SpellMod).toBe(3);
-  expect(variables.SpellDC).toBe(15);
+});
+
+test("Spell Slots are tracked per Class and restored on Long Rest", () => {
+  const character = bardCharacter();
+  expect(spellcasting.spellSlotPool(character, "bard").levels[3]).toMatchObject({ maximum: 2, available: 2 });
+  expect(spellcasting.spendSpellSlot(character, "bard", 3).spent).toBe(1);
+  expect(spellcasting.spellSlotPool(character, "bard").levels[3].available).toBe(1);
+
+  spellcasting.handleRestCompleted({ detail: { type: "long_rest", character } });
+  expect(spellcasting.spellSlotPool(character, "bard").levels[3].available).toBe(2);
+});
+
+test("Cantrips spend no Slot and no Overcast resource", () => {
+  const character = bardCharacter();
+  const result = spellcasting.castSpell(character, {
+    id: "mock_cantrip",
+    name: "Mock Cantrip",
+    slotLevel: 0,
+    sourceClassId: "bard",
+  });
+  expect(result.success).toBe(true);
+  expect(result.resource).toMatchObject({ type: "cantrip", spent: 0 });
+  expect(character.currentSp).toBe(20);
+});
+
+test("Overcast costs 15 SP per Slot Level and overflow becomes Fixed Damage", () => {
+  const character = bardCharacter({ currentSp: 20 });
+  character.classes[0].spellcasting.slots = { 3: 1 };
+  spellcasting.spendSpellSlot(character, "bard", 3);
+
+  const fixedDamageCalls = [];
+  const result = spellcasting.castSpell(character, {
+    id: "mock_level_three",
+    name: "Mock Level Three",
+    slotLevel: 3,
+    sourceClassId: "bard",
+  }, {
+    slotLevel: 3,
+    overcast: true,
+    fixedDamageRuntime: {
+      applyFixedDamage(target, amount) {
+        fixedDamageCalls.push({ target, amount });
+        return { applied: true, amount };
+      },
+    },
+  });
+
+  expect(result.success).toBe(true);
+  expect(result.resource.type).toBe("overcast");
+  expect(result.resource.overcast).toMatchObject({ spCost: 45, spSpent: 20, spAfter: 0, overflowFixedDamage: 25 });
+  expect(fixedDamageCalls).toHaveLength(1);
+  expect(fixedDamageCalls[0].amount).toBe(25);
+});
+
+test("Upcast exposes Final Power, Coin Power, ATK Weight and Duration as independent channels", () => {
+  const result = spellcasting.resolveUpcast({
+    slotLevel: 2,
+    upcast: { finalPower: 1, coinPower: 2, atkWeight: 1, duration: 3 },
+  }, 5);
+
+  expect(result).toMatchObject({
+    baseSlotLevel: 2,
+    slotLevel: 5,
+    extraLevels: 3,
+    finalPower: 3,
+    coinPower: 6,
+    atkWeight: 3,
+    duration: 9,
+  });
+});
+
+test("Spell Saves use the Class Spell DC and preserve success behavior metadata", () => {
+  const save = spellcasting.resolveSpellSave(bardCharacter(), "bard", {
+    save: { ability: "dex", onSuccess: "half" },
+  });
+  expect(save).toMatchObject({ abilityId: "dex", onSuccess: "half", dc: 17, classId: "bard" });
+});
+
+test("Casting Time emits a Scene Time Action Instance contract", () => {
+  const action = spellcasting.buildCastingActionMessage({
+    id: "two_round_ritual",
+    name: "Two Round Ritual",
+    castingTimeRounds: 2,
+  }, "bard_pc");
+  expect(action).toMatchObject({
+    tipo_dialogo: "actuar",
+    actorId: "bard_pc",
+    actionDurationSeconds: 12,
+    actionBucket: "prolonged",
+    spellId: "two_round_ritual",
+    source: "spellcasting",
+  });
+  expect(spellcasting.buildCastingActionMessage({ castingTime: "instant" }, "bard_pc")).toBeNull();
+});
+
+test("Concentration creates one Constitution Check per damaging Skill using its highest Final Power", () => {
+  const character = bardCharacter();
+  spellcasting.startConcentration(character, { id: "hold_mock", name: "Hold Mock", concentration: true }, { classId: "bard" });
+
+  const first = spellcasting.concentrationCheckForSkill(character, {
+    skillEventId: "enemy_skill_1",
+    finalPowers: [11, 18, 13],
+  });
+  expect(first).toMatchObject({ required: true, duplicate: false, abilityId: "con", dc: 18, highestFinalPower: 18 });
+
+  const duplicate = spellcasting.concentrationCheckForSkill(character, {
+    skillEventId: "enemy_skill_1",
+    finalPowers: [99],
+  });
+  expect(duplicate.required).toBe(false);
+  expect(duplicate.duplicate).toBe(true);
+  expect(duplicate.dc).toBe(18);
+});
+
+test("Failed Concentration Check ends the active Spell; success preserves it", () => {
+  const character = bardCharacter();
+  spellcasting.startConcentration(character, { id: "focus", concentration: true }, { classId: "bard" });
+  const check = spellcasting.concentrationCheckForSkill(character, { skillEventId: "hit_1", finalPower: 15 });
+  expect(spellcasting.resolveConcentrationCheck(character, check, 15).success).toBe(true);
+  expect(spellcasting.ensureSpellcastingState(character).concentration.active.spellId).toBe("focus");
+
+  const second = spellcasting.concentrationCheckForSkill(character, { skillEventId: "hit_2", finalPower: 19 });
+  expect(spellcasting.resolveConcentrationCheck(character, second, 18).success).toBe(false);
+  expect(spellcasting.ensureSpellcastingState(character).concentration.active).toBeUndefined();
 });


### PR DESCRIPTION
## Summary

Integrates the reusable Spellcasting Basic Rules contract on top of the existing `spellcasting-runtime.js` without replacing Combat, Trait, Fixed Damage, Rest or Scene Time engines.

### Implemented
- preserves Bard `SpellMod` / `SpellDC` and parent-Class inheritance for Archetypes;
- allows saved Class data to override the registered Spellcasting Ability when needed;
- per-Class, per-level Spell Slot pools with no invented multiclass merge policy;
- Cantrips spend no Slot;
- Long Rest restores Spell Slots through the existing `luminous:rest-completed` event and persists `spellcastingState` when Player/Firebase context is available;
- Overcast at `15 SP × Slot Level`, with unpaid SP overflow delegated to canonical Fixed Damage;
- Upcast channels for Final Power, Coin Power, ATK Weight and Duration;
- Spell Save metadata using the source Class Spell DC;
- shared target-type normalization;
- Casting Time -> existing Scene Time `actuar` Action Instance contract, including multi-round casts;
- Concentration with one CON check per damaging Skill, using that Skill's highest damaging Final Power, with event de-duplication and failure ending Concentration;
- dedicated documentation and CI gate.

### Integration boundaries
- no universal Spell Power formula is invented in this PR;
- Fixed Damage remains Shield -> HP per its existing contract;
- Scene Time remains the only diegetic clock and Combat rounds remain 6 seconds;
- actual Save/Check rolls remain owned by the existing Check execution layer.

## Validation performed before PR
- `node --check` on the new Spellcasting V1 runtime and Scene Time loader: PASS;
- standalone functional smoke covering Slots, Long Rest restore, Overcast, four Upcast channels, Save DC, Casting Time and Concentration: PASS;
- branch comparison against `main`: 5 intended files only, 0 commits behind.

## Merge gate
Merge only if the dedicated Spellcasting workflow and required repository checks are green and there are no unresolved review threads.