### PR TITLE
feat(vtt): interactive doors windows and DM topology editor

### DIFF
--- a/css/vtt.css
+++ b/css/vtt.css
@@ -4,7 +4,13 @@ html, body {
     width: 100%;
     height: 100%;
     overflow: hidden;
-    background-color: #111; /* Dark background typical for VTT */
+    background-color: #111;
+    color: #e9eef2;
+    font-family: "Share Tech Mono", monospace, sans-serif;
+}
+
+button, input, select {
+    font: inherit;
 }
 
 #vtt-canvas {
@@ -18,30 +24,216 @@ html, body {
     top: 20px;
     right: 20px;
     z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 10px;
+    pointer-events: none;
+}
+
+#vtt-ui-container > * {
+    pointer-events: auto;
+}
+
+.vtt-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 6px;
+    max-width: min(760px, calc(100vw - 40px));
+    padding: 8px;
+    background: rgba(0, 0, 0, .88);
+    border: 1px solid #5d6770;
 }
 
 .brutalist-button {
     background-color: #000;
-    color: #ff0000;
-    border: 2px solid #ff0000;
+    color: #ff3b3b;
+    border: 2px solid #ff3b3b;
     font-family: monospace, sans-serif;
     font-weight: bold;
-    font-size: 14px;
-    padding: 10px 15px;
+    font-size: 12px;
+    padding: 8px 11px;
     cursor: pointer;
     text-transform: uppercase;
     transition: all 0.1s ease;
-    box-shadow: 4px 4px 0px rgba(255, 0, 0, 0.3);
+    box-shadow: 3px 3px 0 rgba(255, 0, 0, 0.24);
 }
 
-.brutalist-button:hover {
-    background-color: #ff0000;
+.brutalist-button:hover,
+.brutalist-button.is-active {
+    background-color: #ff3b3b;
     color: #000;
-    box-shadow: 2px 2px 0px rgba(255, 0, 0, 0.5);
+    box-shadow: 1px 1px 0 rgba(255, 0, 0, 0.45);
     transform: translate(2px, 2px);
 }
 
 .brutalist-button:active {
-    box-shadow: 0px 0px 0px rgba(255, 0, 0, 0);
-    transform: translate(4px, 4px);
+    box-shadow: none;
+    transform: translate(3px, 3px);
+}
+
+.vtt-panel {
+    position: absolute;
+    top: 96px;
+    left: 20px;
+    z-index: 1100;
+    width: min(310px, calc(100vw - 40px));
+    padding: 14px;
+    background: rgba(5, 7, 9, .96);
+    border: 1px solid #c49a00;
+    box-shadow: 0 10px 28px rgba(0, 0, 0, .7);
+}
+
+.vtt-panel header,
+.vtt-context-menu header {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding-bottom: 10px;
+    margin-bottom: 10px;
+    border-bottom: 1px solid #46505a;
+}
+
+.vtt-panel header strong,
+.vtt-context-menu header strong {
+    color: #d7b151;
+    letter-spacing: .08em;
+}
+
+.vtt-panel header small,
+.vtt-context-menu header span {
+    color: #89949e;
+    font-size: 11px;
+}
+
+.vtt-panel label,
+.vtt-threshold-grid label {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    margin-bottom: 10px;
+}
+
+.vtt-panel label > span {
+    color: #9ba5ad;
+    font-size: 10px;
+    letter-spacing: .07em;
+}
+
+.vtt-panel input,
+.vtt-panel select {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 8px;
+    background: #11161a;
+    color: #fff;
+    border: 1px solid #53606d;
+}
+
+.vtt-threshold-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 2px;
+}
+
+.vtt-danger-button {
+    width: 100%;
+    padding: 9px;
+    background: #31070a;
+    color: #ff6673;
+    border: 1px solid #ff6673;
+    cursor: pointer;
+}
+
+.vtt-context-menu {
+    position: absolute;
+    z-index: 1600;
+    width: 250px;
+    padding: 12px;
+    background: rgba(4, 7, 9, .98);
+    border: 1px solid #c49a00;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, .8);
+}
+
+#vtt-context-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.vtt-context-action {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+
+.vtt-context-action button {
+    width: 100%;
+    padding: 9px 10px;
+    background: #141a1f;
+    color: #e7edf2;
+    border: 1px solid #68737d;
+    cursor: pointer;
+    text-align: left;
+}
+
+.vtt-context-action button:hover:not(:disabled) {
+    border-color: #d7b151;
+    color: #d7b151;
+}
+
+.vtt-context-action button:disabled {
+    opacity: .42;
+    cursor: not-allowed;
+}
+
+.vtt-context-action small,
+.vtt-context-note {
+    color: #8f9aa2;
+    font-size: 10px;
+}
+
+.vtt-context-note {
+    padding: 8px;
+    border: 1px dashed #68737d;
+}
+
+.vtt-notice {
+    position: absolute;
+    left: 50%;
+    bottom: 28px;
+    transform: translateX(-50%);
+    z-index: 1800;
+    max-width: min(560px, calc(100vw - 40px));
+    padding: 10px 15px;
+    background: rgba(4, 7, 9, .96);
+    border: 1px solid #68737d;
+    box-shadow: 0 8px 22px rgba(0, 0, 0, .7);
+    text-align: center;
+    font-size: 12px;
+}
+
+.vtt-notice[data-mode="success"] { border-color: #52b788; }
+.vtt-notice[data-mode="error"] { border-color: #ff6673; }
+.vtt-notice[data-mode="pending"] { border-color: #d7b151; }
+
+[hidden] {
+    display: none !important;
+}
+
+@media (max-width: 900px) {
+    #vtt-ui-container {
+        top: 10px;
+        right: 10px;
+    }
+    .vtt-panel {
+        top: auto;
+        bottom: 10px;
+        left: 10px;
+    }
+    .brutalist-button {
+        font-size: 10px;
+        padding: 6px 8px;
+    }
 }

--- a/database.rules.json
+++ b/database.rules.json
@@ -92,6 +92,21 @@
         }
       }
     },
+    "vtt_topology": {
+      ".read": "auth != null",
+      "$mapId": {
+        ".write": "auth != null && auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1'"
+      }
+    },
+    "vtt_topology_action_requests": {
+      "$mapId": {
+        ".read": "auth != null && auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1'",
+        "$requestId": {
+          ".read": "auth != null && (auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1' || data.child('requesterUid').val() === auth.uid)",
+          ".write": "auth != null && (auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1' || (!data.exists() && newData.child('requesterUid').val() === auth.uid && newData.child('mapId').val() === $mapId))"
+        }
+      }
+    },
     "theatre_opposed_checks": {
       ".read": "auth != null && auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1'",
       "$sessionId": {

--- a/js/vtt/check-portal.js
+++ b/js/vtt/check-portal.js
@@ -1,0 +1,139 @@
+(function (root, factory) {
+    const api = factory(root);
+    if (typeof module !== 'undefined' && module.exports) module.exports = api;
+    if (root) root.LuminousVttCheckPortal = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (browserRoot) {
+    'use strict';
+
+    const PORTAL_ID = 'vtt-check-portal';
+    const STYLE_ID = 'vtt-check-portal-style';
+    const MOVABLE_SELECTOR = [
+        '#theatre-check-command-prompt',
+        '#theatre-check-player-notice',
+        '.theatre-check-hud',
+        '.theatre-roll-result-card',
+        '.theatre-check-dm-toast',
+        '.dm-npc-roll-hud',
+    ].join(',');
+
+    function hostWindow(root = browserRoot) {
+        try {
+            if (root?.parent && root.parent !== root && root.parent.document) return root.parent;
+        } catch (_) {}
+        return root;
+    }
+
+    function hostDocument(root = browserRoot) {
+        return hostWindow(root)?.document || null;
+    }
+
+    function isDm(root = browserRoot) {
+        return Boolean(hostDocument(root)?.body?.classList?.contains('on-game-dashboard'));
+    }
+
+    function mapIsActive(root = browserRoot) {
+        const doc = hostDocument(root);
+        if (!doc) return false;
+        if (isDm(root)) return Boolean(doc.getElementById('modulo-mapa')?.classList?.contains('active-module'));
+        return Boolean(doc.body?.classList?.contains('player-instance-map'));
+    }
+
+    function theatreRoot(root = browserRoot) {
+        const doc = hostDocument(root);
+        if (!doc) return null;
+        if (isDm(root)) return doc.querySelector('#modulo-teatro .stage-view-wrapper') || doc.getElementById('modulo-teatro');
+        return doc.getElementById('theatre-view-player');
+    }
+
+    function ensurePortal(root = browserRoot) {
+        const doc = hostDocument(root);
+        if (!doc?.body) return null;
+        let style = doc.getElementById(STYLE_ID);
+        if (!style) {
+            style = doc.createElement('style');
+            style.id = STYLE_ID;
+            style.textContent = `
+#${PORTAL_ID} { position: fixed; inset: 0; z-index: 40000; pointer-events: none; display: none; }
+#${PORTAL_ID}.is-active { display: block; }
+#${PORTAL_ID} > * { pointer-events: auto; }
+#${PORTAL_ID} .theatre-check-command-prompt,
+#${PORTAL_ID} #theatre-check-command-prompt,
+#${PORTAL_ID} #theatre-check-player-notice { position: fixed !important; left: 50% !important; top: 50% !important; transform: translate(-50%, -50%) !important; z-index: 40010 !important; }
+#${PORTAL_ID} .theatre-check-hud,
+#${PORTAL_ID} .theatre-roll-result-card,
+#${PORTAL_ID} .dm-npc-roll-hud { z-index: 40020 !important; }
+`;
+            doc.head?.appendChild(style);
+        }
+        let portal = doc.getElementById(PORTAL_ID);
+        if (!portal) {
+            portal = doc.createElement('div');
+            portal.id = PORTAL_ID;
+            portal.setAttribute('aria-live', 'polite');
+            doc.body.appendChild(portal);
+        }
+        return portal;
+    }
+
+    function ensureTheatreFront(root = browserRoot) {
+        const doc = hostDocument(root);
+        const theatre = theatreRoot(root);
+        if (!doc || !theatre) return null;
+        let front = theatre.querySelector(':scope > #theatre-check-front-layer');
+        if (!front) {
+            front = doc.createElement('div');
+            front.id = 'theatre-check-front-layer';
+            front.className = 'theatre-check-front-layer';
+            front.setAttribute('aria-live', 'polite');
+            theatre.appendChild(front);
+        }
+        return front;
+    }
+
+    function moveEligibleIntoPortal(root = browserRoot) {
+        const doc = hostDocument(root);
+        const portal = ensurePortal(root);
+        if (!doc || !portal) return;
+        portal.classList.toggle('is-active', mapIsActive(root));
+        if (!mapIsActive(root)) return;
+
+        Array.from(doc.querySelectorAll(MOVABLE_SELECTOR)).forEach((node) => {
+            if (node === portal || portal.contains(node)) return;
+            portal.appendChild(node);
+        });
+    }
+
+    function restorePortal(root = browserRoot) {
+        const portal = ensurePortal(root);
+        if (!portal || mapIsActive(root)) return;
+        const front = ensureTheatreFront(root);
+        if (!front) return;
+        Array.from(portal.children).forEach((node) => front.appendChild(node));
+        portal.classList.remove('is-active');
+    }
+
+    function start(root = browserRoot) {
+        const doc = hostDocument(root);
+        if (!doc?.body || typeof MutationObserver === 'undefined') return null;
+        ensurePortal(root);
+        const sync = () => {
+            if (mapIsActive(root)) moveEligibleIntoPortal(root);
+            else restorePortal(root);
+        };
+        const observer = new MutationObserver(sync);
+        observer.observe(doc.body, { subtree: true, childList: true, attributes: true, attributeFilter: ['class', 'style', 'aria-hidden'] });
+        sync();
+        return Object.freeze({ stop: () => observer.disconnect(), sync });
+    }
+
+    return Object.freeze({
+        PORTAL_ID,
+        STYLE_ID,
+        MOVABLE_SELECTOR,
+        hostWindow,
+        hostDocument,
+        isDm,
+        mapIsActive,
+        start,
+    });
+});

--- a/js/vtt/engine.js
+++ b/js/vtt/engine.js
@@ -30,6 +30,10 @@ export class Engine {
         return globalThis.LuminousVttTokenInteraction || null;
     }
 
+    get topologyRules() {
+        return globalThis.LuminousVttTopology || null;
+    }
+
     init() {
         window.addEventListener('resize', this.handleResize);
         this.canvas.addEventListener('mousedown', this.handleTokenMouseDown);
@@ -160,13 +164,23 @@ export class Engine {
         requestAnimationFrame(this.loop);
     }
 
+    visionWallsForLayer(zLayer) {
+        const legacy = (this.mapData.walls || []).filter((wall) => wall.z.includes(zLayer) && wall.blocksVision);
+        const topology = this.topologyRules;
+        if (!topology || !Array.isArray(this.mapData.topology)) return legacy;
+        return [
+            ...legacy,
+            ...topology.blockingSegments(this.mapData.topology, 'vision', zLayer, this.mapData.grid),
+        ];
+    }
+
     calculateVision() {
         const player = this.mapData.tokens[0];
         if (!player) return null;
 
         const isLookingAway = this.activeZ !== player.z[0];
         const currentVisionRadius = isLookingAway ? (this.baseVisionRadius * 0.5) : this.baseVisionRadius;
-        const visionWalls = this.mapData.walls.filter(w => w.z.includes(this.activeZ) && w.blocksVision);
+        const visionWalls = this.visionWallsForLayer(this.activeZ);
 
         const points = [];
         for (const wall of visionWalls) {

--- a/js/vtt/main.js
+++ b/js/vtt/main.js
@@ -1,16 +1,33 @@
 import { Engine } from './engine.js';
+import { TopologyController } from './topology-controller.js';
 import { mockMapData } from './mapData.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     const canvas = document.getElementById('vtt-canvas');
     if (!canvas) {
-        console.error("VTT Canvas not found!");
+        console.error('VTT Canvas not found!');
         return;
     }
 
     const engine = new Engine(canvas, mockMapData);
+    let controller = null;
 
-    // Wire UI
+    const stateApi = globalThis.LuminousVttStateBridge;
+    if (!stateApi) {
+        console.error('VTT state bridge not found.');
+        return;
+    }
+
+    const bridge = stateApi.createBridge({
+        mapData: mockMapData,
+        onTopologyChanged: () => controller?.handleTopologyChanged(),
+        notify: (message, mode) => controller?.notify(message, mode),
+    });
+
+    controller = new TopologyController(canvas, engine, mockMapData, bridge);
+    bridge.start();
+    const checkPortal = globalThis.LuminousVttCheckPortal?.start?.() || null;
+
     const exportBtn = document.getElementById('btn-export-uv');
     if (exportBtn) {
         exportBtn.addEventListener('click', () => {
@@ -18,20 +35,33 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    // Start the game loop
     engine.start();
 
-    // Example: add keyboard listener to change Z-layer for testing
-    window.addEventListener('keydown', (e) => {
-        if (e.key === '0') {
+    window.LuminousVttRuntime = Object.freeze({
+        engine,
+        controller,
+        bridge,
+    });
+
+    window.addEventListener('keydown', (event) => {
+        if (event.key === '0') {
             engine.setZLayer(0);
-            console.log("Switched to Z-Layer 0");
-        } else if (e.key === '1') {
+            controller.handleTopologyChanged();
+        } else if (event.key === '1') {
             engine.setZLayer(1);
-            console.log("Switched to Z-Layer 1");
-        } else if (e.key === '2') {
+            controller.handleTopologyChanged();
+        } else if (event.key === '2') {
             engine.setZLayer(2);
-            console.log("Switched to Z-Layer 2");
+            controller.handleTopologyChanged();
+        } else if (event.key === 'Escape') {
+            controller.hideContextMenu();
+            controller.setTool('select');
         }
     });
+
+    window.addEventListener('beforeunload', () => {
+        bridge.stop();
+        checkPortal?.stop?.();
+        engine.stop();
+    }, { once: true });
 });

--- a/js/vtt/mapData.js
+++ b/js/vtt/mapData.js
@@ -1,4 +1,5 @@
 export const mockMapData = {
+    id: 'default',
     grid: {
         cols: 30,
         rows: 30,
@@ -16,8 +17,36 @@ export const mockMapData = {
         { x1: 70, y1: 2030, x2: 70, y2: 70, z: [0, 1], blocksMovement: true, blocksVision: true },
 
         { x1: 350, y1: 70, x2: 350, y2: 490, z: [0], blocksMovement: true, blocksVision: true },
-        { x1: 350, y1: 490, x2: 350, y2: 630, z: [0], blocksMovement: true, blocksVision: false },
         { x1: 700, y1: 70, x2: 700, y2: 980, z: [1], blocksMovement: true, blocksVision: true }
+    ],
+    topology: [
+        {
+            id: 'door_demo',
+            type: 'door',
+            from: { col: 4, row: 3 },
+            to: { col: 4, row: 4 },
+            z: [0],
+            state: 'locked',
+            thresholds: { lockpick: 15, break: 15 }
+        },
+        {
+            id: 'window_demo',
+            type: 'window',
+            from: { col: 4, row: 4 },
+            to: { col: 4, row: 5 },
+            z: [0],
+            state: 'locked',
+            thresholds: { lockpick: 12, break: 10 }
+        },
+        {
+            id: 'curtain_window_demo',
+            type: 'curtain_window',
+            from: { col: 4, row: 5 },
+            to: { col: 4, row: 6 },
+            z: [0],
+            state: 'closed',
+            thresholds: { lockpick: 12, break: 10 }
+        }
     ],
     tokens: [
         {

--- a/js/vtt/renderer.js
+++ b/js/vtt/renderer.js
@@ -61,6 +61,73 @@ export class Renderer {
         this.ctx.restore();
     }
 
+    topologyStyle(element, preview = false) {
+        if (preview) return { stroke: '#ffffff', width: 4, dash: [8, 5], label: '' };
+        const state = element.state;
+        const broken = state === 'broken';
+        const open = state === 'open';
+        const styles = {
+            wall: { stroke: '#ff3030', width: 4, label: 'WALL' },
+            door: { stroke: '#ffb000', width: 7, label: state === 'locked' ? 'D·LOCK' : 'DOOR' },
+            window: { stroke: '#00cfff', width: 6, label: state === 'locked' ? 'W·LOCK' : 'WINDOW' },
+            curtain_window: { stroke: '#b784ff', width: 7, label: state === 'locked' ? 'C·LOCK' : 'CURTAIN' },
+        };
+        const base = styles[element.type] || styles.wall;
+        return {
+            ...base,
+            dash: broken ? [5, 7] : open ? [12, 9] : [],
+        };
+    }
+
+    drawTopologyElement(element, isOnionSkin = false, preview = false) {
+        const topology = globalThis.LuminousVttTopology;
+        if (!topology) return;
+        const normalized = preview ? element : topology.normalizeElement(element);
+        const line = topology.segment(normalized, this.mapData.grid);
+        const style = this.topologyStyle(normalized, preview);
+        const ctx = this.ctx;
+
+        ctx.save();
+        ctx.globalAlpha = isOnionSkin ? 0.28 : preview ? 0.75 : 1;
+        ctx.strokeStyle = isOnionSkin ? '#6f6f6f' : style.stroke;
+        ctx.lineWidth = style.width;
+        ctx.lineCap = 'round';
+        ctx.setLineDash(style.dash || []);
+        ctx.beginPath();
+        ctx.moveTo(line.x1, line.y1);
+        ctx.lineTo(line.x2, line.y2);
+        ctx.stroke();
+        ctx.setLineDash([]);
+
+        if (!preview && normalized.type !== 'wall' && !isOnionSkin) {
+            const mx = (line.x1 + line.x2) / 2;
+            const my = (line.y1 + line.y2) / 2;
+            ctx.font = 'bold 10px monospace';
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'middle';
+            const label = normalized.state === 'broken' ? 'BROKEN' : style.label;
+            const metrics = ctx.measureText(label);
+            ctx.fillStyle = 'rgba(0,0,0,.82)';
+            ctx.fillRect(mx - (metrics.width / 2) - 5, my - 9, metrics.width + 10, 18);
+            ctx.fillStyle = style.stroke;
+            ctx.fillText(label, mx, my);
+        }
+        ctx.restore();
+    }
+
+    drawTopology(zLayer, isOnionSkin = false) {
+        const topology = globalThis.LuminousVttTopology;
+        if (!topology || !Array.isArray(this.mapData.topology)) return;
+        this.mapData.topology.forEach((element) => {
+            if (topology.elementOnLayer(element, zLayer)) this.drawTopologyElement(element, isOnionSkin, false);
+        });
+
+        const preview = this.mapData.topologyPreview;
+        if (!isOnionSkin && preview && topology.elementOnLayer(preview, zLayer)) {
+            this.drawTopologyElement(preview, false, true);
+        }
+    }
+
     drawPersonIcon(token, radius) {
         const ctx = this.ctx;
         const iconColor = token.iconColor || '#ffffff';
@@ -114,6 +181,7 @@ export class Renderer {
             camera.applyTransformSimple(this.ctx);
             this.drawGrid(true);
             this.drawWalls(activeZ, false);
+            this.drawTopology(activeZ, false);
             this.ctx.restore();
             return;
         }
@@ -152,9 +220,11 @@ export class Renderer {
 
         if (activeZ > 0) {
             this.drawWalls(activeZ - 1, true);
+            this.drawTopology(activeZ - 1, true);
         }
 
         this.drawWalls(activeZ, false);
+        this.drawTopology(activeZ, false);
         this.drawTokens(activeZ);
 
         if (isLookingAway) {

--- a/js/vtt/state-bridge.js
+++ b/js/vtt/state-bridge.js
@@ -134,6 +134,7 @@
         const mapId = safeString(mapData.id || mapData.mapId || 'default') || 'default';
         const dm = isDmSurface(root);
         const watchedChecks = new Map();
+        const issuingChecks = new Set();
         const subscriptions = [];
         let started = false;
 
@@ -344,40 +345,54 @@
 
         async function issueTopologyCheck(requestId, request) {
             if (!dm || !db || request.status !== 'pending' || !request.vttContext || request.vttContext.mapId !== mapId) return;
-            const element = elementById(request.vttContext.elementId);
-            const descriptor = topology.checkDescriptor(element, request.vttContext.method);
-            if (!descriptor || request.requesterUid == null) {
-                await db.ref(`${CHECK_REQUEST_ROOT}/${requestId}`).update({ status: 'denied', decidedAt: firebase.database.ServerValue.TIMESTAMP });
-                return;
+            if (issuingChecks.has(requestId)) return;
+            issuingChecks.add(requestId);
+            try {
+                const freshSnapshot = await db.ref(`${CHECK_REQUEST_ROOT}/${requestId}`).once('value');
+                const freshRequest = freshSnapshot.val() || {};
+                if (freshRequest.status !== 'pending' || freshRequest.commandId) return;
+
+                const element = elementById(freshRequest.vttContext?.elementId);
+                const descriptor = topology.checkDescriptor(element, freshRequest.vttContext?.method);
+                if (!descriptor || freshRequest.requesterUid == null) {
+                    await db.ref(`${CHECK_REQUEST_ROOT}/${requestId}`).update({
+                        status: 'denied',
+                        decidedAt: firebase.database.ServerValue.TIMESTAMP,
+                    });
+                    return;
+                }
+
+                const commandRef = db.ref(`${CHECK_COMMAND_ROOT}/${freshRequest.requesterUid}`).push();
+                const command = {
+                    schemaVersion: 1,
+                    targetUid: freshRequest.requesterUid,
+                    targetPlayerId: freshRequest.playerId || null,
+                    targetName: freshRequest.playerName || 'PLAYER',
+                    roomKey: freshRequest.roomKey || roomKey(root),
+                    requestedBy: 'player',
+                    requestId,
+                    rollSpec: descriptor.rollSpec,
+                    check: {
+                        thresholdRaw: descriptor.threshold,
+                        hiddenThreshold: true,
+                        modifierType: 'neutral',
+                        modifierValue: 0,
+                        tipText: '',
+                    },
+                    status: 'issued',
+                    issuedAt: firebase.database.ServerValue.TIMESTAMP,
+                    clientIssuedAt: Date.now(),
+                };
+                await commandRef.set(command);
+                await db.ref(`${CHECK_REQUEST_ROOT}/${requestId}`).update({
+                    status: 'approved',
+                    commandId: commandRef.key,
+                    decidedAt: firebase.database.ServerValue.TIMESTAMP,
+                });
+                await watchCheckResult(requestId, { ...freshRequest, status: 'approved', commandId: commandRef.key });
+            } finally {
+                issuingChecks.delete(requestId);
             }
-            const commandRef = db.ref(`${CHECK_COMMAND_ROOT}/${request.requesterUid}`).push();
-            const command = {
-                schemaVersion: 1,
-                targetUid: request.requesterUid,
-                targetPlayerId: request.playerId || null,
-                targetName: request.playerName || 'PLAYER',
-                roomKey: request.roomKey || roomKey(root),
-                requestedBy: 'player',
-                requestId,
-                rollSpec: descriptor.rollSpec,
-                check: {
-                    thresholdRaw: descriptor.threshold,
-                    hiddenThreshold: true,
-                    modifierType: 'neutral',
-                    modifierValue: 0,
-                    tipText: '',
-                },
-                status: 'issued',
-                issuedAt: firebase.database.ServerValue.TIMESTAMP,
-                clientIssuedAt: Date.now(),
-            };
-            await commandRef.set(command);
-            await db.ref(`${CHECK_REQUEST_ROOT}/${requestId}`).update({
-                status: 'approved',
-                commandId: commandRef.key,
-                decidedAt: firebase.database.ServerValue.TIMESTAMP,
-            });
-            await watchCheckResult(requestId, { ...request, status: 'approved', commandId: commandRef.key });
         }
 
         function processCheckRequests(snapshot) {
@@ -416,6 +431,7 @@
             subscriptions.splice(0).forEach((unsubscribe) => unsubscribe());
             watchedChecks.forEach(({ liveRef, handler }) => liveRef.off('value', handler));
             watchedChecks.clear();
+            issuingChecks.clear();
             started = false;
         }
 

--- a/js/vtt/state-bridge.js
+++ b/js/vtt/state-bridge.js
@@ -137,6 +137,7 @@
         const issuingChecks = new Set();
         const subscriptions = [];
         let started = false;
+        let seedAttempted = false;
 
         const emitNotice = (message, mode = 'info') => {
             if (typeof notify === 'function') notify(message, mode);
@@ -153,8 +154,11 @@
         const actionRootRef = () => db?.ref(`${ACTION_REQUEST_ROOT}/${mapId}`);
 
         async function seedIfNeeded(snapshot) {
+            if (seedAttempted) return;
+            seedAttempted = true;
             if (!dm || snapshot.exists() || !Array.isArray(mapData.topology) || !mapData.topology.length) return;
-            await topologyRef().set(recordFromElements(mapData.topology, topology));
+            const initialRecord = recordFromElements(mapData.topology, topology);
+            await topologyRef().set(initialRecord);
         }
 
         function subscribe(ref, event, handler) {
@@ -415,7 +419,7 @@
 
             subscribe(topologyRef(), 'value', (snapshot) => {
                 seedIfNeeded(snapshot).catch((error) => console.error('VTT topology seed failed:', error));
-                if (snapshot.exists()) replaceTopology(elementsFromRecord(snapshot.val(), topology));
+                replaceTopology(elementsFromRecord(snapshot.val(), topology));
             });
 
             if (dm) {

--- a/js/vtt/state-bridge.js
+++ b/js/vtt/state-bridge.js
@@ -1,0 +1,454 @@
+(function (root, factory) {
+    const api = factory(root);
+    if (typeof module !== 'undefined' && module.exports) module.exports = api;
+    if (root) root.LuminousVttStateBridge = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (browserRoot) {
+    'use strict';
+
+    const DM_UID = 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1';
+    const TOPOLOGY_ROOT = 'vtt_topology';
+    const ACTION_REQUEST_ROOT = 'vtt_topology_action_requests';
+    const CHECK_REQUEST_ROOT = 'theatre_check_requests';
+    const CHECK_COMMAND_ROOT = 'theatre_check_commands';
+    const CHECK_LIVE_ROOT = 'theatre_check_live';
+    const ITEM_ALIASES = Object.freeze({
+        lockpick: Object.freeze(['lockpick', 'lockpicks', 'ganzua', 'ganzúa', 'ganzuas', 'ganzúas']),
+    });
+
+    const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+    const safeString = (value) => String(value ?? '').trim();
+    const normalizeText = (value) => safeString(value).normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+
+    function hostWindow(root = browserRoot) {
+        if (!root) return null;
+        try {
+            if (root.parent && root.parent !== root && root.parent.document) return root.parent;
+        } catch (_) {}
+        return root;
+    }
+
+    function hostFirebase(root = browserRoot) {
+        const host = hostWindow(root);
+        return host?.firebase || root?.firebase || null;
+    }
+
+    function hostDocument(root = browserRoot) {
+        return hostWindow(root)?.document || root?.document || null;
+    }
+
+    function currentUid(root = browserRoot) {
+        try {
+            return hostFirebase(root)?.auth?.().currentUser?.uid || null;
+        } catch (_) {
+            return null;
+        }
+    }
+
+    function isDmSurface(root = browserRoot) {
+        const doc = hostDocument(root);
+        return currentUid(root) === DM_UID || Boolean(doc?.body?.classList?.contains('on-game-dashboard'));
+    }
+
+    function roomKey(root = browserRoot) {
+        const doc = hostDocument(root);
+        return safeString(doc?.body?.dataset?.theatreRoomId || 'default').replace(/[.#$\[\]\/]/g, '_') || 'default';
+    }
+
+    function playerIdentity(root = browserRoot) {
+        const host = hostWindow(root);
+        const data = host?.datosJugador || {};
+        return {
+            uid: currentUid(root),
+            playerId: host?.localStorage?.getItem?.('playerId') || data.playerId || data.id || '',
+            actorId: data.actorId || data.vinculo_jugador || null,
+            name: safeString(data.characterName || data.character_name || data.nombre || data.name || 'PLAYER') || 'PLAYER',
+        };
+    }
+
+    function itemQuantity(value) {
+        if (!value || typeof value !== 'object') return 1;
+        const candidates = [value.quantity, value.cantidad, value.count, value.qty, value.amount];
+        const numeric = candidates.find((entry) => Number.isFinite(Number(entry)));
+        return numeric === undefined ? 1 : Number(numeric);
+    }
+
+    function nodeMatchesAliases(node, aliases, depth = 0) {
+        if (depth > 5 || node == null) return false;
+        if (typeof node === 'string') return aliases.includes(normalizeText(node));
+        if (Array.isArray(node)) return node.some((entry) => nodeMatchesAliases(entry, aliases, depth + 1));
+        if (typeof node !== 'object') return false;
+        if (itemQuantity(node) <= 0) return false;
+
+        const direct = [node.id, node.itemId, node.item_id, node.name, node.nombre, node.tag, node.slug]
+            .map(normalizeText)
+            .filter(Boolean);
+        if (direct.some((value) => aliases.includes(value))) return true;
+
+        return Object.entries(node).some(([key, value]) => {
+            if (aliases.includes(normalizeText(key)) && (value === true || numberOr(value, 0) > 0 || typeof value === 'object')) return true;
+            return nodeMatchesAliases(value, aliases, depth + 1);
+        });
+    }
+
+    function inventoryHasItem(player = {}, itemId) {
+        const aliases = (ITEM_ALIASES[itemId] || [itemId]).map(normalizeText);
+        const roots = [
+            player.inventory,
+            player.inventario,
+            player.items,
+            player.itemSlots,
+            player.item_slots,
+            player.equipment,
+            player.equipamiento,
+            player.stash,
+            player.mochila,
+        ].filter((value) => value != null);
+        return roots.some((collection) => nodeMatchesAliases(collection, aliases));
+    }
+
+    function recordFromElements(elements, topology) {
+        const record = {};
+        (Array.isArray(elements) ? elements : []).forEach((element) => {
+            const normalized = topology.normalizeElement(element);
+            if (!normalized.id) return;
+            record[normalized.id] = JSON.parse(JSON.stringify(normalized));
+        });
+        return record;
+    }
+
+    function elementsFromRecord(record, topology) {
+        return Object.values(record || {})
+            .filter(Boolean)
+            .map((element) => topology.normalizeElement(element))
+            .sort((a, b) => String(a.id).localeCompare(String(b.id)));
+    }
+
+    function createBridge({ mapData, onTopologyChanged, notify, root = browserRoot } = {}) {
+        if (!mapData) throw new Error('MAP_DATA_REQUIRED');
+        const topology = root?.LuminousVttTopology || (typeof require !== 'undefined' ? require('./topology.js') : null);
+        if (!topology) throw new Error('TOPOLOGY_RUNTIME_REQUIRED');
+
+        const host = hostWindow(root);
+        const firebase = hostFirebase(root);
+        const db = firebase?.database?.() || null;
+        const mapId = safeString(mapData.id || mapData.mapId || 'default') || 'default';
+        const dm = isDmSurface(root);
+        const watchedChecks = new Map();
+        const subscriptions = [];
+        let started = false;
+
+        const emitNotice = (message, mode = 'info') => {
+            if (typeof notify === 'function') notify(message, mode);
+        };
+
+        const replaceTopology = (elements) => {
+            mapData.topology = elements;
+            if (typeof onTopologyChanged === 'function') onTopologyChanged(elements);
+        };
+
+        const elementById = (id) => (mapData.topology || []).find((element) => String(element.id) === String(id)) || null;
+
+        const topologyRef = () => db?.ref(`${TOPOLOGY_ROOT}/${mapId}/elements`);
+        const actionRootRef = () => db?.ref(`${ACTION_REQUEST_ROOT}/${mapId}`);
+
+        async function seedIfNeeded(snapshot) {
+            if (!dm || snapshot.exists() || !Array.isArray(mapData.topology) || !mapData.topology.length) return;
+            await topologyRef().set(recordFromElements(mapData.topology, topology));
+        }
+
+        function subscribe(ref, event, handler) {
+            if (!ref?.on) return;
+            ref.on(event, handler);
+            subscriptions.push(() => ref.off(event, handler));
+        }
+
+        async function saveElement(element) {
+            const normalized = topology.normalizeElement(element);
+            if (!normalized.id) throw new Error('ELEMENT_ID_REQUIRED');
+            if (!db) {
+                const list = Array.isArray(mapData.topology) ? [...mapData.topology] : [];
+                const index = list.findIndex((entry) => String(entry.id) === normalized.id);
+                if (index >= 0) list[index] = normalized;
+                else list.push(normalized);
+                replaceTopology(list);
+                return normalized;
+            }
+            if (!dm) throw new Error('DM_REQUIRED');
+            await topologyRef().child(normalized.id).set(JSON.parse(JSON.stringify(normalized)));
+            return normalized;
+        }
+
+        async function deleteElement(elementId) {
+            if (!db) {
+                replaceTopology((mapData.topology || []).filter((entry) => String(entry.id) !== String(elementId)));
+                return true;
+            }
+            if (!dm) throw new Error('DM_REQUIRED');
+            await topologyRef().child(String(elementId)).remove();
+            return true;
+        }
+
+        async function applyCanonicalAction(elementId, action) {
+            const current = elementById(elementId);
+            if (!current) return { valid: false, reason: 'ELEMENT_NOT_FOUND' };
+            const result = topology.applyAction(current, action);
+            if (!result.valid) return result;
+            await saveElement(result.element);
+            return result;
+        }
+
+        async function processDirectActionRequest(snapshot) {
+            if (!dm) return;
+            const request = snapshot.val() || {};
+            if (request.status !== 'pending' || String(request.mapId || '') !== mapId) return;
+            let result;
+            if (!['open', 'close'].includes(request.action)) {
+                result = { valid: false, reason: 'ACTION_NOT_ALLOWED' };
+            } else {
+                result = await applyCanonicalAction(request.elementId, request.action);
+            }
+            await snapshot.ref.update({
+                status: result.valid ? 'applied' : 'denied',
+                reason: result.reason || null,
+                decidedAt: firebase.database.ServerValue.TIMESTAMP,
+            });
+        }
+
+        async function requestDirectAction(elementId, action) {
+            if (!db) return applyCanonicalAction(elementId, action);
+            if (dm) return applyCanonicalAction(elementId, action);
+            const identity = playerIdentity(root);
+            if (!identity.uid) throw new Error('AUTH_NOT_READY');
+            const requestRef = actionRootRef().push();
+            await requestRef.set({
+                schemaVersion: 1,
+                requesterUid: identity.uid,
+                playerId: identity.playerId || null,
+                actorId: identity.actorId || null,
+                mapId,
+                elementId: String(elementId),
+                action,
+                status: 'pending',
+                clientCreatedAt: Date.now(),
+                createdAt: firebase.database.ServerValue.TIMESTAMP,
+            });
+            emitNotice(action === 'open' ? 'Solicitud para abrir enviada.' : 'Solicitud para cerrar enviada.', 'pending');
+            const handler = (snapshot) => {
+                const value = snapshot.val() || {};
+                if (value.status === 'applied') {
+                    emitNotice(action === 'open' ? 'Abierto.' : 'Cerrado.', 'success');
+                    requestRef.off('value', handler);
+                } else if (value.status === 'denied') {
+                    emitNotice('La interacción fue rechazada.', 'error');
+                    requestRef.off('value', handler);
+                }
+            };
+            requestRef.on('value', handler);
+            return { valid: true, pending: true, requestId: requestRef.key };
+        }
+
+        async function playerData() {
+            const identity = playerIdentity(root);
+            const local = host?.datosJugador || {};
+            if (inventoryHasItem(local, 'lockpick')) return local;
+            if (!db || !identity.playerId) return local;
+            try {
+                const snapshot = await db.ref(`campaña/jugadores/${identity.playerId}`).once('value');
+                return snapshot.val() || local;
+            } catch (_) {
+                return local;
+            }
+        }
+
+        async function hasItem(itemId) {
+            const data = await playerData();
+            return inventoryHasItem(data, itemId);
+        }
+
+        async function requestTopologyCheck(elementId, method) {
+            const element = elementById(elementId);
+            if (!element) throw new Error('ELEMENT_NOT_FOUND');
+            const descriptor = topology.checkDescriptor(element, method);
+            if (!descriptor) throw new Error('CHECK_NOT_AVAILABLE');
+            if (descriptor.requiredItem && !(await hasItem(descriptor.requiredItem))) {
+                emitNotice('Necesitas una Ganzúa para intentar Juego de Manos.', 'error');
+                return { valid: false, reason: 'REQUIRED_ITEM_MISSING' };
+            }
+            if (!db) {
+                emitNotice('El Check requiere una sesión conectada.', 'error');
+                return { valid: false, reason: 'FIREBASE_UNAVAILABLE' };
+            }
+            const identity = playerIdentity(root);
+            if (!identity.uid) throw new Error('AUTH_NOT_READY');
+            const requestRef = db.ref(CHECK_REQUEST_ROOT).push();
+            await requestRef.set({
+                schemaVersion: 1,
+                requesterUid: identity.uid,
+                playerId: identity.playerId || null,
+                actorId: identity.actorId || null,
+                playerName: identity.name,
+                roomKey: roomKey(root),
+                status: 'pending',
+                rollSpec: descriptor.rollSpec,
+                suggestedCheck: {
+                    thresholdRaw: descriptor.threshold,
+                    hiddenThreshold: true,
+                    modifierType: 'neutral',
+                    modifierValue: 0,
+                    tipText: '',
+                },
+                vttContext: {
+                    mapId,
+                    elementId: String(elementId),
+                    method: descriptor.method,
+                    action: descriptor.action,
+                },
+                createdAt: firebase.database.ServerValue.TIMESTAMP,
+                clientCreatedAt: Date.now(),
+            });
+            emitNotice(`${descriptor.rollSpec.label}: solicitud enviada.`, 'pending');
+            const handler = (snapshot) => {
+                const value = snapshot.val() || {};
+                if (value.status === 'approved') emitNotice('Check aprobado. Realiza la tirada.', 'success');
+                else if (value.status === 'denied') emitNotice('El Check fue rechazado.', 'error');
+                if (value.status === 'approved' || value.status === 'denied') requestRef.off('value', handler);
+            };
+            requestRef.on('value', handler);
+            return { valid: true, pending: true, requestId: requestRef.key, descriptor };
+        }
+
+        async function watchCheckResult(requestId, request) {
+            if (!dm || !db || !request?.commandId || watchedChecks.has(requestId)) return;
+            const uid = request.requesterUid;
+            const liveRef = db.ref(`${CHECK_LIVE_ROOT}/${uid}/${request.commandId}`);
+            const handler = async (snapshot) => {
+                const live = snapshot.val() || {};
+                if (live.status !== 'complete') return;
+                liveRef.off('value', handler);
+                watchedChecks.delete(requestId);
+                const passed = live.outcome === 'passed';
+                let applied = false;
+                if (passed) {
+                    const result = await applyCanonicalAction(request.vttContext.elementId, request.vttContext.action);
+                    applied = Boolean(result.valid);
+                }
+                await db.ref(`${CHECK_REQUEST_ROOT}/${requestId}`).update({
+                    vttResolved: passed ? 'passed' : 'failed',
+                    vttApplied: applied,
+                    vttResolvedAt: firebase.database.ServerValue.TIMESTAMP,
+                });
+            };
+            watchedChecks.set(requestId, { liveRef, handler });
+            liveRef.on('value', handler);
+        }
+
+        async function issueTopologyCheck(requestId, request) {
+            if (!dm || !db || request.status !== 'pending' || !request.vttContext || request.vttContext.mapId !== mapId) return;
+            const element = elementById(request.vttContext.elementId);
+            const descriptor = topology.checkDescriptor(element, request.vttContext.method);
+            if (!descriptor || request.requesterUid == null) {
+                await db.ref(`${CHECK_REQUEST_ROOT}/${requestId}`).update({ status: 'denied', decidedAt: firebase.database.ServerValue.TIMESTAMP });
+                return;
+            }
+            const commandRef = db.ref(`${CHECK_COMMAND_ROOT}/${request.requesterUid}`).push();
+            const command = {
+                schemaVersion: 1,
+                targetUid: request.requesterUid,
+                targetPlayerId: request.playerId || null,
+                targetName: request.playerName || 'PLAYER',
+                roomKey: request.roomKey || roomKey(root),
+                requestedBy: 'player',
+                requestId,
+                rollSpec: descriptor.rollSpec,
+                check: {
+                    thresholdRaw: descriptor.threshold,
+                    hiddenThreshold: true,
+                    modifierType: 'neutral',
+                    modifierValue: 0,
+                    tipText: '',
+                },
+                status: 'issued',
+                issuedAt: firebase.database.ServerValue.TIMESTAMP,
+                clientIssuedAt: Date.now(),
+            };
+            await commandRef.set(command);
+            await db.ref(`${CHECK_REQUEST_ROOT}/${requestId}`).update({
+                status: 'approved',
+                commandId: commandRef.key,
+                decidedAt: firebase.database.ServerValue.TIMESTAMP,
+            });
+            await watchCheckResult(requestId, { ...request, status: 'approved', commandId: commandRef.key });
+        }
+
+        function processCheckRequests(snapshot) {
+            if (!dm || !db) return;
+            const all = snapshot.val() || {};
+            Object.entries(all).forEach(([requestId, request]) => {
+                if (!request?.vttContext || request.vttContext.mapId !== mapId) return;
+                if (request.status === 'pending') {
+                    issueTopologyCheck(requestId, request).catch((error) => console.error('VTT check issue failed:', error));
+                } else if (request.status === 'approved' && request.commandId && !request.vttResolved) {
+                    watchCheckResult(requestId, request).catch((error) => console.error('VTT live watch failed:', error));
+                }
+            });
+        }
+
+        function start() {
+            if (started) return true;
+            started = true;
+            if (!db) return false;
+
+            subscribe(topologyRef(), 'value', (snapshot) => {
+                seedIfNeeded(snapshot).catch((error) => console.error('VTT topology seed failed:', error));
+                if (snapshot.exists()) replaceTopology(elementsFromRecord(snapshot.val(), topology));
+            });
+
+            if (dm) {
+                subscribe(actionRootRef(), 'child_added', (snapshot) => {
+                    processDirectActionRequest(snapshot).catch((error) => console.error('VTT action request failed:', error));
+                });
+                subscribe(db.ref(CHECK_REQUEST_ROOT), 'value', processCheckRequests);
+            }
+            return true;
+        }
+
+        function stop() {
+            subscriptions.splice(0).forEach((unsubscribe) => unsubscribe());
+            watchedChecks.forEach(({ liveRef, handler }) => liveRef.off('value', handler));
+            watchedChecks.clear();
+            started = false;
+        }
+
+        return Object.freeze({
+            mapId,
+            isDm: dm,
+            start,
+            stop,
+            saveElement,
+            deleteElement,
+            requestDirectAction,
+            requestTopologyCheck,
+            hasItem,
+            applyCanonicalAction,
+        });
+    }
+
+    return Object.freeze({
+        DM_UID,
+        TOPOLOGY_ROOT,
+        ACTION_REQUEST_ROOT,
+        CHECK_REQUEST_ROOT,
+        CHECK_COMMAND_ROOT,
+        CHECK_LIVE_ROOT,
+        ITEM_ALIASES,
+        hostWindow,
+        currentUid,
+        isDmSurface,
+        roomKey,
+        playerIdentity,
+        inventoryHasItem,
+        recordFromElements,
+        elementsFromRecord,
+        createBridge,
+    });
+});

--- a/js/vtt/token-interaction.js
+++ b/js/vtt/token-interaction.js
@@ -1,11 +1,19 @@
 (function (root, factory) {
-    const api = factory();
+    const api = factory(root);
     if (typeof module !== 'undefined' && module.exports) module.exports = api;
     if (root) root.LuminousVttTokenInteraction = api;
-})(typeof window !== 'undefined' ? window : globalThis, function () {
+})(typeof window !== 'undefined' ? window : globalThis, function (root) {
     'use strict';
 
     const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+    function topologyRuntime() {
+        if (root?.LuminousVttTopology) return root.LuminousVttTopology;
+        if (typeof require !== 'undefined') {
+            try { return require('./topology.js'); } catch (_) {}
+        }
+        return null;
+    }
 
     function tokenRadius(token = {}, grid = {}) {
         const size = Math.max(1, numberOr(grid.size, 70));
@@ -80,11 +88,19 @@
 
     function movementWalls(mapData = {}, token = {}) {
         const layers = tokenLayers(token);
-        return (Array.isArray(mapData.walls) ? mapData.walls : []).filter((wall) => {
+        const legacy = (Array.isArray(mapData.walls) ? mapData.walls : []).filter((wall) => {
             if (!wall || !wall.blocksMovement) return false;
             const wallLayers = Array.isArray(wall.z) ? wall.z : [numberOr(wall.z, 0)];
             return wallLayers.some((layer) => layers.includes(Number(layer)));
         });
+
+        const topology = topologyRuntime();
+        if (!topology || !Array.isArray(mapData.topology)) return legacy;
+        const dynamic = [];
+        layers.forEach((layer) => {
+            dynamic.push(...topology.blockingSegments(mapData.topology, 'movement', layer, mapData.grid));
+        });
+        return [...legacy, ...dynamic];
     }
 
     function canOccupy(token, point, mapData = {}) {
@@ -162,6 +178,8 @@
         findDraggableToken,
         gridBounds,
         snapPointToGrid,
+        pointToSegmentDistance,
+        movementWalls,
         canOccupy,
         isPathClear,
         resolveDrop,

--- a/js/vtt/topology-controller.js
+++ b/js/vtt/topology-controller.js
@@ -136,7 +136,8 @@ export class TopologyController {
 
     handleMouseMove(event) {
         if (!this.isDm || !this.drawStart || !['wall', 'door', 'window', 'curtain_window'].includes(this.tool)) return;
-        const to = this.topology.snapPointToVertex(this.worldPoint(event), this.mapData.grid);
+        const candidate = this.topology.snapPointToVertex(this.worldPoint(event), this.mapData.grid);
+        const to = this.topology.axisAlignedVertex(this.drawStart, candidate);
         this.mapData.topologyPreview = {
             type: this.tool,
             from: this.drawStart,
@@ -150,7 +151,8 @@ export class TopologyController {
     handleMouseUp(event) {
         if (event.button !== 0 || !this.isDm || !this.drawStart) return;
         const from = this.drawStart;
-        const to = this.topology.snapPointToVertex(this.worldPoint(event), this.mapData.grid);
+        const candidate = this.topology.snapPointToVertex(this.worldPoint(event), this.mapData.grid);
+        const to = this.topology.axisAlignedVertex(from, candidate);
         this.drawStart = null;
         this.mapData.topologyPreview = null;
         event.preventDefault();
@@ -181,9 +183,11 @@ export class TopologyController {
     }
 
     currentPlayerToken() {
-        return (this.mapData.tokens || []).find((token) => token.draggable !== false && (token.z || [0]).includes(this.engine.activeZ))
-            || this.mapData.tokens?.[0]
-            || null;
+        return (this.mapData.tokens || []).find((token) => {
+            if (!token || token.draggable === false) return false;
+            const layers = Array.isArray(token.z) ? token.z.map(Number) : [Number(token.z) || 0];
+            return layers.includes(Number(this.engine.activeZ));
+        }) || this.mapData.tokens?.[0] || null;
     }
 
     canReach(element) {

--- a/js/vtt/topology-controller.js
+++ b/js/vtt/topology-controller.js
@@ -1,0 +1,345 @@
+export class TopologyController {
+    constructor(canvas, engine, mapData, stateBridge) {
+        this.canvas = canvas;
+        this.engine = engine;
+        this.mapData = mapData;
+        this.stateBridge = stateBridge;
+        this.topology = globalThis.LuminousVttTopology;
+        this.isDm = Boolean(stateBridge?.isDm);
+        this.tool = 'select';
+        this.drawStart = null;
+        this.selectedId = null;
+
+        this.handleMouseDown = this.handleMouseDown.bind(this);
+        this.handleMouseMove = this.handleMouseMove.bind(this);
+        this.handleMouseUp = this.handleMouseUp.bind(this);
+        this.handleDocumentClick = this.handleDocumentClick.bind(this);
+
+        this.bindCanvas();
+        this.bindUi();
+        this.renderMode();
+    }
+
+    bindCanvas() {
+        this.canvas.addEventListener('mousedown', this.handleMouseDown, true);
+        window.addEventListener('mousemove', this.handleMouseMove, true);
+        window.addEventListener('mouseup', this.handleMouseUp, true);
+        document.addEventListener('click', this.handleDocumentClick);
+    }
+
+    bindUi() {
+        document.querySelectorAll('[data-vtt-tool]').forEach((button) => {
+            button.addEventListener('click', () => this.setTool(button.dataset.vttTool));
+        });
+
+        document.getElementById('vtt-topology-state')?.addEventListener('change', (event) => {
+            this.updateSelected({ state: event.target.value });
+        });
+        document.getElementById('vtt-topology-lockpick')?.addEventListener('change', (event) => {
+            this.updateSelectedThreshold('lockpick', event.target.value);
+        });
+        document.getElementById('vtt-topology-break')?.addEventListener('change', (event) => {
+            this.updateSelectedThreshold('break', event.target.value);
+        });
+        document.getElementById('vtt-topology-delete')?.addEventListener('click', () => {
+            if (!this.selectedId) return;
+            this.stateBridge.deleteElement(this.selectedId)
+                .then(() => {
+                    this.selectedId = null;
+                    this.renderEditor();
+                    this.notify('Elemento eliminado.', 'success');
+                })
+                .catch((error) => this.notify(String(error.message || error), 'error'));
+        });
+    }
+
+    renderMode() {
+        const toolbar = document.getElementById('vtt-topology-toolbar');
+        const exportButton = document.getElementById('btn-export-uv');
+        if (toolbar) toolbar.hidden = !this.isDm;
+        if (exportButton) exportButton.hidden = !this.isDm;
+        document.body.classList.toggle('vtt-dm-mode', this.isDm);
+        document.body.classList.toggle('vtt-player-mode', !this.isDm);
+        this.renderToolButtons();
+        this.renderEditor();
+    }
+
+    setTool(tool) {
+        const valid = ['select', 'wall', 'door', 'window', 'curtain_window', 'erase'];
+        this.tool = valid.includes(tool) ? tool : 'select';
+        this.drawStart = null;
+        this.mapData.topologyPreview = null;
+        this.hideContextMenu();
+        this.renderToolButtons();
+    }
+
+    renderToolButtons() {
+        document.querySelectorAll('[data-vtt-tool]').forEach((button) => {
+            button.classList.toggle('is-active', button.dataset.vttTool === this.tool);
+        });
+    }
+
+    worldPoint(event) {
+        return this.engine.eventWorldPoint(event);
+    }
+
+    topologyAtEvent(event) {
+        if (!this.topology) return null;
+        return this.topology.hitTest(
+            this.mapData.topology,
+            this.worldPoint(event),
+            this.mapData.grid,
+            this.engine.activeZ,
+        );
+    }
+
+    handleMouseDown(event) {
+        if (event.button !== 0) return;
+        if (this.engine.tokenAtEvent(event)) return;
+
+        const hit = this.topologyAtEvent(event);
+        if (!this.isDm) {
+            if (!hit || hit.type === 'wall') return;
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            this.openPlayerMenu(hit, event.clientX, event.clientY);
+            return;
+        }
+
+        if (this.tool === 'select') {
+            if (!hit) return;
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            this.selectedId = hit.id;
+            this.renderEditor();
+            return;
+        }
+
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        if (this.tool === 'erase') {
+            if (!hit) return;
+            this.stateBridge.deleteElement(hit.id)
+                .then(() => this.notify('Elemento eliminado.', 'success'))
+                .catch((error) => this.notify(String(error.message || error), 'error'));
+            return;
+        }
+
+        this.drawStart = this.topology.snapPointToVertex(this.worldPoint(event), this.mapData.grid);
+        this.mapData.topologyPreview = {
+            type: this.tool,
+            from: this.drawStart,
+            to: this.drawStart,
+            z: [this.engine.activeZ],
+        };
+    }
+
+    handleMouseMove(event) {
+        if (!this.isDm || !this.drawStart || !['wall', 'door', 'window', 'curtain_window'].includes(this.tool)) return;
+        const to = this.topology.snapPointToVertex(this.worldPoint(event), this.mapData.grid);
+        this.mapData.topologyPreview = {
+            type: this.tool,
+            from: this.drawStart,
+            to,
+            z: [this.engine.activeZ],
+        };
+        event.preventDefault();
+        event.stopImmediatePropagation();
+    }
+
+    handleMouseUp(event) {
+        if (event.button !== 0 || !this.isDm || !this.drawStart) return;
+        const from = this.drawStart;
+        const to = this.topology.snapPointToVertex(this.worldPoint(event), this.mapData.grid);
+        this.drawStart = null;
+        this.mapData.topologyPreview = null;
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        if (this.topology.sameVertex(from, to)) return;
+
+        const element = this.topology.createElement({
+            type: this.tool,
+            from,
+            to,
+            zLayer: this.engine.activeZ,
+        });
+        this.stateBridge.saveElement(element)
+            .then((saved) => {
+                this.selectedId = saved.id;
+                this.renderEditor();
+                this.notify('Topología guardada.', 'success');
+            })
+            .catch((error) => this.notify(String(error.message || error), 'error'));
+    }
+
+    handleDocumentClick(event) {
+        const menu = document.getElementById('vtt-context-menu');
+        if (!menu || menu.hidden) return;
+        if (menu.contains(event.target)) return;
+        if (event.target === this.canvas) return;
+        this.hideContextMenu();
+    }
+
+    currentPlayerToken() {
+        return (this.mapData.tokens || []).find((token) => token.draggable !== false && (token.z || [0]).includes(this.engine.activeZ))
+            || this.mapData.tokens?.[0]
+            || null;
+    }
+
+    canReach(element) {
+        const token = this.currentPlayerToken();
+        if (!token) return false;
+        const line = this.topology.segment(element, this.mapData.grid);
+        const distance = this.topology.pointToSegmentDistance(
+            { x: token.x, y: token.y },
+            { x: line.x1, y: line.y1 },
+            { x: line.x2, y: line.y2 },
+        );
+        return distance <= (this.mapData.grid.size * 0.8);
+    }
+
+    async openPlayerMenu(rawElement, clientX, clientY) {
+        const element = this.topology.normalizeElement(rawElement);
+        if (!this.canReach(element)) {
+            this.notify('Acércate a la puerta o ventana para interactuar.', 'error');
+            return;
+        }
+
+        const menu = document.getElementById('vtt-context-menu');
+        const title = document.getElementById('vtt-context-title');
+        const state = document.getElementById('vtt-context-state');
+        const actions = document.getElementById('vtt-context-actions');
+        if (!menu || !title || !state || !actions) return;
+
+        const typeLabels = {
+            door: 'PUERTA',
+            window: 'VENTANA',
+            curtain_window: 'VENTANA CON CORTINA',
+        };
+        title.textContent = typeLabels[element.type] || 'OBJETO';
+        state.textContent = element.state === 'locked' ? 'CERRADA' : String(element.state || '').toUpperCase();
+        actions.replaceChildren();
+
+        const addButton = (label, handler, disabled = false, hint = '') => {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'vtt-context-action';
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.textContent = label;
+            button.disabled = disabled;
+            button.addEventListener('click', async () => {
+                this.hideContextMenu();
+                try {
+                    await handler();
+                } catch (error) {
+                    this.notify(String(error.message || error), 'error');
+                }
+            });
+            wrapper.appendChild(button);
+            if (hint) {
+                const small = document.createElement('small');
+                small.textContent = hint;
+                wrapper.appendChild(small);
+            }
+            actions.appendChild(wrapper);
+        };
+
+        const direct = this.topology.directActions(element);
+        if (direct.includes('open')) addButton('ABRIR', () => this.stateBridge.requestDirectAction(element.id, 'open'));
+        if (direct.includes('close')) addButton('CERRAR', () => this.stateBridge.requestDirectAction(element.id, 'close'));
+
+        if (element.state === 'locked') {
+            const hasLockpick = await this.stateBridge.hasItem('lockpick');
+            addButton(
+                'JUEGO DE MANOS',
+                () => this.stateBridge.requestTopologyCheck(element.id, 'lockpick'),
+                !hasLockpick,
+                hasLockpick ? 'Requiere Ganzúa' : 'No tienes Ganzúa',
+            );
+            addButton('ROMPER · STRENGTH', () => this.stateBridge.requestTopologyCheck(element.id, 'strength'));
+            addButton('ROMPER · ATHLETICS', () => this.stateBridge.requestTopologyCheck(element.id, 'athletics'));
+        }
+
+        if (element.state === 'broken') {
+            const note = document.createElement('div');
+            note.className = 'vtt-context-note';
+            note.textContent = 'ESTÁ ROTA · PASO LIBRE';
+            actions.appendChild(note);
+        }
+
+        menu.style.left = `${Math.min(window.innerWidth - 280, Math.max(12, clientX + 12))}px`;
+        menu.style.top = `${Math.min(window.innerHeight - 260, Math.max(12, clientY + 12))}px`;
+        menu.hidden = false;
+    }
+
+    hideContextMenu() {
+        const menu = document.getElementById('vtt-context-menu');
+        if (menu) menu.hidden = true;
+    }
+
+    selectedElement() {
+        return (this.mapData.topology || []).find((element) => String(element.id) === String(this.selectedId)) || null;
+    }
+
+    renderEditor() {
+        const editor = document.getElementById('vtt-topology-editor');
+        if (!editor) return;
+        if (!this.isDm) {
+            editor.hidden = true;
+            return;
+        }
+        const element = this.selectedElement();
+        editor.hidden = !element;
+        if (!element) return;
+
+        const normalized = this.topology.normalizeElement(element);
+        document.getElementById('vtt-topology-id').textContent = normalized.id;
+        document.getElementById('vtt-topology-type').textContent = normalized.type.toUpperCase().replace('_', ' ');
+        const stateField = document.getElementById('vtt-topology-state-field');
+        const thresholdFields = document.getElementById('vtt-topology-threshold-fields');
+        const state = document.getElementById('vtt-topology-state');
+        const lockpick = document.getElementById('vtt-topology-lockpick');
+        const breakThreshold = document.getElementById('vtt-topology-break');
+
+        const interactive = normalized.type !== 'wall';
+        if (stateField) stateField.hidden = !interactive;
+        if (thresholdFields) thresholdFields.hidden = !interactive;
+        if (state && interactive) state.value = normalized.state;
+        if (lockpick && interactive) lockpick.value = normalized.thresholds.lockpick;
+        if (breakThreshold && interactive) breakThreshold.value = normalized.thresholds.break;
+    }
+
+    updateSelected(patch) {
+        const element = this.selectedElement();
+        if (!element) return;
+        this.stateBridge.saveElement(this.topology.normalizeElement({ ...element, ...patch }))
+            .catch((error) => this.notify(String(error.message || error), 'error'));
+    }
+
+    updateSelectedThreshold(key, value) {
+        const element = this.selectedElement();
+        if (!element || element.type === 'wall') return;
+        const thresholds = {
+            ...element.thresholds,
+            [key]: Math.max(0, Math.trunc(Number(value) || 0)),
+        };
+        this.updateSelected({ thresholds });
+    }
+
+    handleTopologyChanged() {
+        if (this.selectedId && !this.selectedElement()) this.selectedId = null;
+        this.renderEditor();
+    }
+
+    notify(message, mode = 'info') {
+        const node = document.getElementById('vtt-notice');
+        if (!node) return;
+        node.textContent = message;
+        node.dataset.mode = mode;
+        node.hidden = false;
+        window.clearTimeout(this.noticeTimer);
+        this.noticeTimer = window.setTimeout(() => {
+            node.hidden = true;
+        }, 3200);
+    }
+}

--- a/js/vtt/topology.js
+++ b/js/vtt/topology.js
@@ -1,0 +1,290 @@
+(function (root, factory) {
+    const api = factory();
+    if (typeof module !== 'undefined' && module.exports) module.exports = api;
+    if (root) root.LuminousVttTopology = api;
+})(typeof window !== 'undefined' ? window : globalThis, function () {
+    'use strict';
+
+    const TYPES = Object.freeze({
+        WALL: 'wall',
+        DOOR: 'door',
+        WINDOW: 'window',
+        CURTAIN_WINDOW: 'curtain_window',
+    });
+
+    const STATES = Object.freeze({
+        OPEN: 'open',
+        CLOSED: 'closed',
+        LOCKED: 'locked',
+        BROKEN: 'broken',
+    });
+
+    const DEFAULT_THRESHOLDS = Object.freeze({
+        [TYPES.DOOR]: Object.freeze({ lockpick: 15, break: 15 }),
+        [TYPES.WINDOW]: Object.freeze({ lockpick: 12, break: 10 }),
+        [TYPES.CURTAIN_WINDOW]: Object.freeze({ lockpick: 12, break: 10 }),
+    });
+
+    const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+    const clampInteger = (value, fallback = 0) => Math.max(0, Math.trunc(numberOr(value, fallback)));
+
+    function elementLayers(element = {}) {
+        if (Array.isArray(element.z)) return element.z.map(Number);
+        if (Number.isFinite(Number(element.z))) return [Number(element.z)];
+        return [0];
+    }
+
+    function elementOnLayer(element, zLayer) {
+        return elementLayers(element).includes(Number(zLayer));
+    }
+
+    function defaultThresholds(type) {
+        const values = DEFAULT_THRESHOLDS[type] || {};
+        return {
+            lockpick: clampInteger(values.lockpick, 0),
+            break: clampInteger(values.break, 0),
+        };
+    }
+
+    function normalizeState(type, state) {
+        if (type === TYPES.WALL) return null;
+        const normalized = String(state || STATES.CLOSED).toLowerCase();
+        return Object.values(STATES).includes(normalized) ? normalized : STATES.CLOSED;
+    }
+
+    function normalizeVertex(vertex = {}) {
+        return {
+            col: Math.max(0, Math.trunc(numberOr(vertex.col, 0))),
+            row: Math.max(0, Math.trunc(numberOr(vertex.row, 0))),
+        };
+    }
+
+    function normalizeElement(element = {}) {
+        const type = Object.values(TYPES).includes(element.type) ? element.type : TYPES.WALL;
+        const defaults = defaultThresholds(type);
+        return {
+            ...element,
+            id: String(element.id || ''),
+            type,
+            from: normalizeVertex(element.from),
+            to: normalizeVertex(element.to),
+            z: elementLayers(element),
+            state: normalizeState(type, element.state),
+            thresholds: type === TYPES.WALL ? undefined : {
+                lockpick: clampInteger(element.thresholds?.lockpick, defaults.lockpick),
+                break: clampInteger(element.thresholds?.break, defaults.break),
+            },
+        };
+    }
+
+    function vertexToPoint(vertex, grid = {}) {
+        const size = Math.max(1, numberOr(grid.size, 70));
+        return {
+            x: numberOr(vertex?.col) * size,
+            y: numberOr(vertex?.row) * size,
+        };
+    }
+
+    function segment(element, grid = {}) {
+        const normalized = normalizeElement(element);
+        const a = vertexToPoint(normalized.from, grid);
+        const b = vertexToPoint(normalized.to, grid);
+        return {
+            id: normalized.id,
+            type: normalized.type,
+            state: normalized.state,
+            x1: a.x,
+            y1: a.y,
+            x2: b.x,
+            y2: b.y,
+            z: normalized.z,
+            element: normalized,
+        };
+    }
+
+    function effectiveFlags(element = {}) {
+        const normalized = normalizeElement(element);
+        const { type, state } = normalized;
+
+        if (type === TYPES.WALL) return { blocksMovement: true, blocksVision: true };
+        if (state === STATES.OPEN || state === STATES.BROKEN) {
+            return { blocksMovement: false, blocksVision: false };
+        }
+        if (type === TYPES.WINDOW) {
+            return { blocksMovement: true, blocksVision: false };
+        }
+        return { blocksMovement: true, blocksVision: true };
+    }
+
+    function blockingSegments(elements, kind, zLayer, grid) {
+        const flag = kind === 'vision' ? 'blocksVision' : 'blocksMovement';
+        return (Array.isArray(elements) ? elements : [])
+            .map(normalizeElement)
+            .filter((element) => elementOnLayer(element, zLayer) && effectiveFlags(element)[flag])
+            .map((element) => ({ ...segment(element, grid), ...effectiveFlags(element) }));
+    }
+
+    function pointToSegmentDistance(point, a, b) {
+        const px = numberOr(point?.x);
+        const py = numberOr(point?.y);
+        const ax = numberOr(a?.x);
+        const ay = numberOr(a?.y);
+        const bx = numberOr(b?.x);
+        const by = numberOr(b?.y);
+        const abx = bx - ax;
+        const aby = by - ay;
+        const lengthSq = (abx * abx) + (aby * aby);
+        if (lengthSq === 0) return Math.hypot(px - ax, py - ay);
+        const t = Math.max(0, Math.min(1, (((px - ax) * abx) + ((py - ay) * aby)) / lengthSq));
+        return Math.hypot(px - (ax + (abx * t)), py - (ay + (aby * t)));
+    }
+
+    function hitTest(elements, point, grid, zLayer, tolerancePx) {
+        const size = Math.max(1, numberOr(grid?.size, 70));
+        const tolerance = Math.max(4, numberOr(tolerancePx, size * 0.16));
+        const list = Array.isArray(elements) ? elements : [];
+        let best = null;
+        let bestDistance = Infinity;
+
+        for (const raw of list) {
+            const element = normalizeElement(raw);
+            if (!elementOnLayer(element, zLayer)) continue;
+            const line = segment(element, grid);
+            const distance = pointToSegmentDistance(
+                point,
+                { x: line.x1, y: line.y1 },
+                { x: line.x2, y: line.y2 },
+            );
+            if (distance <= tolerance && distance < bestDistance) {
+                best = raw;
+                bestDistance = distance;
+            }
+        }
+        return best;
+    }
+
+    function snapPointToVertex(point, grid = {}) {
+        const size = Math.max(1, numberOr(grid.size, 70));
+        const cols = Math.max(1, Math.trunc(numberOr(grid.cols, 1)));
+        const rows = Math.max(1, Math.trunc(numberOr(grid.rows, 1)));
+        return {
+            col: Math.max(0, Math.min(cols, Math.round(numberOr(point?.x) / size))),
+            row: Math.max(0, Math.min(rows, Math.round(numberOr(point?.y) / size))),
+        };
+    }
+
+    function sameVertex(a, b) {
+        return Number(a?.col) === Number(b?.col) && Number(a?.row) === Number(b?.row);
+    }
+
+    function directActions(element = {}) {
+        const normalized = normalizeElement(element);
+        if (normalized.type === TYPES.WALL || normalized.state === STATES.BROKEN) return [];
+        if (normalized.state === STATES.OPEN) return ['close'];
+        if (normalized.state === STATES.CLOSED) return ['open'];
+        return [];
+    }
+
+    function checkDescriptor(element = {}, method) {
+        const normalized = normalizeElement(element);
+        if (normalized.type === TYPES.WALL || normalized.state !== STATES.LOCKED) return null;
+
+        if (method === 'lockpick') {
+            return {
+                method,
+                action: 'unlock',
+                threshold: normalized.thresholds.lockpick,
+                requiredItem: 'lockpick',
+                rollSpec: {
+                    kind: 'skill',
+                    abilityId: 'dex',
+                    skillId: 'sleight_of_hand',
+                    label: 'Sleight of Hand',
+                },
+            };
+        }
+        if (method === 'strength') {
+            return {
+                method,
+                action: 'break',
+                threshold: normalized.thresholds.break,
+                requiredItem: null,
+                rollSpec: {
+                    kind: 'ability',
+                    abilityId: 'str',
+                    skillId: null,
+                    label: 'STRENGTH',
+                },
+            };
+        }
+        if (method === 'athletics') {
+            return {
+                method,
+                action: 'break',
+                threshold: normalized.thresholds.break,
+                requiredItem: null,
+                rollSpec: {
+                    kind: 'skill',
+                    abilityId: 'str',
+                    skillId: 'athletics',
+                    label: 'Athletics',
+                },
+            };
+        }
+        return null;
+    }
+
+    function applyAction(element = {}, action) {
+        const normalized = normalizeElement(element);
+        if (normalized.type === TYPES.WALL) return { valid: false, reason: 'NOT_INTERACTIVE', element: normalized };
+
+        if (action === 'open' && normalized.state === STATES.CLOSED) {
+            return { valid: true, reason: null, element: { ...normalized, state: STATES.OPEN } };
+        }
+        if (action === 'close' && normalized.state === STATES.OPEN) {
+            return { valid: true, reason: null, element: { ...normalized, state: STATES.CLOSED } };
+        }
+        if (action === 'unlock' && normalized.state === STATES.LOCKED) {
+            return { valid: true, reason: null, element: { ...normalized, state: STATES.OPEN } };
+        }
+        if (action === 'break' && normalized.state === STATES.LOCKED) {
+            return { valid: true, reason: null, element: { ...normalized, state: STATES.BROKEN } };
+        }
+        return { valid: false, reason: 'INVALID_STATE_TRANSITION', element: normalized };
+    }
+
+    function createElement({ id, type, from, to, zLayer = 0 } = {}) {
+        const normalizedType = Object.values(TYPES).includes(type) ? type : TYPES.WALL;
+        return normalizeElement({
+            id: id || `topology_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 7)}`,
+            type: normalizedType,
+            from,
+            to,
+            z: [Number(zLayer) || 0],
+            state: normalizedType === TYPES.WALL ? null : STATES.CLOSED,
+            thresholds: defaultThresholds(normalizedType),
+        });
+    }
+
+    return Object.freeze({
+        TYPES,
+        STATES,
+        DEFAULT_THRESHOLDS,
+        elementLayers,
+        elementOnLayer,
+        defaultThresholds,
+        normalizeElement,
+        vertexToPoint,
+        segment,
+        effectiveFlags,
+        blockingSegments,
+        pointToSegmentDistance,
+        hitTest,
+        snapPointToVertex,
+        sameVertex,
+        directActions,
+        checkDescriptor,
+        applyAction,
+        createElement,
+    });
+});

--- a/js/vtt/topology.js
+++ b/js/vtt/topology.js
@@ -173,6 +173,15 @@
         };
     }
 
+    function axisAlignedVertex(from, candidate) {
+        const start = normalizeVertex(from);
+        const target = normalizeVertex(candidate);
+        const deltaCol = Math.abs(target.col - start.col);
+        const deltaRow = Math.abs(target.row - start.row);
+        if (deltaCol >= deltaRow) return { col: target.col, row: start.row };
+        return { col: start.col, row: target.row };
+    }
+
     function sameVertex(a, b) {
         return Number(a?.col) === Number(b?.col) && Number(a?.row) === Number(b?.row);
     }
@@ -281,6 +290,7 @@
         pointToSegmentDistance,
         hitTest,
         snapPointToVertex,
+        axisAlignedVertex,
         sameVertex,
         directActions,
         checkDescriptor,

--- a/tests/vtt_topology.spec.js
+++ b/tests/vtt_topology.spec.js
@@ -1,0 +1,156 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+const topology = require('../js/vtt/topology.js');
+const tokenRules = require('../js/vtt/token-interaction.js');
+const stateBridge = require('../js/vtt/state-bridge.js');
+
+const grid = { cols: 10, rows: 10, size: 70 };
+const verticalEdge = { from: { col: 2, row: 1 }, to: { col: 2, row: 2 }, z: [0] };
+
+const element = (type, state, thresholds) => topology.normalizeElement({
+    id: `${type}_${state}`,
+    type,
+    state,
+    thresholds,
+    ...verticalEdge,
+});
+
+test('door and window thresholds use the agreed base values', () => {
+    expect(topology.defaultThresholds('door')).toEqual({ lockpick: 15, break: 15 });
+    expect(topology.defaultThresholds('window')).toEqual({ lockpick: 12, break: 10 });
+    expect(topology.defaultThresholds('curtain_window')).toEqual({ lockpick: 12, break: 10 });
+});
+
+test('closed topology has the correct movement and vision behavior', () => {
+    expect(topology.effectiveFlags(element('door', 'locked'))).toEqual({
+        blocksMovement: true,
+        blocksVision: true,
+    });
+    expect(topology.effectiveFlags(element('window', 'locked'))).toEqual({
+        blocksMovement: true,
+        blocksVision: false,
+    });
+    expect(topology.effectiveFlags(element('curtain_window', 'closed'))).toEqual({
+        blocksMovement: true,
+        blocksVision: true,
+    });
+});
+
+test('open and broken doors or windows stop blocking movement and vision', () => {
+    for (const type of ['door', 'window', 'curtain_window']) {
+        expect(topology.effectiveFlags(element(type, 'open'))).toEqual({
+            blocksMovement: false,
+            blocksVision: false,
+        });
+        expect(topology.effectiveFlags(element(type, 'broken'))).toEqual({
+            blocksMovement: false,
+            blocksVision: false,
+        });
+    }
+});
+
+test('locked interactions generate the canonical D&D checks', () => {
+    const door = element('door', 'locked', { lockpick: 19, break: 21 });
+    expect(topology.checkDescriptor(door, 'lockpick')).toMatchObject({
+        action: 'unlock',
+        threshold: 19,
+        requiredItem: 'lockpick',
+        rollSpec: { kind: 'skill', abilityId: 'dex', skillId: 'sleight_of_hand' },
+    });
+    expect(topology.checkDescriptor(door, 'strength')).toMatchObject({
+        action: 'break',
+        threshold: 21,
+        rollSpec: { kind: 'ability', abilityId: 'str', skillId: null },
+    });
+    expect(topology.checkDescriptor(door, 'athletics')).toMatchObject({
+        action: 'break',
+        threshold: 21,
+        rollSpec: { kind: 'skill', abilityId: 'str', skillId: 'athletics' },
+    });
+});
+
+test('successful topology actions change state without inventing a second dice system', () => {
+    const lockedDoor = element('door', 'locked');
+    expect(topology.applyAction(lockedDoor, 'unlock')).toMatchObject({
+        valid: true,
+        element: { state: 'open' },
+    });
+    expect(topology.applyAction(lockedDoor, 'break')).toMatchObject({
+        valid: true,
+        element: { state: 'broken' },
+    });
+    expect(topology.applyAction(element('door', 'open'), 'close')).toMatchObject({
+        valid: true,
+        element: { state: 'closed' },
+    });
+});
+
+test('DM authoring snaps topology to square-grid contours, not diagonals through cells', () => {
+    expect(topology.axisAlignedVertex({ col: 2, row: 2 }, { col: 6, row: 4 })).toEqual({ col: 6, row: 2 });
+    expect(topology.axisAlignedVertex({ col: 2, row: 2 }, { col: 3, row: 7 })).toEqual({ col: 2, row: 7 });
+});
+
+test('token movement is blocked by closed topology and allowed after opening', () => {
+    const token = { id: 'player', x: 105, y: 105, radius: 20, z: [0] };
+    const closedDoor = {
+        id: 'door',
+        type: 'door',
+        state: 'closed',
+        from: { col: 2, row: 0 },
+        to: { col: 2, row: 4 },
+        z: [0],
+        thresholds: { lockpick: 15, break: 15 },
+    };
+    const blocked = tokenRules.resolveDrop(token, { x: 105, y: 105 }, { x: 245, y: 105 }, {
+        grid,
+        walls: [],
+        topology: [closedDoor],
+    });
+    expect(blocked.valid).toBe(false);
+    expect(blocked.reason).toBe('BLOCKED_BY_WALL');
+
+    const open = tokenRules.resolveDrop(token, { x: 105, y: 105 }, { x: 245, y: 105 }, {
+        grid,
+        walls: [],
+        topology: [{ ...closedDoor, state: 'open' }],
+    });
+    expect(open.valid).toBe(true);
+});
+
+test('Ganzúa requirement recognizes inventory aliases and rejects zero quantity', () => {
+    expect(stateBridge.inventoryHasItem({ inventory: [{ nombre: 'Ganzúa', cantidad: 1 }] }, 'lockpick')).toBe(true);
+    expect(stateBridge.inventoryHasItem({ items: { lockpick: { quantity: 2 } } }, 'lockpick')).toBe(true);
+    expect(stateBridge.inventoryHasItem({ inventario: [{ name: 'Lockpick', quantity: 0 }] }, 'lockpick')).toBe(false);
+    expect(stateBridge.inventoryHasItem({ inventory: [{ name: 'Torch', quantity: 1 }] }, 'lockpick')).toBe(false);
+});
+
+test('VTT wiring exposes DM topology tools and routes checks through existing coordinator roots', () => {
+    const html = read('vtt.html');
+    const engine = read('js/vtt/engine.js');
+    const controller = read('js/vtt/topology-controller.js');
+    const bridge = read('js/vtt/state-bridge.js');
+    const portal = read('js/vtt/check-portal.js');
+
+    expect(html).toContain('data-vtt-tool="wall"');
+    expect(html).toContain('data-vtt-tool="door"');
+    expect(html).toContain('data-vtt-tool="window"');
+    expect(html).toContain('data-vtt-tool="curtain_window"');
+    expect(controller).toContain('axisAlignedVertex');
+    expect(engine).toContain("blockingSegments(this.mapData.topology, 'vision'");
+    expect(bridge).toContain("const CHECK_REQUEST_ROOT = 'theatre_check_requests'");
+    expect(bridge).toContain("const CHECK_COMMAND_ROOT = 'theatre_check_commands'");
+    expect(bridge).toContain("const CHECK_LIVE_ROOT = 'theatre_check_live'");
+    expect(bridge).toContain("live.outcome === 'passed'");
+    expect(portal).toContain("#theatre-check-command-prompt");
+});
+
+test('Firebase rules keep topology canonical as DM-write and player actions request-only', () => {
+    const rules = JSON.parse(read('database.rules.json')).rules;
+    expect(rules.vtt_topology['.read']).toBe('auth != null');
+    expect(rules.vtt_topology.$mapId['.write']).toContain("auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1'");
+    expect(rules.vtt_topology_action_requests.$mapId.$requestId['.write']).toContain('!data.exists()');
+    expect(rules.vtt_topology_action_requests.$mapId.$requestId['.write']).toContain("newData.child('requesterUid').val() === auth.uid");
+});

--- a/tests/vtt_topology.spec.js
+++ b/tests/vtt_topology.spec.js
@@ -1,6 +1,8 @@
 const { test, expect } = require('@playwright/test');
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
+const { execFileSync } = require('node:child_process');
 
 const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
 const topology = require('../js/vtt/topology.js');
@@ -145,6 +147,36 @@ test('VTT wiring exposes DM topology tools and routes checks through existing co
     expect(bridge).toContain("const CHECK_LIVE_ROOT = 'theatre_check_live'");
     expect(bridge).toContain("live.outcome === 'passed'");
     expect(portal).toContain("#theatre-check-command-prompt");
+});
+
+test('new and modified VTT JavaScript files pass Node syntax parsing', () => {
+    const commonJsCompatible = [
+        'js/vtt/topology.js',
+        'js/vtt/state-bridge.js',
+        'js/vtt/check-portal.js',
+        'js/vtt/token-interaction.js',
+    ];
+    for (const file of commonJsCompatible) {
+        execFileSync(process.execPath, ['--check', path.join(__dirname, '..', file)], { stdio: 'pipe' });
+    }
+
+    const esModules = [
+        'js/vtt/topology-controller.js',
+        'js/vtt/engine.js',
+        'js/vtt/renderer.js',
+        'js/vtt/main.js',
+        'js/vtt/mapData.js',
+    ];
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'luminous-vtt-syntax-'));
+    try {
+        for (const file of esModules) {
+            const tempFile = path.join(tempDir, `${path.basename(file, '.js')}.mjs`);
+            fs.writeFileSync(tempFile, read(file));
+            execFileSync(process.execPath, ['--check', tempFile], { stdio: 'pipe' });
+        }
+    } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    }
 });
 
 test('Firebase rules keep topology canonical as DM-write and player actions request-only', () => {

--- a/vtt.html
+++ b/vtt.html
@@ -1,19 +1,67 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Independent VTT Engine</title>
+    <title>Luminous VTT Map</title>
     <link rel="stylesheet" href="css/vtt.css">
 </head>
 <body>
     <canvas id="vtt-canvas"></canvas>
 
     <div id="vtt-ui-container">
+        <div id="vtt-topology-toolbar" class="vtt-toolbar" hidden aria-label="Editor de topología del DM">
+            <button type="button" data-vtt-tool="select" class="brutalist-button">SELECT</button>
+            <button type="button" data-vtt-tool="wall" class="brutalist-button">WALL</button>
+            <button type="button" data-vtt-tool="door" class="brutalist-button">DOOR</button>
+            <button type="button" data-vtt-tool="window" class="brutalist-button">WINDOW</button>
+            <button type="button" data-vtt-tool="curtain_window" class="brutalist-button">CURTAIN WINDOW</button>
+            <button type="button" data-vtt-tool="erase" class="brutalist-button">ERASE</button>
+        </div>
         <button id="btn-export-uv" class="brutalist-button">[ EXPORTAR PLANTILLA UV ]</button>
     </div>
 
+    <aside id="vtt-topology-editor" class="vtt-panel" hidden>
+        <header>
+            <strong id="vtt-topology-type">TOPOLOGY</strong>
+            <small id="vtt-topology-id"></small>
+        </header>
+        <label id="vtt-topology-state-field">
+            <span>ESTADO</span>
+            <select id="vtt-topology-state">
+                <option value="open">OPEN</option>
+                <option value="closed">CLOSED</option>
+                <option value="locked">LOCKED</option>
+                <option value="broken">BROKEN</option>
+            </select>
+        </label>
+        <div id="vtt-topology-threshold-fields" class="vtt-threshold-grid">
+            <label>
+                <span>JUEGO DE MANOS</span>
+                <input id="vtt-topology-lockpick" type="number" min="0" step="1">
+            </label>
+            <label>
+                <span>ROMPER · STR / ATHLETICS</span>
+                <input id="vtt-topology-break" type="number" min="0" step="1">
+            </label>
+        </div>
+        <button id="vtt-topology-delete" type="button" class="vtt-danger-button">BORRAR ELEMENTO</button>
+    </aside>
+
+    <section id="vtt-context-menu" class="vtt-context-menu" hidden>
+        <header>
+            <strong id="vtt-context-title">OBJETO</strong>
+            <span id="vtt-context-state"></span>
+        </header>
+        <div id="vtt-context-actions"></div>
+    </section>
+
+    <div id="vtt-notice" class="vtt-notice" hidden role="status" aria-live="polite"></div>
+
+    <script src="js/vtt/topology.js"></script>
+    <script src="js/vtt/state-bridge.js"></script>
     <script src="js/vtt/token-interaction.js"></script>
+    <script src="js/vtt/check-portal.js"></script>
     <script type="module" src="js/vtt/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- adds a DM topology editor that authors grid-edge walls, doors, windows, and curtain windows
- keeps square-map topology snapped to grid vertices and constrained to horizontal/vertical cell contours
- makes topology participate in both token movement collision and current VTT line-of-sight
- adds clickable player interactions for open/close, lockpicking, and breaking
- reuses the existing Luminous D&D Check coordinator for Sleight of Hand, Strength, and Athletics instead of adding a second dice system
- persists canonical topology in Firebase with DM-only writes; players submit interaction intents

## Rules implemented
### Doors
- states: open / closed / locked / broken
- open can be closed; closed/unlocked can be opened
- locked is shown to players as closed and cannot be directly opened
- lockpick: Sleight of Hand, requires Ganzúa, base Threshold 15
- break: Strength or Athletics, base Threshold 15
- thresholds are editable by the DM per element

### Windows
- closed/locked blocks movement but permits vision
- lockpick: Sleight of Hand + Ganzúa, base Threshold 12
- break: Strength or Athletics, base Threshold 10
- open/broken permits movement and vision
- thresholds are editable by the DM per element

### Curtain windows
- closed/locked blocks movement and vision like a wall
- open/broken permits movement and vision
- uses window thresholds when locked

## Multiplayer / authority
- players never directly mutate canonical topology
- open/close requests go through `vtt_topology_action_requests`
- only the DM writes `vtt_topology`
- locked interactions reuse `theatre_check_requests`, `theatre_check_commands`, and `theatre_check_live`
- only a completed `passed` result applies unlock/break to canonical topology
- duplicate Check issuance is guarded against repeated Firebase callbacks
- initial topology seeding runs once; deleting the final element leaves the canonical map intentionally empty instead of restoring demo data

## UI
DM tools:
- SELECT
- WALL
- DOOR
- WINDOW
- CURTAIN WINDOW
- ERASE
- state editor
- lockpick Threshold editor
- break Threshold editor

Players can click a reachable door/window to receive contextual actions. A lockpick action is disabled if no recognized Ganzúa/lockpick exists in the player's inventory data.

## Tests
`tests/vtt_topology.spec.js` covers:
- default Thresholds
- movement/vision flags by type and state
- open/broken behavior
- Sleight of Hand / Strength / Athletics descriptors
- state transitions
- orthogonal grid-edge authoring
- movement collision against topology
- Ganzúa inventory aliases
- existing Check coordinator wiring
- syntax parsing for all new/modified VTT JavaScript modules
- Firebase authority rules

Validation on head `b292c5b8d916ad2c340064a223e37ca4bb1c1ed3`:
- Background Narratives: success
- Theatre Roll Visualizer: success
- NPC Theatre Rolls: success
- Trait Engine: success
- non-browser repository regression suite: 796/796 passed

## Out of scope
- dynamic lighting
- vision distance in feet
- Fog of War
- movement budget / Speed costs
- consuming or breaking a Ganzúa
