### PR TITLE
Character Persistence Schema v1 groundwork for #591

### DIFF
--- a/.github/workflows/character-persistence.yml
+++ b/.github/workflows/character-persistence.yml
@@ -1,0 +1,47 @@
+name: Character Persistence Schema
+
+on:
+  pull_request:
+    paths:
+      - "js/character-persistence.js"
+      - "js/character-persistence-firebase.js"
+      - "js/content-registry.js"
+      - "js/content-registry-bootstrap.js"
+      - "js/character-build-rules.js"
+      - "js/archetype-engine.js"
+      - "js/archetype-trait-catalog.js"
+      - "tests/character_persistence.spec.js"
+      - "docs/character-persistence-v1.md"
+      - ".github/workflows/character-persistence.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  character-persistence:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Syntax checks
+        run: |
+          node --check js/character-persistence.js
+          node --check js/character-persistence-firebase.js
+          node --check tests/character_persistence.spec.js
+
+      - name: Persistence contract
+        run: npx playwright test tests/character_persistence.spec.js --workers=1
+
+      - name: Registry dependency contract
+        run: npx playwright test tests/content_registry.spec.js --workers=1

--- a/.github/workflows/character-persistence.yml
+++ b/.github/workflows/character-persistence.yml
@@ -8,9 +8,12 @@ on:
       - "js/content-registry.js"
       - "js/content-registry-bootstrap.js"
       - "js/character-build-rules.js"
+      - "js/derived-stats-engine.js"
       - "js/archetype-engine.js"
       - "js/archetype-trait-catalog.js"
       - "tests/character_persistence.spec.js"
+      - "tests/character_persistence_derived_stats.spec.js"
+      - "tests/derived_stats.spec.js"
       - "docs/character-persistence-v1.md"
       - ".github/workflows/character-persistence.yml"
 
@@ -39,9 +42,16 @@ jobs:
           node --check js/character-persistence.js
           node --check js/character-persistence-firebase.js
           node --check tests/character_persistence.spec.js
+          node --check tests/character_persistence_derived_stats.spec.js
 
       - name: Persistence contract
         run: npx playwright test tests/character_persistence.spec.js --workers=1
 
+      - name: Persistence + Derived Stats contract
+        run: npx playwright test tests/character_persistence_derived_stats.spec.js tests/derived_stats.spec.js --workers=1
+
       - name: Registry dependency contract
         run: npx playwright test tests/content_registry.spec.js --workers=1
+
+      - name: Repository regression suite
+        run: npx playwright test --workers=1

--- a/docs/character-persistence-v1.md
+++ b/docs/character-persistence-v1.md
@@ -1,8 +1,8 @@
 # Character Persistence Schema v1
 
-Tracked by GitHub Issue #591. This document describes the v1 persistence boundary and the migration core implemented ahead of final integration.
+Tracked by GitHub Issue #591. This document describes the v1 persistence boundary and migration core.
 
-> Status: the migration/validation core is implemented, but #591 remains blocked by #587 (Derived Stats v1). The final persistent-vs-derived field boundary and integration into the live creation/load surfaces must not be frozen until #587 is complete.
+> Status: #587 (Derived Stats v1) is complete. The persistent-vs-derived contract below is now validated against the canonical `LuminousDerivedStats` resolver. Live creation/load integration remains a separate close gate for #591.
 
 ## Purpose
 
@@ -111,7 +111,9 @@ v0 (no schemaVersion) -> v1
 
 ## Base vs derived state
 
-#587 is the authority that will finalize this boundary. Until it is complete, v1 strips only a conservative denylist of fields that are unambiguously runtime/derived caches:
+#587 defines the canonical Derived Stats boundary. Persistence keeps user choices and Base Stats; `LuminousDerivedStats` reconstructs effective Scores, Ability Mods, HP, OFF/DEF, Speed and other deterministic derived values.
+
+V1 strips the following unambiguously runtime/derived caches from the canonical save:
 
 ```text
 abilityMods
@@ -128,7 +130,7 @@ uiBreakdown
 uiState
 ```
 
-Inside `characterBuild`, the current denylist is:
+Inside `characterBuild`, the denylist is:
 
 ```text
 effectiveStats
@@ -139,9 +141,9 @@ runtime
 cache
 ```
 
-The migration deliberately does **not** remove ambiguous fields such as inventory, equipment, statuses, finance, actor links or unknown extensions. #587 must be completed before this list is declared final for #591.
+The migration deliberately does **not** remove ambiguous compatibility fields such as inventory, equipment, statuses, finance, actor links or unknown extensions. Existing top-level effective/cache-shaped fields that old consumers still need may remain as compatibility data, but `characterBuild.baseStats` is the canonical source for Derived Stats and those compatibility fields must never be treated as Base Stats.
 
-Most importantly, persistence does not calculate racial bonuses, Ability Mods, OFF/DEF/Speed, HP, or any other derived value. It preserves `baseStats` and user choices. That prevents save/reload from reapplying racial bonuses.
+Persistence does not calculate racial bonuses, Ability Mods, OFF/DEF/Speed, HP, or any other derived value. It preserves `baseStats` and user choices. Regression coverage with #587 verifies that saving/reloading a Human Base 10 remains Effective 11 rather than becoming 12.
 
 ## Firebase adapter
 
@@ -176,7 +178,7 @@ That live path does not yet pass through this module. It must be integrated befo
 
 `hoja_personaje.js` currently reads the player node, assigns `snap.val()` directly to `window.datosJugador`, caches it, and renders it. That live path also does not yet pass through the migration boundary.
 
-It must be integrated before #591 closes, after #587 freezes which values are base/persistent versus derived/runtime.
+It must be integrated before #591 closes so legacy input is normalized and validated before Character runtime/rendering.
 
 ### Character Manager / Actor data
 
@@ -186,7 +188,7 @@ It must be integrated before #591 closes, after #587 freezes which values are ba
 
 Before this issue can be marked complete:
 
-1. #587 must be complete and the persistent/derived denylist reviewed against its contract.
+1. #587 must be complete and Persistence must remain regression-tested against its resolver. **Complete for this foundation.**
 2. New Character creation must save through `prepareForSave()`/Firebase adapter and write `schemaVersion: 1`.
 3. Player load must run migration/validation before Character runtime/rendering.
 4. A validated migrated save must round-trip through load -> modify -> save -> reload.
@@ -196,7 +198,7 @@ Before this issue can be marked complete:
 ## Focused regression suite
 
 ```bash
-npx playwright test tests/character_persistence.spec.js --workers=1
+npx playwright test tests/character_persistence.spec.js tests/character_persistence_derived_stats.spec.js --workers=1
 ```
 
-The focused suite covers the mandatory #591 migration cases, including idempotence, legacy aliases, unknown canonical IDs, transient-data stripping, multiclass/Archetypes, backup behavior and future-schema safety.
+The focused suite covers the mandatory #591 migration cases, including idempotence, legacy aliases, unknown canonical IDs, transient-data stripping, multiclass/Archetypes, backup behavior, future-schema safety, and the #587 Base/Effective no-double-application contract.

--- a/docs/character-persistence-v1.md
+++ b/docs/character-persistence-v1.md
@@ -1,0 +1,202 @@
+# Character Persistence Schema v1
+
+Tracked by GitHub Issue #591. This document describes the v1 persistence boundary and the migration core implemented ahead of final integration.
+
+> Status: the migration/validation core is implemented, but #591 remains blocked by #587 (Derived Stats v1). The final persistent-vs-derived field boundary and integration into the live creation/load surfaces must not be frozen until #587 is complete.
+
+## Purpose
+
+Character persistence must have one explicit boundary:
+
+```text
+raw save
+  -> detectVersion()
+  -> migrate(vN -> vN+1 ...)
+  -> normalizeCanonicalCharacter()
+  -> validateCanonicalCharacter()
+  -> Character Core/runtime
+```
+
+The migration layer accepts legacy data. New systems should not add more local fallback logic when a legacy shape can be handled here.
+
+## Schema version
+
+Current version:
+
+```js
+schemaVersion: 1
+```
+
+A v1 character contains a canonical `characterBuild` alongside existing compatible user data. The v1 migration is intentionally non-destructive because the current `campaña/jugadores/*` record also contains data used by economy, UI, Theatre links and other live systems.
+
+```js
+{
+  schemaVersion: 1,
+  characterIdentity: {
+    characterId: null,
+    name: "Aster"
+  },
+  characterBuild: {
+    raceId: "human",
+    raceSubtypeId: null,
+    backgroundId: "nest_heir",
+    classes: [
+      { classId: "bard", levels: 15 }
+    ],
+    archetypes: [
+      {
+        classId: "bard",
+        archetypeId: "college_of_whispers",
+        selectedAtClassLevel: 15
+      }
+    ],
+    baseStats: {},
+    racialStatChoices: [],
+    milestoneSelections: [],
+    traitSelections: [],
+    skillSelections: [],
+    spellSelections: []
+  }
+}
+```
+
+Typed fields use the canonical local IDs established by #590. The field supplies the type (`raceId`, `classId`, etc.), so `human` is the local form of `race:human` and `bard` is the local form of `class:bard`.
+
+## Compatibility strategy
+
+V1 does not rewrite the entire Firebase player record into a new nested object. Migration starts from a clone of the raw document, adds/replaces the canonical persistence fields, and preserves unrelated existing fields.
+
+This matters because a player node currently mixes Character data with other persistent user data. Unknown fields are therefore preserved rather than silently deleted.
+
+Legacy fields such as `originId`, `clase`, `backgroundId`, `humanPerks`, finance data and other existing values remain available to old consumers during the transition. Canonical consumers read from `characterBuild`.
+
+## Legacy aliases
+
+Identity migration consumes #590's `LuminousContentRegistry`. A small explicit alias table exists only for legacy creation IDs whose current equivalent is verified in repository catalogs:
+
+```text
+humano              -> human
+centauro             -> centaur
+goliat               -> goliath
+hada                 -> fairy
+semi_dragon          -> half_dragon
+yuanti_pura_sangre   -> yuan_ti_pureblood
+```
+
+Class display names such as `Bárbaro`, `Bardo`, `Clérigo` and `Mago` resolve through the explicit display-name compatibility aliases registered by #590.
+
+An old ID without a proven equivalent is not guessed. Example: an older Background ID that does not exist in the current canonical Background catalog remains in the raw-compatible field, canonical `characterBuild.backgroundId` becomes `null`, and migration emits `UNRESOLVED_LEGACY_CONTENT_ID`.
+
+For a document already claiming `schemaVersion: 1`, an unknown canonical ID is an error (`UNKNOWN_CANONICAL_CONTENT_ID`) rather than a silent null conversion.
+
+## Migrations
+
+`js/character-persistence.js` contains the migration registry.
+
+Rules:
+
+- migrations are sequential;
+- each migration must produce exactly the next schema version;
+- running migration again on an already-current document is idempotent;
+- no migration applies gameplay bonuses;
+- the raw input is cloned as `rawBackup` before migration;
+- a newer-than-client schema returns `UNSUPPORTED_FUTURE_SCHEMA` and no writable Character;
+- migration failure never requires overwriting the original record.
+
+The built-in migration is:
+
+```text
+v0 (no schemaVersion) -> v1
+```
+
+## Base vs derived state
+
+#587 is the authority that will finalize this boundary. Until it is complete, v1 strips only a conservative denylist of fields that are unambiguously runtime/derived caches:
+
+```text
+abilityMods
+abilityModifiers
+derivedStats
+statBreakdown
+statBreakdowns
+traitEngineCache
+runtimeCache
+actionEconomy
+encounterState
+combatRuntime
+uiBreakdown
+uiState
+```
+
+Inside `characterBuild`, the current denylist is:
+
+```text
+effectiveStats
+derivedStats
+abilityMods
+breakdowns
+runtime
+cache
+```
+
+The migration deliberately does **not** remove ambiguous fields such as inventory, equipment, statuses, finance, actor links or unknown extensions. #587 must be completed before this list is declared final for #591.
+
+Most importantly, persistence does not calculate racial bonuses, Ability Mods, OFF/DEF/Speed, HP, or any other derived value. It preserves `baseStats` and user choices. That prevents save/reload from reapplying racial bonuses.
+
+## Firebase adapter
+
+`js/character-persistence-firebase.js` provides a mechanics-free adapter:
+
+```js
+readCharacter(ref)
+saveCharacter(ref, character)
+migrateCharacterRef(ref, { backupRef })
+modifyAndSave(ref, modifier)
+```
+
+Writes always run `prepareForSave()` and validation first. A failed migration or future schema performs no write.
+
+For an in-place legacy migration, callers may provide `backupRef`; the raw record is written there before the canonical replacement. If backup writing fails, replacement is not attempted.
+
+Reading does not auto-write. This avoids a page load silently mutating a player's only save.
+
+## Audit of current live surfaces
+
+### Character creation
+
+`creacion_personaje.html` currently builds a legacy `luminousState` and writes it directly with:
+
+```text
+campaña/jugadores/<uid>.set(luminousState)
+```
+
+That live path does not yet pass through this module. It must be integrated before #591 closes so all new saves contain `schemaVersion`.
+
+### Player load
+
+`hoja_personaje.js` currently reads the player node, assigns `snap.val()` directly to `window.datosJugador`, caches it, and renders it. That live path also does not yet pass through the migration boundary.
+
+It must be integrated before #591 closes, after #587 freezes which values are base/persistent versus derived/runtime.
+
+### Character Manager / Actor data
+
+`js/character-manager-engine.js` merges legacy and modern Actor roots and contains Actor/Theatre identity compatibility. Actor/Theatre state is not automatically promoted into Character Core. #591 should centralize Character persistence without erasing the separate Actor model.
+
+## Required close gate for #591
+
+Before this issue can be marked complete:
+
+1. #587 must be complete and the persistent/derived denylist reviewed against its contract.
+2. New Character creation must save through `prepareForSave()`/Firebase adapter and write `schemaVersion: 1`.
+3. Player load must run migration/validation before Character runtime/rendering.
+4. A validated migrated save must round-trip through load -> modify -> save -> reload.
+5. Existing compatibility fields needed by live consumers must remain available or receive explicit adapters.
+6. The focused Persistence suite and full repository suite must be green.
+
+## Focused regression suite
+
+```bash
+npx playwright test tests/character_persistence.spec.js --workers=1
+```
+
+The focused suite covers the mandatory #591 migration cases, including idempotence, legacy aliases, unknown canonical IDs, transient-data stripping, multiclass/Archetypes, backup behavior and future-schema safety.

--- a/js/character-persistence-firebase.js
+++ b/js/character-persistence-firebase.js
@@ -1,0 +1,74 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousCharacterPersistenceFirebase) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousCharacterPersistenceFirebase;
+    return;
+  }
+
+  const persistence = global.LuminousCharacterPersistence || (typeof require === "function" ? require("./character-persistence.js") : null);
+  if (!persistence) return;
+
+  function clone(value) {
+    if (value === undefined) return undefined;
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  async function readRaw(ref) {
+    if (!ref?.once) throw new Error("A Firebase-like ref with once('value') is required.");
+    const snapshot = await ref.once("value");
+    return snapshot?.val ? snapshot.val() : null;
+  }
+
+  async function readCharacter(ref, options = {}) {
+    const raw = await readRaw(ref);
+    if (raw == null) {
+      return {
+        ok: false,
+        character: null,
+        rawBackup: raw,
+        diagnostics: { errors: [{ code: "EMPTY_CHARACTER_SAVE", message: "Character save is empty." }], warnings: [] },
+      };
+    }
+    return persistence.load(raw, options);
+  }
+
+  async function saveCharacter(ref, character, options = {}) {
+    if (!ref?.set) throw new Error("A Firebase-like ref with set() is required.");
+    const prepared = persistence.prepareForSave(character, options);
+    if (!prepared.ok) return { ...prepared, written: false };
+    await ref.set(clone(prepared.character));
+    return { ...prepared, written: true };
+  }
+
+  async function migrateCharacterRef(ref, options = {}) {
+    const raw = await readRaw(ref);
+    const result = persistence.load(raw, options);
+    if (!result.ok) return { ...result, written: false, backupWritten: false };
+
+    let backupWritten = false;
+    if (options.backupRef) {
+      if (!options.backupRef?.set) throw new Error("backupRef must expose set().");
+      await options.backupRef.set(clone(raw));
+      backupWritten = true;
+    }
+
+    const prepared = persistence.prepareForSave(result.character, options);
+    if (!prepared.ok) return { ...prepared, written: false, backupWritten };
+    await ref.set(clone(prepared.character));
+    return { ...prepared, written: true, backupWritten };
+  }
+
+  async function modifyAndSave(ref, modifier, options = {}) {
+    if (typeof modifier !== "function") throw new Error("modifyAndSave requires a modifier function.");
+    const loaded = await readCharacter(ref, options);
+    if (!loaded.ok) return { ...loaded, written: false };
+    const working = clone(loaded.character);
+    const modified = await modifier(working);
+    return saveCharacter(ref, modified === undefined ? working : modified, options);
+  }
+
+  const api = Object.freeze({ readRaw, readCharacter, saveCharacter, migrateCharacterRef, modifyAndSave });
+  global.LuminousCharacterPersistenceFirebase = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/character-persistence.js
+++ b/js/character-persistence.js
@@ -225,10 +225,10 @@
     const backgroundId = backgroundRaw ? resolveContentLocalId("background", backgroundRaw, options, bucket) : null;
     const baseStats = clone(firstOwned(build, ["baseStats"], raw.baseStats ?? {}));
     const racialStatChoices = clone(firstOwned(build, ["racialStatChoices"], raw.racialStatChoices ?? []));
-    const milestoneSelections = clone(firstOwned(build, ["milestoneSelections"], raw.milestoneSelections ?? raw.milestones ?? []));
-    const traitSelections = normalizeStringSelections(firstOwned(build, ["traitSelections"], raw.traitSelections ?? raw.traits ?? raw.humanPerks ?? []));
-    const skillSelections = normalizeStringSelections(firstOwned(build, ["skillSelections"], raw.skillSelections ?? raw.skills ?? []));
-    const spellSelections = normalizeStringSelections(firstOwned(build, ["spellSelections"], raw.spellSelections ?? raw.spells ?? []));
+    const milestoneSelections = clone(firstOwned(build, ["milestoneSelections"], raw.milestoneSelections ?? []));
+    const traitSelections = normalizeStringSelections(firstOwned(build, ["traitSelections"], raw.traitSelections ?? []));
+    const skillSelections = normalizeStringSelections(firstOwned(build, ["skillSelections"], raw.skillSelections ?? []));
+    const spellSelections = normalizeStringSelections(firstOwned(build, ["spellSelections"], raw.spellSelections ?? []));
 
     const next = { ...raw, schemaVersion: CURRENT_SCHEMA_VERSION };
     next.characterBuild = {
@@ -324,7 +324,7 @@
     if (from < 0 || typeof migration !== "function") throw new Error("Migration requires a non-negative fromVersion and a function.");
     if (migrations.has(from)) throw new Error(`Migration from v${from} is already registered.`);
     migrations.set(from, migration);
-    return api;
+    return migration;
   }
 
   function runMigrations(raw, options = {}) {

--- a/js/character-persistence.js
+++ b/js/character-persistence.js
@@ -24,8 +24,8 @@
     "uiState",
   ]);
 
-  // Only aliases whose equivalence is already explicit in current repository catalogs are mapped here.
-  // Unknown legacy content is preserved in the raw-compatible document and reported, never guessed.
+  // Verified aliases from the legacy character-creation IDs to current Race IDs.
+  // Anything without a proven equivalent is preserved as legacy input and diagnosed.
   const LEGACY_CONTENT_ALIASES = Object.freeze({
     race: Object.freeze({
       humano: "human",
@@ -46,6 +46,15 @@
     return Boolean(value) && typeof value === "object" && !Array.isArray(value);
   }
 
+  function owns(object, key) {
+    return Object.prototype.hasOwnProperty.call(object || {}, key);
+  }
+
+  function firstOwned(object, keys, fallback) {
+    for (const key of keys) if (owns(object, key)) return object[key];
+    return fallback;
+  }
+
   function toInteger(value, fallback = 0) {
     const parsed = Number.parseInt(value, 10);
     return Number.isFinite(parsed) ? parsed : fallback;
@@ -55,7 +64,7 @@
     return typeof value === "string" ? value.trim() : "";
   }
 
-  function diagnostics() {
+  function newDiagnostics() {
     return { errors: [], warnings: [] };
   }
 
@@ -100,7 +109,7 @@
     return String(canonical || "").startsWith(prefix) ? String(canonical).slice(prefix.length) : null;
   }
 
-  function resolveContentLocalId(type, value, options = {}, bucket = diagnostics()) {
+  function resolveContentLocalId(type, value, options = {}, bucket = newDiagnostics()) {
     const raw = cleanString(value);
     if (!raw) return null;
     const registry = ensureRegistry(options.registry);
@@ -126,36 +135,34 @@
       return raw;
     }
 
-    pushDiagnostic(bucket, "warning", "UNRESOLVED_LEGACY_CONTENT_ID", `Legacy ${type} '${raw}' has no verified canonical mapping.`, { type, value: raw });
-    return null;
+    if (options.legacyMode === true) {
+      pushDiagnostic(bucket, "warning", "UNRESOLVED_LEGACY_CONTENT_ID", `Legacy ${type} '${raw}' has no verified canonical mapping.`, { type, value: raw });
+      return null;
+    }
+
+    return raw;
   }
 
   function normalizeClassEntries(raw, options, bucket) {
     const build = isObject(raw.characterBuild) ? raw.characterBuild : {};
-    const source = Array.isArray(build.classes)
-      ? build.classes
-      : Array.isArray(raw.classes)
-        ? raw.classes
-        : null;
-
+    const source = owns(build, "classes") ? build.classes : (Array.isArray(raw.classes) ? raw.classes : null);
     const entries = [];
-    if (source) {
+
+    if (Array.isArray(source)) {
       source.forEach((entry) => {
         if (!entry) return;
         const value = typeof entry === "string" ? { classId: entry, levels: 1 } : entry;
         const classId = resolveContentLocalId("class", value.classId || value.id || value.clase || value.name, options, bucket);
         if (!classId) return;
-        const levels = Math.max(1, toInteger(value.levels ?? value.level ?? value.classLevel ?? 1, 1));
-        entries.push({ classId, levels });
+        entries.push({ classId, levels: Math.max(1, toInteger(value.levels ?? value.level ?? value.classLevel ?? 1, 1)) });
       });
     } else {
-      const byId = build.classLevels || raw.classLevels || raw.classesById;
+      const byId = firstOwned(build, ["classLevels"], raw.classLevels || raw.classesById);
       if (isObject(byId)) {
         Object.entries(byId).forEach(([id, amount]) => {
           const classId = resolveContentLocalId("class", id, options, bucket);
           if (!classId) return;
-          const levels = Math.max(1, toInteger(amount?.levels ?? amount?.level ?? amount, 1));
-          entries.push({ classId, levels });
+          entries.push({ classId, levels: Math.max(1, toInteger(amount?.levels ?? amount?.level ?? amount, 1)) });
         });
       } else {
         const legacyClass = raw.clase || raw.classId || raw.className;
@@ -173,7 +180,7 @@
 
   function normalizeArchetypes(raw, options, bucket) {
     const build = isObject(raw.characterBuild) ? raw.characterBuild : {};
-    const source = build.archetypes ?? raw.archetypes ?? [];
+    const source = owns(build, "archetypes") ? build.archetypes : (raw.archetypes ?? []);
     const list = Array.isArray(source)
       ? source
       : isObject(source)
@@ -184,10 +191,10 @@
       const classId = resolveContentLocalId("class", entry?.classId || entry?.parentClassId, options, bucket);
       const archetypeId = resolveContentLocalId("archetype", entry?.archetypeId || entry?.subclassId || entry?.id, options, bucket);
       if (!classId || !archetypeId) return null;
-      const result = { classId, archetypeId };
+      const normalized = { classId, archetypeId };
       const selectedAt = toInteger(entry?.selectedAtClassLevel ?? entry?.selectedAtLevel, 0);
-      if (selectedAt > 0) result.selectedAtClassLevel = selectedAt;
-      return result;
+      if (selectedAt > 0) normalized.selectedAtClassLevel = selectedAt;
+      return normalized;
     }).filter(Boolean).sort((a, b) => a.classId.localeCompare(b.classId));
   }
 
@@ -198,13 +205,13 @@
 
   function normalizeCanonicalCharacter(input, options = {}) {
     const raw = clone(input || {});
-    const bucket = options.diagnostics || diagnostics();
-    const existingBuild = isObject(raw.characterBuild) ? raw.characterBuild : {};
+    const bucket = options.diagnostics || newDiagnostics();
+    const build = isObject(raw.characterBuild) ? raw.characterBuild : {};
 
-    const raceRaw = existingBuild.raceId ?? raw.raceId ?? raw.originId ?? raw.razaId ?? raw.raza;
+    const raceRaw = firstOwned(build, ["raceId"], raw.raceId ?? raw.originId ?? raw.razaId ?? raw.raza);
     const raceId = raceRaw ? resolveContentLocalId("race", raceRaw, options, bucket) : null;
 
-    let raceSubtypeId = cleanString(existingBuild.raceSubtypeId ?? existingBuild.subraceId ?? raw.raceSubtypeId ?? raw.subraceId);
+    let raceSubtypeId = cleanString(firstOwned(build, ["raceSubtypeId", "subraceId"], raw.raceSubtypeId ?? raw.subraceId));
     if (raceSubtypeId && raceId) {
       const registry = ensureRegistry(options.registry);
       const candidate = `${raceId}:${raceSubtypeId}`;
@@ -214,19 +221,18 @@
       }
     }
 
-    const backgroundRaw = existingBuild.backgroundId ?? raw.backgroundId ?? raw.trasfondoId;
+    const backgroundRaw = firstOwned(build, ["backgroundId"], raw.backgroundId ?? raw.trasfondoId);
     const backgroundId = backgroundRaw ? resolveContentLocalId("background", backgroundRaw, options, bucket) : null;
-
-    const baseStats = clone(existingBuild.baseStats ?? raw.baseStats ?? {});
-    const racialStatChoices = clone(existingBuild.racialStatChoices ?? raw.racialStatChoices ?? []);
-    const milestoneSelections = clone(existingBuild.milestoneSelections ?? raw.milestoneSelections ?? raw.milestones ?? []);
-    const traitSelections = normalizeStringSelections(existingBuild.traitSelections ?? raw.traitSelections ?? raw.traits ?? raw.humanPerks ?? []);
-    const skillSelections = normalizeStringSelections(existingBuild.skillSelections ?? raw.skillSelections ?? raw.skills ?? []);
-    const spellSelections = normalizeStringSelections(existingBuild.spellSelections ?? raw.spellSelections ?? raw.spells ?? []);
+    const baseStats = clone(firstOwned(build, ["baseStats"], raw.baseStats ?? {}));
+    const racialStatChoices = clone(firstOwned(build, ["racialStatChoices"], raw.racialStatChoices ?? []));
+    const milestoneSelections = clone(firstOwned(build, ["milestoneSelections"], raw.milestoneSelections ?? raw.milestones ?? []));
+    const traitSelections = normalizeStringSelections(firstOwned(build, ["traitSelections"], raw.traitSelections ?? raw.traits ?? raw.humanPerks ?? []));
+    const skillSelections = normalizeStringSelections(firstOwned(build, ["skillSelections"], raw.skillSelections ?? raw.skills ?? []));
+    const spellSelections = normalizeStringSelections(firstOwned(build, ["spellSelections"], raw.spellSelections ?? raw.spells ?? []));
 
     const next = { ...raw, schemaVersion: CURRENT_SCHEMA_VERSION };
     next.characterBuild = {
-      ...clone(existingBuild),
+      ...clone(build),
       raceId,
       raceSubtypeId: raceSubtypeId || null,
       backgroundId,
@@ -240,8 +246,8 @@
       spellSelections,
     };
 
-    const name = cleanString(raw.characterName || raw.character_name || raw.nombre || raw.name);
-    const characterId = cleanString(raw.characterId || raw.identityId || raw.id);
+    const name = cleanString(raw.characterIdentity?.name || raw.characterName || raw.character_name || raw.nombre || raw.name);
+    const characterId = cleanString(raw.characterIdentity?.characterId || raw.characterId || raw.identityId || raw.id);
     next.characterIdentity = {
       ...(isObject(raw.characterIdentity) ? clone(raw.characterIdentity) : {}),
       characterId: characterId || null,
@@ -264,9 +270,8 @@
   }
 
   function validateCanonicalCharacter(character, options = {}) {
-    const bucket = options.diagnostics || diagnostics();
+    const bucket = options.diagnostics || newDiagnostics();
     const registry = ensureRegistry(options.registry);
-
     if (!isObject(character)) {
       pushDiagnostic(bucket, "error", "INVALID_CHARACTER_DOCUMENT", "Character save must be an object.");
       return { valid: false, diagnostics: bucket };
@@ -282,9 +287,7 @@
     const build = character.characterBuild;
     validateTypedReference(registry, "race", build.raceId, bucket, "characterBuild.raceId");
     validateTypedReference(registry, "background", build.backgroundId, bucket, "characterBuild.backgroundId");
-    if (build.raceId && build.raceSubtypeId) {
-      validateTypedReference(registry, "subrace", `${build.raceId}:${build.raceSubtypeId}`, bucket, "characterBuild.raceSubtypeId");
-    }
+    if (build.raceId && build.raceSubtypeId) validateTypedReference(registry, "subrace", `${build.raceId}:${build.raceSubtypeId}`, bucket, "characterBuild.raceSubtypeId");
 
     if (!Array.isArray(build.classes)) {
       pushDiagnostic(bucket, "error", "INVALID_CLASSES", "characterBuild.classes must be an array.");
@@ -308,12 +311,7 @@
       });
     }
 
-    const selectionTypes = [
-      ["traitSelections", "trait"],
-      ["skillSelections", "skill"],
-      ["spellSelections", "spell"],
-    ];
-    selectionTypes.forEach(([field, type]) => {
+    [["traitSelections", "trait"], ["skillSelections", "skill"], ["spellSelections", "spell"]].forEach(([field, type]) => {
       if (!Array.isArray(build[field])) return;
       build[field].forEach((id, index) => validateTypedReference(registry, type, id, bucket, `characterBuild.${field}[${index}]`));
     });
@@ -331,7 +329,7 @@
 
   function runMigrations(raw, options = {}) {
     const rawBackup = clone(raw);
-    const bucket = diagnostics();
+    const bucket = newDiagnostics();
     if (!isObject(raw)) {
       pushDiagnostic(bucket, "error", "INVALID_CHARACTER_DOCUMENT", "Raw character must be an object.");
       return { ok: false, character: null, rawBackup, diagnostics: bucket, fromVersion: 0, toVersion: null };
@@ -360,7 +358,7 @@
       return { ok: false, character: null, rawBackup, diagnostics: bucket, fromVersion, toVersion: null };
     }
 
-    const normalized = normalizeCanonicalCharacter(current, { ...options, diagnostics: bucket });
+    const normalized = normalizeCanonicalCharacter(current, { ...options, diagnostics: bucket, legacyMode: false });
     const validation = validateCanonicalCharacter(normalized.character, { ...options, diagnostics: bucket });
     return {
       ok: validation.valid,
@@ -383,15 +381,15 @@
   }
 
   function prepareForSave(input, options = {}) {
-    const result = runMigrations(input, options);
-    if (!result.ok) return result;
-    const stripped = stripTransientState(result.character);
-    const bucket = diagnostics();
-    bucket.warnings.push(...clone(result.diagnostics.warnings));
-    const normalized = normalizeCanonicalCharacter(stripped, { ...options, diagnostics: bucket });
+    const loaded = runMigrations(input, options);
+    if (!loaded.ok) return loaded;
+    const stripped = stripTransientState(loaded.character);
+    const bucket = newDiagnostics();
+    bucket.warnings.push(...clone(loaded.diagnostics.warnings));
+    const normalized = normalizeCanonicalCharacter(stripped, { ...options, diagnostics: bucket, legacyMode: false });
     const validation = validateCanonicalCharacter(normalized.character, { ...options, diagnostics: bucket });
     return {
-      ...result,
+      ...loaded,
       ok: validation.valid,
       character: validation.valid ? normalized.character : null,
       candidate: normalized.character,
@@ -404,7 +402,7 @@
   }
 
   registerMigration(0, (raw, options = {}) => {
-    const normalized = normalizeCanonicalCharacter({ ...clone(raw), schemaVersion: CURRENT_SCHEMA_VERSION }, options);
+    const normalized = normalizeCanonicalCharacter({ ...clone(raw), schemaVersion: CURRENT_SCHEMA_VERSION }, { ...options, legacyMode: true });
     return normalized.character;
   });
 

--- a/js/character-persistence.js
+++ b/js/character-persistence.js
@@ -1,0 +1,427 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousCharacterPersistence) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousCharacterPersistence;
+    return;
+  }
+
+  const CURRENT_SCHEMA_VERSION = 1;
+  const migrations = new Map();
+
+  const TRANSIENT_TOP_LEVEL_KEYS = Object.freeze([
+    "abilityMods",
+    "abilityModifiers",
+    "derivedStats",
+    "statBreakdown",
+    "statBreakdowns",
+    "traitEngineCache",
+    "runtimeCache",
+    "actionEconomy",
+    "encounterState",
+    "combatRuntime",
+    "uiBreakdown",
+    "uiState",
+  ]);
+
+  // Only aliases whose equivalence is already explicit in current repository catalogs are mapped here.
+  // Unknown legacy content is preserved in the raw-compatible document and reported, never guessed.
+  const LEGACY_CONTENT_ALIASES = Object.freeze({
+    race: Object.freeze({
+      humano: "human",
+      centauro: "centaur",
+      goliat: "goliath",
+      hada: "fairy",
+      semi_dragon: "half_dragon",
+      yuanti_pura_sangre: "yuan_ti_pureblood",
+    }),
+  });
+
+  function clone(value) {
+    if (value === undefined) return undefined;
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function isObject(value) {
+    return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function toInteger(value, fallback = 0) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+
+  function cleanString(value) {
+    return typeof value === "string" ? value.trim() : "";
+  }
+
+  function diagnostics() {
+    return { errors: [], warnings: [] };
+  }
+
+  function pushDiagnostic(bucket, severity, code, message, details = {}) {
+    const entry = { code, message, ...clone(details) };
+    bucket[severity === "error" ? "errors" : "warnings"].push(entry);
+    return entry;
+  }
+
+  function detectVersion(raw) {
+    if (!isObject(raw)) return 0;
+    if (raw.schemaVersion === undefined || raw.schemaVersion === null || raw.schemaVersion === "") return 0;
+    const version = Number(raw.schemaVersion);
+    return Number.isInteger(version) && version >= 0 ? version : 0;
+  }
+
+  function ensureRegistry(customRegistry) {
+    if (customRegistry) return customRegistry;
+    let registry = global.LuminousContentRegistry || null;
+    if (!registry && typeof require === "function") {
+      try { registry = require("./content-registry.js"); } catch (_) {}
+    }
+
+    let bootstrap = global.LuminousContentRegistryBootstrap || null;
+    if (!bootstrap && typeof require === "function") {
+      try { bootstrap = require("./content-registry-bootstrap.js"); } catch (_) {}
+    }
+    try { bootstrap?.registerAvailableCore?.(); } catch (_) {}
+    return registry;
+  }
+
+  function registeredTypeAvailable(registry, type) {
+    try { return Boolean(registry?.list?.({ type })?.length); } catch (_) { return false; }
+  }
+
+  function localIdFromCanonical(registry, type, canonical) {
+    try {
+      const entry = registry?.get?.(canonical);
+      if (entry?.type === type && entry.id) return entry.id;
+    } catch (_) {}
+    const prefix = `${type}:`;
+    return String(canonical || "").startsWith(prefix) ? String(canonical).slice(prefix.length) : null;
+  }
+
+  function resolveContentLocalId(type, value, options = {}, bucket = diagnostics()) {
+    const raw = cleanString(value);
+    if (!raw) return null;
+    const registry = ensureRegistry(options.registry);
+
+    if (registry) {
+      try {
+        const canonical = raw.startsWith(`${type}:`) ? registry.resolve(raw) : registry.resolve(type, raw);
+        if (canonical) return localIdFromCanonical(registry, type, canonical);
+      } catch (_) {}
+    }
+
+    const aliasTarget = LEGACY_CONTENT_ALIASES[type]?.[raw.toLowerCase()] || null;
+    if (aliasTarget) {
+      if (!registry || !registeredTypeAvailable(registry, type)) return aliasTarget;
+      try {
+        const canonical = registry.resolve(type, aliasTarget);
+        if (canonical) return localIdFromCanonical(registry, type, canonical) || aliasTarget;
+      } catch (_) {}
+    }
+
+    if (!registry || !registeredTypeAvailable(registry, type)) {
+      pushDiagnostic(bucket, "warning", "REGISTRY_TYPE_UNAVAILABLE", `Cannot validate ${type} '${raw}' because that Registry type is not loaded.`, { type, value: raw });
+      return raw;
+    }
+
+    pushDiagnostic(bucket, "warning", "UNRESOLVED_LEGACY_CONTENT_ID", `Legacy ${type} '${raw}' has no verified canonical mapping.`, { type, value: raw });
+    return null;
+  }
+
+  function normalizeClassEntries(raw, options, bucket) {
+    const build = isObject(raw.characterBuild) ? raw.characterBuild : {};
+    const source = Array.isArray(build.classes)
+      ? build.classes
+      : Array.isArray(raw.classes)
+        ? raw.classes
+        : null;
+
+    const entries = [];
+    if (source) {
+      source.forEach((entry) => {
+        if (!entry) return;
+        const value = typeof entry === "string" ? { classId: entry, levels: 1 } : entry;
+        const classId = resolveContentLocalId("class", value.classId || value.id || value.clase || value.name, options, bucket);
+        if (!classId) return;
+        const levels = Math.max(1, toInteger(value.levels ?? value.level ?? value.classLevel ?? 1, 1));
+        entries.push({ classId, levels });
+      });
+    } else {
+      const byId = build.classLevels || raw.classLevels || raw.classesById;
+      if (isObject(byId)) {
+        Object.entries(byId).forEach(([id, amount]) => {
+          const classId = resolveContentLocalId("class", id, options, bucket);
+          if (!classId) return;
+          const levels = Math.max(1, toInteger(amount?.levels ?? amount?.level ?? amount, 1));
+          entries.push({ classId, levels });
+        });
+      } else {
+        const legacyClass = raw.clase || raw.classId || raw.className;
+        if (legacyClass) {
+          const classId = resolveContentLocalId("class", legacyClass, options, bucket);
+          if (classId) entries.push({ classId, levels: Math.max(1, toInteger(raw.classLevel ?? raw.nivelClase ?? 1, 1)) });
+        }
+      }
+    }
+
+    const merged = new Map();
+    entries.forEach((entry) => merged.set(entry.classId, (merged.get(entry.classId) || 0) + entry.levels));
+    return [...merged.entries()].map(([classId, levels]) => ({ classId, levels })).sort((a, b) => a.classId.localeCompare(b.classId));
+  }
+
+  function normalizeArchetypes(raw, options, bucket) {
+    const build = isObject(raw.characterBuild) ? raw.characterBuild : {};
+    const source = build.archetypes ?? raw.archetypes ?? [];
+    const list = Array.isArray(source)
+      ? source
+      : isObject(source)
+        ? Object.entries(source).map(([classId, value]) => typeof value === "string" ? { classId, archetypeId: value } : { classId, ...(value || {}) })
+        : [];
+
+    return list.map((entry) => {
+      const classId = resolveContentLocalId("class", entry?.classId || entry?.parentClassId, options, bucket);
+      const archetypeId = resolveContentLocalId("archetype", entry?.archetypeId || entry?.subclassId || entry?.id, options, bucket);
+      if (!classId || !archetypeId) return null;
+      const result = { classId, archetypeId };
+      const selectedAt = toInteger(entry?.selectedAtClassLevel ?? entry?.selectedAtLevel, 0);
+      if (selectedAt > 0) result.selectedAtClassLevel = selectedAt;
+      return result;
+    }).filter(Boolean).sort((a, b) => a.classId.localeCompare(b.classId));
+  }
+
+  function normalizeStringSelections(value) {
+    const list = Array.isArray(value) ? value : isObject(value) ? Object.keys(value) : [];
+    return [...new Set(list.map((entry) => cleanString(entry?.id || entry?.traitId || entry?.skillId || entry?.spellId || entry)).filter(Boolean))];
+  }
+
+  function normalizeCanonicalCharacter(input, options = {}) {
+    const raw = clone(input || {});
+    const bucket = options.diagnostics || diagnostics();
+    const existingBuild = isObject(raw.characterBuild) ? raw.characterBuild : {};
+
+    const raceRaw = existingBuild.raceId ?? raw.raceId ?? raw.originId ?? raw.razaId ?? raw.raza;
+    const raceId = raceRaw ? resolveContentLocalId("race", raceRaw, options, bucket) : null;
+
+    let raceSubtypeId = cleanString(existingBuild.raceSubtypeId ?? existingBuild.subraceId ?? raw.raceSubtypeId ?? raw.subraceId);
+    if (raceSubtypeId && raceId) {
+      const registry = ensureRegistry(options.registry);
+      const candidate = `${raceId}:${raceSubtypeId}`;
+      if (registry && registeredTypeAvailable(registry, "subrace") && !registry.resolve("subrace", candidate)) {
+        const legacyCandidate = registry.resolve("subrace", `${raceId}_${raceSubtypeId}`);
+        if (legacyCandidate) raceSubtypeId = localIdFromCanonical(registry, "subrace", legacyCandidate)?.split(":").pop() || raceSubtypeId;
+      }
+    }
+
+    const backgroundRaw = existingBuild.backgroundId ?? raw.backgroundId ?? raw.trasfondoId;
+    const backgroundId = backgroundRaw ? resolveContentLocalId("background", backgroundRaw, options, bucket) : null;
+
+    const baseStats = clone(existingBuild.baseStats ?? raw.baseStats ?? {});
+    const racialStatChoices = clone(existingBuild.racialStatChoices ?? raw.racialStatChoices ?? []);
+    const milestoneSelections = clone(existingBuild.milestoneSelections ?? raw.milestoneSelections ?? raw.milestones ?? []);
+    const traitSelections = normalizeStringSelections(existingBuild.traitSelections ?? raw.traitSelections ?? raw.traits ?? raw.humanPerks ?? []);
+    const skillSelections = normalizeStringSelections(existingBuild.skillSelections ?? raw.skillSelections ?? raw.skills ?? []);
+    const spellSelections = normalizeStringSelections(existingBuild.spellSelections ?? raw.spellSelections ?? raw.spells ?? []);
+
+    const next = { ...raw, schemaVersion: CURRENT_SCHEMA_VERSION };
+    next.characterBuild = {
+      ...clone(existingBuild),
+      raceId,
+      raceSubtypeId: raceSubtypeId || null,
+      backgroundId,
+      classes: normalizeClassEntries(raw, options, bucket),
+      archetypes: normalizeArchetypes(raw, options, bucket),
+      baseStats: isObject(baseStats) ? baseStats : {},
+      racialStatChoices: Array.isArray(racialStatChoices) ? racialStatChoices : [],
+      milestoneSelections: Array.isArray(milestoneSelections) ? milestoneSelections : [],
+      traitSelections,
+      skillSelections,
+      spellSelections,
+    };
+
+    const name = cleanString(raw.characterName || raw.character_name || raw.nombre || raw.name);
+    const characterId = cleanString(raw.characterId || raw.identityId || raw.id);
+    next.characterIdentity = {
+      ...(isObject(raw.characterIdentity) ? clone(raw.characterIdentity) : {}),
+      characterId: characterId || null,
+      name: name || null,
+    };
+
+    return { character: next, diagnostics: bucket };
+  }
+
+  function validateTypedReference(registry, type, id, bucket, path) {
+    if (!id) return;
+    if (!registry || !registeredTypeAvailable(registry, type)) {
+      pushDiagnostic(bucket, "warning", "REGISTRY_TYPE_UNAVAILABLE", `Cannot validate ${path}; Registry type '${type}' is not loaded.`, { type, id, path });
+      return;
+    }
+    const result = registry.validateReference(id, type);
+    if (!result.valid) {
+      pushDiagnostic(bucket, "error", "UNKNOWN_CANONICAL_CONTENT_ID", `Unknown canonical ${type} id '${id}' at ${path}.`, { type, id, path, reason: result.reason });
+    }
+  }
+
+  function validateCanonicalCharacter(character, options = {}) {
+    const bucket = options.diagnostics || diagnostics();
+    const registry = ensureRegistry(options.registry);
+
+    if (!isObject(character)) {
+      pushDiagnostic(bucket, "error", "INVALID_CHARACTER_DOCUMENT", "Character save must be an object.");
+      return { valid: false, diagnostics: bucket };
+    }
+    if (detectVersion(character) !== CURRENT_SCHEMA_VERSION) {
+      pushDiagnostic(bucket, "error", "INVALID_SCHEMA_VERSION", `Expected schemaVersion ${CURRENT_SCHEMA_VERSION}.`, { actual: character.schemaVersion });
+    }
+    if (!isObject(character.characterBuild)) {
+      pushDiagnostic(bucket, "error", "MISSING_CHARACTER_BUILD", "Character save requires characterBuild.");
+      return { valid: false, diagnostics: bucket };
+    }
+
+    const build = character.characterBuild;
+    validateTypedReference(registry, "race", build.raceId, bucket, "characterBuild.raceId");
+    validateTypedReference(registry, "background", build.backgroundId, bucket, "characterBuild.backgroundId");
+    if (build.raceId && build.raceSubtypeId) {
+      validateTypedReference(registry, "subrace", `${build.raceId}:${build.raceSubtypeId}`, bucket, "characterBuild.raceSubtypeId");
+    }
+
+    if (!Array.isArray(build.classes)) {
+      pushDiagnostic(bucket, "error", "INVALID_CLASSES", "characterBuild.classes must be an array.");
+    } else {
+      const seen = new Set();
+      build.classes.forEach((entry, index) => {
+        if (!entry?.classId || toInteger(entry.levels, 0) <= 0) {
+          pushDiagnostic(bucket, "error", "INVALID_CLASS_ENTRY", `Invalid class entry at index ${index}.`, { index });
+          return;
+        }
+        if (seen.has(entry.classId)) pushDiagnostic(bucket, "error", "DUPLICATE_CLASS_ENTRY", `Duplicate class '${entry.classId}'.`, { classId: entry.classId });
+        seen.add(entry.classId);
+        validateTypedReference(registry, "class", entry.classId, bucket, `characterBuild.classes[${index}].classId`);
+      });
+    }
+
+    if (Array.isArray(build.archetypes)) {
+      build.archetypes.forEach((entry, index) => {
+        validateTypedReference(registry, "class", entry?.classId, bucket, `characterBuild.archetypes[${index}].classId`);
+        validateTypedReference(registry, "archetype", entry?.archetypeId, bucket, `characterBuild.archetypes[${index}].archetypeId`);
+      });
+    }
+
+    const selectionTypes = [
+      ["traitSelections", "trait"],
+      ["skillSelections", "skill"],
+      ["spellSelections", "spell"],
+    ];
+    selectionTypes.forEach(([field, type]) => {
+      if (!Array.isArray(build[field])) return;
+      build[field].forEach((id, index) => validateTypedReference(registry, type, id, bucket, `characterBuild.${field}[${index}]`));
+    });
+
+    return { valid: bucket.errors.length === 0, diagnostics: bucket };
+  }
+
+  function registerMigration(fromVersion, migration) {
+    const from = toInteger(fromVersion, -1);
+    if (from < 0 || typeof migration !== "function") throw new Error("Migration requires a non-negative fromVersion and a function.");
+    if (migrations.has(from)) throw new Error(`Migration from v${from} is already registered.`);
+    migrations.set(from, migration);
+    return api;
+  }
+
+  function runMigrations(raw, options = {}) {
+    const rawBackup = clone(raw);
+    const bucket = diagnostics();
+    if (!isObject(raw)) {
+      pushDiagnostic(bucket, "error", "INVALID_CHARACTER_DOCUMENT", "Raw character must be an object.");
+      return { ok: false, character: null, rawBackup, diagnostics: bucket, fromVersion: 0, toVersion: null };
+    }
+
+    const fromVersion = detectVersion(raw);
+    if (fromVersion > CURRENT_SCHEMA_VERSION) {
+      pushDiagnostic(bucket, "error", "UNSUPPORTED_FUTURE_SCHEMA", `Save schema v${fromVersion} is newer than supported v${CURRENT_SCHEMA_VERSION}.`, { fromVersion, supportedVersion: CURRENT_SCHEMA_VERSION });
+      return { ok: false, character: null, rawBackup, diagnostics: bucket, fromVersion, toVersion: null };
+    }
+
+    let version = fromVersion;
+    let current = clone(raw);
+    try {
+      while (version < CURRENT_SCHEMA_VERSION) {
+        const migration = migrations.get(version);
+        if (!migration) throw new Error(`Missing migration v${version} -> v${version + 1}.`);
+        current = migration(current, { ...options, diagnostics: bucket });
+        if (!isObject(current)) throw new Error(`Migration v${version} did not return a character object.`);
+        const detected = detectVersion(current);
+        if (detected !== version + 1) throw new Error(`Migration v${version} must produce schemaVersion ${version + 1}, got ${current.schemaVersion}.`);
+        version = detected;
+      }
+    } catch (error) {
+      pushDiagnostic(bucket, "error", "MIGRATION_FAILED", error?.message || String(error), { fromVersion: version });
+      return { ok: false, character: null, rawBackup, diagnostics: bucket, fromVersion, toVersion: null };
+    }
+
+    const normalized = normalizeCanonicalCharacter(current, { ...options, diagnostics: bucket });
+    const validation = validateCanonicalCharacter(normalized.character, { ...options, diagnostics: bucket });
+    return {
+      ok: validation.valid,
+      character: validation.valid ? normalized.character : null,
+      candidate: normalized.character,
+      rawBackup,
+      diagnostics: bucket,
+      fromVersion,
+      toVersion: CURRENT_SCHEMA_VERSION,
+    };
+  }
+
+  function stripTransientState(character) {
+    const next = clone(character || {});
+    TRANSIENT_TOP_LEVEL_KEYS.forEach((key) => { delete next[key]; });
+    if (isObject(next.characterBuild)) {
+      ["effectiveStats", "derivedStats", "abilityMods", "breakdowns", "runtime", "cache"].forEach((key) => { delete next.characterBuild[key]; });
+    }
+    return next;
+  }
+
+  function prepareForSave(input, options = {}) {
+    const result = runMigrations(input, options);
+    if (!result.ok) return result;
+    const stripped = stripTransientState(result.character);
+    const bucket = diagnostics();
+    bucket.warnings.push(...clone(result.diagnostics.warnings));
+    const normalized = normalizeCanonicalCharacter(stripped, { ...options, diagnostics: bucket });
+    const validation = validateCanonicalCharacter(normalized.character, { ...options, diagnostics: bucket });
+    return {
+      ...result,
+      ok: validation.valid,
+      character: validation.valid ? normalized.character : null,
+      candidate: normalized.character,
+      diagnostics: bucket,
+    };
+  }
+
+  function load(raw, options = {}) {
+    return runMigrations(raw, options);
+  }
+
+  registerMigration(0, (raw, options = {}) => {
+    const normalized = normalizeCanonicalCharacter({ ...clone(raw), schemaVersion: CURRENT_SCHEMA_VERSION }, options);
+    return normalized.character;
+  });
+
+  const api = Object.freeze({
+    CURRENT_SCHEMA_VERSION,
+    TRANSIENT_TOP_LEVEL_KEYS,
+    LEGACY_CONTENT_ALIASES,
+    detectVersion,
+    normalizeCanonicalCharacter,
+    validateCanonicalCharacter,
+    registerMigration,
+    runMigrations,
+    load,
+    prepareForSave,
+    stripTransientState,
+  });
+
+  global.LuminousCharacterPersistence = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/tests/character_persistence.spec.js
+++ b/tests/character_persistence.spec.js
@@ -1,0 +1,229 @@
+const { test, expect } = require("@playwright/test");
+const registry = require("../js/content-registry.js");
+const bootstrap = require("../js/content-registry-bootstrap.js");
+const buildRules = require("../js/character-build-rules.js");
+const traitCatalog = require("../js/trait-catalog-core.js");
+const archetypeCatalog = require("../js/archetype-trait-catalog.js");
+const persistence = require("../js/character-persistence.js");
+const firebasePersistence = require("../js/character-persistence-firebase.js");
+
+function registerCore() {
+  registry.clear();
+  bootstrap.resetBootstrapState();
+  bootstrap.registerAvailableCore({ modules: { buildRules, traitCatalog, archetypeCatalog } });
+}
+
+function fakeRef(initial) {
+  let value = JSON.parse(JSON.stringify(initial));
+  const writes = [];
+  return {
+    writes,
+    once: async () => ({ val: () => JSON.parse(JSON.stringify(value)) }),
+    set: async (next) => {
+      value = JSON.parse(JSON.stringify(next));
+      writes.push(JSON.parse(JSON.stringify(next)));
+    },
+    value: () => JSON.parse(JSON.stringify(value)),
+  };
+}
+
+test.beforeEach(registerCore);
+
+test("new prepared saves include schemaVersion 1 and canonical typed build IDs", () => {
+  const result = persistence.prepareForSave({
+    characterName: "Aster",
+    originId: "humano",
+    clase: "Bárbaro",
+    baseStats: { fuerza: 10, destreza: 12 },
+  }, { registry });
+
+  expect(result.ok).toBe(true);
+  expect(result.character.schemaVersion).toBe(1);
+  expect(result.character.characterBuild.raceId).toBe("human");
+  expect(result.character.characterBuild.classes).toEqual([{ classId: "barbarian", levels: 1 }]);
+  expect(result.character.characterBuild.baseStats).toEqual({ fuerza: 10, destreza: 12 });
+});
+
+test("real legacy-shaped save migrates without losing identity, class, selections, stats or unknown user fields", () => {
+  const legacy = {
+    uid: "legacy-user",
+    characterName: "Legacy One",
+    originId: "goliat",
+    backgroundId: "alta_cuna",
+    clase: "Bardo",
+    classLevel: 15,
+    baseStats: { fuerza: 10, destreza: 14, carisma: 16 },
+    traitSelections: ["rage"],
+    humanPerks: [{ id: "bg_perk_legacy", nombre: "Contacto antiguo", desc: "Legacy free-form perk" }],
+    finance: { currentBalance: 500 },
+  };
+
+  const result = persistence.load(legacy, { registry });
+  expect(result.ok).toBe(true);
+  expect(result.character.characterBuild.raceId).toBe("goliath");
+  expect(result.character.characterBuild.classes).toEqual([{ classId: "bard", levels: 15 }]);
+  expect(result.character.characterBuild.baseStats).toEqual(legacy.baseStats);
+  expect(result.character.characterBuild.traitSelections).toEqual(["rage"]);
+  expect(result.character.humanPerks).toEqual(legacy.humanPerks);
+  expect(result.character.finance).toEqual(legacy.finance);
+  expect(result.character.backgroundId).toBe("alta_cuna");
+  expect(result.character.characterBuild.backgroundId).toBeNull();
+  expect(result.diagnostics.warnings.some((entry) => entry.code === "UNRESOLVED_LEGACY_CONTENT_ID")).toBe(true);
+});
+
+test("migration is sequential and idempotent", () => {
+  const legacy = { characterName: "Idem", originId: "centauro", clase: "Guerrero", baseStats: { fuerza: 11 } };
+  const once = persistence.load(legacy, { registry });
+  const twice = persistence.load(once.character, { registry });
+
+  expect(once.ok).toBe(true);
+  expect(twice.ok).toBe(true);
+  expect(twice.character).toEqual(once.character);
+});
+
+test("save and reload do not apply racial bonuses or mutate base Stats", () => {
+  const input = {
+    schemaVersion: 1,
+    characterBuild: {
+      raceId: "human",
+      raceSubtypeId: null,
+      backgroundId: null,
+      classes: [{ classId: "fighter", levels: 8 }],
+      archetypes: [],
+      baseStats: { fuerza: 10, destreza: 10, constitucion: 10, inteligencia: 10, sabiduria: 10, carisma: 10 },
+      racialStatChoices: ["str", "dex"],
+      milestoneSelections: [],
+      traitSelections: [],
+      skillSelections: [],
+      spellSelections: [],
+    },
+  };
+
+  const saved = persistence.prepareForSave(input, { registry });
+  const reloaded = persistence.load(saved.character, { registry });
+  expect(saved.ok).toBe(true);
+  expect(reloaded.ok).toBe(true);
+  expect(reloaded.character.characterBuild.baseStats).toEqual(input.characterBuild.baseStats);
+  expect(reloaded.character.characterBuild.racialStatChoices).toEqual(["str", "dex"]);
+});
+
+test("unknown canonical content ID produces a manageable diagnostic instead of silent coercion", () => {
+  const result = persistence.load({
+    schemaVersion: 1,
+    characterBuild: {
+      raceId: "not_a_real_race",
+      raceSubtypeId: null,
+      backgroundId: null,
+      classes: [],
+      archetypes: [],
+      baseStats: {},
+      racialStatChoices: [],
+      milestoneSelections: [],
+      traitSelections: [],
+      skillSelections: [],
+      spellSelections: [],
+    },
+  }, { registry });
+
+  expect(result.ok).toBe(false);
+  expect(result.character).toBeNull();
+  expect(result.candidate.characterBuild.raceId).toBe("not_a_real_race");
+  expect(result.diagnostics.errors).toContainEqual(expect.objectContaining({
+    code: "UNKNOWN_CANONICAL_CONTENT_ID",
+    path: "characterBuild.raceId",
+  }));
+});
+
+test("verified legacy aliases resolve through the canonical Registry boundary", () => {
+  const result = persistence.load({ originId: "yuanti_pura_sangre", clase: "Mago", baseStats: {} }, { registry });
+  expect(result.ok).toBe(true);
+  expect(result.character.characterBuild.raceId).toBe("yuan_ti_pureblood");
+  expect(result.character.characterBuild.classes[0].classId).toBe("wizard");
+});
+
+test("temporary derived/runtime state is excluded from canonical save while unrelated user data survives", () => {
+  const result = persistence.prepareForSave({
+    characterName: "Runtime",
+    originId: "humano",
+    clase: "Monje",
+    baseStats: { destreza: 12 },
+    derivedStats: { offensiveLevel: 999 },
+    abilityMods: { dex: 99 },
+    actionEconomy: { actions: 0 },
+    uiState: { tab: "combat" },
+    finance: { currentBalance: 1234 },
+  }, { registry });
+
+  expect(result.ok).toBe(true);
+  expect(result.character.derivedStats).toBeUndefined();
+  expect(result.character.abilityMods).toBeUndefined();
+  expect(result.character.actionEconomy).toBeUndefined();
+  expect(result.character.uiState).toBeUndefined();
+  expect(result.character.finance).toEqual({ currentBalance: 1234 });
+});
+
+test("failed migration preserves the untouched raw original and does not produce writable character", () => {
+  const raw = { schemaVersion: 99, characterName: "Future", secretFutureField: { keep: true } };
+  const result = persistence.load(raw, { registry });
+  expect(result.ok).toBe(false);
+  expect(result.character).toBeNull();
+  expect(result.rawBackup).toEqual(raw);
+  expect(result.diagnostics.errors[0].code).toBe("UNSUPPORTED_FUTURE_SCHEMA");
+});
+
+test("multiclass and Archetype selections preserve per-Class levels", () => {
+  const input = {
+    schemaVersion: 1,
+    characterBuild: {
+      raceId: "human",
+      raceSubtypeId: null,
+      backgroundId: null,
+      classes: [
+        { classId: "barbarian", levels: 20 },
+        { classId: "bard", levels: 15 },
+      ],
+      archetypes: [
+        { classId: "barbarian", archetypeId: "path_of_the_devil_lineage", selectedAtClassLevel: 15 },
+        { classId: "bard", archetypeId: "college_of_whispers", selectedAtClassLevel: 15 },
+      ],
+      baseStats: {},
+      racialStatChoices: [],
+      milestoneSelections: [],
+      traitSelections: [],
+      skillSelections: [],
+      spellSelections: [],
+    },
+  };
+
+  const result = persistence.prepareForSave(input, { registry });
+  expect(result.ok).toBe(true);
+  expect(result.character.characterBuild.classes).toEqual([
+    { classId: "barbarian", levels: 20 },
+    { classId: "bard", levels: 15 },
+  ]);
+  expect(result.character.characterBuild.archetypes).toEqual(input.characterBuild.archetypes);
+});
+
+test("newer-than-client schema fails safely and Firebase adapter never overwrites it", async () => {
+  const raw = { schemaVersion: 7, characterName: "Do Not Touch", futureData: { x: 1 } };
+  const ref = fakeRef(raw);
+  const result = await firebasePersistence.migrateCharacterRef(ref, { registry });
+
+  expect(result.ok).toBe(false);
+  expect(result.written).toBe(false);
+  expect(ref.writes).toHaveLength(0);
+  expect(ref.value()).toEqual(raw);
+});
+
+test("validated Firebase migration can write backup before canonical replacement", async () => {
+  const raw = { characterName: "Backup", originId: "humano", clase: "Clérigo", baseStats: { sabiduria: 15 } };
+  const ref = fakeRef(raw);
+  const backupRef = fakeRef(null);
+  const result = await firebasePersistence.migrateCharacterRef(ref, { registry, backupRef });
+
+  expect(result.ok).toBe(true);
+  expect(result.backupWritten).toBe(true);
+  expect(result.written).toBe(true);
+  expect(backupRef.value()).toEqual(raw);
+  expect(ref.value().schemaVersion).toBe(1);
+});

--- a/tests/character_persistence_derived_stats.spec.js
+++ b/tests/character_persistence_derived_stats.spec.js
@@ -1,0 +1,124 @@
+const { test, expect } = require("@playwright/test");
+const registry = require("../js/content-registry.js");
+const bootstrap = require("../js/content-registry-bootstrap.js");
+const buildRules = require("../js/character-build-rules.js");
+const traitCatalog = require("../js/trait-catalog-core.js");
+const archetypeCatalog = require("../js/archetype-trait-catalog.js");
+const persistence = require("../js/character-persistence.js");
+const firebasePersistence = require("../js/character-persistence-firebase.js");
+const derived = require("../js/derived-stats-engine.js");
+
+function registerCore() {
+  registry.clear();
+  bootstrap.resetBootstrapState();
+  bootstrap.registerAvailableCore({ modules: { buildRules, traitCatalog, archetypeCatalog } });
+}
+
+function fakeRef(initial) {
+  let value = JSON.parse(JSON.stringify(initial));
+  return {
+    once: async () => ({ val: () => JSON.parse(JSON.stringify(value)) }),
+    set: async (next) => { value = JSON.parse(JSON.stringify(next)); },
+    value: () => JSON.parse(JSON.stringify(value)),
+  };
+}
+
+test.beforeEach(registerCore);
+
+test("schema v1 Base Stats remain the source for Derived Stats after reload", () => {
+  const prepared = persistence.prepareForSave({
+    characterName: "Persistence + Derived",
+    originId: "humano",
+    clase: "Guerrero",
+    level: 10,
+    baseStats: {
+      fuerza: 10,
+      destreza: 10,
+      constitucion: 10,
+      inteligencia: 10,
+      sabiduria: 10,
+      carisma: 10,
+    },
+    // Compatibility cache from older surfaces must never become the canonical base.
+    stats: {
+      fuerza: 11,
+      destreza: 11,
+      constitucion: 11,
+      inteligencia: 11,
+      sabiduria: 11,
+      carisma: 11,
+    },
+  }, { registry });
+
+  expect(prepared.ok).toBe(true);
+  expect(prepared.character.schemaVersion).toBe(1);
+  expect(prepared.character.characterBuild.baseStats.fuerza).toBe(10);
+
+  const reloaded = persistence.load(prepared.character, { registry });
+  expect(reloaded.ok).toBe(true);
+  const snapshot = derived.resolveCharacterStats(reloaded.character);
+  expect(snapshot.baseStats.fuerza).toBe(10);
+  expect(snapshot.effectiveStats.fuerza).toBe(11);
+  expect(snapshot.effectiveStats.fuerza).not.toBe(12);
+});
+
+test("derived/runtime caches are removed while deterministic Derived Stats can be rebuilt", () => {
+  const prepared = persistence.prepareForSave({
+    characterName: "No Runtime Cache",
+    originId: "humano",
+    clase: "Bardo",
+    level: 10,
+    baseStats: { carisma: 14, constitucion: 12 },
+    derivedStats: { offensiveLevel: 999, defensiveLevel: 999 },
+    abilityMods: { cha: 99 },
+    actionEconomy: { slots: 99 },
+    encounterState: { active: true },
+  }, { registry });
+
+  expect(prepared.ok).toBe(true);
+  expect(prepared.character.derivedStats).toBeUndefined();
+  expect(prepared.character.abilityMods).toBeUndefined();
+  expect(prepared.character.actionEconomy).toBeUndefined();
+  expect(prepared.character.encounterState).toBeUndefined();
+
+  const snapshot = derived.resolveCharacterStats(prepared.character);
+  expect(snapshot.abilities.cha.modifier).toBe(derived.abilityModifier(snapshot.abilities.cha.score));
+  expect(snapshot.offensiveLevel.total).not.toBe(999);
+  expect(snapshot.defensiveLevel.total).not.toBe(999);
+});
+
+test("Firebase read-modify-save round trip preserves schema v1 and recomputes from changed Base Stats", async () => {
+  const ref = fakeRef({
+    characterName: "Round Trip",
+    originId: "humano",
+    clase: "Guerrero",
+    level: 10,
+    baseStats: { fuerza: 10, destreza: 10, constitucion: 10, inteligencia: 10, sabiduria: 10, carisma: 10 },
+  });
+
+  const migrated = await firebasePersistence.migrateCharacterRef(ref, { registry });
+  expect(migrated.ok).toBe(true);
+  expect(ref.value().schemaVersion).toBe(1);
+
+  const modified = await firebasePersistence.modifyAndSave(ref, (character) => {
+    character.characterBuild.baseStats.fuerza = 14;
+  }, { registry });
+  expect(modified.ok).toBe(true);
+  expect(modified.written).toBe(true);
+
+  const loaded = await firebasePersistence.readCharacter(ref, { registry });
+  expect(loaded.ok).toBe(true);
+  expect(loaded.character.characterBuild.baseStats.fuerza).toBe(14);
+  const snapshot = derived.resolveCharacterStats(loaded.character);
+  expect(snapshot.baseStats.fuerza).toBe(14);
+  expect(snapshot.effectiveStats.fuerza).toBe(15);
+});
+
+test("future schema is still protected even when Derived Stats v1 is present", async () => {
+  const ref = fakeRef({ schemaVersion: 99, characterName: "Future", baseStats: { fuerza: 30 } });
+  const result = await firebasePersistence.migrateCharacterRef(ref, { registry });
+  expect(result.ok).toBe(false);
+  expect(result.written).toBe(false);
+  expect(result.diagnostics.errors[0].code).toBe("UNSUPPORTED_FUTURE_SCHEMA");
+  expect(ref.value().schemaVersion).toBe(99);
+});


### PR DESCRIPTION
Implements the migration/validation foundation for #591 without rewriting live Firebase data or changing mechanics.

Adds:
- `LuminousCharacterPersistence` with `schemaVersion: 1`, sequential migration registry, canonical normalization and validation;
- verified legacy Race aliases routed into the #590 identity boundary;
- safe diagnostics for unresolved legacy IDs and invalid v1 canonical IDs;
- conservative stripping of known derived/runtime caches while preserving unrelated player data;
- Firebase adapter that validates before writes, refuses future schemas, and supports backup-before-replacement;
- focused regression coverage for migration safety cases;
- explicit compatibility tests against #587 Derived Stats v1 so Base Stats remain canonical and racial bonuses are not reapplied after save/reload;
- documentation of the audited live creation/load paths and remaining integration gate.

#587 is now complete and this PR is validated against its canonical Derived Stats contract. This PR intentionally remains the Persistence **foundation**: `creacion_personaje.html` still writes the legacy `luminousState` directly and `hoja_personaje.js` still loads `snap.val()` directly. Those live-path integrations remain required before #591 itself can close.

Refs #591.