### PR TITLE
Derived Stats v1 canonical resolver for #587

### DIFF
--- a/.github/workflows/derived-stats.yml
+++ b/.github/workflows/derived-stats.yml
@@ -11,6 +11,7 @@ on:
       - "js/existing-racial-stat-integration.js"
       - "js/player-stat-tooltip-runtime.js"
       - "js/player-stats-ability-bar.js"
+      - "js/player-splash-framing.js"
       - "js/npc-stats-engine.js"
       - "js/character-manager-npc-stats.js"
       - "js/universal-modifier-engine.js"
@@ -45,6 +46,8 @@ jobs:
         run: |
           node --check js/derived-stats-engine.js
           node --check js/derived-stats-runtime.js
+          node --check js/player-splash-framing.js
+          node --check js/universal-speed-runtime.js
           node --check tests/derived_stats.spec.js
       - name: Derived Stats contract
         run: npx playwright test tests/derived_stats.spec.js --workers=1

--- a/.github/workflows/derived-stats.yml
+++ b/.github/workflows/derived-stats.yml
@@ -1,0 +1,52 @@
+name: Derived Stats v1
+
+on:
+  pull_request:
+    paths:
+      - "js/derived-stats-engine.js"
+      - "js/derived-stats-runtime.js"
+      - "js/character-build-rules.js"
+      - "js/racial-stat-runtime.js"
+      - "js/racial-stat-preview-bridge.js"
+      - "js/existing-racial-stat-integration.js"
+      - "js/player-stat-tooltip-runtime.js"
+      - "js/player-stats-ability-bar.js"
+      - "js/npc-stats-engine.js"
+      - "js/character-manager-npc-stats.js"
+      - "js/universal-modifier-engine.js"
+      - "js/universal-speed-runtime.js"
+      - "js/combatEngine.js"
+      - "tests/derived_stats.spec.js"
+      - "tests/racial_stat_integration.spec.js"
+      - "tests/player_stat_modifier_tooltip.spec.js"
+      - "tests/player_stats_ability_bar.spec.js"
+      - "tests/universal_modifier_engine.spec.js"
+      - "tests/universal_speed_runtime.spec.js"
+      - "docs/derived-stats-v1.md"
+      - ".github/workflows/derived-stats.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  derived-stats:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Syntax checks
+        run: |
+          node --check js/derived-stats-engine.js
+          node --check js/derived-stats-runtime.js
+          node --check tests/derived_stats.spec.js
+      - name: Derived Stats contract
+        run: npx playwright test tests/derived_stats.spec.js --workers=1
+      - name: Existing Stats regressions
+        run: npx playwright test tests/racial_stat_integration.spec.js tests/player_stat_modifier_tooltip.spec.js tests/player_stats_ability_bar.spec.js tests/universal_modifier_engine.spec.js tests/universal_speed_runtime.spec.js --workers=1

--- a/docs/derived-stats-v1.md
+++ b/docs/derived-stats-v1.md
@@ -1,0 +1,186 @@
+# Derived Stats v1
+
+Tracked by GitHub Issue #587.
+
+## Authority
+
+`js/derived-stats-engine.js` is the pure Character Core resolver for effective and derived values.
+
+```text
+persistent Character
+  -> normalize base Scores
+  -> persistent Score sources
+  -> runtime Score sources
+  -> Ability Mod
+  -> Character build calculation
+  -> runtime modifier channels
+  -> HP / SP / OFF / DEF / Speed snapshot
+```
+
+The public entry point is:
+
+```js
+LuminousDerivedStats.resolveCharacterStats(character, context)
+```
+
+It does not write Firebase, mutate the Character or persist runtime state.
+
+`js/derived-stats-runtime.js` is the compatibility boundary that lets existing Player, DM, NPC and Combat surfaces consume the resolver while their older APIs remain available. It is intentionally an adapter, not another calculator.
+
+## Base, effective and runtime
+
+For every D&D Ability:
+
+```text
+Base Score
++ Racial Score bonus
++ Background Score bonus
++ persistent Trait Score bonus
+= Persistent Effective Score
++ runtime Trait/temporary Score bonus
+= Effective Score
+-> Ability Mod = floor((Effective Score - 10) / 2)
+```
+
+`baseStats` is never mutated by the resolver.
+
+Modern data prefers `characterBuild.baseStats` / `baseStats`. A legacy record that only contains `stats` and has `characterBuild.breakdown.racialStatBonuses` is normalized by subtracting that already-applied racial layer before recalculation. This prevents the supported reload case from turning Human 10 + 1 into 12.
+
+A legacy record without a base layer or a stored racial breakdown keeps the historical assumption that `stats` is the base input. Persistence migration #591 is the correct place to quarantine/upgrade ambiguous old records; Derived Stats does not guess historical intent.
+
+## Ability Mod and Proficiency
+
+Ability Mod has one formula:
+
+```js
+Math.floor((score - 10) / 2)
+```
+
+Character Proficiency keeps the established Luminous progression:
+
+```js
+Math.ceil(CharacterLevel / 20)
+```
+
+NPCs may provide an explicit proficiency override because their existing D&D profile already stores one. Ability/Skill proficiency state and Check resolution remain owned by #597; Derived Stats only supplies the Character's canonical Ability Mod and base Proficiency bonus.
+
+## Character Level / multiclass boundary
+
+Derived Stats needs Character Level for Proficiency and build math. It uses an explicit Character Level when present, otherwise the sum of canonical `characterBuild.classes[].levels`.
+
+It does **not** resolve Class-specific Trait progression. That remains the responsibility of #586. Multiclass only affects Derived Stats where an existing rule explicitly consumes the class mix, such as `character-build-rules.js` weighted HP/OFF/DEF values.
+
+## HP
+
+When a complete canonical Character build is available, HP comes from the existing `character-build-rules.js` calculation using the final effective Constitution Score. The resolver does not introduce a second HP formula.
+
+Snapshot fields:
+
+```js
+hp: {
+  current,
+  max,
+  base,
+  coefficient,
+  runtimeCoefficient,
+  breakdown
+}
+```
+
+Runtime HP coefficient is contextual and never written back to base Character data by this engine.
+
+## SP
+
+The audited repository currently stores current SP (`sp_actual`) but does not define one canonical Max SP formula. Derived Stats v1 therefore does not invent one.
+
+```js
+sp: {
+  current: -12,
+  max: null,
+  source: "current-only"
+}
+```
+
+If a supported record already contains a max-SP field, it is exposed with `source: "stored"`. A future rule may define Max SP through a separate confirmed contract.
+
+## Offensive / Defensive Level
+
+The canonical Character-level breakdown is:
+
+```text
+Character Level
++ Class modifier
++ Race modifier (DEF where applicable)
++ DM modifier
++ Item modifier
++ runtime Trait/Status channel
+= Character OFF / DEF
+```
+
+Class/Race values come from `character-build-rules.js`; runtime channels come from `universal-modifier-engine.js`.
+
+Combat may still add **Skill-specific** scaling and resonance after this base. Those are properties of the Skill resolution, not a second Character OFF/DEF source.
+
+## Speed
+
+There is no new Speed progression formula in #587. Stored base/min/max Speed is the baseline. `speed`, `min_speed` and `max_speed` Universal Modifier channels are layered exactly once to produce the canonical runtime range.
+
+Conditions that force a fixed Speed remain a Combat/Condition runtime concern; they must not rewrite the persistent Character baseline.
+
+## Breakdown rule
+
+Breakdowns are generated from the same values used by the result. They are explanatory output, not additive caches that a consumer should re-sum into the Character.
+
+For Ability modifiers the resolver records incremental modifier deltas after each Score source, avoiding the common error of converting every +Score source to a modifier independently and then adding them twice.
+
+## Compatibility surfaces
+
+`derived-stats-runtime.js` provides adapters for:
+
+- `LuminousPlayerStats`
+- `LuminousDmPlayerDndStudio`
+- `LuminousNpcStats`
+- `CombatEngine`
+
+Existing UI-specific code can remain while migration is incremental, but externally exposed Score/Modifier/OFF/DEF values must match the canonical snapshot. #599 may later consolidate redundant fallback implementations after this behavior is frozen by tests.
+
+## Persistence boundary
+
+Derived Stats is read-only. Persistent save ownership belongs to #591.
+
+Do persist:
+
+- Base Scores.
+- Race/Class/Background/Archetype identity and choices.
+- user selections that cannot be reconstructed.
+- explicitly persistent Character state.
+
+Do not persist as source-of-truth from this resolver:
+
+- Ability Mods.
+- effective OFF/DEF/Speed calculations.
+- UI breakdowns.
+- Trait Engine caches.
+- Action Economy / Encounter state.
+- temporary Trait/Status modifiers.
+
+## Regression gate
+
+Focused gate:
+
+```bash
+npx playwright test tests/derived_stats.spec.js tests/racial_stat_integration.spec.js tests/player_stat_modifier_tooltip.spec.js tests/universal_modifier_engine.spec.js --workers=1
+```
+
+The matrix covers:
+
+1. Human 10 + racial 1 remains 11 after reload.
+2. DM base editing remains separated from effective Score.
+3. Player/DM/NPC/Combat share Ability Modifier semantics.
+4. Runtime Traits do not rewrite base Scores.
+5. Multiclass does not implicitly change Ability math.
+6. Tooltip breakdown equals the actual modifier.
+7. Legacy stored racial breakdown normalizes before calculation.
+8. NPC and PC share Score -> Modifier semantics.
+9. OFF/DEF/Speed use one base plus Universal Modifier channels.
+10. SP does not gain an invented Max formula.

--- a/js/derived-stats-engine.js
+++ b/js/derived-stats-engine.js
@@ -170,6 +170,19 @@
     return { base, racial, background: extra.background, traits: extra.traits, stats };
   }
 
+  function canonicalStatView(character, stats, base) {
+    const build = character.characterBuild || {};
+    return {
+      ...clone(character),
+      baseStats: { ...(base || {}) },
+      stats: { ...(stats || {}) },
+      characterBuild: {
+        ...clone(build),
+        baseStats: { ...(base || {}) },
+      },
+    };
+  }
+
   function runtimeStats(character, persistent, options = {}) {
     const direct = normalizeAbilityBonuses(options.runtimeStatBonuses || {});
     const starting = { ...persistent.stats };
@@ -182,10 +195,10 @@
     }
 
     try {
-      const unit = { ...clone(character), stats: { ...starting } };
-      const runtimeCharacter = { ...clone(character), stats: { ...starting } };
+      const runtimeCharacter = canonicalStatView(character, starting, persistent.base);
+      const runtimeUnit = canonicalStatView(options.unit || character, starting, persistent.base);
       const resolved = engine.resolveStats({
-        unit,
+        unit: runtimeUnit,
         character: runtimeCharacter,
         traits: traitDefinitions,
         traitState: options.traitState || {},
@@ -290,9 +303,11 @@
     if (!engine) return { trait: {}, status: {}, merged: {} };
     let trait = {};
     let status = {};
+    const traitUnit = options.traitUnit || character;
+    const statusUnit = options.unit || character;
     try {
       if (engine.resolveTraitModifiers) trait = engine.resolveTraitModifiers({
-        unit: options.unit || character,
+        unit: traitUnit,
         character,
         traits: options.traits || options.traitDefinitions || [],
         traitState: options.traitState || {},
@@ -301,7 +316,7 @@
       }) || {};
     } catch (_) {}
     try {
-      if (engine.resolveStatusModifiers) status = engine.resolveStatusModifiers({ unit: options.unit || character, skill: options.skill }) || {};
+      if (engine.resolveStatusModifiers) status = engine.resolveStatusModifiers({ unit: statusUnit, skill: options.skill }) || {};
     } catch (_) {}
     const merged = engine.mergeModifiers ? engine.mergeModifiers(trait, status) : { ...trait, ...status };
     return { trait, status, merged };
@@ -323,7 +338,7 @@
     return Object.freeze({ level, classModifier, raceModifier, dmModifier, itemModifier, runtimeModifier, total });
   }
 
-  function hpSnapshot(character, calculation, channels, options = {}) {
+  function hpSnapshot(character, calculation, options = {}) {
     const storedBase = readFirst(character, ["combatStats.hp_base", "hp_base"], 0);
     const storedCoef = readFirst(character, ["combatStats.hp_coefficient", "hp_coefficient"], 0);
     const storedMax = readFirst(character, ["combatStats.hp_max", "hp_max", "maxHp", "max_hp"], null);
@@ -363,7 +378,15 @@
     const runtime = runtimeStats(source, persistent, options);
     const abilities = abilitySnapshots(persistent, runtime);
     const calculation = buildCalculation(source, abilities, level, options);
-    const channels = channelModifiers(source, options);
+
+    const canonicalCharacter = canonicalStatView(source, runtime.stats, persistent.base);
+    const canonicalTraitUnit = canonicalStatView(options.unit || source, runtime.stats, persistent.base);
+    const channels = channelModifiers(canonicalCharacter, {
+      ...options,
+      traitUnit: canonicalTraitUnit,
+      unit: options.unit || source,
+    });
+
     const offensiveLevel = combatLevelSnapshot(source, "offensive", level, calculation, channels);
     const defensiveLevel = combatLevelSnapshot(source, "defensive", level, calculation, channels);
     const proficiency = Object.freeze({
@@ -373,7 +396,7 @@
       level,
       source: Number.isFinite(Number(options.proficiencyBonusOverride)) ? "override" : "character-level",
     });
-    const hp = hpSnapshot(source, calculation, channels, { ...options, defensiveLevel: defensiveLevel.total });
+    const hp = hpSnapshot(source, calculation, { ...options, defensiveLevel: defensiveLevel.total });
     const sp = spSnapshot(source);
     const speed = speedSnapshot(source, channels, options);
 

--- a/js/derived-stats-engine.js
+++ b/js/derived-stats-engine.js
@@ -1,0 +1,432 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousDerivedStats) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousDerivedStats;
+    return;
+  }
+
+  const VERSION = 1;
+  const ABILITIES = Object.freeze([
+    Object.freeze({ id: "str", key: "fuerza" }),
+    Object.freeze({ id: "dex", key: "destreza" }),
+    Object.freeze({ id: "con", key: "constitucion" }),
+    Object.freeze({ id: "int", key: "inteligencia" }),
+    Object.freeze({ id: "wis", key: "sabiduria" }),
+    Object.freeze({ id: "cha", key: "carisma" }),
+  ]);
+  const ABILITY_BY_ID = Object.freeze(Object.fromEntries(ABILITIES.map((entry) => [entry.id, entry])));
+  const ABILITY_BY_KEY = Object.freeze(Object.fromEntries(ABILITIES.map((entry) => [entry.key, entry])));
+  const ZERO_ABILITY_MAP = Object.freeze(Object.fromEntries(ABILITIES.map((entry) => [entry.id, 0])));
+
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const integerOr = (value, fallback = 0) => Number.isFinite(Number.parseInt(value, 10)) ? Number.parseInt(value, 10) : fallback;
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/\s+/g, "_");
+
+  function safeRequire(path) {
+    if (typeof require !== "function") return null;
+    try { return require(path); } catch (_) { return null; }
+  }
+
+  function buildRules() {
+    let rules = global.LuminousCharacterBuildRules || safeRequire("./character-build-rules.js");
+    const canonical = global.LuminousCanonicalRaceIntegration || safeRequire("./canonical-race-integration.js");
+    const existing = global.LuminousExistingRacialStatIntegration || safeRequire("./existing-racial-stat-integration.js");
+    try { if (canonical?.installRules) rules = canonical.installRules(rules) || rules; } catch (_) {}
+    try { if (existing?.installRules) rules = existing.installRules(rules) || rules; } catch (_) {}
+    return rules;
+  }
+
+  function modifierEngine() {
+    return global.LuminousUniversalModifiers || safeRequire("./universal-modifier-engine.js");
+  }
+
+  function abilityModifier(score) {
+    return Math.floor((numberOr(score, 10) - 10) / 2);
+  }
+
+  function proficiencyBonus(level) {
+    return Math.max(0, Math.ceil(Math.max(0, numberOr(level, 0)) / 20));
+  }
+
+  function abilityId(value) {
+    const id = normalizeId(value);
+    if (ABILITY_BY_ID[id]) return id;
+    return ABILITY_BY_KEY[id]?.id || null;
+  }
+
+  function abilityKey(value) {
+    const id = abilityId(value);
+    return id ? ABILITY_BY_ID[id].key : null;
+  }
+
+  function emptyAbilityBonuses() {
+    return { ...ZERO_ABILITY_MAP };
+  }
+
+  function normalizeAbilityBonuses(source) {
+    const output = emptyAbilityBonuses();
+    if (!source || typeof source !== "object") return output;
+    Object.entries(source).forEach(([rawKey, rawValue]) => {
+      const id = abilityId(rawKey);
+      if (id) output[id] += numberOr(rawValue, 0);
+    });
+    return output;
+  }
+
+  function addAbilityMaps(...sources) {
+    const output = emptyAbilityBonuses();
+    sources.forEach((source) => {
+      const normalized = normalizeAbilityBonuses(source);
+      ABILITIES.forEach(({ id }) => { output[id] += normalized[id]; });
+    });
+    return output;
+  }
+
+  function storedRacialBreakdown(character = {}) {
+    const build = character.characterBuild || {};
+    const value = build.breakdown?.racialStatBonuses || character.racialStatBonuses || null;
+    return value && typeof value === "object" ? normalizeAbilityBonuses(value) : null;
+  }
+
+  function hasBaseStats(character = {}) {
+    const source = character.characterBuild?.baseStats || character.baseStats;
+    return Boolean(source && typeof source === "object" && ABILITIES.some(({ id, key }) => Number.isFinite(Number(source[key] ?? source[id]))));
+  }
+
+  function baseStats(character = {}) {
+    const modern = character.characterBuild?.baseStats || character.baseStats;
+    const storedStats = character.stats || character.dndStats || {};
+    const storedRacial = storedRacialBreakdown(character);
+    const modernBase = hasBaseStats(character);
+    const output = {};
+
+    ABILITIES.forEach(({ id, key }) => {
+      if (modernBase) {
+        output[key] = integerOr(modern?.[key] ?? modern?.[id], 10);
+        return;
+      }
+      const stored = integerOr(storedStats?.[key] ?? storedStats?.[id], 10);
+      output[key] = storedRacial ? stored - numberOr(storedRacial[id], 0) : stored;
+    });
+    return output;
+  }
+
+  function characterLevel(character = {}) {
+    const direct = character.characterBuild?.calculatedAtLevel ?? character.characterBuild?.characterLevel ?? character.level ?? character.characterLevel;
+    if (Number.isFinite(Number(direct))) return Math.max(1, integerOr(direct, 1));
+    const classes = character.characterBuild?.classes || character.classes;
+    if (Array.isArray(classes)) {
+      const total = classes.reduce((sum, entry) => sum + Math.max(0, integerOr(entry?.levels ?? entry?.level, 0)), 0);
+      if (total > 0) return total;
+    }
+    return 1;
+  }
+
+  function racialInput(character = {}) {
+    const build = character.characterBuild || {};
+    return {
+      raceId: normalizeId(build.raceId ?? character.raceId ?? character.race?.id),
+      raceSubtypeId: normalizeId(build.raceSubtypeId ?? build.subraceId ?? character.raceSubtypeId ?? character.race?.subtypeId) || null,
+      racialStatChoices: clone(build.racialStatChoices ?? character.racialStatChoices ?? []),
+    };
+  }
+
+  function racialBonuses(character = {}, options = {}) {
+    if (options.racialBonuses) return normalizeAbilityBonuses(options.racialBonuses);
+    const input = racialInput(character);
+    if (!input.raceId) return emptyAbilityBonuses();
+    const rules = options.buildRules || buildRules();
+    if (!rules) return storedRacialBreakdown(character) || emptyAbilityBonuses();
+    try {
+      if (rules.EXISTING_RACIAL_STAT_RULES?.[input.raceId] && typeof rules.resolveExistingRacialStatBonuses === "function") {
+        return normalizeAbilityBonuses(rules.resolveExistingRacialStatBonuses(input));
+      }
+      if (typeof rules.resolveRacialStatBonuses === "function") return normalizeAbilityBonuses(rules.resolveRacialStatBonuses(input));
+    } catch (_) {}
+    return storedRacialBreakdown(character) || emptyAbilityBonuses();
+  }
+
+  function persistentScoreBonuses(character = {}, options = {}) {
+    const breakdown = character.characterBuild?.breakdown || {};
+    const background = normalizeAbilityBonuses(
+      options.backgroundStatBonuses ?? breakdown.backgroundStatBonuses ?? character.backgroundStatBonuses ?? {},
+    );
+    const traits = normalizeAbilityBonuses(
+      options.traitStatBonuses ?? breakdown.traitStatBonuses ?? breakdown.traitsStatBonuses ?? character.traitStatBonuses ?? character.traitsStatBonuses ?? {},
+    );
+    return { background, traits };
+  }
+
+  function persistentEffectiveStats(character = {}, options = {}) {
+    const base = baseStats(character);
+    const racial = racialBonuses(character, options);
+    const extra = persistentScoreBonuses(character, options);
+    const stats = {};
+    ABILITIES.forEach(({ id, key }) => {
+      stats[key] = numberOr(base[key], 10) + racial[id] + extra.background[id] + extra.traits[id];
+    });
+    return { base, racial, background: extra.background, traits: extra.traits, stats };
+  }
+
+  function runtimeStats(character, persistent, options = {}) {
+    const direct = normalizeAbilityBonuses(options.runtimeStatBonuses || {});
+    const starting = { ...persistent.stats };
+    ABILITIES.forEach(({ id, key }) => { starting[key] += direct[id]; });
+
+    const engine = options.modifierEngine || modifierEngine();
+    const traitDefinitions = options.traits || options.traitDefinitions || [];
+    if (!engine?.resolveStats || !Array.isArray(traitDefinitions) || !traitDefinitions.length) {
+      return { stats: starting, runtime: direct, traitRuntime: emptyAbilityBonuses(), statCaps: clone(character.statCaps || {}) };
+    }
+
+    try {
+      const unit = { ...clone(character), stats: { ...starting } };
+      const runtimeCharacter = { ...clone(character), stats: { ...starting } };
+      const resolved = engine.resolveStats({
+        unit,
+        character: runtimeCharacter,
+        traits: traitDefinitions,
+        traitState: options.traitState || {},
+        context: options.context || "any",
+        equipment: options.equipment,
+      });
+      const traitRuntime = emptyAbilityBonuses();
+      ABILITIES.forEach(({ id, key }) => { traitRuntime[id] = numberOr(resolved?.stats?.[key], starting[key]) - starting[key]; });
+      return {
+        stats: Object.fromEntries(ABILITIES.map(({ key }) => [key, numberOr(resolved?.stats?.[key], starting[key])])),
+        runtime: addAbilityMaps(direct, traitRuntime),
+        traitRuntime,
+        statCaps: clone(resolved?.statCaps || character.statCaps || {}),
+      };
+    } catch (_) {
+      return { stats: starting, runtime: direct, traitRuntime: emptyAbilityBonuses(), statCaps: clone(character.statCaps || {}) };
+    }
+  }
+
+  function modifierDeltas(baseScore, sources) {
+    let score = numberOr(baseScore, 10);
+    let previous = abilityModifier(score);
+    const result = { base: previous };
+    for (const [name, amount] of sources) {
+      score += numberOr(amount, 0);
+      const next = abilityModifier(score);
+      result[name] = next - previous;
+      previous = next;
+    }
+    result.total = previous;
+    return result;
+  }
+
+  function abilitySnapshots(persistent, runtime) {
+    const output = {};
+    ABILITIES.forEach(({ id, key }) => {
+      const baseScore = numberOr(persistent.base[key], 10);
+      const racialScoreBonus = numberOr(persistent.racial[id], 0);
+      const backgroundScoreBonus = numberOr(persistent.background[id], 0);
+      const traitScoreBonus = numberOr(persistent.traits[id], 0);
+      const runtimeScoreBonus = numberOr(runtime.runtime[id], 0);
+      const score = numberOr(runtime.stats[key], baseScore + racialScoreBonus + backgroundScoreBonus + traitScoreBonus + runtimeScoreBonus);
+      const modifier = abilityModifier(score);
+      const modifierBreakdown = modifierDeltas(baseScore, [
+        ["racial", racialScoreBonus],
+        ["background", backgroundScoreBonus],
+        ["traits", traitScoreBonus],
+        ["runtime", runtimeScoreBonus],
+      ]);
+      output[id] = Object.freeze({
+        id,
+        key,
+        baseScore,
+        racialScoreBonus,
+        backgroundScoreBonus,
+        traitScoreBonus,
+        runtimeScoreBonus,
+        score,
+        modifier,
+        modifierBreakdown: Object.freeze(modifierBreakdown),
+      });
+    });
+    return Object.freeze(output);
+  }
+
+  function buildInput(character, abilities, level, options = {}) {
+    const build = character.characterBuild || {};
+    return {
+      level,
+      constitution: abilities.con.score,
+      classes: clone(build.classes ?? character.classes ?? []),
+      backgroundId: build.backgroundId ?? character.backgroundId ?? null,
+      raceId: build.raceId ?? character.raceId ?? character.race?.id ?? null,
+      raceSubtypeId: build.raceSubtypeId ?? build.subraceId ?? character.raceSubtypeId ?? null,
+      racialStatChoices: clone(build.racialStatChoices ?? character.racialStatChoices ?? []),
+      transformationHpCoefBonus: numberOr(options.transformationHpCoefBonus ?? character.transformationHpCoefBonus, 0),
+      baseOffLevel: level,
+      baseDefLevel: level,
+      runtimeHpCoef: 0,
+      runtimeOff: 0,
+      runtimeDef: 0,
+    };
+  }
+
+  function buildCalculation(character, abilities, level, options = {}) {
+    const rules = options.buildRules || buildRules();
+    if (!rules?.calculateBuild) return null;
+    try { return rules.calculateBuild(buildInput(character, abilities, level, options)); } catch (_) { return null; }
+  }
+
+  function readFirst(character, paths, fallback = null) {
+    for (const path of paths) {
+      let current = character;
+      for (const part of path.split(".")) current = current?.[part];
+      if (Number.isFinite(Number(current))) return Number(current);
+    }
+    return fallback;
+  }
+
+  function channelModifiers(character, options = {}) {
+    const engine = options.modifierEngine || modifierEngine();
+    if (!engine) return { trait: {}, status: {}, merged: {} };
+    let trait = {};
+    let status = {};
+    try {
+      if (engine.resolveTraitModifiers) trait = engine.resolveTraitModifiers({
+        unit: options.unit || character,
+        character,
+        traits: options.traits || options.traitDefinitions || [],
+        traitState: options.traitState || {},
+        context: options.context || "any",
+        equipment: options.equipment,
+      }) || {};
+    } catch (_) {}
+    try {
+      if (engine.resolveStatusModifiers) status = engine.resolveStatusModifiers({ unit: options.unit || character, skill: options.skill }) || {};
+    } catch (_) {}
+    const merged = engine.mergeModifiers ? engine.mergeModifiers(trait, status) : { ...trait, ...status };
+    return { trait, status, merged };
+  }
+
+  function combatLevelSnapshot(character, kind, level, calculation, channels) {
+    const offense = kind === "offensive";
+    const stored = character.combatLevels?.[kind] || {};
+    const classModifier = calculation?.valid
+      ? numberOr(offense ? calculation.classOffMod : calculation.classDefMod, 0)
+      : numberOr(stored.classModifier ?? character.classModifiers?.[offense ? "offensiveLevel" : "defensiveLevel"], 0);
+    const raceModifier = offense ? 0 : (calculation?.valid
+      ? numberOr(calculation.raceDefMod, 0)
+      : numberOr(stored.raceModifier ?? character.raceModifiers?.defensiveLevel, 0));
+    const dmModifier = numberOr(stored.dmModifier ?? character.combatStats?.[offense ? "off_lvl_mod" : "def_lvl_mod"], 0);
+    const itemModifier = numberOr(stored.itemModifier ?? character.equipmentModifiers?.[offense ? "offensiveLevel" : "defensiveLevel"], 0);
+    const runtimeModifier = numberOr(channels.merged?.[offense ? "offensive_level" : "defensive_level"], 0);
+    const total = Math.max(1, level + classModifier + raceModifier + dmModifier + itemModifier + runtimeModifier);
+    return Object.freeze({ level, classModifier, raceModifier, dmModifier, itemModifier, runtimeModifier, total });
+  }
+
+  function hpSnapshot(character, calculation, channels, options = {}) {
+    const storedBase = readFirst(character, ["combatStats.hp_base", "hp_base"], 0);
+    const storedCoef = readFirst(character, ["combatStats.hp_coefficient", "hp_coefficient"], 0);
+    const storedMax = readFirst(character, ["combatStats.hp_max", "hp_max", "maxHp", "max_hp"], null);
+    const current = readFirst(character, ["combatStats.hp_actual", "hp_actual", "hp", "currentHp", "current_hp"], storedMax ?? 0);
+    const base = calculation?.valid ? numberOr(calculation.hpBase, storedBase) : storedBase;
+    const coefficient = calculation?.valid ? numberOr(calculation.intrinsicHpCoef, storedCoef) : storedCoef;
+    const runtimeCoefficient = numberOr(options.runtimeHpCoef, 0);
+    const defensiveLevel = numberOr(options.defensiveLevel, calculation?.defLevel ?? character.level ?? 1);
+    const calculatedMax = Math.max(0, Math.round(base + (coefficient + runtimeCoefficient) * defensiveLevel));
+    const max = calculation?.valid || options.recalculateHp === true ? calculatedMax : (storedMax ?? calculatedMax);
+    return Object.freeze({ current, max, base, coefficient, runtimeCoefficient, breakdown: Object.freeze({ base, coefficient, runtimeCoefficient, defensiveLevel }) });
+  }
+
+  function spSnapshot(character) {
+    const current = readFirst(character, ["combatStats.sp_actual", "combatStats.sp", "sp_actual", "sp", "currentSp", "current_sp"], 0);
+    const max = readFirst(character, ["combatStats.sp_max", "combatStats.maxSp", "sp_max", "maxSp", "max_sp"], null);
+    return Object.freeze({ current, max, source: max == null ? "current-only" : "stored" });
+  }
+
+  function speedSnapshot(character, channels, options = {}) {
+    const baseCurrent = numberOr(options.baseSpeed ?? readFirst(character, ["combatStats.speed", "baseSpeed", "base_speed", "speed"], 0), 0);
+    const baseMin = numberOr(options.baseMinSpeed ?? readFirst(character, ["combatStats.minSpeed", "combatStats.min_speed", "minSpeed", "min_speed"], baseCurrent), baseCurrent);
+    const baseMax = Math.max(baseMin, numberOr(options.baseMaxSpeed ?? readFirst(character, ["combatStats.maxSpeed", "combatStats.max_speed", "maxSpeed", "max_speed"], baseCurrent), baseCurrent));
+    const passive = numberOr(channels.merged?.speed, 0);
+    const minModifier = numberOr(channels.merged?.min_speed, 0);
+    const maxModifier = numberOr(channels.merged?.max_speed, 0);
+    const min = baseMin + minModifier + passive;
+    const max = Math.max(min, baseMax + maxModifier + passive);
+    const current = Math.max(min, Math.min(max, baseCurrent + passive));
+    return Object.freeze({ current, min, max, baseCurrent, baseMin, baseMax, passiveModifier: passive, minModifier, maxModifier });
+  }
+
+  function resolveCharacterStats(character = {}, options = {}) {
+    const source = character && typeof character === "object" ? character : {};
+    const level = characterLevel(source);
+    const persistent = persistentEffectiveStats(source, options);
+    const runtime = runtimeStats(source, persistent, options);
+    const abilities = abilitySnapshots(persistent, runtime);
+    const calculation = buildCalculation(source, abilities, level, options);
+    const channels = channelModifiers(source, options);
+    const offensiveLevel = combatLevelSnapshot(source, "offensive", level, calculation, channels);
+    const defensiveLevel = combatLevelSnapshot(source, "defensive", level, calculation, channels);
+    const proficiency = Object.freeze({
+      bonus: Number.isFinite(Number(options.proficiencyBonusOverride))
+        ? Math.max(0, numberOr(options.proficiencyBonusOverride, 0))
+        : proficiencyBonus(level),
+      level,
+      source: Number.isFinite(Number(options.proficiencyBonusOverride)) ? "override" : "character-level",
+    });
+    const hp = hpSnapshot(source, calculation, channels, { ...options, defensiveLevel: defensiveLevel.total });
+    const sp = spSnapshot(source);
+    const speed = speedSnapshot(source, channels, options);
+
+    return Object.freeze({
+      version: VERSION,
+      level,
+      baseStats: Object.freeze({ ...persistent.base }),
+      effectiveStats: Object.freeze({ ...runtime.stats }),
+      persistentEffectiveStats: Object.freeze({ ...persistent.stats }),
+      abilities,
+      proficiency,
+      hp,
+      sp,
+      offensiveLevel,
+      defensiveLevel,
+      speed,
+      build: calculation ? Object.freeze(clone(calculation)) : null,
+      runtime: Object.freeze({
+        statBonuses: Object.freeze({ ...runtime.runtime }),
+        traitStatBonuses: Object.freeze({ ...runtime.traitRuntime }),
+        channels: Object.freeze({ ...channels.merged }),
+      }),
+      breakdowns: Object.freeze({
+        abilities: Object.freeze(Object.fromEntries(ABILITIES.map(({ id }) => [id, abilities[id].modifierBreakdown]))),
+        offensiveLevel,
+        defensiveLevel,
+        hp: hp.breakdown,
+        speed,
+      }),
+    });
+  }
+
+  function resolveAbility(character, id, options = {}) {
+    const normalized = abilityId(id);
+    return normalized ? resolveCharacterStats(character, options).abilities[normalized] : null;
+  }
+
+  const api = Object.freeze({
+    VERSION,
+    ABILITIES,
+    abilityId,
+    abilityKey,
+    abilityModifier,
+    proficiencyBonus,
+    characterLevel,
+    hasBaseStats,
+    baseStats,
+    racialBonuses,
+    persistentEffectiveStats,
+    resolveCharacterStats,
+    resolveAbility,
+  });
+
+  global.LuminousDerivedStats = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/derived-stats-runtime.js
+++ b/js/derived-stats-runtime.js
@@ -1,0 +1,282 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousDerivedStatsRuntime) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousDerivedStatsRuntime;
+    return;
+  }
+
+  const doc = global.document || null;
+  let engine = global.LuminousDerivedStats || (typeof require === "function" ? (() => {
+    try { return require("./derived-stats-engine.js"); } catch (_) { return null; }
+  })() : null);
+  const patched = new WeakSet();
+  let loaderStarted = false;
+
+  function ensureEngine() {
+    if (global.LuminousDerivedStats) {
+      engine = global.LuminousDerivedStats;
+      return engine;
+    }
+    if (engine) return engine;
+    if (!doc || loaderStarted) return null;
+    loaderStarted = true;
+    let script = doc.getElementById("derived-stats-engine-script");
+    if (!script) {
+      script = doc.createElement("script");
+      script.id = "derived-stats-engine-script";
+      script.src = "js/derived-stats-engine.js";
+      script.async = false;
+      script.dataset.engine = "derived-stats-v1";
+      doc.head?.appendChild(script);
+    }
+    script.addEventListener?.("load", () => {
+      engine = global.LuminousDerivedStats || engine;
+      install();
+    }, { once: true });
+    return null;
+  }
+
+  function characterData(value) {
+    if (value && typeof value === "object") return value;
+    return global.datosJugador || global.currentPlayerData || {};
+  }
+
+  function traitsFor(character, options = {}) {
+    if (Array.isArray(options.traits)) return options.traits;
+    if (Array.isArray(character?.traitDefinitions)) return character.traitDefinitions;
+    if (Array.isArray(character?.traits) && character.traits.every((entry) => entry && typeof entry === "object")) return character.traits;
+    try { return global.LuminousPlayerTraitRuntime?.getTraits?.() || []; } catch (_) { return []; }
+  }
+
+  function snapshot(character, options = {}) {
+    const api = ensureEngine();
+    if (!api) return null;
+    const data = characterData(character);
+    return api.resolveCharacterStats(data, {
+      ...options,
+      traits: traitsFor(data, options),
+      unit: options.unit || data,
+    });
+  }
+
+  function installPlayerStats() {
+    const current = global.LuminousPlayerStats;
+    const api = ensureEngine();
+    if (!current || !api || patched.has(current)) return false;
+    const original = current;
+    const wrapped = Object.freeze({
+      ...original,
+      __derivedStatsV1: true,
+      abilityModifier: api.abilityModifier,
+      proficiencyBonus: api.proficiencyBonus,
+      abilityScore(ability, data) {
+        const id = api.abilityId(ability?.id || ability?.key || ability);
+        return snapshot(data)?.abilities?.[id]?.score ?? original.abilityScore?.(ability, data) ?? 10;
+      },
+      abilityRollMath(ability, data) {
+        const legacy = original.abilityRollMath?.(ability, data) || {};
+        const id = api.abilityId(ability?.id || ability?.key || ability);
+        const resolved = snapshot(data);
+        const abilitySnapshot = resolved?.abilities?.[id];
+        if (!abilitySnapshot) return legacy;
+        const proficiency = resolved.proficiency.bonus;
+        const proficiencyValue = Number.isFinite(Number(legacy.proficiencyValue)) ? Number(legacy.proficiencyValue) : 0;
+        return {
+          ...legacy,
+          score: abilitySnapshot.score,
+          modifier: abilitySnapshot.modifier,
+          proficiency,
+          proficiencyValue,
+          base: abilitySnapshot.modifier + proficiencyValue,
+        };
+      },
+      combatLevelBreakdown(kind, data) {
+        const resolved = snapshot(data);
+        const value = kind === "defensive" ? resolved?.defensiveLevel : resolved?.offensiveLevel;
+        return value ? { ...value } : original.combatLevelBreakdown?.(kind, data);
+      },
+      currentHp(data) {
+        return snapshot(data)?.hp?.current ?? original.currentHp?.(data) ?? 0;
+      },
+      maxHp(data) {
+        return snapshot(data)?.hp?.max ?? original.maxHp?.(data) ?? 0;
+      },
+    });
+    patched.add(current);
+    global.LuminousPlayerStats = wrapped;
+    return true;
+  }
+
+  function dmPreviewCharacter(studio, baseStats, input) {
+    const selected = global.document?.getElementById?.("dm-player-dnd-select")?.value || "";
+    const stored = studio?.getPlayer?.(selected) || {};
+    return {
+      ...stored,
+      baseStats: { ...(baseStats || {}) },
+      characterBuild: {
+        ...(stored.characterBuild || {}),
+        baseStats: { ...(baseStats || {}) },
+        raceId: input?.raceId ?? stored.characterBuild?.raceId,
+        raceSubtypeId: input?.raceSubtypeId ?? stored.characterBuild?.raceSubtypeId,
+        racialStatChoices: input?.racialStatChoices ?? stored.characterBuild?.racialStatChoices ?? [],
+      },
+    };
+  }
+
+  function installDmStudio() {
+    const current = global.LuminousDmPlayerDndStudio;
+    const api = ensureEngine();
+    if (!current || !api || patched.has(current)) return false;
+    const original = current;
+    const wrapped = Object.freeze({
+      ...original,
+      __derivedStatsV1: true,
+      abilityModifier: api.abilityModifier,
+      proficiencyBonus: api.proficiencyBonus,
+      resolveEffectiveStats(baseStats, input) {
+        const character = dmPreviewCharacter(original, baseStats || original.baseStatsFromForm?.(), input || original.racialStatInput?.());
+        return { ...api.resolveCharacterStats(character).persistentEffectiveStats };
+      },
+      effectiveAbilityScore(abilityId) {
+        const base = original.baseStatsFromForm?.() || {};
+        const input = original.racialStatInput?.() || {};
+        const character = dmPreviewCharacter(original, base, input);
+        return api.resolveAbility(character, abilityId)?.score ?? original.effectiveAbilityScore?.(abilityId) ?? 10;
+      },
+      combatBreakdown(player, kind, levelOverride) {
+        const character = { ...(player || {}) };
+        if (levelOverride != null) character.level = levelOverride;
+        const resolved = api.resolveCharacterStats(character);
+        const value = kind === "defensive" ? resolved.defensiveLevel : resolved.offensiveLevel;
+        return { ...value };
+      },
+    });
+    patched.add(current);
+    global.LuminousDmPlayerDndStudio = wrapped;
+    return true;
+  }
+
+  function installNpcStats() {
+    const current = global.LuminousNpcStats;
+    const api = ensureEngine();
+    if (!current || !api || patched.has(current)) return false;
+    const original = current;
+    const wrapped = Object.freeze({
+      ...original,
+      __derivedStatsV1: true,
+      abilityModifier: api.abilityModifier,
+      abilityRollMath(abilityId, npc) {
+        const data = npc || {};
+        const proficiencyOverride = Number.isFinite(Number(data.proficiencyBonus)) ? Number(data.proficiencyBonus) : undefined;
+        const resolved = api.resolveCharacterStats(data, { proficiencyBonusOverride: proficiencyOverride });
+        const id = api.abilityId(abilityId);
+        const ability = resolved.abilities[id];
+        if (!ability) return original.abilityRollMath?.(abilityId, npc);
+        const legacy = original.abilityRollMath?.(abilityId, npc) || {};
+        return {
+          ...legacy,
+          score: ability.score,
+          modifier: ability.modifier,
+          proficiency: resolved.proficiency.bonus,
+        };
+      },
+    });
+    patched.add(current);
+    global.LuminousNpcStats = wrapped;
+    return true;
+  }
+
+  function combatSkillScaling(unit, skill) {
+    if (!skill) return 0;
+    if (skill.scaling_stat && unit?.stats) return Number(unit.stats[skill.scaling_stat]) || 0;
+    return Number(skill.offenseModifier ?? skill.defenseModifier ?? 0) || 0;
+  }
+
+  function installCombat() {
+    const combat = global.CombatEngine;
+    const api = ensureEngine();
+    if (!combat || !api || patched.has(combat)) return false;
+    const originalOff = typeof combat.getOffensiveLevel === "function" ? combat.getOffensiveLevel.bind(combat) : null;
+    const originalDef = typeof combat.getDefensiveLevel === "function" ? combat.getDefensiveLevel.bind(combat) : null;
+
+    if (originalOff) {
+      combat.getOffensiveLevel = function derivedOffensiveLevel(unit, skill) {
+        try {
+          const resolved = api.resolveCharacterStats(unit || {}, { unit, skill, traits: traitsFor(unit || {}) });
+          const scaling = combatSkillScaling(unit, skill);
+          const resonance = Number(skill?.resonance || skill?.resonanceModifier || 0) || 0;
+          return Math.max(1, resolved.offensiveLevel.total + scaling + resonance);
+        } catch (_) {
+          return originalOff(unit, skill);
+        }
+      };
+    }
+
+    if (originalDef) {
+      combat.getDefensiveLevel = function derivedDefensiveLevel(unit, skillOrPart) {
+        try {
+          const resolved = api.resolveCharacterStats(unit || {}, { unit, skill: skillOrPart, traits: traitsFor(unit || {}) });
+          const scaling = combatSkillScaling(unit, skillOrPart);
+          return Math.max(1, resolved.defensiveLevel.total + scaling);
+        } catch (_) {
+          return originalDef(unit, skillOrPart);
+        }
+      };
+    }
+
+    Object.defineProperty(combat, "__derivedStatsV1", { value: true, configurable: true });
+    patched.add(combat);
+    return true;
+  }
+
+  function syncVisibleStats() {
+    const api = ensureEngine();
+    if (!api || !doc) return false;
+    const player = global.datosJugador;
+    if (player) {
+      const resolved = snapshot(player);
+      const panel = doc.querySelector?.("#stats-modal .player-ability-console");
+      if (panel && resolved) {
+        Object.values(resolved.abilities).forEach((ability) => {
+          const box = panel.querySelector?.(`[data-stat-id="${ability.id}"]`);
+          const score = box?.querySelector?.("[data-stat-score]");
+          const mod = box?.querySelector?.("[data-stat-modifier]");
+          if (score) score.textContent = String(ability.score);
+          if (mod) mod.textContent = ability.modifier >= 0 ? `+${ability.modifier}` : String(ability.modifier);
+        });
+        const off = panel.querySelector?.('[data-combat-level="offensive"]');
+        const def = panel.querySelector?.('[data-combat-level="defensive"]');
+        if (off) off.textContent = String(resolved.offensiveLevel.total);
+        if (def) def.textContent = String(resolved.defensiveLevel.total);
+      }
+    }
+    return true;
+  }
+
+  function install() {
+    if (!ensureEngine()) return false;
+    const results = [installPlayerStats(), installDmStudio(), installNpcStats(), installCombat()];
+    syncVisibleStats();
+    return results.some(Boolean) || true;
+  }
+
+  const api = Object.freeze({
+    ensureEngine,
+    snapshot,
+    installPlayerStats,
+    installDmStudio,
+    installNpcStats,
+    installCombat,
+    syncVisibleStats,
+    install,
+  });
+
+  global.LuminousDerivedStatsRuntime = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+
+  if (doc) {
+    install();
+    global.setInterval?.(install, 500);
+  }
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/derived-stats-runtime.js
+++ b/js/derived-stats-runtime.js
@@ -169,7 +169,7 @@
       abilityRollMath(profile, abilityId) {
         const legacy = original.abilityRollMath?.(profile, abilityId) || null;
         const normalized = original.normalizeProfile?.(profile || {}) || profile || {};
-        const proficiencyOverride = Number.isFinite(Number(normalized.proficiencyBonus)) ? Number(normalized.proficiencyBonus) : undefined;
+        const proficiencyBonusOverride = Number.isFinite(Number(normalized.proficiencyBonus)) ? Number(normalized.proficiencyBonus) : undefined;
         const resolved = api.resolveCharacterStats({ stats: normalized.stats || profile?.stats || {} }, { proficiencyBonusOverride });
         const id = api.abilityId(abilityId);
         const ability = resolved.abilities[id];
@@ -190,9 +190,12 @@
     return true;
   }
 
-  function combatSkillScaling(unit, skill, kind) {
+  function combatSkillScaling(unit, skill, kind, resolved) {
     if (!skill) return 0;
-    if (skill.scaling_stat && unit?.stats) return Number(unit.stats[String(skill.scaling_stat).toLowerCase()]) || 0;
+    if (skill.scaling_stat) {
+      const key = String(skill.scaling_stat).toLowerCase();
+      return Number(resolved?.effectiveStats?.[key] ?? unit?.stats?.[key]) || 0;
+    }
     return kind === "defensive"
       ? (Number(skill.defenseModifier) || 0)
       : (Number(skill.offenseModifier) || 0);
@@ -217,7 +220,7 @@
       combat.getOffensiveLevel = function derivedOffensiveLevel(unit, skill = {}) {
         try {
           const resolved = combat.resolveDerivedStats(unit, { skill, context: "combat" });
-          const scaling = combatSkillScaling(unit, skill, "offensive");
+          const scaling = combatSkillScaling(unit, skill, "offensive", resolved);
           const resonance = Number(skill?.resonanceOffenseBonus) || 0;
           return Math.max(1, resolved.offensiveLevel.total + scaling + resonance);
         } catch (_) {
@@ -230,7 +233,7 @@
       combat.getDefensiveLevel = function derivedDefensiveLevel(unit, skillOrPart = {}) {
         try {
           const resolved = combat.resolveDerivedStats(unit, { skill: skillOrPart, context: "combat" });
-          const scaling = combatSkillScaling(unit, skillOrPart, "defensive");
+          const scaling = combatSkillScaling(unit, skillOrPart, "defensive", resolved);
           const resonance = Number(skillOrPart?.resonanceDefenseBonus) || 0;
           return Math.max(1, resolved.defensiveLevel.total + scaling + resonance);
         } catch (_) {

--- a/js/derived-stats-runtime.js
+++ b/js/derived-stats-runtime.js
@@ -166,19 +166,22 @@
       ...original,
       __derivedStatsV1: true,
       abilityModifier: api.abilityModifier,
-      abilityRollMath(abilityId, npc) {
-        const data = npc || {};
-        const proficiencyOverride = Number.isFinite(Number(data.proficiencyBonus)) ? Number(data.proficiencyBonus) : undefined;
-        const resolved = api.resolveCharacterStats(data, { proficiencyBonusOverride: proficiencyOverride });
+      abilityRollMath(profile, abilityId) {
+        const legacy = original.abilityRollMath?.(profile, abilityId) || null;
+        const normalized = original.normalizeProfile?.(profile || {}) || profile || {};
+        const proficiencyOverride = Number.isFinite(Number(normalized.proficiencyBonus)) ? Number(normalized.proficiencyBonus) : undefined;
+        const resolved = api.resolveCharacterStats({ stats: normalized.stats || profile?.stats || {} }, { proficiencyBonusOverride });
         const id = api.abilityId(abilityId);
         const ability = resolved.abilities[id];
-        if (!ability) return original.abilityRollMath?.(abilityId, npc);
-        const legacy = original.abilityRollMath?.(abilityId, npc) || {};
+        if (!ability) return legacy;
+        const proficiencyValue = Number.isFinite(Number(legacy?.proficiencyValue)) ? Number(legacy.proficiencyValue) : 0;
         return {
-          ...legacy,
+          ...(legacy || {}),
           score: ability.score,
           modifier: ability.modifier,
           proficiency: resolved.proficiency.bonus,
+          proficiencyValue,
+          base: ability.modifier + proficiencyValue,
         };
       },
     });
@@ -187,10 +190,12 @@
     return true;
   }
 
-  function combatSkillScaling(unit, skill) {
+  function combatSkillScaling(unit, skill, kind) {
     if (!skill) return 0;
-    if (skill.scaling_stat && unit?.stats) return Number(unit.stats[skill.scaling_stat]) || 0;
-    return Number(skill.offenseModifier ?? skill.defenseModifier ?? 0) || 0;
+    if (skill.scaling_stat && unit?.stats) return Number(unit.stats[String(skill.scaling_stat).toLowerCase()]) || 0;
+    return kind === "defensive"
+      ? (Number(skill.defenseModifier) || 0)
+      : (Number(skill.offenseModifier) || 0);
   }
 
   function installCombat() {
@@ -200,12 +205,20 @@
     const originalOff = typeof combat.getOffensiveLevel === "function" ? combat.getOffensiveLevel.bind(combat) : null;
     const originalDef = typeof combat.getDefensiveLevel === "function" ? combat.getDefensiveLevel.bind(combat) : null;
 
+    combat.resolveDerivedStats = function resolveCombatDerivedStats(unit, options = {}) {
+      return api.resolveCharacterStats(unit || {}, {
+        ...options,
+        unit: options.unit || unit,
+        traits: traitsFor(unit || {}, options),
+      });
+    };
+
     if (originalOff) {
-      combat.getOffensiveLevel = function derivedOffensiveLevel(unit, skill) {
+      combat.getOffensiveLevel = function derivedOffensiveLevel(unit, skill = {}) {
         try {
-          const resolved = api.resolveCharacterStats(unit || {}, { unit, skill, traits: traitsFor(unit || {}) });
-          const scaling = combatSkillScaling(unit, skill);
-          const resonance = Number(skill?.resonance || skill?.resonanceModifier || 0) || 0;
+          const resolved = combat.resolveDerivedStats(unit, { skill, context: "combat" });
+          const scaling = combatSkillScaling(unit, skill, "offensive");
+          const resonance = Number(skill?.resonanceOffenseBonus) || 0;
           return Math.max(1, resolved.offensiveLevel.total + scaling + resonance);
         } catch (_) {
           return originalOff(unit, skill);
@@ -214,11 +227,12 @@
     }
 
     if (originalDef) {
-      combat.getDefensiveLevel = function derivedDefensiveLevel(unit, skillOrPart) {
+      combat.getDefensiveLevel = function derivedDefensiveLevel(unit, skillOrPart = {}) {
         try {
-          const resolved = api.resolveCharacterStats(unit || {}, { unit, skill: skillOrPart, traits: traitsFor(unit || {}) });
-          const scaling = combatSkillScaling(unit, skillOrPart);
-          return Math.max(1, resolved.defensiveLevel.total + scaling);
+          const resolved = combat.resolveDerivedStats(unit, { skill: skillOrPart, context: "combat" });
+          const scaling = combatSkillScaling(unit, skillOrPart, "defensive");
+          const resonance = Number(skillOrPart?.resonanceDefenseBonus) || 0;
+          return Math.max(1, resolved.defensiveLevel.total + scaling + resonance);
         } catch (_) {
           return originalDef(unit, skillOrPart);
         }

--- a/js/player-splash-framing.js
+++ b/js/player-splash-framing.js
@@ -29,6 +29,18 @@
     return script;
   }
 
+  function ensureDerivedStatsRuntime() {
+    let script = doc.getElementById("derived-stats-runtime-script");
+    if (script) return script;
+    script = doc.createElement("script");
+    script.id = "derived-stats-runtime-script";
+    script.src = "js/derived-stats-runtime.js";
+    script.async = false;
+    script.dataset.engine = "derived-stats-v1";
+    doc.head?.appendChild(script);
+    return script;
+  }
+
   function normalizeFrame(source) {
     const raw = source || {};
     return {
@@ -311,6 +323,7 @@
 
   function boot() {
     ensureStatModifierTooltipRuntime();
+    ensureDerivedStatsRuntime();
     const tick = () => {
       if (doc.getElementById("dashboard-jugadores")) {
         mountDmControls();
@@ -340,5 +353,6 @@
     closeLightbox,
     syncPlayerFrame,
     ensureStatModifierTooltipRuntime,
+    ensureDerivedStatsRuntime,
   });
 })(window);

--- a/js/universal-speed-runtime.js
+++ b/js/universal-speed-runtime.js
@@ -7,6 +7,35 @@
   const BASE_SPEED = typeof Symbol === "function" ? Symbol.for("luminous.baseSpeed") : "__luminousBaseSpeed";
   const decoratedUnits = typeof WeakSet === "function" ? new WeakSet() : null;
   const resolvingUnits = typeof WeakSet === "function" ? new WeakSet() : null;
+  let derivedLoaderStarted = false;
+
+  function ensureDerivedStatsRuntime() {
+    if (global.LuminousDerivedStatsRuntime) {
+      global.LuminousDerivedStatsRuntime.install?.();
+      return true;
+    }
+    if (typeof require === "function") {
+      try {
+        const runtime = require("./derived-stats-runtime.js");
+        runtime?.install?.();
+        if (runtime) return true;
+      } catch (_) {}
+    }
+    const doc = global.document;
+    if (!doc || derivedLoaderStarted) return false;
+    derivedLoaderStarted = true;
+    let script = doc.getElementById("derived-stats-runtime-script");
+    if (!script) {
+      script = doc.createElement("script");
+      script.id = "derived-stats-runtime-script";
+      script.src = "js/derived-stats-runtime.js";
+      script.async = false;
+      script.dataset.engine = "derived-stats-v1";
+      doc.head?.appendChild(script);
+    }
+    script.addEventListener?.("load", () => global.LuminousDerivedStatsRuntime?.install?.(), { once: true });
+    return false;
+  }
 
   function identityValues(entity = {}) {
     return [entity?.id, entity?.playerId, entity?.player_id, entity?.characterId, entity?.character_id, entity?.uid, entity?.vinculo_jugador]
@@ -67,6 +96,12 @@
   function effectiveSpeed(unit, options = {}) {
     const fixed = global.LuminousConditionRuntime?.fixedSpeedFor?.(unit);
     if (fixed != null && Number.isFinite(Number(fixed))) return Number(fixed);
+    const derived = global.LuminousDerivedStatsRuntime?.snapshot?.(
+      options.character || (isCurrentPlayerUnit(unit) ? currentPlayerCharacter() : unit) || unit || {},
+      { unit, traits: options.traits || traitsForUnit(unit), context: "combat", baseSpeed: options.baseSpeed },
+    );
+    if (derived?.speed && Number.isFinite(Number(derived.speed.current))) return Number(derived.speed.current);
+
     const modifiers = options.modifierEngine || global.LuminousUniversalModifiers;
     const character = options.character || (isCurrentPlayerUnit(unit) ? currentPlayerCharacter() : unit) || unit || {};
     const traits = options.traits || traitsForUnit(unit);
@@ -155,6 +190,7 @@
   }
 
   function install() {
+    ensureDerivedStatsRuntime();
     const engine = global.CombatEngine;
     const modifiers = global.LuminousUniversalModifiers;
     if (!engine || !modifiers) return false;
@@ -194,7 +230,7 @@
     return true;
   }
 
-  const api = Object.freeze({ effectiveSpeed, decorateSpeed, decorateKnownCombatants, rawSpeed, withResolvedSpeeds, install });
+  const api = Object.freeze({ effectiveSpeed, decorateSpeed, decorateKnownCombatants, rawSpeed, withResolvedSpeeds, ensureDerivedStatsRuntime, install });
   global.LuminousUniversalSpeedRuntime = api;
   if (typeof module !== "undefined" && module.exports) module.exports = api;
 

--- a/tests/derived_stats.spec.js
+++ b/tests/derived_stats.spec.js
@@ -1,0 +1,274 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const derived = require("../js/derived-stats-engine.js");
+const modifierEngine = require("../js/universal-modifier-engine.js");
+const traitCatalog = require("../js/trait-catalog-core.js");
+const tooltip = require("../js/player-stat-tooltip-runtime.js");
+
+const BASE_10 = Object.freeze({
+  fuerza: 10,
+  destreza: 10,
+  constitucion: 10,
+  inteligencia: 10,
+  sabiduria: 10,
+  carisma: 10,
+});
+
+function character(overrides = {}) {
+  return {
+    level: 10,
+    baseStats: { ...BASE_10 },
+    stats: { ...BASE_10 },
+    characterBuild: {
+      raceId: "human",
+      raceSubtypeId: null,
+      racialStatChoices: [],
+      backgroundId: "chef",
+      classes: [{ classId: "fighter", levels: 10 }],
+      ...(overrides.characterBuild || {}),
+    },
+    ...overrides,
+    baseStats: { ...BASE_10, ...(overrides.baseStats || {}) },
+  };
+}
+
+function resetRuntimeGlobals() {
+  delete global.LuminousDerivedStatsRuntime;
+  delete global.LuminousPlayerStats;
+  delete global.LuminousDmPlayerDndStudio;
+  delete global.LuminousNpcStats;
+  delete global.CombatEngine;
+}
+
+test.afterEach(() => resetRuntimeGlobals());
+
+test("Human base 10 + racial +1 resolves 11 and reload never reapplies the bonus", () => {
+  const first = derived.resolveCharacterStats(character());
+  expect(first.baseStats.fuerza).toBe(10);
+  expect(first.effectiveStats.fuerza).toBe(11);
+  expect(first.abilities.str.modifier).toBe(0);
+
+  const reloaded = character({
+    stats: { fuerza: 11, destreza: 11, constitucion: 11, inteligencia: 11, sabiduria: 11, carisma: 11 },
+  });
+  const second = derived.resolveCharacterStats(reloaded);
+  expect(second.baseStats.fuerza).toBe(10);
+  expect(second.effectiveStats.fuerza).toBe(11);
+  expect(second.effectiveStats.fuerza).not.toBe(12);
+});
+
+test("DM editing stays on base Score while canonical effective Score remains separate", () => {
+  const source = character();
+  const snapshot = derived.resolveCharacterStats(source);
+  expect(source.baseStats.fuerza).toBe(10);
+  expect(snapshot.baseStats.fuerza).toBe(10);
+  expect(snapshot.effectiveStats.fuerza).toBe(11);
+  expect(source.baseStats.fuerza).toBe(10);
+});
+
+test("Player, DM, NPC and Combat adapters expose the same canonical Ability Mod", () => {
+  const source = character({ baseStats: { fuerza: 14 } });
+  const canonical = derived.resolveCharacterStats(source);
+
+  global.LuminousPlayerStats = Object.freeze({
+    abilityScore: () => 999,
+    abilityModifier: () => 999,
+    proficiencyBonus: () => 999,
+    abilityRollMath: () => ({ state: "none", proficiencyValue: 0 }),
+    combatLevelBreakdown: () => ({ total: -1 }),
+    currentHp: () => -1,
+    maxHp: () => -1,
+  });
+  global.LuminousDmPlayerDndStudio = Object.freeze({
+    abilityModifier: () => 999,
+    proficiencyBonus: () => 999,
+    resolveEffectiveStats: () => ({}),
+    effectiveAbilityScore: () => 999,
+    combatBreakdown: () => ({ total: -1 }),
+    baseStatsFromForm: () => ({ ...source.baseStats }),
+    racialStatInput: () => ({ raceId: "human", racialStatChoices: [] }),
+  });
+  global.LuminousNpcStats = Object.freeze({
+    abilityModifier: () => 999,
+    abilityRollMath: (profile, abilityId) => ({ abilityId, score: profile.stats.fuerza, proficiencyValue: 0 }),
+  });
+  global.CombatEngine = {
+    getOffensiveLevel: () => -1,
+    getDefensiveLevel: () => -1,
+  };
+
+  delete require.cache[require.resolve("../js/derived-stats-runtime.js")];
+  const runtime = require("../js/derived-stats-runtime.js");
+  runtime.install();
+
+  const playerRoll = global.LuminousPlayerStats.abilityRollMath({ id: "str", key: "fuerza" }, source);
+  expect(playerRoll.modifier).toBe(canonical.abilities.str.modifier);
+  expect(global.LuminousPlayerStats.abilityModifier(canonical.abilities.str.score)).toBe(canonical.abilities.str.modifier);
+  expect(global.LuminousDmPlayerDndStudio.abilityModifier(canonical.abilities.str.score)).toBe(canonical.abilities.str.modifier);
+
+  const npc = { stats: { ...source.baseStats }, proficiencyBonus: 1 };
+  const npcRoll = global.LuminousNpcStats.abilityRollMath(npc, "str");
+  expect(npcRoll.modifier).toBe(derived.abilityModifier(14));
+
+  const combatSnapshot = global.CombatEngine.resolveDerivedStats(source);
+  expect(combatSnapshot.abilities.str.modifier).toBe(canonical.abilities.str.modifier);
+});
+
+test("runtime Trait modifies effective Score without rewriting base Score", () => {
+  const source = {
+    ...character({
+      level: 100,
+      baseStats: { fuerza: 20, constitucion: 18 },
+      characterBuild: {
+        raceId: null,
+        backgroundId: "chef",
+        classes: [{ classId: "barbarian", levels: 100 }],
+      },
+    }),
+    classes: [{ classId: "barbarian", levels: 100 }],
+  };
+  const before = JSON.parse(JSON.stringify(source.baseStats));
+  const snapshot = derived.resolveCharacterStats(source, {
+    modifierEngine,
+    traits: [traitCatalog.getDefinition("primordial_champion")],
+    context: "any",
+  });
+
+  expect(snapshot.baseStats.fuerza).toBe(20);
+  expect(snapshot.effectiveStats.fuerza).toBe(24);
+  expect(snapshot.abilities.str.runtimeScoreBonus).toBe(4);
+  expect(source.baseStats).toEqual(before);
+});
+
+test("multiclass only affects derived build through explicit weighted class rules", () => {
+  const multi = character({
+    level: 100,
+    characterBuild: {
+      raceId: "human",
+      backgroundId: "chef",
+      classes: [
+        { classId: "barbarian", levels: 25 },
+        { classId: "bard", levels: 75 },
+      ],
+    },
+  });
+  const snapshot = derived.resolveCharacterStats(multi);
+  expect(snapshot.level).toBe(100);
+  expect(snapshot.build.classLevelTotal).toBe(100);
+  expect(snapshot.abilities.str.score).toBe(11);
+  expect(snapshot.abilities.str.modifier).toBe(0);
+});
+
+test("tooltip modifier breakdown sums exactly to the canonical visible modifier", () => {
+  const source = character({
+    baseStats: { fuerza: 11 },
+    characterBuild: {
+      raceId: "human",
+      backgroundId: "chef",
+      classes: [{ classId: "fighter", levels: 10 }],
+      breakdown: {
+        backgroundStatBonuses: { str: 1 },
+        traitStatBonuses: { str: 1 },
+      },
+    },
+  });
+  const snapshot = derived.resolveCharacterStats(source);
+  const ability = snapshot.abilities.str;
+  const parts = tooltip.modifierContributions({
+    baseScore: ability.baseScore,
+    racialScoreBonus: ability.racialScoreBonus,
+    backgroundScoreBonus: ability.backgroundScoreBonus,
+    traitsScoreBonus: ability.traitScoreBonus,
+  });
+  expect(parts.total).toBe(ability.modifier);
+  expect(parts.baseModifier + parts.racial + parts.background + parts.traits).toBe(ability.modifier);
+});
+
+test("legacy effective stats with stored racial breakdown normalize before calculation", () => {
+  const legacy = {
+    level: 10,
+    stats: { fuerza: 11, destreza: 11, constitucion: 11, inteligencia: 11, sabiduria: 11, carisma: 11 },
+    characterBuild: {
+      raceId: "human",
+      backgroundId: "chef",
+      classes: [{ classId: "fighter", levels: 10 }],
+      breakdown: { racialStatBonuses: { str: 1, dex: 1, con: 1, int: 1, wis: 1, cha: 1 } },
+    },
+  };
+  const snapshot = derived.resolveCharacterStats(legacy);
+  expect(snapshot.baseStats.fuerza).toBe(10);
+  expect(snapshot.effectiveStats.fuerza).toBe(11);
+});
+
+test("NPC and PC use identical shared Score -> Modifier semantics", () => {
+  const pc = derived.resolveCharacterStats(character({ baseStats: { destreza: 17 } }));
+  const npc = derived.resolveCharacterStats({ stats: { destreza: 18 } }, { proficiencyBonusOverride: 3 });
+  expect(pc.abilities.dex.modifier).toBe(derived.abilityModifier(pc.abilities.dex.score));
+  expect(npc.abilities.dex.modifier).toBe(derived.abilityModifier(npc.abilities.dex.score));
+  expect(npc.proficiency).toMatchObject({ bonus: 3, source: "override" });
+});
+
+test("OFF DEF and Speed are one canonical base plus Universal Modifier channels", () => {
+  const source = {
+    ...character({
+      level: 100,
+      characterBuild: {
+        raceId: null,
+        backgroundId: "chef",
+        classes: [{ classId: "barbarian", levels: 100 }],
+      },
+    }),
+    classes: [{ classId: "barbarian", levels: 100 }],
+    combatStats: { minSpeed: 2, maxSpeed: 6 },
+  };
+  const traits = [traitCatalog.getDefinition("armorless_defense"), traitCatalog.getDefinition("fast_movement")];
+  const snapshot = derived.resolveCharacterStats(source, { modifierEngine, traits, context: "combat" });
+
+  expect(snapshot.defensiveLevel.runtimeModifier).toBe(derived.abilityModifier(snapshot.abilities.con.score));
+  expect(snapshot.speed.minModifier).toBe(1);
+  expect(snapshot.speed.min).toBe(3);
+  expect(snapshot.offensiveLevel.total).toBe(
+    snapshot.offensiveLevel.level + snapshot.offensiveLevel.classModifier + snapshot.offensiveLevel.raceModifier +
+    snapshot.offensiveLevel.dmModifier + snapshot.offensiveLevel.itemModifier + snapshot.offensiveLevel.runtimeModifier
+  );
+  expect(snapshot.defensiveLevel.total).toBe(
+    snapshot.defensiveLevel.level + snapshot.defensiveLevel.classModifier + snapshot.defensiveLevel.raceModifier +
+    snapshot.defensiveLevel.dmModifier + snapshot.defensiveLevel.itemModifier + snapshot.defensiveLevel.runtimeModifier
+  );
+});
+
+test("SP contract preserves existing current value without inventing a Max SP formula", () => {
+  expect(derived.resolveCharacterStats({ combatStats: { sp_actual: -12 } }).sp).toEqual({ current: -12, max: null, source: "current-only" });
+  expect(derived.resolveCharacterStats({ combatStats: { sp_actual: 5, sp_max: 45 } }).sp).toEqual({ current: 5, max: 45, source: "stored" });
+});
+
+test("Derived Stats runtime owns Combat base while preserving Skill-specific scaling", () => {
+  const source = character({
+    level: 10,
+    baseStats: { fuerza: 14 },
+    stats: { fuerza: 15 },
+  });
+  global.CombatEngine = {
+    getOffensiveLevel: () => 999,
+    getDefensiveLevel: () => 999,
+  };
+  delete require.cache[require.resolve("../js/derived-stats-runtime.js")];
+  const runtime = require("../js/derived-stats-runtime.js");
+  runtime.installCombat();
+
+  const base = derived.resolveCharacterStats(source).offensiveLevel.total;
+  const skill = { scaling_stat: "fuerza", resonance: 2 };
+  expect(global.CombatEngine.getOffensiveLevel(source, skill)).toBe(base + 15 + 2);
+  expect(global.CombatEngine.__derivedStatsV1).toBe(true);
+});
+
+test("runtime and engine stay mechanics-only and do not persist derived state", () => {
+  const engineSource = fs.readFileSync(path.join(__dirname, "..", "js/derived-stats-engine.js"), "utf8");
+  const runtimeSource = fs.readFileSync(path.join(__dirname, "..", "js/derived-stats-runtime.js"), "utf8");
+  expect(engineSource).not.toContain("firebase.database");
+  expect(engineSource).not.toContain(".update(");
+  expect(engineSource).not.toContain(".set(");
+  expect(runtimeSource).not.toContain("firebase.database");
+});

--- a/tests/derived_stats.spec.js
+++ b/tests/derived_stats.spec.js
@@ -17,20 +17,20 @@ const BASE_10 = Object.freeze({
 });
 
 function character(overrides = {}) {
+  const overrideBuild = overrides.characterBuild || {};
   return {
     level: 10,
-    baseStats: { ...BASE_10 },
     stats: { ...BASE_10 },
+    ...overrides,
+    baseStats: { ...BASE_10, ...(overrides.baseStats || {}) },
     characterBuild: {
       raceId: "human",
       raceSubtypeId: null,
       racialStatChoices: [],
       backgroundId: "chef",
       classes: [{ classId: "fighter", levels: 10 }],
-      ...(overrides.characterBuild || {}),
+      ...overrideBuild,
     },
-    ...overrides,
-    baseStats: { ...BASE_10, ...(overrides.baseStats || {}) },
   };
 }
 
@@ -92,6 +92,7 @@ test("Player, DM, NPC and Combat adapters expose the same canonical Ability Mod"
   });
   global.LuminousNpcStats = Object.freeze({
     abilityModifier: () => 999,
+    normalizeProfile: (profile) => profile,
     abilityRollMath: (profile, abilityId) => ({ abilityId, score: profile.stats.fuerza, proficiencyValue: 0 }),
   });
   global.CombatEngine = {
@@ -214,6 +215,7 @@ test("OFF DEF and Speed are one canonical base plus Universal Modifier channels"
   const source = {
     ...character({
       level: 100,
+      baseStats: { constitucion: 18 },
       characterBuild: {
         raceId: null,
         backgroundId: "chef",
@@ -259,9 +261,18 @@ test("Derived Stats runtime owns Combat base while preserving Skill-specific sca
   runtime.installCombat();
 
   const base = derived.resolveCharacterStats(source).offensiveLevel.total;
-  const skill = { scaling_stat: "fuerza", resonance: 2 };
+  const skill = { scaling_stat: "fuerza", resonanceOffenseBonus: 2 };
   expect(global.CombatEngine.getOffensiveLevel(source, skill)).toBe(base + 15 + 2);
   expect(global.CombatEngine.__derivedStatsV1).toBe(true);
+});
+
+test("production Player DM and Combat loaders request Derived Stats v1", () => {
+  const splashSource = fs.readFileSync(path.join(__dirname, "..", "js/player-splash-framing.js"), "utf8");
+  const speedSource = fs.readFileSync(path.join(__dirname, "..", "js/universal-speed-runtime.js"), "utf8");
+  expect(splashSource).toContain('script.id = "derived-stats-runtime-script"');
+  expect(splashSource).toContain('script.src = "js/derived-stats-runtime.js"');
+  expect(speedSource).toContain("function ensureDerivedStatsRuntime()");
+  expect(speedSource).toContain('script.src = "js/derived-stats-runtime.js"');
 });
 
 test("runtime and engine stay mechanics-only and do not persist derived state", () => {


### PR DESCRIPTION
Implements the canonical Derived Stats v1 boundary for #587 without rebalancing existing formulas.

Adds:
- pure `LuminousDerivedStats.resolveCharacterStats()` for Base/Effective Scores, Ability Mods, Proficiency, HP, SP, OFF/DEF and Speed;
- explicit legacy normalization that prevents supported racial bonuses from being reapplied on reload;
- composition with existing Character Build and Universal Modifier engines instead of duplicating their rules;
- compatibility runtime for Player, DM, NPC and Combat APIs;
- production loaders for Player/DM stat surfaces and Combat speed/runtime surfaces;
- documented persistent-vs-runtime boundary, including that no canonical Max SP formula currently exists;
- cross-surface regression matrix plus existing Stats/Modifier/Speed suites in CI.

Validation green:
- Derived Stats v1 contract;
- existing Stats/Race/Tooltip/Speed regressions;
- Trait Engine;
- repository-wide non-browser regression suite.

Closes #587.