### PR TITLE
Canonical Content Registry v1 for #590

### DIFF
--- a/.github/workflows/content-registry.yml
+++ b/.github/workflows/content-registry.yml
@@ -1,0 +1,49 @@
+name: Canonical Content Registry
+
+on:
+  pull_request:
+    paths:
+      - "js/content-registry.js"
+      - "js/content-registry-bootstrap.js"
+      - "js/character-build-rules.js"
+      - "js/canonical-race-integration.js"
+      - "js/trait-catalog-core.js"
+      - "js/archetype-engine.js"
+      - "js/archetype-trait-catalog.js"
+      - "js/language-catalog-engine.js"
+      - "js/status-engine.js"
+      - "tests/content_registry.spec.js"
+      - "docs/content-registry-v1.md"
+      - ".github/workflows/content-registry.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  canonical-content-registry:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Syntax checks
+        run: |
+          node --check js/content-registry.js
+          node --check js/content-registry-bootstrap.js
+          node --check tests/content_registry.spec.js
+
+      - name: Canonical Registry contract
+        run: npx playwright test tests/content_registry.spec.js --workers=1
+
+      - name: Full regression suite
+        run: npm test -- --workers=1

--- a/docs/content-registry-v1.md
+++ b/docs/content-registry-v1.md
@@ -1,0 +1,185 @@
+# Canonical Content Registry v1
+
+Tracked by GitHub Issue #590.
+
+## Purpose
+
+Luminous content identity must be stable across localization, display-name changes, imports, legacy saves, and module load order.
+
+The Registry identifies and validates content. It does **not** execute mechanics and it does not replace specialized catalogs.
+
+## Canonical identity
+
+The v1 full canonical key is:
+
+```text
+<type>:<local-id>
+```
+
+Examples:
+
+```text
+class:bard
+race:human
+background:nest_heir
+archetype:college_of_whispers
+trait:rage
+skill:athletics
+spell:test_spell
+status:bleed
+language:common
+subrace:dragonborn:red
+```
+
+The Issue examples using dotted names are conceptual. V1 deliberately uses `:` because Firebase Realtime Database forbids `.`, `#`, `$`, `[`, `]` and `/` in keys, while `:` is permitted.
+
+Existing catalog-local IDs such as `bard`, `human`, `rage` and `college_of_whispers` remain valid local IDs. The Registry qualifies them with a content type instead of performing a destructive repository-wide rename.
+
+## Rules
+
+1. **Display name is never identity.** A localized or renamed `name` cannot change a canonical ID.
+2. **Every new Core definition must declare an explicit ID.** The Registry never creates canonical identity from `name`, `nombre`, translated text, capitalization, accents, or script order.
+3. **Type is part of identity.** `race:goblin` and `language:goblin` are different entities.
+4. **Duplicate canonical IDs fail visibly.** A second source cannot silently replace an existing definition.
+5. **Aliases are compatibility only.** An alias resolves to one canonical ID; it is not a second persistent identity.
+6. **Persistent references should move toward canonical IDs or explicit local ID + known type.** Never persist localized display text as the authoritative identity for new data.
+7. **Mechanics remain in their owner modules.** Registry lookup does not execute Traits, Skills, Spells, Statuses, Classes, Races, or Items.
+
+## Local ID policy
+
+A local ID:
+
+- is explicit;
+- is lowercase ASCII;
+- starts with an alphanumeric character;
+- may contain `a-z`, `0-9`, `_`, and `-`;
+- may contain `:` only as a hierarchy separator inside the local ID;
+- must not contain Firebase-forbidden key characters.
+
+Examples:
+
+```text
+human
+half_elf
+college_of_whispers
+dragonborn:red
+bard:college_of_whispers
+```
+
+A contributor must not run a display name through a slug function and treat the result as a new canonical identity.
+
+## Registry API
+
+`js/content-registry.js` exposes `LuminousContentRegistry` in the browser and CommonJS in tests.
+
+Primary operations:
+
+```js
+registry.register({ type, id, name, sourceKey, definition, aliases })
+registry.registerCatalog(type, catalog, options)
+registry.registerAlias(type, legacyId, canonicalTarget)
+registry.resolve(type, idOrAlias)
+registry.get(type, idOrAlias)
+registry.get("race:human")
+registry.list({ type, source })
+registry.validateReference(reference, expectedType)
+```
+
+`canonicalId(type, id)` constructs the qualified key only from an explicit type and explicit local ID.
+
+## Existing catalogs
+
+`js/content-registry-bootstrap.js` is the compatibility boundary for existing catalogs. It can register current definitions without changing their mechanics or storage schemas.
+
+Initial adapters cover:
+
+- Classes, Races, Subraces and Backgrounds from `character-build-rules.js`;
+- Core Traits from `trait-catalog-core.js`;
+- Archetypes and Archetype Traits from `archetype-trait-catalog.js`;
+- D&D in-world Languages when `language-catalog-engine.js` is available;
+- the existing Status registry when available;
+- Skill, Spell, Item and Equipment catalogs when those modules expose definitions through a catalog object.
+
+Specialized catalogs remain authoritative for their mechanical definitions. The Registry is authoritative for cross-module identity and collision/reference validation.
+
+## Legacy aliases
+
+Legacy values may be mapped explicitly:
+
+```js
+registry.registerAlias("class", "Bard", "class:bard");
+registry.registerAlias("race", "Humano", "race:human");
+```
+
+The bootstrap may opt into display-name aliases for an existing catalog only as a migration bridge. These aliases are not permission for new code to persist translated names.
+
+Alias normalization is intentionally more permissive than canonical ID creation so old values with spaces/accents can be found. This behavior must remain confined to legacy resolution.
+
+## Localization boundary
+
+Localization consumes identity; it never creates it.
+
+```text
+race:human
+   ├─ es-419 -> Humano
+   ├─ en     -> Human
+   ├─ ko     -> future label
+   └─ ja     -> future label
+```
+
+All four labels refer to the same canonical record. `labelKey`/localization keys are presentation metadata and do not participate in Registry identity.
+
+This is the required boundary for #596.
+
+## Persistence boundary
+
+For new schemas, prefer storing canonical IDs or fields whose type is explicit and whose value is a canonical local ID. Migration code may accept aliases, but canonical save/re-save should not regenerate an ID from visible text.
+
+This is the required identity foundation for #591.
+
+## Existing local normalizers
+
+The repository contains historical `normalizeId()`/slug helpers in several runtimes. They remain as compatibility behavior until their owning domains are consolidated safely.
+
+From this contract forward:
+
+- they may normalize already-identified runtime values for legacy compatibility;
+- they must not be used to invent the identity of a new Core definition from a display name;
+- new cross-module identity/ref validation should use `LuminousContentRegistry`;
+- removal/consolidation of redundant normalizers belongs to the preserve-behavior work in #599, after regressions exist.
+
+## Collision policy
+
+Registering two distinct definitions under the same full canonical ID is an error, even when they come from different sources.
+
+Two entries may share a visible name if their IDs differ:
+
+```text
+trait:source_a_echo -> "Echo"
+trait:source_b_echo -> "Echo"
+```
+
+This prevents display names from becoming accidental global identifiers.
+
+## Definition checklist for new Core content
+
+Before adding a new definition:
+
+- choose an explicit stable local `id`;
+- identify its `type`;
+- keep `name`/localized label separate;
+- register it directly or through the owning catalog adapter;
+- add aliases only for known legacy identifiers;
+- validate cross-references by canonical ID/type;
+- do not silently overwrite a collision;
+- do not regenerate the ID when saving.
+
+## Regression gate
+
+Focused contract:
+
+```bash
+npx playwright test tests/content_registry.spec.js --workers=1
+```
+
+The dedicated CI workflow also runs the complete repository regression suite because this contract is a P0 dependency for Persistence and Localization.

--- a/js/content-registry-bootstrap.js
+++ b/js/content-registry-bootstrap.js
@@ -1,0 +1,128 @@
+(function (global) {
+  "use strict";
+
+  const registry = global.LuminousContentRegistry || (typeof require === "function" ? require("./content-registry.js") : null);
+  if (!registry) return;
+
+  const registeredSources = new Set();
+
+  function safeRequire(path) {
+    if (typeof require !== "function") return null;
+    try { return require(path); } catch (_) { return null; }
+  }
+
+  function registerSourceOnce(source, callback) {
+    if (registeredSources.has(source)) return [];
+    const registered = callback() || [];
+    registeredSources.add(source);
+    return registered;
+  }
+
+  function registerBuildRules(build) {
+    if (!build) return [];
+    return registerSourceOnce("character-build-rules", () => {
+      const out = [];
+      out.push(...registry.registerCatalog("class", build.CLASSES || [], { source: "character-build-rules", nameAliases: true }));
+      out.push(...registry.registerCatalog("race", build.RACES || [], { source: "character-build-rules", nameAliases: true }));
+      out.push(...registry.registerCatalog("background", build.BACKGROUNDS || [], { source: "character-build-rules", nameAliases: true }));
+
+      (build.RACES || []).forEach((race) => {
+        (race.subtypes || []).forEach((subtype) => {
+          const entry = registry.register({
+            type: "subrace",
+            id: `${race.id}:${subtype.id}`,
+            name: subtype.name,
+            sourceKey: "character-build-rules",
+            definition: { ...subtype, parentRaceId: race.id },
+            aliases: [`${race.id}_${subtype.id}`],
+          }, { source: "character-build-rules" });
+          out.push(entry);
+        });
+      });
+      return out;
+    });
+  }
+
+  function registerTraitCatalog(catalog, source = "trait-catalog-core") {
+    if (!catalog?.DEFINITIONS) return [];
+    return registerSourceOnce(source, () => registry.registerCatalog("trait", catalog.DEFINITIONS, { source }));
+  }
+
+  function registerArchetypeCatalog(catalog) {
+    if (!catalog) return [];
+    return registerSourceOnce("archetype-trait-catalog", () => {
+      const out = [];
+      out.push(...registry.registerCatalog("archetype", catalog.ARCHETYPES || {}, { source: "archetype-trait-catalog", nameAliases: true }));
+      out.push(...registry.registerCatalog("trait", catalog.DEFINITIONS || {}, { source: "archetype-trait-catalog" }));
+      return out;
+    });
+  }
+
+  function registerLanguageCatalog(catalog) {
+    const definitions = catalog?.DND_DEFAULTS;
+    if (!definitions) return [];
+    return registerSourceOnce("language-catalog-engine", () => {
+      const adapted = Object.entries(definitions).map(([id, definition]) => ({
+        id,
+        name: definition?.nombre || definition?.name || id,
+        definition: { ...definition, id },
+      }));
+      return registry.registerCatalog("language", adapted, { source: "language-catalog-engine", nameAliases: true });
+    });
+  }
+
+  function registerStatusRegistry(statusRegistry) {
+    if (!statusRegistry || typeof statusRegistry !== "object") return [];
+    return registerSourceOnce("status-registry", () => registry.registerCatalog("status", statusRegistry, { source: "status-registry" }));
+  }
+
+  function registerGenericCatalog(type, catalog, source) {
+    if (!catalog) return [];
+    const definitions = catalog.DEFINITIONS || catalog.definitions || catalog;
+    if (!definitions || typeof definitions !== "object") return [];
+    return registerSourceOnce(source, () => registry.registerCatalog(type, definitions, { source }));
+  }
+
+  function registerAvailableCore(options = {}) {
+    const modules = options.modules || {};
+    const build = modules.buildRules || global.LuminousCharacterBuildRules || safeRequire("./character-build-rules.js");
+    const traitCatalog = modules.traitCatalog || global.LuminousTraitCatalogCore || safeRequire("./trait-catalog-core.js");
+    const archetypeCatalog = modules.archetypeCatalog || global.LuminousArchetypeTraitCatalog || safeRequire("./archetype-trait-catalog.js");
+    const languageCatalog = modules.languageCatalog || global.LuminousLanguageCatalog || null;
+    const statusRegistry = modules.statusRegistry || global.STATUS_REGISTRY || null;
+
+    const registered = [];
+    registered.push(...registerBuildRules(build));
+    registered.push(...registerTraitCatalog(traitCatalog));
+    registered.push(...registerArchetypeCatalog(archetypeCatalog));
+    registered.push(...registerLanguageCatalog(languageCatalog));
+    registered.push(...registerStatusRegistry(statusRegistry));
+
+    const optionalCatalogs = [
+      ["skill", modules.skillCatalog || global.LuminousSkillCatalog, "skill-catalog"],
+      ["spell", modules.spellCatalog || global.LuminousSpellCatalog, "spell-catalog"],
+      ["item", modules.itemCatalog || global.LuminousItemCatalog, "item-catalog"],
+      ["equipment", modules.equipmentCatalog || global.LuminousEquipmentCatalog, "equipment-catalog"],
+    ];
+    optionalCatalogs.forEach(([type, catalog, source]) => registered.push(...registerGenericCatalog(type, catalog, source)));
+    return registered;
+  }
+
+  function resetBootstrapState() {
+    registeredSources.clear();
+  }
+
+  const api = Object.freeze({
+    registerAvailableCore,
+    registerBuildRules,
+    registerTraitCatalog,
+    registerArchetypeCatalog,
+    registerLanguageCatalog,
+    registerStatusRegistry,
+    registerGenericCatalog,
+    resetBootstrapState,
+  });
+
+  global.LuminousContentRegistryBootstrap = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/content-registry.js
+++ b/js/content-registry.js
@@ -126,12 +126,12 @@
     const source = options.source || "catalog";
     const raw = Array.isArray(catalog)
       ? catalog
-      : Object.entries(catalog || {}).map(([key, value]) => ({ id: value?.id || key, ...(value || {}) }));
+      : Object.entries(catalog || {}).map(([key, value]) => ({ ...(value || {}), id: value?.id || key }));
     const registered = [];
     raw.filter(Boolean).forEach((definition) => {
       const id = definition.id;
       if (!id) throw new Error(`Catalog ${source} contains a definition without explicit id.`);
-      registered.push(register({ type, id, ...definition }, { source, nameAliases: options.nameAliases === true, allowSameDefinition: options.allowSameDefinition === true }));
+      registered.push(register({ ...definition, type, id }, { source, nameAliases: options.nameAliases === true, allowSameDefinition: options.allowSameDefinition === true }));
     });
     return registered;
   }

--- a/js/content-registry.js
+++ b/js/content-registry.js
@@ -1,0 +1,216 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousContentRegistry) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousContentRegistry;
+    return;
+  }
+
+  const FIREBASE_FORBIDDEN = /[.#$\[\]\/\u0000-\u001F\u007F]/;
+  const TYPE_PATTERN = /^[a-z][a-z0-9_]*$/;
+  const ID_SEGMENT_PATTERN = /^[a-z0-9][a-z0-9_-]*$/;
+  const entries = new Map();
+  const aliases = new Map();
+
+  function clone(value) {
+    if (value == null) return value;
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function normalizeType(value) {
+    const type = String(value ?? "").trim().toLowerCase().replace(/\s+/g, "_");
+    if (!TYPE_PATTERN.test(type)) throw new Error(`Invalid content type: ${value}`);
+    return type;
+  }
+
+  function validateLocalId(value) {
+    const id = String(value ?? "").trim();
+    if (!id) return { valid: false, reason: "empty" };
+    if (FIREBASE_FORBIDDEN.test(id)) return { valid: false, reason: "firebase_forbidden_character" };
+    const parts = id.split(":");
+    if (!parts.every((part) => ID_SEGMENT_PATTERN.test(part))) return { valid: false, reason: "invalid_segment" };
+    return { valid: true, id };
+  }
+
+  function assertLocalId(value) {
+    const result = validateLocalId(value);
+    if (!result.valid) throw new Error(`Invalid canonical content id '${value}': ${result.reason}`);
+    return result.id;
+  }
+
+  function canonicalId(type, id) {
+    return `${normalizeType(type)}:${assertLocalId(id)}`;
+  }
+
+  function parseCanonicalId(value) {
+    const text = String(value ?? "").trim();
+    const index = text.indexOf(":");
+    if (index <= 0) return null;
+    const type = text.slice(0, index);
+    const id = text.slice(index + 1);
+    try {
+      return { type: normalizeType(type), id: assertLocalId(id), canonicalId: canonicalId(type, id) };
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function isFirebaseSafeId(value) {
+    const text = String(value ?? "");
+    return Boolean(text) && !FIREBASE_FORBIDDEN.test(text);
+  }
+
+  function legacyAliasToken(value) {
+    return String(value ?? "")
+      .trim()
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, "_")
+      .replace(/^_+|_+$/g, "")
+      .replace(/_+/g, "_");
+  }
+
+  function aliasKey(type, alias) {
+    const token = legacyAliasToken(alias);
+    if (!token) throw new Error(`Invalid legacy alias: ${alias}`);
+    return `${normalizeType(type)}:${token}`;
+  }
+
+  function registerAlias(type, alias, target, metadata = {}) {
+    const parsedTarget = parseCanonicalId(target) || parseCanonicalId(canonicalId(type, target));
+    if (!parsedTarget) throw new Error(`Invalid alias target: ${target}`);
+    if (parsedTarget.type !== normalizeType(type)) throw new Error(`Alias type mismatch: ${type} -> ${target}`);
+    if (!entries.has(parsedTarget.canonicalId)) throw new Error(`Alias target is not registered: ${parsedTarget.canonicalId}`);
+    const key = aliasKey(type, alias);
+    const existing = aliases.get(key);
+    if (existing && existing.target !== parsedTarget.canonicalId) {
+      throw new Error(`Alias collision for ${type}:${alias}: ${existing.target} vs ${parsedTarget.canonicalId}`);
+    }
+    aliases.set(key, { target: parsedTarget.canonicalId, alias: String(alias), metadata: clone(metadata) || {} });
+    return parsedTarget.canonicalId;
+  }
+
+  function register(input = {}, options = {}) {
+    if (!input || typeof input !== "object") throw new Error("Content definition must be an object.");
+    const type = normalizeType(input.type || options.type);
+    const id = assertLocalId(input.id);
+    const key = canonicalId(type, id);
+    const source = String(input.sourceKey || options.source || input.source?.id || input.source?.type || "core");
+    const normalized = Object.freeze({
+      canonicalId: key,
+      type,
+      id,
+      name: input.name ?? input.nombre ?? null,
+      labelKey: input.labelKey ?? input.localizationKey ?? null,
+      source,
+      definition: clone(input.definition ?? input),
+    });
+
+    const existing = entries.get(key);
+    if (existing) {
+      if (options.allowSameDefinition === true && JSON.stringify(existing.definition) === JSON.stringify(normalized.definition)) return clone(existing);
+      throw new Error(`Canonical content collision: ${key} is already registered by ${existing.source}.`);
+    }
+    entries.set(key, normalized);
+
+    const explicitAliases = Array.isArray(input.aliases) ? input.aliases : [];
+    explicitAliases.forEach((alias) => registerAlias(type, alias, key, { source, explicit: true }));
+    if (options.nameAliases === true && normalized.name) {
+      registerAlias(type, normalized.name, key, { source, legacyDisplayName: true });
+    }
+    return clone(normalized);
+  }
+
+  function registerCatalog(type, catalog, options = {}) {
+    const source = options.source || "catalog";
+    const raw = Array.isArray(catalog)
+      ? catalog
+      : Object.entries(catalog || {}).map(([key, value]) => ({ id: value?.id || key, ...(value || {}) }));
+    const registered = [];
+    raw.filter(Boolean).forEach((definition) => {
+      const id = definition.id;
+      if (!id) throw new Error(`Catalog ${source} contains a definition without explicit id.`);
+      registered.push(register({ type, id, ...definition }, { source, nameAliases: options.nameAliases === true, allowSameDefinition: options.allowSameDefinition === true }));
+    });
+    return registered;
+  }
+
+  function resolve(typeOrCanonicalId, maybeLegacyId) {
+    if (maybeLegacyId === undefined) {
+      const parsed = parseCanonicalId(typeOrCanonicalId);
+      if (parsed && entries.has(parsed.canonicalId)) return parsed.canonicalId;
+      return null;
+    }
+    const type = normalizeType(typeOrCanonicalId);
+    const raw = String(maybeLegacyId ?? "").trim();
+    try {
+      const exact = canonicalId(type, raw);
+      if (entries.has(exact)) return exact;
+    } catch (_) {}
+    return aliases.get(aliasKey(type, raw))?.target || null;
+  }
+
+  function get(typeOrCanonicalId, maybeId) {
+    const key = maybeId === undefined ? resolve(typeOrCanonicalId) : resolve(typeOrCanonicalId, maybeId);
+    const found = key ? entries.get(key) : null;
+    return found ? clone(found) : null;
+  }
+
+  function has(typeOrCanonicalId, maybeId) {
+    return Boolean(maybeId === undefined ? resolve(typeOrCanonicalId) : resolve(typeOrCanonicalId, maybeId));
+  }
+
+  function list(options = {}) {
+    const type = options.type ? normalizeType(options.type) : null;
+    const source = options.source ? String(options.source) : null;
+    return [...entries.values()]
+      .filter((entry) => (!type || entry.type === type) && (!source || entry.source === source))
+      .map(clone)
+      .sort((a, b) => a.canonicalId.localeCompare(b.canonicalId));
+  }
+
+  function validateReference(reference, expectedType = null) {
+    const key = expectedType && !parseCanonicalId(reference)
+      ? resolve(expectedType, reference)
+      : resolve(reference);
+    if (!key) return { valid: false, canonicalId: null, reason: "unknown_content_id" };
+    const entry = entries.get(key);
+    if (expectedType && entry.type !== normalizeType(expectedType)) {
+      return { valid: false, canonicalId: key, reason: "type_mismatch", actualType: entry.type };
+    }
+    return { valid: true, canonicalId: key, entry: clone(entry) };
+  }
+
+  function clear(options = {}) {
+    if (options.type) {
+      const type = normalizeType(options.type);
+      [...entries.keys()].filter((key) => entries.get(key)?.type === type).forEach((key) => entries.delete(key));
+      [...aliases.keys()].filter((key) => key.startsWith(`${type}:`)).forEach((key) => aliases.delete(key));
+      return;
+    }
+    entries.clear();
+    aliases.clear();
+  }
+
+  const api = Object.freeze({
+    version: 1,
+    canonicalId,
+    parseCanonicalId,
+    validateLocalId,
+    isFirebaseSafeId,
+    legacyAliasToken,
+    register,
+    registerCatalog,
+    registerAlias,
+    resolve,
+    get,
+    has,
+    list,
+    validateReference,
+    clear,
+  });
+
+  global.LuminousContentRegistry = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/tests/content_registry.spec.js
+++ b/tests/content_registry.spec.js
@@ -1,0 +1,139 @@
+const { test, expect } = require("@playwright/test");
+const registry = require("../js/content-registry.js");
+const bootstrap = require("../js/content-registry-bootstrap.js");
+const buildRules = require("../js/character-build-rules.js");
+const traitCatalog = require("../js/trait-catalog-core.js");
+const archetypeCatalog = require("../js/archetype-trait-catalog.js");
+
+test.beforeEach(() => {
+  registry.clear();
+  bootstrap.resetBootstrapState();
+});
+
+test("same visible name from different sources is safe when canonical IDs differ", () => {
+  registry.register({ type: "trait", id: "source_a_echo", name: "Echo", sourceKey: "source-a" });
+  registry.register({ type: "trait", id: "source_b_echo", name: "Echo", sourceKey: "source-b" });
+
+  expect(registry.get("trait:source_a_echo").name).toBe("Echo");
+  expect(registry.get("trait:source_b_echo").name).toBe("Echo");
+  expect(registry.list({ type: "trait" }).map((entry) => entry.canonicalId)).toEqual([
+    "trait:source_a_echo",
+    "trait:source_b_echo",
+  ]);
+});
+
+test("visible name and localization text never generate canonical identity", () => {
+  registry.register({ type: "race", id: "human", name: "Humano", labelKey: "race.human.name" });
+  const entry = registry.get("race", "human");
+
+  expect(entry.canonicalId).toBe("race:human");
+  expect(registry.canonicalId("race", "human")).toBe("race:human");
+  expect(() => registry.register({ type: "race", name: "Human" })).toThrow(/canonical content id|definition/i);
+});
+
+test("explicit legacy alias resolves to one canonical ID", () => {
+  registry.register({ type: "class", id: "bard", name: "Bardo" });
+  registry.registerAlias("class", "Bard", "class:bard");
+  registry.registerAlias("class", "Bardo Legacy", "bard");
+
+  expect(registry.resolve("class", "Bard")).toBe("class:bard");
+  expect(registry.resolve("class", "Bardo Legacy")).toBe("class:bard");
+});
+
+test("duplicate canonical ID is a visible collision", () => {
+  registry.register({ type: "status", id: "bleed", name: "Bleed", sourceKey: "core" });
+  expect(() => registry.register({ type: "status", id: "bleed", name: "Hemorrhage", sourceKey: "mod" }))
+    .toThrow(/collision.*status:bleed/i);
+});
+
+test("cross references validate canonical Class IDs without using display names", () => {
+  registry.register({ type: "class", id: "bard", name: "Bardo" });
+  registry.register({
+    type: "trait",
+    id: "bardic_example",
+    name: "Example",
+    sourceKey: "test",
+    definition: { id: "bardic_example", source: { type: "class", classId: "bard" } },
+  });
+
+  expect(registry.validateReference("bard", "class")).toMatchObject({ valid: true, canonicalId: "class:bard" });
+  expect(registry.validateReference("wizard", "class")).toEqual({ valid: false, canonicalId: null, reason: "unknown_content_id" });
+});
+
+test("legacy Character values can normalize without changing the saved selection meaning", () => {
+  registry.register({ type: "race", id: "human", name: "Humano" }, { nameAliases: true });
+  expect(registry.resolve("race", "Humano")).toBe("race:human");
+  expect(registry.resolve("race", "human")).toBe("race:human");
+});
+
+test("registration order and translated names do not change explicit IDs", () => {
+  registry.register({ type: "race", id: "human", name: "Human" });
+  registry.register({ type: "class", id: "bard", name: "Bard" });
+  const first = registry.list().map((entry) => entry.canonicalId);
+
+  registry.clear();
+  registry.register({ type: "class", id: "bard", name: "Bardo" });
+  registry.register({ type: "race", id: "human", name: "Humano" });
+  const second = registry.list().map((entry) => entry.canonicalId);
+
+  expect(second).toEqual(first);
+  expect(second).toEqual(["class:bard", "race:human"]);
+});
+
+test("canonical IDs are Firebase-key safe under the v1 policy", () => {
+  for (const id of [
+    registry.canonicalId("class", "bard"),
+    registry.canonicalId("race", "human"),
+    registry.canonicalId("archetype", "bard:college_of_whispers"),
+    registry.canonicalId("trait", "general_alert"),
+  ]) expect(registry.isFirebaseSafeId(id)).toBe(true);
+
+  for (const bad of ["race.human", "race/human", "race#human", "race[human]"]) {
+    expect(registry.isFirebaseSafeId(bad)).toBe(false);
+  }
+  expect(registry.validateLocalId("human.name")).toMatchObject({ valid: false });
+});
+
+test("core Character, Trait and Archetype catalogs register behind one query layer", () => {
+  bootstrap.registerAvailableCore({
+    modules: {
+      buildRules,
+      traitCatalog,
+      archetypeCatalog,
+      languageCatalog: {
+        DND_DEFAULTS: {
+          common: { nombre: "Común", universal: true },
+        },
+      },
+      skillCatalog: {
+        DEFINITIONS: { athletics: { id: "athletics", name: "Athletics" } },
+      },
+      spellCatalog: {
+        DEFINITIONS: { test_spell: { id: "test_spell", name: "Test Spell" } },
+      },
+    },
+  });
+
+  expect(registry.has("class", "barbarian")).toBe(true);
+  expect(registry.has("race", "human")).toBe(true);
+  expect(registry.has("background", "nest_heir")).toBe(true);
+  expect(registry.has("archetype", "college_of_whispers")).toBe(true);
+  expect(registry.has("trait", "rage")).toBe(true);
+  expect(registry.has("trait", "psychic_blade")).toBe(true);
+  expect(registry.has("language", "common")).toBe(true);
+  expect(registry.has("skill", "athletics")).toBe(true);
+  expect(registry.has("spell", "test_spell")).toBe(true);
+  expect(registry.resolve("race", "Humano")).toBe("race:human");
+});
+
+test("same source bootstrap is idempotent but different sources still collide", () => {
+  const modules = { buildRules, traitCatalog, archetypeCatalog };
+  bootstrap.registerAvailableCore({ modules });
+  const before = registry.list().length;
+  bootstrap.registerAvailableCore({ modules });
+  expect(registry.list().length).toBe(before);
+
+  expect(() => bootstrap.registerGenericCatalog("trait", {
+    rage: { id: "rage", name: "Different Rage" },
+  }, "conflicting-mod" )).toThrow(/collision.*trait:rage/i);
+});


### PR DESCRIPTION
Implements the P0 canonical identity foundation required by #590 without rewriting existing catalogs or changing rules/balance.

Adds:
- central `LuminousContentRegistry` with explicit `type:id` canonical keys;
- collision detection and typed reference validation;
- explicit legacy alias resolution separated from canonical ID creation;
- Firebase-safe ID policy;
- compatibility bootstrap for existing Character/Class/Race/Background, Trait and Archetype catalogs plus optional Language/Status/Skill/Spell/Item/Equipment catalogs;
- focused regression coverage for all mandatory #590 identity cases;
- documented policy for Localization (#596), Persistence (#591), and legacy local normalizers;
- dedicated CI gate plus full repository regression suite.

This PR intentionally does not migrate persistence schemas, rename existing local IDs, alter mechanics, or delete legacy normalizers. Those migrations/consolidations remain separate preserve-behavior work.

Closes #590 once CI is green.