### PR TITLE
feat(spellcasting): caster abilities and automatic Limbus spell slots

### DIFF
--- a/.github/workflows/spellcasting-basic-rules.yml
+++ b/.github/workflows/spellcasting-basic-rules.yml
@@ -5,8 +5,10 @@ on:
     paths:
       - "js/spellcasting-runtime.js"
       - "js/spellcasting-basic-rules-runtime.js"
+      - "js/caster-spellcasting-traits-runtime.js"
       - "js/scene-time-engine.js"
       - "tests/spellcasting_runtime.spec.js"
+      - "tests/caster_spellcasting_progression.spec.js"
       - "docs/spellcasting-basic-rules.md"
       - ".github/workflows/spellcasting-basic-rules.yml"
 
@@ -30,10 +32,16 @@ jobs:
         run: |
           node --check js/spellcasting-runtime.js
           node --check js/spellcasting-basic-rules-runtime.js
+          node --check js/caster-spellcasting-traits-runtime.js
           node --check js/scene-time-engine.js
           node --check tests/spellcasting_runtime.spec.js
+          node --check tests/caster_spellcasting_progression.spec.js
       - name: Focused Spellcasting regressions
-        run: npx playwright test tests/spellcasting_runtime.spec.js --workers=1
+        run: >-
+          npx playwright test
+          tests/spellcasting_runtime.spec.js
+          tests/caster_spellcasting_progression.spec.js
+          --workers=1
       - name: Related integration regressions
         run: >-
           npx playwright test

--- a/docs/spellcasting-basic-rules.md
+++ b/docs/spellcasting-basic-rules.md
@@ -2,26 +2,167 @@
 
 ## Scope
 
-`js/spellcasting-runtime.js` remains the shared Spell Mod / Spell DC bridge. `js/spellcasting-basic-rules-runtime.js` extends it with the reusable resource and resolution contract without replacing the Trait, Combat, Fixed Damage, Rest, Action Economy, or Scene Time engines.
+`js/spellcasting-runtime.js` owns the shared Spellcasting Ability registry, Limbus caster progression, automatic Spell Slot tables, Spell Mod, Spell Attack and Spell Save DC bridge. `js/spellcasting-basic-rules-runtime.js` extends it with resource spending, recovery, Overcast, Upcast, Saving Throw, Casting Time and Concentration contracts.
 
-This version intentionally does **not** invent a universal Spell Power formula. Spells may define their own Skill/Coin power, while the runtime owns the shared resources and resolution metadata below.
+`js/caster-spellcasting-traits-runtime.js` exposes the Level 1 **Spellcasting Ability** Trait for every caster Class and is auto-loaded by the Spellcasting runtime.
 
-## Spellcasting Ability and DC
+This version intentionally does **not** invent a universal Spell Power formula. Spells may define their own Skill/Coin power while the runtime owns the shared resources and resolution metadata below.
 
-A Class registers one default Spellcasting Ability. Bard remains Charisma. A saved Class entry may explicitly override its Spellcasting Ability when a Class or feature requires it.
+## Limbus Class Level conversion
+
+Caster progression follows the project conversion:
+
+- D&D Level 1 = Limbus Class Level 1.
+- From D&D Level 2 onward, `Limbus milestone = D&D Level × 5`.
+- Intermediate Limbus Levels keep the latest unlocked D&D row.
+
+Runtime conversion:
+
+`Effective D&D Level = max(1, floor(Limbus Class Level / 5))`, capped at 20, for any Class Level above 0.
+
+Examples:
+
+- Limbus 1–9 -> D&D row 1
+- Limbus 10–14 -> D&D row 2
+- Limbus 15–19 -> D&D row 3
+- Limbus 25–29 -> D&D row 5
+- Limbus 85–89 -> D&D row 17
+- Limbus 100 -> D&D row 20
+
+Spell Slots use the **source Class Level**, not total Character Level.
+
+## Spellcasting Ability Trait
+
+Every caster Class receives one passive Level 1 Trait named **Spellcasting Ability**.
+
+The Trait records:
+
+- Spellcasting Ability
+- caster progression
+- automatic Slot generation
+- recovery rule
+- `Spell Attack = Proficiency + SpellMod`
+- `Spell Save DC = 8 + Proficiency + SpellMod`
+
+Bard keeps its existing `spellcasting` Trait id for compatibility; the shared caster runtime normalizes that definition to the same Spellcasting Ability contract and de-duplicates the Level 1 grant.
+
+### Class profiles
+
+| Class | Spellcasting Ability | Progression | Slot recovery |
+| --- | --- | --- | --- |
+| Artificer | Intelligence | Half | Long Rest |
+| Bard | Charisma | Full | Long Rest |
+| Cleric | Wisdom | Full | Long Rest |
+| Druid | Wisdom | Full | Long Rest |
+| Paladin | Charisma | Half | Long Rest |
+| Ranger | Wisdom | Half | Long Rest |
+| Sorcerer | Charisma | Full | Long Rest |
+| Warlock | Charisma | Pact | Short Rest or Long Rest |
+| Wizard | Intelligence | Full | Long Rest |
+
+Spanish/legacy aliases such as `hechicero`, `mago`, `brujo`, `bardo`, `clerigo` and `druida` normalize to the canonical Class ids.
+
+## Spellcasting Ability, Spell Attack and DC
+
+A Class profile supplies the default Spellcasting Ability. A saved Class entry may explicitly override its Ability when a future Class feature requires it.
 
 - `SpellMod = Class Spellcasting Ability modifier`
+- `SpellAttack = SpellMod + Proficiency`
 - `SpellDC = 8 + SpellMod + Proficiency`
 - Archetype Traits inherit their parent `classId` and therefore the parent Class Spellcasting Ability.
 
-## Spell Slots
+## Automatic Spell Slots
 
-Slots are tracked **per Class and Slot Level** in `character.spellcastingState.slotsByClass`. The runtime does not assume a multiclass slot-merging policy. Each Class supplies its own slot table.
+Slots are tracked **per Class and Slot Level** in `character.spellcastingState.slotsByClass`.
+
+If saved Class data explicitly supplies a Slot table, that table remains an override for compatibility. Otherwise the runtime derives the table automatically from:
+
+`source Class Level -> effective D&D Level -> caster progression -> Slot table`
+
+Current V1 keeps Class Slot pools independent. It does not merge Full/Half/Third caster levels into one D&D multiclass pool.
+
+### Full Caster progression
+
+Used by Bard, Cleric, Druid, Sorcerer and Wizard.
+
+| Limbus | Effective D&D | SL1 | SL2 | SL3 | SL4 | SL5 | SL6 | SL7 | SL8 | SL9 |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 1 | 2 | - | - | - | - | - | - | - | - |
+| 10 | 2 | 3 | - | - | - | - | - | - | - | - |
+| 15 | 3 | 4 | 2 | - | - | - | - | - | - | - |
+| 20 | 4 | 4 | 3 | - | - | - | - | - | - | - |
+| 25 | 5 | 4 | 3 | 2 | - | - | - | - | - | - |
+| 30 | 6 | 4 | 3 | 3 | - | - | - | - | - | - |
+| 35 | 7 | 4 | 3 | 3 | 1 | - | - | - | - | - |
+| 40 | 8 | 4 | 3 | 3 | 2 | - | - | - | - | - |
+| 45 | 9 | 4 | 3 | 3 | 3 | 1 | - | - | - | - |
+| 50 | 10 | 4 | 3 | 3 | 3 | 2 | - | - | - | - |
+| 55 | 11 | 4 | 3 | 3 | 3 | 2 | 1 | - | - | - |
+| 60 | 12 | 4 | 3 | 3 | 3 | 2 | 1 | - | - | - |
+| 65 | 13 | 4 | 3 | 3 | 3 | 2 | 1 | 1 | - | - |
+| 70 | 14 | 4 | 3 | 3 | 3 | 2 | 1 | 1 | - | - |
+| 75 | 15 | 4 | 3 | 3 | 3 | 2 | 1 | 1 | 1 | - |
+| 80 | 16 | 4 | 3 | 3 | 3 | 2 | 1 | 1 | 1 | - |
+| 85 | 17 | 4 | 3 | 3 | 3 | 2 | 1 | 1 | 1 | 1 |
+| 90 | 18 | 4 | 3 | 3 | 3 | 3 | 1 | 1 | 1 | 1 |
+| 95 | 19 | 4 | 3 | 3 | 3 | 3 | 2 | 1 | 1 | 1 |
+| 100 | 20 | 4 | 3 | 3 | 3 | 3 | 2 | 2 | 1 | 1 |
+
+### Half Caster progression
+
+Used by Artificer, Paladin and Ranger.
+
+| Limbus | Effective D&D | SL1 | SL2 | SL3 | SL4 | SL5 |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 1 | 2 | - | - | - | - |
+| 10 | 2 | 2 | - | - | - | - |
+| 15 | 3 | 3 | - | - | - | - |
+| 20 | 4 | 3 | - | - | - | - |
+| 25 | 5 | 4 | 2 | - | - | - |
+| 30 | 6 | 4 | 2 | - | - | - |
+| 35 | 7 | 4 | 3 | - | - | - |
+| 40 | 8 | 4 | 3 | - | - | - |
+| 45 | 9 | 4 | 3 | 2 | - | - |
+| 50 | 10 | 4 | 3 | 2 | - | - |
+| 55 | 11 | 4 | 3 | 3 | - | - |
+| 60 | 12 | 4 | 3 | 3 | - | - |
+| 65 | 13 | 4 | 3 | 3 | 1 | - |
+| 70 | 14 | 4 | 3 | 3 | 1 | - |
+| 75 | 15 | 4 | 3 | 3 | 2 | - |
+| 80 | 16 | 4 | 3 | 3 | 2 | - |
+| 85 | 17 | 4 | 3 | 3 | 3 | 1 |
+| 90 | 18 | 4 | 3 | 3 | 3 | 1 |
+| 95 | 19 | 4 | 3 | 3 | 3 | 2 |
+| 100 | 20 | 4 | 3 | 3 | 3 | 2 |
+
+### Pact Caster progression
+
+Warlock keeps Pact Slots separate from Full/Half progression.
+
+| Limbus | Effective D&D | Pact Slots | Slot Level |
+| ---: | ---: | ---: | ---: |
+| 1 | 1 | 1 | 1 |
+| 10 | 2 | 2 | 1 |
+| 15 | 3 | 2 | 2 |
+| 20 | 4 | 2 | 2 |
+| 25 | 5 | 2 | 3 |
+| 30 | 6 | 2 | 3 |
+| 35 | 7 | 2 | 4 |
+| 40 | 8 | 2 | 4 |
+| 45 | 9 | 2 | 5 |
+| 50 | 10 | 2 | 5 |
+| 55–80 | 11–16 | 3 | 5 |
+| 85–100 | 17–20 | 4 | 5 |
+
+The base runtime also exposes a reusable `third` progression table for future archetypes such as Eldritch Knight or Arcane Trickster; those archetypes are not assigned by this caster-Class patch.
+
+### Slot spending and recovery
 
 - Cantrips (`slotLevel: 0`) spend no Slot.
 - A leveled Spell normally spends one Slot of the level used to cast it.
 - Casting with a higher Slot Level is Upcast.
-- Long Rest restores spent Spell Slots.
+- Long Rest restores Full and Half caster Slots.
+- Warlock Pact Slots restore on Short Rest or Long Rest.
 
 ## Overcast
 
@@ -91,8 +232,9 @@ The runtime de-duplicates checks by `skillEventId` / event id so repeated combat
 
 ## Integration boundaries
 
-- Trait Engine: continues to receive `SpellMod` and `SpellDC` through the existing wrapper; the V1 extension may override the Class Ability from saved Class data.
+- Trait Engine: receives `SpellMod`, `SpellAttack` and `SpellDC` from the source Class Spellcasting profile.
+- Trait Catalog: receives one Level 1 Spellcasting Ability grant for each caster Class.
 - Fixed Damage: owns Overcast overflow damage application.
 - Scene Time: owns elapsed time and Action Instance progression.
-- Rest Runtime: emits `luminous:rest-completed`; Spellcasting listens for Long Rest, restores Slots, and persists `spellcastingState` when Firebase/player identity is available.
-- Combat/Save UI: consumes the returned casting, Save, Upcast, target, and Concentration contracts. This module does not replace Coin Engine or Check execution.
+- Rest Runtime: emits `luminous:rest-completed`; Spellcasting restores Slots according to each Class recovery profile and persists `spellcastingState` when Firebase/player identity is available.
+- Combat/Save UI: consumes the returned casting, Save, Upcast, target and Concentration contracts. This module does not replace Coin Engine or Check execution.

--- a/js/caster-spellcasting-traits-runtime.js
+++ b/js/caster-spellcasting-traits-runtime.js
@@ -1,0 +1,169 @@
+(function (global) {
+  "use strict";
+
+  const spellcasting = global.LuminousSpellcastingRuntime || (typeof require === "function" ? require("./spellcasting-runtime.js") : null);
+  if (!spellcasting) return;
+
+  const CATALOG_VERSION = 5;
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+  const CLASS_NAMES = Object.freeze({
+    artificer: "Artificer",
+    bard: "Bard",
+    cleric: "Cleric",
+    druid: "Druid",
+    paladin: "Paladin",
+    ranger: "Ranger",
+    sorcerer: "Sorcerer",
+    warlock: "Warlock",
+    wizard: "Wizard",
+  });
+
+  const ABILITY_NAMES = Object.freeze({ int: "Intelligence", wis: "Wisdom", cha: "Charisma" });
+  const PROGRESSION_NAMES = Object.freeze({ full: "Full Caster", half: "Half Caster", pact: "Pact Caster", third: "Third Caster" });
+
+  function sourceFor(classId) {
+    return { type: "class", id: classId, classId, className: CLASS_NAMES[classId] || classId };
+  }
+
+  function traitIdFor(classId) {
+    return classId === "bard" ? "spellcasting" : `spellcasting_ability_${classId}`;
+  }
+
+  function descriptionFor(classId, profile) {
+    const className = CLASS_NAMES[classId] || classId;
+    const abilityName = ABILITY_NAMES[profile.abilityId] || profile.abilityId.toUpperCase();
+    const progressionName = PROGRESSION_NAMES[profile.progression] || profile.progression;
+    const recovery = profile.recovery === "short_or_long_rest" ? "Short Rest or Long Rest" : "Long Rest";
+    return `${abilityName} is the ${className} Spellcasting Ability. Spell Attack = Proficiency + ${abilityName} Modifier. Spell Save DC = 8 + Proficiency + ${abilityName} Modifier. ${className} uses ${progressionName} progression. Spell Slots are derived automatically from ${className} Class Level using the Limbus level conversion and recover on ${recovery}.`;
+  }
+
+  function definitionFor(classId) {
+    const profile = spellcasting.getClassSpellcastingProfile(classId);
+    if (!profile) return null;
+    return {
+      schemaVersion: 1,
+      id: traitIdFor(classId),
+      name: "Spellcasting Ability",
+      description: descriptionFor(classId, profile),
+      source: sourceFor(classId),
+      contexts: ["any"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [],
+      rules: [],
+      mechanics: {
+        spellcasting: true,
+        abilityId: profile.abilityId,
+        progression: profile.progression,
+        automaticSlots: true,
+        slotLevelSource: "class_level",
+        limbusLevelConversion: "dnd_level_1_equals_limbus_1_then_dnd_level_times_5",
+        recovery: profile.recovery,
+        spellAttackFormula: "Proficiency + SpellMod",
+        spellSaveDcFormula: "8 + Proficiency + SpellMod",
+      },
+    };
+  }
+
+  const CASTER_CLASS_IDS = Object.freeze(Object.keys(spellcasting.CLASS_SPELLCASTING_PROFILES || {}));
+  const CASTER_DEFINITIONS = Object.freeze(Object.fromEntries(CASTER_CLASS_IDS.map((classId) => [traitIdFor(classId), definitionFor(classId)]).filter(([, definition]) => definition)));
+
+  function grantFor(classId) {
+    const traitId = traitIdFor(classId);
+    return {
+      id: `core_class_${classId}_l1_${traitId}`,
+      sourceType: "class",
+      sourceId: classId,
+      source: { className: CLASS_NAMES[classId] || classId, atLevel: 1, requiredClassLevel: 1 },
+      atLevel: 1,
+      traitId,
+      grantType: "trait",
+      multiclassPolicy: "allowed",
+    };
+  }
+
+  // Bard already owns core_class_bard_l1_spellcasting in bard-class-runtime.js.
+  const CASTER_GRANTS = Object.freeze(CASTER_CLASS_IDS.filter((classId) => classId !== "bard").map(grantFor));
+
+  function catalogIsCurrent(source) {
+    if (!source?.__casterSpellcastingTraitsExtended) return false;
+    const bard = source.getDefinition?.("spellcasting") || source.DEFINITIONS?.spellcasting;
+    return bard?.name === "Spellcasting Ability" && bard?.mechanics?.progression === "full" && bard?.mechanics?.automaticSlots === true;
+  }
+
+  function wrapCatalog() {
+    const source = global.LuminousTraitCatalogCore || (typeof require === "function" ? require("./trait-catalog-core.js") : null);
+    if (!source) return false;
+    if (catalogIsCurrent(source)) return true;
+
+    const baseDefinitions = source.allDefinitions?.bind(source) || (() => clone(source.DEFINITIONS || {}));
+    const baseGrants = source.allGrants?.bind(source) || (() => clone(source.GRANTS || []));
+    const baseGet = source.getDefinition?.bind(source) || (() => null);
+    const baseValidate = source.validateAll?.bind(source) || (() => ({ valid: true, errors: [], warnings: [] }));
+
+    const allDefinitions = () => ({ ...baseDefinitions(), ...clone(CASTER_DEFINITIONS) });
+    const allGrants = () => {
+      const existing = baseGrants();
+      const identities = new Set(existing.map((grant) => `${grant.sourceType}:${grant.sourceId}:${grant.traitId}:${grant.atLevel}`));
+      const additions = CASTER_GRANTS.filter((grant) => !identities.has(`${grant.sourceType}:${grant.sourceId}:${grant.traitId}:${grant.atLevel}`));
+      return [...existing, ...clone(additions)];
+    };
+    const getDefinition = (id) => clone(CASTER_DEFINITIONS[normalizeId(id)] || baseGet(id));
+    const validateAll = (engine = global.LuminousTraitEngine) => {
+      const baseResult = baseValidate(engine);
+      const errors = [...(baseResult.errors || [])];
+      const warnings = [...(baseResult.warnings || [])];
+      Object.entries(CASTER_DEFINITIONS).forEach(([key, definition]) => {
+        if (!engine?.validateTrait) {
+          errors.push(`${key}: Trait Engine is not available.`);
+          return;
+        }
+        const validation = engine.validateTrait(definition);
+        validation.errors.forEach((message) => errors.push(`${key}: ${message}`));
+        validation.warnings.forEach((message) => warnings.push(`${key}: ${message}`));
+      });
+      return { valid: baseResult.valid !== false && !errors.length, errors, warnings };
+    };
+
+    global.LuminousTraitCatalogCore = Object.freeze({
+      ...source,
+      __casterSpellcastingTraitsExtended: true,
+      CATALOG_VERSION: Math.max(CATALOG_VERSION, Number(source.CATALOG_VERSION || 0)),
+      DEFINITIONS: Object.freeze(allDefinitions()),
+      GRANTS: Object.freeze(allGrants()),
+      allDefinitions,
+      allGrants,
+      getDefinition,
+      validateAll,
+    });
+    return true;
+  }
+
+  function install() {
+    return wrapCatalog();
+  }
+
+  const api = Object.freeze({
+    CATALOG_VERSION,
+    CLASS_NAMES,
+    CASTER_CLASS_IDS,
+    CASTER_DEFINITIONS,
+    CASTER_GRANTS,
+    traitIdFor,
+    definitionFor,
+    grantFor,
+    wrapCatalog,
+    install,
+  });
+
+  global.LuminousCasterSpellcastingTraitsRuntime = api;
+  install();
+
+  if (global.document && global.setInterval) {
+    const timer = global.setInterval(install, 800);
+    timer?.unref?.();
+  }
+
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/caster-spellcasting-traits-runtime.js
+++ b/js/caster-spellcasting-traits-runtime.js
@@ -181,6 +181,13 @@
   global.LuminousCasterSpellcastingTraitsRuntime = api;
   install();
 
+  // Node test/import stacks can load Bard after Spellcasting in the same module
+  // turn. Reconcile once the synchronous require chain finishes so wrapper order
+  // cannot leave duplicate semantic Grants in the final catalog.
+  if (!global.document && typeof queueMicrotask === "function") {
+    queueMicrotask(install);
+  }
+
   if (global.document && global.setInterval) {
     const timer = global.setInterval(install, 800);
     timer?.unref?.();

--- a/js/caster-spellcasting-traits-runtime.js
+++ b/js/caster-spellcasting-traits-runtime.js
@@ -83,13 +83,22 @@
     };
   }
 
-  // Bard already owns core_class_bard_l1_spellcasting in bard-class-runtime.js.
-  const CASTER_GRANTS = Object.freeze(CASTER_CLASS_IDS.filter((classId) => classId !== "bard").map(grantFor));
+  const CASTER_GRANTS = Object.freeze(CASTER_CLASS_IDS.map(grantFor));
+
+  function grantIdentity(grant = {}) {
+    return `${grant.sourceType}:${grant.sourceId}:${grant.traitId}:${grant.atLevel}`;
+  }
 
   function catalogIsCurrent(source) {
     if (!source?.__casterSpellcastingTraitsExtended) return false;
     const bard = source.getDefinition?.("spellcasting") || source.DEFINITIONS?.spellcasting;
-    return bard?.name === "Spellcasting Ability" && bard?.mechanics?.progression === "full" && bard?.mechanics?.automaticSlots === true;
+    const grants = source.allGrants?.() || source.GRANTS || [];
+    const identities = grants.map(grantIdentity);
+    return bard?.name === "Spellcasting Ability"
+      && bard?.mechanics?.progression === "full"
+      && bard?.mechanics?.automaticSlots === true
+      && new Set(identities).size === identities.length
+      && CASTER_GRANTS.every((grant) => identities.includes(grantIdentity(grant)));
   }
 
   function wrapCatalog() {
@@ -104,10 +113,14 @@
 
     const allDefinitions = () => ({ ...baseDefinitions(), ...clone(CASTER_DEFINITIONS) });
     const allGrants = () => {
-      const existing = baseGrants();
-      const identities = new Set(existing.map((grant) => `${grant.sourceType}:${grant.sourceId}:${grant.traitId}:${grant.atLevel}`));
-      const additions = CASTER_GRANTS.filter((grant) => !identities.has(`${grant.sourceType}:${grant.sourceId}:${grant.traitId}:${grant.atLevel}`));
-      return [...existing, ...clone(additions)];
+      const combined = [...baseGrants(), ...clone(CASTER_GRANTS)];
+      const seen = new Set();
+      return combined.filter((grant) => {
+        const identity = grantIdentity(grant);
+        if (seen.has(identity)) return false;
+        seen.add(identity);
+        return true;
+      });
     };
     const getDefinition = (id) => clone(CASTER_DEFINITIONS[normalizeId(id)] || baseGet(id));
     const validateAll = (engine = global.LuminousTraitEngine) => {
@@ -122,6 +135,13 @@
         const validation = engine.validateTrait(definition);
         validation.errors.forEach((message) => errors.push(`${key}: ${message}`));
         validation.warnings.forEach((message) => warnings.push(`${key}: ${message}`));
+      });
+      const grants = allGrants();
+      const identities = new Set();
+      grants.forEach((grant) => {
+        const identity = grantIdentity(grant);
+        if (identities.has(identity)) errors.push(`Duplicate caster grant identity: ${identity}`);
+        identities.add(identity);
       });
       return { valid: baseResult.valid !== false && !errors.length, errors, warnings };
     };
@@ -153,6 +173,7 @@
     traitIdFor,
     definitionFor,
     grantFor,
+    grantIdentity,
     wrapCatalog,
     install,
   });

--- a/js/dm-trait-catalog-importer.js
+++ b/js/dm-trait-catalog-importer.js
@@ -64,6 +64,7 @@
   function collectCatalog() {
     const definitions = {};
     const grants = [];
+    const grantIdentities = new Set();
     const errors = [];
     const providers = catalogProviders();
 
@@ -93,6 +94,9 @@
 
       if (!includeGrants) return;
       (catalog.allGrants?.() || []).forEach((grant) => {
+        const identity = grantIdentity(grant);
+        if (grantIdentities.has(identity)) return;
+        grantIdentities.add(identity);
         grants.push({
           id: grant?.id,
           grant,

--- a/js/dm-trait-catalog-importer.js
+++ b/js/dm-trait-catalog-importer.js
@@ -11,7 +11,9 @@
 
   const initialCoreCatalog = global.LuminousTraitCatalogCore || optionalRequire("./trait-catalog-core.js");
   const initialBardRuntime = global.LuminousBardClassRuntime || optionalRequire("./bard-class-runtime.js");
+  const initialCasterSpellcastingRuntime = global.LuminousCasterSpellcastingTraitsRuntime || optionalRequire("./caster-spellcasting-traits-runtime.js");
   initialBardRuntime?.wrapCatalog?.();
+  initialCasterSpellcastingRuntime?.wrapCatalog?.();
   const initialRacialCatalog = global.LuminousRacialTraitCatalog || optionalRequire("./racial-trait-catalog.js");
   const initialArchetypeCatalog = global.LuminousArchetypeTraitCatalog || optionalRequire("./archetype-trait-catalog.js");
 
@@ -287,10 +289,12 @@
 
   async function ensureBuiltInCatalogs() {
     initialBardRuntime?.wrapCatalog?.();
+    initialCasterSpellcastingRuntime?.wrapCatalog?.();
     if (!doc) return catalogProviders();
 
     await ensureScript("bard-class-runtime-script", "js/bard-class-runtime.js", () => Boolean(global.LuminousBardClassRuntime));
     global.LuminousBardClassRuntime?.wrapCatalog?.();
+    global.LuminousCasterSpellcastingTraitsRuntime?.wrapCatalog?.();
 
     await Promise.all([
       ensureScript("racial-trait-catalog-script", "js/racial-trait-catalog.js", () => Boolean(global.LuminousRacialTraitCatalog)),

--- a/js/spellcasting-basic-rules-runtime.js
+++ b/js/spellcasting-basic-rules-runtime.js
@@ -27,6 +27,7 @@
   const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
   const intOr = (value, fallback = 0) => Number.isFinite(Number.parseInt(value, 10)) ? Number.parseInt(value, 10) : fallback;
   const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const canonicalClassId = (value) => base.canonicalSpellcastingClassId?.(value) || normalizeId(value);
   let restListenerBound = false;
 
   function normalizeAbility(value) {
@@ -44,8 +45,8 @@
   }
 
   function classEntry(character, classId) {
-    const id = normalizeId(classId);
-    return classEntries(character).find((entry) => normalizeId(entry.classId || entry.id) === id) || null;
+    const id = canonicalClassId(classId);
+    return classEntries(character).find((entry) => canonicalClassId(entry.classId || entry.id) === id) || null;
   }
 
   function classSpellcastingAbility(character = {}, classId) {
@@ -66,7 +67,7 @@
   }
 
   function resolveSpellcasting(character = {}, classId, runtime = {}, variables = {}) {
-    const normalizedClassId = normalizeId(classId);
+    const normalizedClassId = canonicalClassId(classId);
     const abilityId = classSpellcastingAbility(character, normalizedClassId);
     if (!abilityId) return null;
     const variableName = ABILITY_VARIABLES[abilityId];
@@ -75,7 +76,17 @@
       : (Number.isFinite(Number(runtime?.[variableName])) ? Number(runtime[variableName]) : statModifier(character, abilityId));
     const baseResolved = base.resolveSpellcasting(character, normalizedClassId, runtime, variables);
     const proficiency = numberOr(variables?.Proficiency ?? runtime?.Proficiency ?? character.proficiency ?? baseResolved?.proficiency, 0);
-    return { classId: normalizedClassId, abilityId, spellMod, proficiency, spellDC: 8 + spellMod + proficiency };
+    const profile = base.getClassSpellcastingProfile?.(normalizedClassId) || null;
+    return {
+      classId: normalizedClassId,
+      abilityId,
+      progression: profile?.progression || baseResolved?.progression || null,
+      recovery: profile?.recovery || baseResolved?.recovery || null,
+      spellMod,
+      proficiency,
+      spellAttack: spellMod + proficiency,
+      spellDC: 8 + spellMod + proficiency,
+    };
   }
 
   function resolveForTrait(character = {}, trait = {}, runtime = {}, variables = {}) {
@@ -93,12 +104,25 @@
     return table;
   }
 
+  function configuredSlotTable(character = {}, classId) {
+    const rawId = normalizeId(classId), id = canonicalClassId(classId), entry = classEntry(character, id);
+    const aliases = [...new Set([rawId, id])];
+    const candidates = [
+      entry?.spellSlots,
+      entry?.spell_slots,
+      entry?.spellcasting?.slots,
+      ...aliases.map((key) => character?.spellSlotsByClass?.[key]),
+      ...aliases.map((key) => character?.spellSlots?.[key]),
+      ...aliases.map((key) => character?.characterBuild?.spellSlotsByClass?.[key]),
+    ];
+    return normalizeSlotTable(candidates.find((value) => value && typeof value === "object" && Object.keys(value).length) || {});
+  }
+
   function slotTableForClass(character = {}, classId, explicit = null) {
     if (explicit && typeof explicit === "object") return normalizeSlotTable(explicit);
-    const id = normalizeId(classId), entry = classEntry(character, id);
-    const candidates = [entry?.spellSlots, entry?.spell_slots, entry?.spellcasting?.slots,
-      character?.spellSlotsByClass?.[id], character?.spellSlots?.[id], character?.characterBuild?.spellSlotsByClass?.[id]];
-    return normalizeSlotTable(candidates.find((value) => value && typeof value === "object" && Object.keys(value).length) || {});
+    const configured = configuredSlotTable(character, classId);
+    if (Object.keys(configured).length) return configured;
+    return normalizeSlotTable(base.getClassSpellSlotTable?.(character, canonicalClassId(classId)) || {});
   }
 
   function ensureSpellcastingState(character) {
@@ -113,7 +137,7 @@
   }
 
   function reconcileSlotPool(character, classId, explicitTable = null) {
-    const state = ensureSpellcastingState(character), id = normalizeId(classId), maxima = slotTableForClass(character, id, explicitTable);
+    const state = ensureSpellcastingState(character), id = canonicalClassId(classId), maxima = slotTableForClass(character, id, explicitTable);
     if (!id) throw new Error("Spell Slot pool requires classId.");
     if (!state.slotsByClass[id]?.levels) state.slotsByClass[id] = { levels: {} };
     const levels = state.slotsByClass[id].levels;
@@ -126,7 +150,7 @@
   }
 
   function spellSlotPool(character, classId, explicitTable = null) {
-    const id = normalizeId(classId), pool = reconcileSlotPool(character, id, explicitTable), levels = {};
+    const id = canonicalClassId(classId), pool = reconcileSlotPool(character, id, explicitTable), levels = {};
     Object.entries(pool.levels).forEach(([level, entry]) => {
       const maximum = Math.max(0, intOr(entry.maximum, 0)), spent = Math.max(0, Math.min(maximum, intOr(entry.spent, 0)));
       levels[level] = { level: Number(level), maximum, spent, available: maximum - spent };
@@ -136,7 +160,7 @@
 
   function canSpendSpellSlot(character, classId, slotLevel, explicitTable = null) {
     const level = Math.max(0, intOr(slotLevel, 0));
-    if (level === 0) return { available: true, cantrip: true, classId: normalizeId(classId), slotLevel: 0 };
+    if (level === 0) return { available: true, cantrip: true, classId: canonicalClassId(classId), slotLevel: 0 };
     const pool = spellSlotPool(character, classId, explicitTable), levelPool = pool.levels[level] || { maximum: 0, spent: 0, available: 0 };
     return { available: levelPool.available > 0, cantrip: false, classId: pool.classId, slotLevel: level, levelPool, pool,
       reason: levelPool.available > 0 ? null : `No Level ${level} Spell Slots available for ${pool.classId}.` };
@@ -151,16 +175,23 @@
 
   function syncSpellSlotPools(character) {
     return classEntries(character).map((entry) => {
-      const classId = normalizeId(entry.classId || entry.id), table = slotTableForClass(character, classId);
+      const classId = canonicalClassId(entry.classId || entry.id), table = slotTableForClass(character, classId);
       return classId && Object.keys(table).length ? spellSlotPool(character, classId, table) : null;
     }).filter(Boolean);
   }
 
-  function restoreSpellSlots(character, classId = null) {
+  function shouldRestoreForRest(classId, restType) {
+    const type = normalizeId(restType || "long_rest");
+    if (type === "long_rest") return true;
+    if (type !== "short_rest") return false;
+    return base.getClassSpellcastingProfile?.(classId)?.recovery === "short_or_long_rest";
+  }
+
+  function restoreSpellSlots(character, classId = null, restType = "long_rest") {
     syncSpellSlotPools(character);
-    const state = ensureSpellcastingState(character), ids = classId ? [normalizeId(classId)] : Object.keys(state.slotsByClass), changes = [];
+    const state = ensureSpellcastingState(character), ids = classId ? [canonicalClassId(classId)] : Object.keys(state.slotsByClass), changes = [];
     ids.forEach((id) => {
-      if (!state.slotsByClass[id]?.levels) return;
+      if (!state.slotsByClass[id]?.levels || !shouldRestoreForRest(id, restType)) return;
       Object.values(state.slotsByClass[id].levels).forEach((entry) => { entry.spent = 0; });
       changes.push(spellSlotPool(character, id));
     });
@@ -262,7 +293,7 @@
     const state = ensureSpellcastingState(character), requires = spell.concentration === true || spell.requiresConcentration === true || spell.requires_concentration === true;
     if (!requires) return { started: false, concentration: clone(state.concentration.active || null) };
     state.concentration.active = { spellId: normalizeId(spell.id || spell.name), spellName: String(spell.name || spell.id || "Spell"),
-      startedAt: options.startedAt ?? Date.now(), sourceClassId: normalizeId(options.classId || spell.classId || spell.sourceClassId) };
+      startedAt: options.startedAt ?? Date.now(), sourceClassId: canonicalClassId(options.classId || spell.classId || spell.sourceClassId) };
     return { started: true, concentration: clone(state.concentration.active) };
   }
 
@@ -297,13 +328,13 @@
   function normalizeSpell(spell = {}, options = {}) {
     const slotLevel = Math.max(0, intOr(spell.slotLevel ?? spell.level ?? spell.spellLevel, 0));
     return { ...spell, id: normalizeId(spell.id || spell.name), slotLevel, cantrip: slotLevel === 0 || spell.cantrip === true,
-      sourceClassId: normalizeId(spell.sourceClassId || spell.classId || options.classId), targetType: normalizeTargetType(spell.targetType || spell.target_type),
+      sourceClassId: canonicalClassId(spell.sourceClassId || spell.classId || options.classId), targetType: normalizeTargetType(spell.targetType || spell.target_type),
       save: normalizeSave(spell), concentration: spell.concentration === true || spell.requiresConcentration === true || spell.requires_concentration === true,
       castingTimeSeconds: normalizeCastingTimeSeconds(spell), upcast: normalizeUpcast(spell) };
   }
 
   function castSpell(character, spellInput = {}, options = {}) {
-    const spell = normalizeSpell(spellInput, options), classId = normalizeId(options.classId || spell.sourceClassId);
+    const spell = normalizeSpell(spellInput, options), classId = canonicalClassId(options.classId || spell.sourceClassId);
     if (!classId) return { success: false, reason: "Spell has no source Class.", spell };
     const requestedSlotLevel = spell.cantrip ? 0 : Math.max(spell.slotLevel, intOr(options.slotLevel, spell.slotLevel));
     let resource = { type: "cantrip", spent: 0 };
@@ -331,11 +362,11 @@
   }
 
   function handleRestCompleted(event) {
-    const detail = event?.detail || {};
-    if (normalizeId(detail.type) !== "long_rest") return null;
+    const detail = event?.detail || {}, type = normalizeId(detail.type);
+    if (!["long_rest", "short_rest"].includes(type)) return null;
     const character = detail.character || global.LuminousPlayerTraitRuntime?.getCharacter?.() || global.datosJugador || null;
     if (!character) return null;
-    const restored = restoreSpellSlots(character); persistSpellcastingState(character); return restored;
+    const restored = restoreSpellSlots(character, null, type); persistSpellcastingState(character); return restored;
   }
 
   function bindRestIntegration() {
@@ -362,7 +393,7 @@
     global.LuminousTraitEngine = Object.freeze({ ...source, __spellcastingBasicRulesWrapped: true,
       buildVariables(character = {}, runtime = {}, trait = {}) {
         const variables = original(character, runtime, trait), resolved = resolveForTrait(character, trait, runtime, variables);
-        return resolved ? { ...variables, SpellMod: resolved.spellMod, SpellDC: resolved.spellDC } : variables;
+        return resolved ? { ...variables, SpellMod: resolved.spellMod, SpellAttack: resolved.spellAttack, SpellDC: resolved.spellDC } : variables;
       } });
     return true;
   }
@@ -370,8 +401,8 @@
   function install() { ensureFixedDamageAsset(); bindRestIntegration(); return wrapTraitEngine(); }
 
   const api = Object.freeze({ ...base, __basicRulesV1: true, SCHEMA_VERSION, STATE_KEY, OVERCAST_SP_PER_SLOT_LEVEL, VALID_TARGET_TYPES,
-    normalizeAbility, classSpellcastingAbility, resolveSpellcasting, resolveForTrait, normalizeSlotTable, slotTableForClass, ensureSpellcastingState,
-    reconcileSlotPool, spellSlotPool, canSpendSpellSlot, spendSpellSlot, syncSpellSlotPools, restoreSpellSlots, readCurrentSp, writeCurrentSp,
+    normalizeAbility, classSpellcastingAbility, resolveSpellcasting, resolveForTrait, normalizeSlotTable, configuredSlotTable, slotTableForClass, ensureSpellcastingState,
+    reconcileSlotPool, spellSlotPool, canSpendSpellSlot, spendSpellSlot, syncSpellSlotPools, shouldRestoreForRest, restoreSpellSlots, readCurrentSp, writeCurrentSp,
     applyOvercast, normalizeTargetType, normalizeSave, resolveSpellSave, normalizeUpcast, resolveUpcast, normalizeCastingTimeSeconds,
     buildCastingActionMessage, startConcentration, endConcentration, concentrationCheckForSkill, resolveConcentrationCheck, normalizeSpell, castSpell,
     persistSpellcastingState, handleRestCompleted, bindRestIntegration, ensureFixedDamageAsset, wrapTraitEngine, install });

--- a/js/spellcasting-runtime.js
+++ b/js/spellcasting-runtime.js
@@ -6,6 +6,7 @@
   const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
   const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
   const intOr = (value, fallback = 0) => Number.isFinite(Number.parseInt(value, 10)) ? Number.parseInt(value, 10) : fallback;
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
 
   const ABILITY_VARIABLES = Object.freeze({
     str: "StrengthMod",
@@ -25,36 +26,233 @@
     cha: ["carisma", "charisma", "cha"],
   });
 
-  // Class spellcasting is declared once here and consumed everywhere through SpellMod / SpellDC.
-  // Add future Classes to this registry instead of repeating an Ability Mod on every Spell/Trait.
-  const classAbilities = new Map([
-    ["bard", "cha"],
+  const CLASS_ID_ALIASES = Object.freeze({
+    artificer: "artificer",
+    artifice: "artificer",
+    artificio: "artificer",
+    bard: "bard",
+    bardo: "bard",
+    cleric: "cleric",
+    clerigo: "cleric",
+    clérigo: "cleric",
+    druid: "druid",
+    druida: "druid",
+    paladin: "paladin",
+    paladín: "paladin",
+    ranger: "ranger",
+    explorador: "ranger",
+    sorcerer: "sorcerer",
+    hechicero: "sorcerer",
+    warlock: "warlock",
+    brujo: "warlock",
+    wizard: "wizard",
+    mago: "wizard",
+  });
+
+  const FULL_CASTER_SLOTS = Object.freeze([
+    null,
+    [2, 0, 0, 0, 0, 0, 0, 0, 0],
+    [3, 0, 0, 0, 0, 0, 0, 0, 0],
+    [4, 2, 0, 0, 0, 0, 0, 0, 0],
+    [4, 3, 0, 0, 0, 0, 0, 0, 0],
+    [4, 3, 2, 0, 0, 0, 0, 0, 0],
+    [4, 3, 3, 0, 0, 0, 0, 0, 0],
+    [4, 3, 3, 1, 0, 0, 0, 0, 0],
+    [4, 3, 3, 2, 0, 0, 0, 0, 0],
+    [4, 3, 3, 3, 1, 0, 0, 0, 0],
+    [4, 3, 3, 3, 2, 0, 0, 0, 0],
+    [4, 3, 3, 3, 2, 1, 0, 0, 0],
+    [4, 3, 3, 3, 2, 1, 0, 0, 0],
+    [4, 3, 3, 3, 2, 1, 1, 0, 0],
+    [4, 3, 3, 3, 2, 1, 1, 0, 0],
+    [4, 3, 3, 3, 2, 1, 1, 1, 0],
+    [4, 3, 3, 3, 2, 1, 1, 1, 0],
+    [4, 3, 3, 3, 2, 1, 1, 1, 1],
+    [4, 3, 3, 3, 3, 1, 1, 1, 1],
+    [4, 3, 3, 3, 3, 2, 1, 1, 1],
+    [4, 3, 3, 3, 3, 2, 2, 1, 1],
   ]);
 
+  const HALF_CASTER_SLOTS = Object.freeze([
+    null,
+    [2, 0, 0, 0, 0],
+    [2, 0, 0, 0, 0],
+    [3, 0, 0, 0, 0],
+    [3, 0, 0, 0, 0],
+    [4, 2, 0, 0, 0],
+    [4, 2, 0, 0, 0],
+    [4, 3, 0, 0, 0],
+    [4, 3, 0, 0, 0],
+    [4, 3, 2, 0, 0],
+    [4, 3, 2, 0, 0],
+    [4, 3, 3, 0, 0],
+    [4, 3, 3, 0, 0],
+    [4, 3, 3, 1, 0],
+    [4, 3, 3, 1, 0],
+    [4, 3, 3, 2, 0],
+    [4, 3, 3, 2, 0],
+    [4, 3, 3, 3, 1],
+    [4, 3, 3, 3, 1],
+    [4, 3, 3, 3, 2],
+    [4, 3, 3, 3, 2],
+  ]);
+
+  const THIRD_CASTER_SLOTS = Object.freeze([
+    null,
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+    [2, 0, 0, 0],
+    [3, 0, 0, 0],
+    [3, 0, 0, 0],
+    [3, 0, 0, 0],
+    [4, 2, 0, 0],
+    [4, 2, 0, 0],
+    [4, 2, 0, 0],
+    [4, 3, 0, 0],
+    [4, 3, 0, 0],
+    [4, 3, 0, 0],
+    [4, 3, 2, 0],
+    [4, 3, 2, 0],
+    [4, 3, 2, 0],
+    [4, 3, 3, 0],
+    [4, 3, 3, 0],
+    [4, 3, 3, 0],
+    [4, 3, 3, 1],
+    [4, 3, 3, 1],
+  ]);
+
+  const CLASS_SPELLCASTING_PROFILES = Object.freeze({
+    artificer: Object.freeze({ classId: "artificer", abilityId: "int", progression: "half", recovery: "long_rest" }),
+    bard: Object.freeze({ classId: "bard", abilityId: "cha", progression: "full", recovery: "long_rest" }),
+    cleric: Object.freeze({ classId: "cleric", abilityId: "wis", progression: "full", recovery: "long_rest" }),
+    druid: Object.freeze({ classId: "druid", abilityId: "wis", progression: "full", recovery: "long_rest" }),
+    paladin: Object.freeze({ classId: "paladin", abilityId: "cha", progression: "half", recovery: "long_rest" }),
+    ranger: Object.freeze({ classId: "ranger", abilityId: "wis", progression: "half", recovery: "long_rest" }),
+    sorcerer: Object.freeze({ classId: "sorcerer", abilityId: "cha", progression: "full", recovery: "long_rest" }),
+    warlock: Object.freeze({ classId: "warlock", abilityId: "cha", progression: "pact", recovery: "short_or_long_rest" }),
+    wizard: Object.freeze({ classId: "wizard", abilityId: "int", progression: "full", recovery: "long_rest" }),
+  });
+
+  const classAbilities = new Map();
+  const classProfiles = new Map(Object.entries(CLASS_SPELLCASTING_PROFILES).map(([id, profile]) => [id, clone(profile)]));
+
+  function canonicalSpellcastingClassId(classId) {
+    const id = normalizeId(classId);
+    return CLASS_ID_ALIASES[id] || id;
+  }
+
+  function sameSpellcastingClassId(left, right) {
+    return canonicalSpellcastingClassId(left) === canonicalSpellcastingClassId(right);
+  }
+
+  function normalizeAbilityId(abilityId) {
+    const raw = normalizeId(abilityId);
+    if (ABILITY_VARIABLES[raw]) return raw;
+    for (const [id, aliases] of Object.entries(ABILITY_ALIASES)) {
+      if (aliases.includes(raw)) return id;
+    }
+    return null;
+  }
+
+  function registerClassSpellcastingProfile(classId, profile = {}) {
+    const classKey = canonicalSpellcastingClassId(classId);
+    const abilityId = normalizeAbilityId(profile.abilityId || profile.ability || profile.stat);
+    const progression = normalizeId(profile.progression || "full");
+    const recovery = normalizeId(profile.recovery || (progression === "pact" ? "short_or_long_rest" : "long_rest"));
+    if (!classKey) throw new Error("Spellcasting Class id is required.");
+    if (!ABILITY_VARIABLES[abilityId]) throw new Error(`Unsupported Spellcasting Ability: ${profile.abilityId || profile.ability || profile.stat}`);
+    if (!["full", "half", "third", "pact"].includes(progression)) throw new Error(`Unsupported Spellcasting progression: ${profile.progression}`);
+    const next = { classId: classKey, abilityId, progression, recovery };
+    classProfiles.set(classKey, next);
+    classAbilities.set(classKey, abilityId);
+    return clone(next);
+  }
+
   function registerClassSpellcastingAbility(classId, abilityId) {
-    const classKey = normalizeId(classId);
-    const abilityKey = normalizeId(abilityId).slice(0, 3);
+    const classKey = canonicalSpellcastingClassId(classId);
+    const abilityKey = normalizeAbilityId(abilityId);
     if (!classKey) throw new Error("Spellcasting Class id is required.");
     if (!ABILITY_VARIABLES[abilityKey]) throw new Error(`Unsupported Spellcasting Ability: ${abilityId}`);
     classAbilities.set(classKey, abilityKey);
+    const current = classProfiles.get(classKey);
+    if (current) classProfiles.set(classKey, { ...current, abilityId: abilityKey });
     return { classId: classKey, abilityId: abilityKey };
   }
 
+  Object.entries(CLASS_SPELLCASTING_PROFILES).forEach(([classId, profile]) => {
+    registerClassSpellcastingProfile(classId, profile);
+  });
+
+  function getClassSpellcastingProfile(classId) {
+    return clone(classProfiles.get(canonicalSpellcastingClassId(classId)) || null);
+  }
+
   function getClassSpellcastingAbility(classId) {
-    return classAbilities.get(normalizeId(classId)) || null;
+    return classAbilities.get(canonicalSpellcastingClassId(classId)) || null;
+  }
+
+  function classEntries(character = {}) {
+    const build = character?.characterBuild && typeof character.characterBuild === "object" ? character.characterBuild : {};
+    const source = Array.isArray(character.classes) ? character.classes : (Array.isArray(build.classes) ? build.classes : []);
+    return source.filter((entry) => entry && typeof entry === "object");
+  }
+
+  function getClassEntry(character = {}, classId) {
+    return classEntries(character).find((entry) => sameSpellcastingClassId(entry.classId || entry.id, classId)) || null;
+  }
+
+  function getClassLevel(character = {}, classId) {
+    const entry = getClassEntry(character, classId);
+    return Math.max(0, intOr(entry?.levels ?? entry?.level, 0));
+  }
+
+  function limbusClassLevelToDndLevel(classLevel) {
+    const level = Math.max(0, intOr(classLevel, 0));
+    if (level <= 0) return 0;
+    return Math.min(20, Math.max(1, Math.floor(level / 5)));
+  }
+
+  function arrayToSlotTable(row = []) {
+    const table = {};
+    row.forEach((maximum, index) => {
+      if (maximum > 0) table[index + 1] = maximum;
+    });
+    return table;
+  }
+
+  function pactSlotTable(dndLevel) {
+    const level = Math.max(0, Math.min(20, intOr(dndLevel, 0)));
+    if (!level) return {};
+    const slotLevel = level >= 9 ? 5 : (level >= 7 ? 4 : (level >= 5 ? 3 : (level >= 3 ? 2 : 1)));
+    const slots = level >= 17 ? 4 : (level >= 11 ? 3 : (level >= 2 ? 2 : 1));
+    return { [slotLevel]: slots };
+  }
+
+  function slotTableForProgression(progression, dndLevel) {
+    const kind = normalizeId(progression);
+    const level = Math.max(0, Math.min(20, intOr(dndLevel, 0)));
+    if (!level) return {};
+    if (kind === "pact") return pactSlotTable(level);
+    const source = kind === "half" ? HALF_CASTER_SLOTS : (kind === "third" ? THIRD_CASTER_SLOTS : FULL_CASTER_SLOTS);
+    return arrayToSlotTable(source[level] || []);
+  }
+
+  function getClassSpellSlotTable(character = {}, classId, classLevel = null) {
+    const profile = getClassSpellcastingProfile(classId);
+    if (!profile) return {};
+    const limbusLevel = classLevel == null ? getClassLevel(character, classId) : Math.max(0, intOr(classLevel, 0));
+    const dndLevel = limbusClassLevelToDndLevel(limbusLevel);
+    return slotTableForProgression(profile.progression, dndLevel);
   }
 
   function totalLevel(character = {}, runtime = {}) {
     const explicit = runtime.Level ?? runtime.level ?? character.level ?? character.characterBuild?.calculatedAtLevel;
     if (Number.isFinite(Number(explicit))) return Math.max(0, intOr(explicit, 0));
-    const classes = Array.isArray(character.classes)
-      ? character.classes
-      : (Array.isArray(character.characterBuild?.classes) ? character.characterBuild.classes : []);
-    return classes.reduce((sum, entry) => sum + Math.max(0, intOr(entry?.levels ?? entry?.level, 0)), 0);
+    return classEntries(character).reduce((sum, entry) => sum + Math.max(0, intOr(entry?.levels ?? entry?.level, 0)), 0);
   }
 
   function statModifier(character = {}, abilityId) {
-    const ability = normalizeId(abilityId).slice(0, 3);
+    const ability = normalizeAbilityId(abilityId);
     const stats = character.stats || character.dndStats || {};
     const aliases = ABILITY_ALIASES[ability] || [ability];
     const score = aliases
@@ -65,7 +263,7 @@
 
   function classIdForTrait(trait = {}, runtime = {}) {
     const source = trait.source || {};
-    return normalizeId(
+    return canonicalSpellcastingClassId(
       runtime.sourceClassId
       || runtime.classId
       || source.classId
@@ -74,7 +272,8 @@
   }
 
   function resolveSpellcasting(character = {}, classId, runtime = {}, variables = {}) {
-    const normalizedClassId = normalizeId(classId);
+    const normalizedClassId = canonicalSpellcastingClassId(classId);
+    const profile = getClassSpellcastingProfile(normalizedClassId);
     const abilityId = getClassSpellcastingAbility(normalizedClassId);
     if (!abilityId) return null;
     const variableName = ABILITY_VARIABLES[abilityId];
@@ -87,8 +286,11 @@
     return {
       classId: normalizedClassId,
       abilityId,
+      progression: profile?.progression || null,
+      recovery: profile?.recovery || null,
       spellMod,
       proficiency,
+      spellAttack: spellMod + proficiency,
       spellDC: 8 + spellMod + proficiency,
     };
   }
@@ -113,6 +315,7 @@
         return {
           ...variables,
           SpellMod: spellcasting.spellMod,
+          SpellAttack: spellcasting.spellAttack,
           SpellDC: spellcasting.spellDC,
         };
       },
@@ -127,8 +330,24 @@
 
   const api = Object.freeze({
     ABILITY_VARIABLES,
+    ABILITY_ALIASES,
+    CLASS_ID_ALIASES,
+    CLASS_SPELLCASTING_PROFILES,
+    FULL_CASTER_SLOTS,
+    HALF_CASTER_SLOTS,
+    THIRD_CASTER_SLOTS,
+    canonicalSpellcastingClassId,
+    sameSpellcastingClassId,
+    normalizeAbilityId,
+    registerClassSpellcastingProfile,
     registerClassSpellcastingAbility,
+    getClassSpellcastingProfile,
     getClassSpellcastingAbility,
+    getClassEntry,
+    getClassLevel,
+    limbusClassLevelToDndLevel,
+    slotTableForProgression,
+    getClassSpellSlotTable,
     classIdForTrait,
     resolveSpellcasting,
     resolveForTrait,

--- a/js/spellcasting-runtime.js
+++ b/js/spellcasting-runtime.js
@@ -324,8 +324,26 @@
     return true;
   }
 
+  function ensureCasterSpellcastingTraitsAsset() {
+    if (global.LuminousCasterSpellcastingTraitsRuntime) return global.LuminousCasterSpellcastingTraitsRuntime;
+    if (typeof require === "function" && !global.document) {
+      try { return require("./caster-spellcasting-traits-runtime.js"); } catch (_) { return null; }
+    }
+    if (!global.document) return null;
+    let script = global.document.getElementById("caster-spellcasting-traits-runtime-script");
+    if (script) return script;
+    script = global.document.createElement("script");
+    script.id = "caster-spellcasting-traits-runtime-script";
+    script.src = "js/caster-spellcasting-traits-runtime.js";
+    script.async = false;
+    global.document.head?.appendChild(script);
+    return script;
+  }
+
   function install() {
-    return wrapTraitEngine();
+    const wrapped = wrapTraitEngine();
+    ensureCasterSpellcastingTraitsAsset();
+    return wrapped;
   }
 
   const api = Object.freeze({
@@ -352,6 +370,7 @@
     resolveSpellcasting,
     resolveForTrait,
     wrapTraitEngine,
+    ensureCasterSpellcastingTraitsAsset,
     install,
   });
 

--- a/tests/caster_spellcasting_progression.spec.js
+++ b/tests/caster_spellcasting_progression.spec.js
@@ -126,7 +126,7 @@ test("Short Rest restores Pact Slots only; Long Rest restores all caster Slots",
   expect(spellcasting.spellSlotPool(character, "sorcerer").levels[2].available).toBe(2);
 });
 
-test("Every caster receives a Level 1 Spellcasting Ability Trait without duplicating Bard's existing grant", () => {
+test("Every caster receives one Level 1 Spellcasting Ability Trait grant", () => {
   const catalog = global.LuminousTraitCatalogCore;
   const definitions = catalog.allDefinitions();
   const grants = catalog.allGrants();
@@ -134,21 +134,20 @@ test("Every caster receives a Level 1 Spellcasting Ability Trait without duplica
   for (const classId of casterTraits.CASTER_CLASS_IDS) {
     const traitId = casterTraits.traitIdFor(classId);
     const definition = definitions[traitId];
+    const profile = spellcasting.getClassSpellcastingProfile(classId);
     expect(definition).toBeTruthy();
     expect(definition.name).toBe("Spellcasting Ability");
     expect(definition.source.classId).toBe(classId);
-    expect(definition.mechanics.abilityId).toBe(spellcasting.getClassSpellcastingProfile(classId).abilityId);
-    expect(definition.mechanics.progression).toBe(spellcasting.getClassSpellcastingProfile(classId).progression);
+    expect(definition.mechanics.abilityId).toBe(profile.abilityId);
+    expect(definition.mechanics.progression).toBe(profile.progression);
     expect(definition.mechanics.automaticSlots).toBe(true);
+
+    const matching = grants.filter((grant) => grant.sourceType === "class" && grant.sourceId === classId && grant.atLevel === 1 && grant.traitId === traitId);
+    expect(matching).toHaveLength(1);
   }
 
-  const generatedBardGrants = casterTraits.CASTER_GRANTS.filter((grant) => grant.sourceId === "bard");
-  expect(generatedBardGrants).toHaveLength(0);
-
-  for (const classId of casterTraits.CASTER_CLASS_IDS.filter((id) => id !== "bard")) {
-    const traitId = casterTraits.traitIdFor(classId);
-    expect(grants.some((grant) => grant.sourceType === "class" && grant.sourceId === classId && grant.atLevel === 1 && grant.traitId === traitId)).toBe(true);
-  }
+  const identities = grants.map(casterTraits.grantIdentity);
+  expect(new Set(identities).size).toBe(identities.length);
 });
 
 test("Caster Spellcasting Trait catalog validates against the Trait Engine", () => {

--- a/tests/caster_spellcasting_progression.spec.js
+++ b/tests/caster_spellcasting_progression.spec.js
@@ -1,0 +1,158 @@
+const { test, expect } = require("@playwright/test");
+
+const baseTraitEngine = require("../js/trait-engine.js");
+global.LuminousTraitEngine = baseTraitEngine;
+
+delete global.LuminousSpellcastingRuntime;
+delete global.LuminousCasterSpellcastingTraitsRuntime;
+delete global.LuminousTraitCatalogCore;
+delete require.cache[require.resolve("../js/spellcasting-runtime.js")];
+delete require.cache[require.resolve("../js/spellcasting-basic-rules-runtime.js")];
+delete require.cache[require.resolve("../js/trait-catalog-core.js")];
+delete require.cache[require.resolve("../js/caster-spellcasting-traits-runtime.js")];
+
+require("../js/spellcasting-runtime.js");
+const spellcasting = require("../js/spellcasting-basic-rules-runtime.js");
+require("../js/trait-catalog-core.js");
+const casterTraits = require("../js/caster-spellcasting-traits-runtime.js");
+
+function characterWithClass(classId, levels, stats = {}) {
+  return {
+    id: `${classId}_pc`,
+    level: levels,
+    proficiency: 3,
+    classes: [{ classId, levels }],
+    stats: { inteligencia: 18, sabiduria: 16, carisma: 20, ...stats },
+    currentSp: 50,
+  };
+}
+
+test("Caster profiles define the Spellcasting Ability and progression for every caster Class", () => {
+  expect(spellcasting.getClassSpellcastingProfile("artificer")).toMatchObject({ abilityId: "int", progression: "half", recovery: "long_rest" });
+  expect(spellcasting.getClassSpellcastingProfile("bard")).toMatchObject({ abilityId: "cha", progression: "full", recovery: "long_rest" });
+  expect(spellcasting.getClassSpellcastingProfile("cleric")).toMatchObject({ abilityId: "wis", progression: "full", recovery: "long_rest" });
+  expect(spellcasting.getClassSpellcastingProfile("druid")).toMatchObject({ abilityId: "wis", progression: "full", recovery: "long_rest" });
+  expect(spellcasting.getClassSpellcastingProfile("paladin")).toMatchObject({ abilityId: "cha", progression: "half", recovery: "long_rest" });
+  expect(spellcasting.getClassSpellcastingProfile("ranger")).toMatchObject({ abilityId: "wis", progression: "half", recovery: "long_rest" });
+  expect(spellcasting.getClassSpellcastingProfile("sorcerer")).toMatchObject({ abilityId: "cha", progression: "full", recovery: "long_rest" });
+  expect(spellcasting.getClassSpellcastingProfile("warlock")).toMatchObject({ abilityId: "cha", progression: "pact", recovery: "short_or_long_rest" });
+  expect(spellcasting.getClassSpellcastingProfile("wizard")).toMatchObject({ abilityId: "int", progression: "full", recovery: "long_rest" });
+});
+
+test("Spanish Class aliases resolve to the canonical caster profile", () => {
+  expect(spellcasting.canonicalSpellcastingClassId("hechicero")).toBe("sorcerer");
+  expect(spellcasting.canonicalSpellcastingClassId("mago")).toBe("wizard");
+  expect(spellcasting.canonicalSpellcastingClassId("brujo")).toBe("warlock");
+  expect(spellcasting.getClassSpellcastingAbility("bardo")).toBe("cha");
+});
+
+test("Limbus Class Levels use D&D milestones while intermediate Levels keep the previous row", () => {
+  expect(spellcasting.limbusClassLevelToDndLevel(1)).toBe(1);
+  expect(spellcasting.limbusClassLevelToDndLevel(9)).toBe(1);
+  expect(spellcasting.limbusClassLevelToDndLevel(10)).toBe(2);
+  expect(spellcasting.limbusClassLevelToDndLevel(14)).toBe(2);
+  expect(spellcasting.limbusClassLevelToDndLevel(15)).toBe(3);
+  expect(spellcasting.limbusClassLevelToDndLevel(99)).toBe(19);
+  expect(spellcasting.limbusClassLevelToDndLevel(100)).toBe(20);
+});
+
+test("Full Caster slots are derived automatically from Limbus Class Level", () => {
+  expect(spellcasting.getClassSpellSlotTable(characterWithClass("sorcerer", 1), "sorcerer")).toEqual({ 1: 2 });
+  expect(spellcasting.getClassSpellSlotTable(characterWithClass("sorcerer", 10), "sorcerer")).toEqual({ 1: 3 });
+  expect(spellcasting.getClassSpellSlotTable(characterWithClass("sorcerer", 15), "sorcerer")).toEqual({ 1: 4, 2: 2 });
+  expect(spellcasting.getClassSpellSlotTable(characterWithClass("sorcerer", 25), "sorcerer")).toEqual({ 1: 4, 2: 3, 3: 2 });
+  expect(spellcasting.getClassSpellSlotTable(characterWithClass("sorcerer", 85), "sorcerer")).toEqual({
+    1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1,
+  });
+});
+
+test("Half Caster slots are derived automatically from Limbus Class Level", () => {
+  expect(spellcasting.getClassSpellSlotTable(characterWithClass("artificer", 1), "artificer")).toEqual({ 1: 2 });
+  expect(spellcasting.getClassSpellSlotTable(characterWithClass("paladin", 25), "paladin")).toEqual({ 1: 4, 2: 2 });
+  expect(spellcasting.getClassSpellSlotTable(characterWithClass("ranger", 45), "ranger")).toEqual({ 1: 4, 2: 3, 3: 2 });
+  expect(spellcasting.getClassSpellSlotTable(characterWithClass("paladin", 85), "paladin")).toEqual({ 1: 4, 2: 3, 3: 3, 4: 3, 5: 1 });
+});
+
+test("Pact Caster slots keep one active Slot Level and scale count separately", () => {
+  expect(spellcasting.getClassSpellSlotTable(characterWithClass("warlock", 1), "warlock")).toEqual({ 1: 1 });
+  expect(spellcasting.getClassSpellSlotTable(characterWithClass("warlock", 15), "warlock")).toEqual({ 2: 2 });
+  expect(spellcasting.getClassSpellSlotTable(characterWithClass("warlock", 45), "warlock")).toEqual({ 5: 2 });
+  expect(spellcasting.getClassSpellSlotTable(characterWithClass("warlock", 55), "warlock")).toEqual({ 5: 3 });
+  expect(spellcasting.getClassSpellSlotTable(characterWithClass("warlock", 85), "warlock")).toEqual({ 5: 4 });
+});
+
+test("Automatic Spell Slots use source Class Level instead of total Character Level", () => {
+  const multiclass = {
+    level: 85,
+    proficiency: 5,
+    classes: [
+      { classId: "sorcerer", levels: 15 },
+      { classId: "fighter", levels: 70 },
+    ],
+    stats: { carisma: 20 },
+  };
+  expect(spellcasting.getClassSpellSlotTable(multiclass, "sorcerer")).toEqual({ 1: 4, 2: 2 });
+});
+
+test("Spellcasting Ability drives Spell Mod, Spell Attack and Spell Save DC", () => {
+  const sorcerer = spellcasting.resolveSpellcasting(characterWithClass("sorcerer", 15), "sorcerer");
+  const cleric = spellcasting.resolveSpellcasting(characterWithClass("cleric", 15), "cleric");
+  const artificer = spellcasting.resolveSpellcasting(characterWithClass("artificer", 15), "artificer");
+
+  expect(sorcerer).toMatchObject({ abilityId: "cha", spellMod: 5, spellAttack: 8, spellDC: 16 });
+  expect(cleric).toMatchObject({ abilityId: "wis", spellMod: 3, spellAttack: 6, spellDC: 14 });
+  expect(artificer).toMatchObject({ abilityId: "int", spellMod: 4, spellAttack: 7, spellDC: 15 });
+});
+
+test("Short Rest restores Pact Slots only; Long Rest restores all caster Slots", () => {
+  const character = {
+    level: 30,
+    proficiency: 3,
+    classes: [
+      { classId: "sorcerer", levels: 15 },
+      { classId: "warlock", levels: 15 },
+    ],
+    stats: { carisma: 18 },
+  };
+
+  expect(spellcasting.spendSpellSlot(character, "sorcerer", 2).spent).toBe(1);
+  expect(spellcasting.spendSpellSlot(character, "warlock", 2).spent).toBe(1);
+
+  spellcasting.restoreSpellSlots(character, null, "short_rest");
+  expect(spellcasting.spellSlotPool(character, "sorcerer").levels[2].available).toBe(1);
+  expect(spellcasting.spellSlotPool(character, "warlock").levels[2].available).toBe(2);
+
+  spellcasting.restoreSpellSlots(character, null, "long_rest");
+  expect(spellcasting.spellSlotPool(character, "sorcerer").levels[2].available).toBe(2);
+});
+
+test("Every caster receives a Level 1 Spellcasting Ability Trait without duplicating Bard's existing grant", () => {
+  const catalog = global.LuminousTraitCatalogCore;
+  const definitions = catalog.allDefinitions();
+  const grants = catalog.allGrants();
+
+  for (const classId of casterTraits.CASTER_CLASS_IDS) {
+    const traitId = casterTraits.traitIdFor(classId);
+    const definition = definitions[traitId];
+    expect(definition).toBeTruthy();
+    expect(definition.name).toBe("Spellcasting Ability");
+    expect(definition.source.classId).toBe(classId);
+    expect(definition.mechanics.abilityId).toBe(spellcasting.getClassSpellcastingProfile(classId).abilityId);
+    expect(definition.mechanics.progression).toBe(spellcasting.getClassSpellcastingProfile(classId).progression);
+    expect(definition.mechanics.automaticSlots).toBe(true);
+  }
+
+  const generatedBardGrants = casterTraits.CASTER_GRANTS.filter((grant) => grant.sourceId === "bard");
+  expect(generatedBardGrants).toHaveLength(0);
+
+  for (const classId of casterTraits.CASTER_CLASS_IDS.filter((id) => id !== "bard")) {
+    const traitId = casterTraits.traitIdFor(classId);
+    expect(grants.some((grant) => grant.sourceType === "class" && grant.sourceId === classId && grant.atLevel === 1 && grant.traitId === traitId)).toBe(true);
+  }
+});
+
+test("Caster Spellcasting Trait catalog validates against the Trait Engine", () => {
+  const validation = global.LuminousTraitCatalogCore.validateAll(baseTraitEngine);
+  expect(validation.errors).toEqual([]);
+  expect(validation.valid).toBe(true);
+});


### PR DESCRIPTION
## Summary

Adds the shared caster Spellcasting contract requested for Limbus.

### Spellcasting Ability
- Adds canonical caster profiles for Artificer, Bard, Cleric, Druid, Paladin, Ranger, Sorcerer, Warlock and Wizard.
- Defines the correct Spellcasting Ability per Class.
- Exposes `SpellMod`, `SpellAttack` and `SpellDC`.
- Adds one Level 1 `Spellcasting Ability` Trait grant per caster Class.
- Reuses Bard's existing `spellcasting` Trait id and de-duplicates its grant for compatibility.
- Supports Spanish/legacy Class aliases such as `hechicero`, `mago`, `brujo`, `bardo`, `clerigo` and `druida`.

### Automatic Spell Slots
- Implements the Limbus conversion: Level 1 is shared; later D&D milestones map to `D&D Level × 5`.
- Intermediate Limbus Levels retain the previous D&D slot row.
- Adds Full, Half, Third (future archetype support) and Pact progression tables.
- Derives Slot pools from the source Class Level, not total Character Level.
- Preserves explicit saved Slot tables as compatibility overrides.
- Long Rest restores Full/Half pools; Short Rest also restores Warlock Pact Slots.

### Tests / docs
- Adds regression coverage for caster profiles, aliases, milestone conversion, Full/Half/Pact slots, multiclass isolation, Spell Attack/DC, rest recovery and Level 1 Trait grants.
- Expands `docs/spellcasting-basic-rules.md` with the complete Limbus caster contract and slot tables.

## Current V1 multiclass rule
Slot pools remain per Class. This patch intentionally does not merge Full/Half/Third caster levels into a shared D&D multiclass pool.
