### PR TITLE
feat(vtt): racial darkvision, z-level movement and DM edit mode

### DIFF
--- a/css/vtt.css
+++ b/css/vtt.css
@@ -9,9 +9,7 @@ html, body {
     font-family: "Share Tech Mono", monospace, sans-serif;
 }
 
-button, input, select {
-    font: inherit;
-}
+button, input, select { font: inherit; }
 
 #vtt-canvas {
     display: block;
@@ -31,9 +29,7 @@ button, input, select {
     pointer-events: none;
 }
 
-#vtt-ui-container > * {
-    pointer-events: auto;
-}
+#vtt-ui-container > * { pointer-events: auto; }
 
 .vtt-toolbar {
     display: flex;
@@ -47,38 +43,33 @@ button, input, select {
     border: 1px solid #5d6770;
 }
 
-.vtt-vertical-toolbar {
-    border-color: #4f7f99;
-}
-
 .vtt-toolbar-title {
-    padding: 0 5px;
-    color: #7fd6ff;
+    color: #89949e;
     font-size: 10px;
-    font-weight: bold;
     letter-spacing: .12em;
+    margin-right: 3px;
 }
 
 .vtt-toolbar-field {
     display: flex;
     align-items: center;
     gap: 6px;
-    padding-left: 6px;
-    border-left: 1px solid #43515c;
+    padding-left: 7px;
+    border-left: 1px solid #46505a;
 }
 
 .vtt-toolbar-field span {
-    color: #8fb8cc;
+    color: #9ba5ad;
     font-size: 9px;
     letter-spacing: .08em;
 }
 
 .vtt-toolbar-field select {
-    max-width: 180px;
-    padding: 6px 8px;
-    background: #0c1216;
-    color: #dff5ff;
-    border: 1px solid #4f7f99;
+    min-width: 120px;
+    padding: 6px;
+    color: #e9eef2;
+    background: #11161a;
+    border: 1px solid #53606d;
 }
 
 .brutalist-button {
@@ -103,23 +94,26 @@ button, input, select {
     transform: translate(2px, 2px);
 }
 
-#vtt-vertical-toolbar .brutalist-button {
-    color: #7fd6ff;
-    border-color: #4f7f99;
-    box-shadow: 3px 3px 0 rgba(80, 173, 220, .18);
-}
-
-#vtt-vertical-toolbar .brutalist-button:hover,
-#vtt-vertical-toolbar .brutalist-button.is-active {
-    background: #7fd6ff;
-    color: #061016;
-    box-shadow: 1px 1px 0 rgba(80, 173, 220, .35);
-}
-
 .brutalist-button:active {
     box-shadow: none;
     transform: translate(3px, 3px);
 }
+
+.vtt-edit-toggle {
+    border-color: #d7b151;
+    color: #d7b151;
+    box-shadow: 3px 3px 0 rgba(215, 177, 81, .22);
+}
+
+.vtt-edit-toggle:hover,
+.vtt-edit-toggle.is-active {
+    background: #d7b151;
+    border-color: #d7b151;
+    color: #050709;
+    box-shadow: 1px 1px 0 rgba(215, 177, 81, .4);
+}
+
+.vtt-dm-edit-active #vtt-canvas { outline: 1px solid rgba(215, 177, 81, .34); outline-offset: -1px; }
 
 .vtt-panel {
     position: absolute;
@@ -135,9 +129,8 @@ button, input, select {
 
 .vtt-vertical-panel {
     top: 96px;
-    left: auto;
-    right: 20px;
-    border-color: #4f7f99;
+    left: 350px;
+    border-color: #54b8df;
 }
 
 .vtt-panel header,
@@ -156,9 +149,7 @@ button, input, select {
     letter-spacing: .08em;
 }
 
-.vtt-vertical-panel header strong {
-    color: #7fd6ff;
-}
+.vtt-vertical-panel header strong { color: #7fd6ff; }
 
 .vtt-panel header small,
 .vtt-context-menu header span {
@@ -199,25 +190,20 @@ button, input, select {
 .vtt-vertical-readout {
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    gap: 10px;
     margin-bottom: 10px;
-    padding: 8px;
-    background: #0b1115;
-    border: 1px solid #344a57;
-}
-
-.vtt-vertical-readout span {
-    color: #8fa4af;
+    padding: 7px 8px;
+    border: 1px solid #33414b;
+    background: #0d1216;
     font-size: 10px;
 }
 
-.vtt-vertical-readout strong {
-    color: #7fd6ff;
-}
+.vtt-vertical-readout span { color: #89949e; }
+.vtt-vertical-readout strong { color: #7fd6ff; }
 
 .vtt-panel-help {
-    margin: 10px 0 12px;
-    color: #7f8c95;
+    margin: 8px 0 12px;
+    color: #84909a;
     font-size: 10px;
     line-height: 1.45;
 }
@@ -303,30 +289,11 @@ button, input, select {
 .vtt-notice[data-mode="error"] { border-color: #ff6673; }
 .vtt-notice[data-mode="pending"] { border-color: #d7b151; }
 
-[hidden] {
-    display: none !important;
-}
+[hidden] { display: none !important; }
 
 @media (max-width: 900px) {
-    #vtt-ui-container {
-        top: 10px;
-        right: 10px;
-    }
-    .vtt-panel,
-    .vtt-vertical-panel {
-        top: auto;
-        right: auto;
-        bottom: 10px;
-        left: 10px;
-    }
-    .brutalist-button {
-        font-size: 10px;
-        padding: 6px 8px;
-    }
-    .vtt-toolbar-field {
-        width: 100%;
-        justify-content: flex-end;
-        border-left: 0;
-        padding-left: 0;
-    }
+    #vtt-ui-container { top: 10px; right: 10px; }
+    .vtt-panel { top: auto; bottom: 10px; left: 10px; }
+    .vtt-vertical-panel { left: auto; right: 10px; }
+    .brutalist-button { font-size: 10px; padding: 6px 8px; }
 }

--- a/css/vtt.css
+++ b/css/vtt.css
@@ -39,11 +39,46 @@ button, input, select {
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-end;
+    align-items: center;
     gap: 6px;
-    max-width: min(760px, calc(100vw - 40px));
+    max-width: min(900px, calc(100vw - 40px));
     padding: 8px;
     background: rgba(0, 0, 0, .88);
     border: 1px solid #5d6770;
+}
+
+.vtt-vertical-toolbar {
+    border-color: #4f7f99;
+}
+
+.vtt-toolbar-title {
+    padding: 0 5px;
+    color: #7fd6ff;
+    font-size: 10px;
+    font-weight: bold;
+    letter-spacing: .12em;
+}
+
+.vtt-toolbar-field {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding-left: 6px;
+    border-left: 1px solid #43515c;
+}
+
+.vtt-toolbar-field span {
+    color: #8fb8cc;
+    font-size: 9px;
+    letter-spacing: .08em;
+}
+
+.vtt-toolbar-field select {
+    max-width: 180px;
+    padding: 6px 8px;
+    background: #0c1216;
+    color: #dff5ff;
+    border: 1px solid #4f7f99;
 }
 
 .brutalist-button {
@@ -68,6 +103,19 @@ button, input, select {
     transform: translate(2px, 2px);
 }
 
+#vtt-vertical-toolbar .brutalist-button {
+    color: #7fd6ff;
+    border-color: #4f7f99;
+    box-shadow: 3px 3px 0 rgba(80, 173, 220, .18);
+}
+
+#vtt-vertical-toolbar .brutalist-button:hover,
+#vtt-vertical-toolbar .brutalist-button.is-active {
+    background: #7fd6ff;
+    color: #061016;
+    box-shadow: 1px 1px 0 rgba(80, 173, 220, .35);
+}
+
 .brutalist-button:active {
     box-shadow: none;
     transform: translate(3px, 3px);
@@ -85,6 +133,13 @@ button, input, select {
     box-shadow: 0 10px 28px rgba(0, 0, 0, .7);
 }
 
+.vtt-vertical-panel {
+    top: 96px;
+    left: auto;
+    right: 20px;
+    border-color: #4f7f99;
+}
+
 .vtt-panel header,
 .vtt-context-menu header {
     display: flex;
@@ -99,6 +154,10 @@ button, input, select {
 .vtt-context-menu header strong {
     color: #d7b151;
     letter-spacing: .08em;
+}
+
+.vtt-vertical-panel header strong {
+    color: #7fd6ff;
 }
 
 .vtt-panel header small,
@@ -135,6 +194,32 @@ button, input, select {
     display: grid;
     grid-template-columns: 1fr;
     gap: 2px;
+}
+
+.vtt-vertical-readout {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+    padding: 8px;
+    background: #0b1115;
+    border: 1px solid #344a57;
+}
+
+.vtt-vertical-readout span {
+    color: #8fa4af;
+    font-size: 10px;
+}
+
+.vtt-vertical-readout strong {
+    color: #7fd6ff;
+}
+
+.vtt-panel-help {
+    margin: 10px 0 12px;
+    color: #7f8c95;
+    font-size: 10px;
+    line-height: 1.45;
 }
 
 .vtt-danger-button {
@@ -227,13 +312,21 @@ button, input, select {
         top: 10px;
         right: 10px;
     }
-    .vtt-panel {
+    .vtt-panel,
+    .vtt-vertical-panel {
         top: auto;
+        right: auto;
         bottom: 10px;
         left: 10px;
     }
     .brutalist-button {
         font-size: 10px;
         padding: 6px 8px;
+    }
+    .vtt-toolbar-field {
+        width: 100%;
+        justify-content: flex-end;
+        border-left: 0;
+        padding-left: 0;
     }
 }

--- a/js/racial-sense-runtime.js
+++ b/js/racial-sense-runtime.js
@@ -1,0 +1,104 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousRacialSenseRuntime = api;
+})(typeof window !== 'undefined' ? window : globalThis, function () {
+  'use strict';
+
+  const DEFAULT_DARKVISION_FT = 60;
+  const STANDARD_DARKVISION_RACES = Object.freeze([
+    'dwarf', 'elf', 'gnome', 'half_elf', 'half_orc', 'orc',
+    'kobold', 'goblin', 'fairy', 'aasimar', 'tiefling', 'felinae',
+    'half_dragon', 'lupae', 'moonfae', 'yuan_ti_pureblood', 'undae', 'elnae',
+  ]);
+  const STANDARD_SET = new Set(STANDARD_DARKVISION_RACES);
+  const SUPERIOR_DARKVISION = Object.freeze({
+    'dwarf:duergar': 120,
+    'elf:drow': 120,
+  });
+
+  const cleanId = (value) => String(value ?? '').trim().toLowerCase().replace(/[\s-]+/g, '_');
+  const finiteNonNegative = (value, fallback = 0) => {
+    const number = Number(value);
+    return Number.isFinite(number) ? Math.max(0, number) : fallback;
+  };
+
+  function buildFromCharacter(character = {}) {
+    return character.characterBuild
+      || character.build
+      || character.character_build
+      || character;
+  }
+
+  function resolveRacialSenses(build = {}) {
+    const raceId = cleanId(build.raceId || build.race || build.razaId || build.raza);
+    const subtypeId = cleanId(build.raceSubtypeId || build.subraceId || build.subtypeId || build.subrazaId);
+    const superior = SUPERIOR_DARKVISION[`${raceId}:${subtypeId}`] || 0;
+    const darkvisionFt = superior || (STANDARD_SET.has(raceId) ? DEFAULT_DARKVISION_FT : 0);
+    return Object.freeze({
+      raceId: raceId || null,
+      raceSubtypeId: subtypeId || null,
+      darkvisionFt,
+      darkvisionMonochrome: darkvisionFt > 0,
+      dimAsBright: darkvisionFt > 0,
+      darknessAsDim: darkvisionFt > 0,
+      source: darkvisionFt > 0 ? 'racial' : null,
+    });
+  }
+
+  function resolveCharacterSenses(character = {}) {
+    const racial = resolveRacialSenses(buildFromCharacter(character));
+    const explicit = character.senses || character.vision || {};
+    const explicitDarkvision = finiteNonNegative(explicit.darkvisionFt ?? explicit.darkvision_ft, 0);
+    const darkvisionFt = Math.max(racial.darkvisionFt, explicitDarkvision);
+    return Object.freeze({
+      ...racial,
+      darkvisionFt,
+      darkvisionMonochrome: darkvisionFt > 0,
+      dimAsBright: darkvisionFt > 0,
+      darknessAsDim: darkvisionFt > 0,
+      source: explicitDarkvision > racial.darkvisionFt ? 'character_override' : racial.source,
+    });
+  }
+
+  function perceptionForLightLevel(lightLevel, senses = {}, distanceFt = 0) {
+    const level = cleanId(lightLevel || 'bright');
+    const distance = finiteNonNegative(distanceFt, 0);
+    const darkvisionFt = finiteNonNegative(senses.darkvisionFt, 0);
+    const inDarkvision = darkvisionFt > 0 && distance <= darkvisionFt;
+
+    if (level === 'bright') {
+      return Object.freeze({ visible: true, perceivedLight: 'bright', mode: 'normal', monochrome: false });
+    }
+    if (level === 'dim') {
+      return Object.freeze({
+        visible: true,
+        perceivedLight: inDarkvision && senses.dimAsBright !== false ? 'bright' : 'dim',
+        mode: inDarkvision ? 'darkvision_dim' : 'normal_dim',
+        monochrome: false,
+      });
+    }
+    if (level === 'darkness') {
+      if (!inDarkvision || senses.darknessAsDim === false) {
+        return Object.freeze({ visible: false, perceivedLight: 'darkness', mode: 'none', monochrome: false });
+      }
+      return Object.freeze({
+        visible: true,
+        perceivedLight: 'dim',
+        mode: 'darkvision',
+        monochrome: senses.darkvisionMonochrome !== false,
+      });
+    }
+    return Object.freeze({ visible: true, perceivedLight: level || 'bright', mode: 'normal', monochrome: false });
+  }
+
+  return Object.freeze({
+    DEFAULT_DARKVISION_FT,
+    STANDARD_DARKVISION_RACES,
+    SUPERIOR_DARKVISION,
+    buildFromCharacter,
+    resolveRacialSenses,
+    resolveCharacterSenses,
+    perceptionForLightLevel,
+  });
+});

--- a/js/vtt/character-vision-bridge.js
+++ b/js/vtt/character-vision-bridge.js
@@ -1,0 +1,159 @@
+(function (root, factory) {
+  const api = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttCharacterVisionBridge = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (browserRoot) {
+  'use strict';
+
+  const clean = (value) => String(value ?? '').trim();
+
+  function hostWindow(root = browserRoot) {
+    if (!root) return null;
+    try {
+      if (root.parent && root.parent !== root && root.parent.document) return root.parent;
+    } catch (_) {}
+    return root;
+  }
+
+  function hostFirebase(root = browserRoot) {
+    const host = hostWindow(root);
+    return host?.firebase || root?.firebase || null;
+  }
+
+  function currentPlayerId(root = browserRoot) {
+    const host = hostWindow(root);
+    const data = host?.datosJugador || {};
+    return clean(host?.localStorage?.getItem?.('playerId') || data.playerId || data.id || '');
+  }
+
+  function tokenLink(token = {}, root = browserRoot) {
+    const link = token.characterLink || {};
+    if (link.mode === 'current_player') {
+      return { playerId: currentPlayerId(root) || null, actorId: clean(link.actorId || token.actorId) || null };
+    }
+    return {
+      playerId: clean(link.playerId || token.playerId) || null,
+      actorId: clean(link.actorId || token.actorId) || null,
+    };
+  }
+
+  function resolveBuildCarrier(player, actor) {
+    if (player?.characterBuild || player?.build || player?.character_build) return player;
+    if (actor?.characterBuild || actor?.build || actor?.character_build) return actor;
+    return player || actor || {};
+  }
+
+  function createBridge({ mapData, root = browserRoot, onSensesChanged } = {}) {
+    if (!mapData) throw new Error('MAP_DATA_REQUIRED');
+    const runtime = root?.LuminousRacialSenseRuntime
+      || (typeof require !== 'undefined' ? require('../racial-sense-runtime.js') : null);
+    if (!runtime) throw new Error('RACIAL_SENSE_RUNTIME_REQUIRED');
+
+    const host = hostWindow(root);
+    const firebase = hostFirebase(root);
+    const db = firebase?.database?.() || null;
+    const subscriptions = [];
+    const records = new Map();
+    let started = false;
+
+    function emit(token, character) {
+      token.senses = runtime.resolveCharacterSenses(character || {});
+      token.characterVision = {
+        raceId: token.senses.raceId,
+        raceSubtypeId: token.senses.raceSubtypeId,
+        darkvisionFt: token.senses.darkvisionFt,
+        source: token.senses.source,
+      };
+      if (typeof onSensesChanged === 'function') onSensesChanged(token, token.senses);
+      try {
+        root?.document?.dispatchEvent?.(new root.CustomEvent('vtt:token-senses-changed', {
+          detail: { tokenId: token.id, senses: { ...token.senses } },
+        }));
+      } catch (_) {}
+      return token.senses;
+    }
+
+    function localCurrentPlayer() {
+      return host?.datosJugador || null;
+    }
+
+    function applyRecord(token, record) {
+      const carrier = resolveBuildCarrier(record?.player, record?.actor);
+      return emit(token, carrier);
+    }
+
+    function subscribeValue(path, callback) {
+      if (!db || !path) return;
+      const ref = db.ref(path);
+      const handler = (snapshot) => callback(snapshot.val() || null);
+      ref.on('value', handler);
+      subscriptions.push(() => ref.off('value', handler));
+    }
+
+    function bindActor(token, record, actorId) {
+      if (!db || !actorId || record.boundActors?.has(actorId)) return;
+      record.boundActors ||= new Set();
+      record.boundActors.add(actorId);
+      const accept = (actor) => {
+        if (actor) record.actor = actor;
+        applyRecord(token, record);
+      };
+      subscribeValue(`campaña/base_datos_npcs/${actorId}`, (actor) => {
+        if (actor) accept(actor);
+      });
+      subscribeValue(`campaña/actores/${actorId}`, (actor) => {
+        if (actor && !record.actor) accept(actor);
+      });
+    }
+
+    function bindToken(token) {
+      const link = tokenLink(token, root);
+      const record = { player: null, actor: null, boundActors: new Set() };
+      records.set(token.id, record);
+
+      if (!db) {
+        if (link.playerId && link.playerId === currentPlayerId(root)) record.player = localCurrentPlayer();
+        applyRecord(token, record);
+        return;
+      }
+
+      if (link.playerId) {
+        subscribeValue(`campaña/jugadores/${link.playerId}`, (player) => {
+          record.player = player;
+          const actorId = clean(player?.actorId || link.actorId);
+          if (actorId) bindActor(token, record, actorId);
+          applyRecord(token, record);
+        });
+      } else if (link.actorId) {
+        bindActor(token, record, link.actorId);
+      } else {
+        const local = localCurrentPlayer();
+        if (local) record.player = local;
+        applyRecord(token, record);
+      }
+    }
+
+    function start() {
+      if (started) return true;
+      started = true;
+      (mapData.tokens || []).forEach(bindToken);
+      return true;
+    }
+
+    function refreshToken(tokenId, character) {
+      const token = (mapData.tokens || []).find((entry) => String(entry.id) === String(tokenId));
+      if (!token) return null;
+      return emit(token, character);
+    }
+
+    function stop() {
+      subscriptions.splice(0).forEach((unsubscribe) => unsubscribe());
+      records.clear();
+      started = false;
+    }
+
+    return Object.freeze({ start, stop, refreshToken, tokenLink: (token) => tokenLink(token, root) });
+  }
+
+  return Object.freeze({ hostWindow, hostFirebase, currentPlayerId, tokenLink, resolveBuildCarrier, createBridge });
+});

--- a/js/vtt/dm-edit-mode.js
+++ b/js/vtt/dm-edit-mode.js
@@ -1,0 +1,62 @@
+(function (root, factory) {
+    const api = factory(root);
+    if (typeof module !== 'undefined' && module.exports) module.exports = api;
+    if (root) root.LuminousVttDmEditMode = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (browserRoot) {
+    'use strict';
+
+    function createController({ isDm = false, mapData, topologyController, verticalPortalController, root = browserRoot } = {}) {
+        if (!mapData) throw new Error('MAP_DATA_REQUIRED');
+        mapData.dmEditMode ||= { active: false };
+        mapData.dmEditMode.active = Boolean(isDm && mapData.dmEditMode.active);
+
+        const button = root?.document?.getElementById?.('vtt-dm-edit-toggle') || null;
+
+        function apply() {
+            const active = Boolean(isDm && mapData.dmEditMode.active);
+            root?.document?.body?.classList?.toggle('vtt-dm-edit-active', active);
+            root?.document?.body?.classList?.toggle('vtt-dm-edit-available', Boolean(isDm));
+            if (button) {
+                button.hidden = !isDm;
+                button.classList.toggle('is-active', active);
+                button.setAttribute('aria-pressed', active ? 'true' : 'false');
+                button.textContent = active ? 'EDIT MODE · ON' : 'EDIT MODE';
+            }
+            topologyController?.renderMode?.();
+            verticalPortalController?.renderMode?.();
+            if (!active) {
+                topologyController?.setTool?.('select');
+                verticalPortalController?.setTool?.('select', false);
+            }
+            return active;
+        }
+
+        function setActive(value) {
+            mapData.dmEditMode.active = Boolean(isDm && value);
+            return apply();
+        }
+
+        function toggle() {
+            return setActive(!mapData.dmEditMode.active);
+        }
+
+        const clickHandler = () => toggle();
+        button?.addEventListener?.('click', clickHandler);
+        apply();
+
+        function stop() {
+            button?.removeEventListener?.('click', clickHandler);
+        }
+
+        return Object.freeze({
+            isDm: Boolean(isDm),
+            isActive: () => Boolean(isDm && mapData.dmEditMode.active),
+            setActive,
+            toggle,
+            apply,
+            stop,
+        });
+    }
+
+    return Object.freeze({ createController });
+});

--- a/js/vtt/engine.js
+++ b/js/vtt/engine.js
@@ -12,7 +12,7 @@ export class Engine {
 
         this.activeZ = 0;
         this.isRunning = false;
-        this.baseVisionRadius = 400;
+        this.legacyVisionRadius = 400;
         this.isExporting = false;
         this.tokenDrag = null;
 
@@ -32,6 +32,14 @@ export class Engine {
 
     get topologyRules() {
         return globalThis.LuminousVttTopology || null;
+    }
+
+    get racialSenseRules() {
+        return globalThis.LuminousRacialSenseRuntime || null;
+    }
+
+    get spatialVisionRules() {
+        return globalThis.LuminousVttSpatialVision || null;
     }
 
     init() {
@@ -58,6 +66,13 @@ export class Engine {
             this.mapData.grid,
             this.activeZ,
         );
+    }
+
+    viewerToken() {
+        return (this.mapData.tokens || []).find((token) => token.viewer === true)
+            || (this.mapData.tokens || []).find((token) => token.draggable !== false)
+            || this.mapData.tokens?.[0]
+            || null;
     }
 
     handleTokenMouseDown(event) {
@@ -110,12 +125,14 @@ export class Engine {
         if (result.valid) {
             token.x = result.x;
             token.y = result.y;
-            token.gridPosition = { col: result.col, row: result.row, z: token.z?.[0] ?? 0 };
+            const zLayer = this.spatialVisionRules?.layerOf?.(token) ?? token.z?.[0] ?? 0;
+            token.zLayer = zLayer;
+            token.gridPosition = { col: result.col, row: result.row, z: zLayer };
             this.canvas.dispatchEvent(new CustomEvent('vtt:token-moved', {
                 detail: {
                     tokenId: token.id,
                     from: { x: drag.originX, y: drag.originY },
-                    to: { x: token.x, y: token.y, ...token.gridPosition },
+                    to: { x: token.x, y: token.y, ...token.gridPosition, elevationFt: token.elevationFt ?? 0 },
                 },
             }));
         } else {
@@ -174,68 +191,122 @@ export class Engine {
         ];
     }
 
-    calculateVision() {
-        const player = this.mapData.tokens[0];
-        if (!player) return null;
+    ambientLightLevel() {
+        return String(this.mapData.ambientLight?.level || 'bright').toLowerCase();
+    }
 
-        const isLookingAway = this.activeZ !== player.z[0];
-        const currentVisionRadius = isLookingAway ? (this.baseVisionRadius * 0.5) : this.baseVisionRadius;
-        const visionWalls = this.visionWallsForLayer(this.activeZ);
+    visionProfile(player) {
+        const senseRules = this.racialSenseRules;
+        const spatial = this.spatialVisionRules;
+        const senses = player.senses || senseRules?.resolveCharacterSenses?.(player) || { darkvisionFt: 0 };
+        const ambient = this.ambientLightLevel();
+        const crossLayer = (spatial?.layerOf?.(player) ?? player.z?.[0] ?? 0) !== this.activeZ;
 
-        const points = [];
-        for (const wall of visionWalls) {
-            points.push({x: wall.x1, y: wall.y1});
-            points.push({x: wall.x2, y: wall.y2});
+        if (ambient === 'darkness') {
+            const darkvisionFt = Number(senses.darkvisionFt) || 0;
+            if (darkvisionFt <= 0) {
+                return { visible: false, radiusPx: 0, monochrome: false, mode: 'none', senses, crossLayer };
+            }
+            const radiusPx = spatial?.horizontalRadiusPxForRange?.(darkvisionFt, player, this.activeZ, this.mapData)
+                ?? ((darkvisionFt / (this.mapData.grid.distancePerCell || 5)) * this.mapData.grid.size);
+            if (radiusPx <= 0) {
+                return { visible: false, radiusPx: 0, monochrome: false, mode: 'none', senses, crossLayer };
+            }
+            return { visible: true, radiusPx, monochrome: true, mode: 'darkvision', senses, crossLayer };
         }
 
+        return {
+            visible: true,
+            radiusPx: this.legacyVisionRadius,
+            monochrome: false,
+            mode: ambient === 'dim' ? 'normal_dim' : 'normal',
+            senses,
+            crossLayer,
+        };
+    }
+
+    verticalPortalPoints(player) {
+        const spatial = this.spatialVisionRules;
+        if (!spatial) return [];
+        const fromLayer = spatial.layerOf(player);
+        if (fromLayer === this.activeZ) return [];
+        return (this.mapData.verticalPortals || [])
+            .filter((portal) => spatial.portalConnects(portal, fromLayer, this.activeZ) && spatial.portalAllows(portal, 'vision'))
+            .flatMap((portal) => [
+                spatial.vertexToPoint(portal.from || portal.a, this.mapData),
+                spatial.vertexToPoint(portal.to || portal.b, this.mapData),
+            ]);
+    }
+
+    calculateVision() {
+        const player = this.viewerToken();
+        if (!player) return null;
+
+        const profile = this.visionProfile(player);
+        const center = { x: player.x, y: player.y };
+        if (!profile.visible) {
+            return {
+                fovPolygon: [],
+                visionRadius: 0,
+                tokenPos: center,
+                visible: false,
+                monochrome: false,
+                perceptionMode: 'none',
+                crossLayer: profile.crossLayer,
+                senses: profile.senses,
+            };
+        }
+
+        const currentVisionRadius = profile.radiusPx;
+        const visionWalls = this.visionWallsForLayer(this.activeZ);
+        const points = [];
+        for (const wall of visionWalls) {
+            points.push({ x: wall.x1, y: wall.y1 });
+            points.push({ x: wall.x2, y: wall.y2 });
+        }
+        points.push(...this.verticalPortalPoints(player));
+
         const margin = currentVisionRadius + 10;
-        points.push({x: player.x - margin, y: player.y - margin});
-        points.push({x: player.x + margin, y: player.y - margin});
-        points.push({x: player.x + margin, y: player.y + margin});
-        points.push({x: player.x - margin, y: player.y + margin});
+        points.push({ x: player.x - margin, y: player.y - margin });
+        points.push({ x: player.x + margin, y: player.y - margin });
+        points.push({ x: player.x + margin, y: player.y + margin });
+        points.push({ x: player.x - margin, y: player.y + margin });
 
         const bounds = [
-            { a: {x: player.x - margin, y: player.y - margin}, b: {x: player.x + margin, y: player.y - margin} },
-            { a: {x: player.x + margin, y: player.y - margin}, b: {x: player.x + margin, y: player.y + margin} },
-            { a: {x: player.x + margin, y: player.y + margin}, b: {x: player.x - margin, y: player.y + margin} },
-            { a: {x: player.x - margin, y: player.y + margin}, b: {x: player.x - margin, y: player.y - margin} }
+            { a: { x: player.x - margin, y: player.y - margin }, b: { x: player.x + margin, y: player.y - margin } },
+            { a: { x: player.x + margin, y: player.y - margin }, b: { x: player.x + margin, y: player.y + margin } },
+            { a: { x: player.x + margin, y: player.y + margin }, b: { x: player.x - margin, y: player.y + margin } },
+            { a: { x: player.x - margin, y: player.y + margin }, b: { x: player.x - margin, y: player.y - margin } },
         ];
 
         let angles = [];
-        for (const pt of points) {
-            const angle = Math.atan2(pt.y - player.y, pt.x - player.x);
-            angles.push(angle - 0.00001);
-            angles.push(angle);
-            angles.push(angle + 0.00001);
+        for (const point of points) {
+            const angle = Math.atan2(point.y - player.y, point.x - player.x);
+            angles.push(angle - 0.00001, angle, angle + 0.00001);
         }
-
         angles = [...new Set(angles)].sort((a, b) => a - b);
 
         const fovPolygon = [];
-        const center = { x: player.x, y: player.y };
-
+        const spatial = this.spatialVisionRules;
         for (const angle of angles) {
             const dx = Math.cos(angle);
             const dy = Math.sin(angle);
             const rayLength = margin * 2;
-
             const ray = {
                 a: center,
-                b: { x: center.x + dx * rayLength, y: center.y + dy * rayLength }
+                b: { x: center.x + dx * rayLength, y: center.y + dy * rayLength },
             };
 
             let closestIntersect = null;
             let minT = Infinity;
-
             for (const wall of visionWalls) {
-                const segment = { a: {x: wall.x1, y: wall.y1}, b: {x: wall.x2, y: wall.y2} };
+                const segment = { a: { x: wall.x1, y: wall.y1 }, b: { x: wall.x2, y: wall.y2 } };
                 const intersect = getIntersection(ray, segment);
                 if (intersect && intersect.param < minT) {
                     minT = intersect.param;
                     closestIntersect = intersect;
                 }
             }
-
             for (const bound of bounds) {
                 const intersect = getIntersection(ray, bound);
                 if (intersect && intersect.param < minT) {
@@ -244,14 +315,22 @@ export class Engine {
                 }
             }
 
-            if (closestIntersect) fovPolygon.push(closestIntersect);
+            if (!closestIntersect) continue;
+            if (profile.crossLayer && spatial
+                && !spatial.canTraverseLayers(player, closestIntersect, this.activeZ, this.mapData, 'vision')) continue;
+            fovPolygon.push(closestIntersect);
         }
 
+        const visible = !profile.crossLayer || fovPolygon.length >= 3;
         return {
             fovPolygon,
             visionRadius: currentVisionRadius,
             tokenPos: center,
-            isLookingAway
+            visible,
+            monochrome: profile.monochrome,
+            perceptionMode: profile.mode,
+            crossLayer: profile.crossLayer,
+            senses: profile.senses,
         };
     }
 

--- a/js/vtt/engine.js
+++ b/js/vtt/engine.js
@@ -15,6 +15,7 @@ export class Engine {
         this.legacyVisionRadius = 400;
         this.isExporting = false;
         this.tokenDrag = null;
+        this.tokenControlResolver = null;
 
         this.handleResize = this.handleResize.bind(this);
         this.handleTokenMouseDown = this.handleTokenMouseDown.bind(this);
@@ -26,20 +27,14 @@ export class Engine {
         this.init();
     }
 
-    get tokenRules() {
-        return globalThis.LuminousVttTokenInteraction || null;
-    }
+    get tokenRules() { return globalThis.LuminousVttTokenInteraction || null; }
+    get topologyRules() { return globalThis.LuminousVttTopology || null; }
+    get racialSenseRules() { return globalThis.LuminousRacialSenseRuntime || null; }
+    get spatialVisionRules() { return globalThis.LuminousVttSpatialVision || null; }
+    get verticalMovementRules() { return globalThis.LuminousVttVerticalMovement || null; }
 
-    get topologyRules() {
-        return globalThis.LuminousVttTopology || null;
-    }
-
-    get racialSenseRules() {
-        return globalThis.LuminousRacialSenseRuntime || null;
-    }
-
-    get spatialVisionRules() {
-        return globalThis.LuminousVttSpatialVision || null;
+    setTokenControlResolver(resolver) {
+        this.tokenControlResolver = typeof resolver === 'function' ? resolver : null;
     }
 
     init() {
@@ -47,7 +42,6 @@ export class Engine {
         this.canvas.addEventListener('mousedown', this.handleTokenMouseDown);
         window.addEventListener('mousemove', this.handleTokenMouseMove);
         window.addEventListener('mouseup', this.handleTokenMouseUp);
-
         this.handleResize();
         this.centerCamera();
     }
@@ -65,6 +59,7 @@ export class Engine {
             this.eventWorldPoint(event),
             this.mapData.grid,
             this.activeZ,
+            this.tokenControlResolver,
         );
     }
 
@@ -85,6 +80,8 @@ export class Engine {
             token,
             originX: token.x,
             originY: token.y,
+            originZ: Number(token.zLayer ?? token.gridPosition?.z ?? token.z?.[0] ?? 0),
+            originElevationFt: Number(token.elevationFt ?? 0),
             grabOffsetX: worldPoint.x - token.x,
             grabOffsetY: worldPoint.y - token.y,
         };
@@ -97,7 +94,6 @@ export class Engine {
             this.canvas.style.cursor = this.tokenAtEvent(event) ? 'grab' : 'default';
             return;
         }
-
         const worldPoint = this.eventWorldPoint(event);
         this.tokenDrag.token.x = worldPoint.x - this.tokenDrag.grabOffsetX;
         this.tokenDrag.token.y = worldPoint.y - this.tokenDrag.grabOffsetY;
@@ -127,17 +123,48 @@ export class Engine {
             token.y = result.y;
             const zLayer = this.spatialVisionRules?.layerOf?.(token) ?? token.z?.[0] ?? 0;
             token.zLayer = zLayer;
+            token.z = [Number(zLayer)];
             token.gridPosition = { col: result.col, row: result.row, z: zLayer };
+
+            const transition = this.verticalMovementRules?.transitionOnDrop?.(
+                token,
+                { x: token.x, y: token.y },
+                this.mapData,
+            ) || { valid: false, reason: 'NO_VERTICAL_TRANSITION' };
+
+            if (transition.valid && transition.complete && token.viewer === true) this.setZLayer(transition.targetZ);
+
             this.canvas.dispatchEvent(new CustomEvent('vtt:token-moved', {
                 detail: {
                     tokenId: token.id,
-                    from: { x: drag.originX, y: drag.originY },
-                    to: { x: token.x, y: token.y, ...token.gridPosition, elevationFt: token.elevationFt ?? 0 },
+                    from: { x: drag.originX, y: drag.originY, z: drag.originZ, elevationFt: drag.originElevationFt },
+                    to: {
+                        x: token.x,
+                        y: token.y,
+                        ...token.gridPosition,
+                        elevationFt: token.elevationFt ?? 0,
+                        verticalMovement: token.verticalMovement || null,
+                    },
+                    transition: transition.valid ? {
+                        routeId: transition.route?.id || null,
+                        complete: Boolean(transition.complete),
+                        targetZ: transition.targetZ,
+                        costSpentFt: transition.costSpentFt ?? null,
+                    } : null,
                 },
             }));
+
+            if (transition.valid) {
+                this.canvas.dispatchEvent(new CustomEvent('vtt:token-z-transition', {
+                    detail: { tokenId: token.id, ...transition },
+                }));
+            }
         } else {
             token.x = drag.originX;
             token.y = drag.originY;
+            token.zLayer = drag.originZ;
+            token.z = [drag.originZ];
+            token.elevationFt = drag.originElevationFt;
         }
 
         this.tokenDrag = null;
@@ -148,7 +175,6 @@ export class Engine {
         const { cols, rows, size } = this.mapData.grid;
         const mapWidth = cols * size;
         const mapHeight = rows * size;
-
         this.camera.x = (this.canvas.width / 2) - (mapWidth / 2);
         this.camera.y = (this.canvas.height / 2) - (mapHeight / 2);
     }
@@ -165,19 +191,12 @@ export class Engine {
         }
     }
 
-    stop() {
-        this.isRunning = false;
-    }
+    stop() { this.isRunning = false; }
 
     loop() {
         if (!this.isRunning) return;
-
         const renderData = this.calculateVision();
-
-        if (!this.isExporting) {
-            this.renderer.render(this.camera, this.activeZ, renderData, this.isExporting);
-        }
-
+        if (!this.isExporting) this.renderer.render(this.camera, this.activeZ, renderData, this.isExporting);
         requestAnimationFrame(this.loop);
     }
 
@@ -185,15 +204,10 @@ export class Engine {
         const legacy = (this.mapData.walls || []).filter((wall) => wall.z.includes(zLayer) && wall.blocksVision);
         const topology = this.topologyRules;
         if (!topology || !Array.isArray(this.mapData.topology)) return legacy;
-        return [
-            ...legacy,
-            ...topology.blockingSegments(this.mapData.topology, 'vision', zLayer, this.mapData.grid),
-        ];
+        return [...legacy, ...topology.blockingSegments(this.mapData.topology, 'vision', zLayer, this.mapData.grid)];
     }
 
-    ambientLightLevel() {
-        return String(this.mapData.ambientLight?.level || 'bright').toLowerCase();
-    }
+    ambientLightLevel() { return String(this.mapData.ambientLight?.level || 'bright').toLowerCase(); }
 
     visionProfile(player) {
         const senseRules = this.racialSenseRules;
@@ -204,14 +218,10 @@ export class Engine {
 
         if (ambient === 'darkness') {
             const darkvisionFt = Number(senses.darkvisionFt) || 0;
-            if (darkvisionFt <= 0) {
-                return { visible: false, radiusPx: 0, monochrome: false, mode: 'none', senses, crossLayer };
-            }
+            if (darkvisionFt <= 0) return { visible: false, radiusPx: 0, monochrome: false, mode: 'none', senses, crossLayer };
             const radiusPx = spatial?.horizontalRadiusPxForRange?.(darkvisionFt, player, this.activeZ, this.mapData)
                 ?? ((darkvisionFt / (this.mapData.grid.distancePerCell || 5)) * this.mapData.grid.size);
-            if (radiusPx <= 0) {
-                return { visible: false, radiusPx: 0, monochrome: false, mode: 'none', senses, crossLayer };
-            }
+            if (radiusPx <= 0) return { visible: false, radiusPx: 0, monochrome: false, mode: 'none', senses, crossLayer };
             return { visible: true, radiusPx, monochrome: true, mode: 'darkvision', senses, crossLayer };
         }
 
@@ -246,14 +256,8 @@ export class Engine {
         const center = { x: player.x, y: player.y };
         if (!profile.visible) {
             return {
-                fovPolygon: [],
-                visionRadius: 0,
-                tokenPos: center,
-                visible: false,
-                monochrome: false,
-                perceptionMode: 'none',
-                crossLayer: profile.crossLayer,
-                senses: profile.senses,
+                fovPolygon: [], visionRadius: 0, tokenPos: center, visible: false, monochrome: false,
+                perceptionMode: 'none', crossLayer: profile.crossLayer, senses: profile.senses,
             };
         }
 
@@ -267,10 +271,10 @@ export class Engine {
         points.push(...this.verticalPortalPoints(player));
 
         const margin = currentVisionRadius + 10;
-        points.push({ x: player.x - margin, y: player.y - margin });
-        points.push({ x: player.x + margin, y: player.y - margin });
-        points.push({ x: player.x + margin, y: player.y + margin });
-        points.push({ x: player.x - margin, y: player.y + margin });
+        points.push(
+            { x: player.x - margin, y: player.y - margin }, { x: player.x + margin, y: player.y - margin },
+            { x: player.x + margin, y: player.y + margin }, { x: player.x - margin, y: player.y + margin },
+        );
 
         const bounds = [
             { a: { x: player.x - margin, y: player.y - margin }, b: { x: player.x + margin, y: player.y - margin } },
@@ -289,94 +293,47 @@ export class Engine {
         const fovPolygon = [];
         const spatial = this.spatialVisionRules;
         for (const angle of angles) {
-            const dx = Math.cos(angle);
-            const dy = Math.sin(angle);
-            const rayLength = margin * 2;
-            const ray = {
-                a: center,
-                b: { x: center.x + dx * rayLength, y: center.y + dy * rayLength },
-            };
-
-            let closestIntersect = null;
-            let minT = Infinity;
+            const dx = Math.cos(angle), dy = Math.sin(angle), rayLength = margin * 2;
+            const ray = { a: center, b: { x: center.x + dx * rayLength, y: center.y + dy * rayLength } };
+            let closestIntersect = null, minT = Infinity;
             for (const wall of visionWalls) {
-                const segment = { a: { x: wall.x1, y: wall.y1 }, b: { x: wall.x2, y: wall.y2 } };
-                const intersect = getIntersection(ray, segment);
-                if (intersect && intersect.param < minT) {
-                    minT = intersect.param;
-                    closestIntersect = intersect;
-                }
+                const intersect = getIntersection(ray, { a: { x: wall.x1, y: wall.y1 }, b: { x: wall.x2, y: wall.y2 } });
+                if (intersect && intersect.param < minT) { minT = intersect.param; closestIntersect = intersect; }
             }
             for (const bound of bounds) {
                 const intersect = getIntersection(ray, bound);
-                if (intersect && intersect.param < minT) {
-                    minT = intersect.param;
-                    closestIntersect = intersect;
-                }
+                if (intersect && intersect.param < minT) { minT = intersect.param; closestIntersect = intersect; }
             }
-
             if (!closestIntersect) continue;
-            if (profile.crossLayer && spatial
-                && !spatial.canTraverseLayers(player, closestIntersect, this.activeZ, this.mapData, 'vision')) continue;
+            if (profile.crossLayer && spatial && !spatial.canTraverseLayers(player, closestIntersect, this.activeZ, this.mapData, 'vision')) continue;
             fovPolygon.push(closestIntersect);
         }
 
         const visible = !profile.crossLayer || fovPolygon.length >= 3;
         return {
-            fovPolygon,
-            visionRadius: currentVisionRadius,
-            tokenPos: center,
-            visible,
-            monochrome: profile.monochrome,
-            perceptionMode: profile.mode,
-            crossLayer: profile.crossLayer,
-            senses: profile.senses,
+            fovPolygon, visionRadius: currentVisionRadius, tokenPos: center, visible,
+            monochrome: profile.monochrome, perceptionMode: profile.mode, crossLayer: profile.crossLayer, senses: profile.senses,
         };
     }
 
-    setZLayer(z) {
-        this.activeZ = z;
-    }
+    setZLayer(z) { this.activeZ = Number(z) || 0; }
 
     exportUVTemplate() {
         this.isExporting = true;
-
-        const prevZoom = this.camera.zoom;
-        const prevX = this.camera.x;
-        const prevY = this.camera.y;
-
-        this.camera.zoom = 1;
-        this.camera.x = 0;
-        this.camera.y = 0;
-
-        const prevWidth = this.canvas.width;
-        const prevHeight = this.canvas.height;
+        const prevZoom = this.camera.zoom, prevX = this.camera.x, prevY = this.camera.y;
+        this.camera.zoom = 1; this.camera.x = 0; this.camera.y = 0;
+        const prevWidth = this.canvas.width, prevHeight = this.canvas.height;
         this.canvas.width = this.mapData.grid.cols * this.mapData.grid.size;
         this.canvas.height = this.mapData.grid.rows * this.mapData.grid.size;
-
         this.renderer.render(this.camera, this.activeZ, null, this.isExporting);
-
         const dataURL = this.canvas.toDataURL('image/png');
         const filename = `Plantilla_Z${this.activeZ}_${this.canvas.width}x${this.canvas.height}_Grid70px.png`;
-
         const link = document.createElement('a');
-        link.href = dataURL;
-        link.download = filename;
-
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-
-        this.camera.zoom = prevZoom;
-        this.camera.x = prevX;
-        this.camera.y = prevY;
-
-        this.canvas.width = prevWidth;
-        this.canvas.height = prevHeight;
-
+        link.href = dataURL; link.download = filename;
+        document.body.appendChild(link); link.click(); document.body.removeChild(link);
+        this.camera.zoom = prevZoom; this.camera.x = prevX; this.camera.y = prevY;
+        this.canvas.width = prevWidth; this.canvas.height = prevHeight;
         this.isExporting = false;
-
-        const renderData = this.calculateVision();
-        this.renderer.render(this.camera, this.activeZ, renderData, this.isExporting);
+        this.renderer.render(this.camera, this.activeZ, this.calculateVision(), this.isExporting);
     }
 }

--- a/js/vtt/main.js
+++ b/js/vtt/main.js
@@ -10,6 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
     }
 
+    mockMapData.dmEditMode ||= { active: false };
     const engine = new Engine(canvas, mockMapData);
     let controller = null;
     let verticalController = null;
@@ -39,11 +40,24 @@ document.addEventListener('DOMContentLoaded', () => {
         notify: (message, mode) => verticalController?.notify(message, mode),
     });
 
-    // Vertical controller binds capture listeners first so an active Z tool wins over
-    // topology selection or token dragging. When no vertical tool is active it yields.
+    // Z tools bind first so an active vertical authoring tool wins over topology/token drag.
     verticalController = new VerticalPortalController(canvas, engine, mockMapData, verticalBridge);
     controller = new TopologyController(canvas, engine, mockMapData, bridge);
     verticalController.setTopologyController(controller);
+
+    const tokenControlApi = globalThis.LuminousVttTokenControl;
+    engine.setTokenControlResolver(tokenControlApi?.createResolver?.({ isDm: bridge.isDm }) || null);
+    if (!bridge.isDm) {
+        const viewer = (mockMapData.tokens || []).find((token) => token.characterLink?.mode === 'current_player');
+        if (viewer) viewer.viewer = true;
+    }
+
+    const editMode = globalThis.LuminousVttDmEditMode?.createController?.({
+        isDm: bridge.isDm,
+        mapData: mockMapData,
+        topologyController: controller,
+        verticalPortalController: verticalController,
+    }) || null;
 
     bridge.start();
     verticalBridge.start();
@@ -58,11 +72,19 @@ document.addEventListener('DOMContentLoaded', () => {
     const checkPortal = globalThis.LuminousVttCheckPortal?.start?.() || null;
 
     const exportBtn = document.getElementById('btn-export-uv');
-    if (exportBtn) {
-        exportBtn.addEventListener('click', () => {
-            engine.exportUVTemplate();
-        });
-    }
+    exportBtn?.addEventListener('click', () => engine.exportUVTemplate());
+
+    const applyLayer = (zLayer) => {
+        engine.setZLayer(zLayer);
+        controller.handleTopologyChanged();
+        verticalController.handleLayerChanged();
+    };
+
+    canvas.addEventListener('vtt:token-z-transition', (event) => {
+        const detail = event.detail || {};
+        const token = (mockMapData.tokens || []).find((entry) => String(entry.id) === String(detail.tokenId));
+        if (detail.complete && token?.viewer === true && Number.isFinite(Number(detail.targetZ))) applyLayer(Number(detail.targetZ));
+    });
 
     engine.start();
 
@@ -72,23 +94,16 @@ document.addEventListener('DOMContentLoaded', () => {
         bridge,
         verticalController,
         verticalBridge,
+        editMode,
         characterVisionBridge,
     });
 
-    const applyLayer = (zLayer) => {
-        engine.setZLayer(zLayer);
-        controller.handleTopologyChanged();
-        verticalController.handleLayerChanged();
-    };
-
     window.addEventListener('keydown', (event) => {
-        if (event.key === '0') {
-            applyLayer(0);
-        } else if (event.key === '1') {
-            applyLayer(1);
-        } else if (event.key === '2') {
-            applyLayer(2);
-        } else if (event.key === 'Escape') {
+        if (event.key === '0') applyLayer(0);
+        else if (event.key === '1') applyLayer(1);
+        else if (event.key === '2') applyLayer(2);
+        else if ((event.key === 'e' || event.key === 'E') && bridge.isDm && !event.ctrlKey && !event.metaKey && !event.altKey) editMode?.toggle?.();
+        else if (event.key === 'Escape') {
             controller.hideContextMenu();
             controller.setTool('select');
             verticalController.setTool('select', false);
@@ -96,6 +111,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     window.addEventListener('beforeunload', () => {
+        editMode?.stop?.();
         characterVisionBridge?.stop?.();
         verticalController.destroy();
         verticalBridge.stop();

--- a/js/vtt/main.js
+++ b/js/vtt/main.js
@@ -1,5 +1,6 @@
 import { Engine } from './engine.js';
 import { TopologyController } from './topology-controller.js';
+import { VerticalPortalController } from './vertical-portal-controller.js';
 import { mockMapData } from './mapData.js';
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -11,6 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const engine = new Engine(canvas, mockMapData);
     let controller = null;
+    let verticalController = null;
 
     const stateApi = globalThis.LuminousVttStateBridge;
     if (!stateApi) {
@@ -24,8 +26,27 @@ document.addEventListener('DOMContentLoaded', () => {
         notify: (message, mode) => controller?.notify(message, mode),
     });
 
+    const verticalStateApi = globalThis.LuminousVttVerticalPortalState;
+    if (!verticalStateApi) {
+        console.error('VTT vertical portal state bridge not found.');
+        return;
+    }
+
+    const verticalBridge = verticalStateApi.createBridge({
+        mapData: mockMapData,
+        isDm: bridge.isDm,
+        onChanged: () => verticalController?.handlePortalsChanged(),
+        notify: (message, mode) => verticalController?.notify(message, mode),
+    });
+
+    // Vertical controller binds capture listeners first so an active Z tool wins over
+    // topology selection or token dragging. When no vertical tool is active it yields.
+    verticalController = new VerticalPortalController(canvas, engine, mockMapData, verticalBridge);
     controller = new TopologyController(canvas, engine, mockMapData, bridge);
+    verticalController.setTopologyController(controller);
+
     bridge.start();
+    verticalBridge.start();
 
     const characterVisionApi = globalThis.LuminousVttCharacterVisionBridge;
     const characterVisionBridge = characterVisionApi?.createBridge?.({
@@ -49,27 +70,35 @@ document.addEventListener('DOMContentLoaded', () => {
         engine,
         controller,
         bridge,
+        verticalController,
+        verticalBridge,
         characterVisionBridge,
     });
 
+    const applyLayer = (zLayer) => {
+        engine.setZLayer(zLayer);
+        controller.handleTopologyChanged();
+        verticalController.handleLayerChanged();
+    };
+
     window.addEventListener('keydown', (event) => {
         if (event.key === '0') {
-            engine.setZLayer(0);
-            controller.handleTopologyChanged();
+            applyLayer(0);
         } else if (event.key === '1') {
-            engine.setZLayer(1);
-            controller.handleTopologyChanged();
+            applyLayer(1);
         } else if (event.key === '2') {
-            engine.setZLayer(2);
-            controller.handleTopologyChanged();
+            applyLayer(2);
         } else if (event.key === 'Escape') {
             controller.hideContextMenu();
             controller.setTool('select');
+            verticalController.setTool('select', false);
         }
     });
 
     window.addEventListener('beforeunload', () => {
         characterVisionBridge?.stop?.();
+        verticalController.destroy();
+        verticalBridge.stop();
         bridge.stop();
         checkPortal?.stop?.();
         engine.stop();

--- a/js/vtt/main.js
+++ b/js/vtt/main.js
@@ -26,6 +26,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
     controller = new TopologyController(canvas, engine, mockMapData, bridge);
     bridge.start();
+
+    const characterVisionApi = globalThis.LuminousVttCharacterVisionBridge;
+    const characterVisionBridge = characterVisionApi?.createBridge?.({
+        mapData: mockMapData,
+        onSensesChanged: () => {},
+    }) || null;
+    characterVisionBridge?.start?.();
+
     const checkPortal = globalThis.LuminousVttCheckPortal?.start?.() || null;
 
     const exportBtn = document.getElementById('btn-export-uv');
@@ -41,6 +49,7 @@ document.addEventListener('DOMContentLoaded', () => {
         engine,
         controller,
         bridge,
+        characterVisionBridge,
     });
 
     window.addEventListener('keydown', (event) => {
@@ -60,6 +69,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     window.addEventListener('beforeunload', () => {
+        characterVisionBridge?.stop?.();
         bridge.stop();
         checkPortal?.stop?.();
         engine.stop();

--- a/js/vtt/mapData.js
+++ b/js/vtt/mapData.js
@@ -3,8 +3,31 @@ export const mockMapData = {
     grid: {
         cols: 30,
         rows: 30,
-        size: 70
+        size: 70,
+        distancePerCell: 5,
+        distanceUnit: 'ft'
     },
+    ambientLight: {
+        level: 'bright'
+    },
+    defaultZStepFt: 15,
+    zLevels: {
+        0: { zLayer: 0, elevationFt: 0, label: 'Street' },
+        1: { zLayer: 1, elevationFt: 15, label: 'Upper Floor' },
+        2: { zLayer: 2, elevationFt: 30, label: 'Roof' }
+    },
+    verticalPortals: [
+        {
+            id: 'balcony_demo',
+            type: 'balcony_edge',
+            between: [0, 1],
+            from: { col: 2, row: 7 },
+            to: { col: 7, row: 7 },
+            blocksVision: false,
+            blocksLight: false,
+            state: 'open'
+        }
+    ],
     walls: [
         { x1: 0, y1: 0, x2: 2100, y2: 0, z: [0, 1], blocksMovement: true, blocksVision: true },
         { x1: 2100, y1: 0, x2: 2100, y2: 2100, z: [0, 1], blocksMovement: true, blocksVision: true },
@@ -59,6 +82,9 @@ export const mockMapData = {
             iconColor: '#ffffff',
             icon: 'person',
             draggable: true,
+            characterLink: { mode: 'current_player' },
+            elevationFt: 0,
+            zLayer: 0,
             gridPosition: { col: 3, row: 3, z: 0 },
             z: [0]
         }

--- a/js/vtt/renderer.js
+++ b/js/vtt/renderer.js
@@ -119,6 +119,66 @@ export class Renderer {
         }
     }
 
+    verticalPortalStyle(portal, preview = false, selected = false) {
+        if (preview) return { stroke: '#ffffff', width: 5, dash: [8, 5] };
+        const styles = {
+            opening: { stroke: '#ff66d9', width: 6, dash: [5, 5] },
+            balcony_edge: { stroke: '#5dff9a', width: 6, dash: [12, 6] },
+            stairs: { stroke: '#7fd6ff', width: 7, dash: [3, 4] },
+        };
+        const base = styles[portal.type] || styles.opening;
+        return selected ? { ...base, stroke: '#ffffff', width: base.width + 2 } : base;
+    }
+
+    drawVerticalPortalElement(rawPortal, zLayer, preview = false) {
+        const runtime = globalThis.LuminousVttVerticalPortal;
+        if (!runtime || !rawPortal) return;
+        const portal = preview ? rawPortal : runtime.normalizePortal(rawPortal, this.mapData);
+        if (!runtime.portalOnLayer(portal, zLayer)) return;
+        const line = runtime.segment(portal, this.mapData);
+        const selectedId = this.mapData.verticalPortalEditor?.selectedId;
+        const selected = !preview && String(selectedId || '') === String(portal.id || '');
+        const style = this.verticalPortalStyle(portal, preview, selected);
+        const ctx = this.ctx;
+
+        ctx.save();
+        ctx.globalAlpha = preview ? 0.82 : 0.92;
+        ctx.strokeStyle = style.stroke;
+        ctx.lineWidth = style.width;
+        ctx.lineCap = 'round';
+        ctx.setLineDash(style.dash || []);
+        ctx.beginPath();
+        ctx.moveTo(line.x1, line.y1);
+        ctx.lineTo(line.x2, line.y2);
+        ctx.stroke();
+        ctx.setLineDash([]);
+
+        if (!preview) {
+            const mx = (line.x1 + line.x2) / 2;
+            const my = (line.y1 + line.y2) / 2;
+            const other = runtime.otherLayer(portal, zLayer);
+            const label = `${runtime.labelFor(portal)} · Z${other}`;
+            ctx.font = 'bold 10px monospace';
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'middle';
+            const metrics = ctx.measureText(label);
+            ctx.fillStyle = 'rgba(0,0,0,.86)';
+            ctx.fillRect(mx - (metrics.width / 2) - 5, my - 9, metrics.width + 10, 18);
+            ctx.fillStyle = style.stroke;
+            ctx.fillText(label, mx, my);
+        }
+        ctx.restore();
+    }
+
+    drawVerticalPortalGuides(zLayer) {
+        if (!this.mapData.verticalPortalEditor?.visible) return;
+        for (const portal of Array.isArray(this.mapData.verticalPortals) ? this.mapData.verticalPortals : []) {
+            this.drawVerticalPortalElement(portal, zLayer, false);
+        }
+        const preview = this.mapData.verticalPortalEditor?.preview;
+        if (preview) this.drawVerticalPortalElement(preview, zLayer, true);
+    }
+
     drawPersonIcon(token, radius) {
         const ctx = this.ctx;
         const iconColor = token.iconColor || '#ffffff';
@@ -169,7 +229,15 @@ export class Renderer {
             return;
         }
 
-        if (!renderData || renderData.visible === false) return;
+        if (!renderData || renderData.visible === false) {
+            if (this.mapData.verticalPortalEditor?.visible) {
+                this.ctx.save();
+                camera.applyTransformSimple(this.ctx);
+                this.drawVerticalPortalGuides(activeZ);
+                this.ctx.restore();
+            }
+            return;
+        }
         const { fovPolygon, visionRadius, tokenPos, monochrome } = renderData;
         if (!fovPolygon || fovPolygon.length < 3 || visionRadius <= 0) return;
 
@@ -199,5 +267,12 @@ export class Renderer {
         this.drawTopology(activeZ, false);
         this.drawTokens(activeZ);
         this.ctx.restore();
+
+        if (this.mapData.verticalPortalEditor?.visible) {
+            this.ctx.save();
+            camera.applyTransformSimple(this.ctx);
+            this.drawVerticalPortalGuides(activeZ);
+            this.ctx.restore();
+        }
     }
 }

--- a/js/vtt/renderer.js
+++ b/js/vtt/renderer.js
@@ -17,40 +17,24 @@ export class Renderer {
         const { cols, rows, size } = this.mapData.grid;
         const width = cols * size;
         const height = rows * size;
-
         this.ctx.strokeStyle = isExporting ? 'rgba(0, 0, 0, 0.2)' : 'rgba(255, 255, 255, 0.2)';
         this.ctx.lineWidth = 1;
-
         this.ctx.beginPath();
-        for (let x = 0; x <= cols; x++) {
-            this.ctx.moveTo(x * size, 0);
-            this.ctx.lineTo(x * size, height);
-        }
-        for (let y = 0; y <= rows; y++) {
-            this.ctx.moveTo(0, y * size);
-            this.ctx.lineTo(width, y * size);
-        }
+        for (let x = 0; x <= cols; x++) { this.ctx.moveTo(x * size, 0); this.ctx.lineTo(x * size, height); }
+        for (let y = 0; y <= rows; y++) { this.ctx.moveTo(0, y * size); this.ctx.lineTo(width, y * size); }
         this.ctx.stroke();
     }
 
     drawWalls(zLayer, isOnionSkin = false) {
         if (!this.mapData.walls) return;
         this.ctx.save();
-        if (isOnionSkin) {
-            this.ctx.strokeStyle = '#666666';
-            this.ctx.globalAlpha = 0.3;
-        } else {
-            this.ctx.strokeStyle = '#ff0000';
-            this.ctx.globalAlpha = 1.0;
-        }
+        this.ctx.strokeStyle = isOnionSkin ? '#666666' : '#ff0000';
+        this.ctx.globalAlpha = isOnionSkin ? 0.3 : 1;
         this.ctx.lineWidth = 3;
         this.ctx.lineCap = 'round';
         this.ctx.beginPath();
         for (const wall of this.mapData.walls) {
-            if (wall.z.includes(zLayer)) {
-                this.ctx.moveTo(wall.x1, wall.y1);
-                this.ctx.lineTo(wall.x2, wall.y2);
-            }
+            if (wall.z.includes(zLayer)) { this.ctx.moveTo(wall.x1, wall.y1); this.ctx.lineTo(wall.x2, wall.y2); }
         }
         this.ctx.stroke();
         this.ctx.restore();
@@ -78,11 +62,10 @@ export class Renderer {
         const line = topology.segment(normalized, this.mapData.grid);
         const style = this.topologyStyle(normalized, preview);
         const ctx = this.ctx;
-
         ctx.save();
         ctx.globalAlpha = isOnionSkin ? 0.28 : preview ? 0.75 : 1;
         ctx.strokeStyle = isOnionSkin ? '#6f6f6f' : style.stroke;
-        ctx.lineWidth = style.width;
+        ctx.lineWidth = normalized.type === 'wall' ? Math.max(style.width, Number(line.thicknessPx) || 0) : style.width;
         ctx.lineCap = 'round';
         ctx.setLineDash(style.dash || []);
         ctx.beginPath();
@@ -114,9 +97,7 @@ export class Renderer {
             if (topology.elementOnLayer(element, zLayer)) this.drawTopologyElement(element, isOnionSkin, false);
         });
         const preview = this.mapData.topologyPreview;
-        if (!isOnionSkin && preview && topology.elementOnLayer(preview, zLayer)) {
-            this.drawTopologyElement(preview, false, true);
-        }
+        if (!isOnionSkin && preview && topology.elementOnLayer(preview, zLayer)) this.drawTopologyElement(preview, false, true);
     }
 
     verticalPortalStyle(portal, preview = false, selected = false) {
@@ -130,6 +111,39 @@ export class Renderer {
         return selected ? { ...base, stroke: '#ffffff', width: base.width + 2 } : base;
     }
 
+    stairGuideWidthPx(portal) {
+        const feetPerCell = Math.max(0.001, Number(this.mapData.grid?.distancePerCell) || 5);
+        const size = Math.max(1, Number(this.mapData.grid?.size) || 70);
+        return Math.max(7, ((Number(portal.widthFt) || 5) / feetPerCell) * size * 0.35);
+    }
+
+    drawStairRouteGuide(portal, zLayer, style, preview = false) {
+        const routes = globalThis.LuminousVttStairRoute;
+        const route = routes?.routeFor?.(portal, this.mapData);
+        if (!route?.points?.length) return false;
+        const ctx = this.ctx;
+        ctx.save();
+        ctx.globalAlpha = preview ? 0.82 : 0.9;
+        ctx.strokeStyle = style.stroke;
+        ctx.lineWidth = Math.max(style.width, this.stairGuideWidthPx(portal));
+        ctx.lineCap = 'round';
+        ctx.lineJoin = 'round';
+        ctx.setLineDash(style.dash || []);
+        if (route.layout === 'ladder') {
+            const p = route.points[0];
+            ctx.beginPath();
+            ctx.arc(p.x, p.y, Math.max(8, this.stairGuideWidthPx(portal)), 0, Math.PI * 2);
+            ctx.stroke();
+        } else {
+            ctx.beginPath();
+            ctx.moveTo(route.points[0].x, route.points[0].y);
+            for (let i = 1; i < route.points.length; i += 1) ctx.lineTo(route.points[i].x, route.points[i].y);
+            ctx.stroke();
+        }
+        ctx.restore();
+        return true;
+    }
+
     drawVerticalPortalElement(rawPortal, zLayer, preview = false) {
         const runtime = globalThis.LuminousVttVerticalPortal;
         if (!runtime || !rawPortal) return;
@@ -141,23 +155,30 @@ export class Renderer {
         const style = this.verticalPortalStyle(portal, preview, selected);
         const ctx = this.ctx;
 
-        ctx.save();
-        ctx.globalAlpha = preview ? 0.82 : 0.92;
-        ctx.strokeStyle = style.stroke;
-        ctx.lineWidth = style.width;
-        ctx.lineCap = 'round';
-        ctx.setLineDash(style.dash || []);
-        ctx.beginPath();
-        ctx.moveTo(line.x1, line.y1);
-        ctx.lineTo(line.x2, line.y2);
-        ctx.stroke();
-        ctx.setLineDash([]);
+        if (portal.type === 'stairs' && !preview) this.drawStairRouteGuide(portal, zLayer, style, preview);
+        else {
+            ctx.save();
+            ctx.globalAlpha = preview ? 0.82 : 0.92;
+            ctx.strokeStyle = style.stroke;
+            ctx.lineWidth = style.width;
+            ctx.lineCap = 'round';
+            ctx.setLineDash(style.dash || []);
+            ctx.beginPath();
+            ctx.moveTo(line.x1, line.y1);
+            ctx.lineTo(line.x2, line.y2);
+            ctx.stroke();
+            ctx.restore();
+        }
 
         if (!preview) {
             const mx = (line.x1 + line.x2) / 2;
             const my = (line.y1 + line.y2) / 2;
             const other = runtime.otherLayer(portal, zLayer);
-            const label = `${runtime.labelFor(portal)} · Z${other}`;
+            const route = portal.type === 'stairs' ? globalThis.LuminousVttStairRoute?.routeFor?.(portal, this.mapData) : null;
+            const label = portal.type === 'stairs'
+                ? `${runtime.layoutLabel(portal)} · ${route ? route.pathLengthFt.toFixed(1) + 'ft' : ''} · Z${other}`
+                : `${runtime.labelFor(portal)} · Z${other}`;
+            ctx.save();
             ctx.font = 'bold 10px monospace';
             ctx.textAlign = 'center';
             ctx.textBaseline = 'middle';
@@ -166,15 +187,13 @@ export class Renderer {
             ctx.fillRect(mx - (metrics.width / 2) - 5, my - 9, metrics.width + 10, 18);
             ctx.fillStyle = style.stroke;
             ctx.fillText(label, mx, my);
+            ctx.restore();
         }
-        ctx.restore();
     }
 
     drawVerticalPortalGuides(zLayer) {
         if (!this.mapData.verticalPortalEditor?.visible) return;
-        for (const portal of Array.isArray(this.mapData.verticalPortals) ? this.mapData.verticalPortals : []) {
-            this.drawVerticalPortalElement(portal, zLayer, false);
-        }
+        for (const portal of Array.isArray(this.mapData.verticalPortals) ? this.mapData.verticalPortals : []) this.drawVerticalPortalElement(portal, zLayer, false);
         const preview = this.mapData.verticalPortalEditor?.preview;
         if (preview) this.drawVerticalPortalElement(preview, zLayer, true);
     }
@@ -198,10 +217,14 @@ export class Renderer {
         if (!this.mapData.tokens) return;
         const tokenRules = globalThis.LuminousVttTokenInteraction;
         for (const token of this.mapData.tokens) {
-            const tokenLayer = Number(token.zLayer ?? token.gridPosition?.z ?? token.z?.[0] ?? 0);
-            if (tokenLayer !== Number(zLayer)) continue;
+            if (tokenRules?.tokenOnLayer && !tokenRules.tokenOnLayer(token, zLayer)) continue;
+            if (!tokenRules?.tokenOnLayer) {
+                const tokenLayer = Number(token.zLayer ?? token.gridPosition?.z ?? token.z?.[0] ?? 0);
+                if (tokenLayer !== Number(zLayer)) continue;
+            }
             const radius = tokenRules?.tokenRadius?.(token, this.mapData.grid) || token.radius || (this.mapData.grid.size * 0.4);
             this.ctx.save();
+            if (token.verticalMovement) this.ctx.globalAlpha = 0.82;
             this.ctx.fillStyle = token.backgroundColor || '#20242a';
             this.ctx.beginPath();
             this.ctx.arc(token.x, token.y, radius, 0, Math.PI * 2);
@@ -212,13 +235,19 @@ export class Renderer {
             this.ctx.beginPath();
             this.ctx.arc(token.x, token.y, radius, 0, Math.PI * 2);
             this.ctx.stroke();
+            if (token.verticalMovement) {
+                const label = `${Number(token.elevationFt || 0).toFixed(1)}ft`;
+                this.ctx.font = 'bold 9px monospace';
+                this.ctx.textAlign = 'center';
+                this.ctx.fillStyle = '#ffffff';
+                this.ctx.fillText(label, token.x, token.y + radius + 12);
+            }
             this.ctx.restore();
         }
     }
 
     render(camera, activeZ, renderData, isExporting = false) {
         this.clear(isExporting);
-
         if (isExporting) {
             this.ctx.save();
             camera.applyTransformSimple(this.ctx);
@@ -248,16 +277,13 @@ export class Renderer {
         for (let i = 1; i < fovPolygon.length; i++) this.ctx.lineTo(fovPolygon[i].x, fovPolygon[i].y);
         this.ctx.closePath();
         this.ctx.clip();
-
         this.ctx.beginPath();
         this.ctx.arc(tokenPos.x, tokenPos.y, visionRadius, 0, Math.PI * 2, false);
         this.ctx.clip();
-
         if (monochrome) this.ctx.filter = 'grayscale(1)';
         this.ctx.fillStyle = '#111';
         const cameraRectSize = 10000;
         this.ctx.fillRect(tokenPos.x - cameraRectSize / 2, tokenPos.y - cameraRectSize / 2, cameraRectSize, cameraRectSize);
-
         this.drawGrid();
         if (activeZ > 0) {
             this.drawWalls(activeZ - 1, true);

--- a/js/vtt/renderer.js
+++ b/js/vtt/renderer.js
@@ -119,28 +119,6 @@ export class Renderer {
         }
     }
 
-    drawVerticalPortals(zLayer) {
-        const spatial = globalThis.LuminousVttSpatialVision;
-        if (!spatial || !Array.isArray(this.mapData.verticalPortals)) return;
-        const ctx = this.ctx;
-        ctx.save();
-        ctx.strokeStyle = '#5dff9a';
-        ctx.lineWidth = 4;
-        ctx.setLineDash([7, 5]);
-        for (const portal of this.mapData.verticalPortals) {
-            const layers = spatial.portalLayers(portal);
-            if (!layers.includes(Number(zLayer))) continue;
-            const a = spatial.vertexToPoint(portal.from || portal.a, this.mapData);
-            const b = spatial.vertexToPoint(portal.to || portal.b, this.mapData);
-            ctx.beginPath();
-            ctx.moveTo(a.x, a.y);
-            ctx.lineTo(b.x, b.y);
-            ctx.stroke();
-        }
-        ctx.setLineDash([]);
-        ctx.restore();
-    }
-
     drawPersonIcon(token, radius) {
         const ctx = this.ctx;
         const iconColor = token.iconColor || '#ffffff';
@@ -187,7 +165,6 @@ export class Renderer {
             this.drawGrid(true);
             this.drawWalls(activeZ, false);
             this.drawTopology(activeZ, false);
-            this.drawVerticalPortals(activeZ);
             this.ctx.restore();
             return;
         }
@@ -220,7 +197,6 @@ export class Renderer {
         }
         this.drawWalls(activeZ, false);
         this.drawTopology(activeZ, false);
-        this.drawVerticalPortals(activeZ);
         this.drawTokens(activeZ);
         this.ctx.restore();
     }

--- a/js/vtt/renderer.js
+++ b/js/vtt/renderer.js
@@ -35,9 +35,7 @@ export class Renderer {
 
     drawWalls(zLayer, isOnionSkin = false) {
         if (!this.mapData.walls) return;
-
         this.ctx.save();
-
         if (isOnionSkin) {
             this.ctx.strokeStyle = '#666666';
             this.ctx.globalAlpha = 0.3;
@@ -45,10 +43,8 @@ export class Renderer {
             this.ctx.strokeStyle = '#ff0000';
             this.ctx.globalAlpha = 1.0;
         }
-
         this.ctx.lineWidth = 3;
         this.ctx.lineCap = 'round';
-
         this.ctx.beginPath();
         for (const wall of this.mapData.walls) {
             if (wall.z.includes(zLayer)) {
@@ -57,7 +53,6 @@ export class Renderer {
             }
         }
         this.ctx.stroke();
-
         this.ctx.restore();
     }
 
@@ -73,10 +68,7 @@ export class Renderer {
             curtain_window: { stroke: '#b784ff', width: 7, label: state === 'locked' ? 'C·LOCK' : 'CURTAIN' },
         };
         const base = styles[element.type] || styles.wall;
-        return {
-            ...base,
-            dash: broken ? [5, 7] : open ? [12, 9] : [],
-        };
+        return { ...base, dash: broken ? [5, 7] : open ? [12, 9] : [] };
     }
 
     drawTopologyElement(element, isOnionSkin = false, preview = false) {
@@ -121,22 +113,41 @@ export class Renderer {
         this.mapData.topology.forEach((element) => {
             if (topology.elementOnLayer(element, zLayer)) this.drawTopologyElement(element, isOnionSkin, false);
         });
-
         const preview = this.mapData.topologyPreview;
         if (!isOnionSkin && preview && topology.elementOnLayer(preview, zLayer)) {
             this.drawTopologyElement(preview, false, true);
         }
     }
 
+    drawVerticalPortals(zLayer) {
+        const spatial = globalThis.LuminousVttSpatialVision;
+        if (!spatial || !Array.isArray(this.mapData.verticalPortals)) return;
+        const ctx = this.ctx;
+        ctx.save();
+        ctx.strokeStyle = '#5dff9a';
+        ctx.lineWidth = 4;
+        ctx.setLineDash([7, 5]);
+        for (const portal of this.mapData.verticalPortals) {
+            const layers = spatial.portalLayers(portal);
+            if (!layers.includes(Number(zLayer))) continue;
+            const a = spatial.vertexToPoint(portal.from || portal.a, this.mapData);
+            const b = spatial.vertexToPoint(portal.to || portal.b, this.mapData);
+            ctx.beginPath();
+            ctx.moveTo(a.x, a.y);
+            ctx.lineTo(b.x, b.y);
+            ctx.stroke();
+        }
+        ctx.setLineDash([]);
+        ctx.restore();
+    }
+
     drawPersonIcon(token, radius) {
         const ctx = this.ctx;
         const iconColor = token.iconColor || '#ffffff';
-
         ctx.fillStyle = iconColor;
         ctx.beginPath();
         ctx.arc(token.x, token.y - radius * 0.24, radius * 0.22, 0, Math.PI * 2);
         ctx.fill();
-
         ctx.beginPath();
         ctx.arc(token.x, token.y + radius * 0.46, radius * 0.47, Math.PI, Math.PI * 2);
         ctx.lineTo(token.x + radius * 0.47, token.y + radius * 0.56);
@@ -147,23 +158,17 @@ export class Renderer {
 
     drawTokens(zLayer) {
         if (!this.mapData.tokens) return;
-
         const tokenRules = globalThis.LuminousVttTokenInteraction;
         for (const token of this.mapData.tokens) {
-            if (!token.z.includes(zLayer)) continue;
-
-            const radius = tokenRules?.tokenRadius?.(token, this.mapData.grid)
-                || token.radius
-                || (this.mapData.grid.size * 0.4);
-
+            const tokenLayer = Number(token.zLayer ?? token.gridPosition?.z ?? token.z?.[0] ?? 0);
+            if (tokenLayer !== Number(zLayer)) continue;
+            const radius = tokenRules?.tokenRadius?.(token, this.mapData.grid) || token.radius || (this.mapData.grid.size * 0.4);
             this.ctx.save();
             this.ctx.fillStyle = token.backgroundColor || '#20242a';
             this.ctx.beginPath();
             this.ctx.arc(token.x, token.y, radius, 0, Math.PI * 2);
             this.ctx.fill();
-
             if ((token.icon || 'person') === 'person') this.drawPersonIcon(token, radius);
-
             this.ctx.strokeStyle = token.color || '#ffffff';
             this.ctx.lineWidth = Math.max(2, radius * 0.08);
             this.ctx.beginPath();
@@ -182,73 +187,41 @@ export class Renderer {
             this.drawGrid(true);
             this.drawWalls(activeZ, false);
             this.drawTopology(activeZ, false);
+            this.drawVerticalPortals(activeZ);
             this.ctx.restore();
             return;
         }
 
-        if (!renderData) return;
-
-        const { fovPolygon, visionRadius, tokenPos, isLookingAway } = renderData;
+        if (!renderData || renderData.visible === false) return;
+        const { fovPolygon, visionRadius, tokenPos, monochrome } = renderData;
+        if (!fovPolygon || fovPolygon.length < 3 || visionRadius <= 0) return;
 
         this.ctx.save();
         camera.applyTransformSimple(this.ctx);
+        this.ctx.beginPath();
+        this.ctx.moveTo(fovPolygon[0].x, fovPolygon[0].y);
+        for (let i = 1; i < fovPolygon.length; i++) this.ctx.lineTo(fovPolygon[i].x, fovPolygon[i].y);
+        this.ctx.closePath();
+        this.ctx.clip();
 
-        if (fovPolygon && fovPolygon.length > 0) {
-            this.ctx.beginPath();
-            this.ctx.moveTo(fovPolygon[0].x, fovPolygon[0].y);
-            for (let i = 1; i < fovPolygon.length; i++) {
-                this.ctx.lineTo(fovPolygon[i].x, fovPolygon[i].y);
-            }
-            this.ctx.closePath();
-            this.ctx.clip();
+        this.ctx.beginPath();
+        this.ctx.arc(tokenPos.x, tokenPos.y, visionRadius, 0, Math.PI * 2, false);
+        this.ctx.clip();
 
-            this.ctx.beginPath();
-            this.ctx.arc(tokenPos.x, tokenPos.y, visionRadius, 0, Math.PI * 2, false);
-            this.ctx.clip();
-        }
-
+        if (monochrome) this.ctx.filter = 'grayscale(1)';
         this.ctx.fillStyle = '#111';
         const cameraRectSize = 10000;
-        this.ctx.fillRect(
-            tokenPos.x - cameraRectSize/2,
-            tokenPos.y - cameraRectSize/2,
-            cameraRectSize,
-            cameraRectSize
-        );
+        this.ctx.fillRect(tokenPos.x - cameraRectSize / 2, tokenPos.y - cameraRectSize / 2, cameraRectSize, cameraRectSize);
 
         this.drawGrid();
-
         if (activeZ > 0) {
             this.drawWalls(activeZ - 1, true);
             this.drawTopology(activeZ - 1, true);
         }
-
         this.drawWalls(activeZ, false);
         this.drawTopology(activeZ, false);
+        this.drawVerticalPortals(activeZ);
         this.drawTokens(activeZ);
-
-        if (isLookingAway) {
-            const gradient = this.ctx.createRadialGradient(
-                tokenPos.x, tokenPos.y, visionRadius * 0.5,
-                tokenPos.x, tokenPos.y, visionRadius
-            );
-            gradient.addColorStop(0, 'rgba(0, 0, 0, 0)');
-            gradient.addColorStop(1, 'rgba(0, 0, 0, 0.8)');
-
-            this.ctx.fillStyle = gradient;
-            this.ctx.beginPath();
-            this.ctx.arc(tokenPos.x, tokenPos.y, visionRadius, 0, Math.PI * 2);
-            this.ctx.fill();
-        }
-
         this.ctx.restore();
-
-        if (isLookingAway) {
-            this.ctx.save();
-            camera.applyTransformSimple(this.ctx);
-            this.ctx.globalAlpha = 0.5;
-            this.drawTokens(this.mapData.tokens[0].z[0]);
-            this.ctx.restore();
-        }
     }
 }

--- a/js/vtt/spatial-vision.js
+++ b/js/vtt/spatial-vision.js
@@ -1,0 +1,141 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttSpatialVision = api;
+})(typeof window !== 'undefined' ? window : globalThis, function () {
+  'use strict';
+
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+  function layerOf(entity = {}) {
+    if (Number.isFinite(Number(entity.zLayer))) return Number(entity.zLayer);
+    if (Number.isFinite(Number(entity.gridPosition?.z))) return Number(entity.gridPosition.z);
+    if (Array.isArray(entity.z) && entity.z.length) return Number(entity.z[0]) || 0;
+    return 0;
+  }
+
+  function zLevelRecord(mapData = {}, zLayer) {
+    const levels = mapData.zLevels || {};
+    if (Array.isArray(levels)) return levels.find((entry) => Number(entry?.zLayer ?? entry?.z) === Number(zLayer)) || null;
+    return levels[String(zLayer)] || levels[zLayer] || null;
+  }
+
+  function elevationForLayer(mapData = {}, zLayer) {
+    const record = zLevelRecord(mapData, zLayer);
+    if (record && Number.isFinite(Number(record.elevationFt))) return Number(record.elevationFt);
+    const step = numberOr(mapData.defaultZStepFt, 10);
+    return Number(zLayer || 0) * step;
+  }
+
+  function elevationFt(entity = {}, mapData = {}) {
+    if (Number.isFinite(Number(entity.elevationFt))) return Number(entity.elevationFt);
+    return elevationForLayer(mapData, layerOf(entity));
+  }
+
+  function feetPerPixel(mapData = {}) {
+    const size = Math.max(1, numberOr(mapData.grid?.size, 70));
+    const distancePerCell = Math.max(0.001, numberOr(mapData.grid?.distancePerCell, 5));
+    return distancePerCell / size;
+  }
+
+  function horizontalDistanceFt(a = {}, b = {}, mapData = {}) {
+    return Math.hypot(numberOr(b.x) - numberOr(a.x), numberOr(b.y) - numberOr(a.y)) * feetPerPixel(mapData);
+  }
+
+  function distance3dFt(a = {}, b = {}, mapData = {}) {
+    const horizontal = horizontalDistanceFt(a, b, mapData);
+    const vertical = elevationFt(b, mapData) - elevationFt(a, mapData);
+    return Math.hypot(horizontal, vertical);
+  }
+
+  function horizontalRadiusPxForRange(rangeFt, viewer = {}, targetLayer, mapData = {}) {
+    const range = Math.max(0, numberOr(rangeFt));
+    const fromElevation = elevationFt(viewer, mapData);
+    const toElevation = elevationForLayer(mapData, targetLayer);
+    const vertical = Math.abs(toElevation - fromElevation);
+    if (vertical >= range) return 0;
+    const horizontalFt = Math.sqrt(Math.max(0, (range * range) - (vertical * vertical)));
+    return horizontalFt / feetPerPixel(mapData);
+  }
+
+  function orientation(a, b, c) {
+    return ((numberOr(b.y) - numberOr(a.y)) * (numberOr(c.x) - numberOr(b.x)))
+      - ((numberOr(b.x) - numberOr(a.x)) * (numberOr(c.y) - numberOr(b.y)));
+  }
+
+  function onSegment(a, b, c) {
+    return numberOr(b.x) <= Math.max(numberOr(a.x), numberOr(c.x)) + 1e-9
+      && numberOr(b.x) + 1e-9 >= Math.min(numberOr(a.x), numberOr(c.x))
+      && numberOr(b.y) <= Math.max(numberOr(a.y), numberOr(c.y)) + 1e-9
+      && numberOr(b.y) + 1e-9 >= Math.min(numberOr(a.y), numberOr(c.y));
+  }
+
+  function segmentsIntersect(a, b, c, d) {
+    const o1 = orientation(a, b, c);
+    const o2 = orientation(a, b, d);
+    const o3 = orientation(c, d, a);
+    const o4 = orientation(c, d, b);
+    if (((o1 > 0 && o2 < 0) || (o1 < 0 && o2 > 0)) && ((o3 > 0 && o4 < 0) || (o3 < 0 && o4 > 0))) return true;
+    if (Math.abs(o1) < 1e-9 && onSegment(a, c, b)) return true;
+    if (Math.abs(o2) < 1e-9 && onSegment(a, d, b)) return true;
+    if (Math.abs(o3) < 1e-9 && onSegment(c, a, d)) return true;
+    if (Math.abs(o4) < 1e-9 && onSegment(c, b, d)) return true;
+    return false;
+  }
+
+  function vertexToPoint(vertex = {}, mapData = {}) {
+    const size = Math.max(1, numberOr(mapData.grid?.size, 70));
+    return { x: numberOr(vertex.col) * size, y: numberOr(vertex.row) * size };
+  }
+
+  function portalLayers(portal = {}) {
+    if (Array.isArray(portal.between) && portal.between.length >= 2) return portal.between.slice(0, 2).map(Number);
+    return [Number(portal.fromZ ?? 0), Number(portal.toZ ?? 0)];
+  }
+
+  function portalConnects(portal = {}, fromZ, toZ) {
+    const [a, b] = portalLayers(portal);
+    return (a === Number(fromZ) && b === Number(toZ)) || (a === Number(toZ) && b === Number(fromZ));
+  }
+
+  function portalAllows(portal = {}, kind = 'vision') {
+    if (portal.state === 'closed') return false;
+    const flag = kind === 'light' ? 'blocksLight' : 'blocksVision';
+    return portal[flag] !== true;
+  }
+
+  function rayCrossesPortal(fromPoint, targetPoint, portal = {}, mapData = {}) {
+    const a = portal.a || portal.from;
+    const b = portal.b || portal.to;
+    if (!a || !b) return false;
+    return segmentsIntersect(fromPoint, targetPoint, vertexToPoint(a, mapData), vertexToPoint(b, mapData));
+  }
+
+  function canTraverseLayers(viewer = {}, targetPoint = {}, targetLayer, mapData = {}, kind = 'vision') {
+    const fromLayer = layerOf(viewer);
+    const toLayer = Number(targetLayer);
+    if (fromLayer === toLayer) return true;
+    const portals = Array.isArray(mapData.verticalPortals) ? mapData.verticalPortals : [];
+    return portals.some((portal) => portalConnects(portal, fromLayer, toLayer)
+      && portalAllows(portal, kind)
+      && rayCrossesPortal({ x: numberOr(viewer.x), y: numberOr(viewer.y) }, targetPoint, portal, mapData));
+  }
+
+  return Object.freeze({
+    layerOf,
+    zLevelRecord,
+    elevationForLayer,
+    elevationFt,
+    feetPerPixel,
+    horizontalDistanceFt,
+    distance3dFt,
+    horizontalRadiusPxForRange,
+    segmentsIntersect,
+    vertexToPoint,
+    portalLayers,
+    portalConnects,
+    portalAllows,
+    rayCrossesPortal,
+    canTraverseLayers,
+  });
+});

--- a/js/vtt/spatial-vision.js
+++ b/js/vtt/spatial-vision.js
@@ -1,11 +1,19 @@
 (function (root, factory) {
-  const api = factory();
+  const api = factory(root);
   if (typeof module !== 'undefined' && module.exports) module.exports = api;
   if (root) root.LuminousVttSpatialVision = api;
-})(typeof window !== 'undefined' ? window : globalThis, function () {
+})(typeof window !== 'undefined' ? window : globalThis, function (root) {
   'use strict';
 
   const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+  function stairRuntime() {
+    if (root?.LuminousVttStairRoute) return root.LuminousVttStairRoute;
+    if (typeof require !== 'undefined') {
+      try { return require('./stair-route.js'); } catch (_) {}
+    }
+    return null;
+  }
 
   function layerOf(entity = {}) {
     if (Number.isFinite(Number(entity.zLayer))) return Number(entity.zLayer);
@@ -108,7 +116,20 @@
     const a = portal.a || portal.from;
     const b = portal.b || portal.to;
     if (!a || !b) return false;
-    return segmentsIntersect(fromPoint, targetPoint, vertexToPoint(a, mapData), vertexToPoint(b, mapData));
+
+    const originalA = vertexToPoint(a, mapData);
+    const originalB = vertexToPoint(b, mapData);
+    if (segmentsIntersect(fromPoint, targetPoint, originalA, originalB)) return true;
+
+    if (portal.type !== 'stairs') return false;
+    const route = stairRuntime()?.routeFor?.(portal, mapData);
+    if (!route?.points?.length) return false;
+    for (let i = 1; i < route.points.length; i += 1) {
+      const p0 = route.points[i - 1];
+      const p1 = route.points[i];
+      if (segmentsIntersect(fromPoint, targetPoint, { x: p0.x, y: p0.y }, { x: p1.x, y: p1.y })) return true;
+    }
+    return false;
   }
 
   function canTraverseLayers(viewer = {}, targetPoint = {}, targetLayer, mapData = {}, kind = 'vision') {

--- a/js/vtt/stair-route.js
+++ b/js/vtt/stair-route.js
@@ -1,0 +1,234 @@
+(function (root, factory) {
+    const api = factory(root);
+    if (typeof module !== 'undefined' && module.exports) module.exports = api;
+    if (root) root.LuminousVttStairRoute = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (root) {
+    'use strict';
+
+    const LAYOUTS = Object.freeze(['straight', 'switchback', 'spiral', 'ladder']);
+    const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+    function spatialRuntime() {
+        if (root?.LuminousVttSpatialVision) return root.LuminousVttSpatialVision;
+        if (typeof require !== 'undefined') {
+            try { return require('./spatial-vision.js'); } catch (_) {}
+        }
+        return null;
+    }
+
+    function feetPerPixel(mapData = {}) {
+        const spatial = spatialRuntime();
+        if (spatial?.feetPerPixel) return spatial.feetPerPixel(mapData);
+        const size = Math.max(1, numberOr(mapData.grid?.size, 70));
+        return Math.max(0.001, numberOr(mapData.grid?.distancePerCell, 5)) / size;
+    }
+
+    function vertexPoint(vertex = {}, mapData = {}) {
+        const spatial = spatialRuntime();
+        if (spatial?.vertexToPoint) return spatial.vertexToPoint(vertex, mapData);
+        const size = Math.max(1, numberOr(mapData.grid?.size, 70));
+        return { x: numberOr(vertex.col) * size, y: numberOr(vertex.row) * size };
+    }
+
+    function elevationForLayer(mapData = {}, zLayer) {
+        const spatial = spatialRuntime();
+        if (spatial?.elevationForLayer) return spatial.elevationForLayer(mapData, zLayer);
+        const record = mapData.zLevels?.[String(zLayer)] || mapData.zLevels?.[zLayer];
+        if (record && Number.isFinite(Number(record.elevationFt))) return Number(record.elevationFt);
+        return Number(zLayer || 0) * numberOr(mapData.defaultZStepFt, 15);
+    }
+
+    function portalLayers(portal = {}) {
+        const values = Array.isArray(portal.between) ? portal.between : [portal.fromZ ?? 0, portal.toZ ?? 1];
+        return [Number(values[0]) || 0, Number(values[1]) || 0];
+    }
+
+    function layoutOf(portal = {}) {
+        const value = String(portal.layout || 'straight').toLowerCase();
+        return LAYOUTS.includes(value) ? value : 'straight';
+    }
+
+    function widthFt(portal = {}) {
+        return Math.max(2, numberOr(portal.widthFt, 5));
+    }
+
+    function withElevation(point, elevationFt, zLayer = null) {
+        return { x: numberOr(point.x), y: numberOr(point.y), elevationFt: numberOr(elevationFt), zLayer };
+    }
+
+    function perpendicularUnit(a, b) {
+        const dx = numberOr(b.x) - numberOr(a.x);
+        const dy = numberOr(b.y) - numberOr(a.y);
+        const length = Math.hypot(dx, dy) || 1;
+        return { x: -dy / length, y: dx / length };
+    }
+
+    function buildStraight(portal, mapData, fromZ, toZ) {
+        const a = vertexPoint(portal.from, mapData);
+        const b = vertexPoint(portal.to, mapData);
+        return [
+            withElevation(a, elevationForLayer(mapData, fromZ), fromZ),
+            withElevation(b, elevationForLayer(mapData, toZ), toZ),
+        ];
+    }
+
+    function buildSwitchback(portal, mapData, fromZ, toZ) {
+        const a = vertexPoint(portal.from, mapData);
+        const landingA = vertexPoint(portal.to, mapData);
+        const fpp = feetPerPixel(mapData);
+        const offsetPx = widthFt(portal) / Math.max(0.001, fpp);
+        const normal = perpendicularUnit(a, landingA);
+        const landingB = { x: landingA.x + normal.x * offsetPx, y: landingA.y + normal.y * offsetPx };
+        const exit = { x: a.x + normal.x * offsetPx, y: a.y + normal.y * offsetPx };
+        const low = elevationForLayer(mapData, fromZ);
+        const high = elevationForLayer(mapData, toZ);
+        const mid = low + ((high - low) / 2);
+        return [
+            withElevation(a, low, fromZ),
+            withElevation(landingA, mid, null),
+            withElevation(landingB, mid, null),
+            withElevation(exit, high, toZ),
+        ];
+    }
+
+    function buildSpiral(portal, mapData, fromZ, toZ) {
+        const a = vertexPoint(portal.from, mapData);
+        const b = vertexPoint(portal.to, mapData);
+        const center = { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+        const fpp = feetPerPixel(mapData);
+        const minRadius = (widthFt(portal) / Math.max(0.001, fpp)) / 2;
+        let radius = Math.max(minRadius, Math.hypot(a.x - center.x, a.y - center.y));
+        if (radius < 1) radius = Math.max(1, minRadius);
+        const startAngle = Math.atan2(a.y - center.y, a.x - center.x);
+        const low = elevationForLayer(mapData, fromZ);
+        const high = elevationForLayer(mapData, toZ);
+        const points = [];
+        const steps = 12;
+        for (let i = 0; i <= steps; i += 1) {
+            const t = i / steps;
+            const angle = startAngle + (Math.PI * 2 * t);
+            points.push(withElevation({
+                x: center.x + Math.cos(angle) * radius,
+                y: center.y + Math.sin(angle) * radius,
+            }, low + ((high - low) * t), i === 0 ? fromZ : i === steps ? toZ : null));
+        }
+        return points;
+    }
+
+    function buildLadder(portal, mapData, fromZ, toZ) {
+        const a = vertexPoint(portal.from, mapData);
+        const b = vertexPoint(portal.to, mapData);
+        const anchor = { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+        return [
+            withElevation(anchor, elevationForLayer(mapData, fromZ), fromZ),
+            withElevation(anchor, elevationForLayer(mapData, toZ), toZ),
+        ];
+    }
+
+    function pointsFor(portal = {}, mapData = {}) {
+        if (portal.type !== 'stairs') return [];
+        const [fromZ, toZ] = portalLayers(portal);
+        const layout = layoutOf(portal);
+        if (layout === 'switchback') return buildSwitchback(portal, mapData, fromZ, toZ);
+        if (layout === 'spiral') return buildSpiral(portal, mapData, fromZ, toZ);
+        if (layout === 'ladder') return buildLadder(portal, mapData, fromZ, toZ);
+        return buildStraight(portal, mapData, fromZ, toZ);
+    }
+
+    function segmentLengthFt(a, b, mapData = {}) {
+        const horizontal = Math.hypot(numberOr(b.x) - numberOr(a.x), numberOr(b.y) - numberOr(a.y)) * feetPerPixel(mapData);
+        const vertical = numberOr(b.elevationFt) - numberOr(a.elevationFt);
+        return Math.hypot(horizontal, vertical);
+    }
+
+    function pathLengthFt(points, mapData = {}) {
+        let total = 0;
+        for (let i = 1; i < points.length; i += 1) total += segmentLengthFt(points[i - 1], points[i], mapData);
+        return total;
+    }
+
+    function routeFor(portal = {}, mapData = {}) {
+        if (portal.type !== 'stairs') return null;
+        const [fromZ, toZ] = portalLayers(portal);
+        const points = pointsFor(portal, mapData);
+        const layout = layoutOf(portal);
+        return {
+            id: String(portal.id || ''),
+            portalId: String(portal.id || ''),
+            layout,
+            widthFt: widthFt(portal),
+            fromZ,
+            toZ,
+            points,
+            pathLengthFt: pathLengthFt(points, mapData),
+            movementMode: layout === 'ladder' ? 'climb' : 'stairs',
+            costMultiplier: layout === 'ladder' ? Math.max(1, numberOr(portal.costMultiplier, 2)) : Math.max(1, numberOr(portal.costMultiplier, 1)),
+            bidirectional: portal.bidirectional !== false,
+        };
+    }
+
+    function routeEntryForLayer(route, zLayer) {
+        if (!route?.points?.length) return null;
+        if (Number(zLayer) === Number(route.fromZ)) return route.points[0];
+        if (Number(zLayer) === Number(route.toZ)) return route.points[route.points.length - 1];
+        return null;
+    }
+
+    function targetLayer(route, fromLayer) {
+        if (!route) return null;
+        if (Number(fromLayer) === Number(route.fromZ)) return route.toZ;
+        if (Number(fromLayer) === Number(route.toZ)) return route.fromZ;
+        return null;
+    }
+
+    function orderedPoints(route, fromLayer) {
+        if (!route?.points) return [];
+        return Number(fromLayer) === Number(route.toZ) ? [...route.points].reverse() : [...route.points];
+    }
+
+    function pointAtDistance(route, fromLayer, distanceFt, mapData = {}) {
+        const points = orderedPoints(route, fromLayer);
+        if (!points.length) return null;
+        let remaining = Math.max(0, numberOr(distanceFt));
+        for (let i = 1; i < points.length; i += 1) {
+            const a = points[i - 1];
+            const b = points[i];
+            const length = segmentLengthFt(a, b, mapData);
+            if (remaining <= length || i === points.length - 1) {
+                const t = length <= 0 ? 1 : Math.max(0, Math.min(1, remaining / length));
+                return {
+                    x: a.x + ((b.x - a.x) * t),
+                    y: a.y + ((b.y - a.y) * t),
+                    elevationFt: a.elevationFt + ((b.elevationFt - a.elevationFt) * t),
+                    segmentIndex: i - 1,
+                    segmentProgress: t,
+                };
+            }
+            remaining -= length;
+        }
+        const last = points[points.length - 1];
+        return { ...last, segmentIndex: Math.max(0, points.length - 2), segmentProgress: 1 };
+    }
+
+    function distanceToEntry(point, route, zLayer) {
+        const entry = routeEntryForLayer(route, zLayer);
+        if (!entry) return Infinity;
+        return Math.hypot(numberOr(point?.x) - entry.x, numberOr(point?.y) - entry.y);
+    }
+
+    return Object.freeze({
+        LAYOUTS,
+        layoutOf,
+        widthFt,
+        portalLayers,
+        pointsFor,
+        segmentLengthFt,
+        pathLengthFt,
+        routeFor,
+        routeEntryForLayer,
+        targetLayer,
+        orderedPoints,
+        pointAtDistance,
+        distanceToEntry,
+    });
+});

--- a/js/vtt/token-control.js
+++ b/js/vtt/token-control.js
@@ -1,0 +1,53 @@
+(function (root, factory) {
+    const api = factory(root);
+    if (typeof module !== 'undefined' && module.exports) module.exports = api;
+    if (root) root.LuminousVttTokenControl = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (browserRoot) {
+    'use strict';
+
+    const clean = (value) => String(value ?? '').trim();
+
+    function hostWindow(root = browserRoot) {
+        if (!root) return null;
+        try {
+            if (root.parent && root.parent !== root && root.parent.document) return root.parent;
+        } catch (_) {}
+        return root;
+    }
+
+    function identity(root = browserRoot) {
+        const host = hostWindow(root);
+        const data = host?.datosJugador || {};
+        return {
+            uid: clean(host?.firebase?.auth?.().currentUser?.uid),
+            playerId: clean(host?.localStorage?.getItem?.('playerId') || data.playerId || data.id),
+            actorId: clean(data.actorId || data.vinculo_jugador),
+        };
+    }
+
+    function isCurrentPlayerToken(token = {}) {
+        return token.characterLink?.mode === 'current_player';
+    }
+
+    function canPlayerControl(token = {}, current = {}) {
+        if (!token || token.draggable === false) return false;
+        const link = token.characterLink || {};
+        if (link.mode === 'current_player') return true;
+        if (link.uid && clean(link.uid) === clean(current.uid)) return true;
+        if (link.playerId && clean(link.playerId) === clean(current.playerId)) return true;
+        if (link.actorId && clean(link.actorId) === clean(current.actorId)) return true;
+        if (token.ownerUid && clean(token.ownerUid) === clean(current.uid)) return true;
+        if (token.playerId && clean(token.playerId) === clean(current.playerId)) return true;
+        return false;
+    }
+
+    function createResolver({ isDm = false, root = browserRoot } = {}) {
+        return (token) => {
+            if (!token || token.draggable === false) return false;
+            if (isDm) return true;
+            return canPlayerControl(token, identity(root));
+        };
+    }
+
+    return Object.freeze({ hostWindow, identity, isCurrentPlayerToken, canPlayerControl, createResolver });
+});

--- a/js/vtt/token-interaction.js
+++ b/js/vtt/token-interaction.js
@@ -23,10 +23,16 @@
     function tokenLayers(token = {}) {
         if (Array.isArray(token.z)) return token.z;
         if (Number.isFinite(Number(token.z))) return [Number(token.z)];
+        if (Number.isFinite(Number(token.zLayer))) return [Number(token.zLayer)];
         return [0];
     }
 
     function tokenOnLayer(token, zLayer) {
+        if (token?.verticalMovement) {
+            const fromZ = Number(token.verticalMovement.fromZ);
+            const toZ = Number(token.verticalMovement.toZ);
+            if (Number(zLayer) === fromZ || Number(zLayer) === toZ) return true;
+        }
         return tokenLayers(token).includes(Number(zLayer));
     }
 
@@ -38,11 +44,12 @@
         return (dx * dx) + (dy * dy) <= radius * radius;
     }
 
-    function findDraggableToken(tokens, point, grid, zLayer) {
+    function findDraggableToken(tokens, point, grid, zLayer, canControl = null) {
         const list = Array.isArray(tokens) ? tokens : [];
         for (let i = list.length - 1; i >= 0; i -= 1) {
             const token = list[i];
             if (!token || token.draggable === false || !tokenOnLayer(token, zLayer)) continue;
+            if (typeof canControl === 'function' && !canControl(token)) continue;
             if (tokenContainsPoint(token, point, grid)) return token;
         }
         return null;
@@ -61,12 +68,7 @@
         const rawRow = Math.floor(numberOr(point?.y) / size);
         const col = Math.max(0, Math.min(cols - 1, rawCol));
         const row = Math.max(0, Math.min(rows - 1, rawRow));
-        return {
-            x: (col + 0.5) * size,
-            y: (row + 0.5) * size,
-            col,
-            row,
-        };
+        return { x: (col + 0.5) * size, y: (row + 0.5) * size, col, row };
     }
 
     function pointToSegmentDistance(point, a, b) {
@@ -93,13 +95,10 @@
             const wallLayers = Array.isArray(wall.z) ? wall.z : [numberOr(wall.z, 0)];
             return wallLayers.some((layer) => layers.includes(Number(layer)));
         });
-
         const topology = topologyRuntime();
         if (!topology || !Array.isArray(mapData.topology)) return legacy;
         const dynamic = [];
-        layers.forEach((layer) => {
-            dynamic.push(...topology.blockingSegments(mapData.topology, 'movement', layer, mapData.grid));
-        });
+        layers.forEach((layer) => dynamic.push(...topology.blockingSegments(mapData.topology, 'movement', layer, mapData.grid)));
         return [...legacy, ...dynamic];
     }
 
@@ -109,20 +108,13 @@
         const radius = tokenRadius(token, grid);
         const x = numberOr(point?.x);
         const y = numberOr(point?.y);
-
-        if (x - radius < 0 || y - radius < 0 || x + radius > width || y + radius > height) {
-            return { valid: false, reason: 'OUT_OF_BOUNDS' };
-        }
+        if (x - radius < 0 || y - radius < 0 || x + radius > width || y + radius > height) return { valid: false, reason: 'OUT_OF_BOUNDS' };
 
         for (const wall of movementWalls(mapData, token)) {
-            const distance = pointToSegmentDistance(
-                { x, y },
-                { x: wall.x1, y: wall.y1 },
-                { x: wall.x2, y: wall.y2 },
-            );
-            if (distance < radius) return { valid: false, reason: 'BLOCKED_BY_WALL', wall };
+            const distance = pointToSegmentDistance({ x, y }, { x: wall.x1, y: wall.y1 }, { x: wall.x2, y: wall.y2 });
+            const extraThickness = Math.max(0, numberOr(wall.thicknessPx, 0)) / 2;
+            if (distance < radius + extraThickness) return { valid: false, reason: 'BLOCKED_BY_WALL', wall };
         }
-
         return { valid: true, reason: null };
     }
 
@@ -134,54 +126,32 @@
         const distance = Math.hypot(dx, dy);
         const sampleStep = Math.max(4, Math.min(radius * 0.5, numberOr(grid.size, 70) * 0.2));
         const steps = Math.max(1, Math.ceil(distance / sampleStep));
-
         for (let i = 0; i <= steps; i += 1) {
             const t = i / steps;
-            const point = {
-                x: numberOr(from?.x) + (dx * t),
-                y: numberOr(from?.y) + (dy * t),
-            };
+            const point = { x: numberOr(from?.x) + (dx * t), y: numberOr(from?.y) + (dy * t) };
             const occupancy = canOccupy(token, point, mapData);
             if (!occupancy.valid) return occupancy;
         }
-
         return { valid: true, reason: null };
     }
 
     function resolveDrop(token, from, worldPoint, mapData = {}) {
         if (!token || !mapData.grid) return { valid: false, reason: 'INVALID_INPUT' };
-
         const { width, height } = gridBounds(mapData.grid);
         const requestedX = numberOr(worldPoint?.x, NaN);
         const requestedY = numberOr(worldPoint?.y, NaN);
-        if (!Number.isFinite(requestedX) || !Number.isFinite(requestedY)) {
-            return { valid: false, reason: 'INVALID_INPUT' };
-        }
-        if (requestedX < 0 || requestedY < 0 || requestedX >= width || requestedY >= height) {
-            return { valid: false, reason: 'OUT_OF_BOUNDS' };
-        }
-
+        if (!Number.isFinite(requestedX) || !Number.isFinite(requestedY)) return { valid: false, reason: 'INVALID_INPUT' };
+        if (requestedX < 0 || requestedY < 0 || requestedX >= width || requestedY >= height) return { valid: false, reason: 'OUT_OF_BOUNDS' };
         const snapped = snapPointToGrid({ x: requestedX, y: requestedY }, mapData.grid);
         const destination = canOccupy(token, snapped, mapData);
         if (!destination.valid) return { ...snapped, ...destination };
-
         const path = isPathClear(token, from, snapped, mapData);
         if (!path.valid) return { ...snapped, ...path };
-
         return { ...snapped, valid: true, reason: null };
     }
 
     return Object.freeze({
-        tokenRadius,
-        tokenOnLayer,
-        tokenContainsPoint,
-        findDraggableToken,
-        gridBounds,
-        snapPointToGrid,
-        pointToSegmentDistance,
-        movementWalls,
-        canOccupy,
-        isPathClear,
-        resolveDrop,
+        tokenRadius, tokenOnLayer, tokenContainsPoint, findDraggableToken, gridBounds, snapPointToGrid,
+        pointToSegmentDistance, movementWalls, canOccupy, isPathClear, resolveDrop,
     });
 });

--- a/js/vtt/topology-controller.js
+++ b/js/vtt/topology-controller.js
@@ -20,6 +20,8 @@ export class TopologyController {
         this.renderMode();
     }
 
+    editActive() { return Boolean(this.isDm && this.mapData.dmEditMode?.active); }
+
     bindCanvas() {
         this.canvas.addEventListener('mousedown', this.handleMouseDown, true);
         window.addEventListener('mousemove', this.handleMouseMove, true);
@@ -31,18 +33,14 @@ export class TopologyController {
         document.querySelectorAll('[data-vtt-tool]').forEach((button) => {
             button.addEventListener('click', () => this.setTool(button.dataset.vttTool));
         });
-
-        document.getElementById('vtt-topology-state')?.addEventListener('change', (event) => {
-            this.updateSelected({ state: event.target.value });
-        });
-        document.getElementById('vtt-topology-lockpick')?.addEventListener('change', (event) => {
-            this.updateSelectedThreshold('lockpick', event.target.value);
-        });
-        document.getElementById('vtt-topology-break')?.addEventListener('change', (event) => {
-            this.updateSelectedThreshold('break', event.target.value);
+        document.getElementById('vtt-topology-state')?.addEventListener('change', (event) => this.updateSelected({ state: event.target.value }));
+        document.getElementById('vtt-topology-lockpick')?.addEventListener('change', (event) => this.updateSelectedThreshold('lockpick', event.target.value));
+        document.getElementById('vtt-topology-break')?.addEventListener('change', (event) => this.updateSelectedThreshold('break', event.target.value));
+        document.getElementById('vtt-topology-thickness')?.addEventListener('change', (event) => {
+            this.updateSelected({ thicknessFt: Math.max(0.1, Number(event.target.value) || 0.5) });
         });
         document.getElementById('vtt-topology-delete')?.addEventListener('click', () => {
-            if (!this.selectedId) return;
+            if (!this.selectedId || !this.editActive()) return;
             this.stateBridge.deleteElement(this.selectedId)
                 .then(() => {
                     this.selectedId = null;
@@ -54,19 +52,25 @@ export class TopologyController {
     }
 
     renderMode() {
+        const active = this.editActive();
         const toolbar = document.getElementById('vtt-topology-toolbar');
         const exportButton = document.getElementById('btn-export-uv');
-        if (toolbar) toolbar.hidden = !this.isDm;
+        if (toolbar) toolbar.hidden = !active;
         if (exportButton) exportButton.hidden = !this.isDm;
         document.body.classList.toggle('vtt-dm-mode', this.isDm);
         document.body.classList.toggle('vtt-player-mode', !this.isDm);
+        if (!active) {
+            this.tool = 'select';
+            this.drawStart = null;
+            this.mapData.topologyPreview = null;
+        }
         this.renderToolButtons();
         this.renderEditor();
     }
 
     setTool(tool) {
         const valid = ['select', 'wall', 'door', 'window', 'curtain_window', 'erase'];
-        this.tool = valid.includes(tool) ? tool : 'select';
+        this.tool = this.editActive() && valid.includes(tool) ? tool : 'select';
         this.drawStart = null;
         this.mapData.topologyPreview = null;
         this.hideContextMenu();
@@ -74,23 +78,14 @@ export class TopologyController {
     }
 
     renderToolButtons() {
-        document.querySelectorAll('[data-vtt-tool]').forEach((button) => {
-            button.classList.toggle('is-active', button.dataset.vttTool === this.tool);
-        });
+        document.querySelectorAll('[data-vtt-tool]').forEach((button) => button.classList.toggle('is-active', button.dataset.vttTool === this.tool));
     }
 
-    worldPoint(event) {
-        return this.engine.eventWorldPoint(event);
-    }
+    worldPoint(event) { return this.engine.eventWorldPoint(event); }
 
     topologyAtEvent(event) {
         if (!this.topology) return null;
-        return this.topology.hitTest(
-            this.mapData.topology,
-            this.worldPoint(event),
-            this.mapData.grid,
-            this.engine.activeZ,
-        );
+        return this.topology.hitTest(this.mapData.topology, this.worldPoint(event), this.mapData.grid, this.engine.activeZ);
     }
 
     handleMouseDown(event) {
@@ -105,6 +100,7 @@ export class TopologyController {
             this.openPlayerMenu(hit, event.clientX, event.clientY);
             return;
         }
+        if (!this.editActive()) return;
 
         if (this.tool === 'select') {
             if (!hit) return;
@@ -126,45 +122,31 @@ export class TopologyController {
         }
 
         this.drawStart = this.topology.snapPointToVertex(this.worldPoint(event), this.mapData.grid);
-        this.mapData.topologyPreview = {
-            type: this.tool,
-            from: this.drawStart,
-            to: this.drawStart,
-            z: [this.engine.activeZ],
-        };
+        this.mapData.topologyPreview = { type: this.tool, from: this.drawStart, to: this.drawStart, z: [this.engine.activeZ] };
     }
 
     handleMouseMove(event) {
-        if (!this.isDm || !this.drawStart || !['wall', 'door', 'window', 'curtain_window'].includes(this.tool)) return;
+        if (!this.editActive() || !this.drawStart || !['wall', 'door', 'window', 'curtain_window'].includes(this.tool)) return;
         const candidate = this.topology.snapPointToVertex(this.worldPoint(event), this.mapData.grid);
         const to = this.topology.axisAlignedVertex(this.drawStart, candidate);
-        this.mapData.topologyPreview = {
-            type: this.tool,
-            from: this.drawStart,
-            to,
-            z: [this.engine.activeZ],
-        };
+        this.mapData.topologyPreview = { type: this.tool, from: this.drawStart, to, z: [this.engine.activeZ] };
         event.preventDefault();
         event.stopImmediatePropagation();
     }
 
     handleMouseUp(event) {
-        if (event.button !== 0 || !this.isDm || !this.drawStart) return;
+        if (event.button !== 0 || !this.editActive() || !this.drawStart) return;
         const from = this.drawStart;
         const candidate = this.topology.snapPointToVertex(this.worldPoint(event), this.mapData.grid);
         const to = this.topology.axisAlignedVertex(from, candidate);
+        const type = this.tool;
         this.drawStart = null;
         this.mapData.topologyPreview = null;
         event.preventDefault();
         event.stopImmediatePropagation();
         if (this.topology.sameVertex(from, to)) return;
 
-        const element = this.topology.createElement({
-            type: this.tool,
-            from,
-            to,
-            zLayer: this.engine.activeZ,
-        });
+        const element = this.topology.createElement({ type, from, to, zLayer: this.engine.activeZ });
         this.stateBridge.saveElement(element)
             .then((saved) => {
                 this.selectedId = saved.id;
@@ -176,9 +158,7 @@ export class TopologyController {
 
     handleDocumentClick(event) {
         const menu = document.getElementById('vtt-context-menu');
-        if (!menu || menu.hidden) return;
-        if (menu.contains(event.target)) return;
-        if (event.target === this.canvas) return;
+        if (!menu || menu.hidden || menu.contains(event.target) || event.target === this.canvas) return;
         this.hideContextMenu();
     }
 
@@ -194,11 +174,7 @@ export class TopologyController {
         const token = this.currentPlayerToken();
         if (!token) return false;
         const line = this.topology.segment(element, this.mapData.grid);
-        const distance = this.topology.pointToSegmentDistance(
-            { x: token.x, y: token.y },
-            { x: line.x1, y: line.y1 },
-            { x: line.x2, y: line.y2 },
-        );
+        const distance = this.topology.pointToSegmentDistance({ x: token.x, y: token.y }, { x: line.x1, y: line.y1 }, { x: line.x2, y: line.y2 });
         return distance <= (this.mapData.grid.size * 0.8);
     }
 
@@ -215,11 +191,7 @@ export class TopologyController {
         const actions = document.getElementById('vtt-context-actions');
         if (!menu || !title || !state || !actions) return;
 
-        const typeLabels = {
-            door: 'PUERTA',
-            window: 'VENTANA',
-            curtain_window: 'VENTANA CON CORTINA',
-        };
+        const typeLabels = { door: 'PUERTA', window: 'VENTANA', curtain_window: 'VENTANA CON CORTINA' };
         title.textContent = typeLabels[element.type] || 'OBJETO';
         state.textContent = element.state === 'locked' ? 'CERRADA' : String(element.state || '').toUpperCase();
         actions.replaceChildren();
@@ -233,11 +205,7 @@ export class TopologyController {
             button.disabled = disabled;
             button.addEventListener('click', async () => {
                 this.hideContextMenu();
-                try {
-                    await handler();
-                } catch (error) {
-                    this.notify(String(error.message || error), 'error');
-                }
+                try { await handler(); } catch (error) { this.notify(String(error.message || error), 'error'); }
             });
             wrapper.appendChild(button);
             if (hint) {
@@ -254,12 +222,7 @@ export class TopologyController {
 
         if (element.state === 'locked') {
             const hasLockpick = await this.stateBridge.hasItem('lockpick');
-            addButton(
-                'JUEGO DE MANOS',
-                () => this.stateBridge.requestTopologyCheck(element.id, 'lockpick'),
-                !hasLockpick,
-                hasLockpick ? 'Requiere Ganzúa' : 'No tienes Ganzúa',
-            );
+            addButton('JUEGO DE MANOS', () => this.stateBridge.requestTopologyCheck(element.id, 'lockpick'), !hasLockpick, hasLockpick ? 'Requiere Ganzúa' : 'No tienes Ganzúa');
             addButton('ROMPER · STRENGTH', () => this.stateBridge.requestTopologyCheck(element.id, 'strength'));
             addButton('ROMPER · ATHLETICS', () => this.stateBridge.requestTopologyCheck(element.id, 'athletics'));
         }
@@ -288,7 +251,7 @@ export class TopologyController {
     renderEditor() {
         const editor = document.getElementById('vtt-topology-editor');
         if (!editor) return;
-        if (!this.isDm) {
+        if (!this.editActive()) {
             editor.hidden = true;
             return;
         }
@@ -301,32 +264,33 @@ export class TopologyController {
         document.getElementById('vtt-topology-type').textContent = normalized.type.toUpperCase().replace('_', ' ');
         const stateField = document.getElementById('vtt-topology-state-field');
         const thresholdFields = document.getElementById('vtt-topology-threshold-fields');
+        const thicknessField = document.getElementById('vtt-topology-thickness-field');
         const state = document.getElementById('vtt-topology-state');
         const lockpick = document.getElementById('vtt-topology-lockpick');
         const breakThreshold = document.getElementById('vtt-topology-break');
+        const thickness = document.getElementById('vtt-topology-thickness');
 
         const interactive = normalized.type !== 'wall';
         if (stateField) stateField.hidden = !interactive;
         if (thresholdFields) thresholdFields.hidden = !interactive;
+        if (thicknessField) thicknessField.hidden = interactive;
         if (state && interactive) state.value = normalized.state;
         if (lockpick && interactive) lockpick.value = normalized.thresholds.lockpick;
         if (breakThreshold && interactive) breakThreshold.value = normalized.thresholds.break;
+        if (thickness && !interactive) thickness.value = normalized.thicknessFt;
     }
 
     updateSelected(patch) {
         const element = this.selectedElement();
-        if (!element) return;
+        if (!element || !this.editActive()) return;
         this.stateBridge.saveElement(this.topology.normalizeElement({ ...element, ...patch }))
             .catch((error) => this.notify(String(error.message || error), 'error'));
     }
 
     updateSelectedThreshold(key, value) {
         const element = this.selectedElement();
-        if (!element || element.type === 'wall') return;
-        const thresholds = {
-            ...element.thresholds,
-            [key]: Math.max(0, Math.trunc(Number(value) || 0)),
-        };
+        if (!element || element.type === 'wall' || !this.editActive()) return;
+        const thresholds = { ...element.thresholds, [key]: Math.max(0, Math.trunc(Number(value) || 0)) };
         this.updateSelected({ thresholds });
     }
 
@@ -342,8 +306,6 @@ export class TopologyController {
         node.dataset.mode = mode;
         node.hidden = false;
         window.clearTimeout(this.noticeTimer);
-        this.noticeTimer = window.setTimeout(() => {
-            node.hidden = true;
-        }, 3200);
+        this.noticeTimer = window.setTimeout(() => { node.hidden = true; }, 3200);
     }
 }

--- a/js/vtt/topology.js
+++ b/js/vtt/topology.js
@@ -70,6 +70,7 @@
             to: normalizeVertex(element.to),
             z: elementLayers(element),
             state: normalizeState(type, element.state),
+            thicknessFt: type === TYPES.WALL ? Math.max(0.1, numberOr(element.thicknessFt, 0.5)) : Math.max(0, numberOr(element.thicknessFt, 0)),
             thresholds: type === TYPES.WALL ? undefined : {
                 lockpick: clampInteger(element.thresholds?.lockpick, defaults.lockpick),
                 break: clampInteger(element.thresholds?.break, defaults.break),
@@ -85,6 +86,13 @@
         };
     }
 
+    function thicknessPx(element, grid = {}) {
+        const normalized = normalizeElement(element);
+        const size = Math.max(1, numberOr(grid.size, 70));
+        const feetPerCell = Math.max(0.001, numberOr(grid.distancePerCell, 5));
+        return (normalized.thicknessFt / feetPerCell) * size;
+    }
+
     function segment(element, grid = {}) {
         const normalized = normalizeElement(element);
         const a = vertexToPoint(normalized.from, grid);
@@ -98,6 +106,8 @@
             x2: b.x,
             y2: b.y,
             z: normalized.z,
+            thicknessFt: normalized.thicknessFt,
+            thicknessPx: thicknessPx(normalized, grid),
             element: normalized,
         };
     }
@@ -155,7 +165,8 @@
                 { x: line.x1, y: line.y1 },
                 { x: line.x2, y: line.y2 },
             );
-            if (distance <= tolerance && distance < bestDistance) {
+            const effectiveTolerance = Math.max(tolerance, line.thicknessPx / 2);
+            if (distance <= effectiveTolerance && distance < bestDistance) {
                 best = raw;
                 bestDistance = distance;
             }
@@ -204,12 +215,7 @@
                 action: 'unlock',
                 threshold: normalized.thresholds.lockpick,
                 requiredItem: 'lockpick',
-                rollSpec: {
-                    kind: 'skill',
-                    abilityId: 'dex',
-                    skillId: 'sleight_of_hand',
-                    label: 'Sleight of Hand',
-                },
+                rollSpec: { kind: 'skill', abilityId: 'dex', skillId: 'sleight_of_hand', label: 'Sleight of Hand' },
             };
         }
         if (method === 'strength') {
@@ -218,12 +224,7 @@
                 action: 'break',
                 threshold: normalized.thresholds.break,
                 requiredItem: null,
-                rollSpec: {
-                    kind: 'ability',
-                    abilityId: 'str',
-                    skillId: null,
-                    label: 'STRENGTH',
-                },
+                rollSpec: { kind: 'ability', abilityId: 'str', skillId: null, label: 'STRENGTH' },
             };
         }
         if (method === 'athletics') {
@@ -232,12 +233,7 @@
                 action: 'break',
                 threshold: normalized.thresholds.break,
                 requiredItem: null,
-                rollSpec: {
-                    kind: 'skill',
-                    abilityId: 'str',
-                    skillId: 'athletics',
-                    label: 'Athletics',
-                },
+                rollSpec: { kind: 'skill', abilityId: 'str', skillId: 'athletics', label: 'Athletics' },
             };
         }
         return null;
@@ -247,22 +243,14 @@
         const normalized = normalizeElement(element);
         if (normalized.type === TYPES.WALL) return { valid: false, reason: 'NOT_INTERACTIVE', element: normalized };
 
-        if (action === 'open' && normalized.state === STATES.CLOSED) {
-            return { valid: true, reason: null, element: { ...normalized, state: STATES.OPEN } };
-        }
-        if (action === 'close' && normalized.state === STATES.OPEN) {
-            return { valid: true, reason: null, element: { ...normalized, state: STATES.CLOSED } };
-        }
-        if (action === 'unlock' && normalized.state === STATES.LOCKED) {
-            return { valid: true, reason: null, element: { ...normalized, state: STATES.OPEN } };
-        }
-        if (action === 'break' && normalized.state === STATES.LOCKED) {
-            return { valid: true, reason: null, element: { ...normalized, state: STATES.BROKEN } };
-        }
+        if (action === 'open' && normalized.state === STATES.CLOSED) return { valid: true, reason: null, element: { ...normalized, state: STATES.OPEN } };
+        if (action === 'close' && normalized.state === STATES.OPEN) return { valid: true, reason: null, element: { ...normalized, state: STATES.CLOSED } };
+        if (action === 'unlock' && normalized.state === STATES.LOCKED) return { valid: true, reason: null, element: { ...normalized, state: STATES.OPEN } };
+        if (action === 'break' && normalized.state === STATES.LOCKED) return { valid: true, reason: null, element: { ...normalized, state: STATES.BROKEN } };
         return { valid: false, reason: 'INVALID_STATE_TRANSITION', element: normalized };
     }
 
-    function createElement({ id, type, from, to, zLayer = 0 } = {}) {
+    function createElement({ id, type, from, to, zLayer = 0, thicknessFt = 0.5 } = {}) {
         const normalizedType = Object.values(TYPES).includes(type) ? type : TYPES.WALL;
         return normalizeElement({
             id: id || `topology_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 7)}`,
@@ -271,30 +259,15 @@
             to,
             z: [Number(zLayer) || 0],
             state: normalizedType === TYPES.WALL ? null : STATES.CLOSED,
+            thicknessFt: normalizedType === TYPES.WALL ? thicknessFt : 0,
             thresholds: defaultThresholds(normalizedType),
         });
     }
 
     return Object.freeze({
-        TYPES,
-        STATES,
-        DEFAULT_THRESHOLDS,
-        elementLayers,
-        elementOnLayer,
-        defaultThresholds,
-        normalizeElement,
-        vertexToPoint,
-        segment,
-        effectiveFlags,
-        blockingSegments,
-        pointToSegmentDistance,
-        hitTest,
-        snapPointToVertex,
-        axisAlignedVertex,
-        sameVertex,
-        directActions,
-        checkDescriptor,
-        applyAction,
-        createElement,
+        TYPES, STATES, DEFAULT_THRESHOLDS, elementLayers, elementOnLayer, defaultThresholds,
+        normalizeElement, vertexToPoint, thicknessPx, segment, effectiveFlags, blockingSegments,
+        pointToSegmentDistance, hitTest, snapPointToVertex, axisAlignedVertex, sameVertex,
+        directActions, checkDescriptor, applyAction, createElement,
     });
 });

--- a/js/vtt/vertical-movement.js
+++ b/js/vtt/vertical-movement.js
@@ -34,7 +34,7 @@
     function findTransitionAtPoint(point, mapData = {}, zLayer, tolerancePx = null) {
         const routes = routeRuntime();
         if (!routes) return null;
-        const tolerance = tolerancePx == null ? Math.max(12, numberOr(mapData.grid?.size, 70) * 0.55) : Math.max(1, numberOr(tolerancePx));
+        const tolerance = tolerancePx == null ? Math.max(12, numberOr(mapData.grid?.size, 70) * 0.8) : Math.max(1, numberOr(tolerancePx));
         let best = null;
         let bestDistance = Infinity;
         for (const candidate of transitionCandidates(mapData, zLayer)) {
@@ -54,6 +54,14 @@
         const col = Math.max(0, Math.min(cols - 1, Math.floor(numberOr(point.x) / size)));
         const row = Math.max(0, Math.min(rows - 1, Math.floor(numberOr(point.y) / size)));
         return { col, row, z: Number(zLayer) || 0 };
+    }
+
+    function centerForGridPosition(gridPosition = {}, mapData = {}) {
+        const size = Math.max(1, numberOr(mapData.grid?.size, 70));
+        return {
+            x: (Number(gridPosition.col) + 0.5) * size,
+            y: (Number(gridPosition.row) + 0.5) * size,
+        };
     }
 
     function hasDedicatedClimbSpeed(token = {}) {
@@ -96,12 +104,14 @@
         const targetZ = routes.targetLayer(route, sourceLayer);
         const ordered = routes.orderedPoints(route, sourceLayer);
         const exit = ordered[ordered.length - 1];
-        token.x = exit.x;
-        token.y = exit.y;
+        const gridPosition = gridPositionForPoint(exit, targetZ, mapData);
+        const center = centerForGridPosition(gridPosition, mapData);
+        token.x = center.x;
+        token.y = center.y;
         token.elevationFt = exit.elevationFt;
         token.zLayer = Number(targetZ);
         token.z = [Number(targetZ)];
-        token.gridPosition = gridPositionForPoint(exit, targetZ, mapData);
+        token.gridPosition = gridPosition;
         token.lastVerticalTravel = {
             routeId: route.id,
             fromZ: Number(sourceLayer),
@@ -131,9 +141,7 @@
         const spendFt = Math.min(availableFt, totalCostFt);
         token.movementRemainingFt = Math.max(0, availableFt - spendFt);
         const travelFt = spendFt / multiplier;
-        if (travelFt + 1e-9 >= route.pathLengthFt) {
-            return completeTransition(token, route, sourceLayer, mapData, spendFt);
-        }
+        if (travelFt + 1e-9 >= route.pathLengthFt) return completeTransition(token, route, sourceLayer, mapData, spendFt);
 
         const point = routes.pointAtDistance(route, sourceLayer, travelFt, mapData);
         applyPoint(token, point, sourceLayer, route, travelFt, spendFt, mapData);
@@ -161,6 +169,7 @@
         transitionCandidates,
         findTransitionAtPoint,
         gridPositionForPoint,
+        centerForGridPosition,
         hasDedicatedClimbSpeed,
         effectiveMultiplier,
         availableMovementFt,

--- a/js/vtt/vertical-movement.js
+++ b/js/vtt/vertical-movement.js
@@ -1,0 +1,171 @@
+(function (root, factory) {
+    const api = factory(root);
+    if (typeof module !== 'undefined' && module.exports) module.exports = api;
+    if (root) root.LuminousVttVerticalMovement = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (root) {
+    'use strict';
+
+    const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+    function routeRuntime() {
+        if (root?.LuminousVttStairRoute) return root.LuminousVttStairRoute;
+        if (typeof require !== 'undefined') {
+            try { return require('./stair-route.js'); } catch (_) {}
+        }
+        return null;
+    }
+
+    function tokenLayer(token = {}) {
+        if (Number.isFinite(Number(token.zLayer))) return Number(token.zLayer);
+        if (Number.isFinite(Number(token.gridPosition?.z))) return Number(token.gridPosition.z);
+        if (Array.isArray(token.z) && token.z.length) return Number(token.z[0]) || 0;
+        return 0;
+    }
+
+    function transitionCandidates(mapData = {}, zLayer) {
+        const routes = routeRuntime();
+        if (!routes) return [];
+        return (Array.isArray(mapData.verticalPortals) ? mapData.verticalPortals : [])
+            .filter((portal) => portal?.type === 'stairs' && portal.state !== 'closed' && portal.allowsMovement !== false)
+            .map((portal) => ({ portal, route: routes.routeFor(portal, mapData) }))
+            .filter(({ route }) => route && routes.routeEntryForLayer(route, zLayer));
+    }
+
+    function findTransitionAtPoint(point, mapData = {}, zLayer, tolerancePx = null) {
+        const routes = routeRuntime();
+        if (!routes) return null;
+        const tolerance = tolerancePx == null ? Math.max(12, numberOr(mapData.grid?.size, 70) * 0.55) : Math.max(1, numberOr(tolerancePx));
+        let best = null;
+        let bestDistance = Infinity;
+        for (const candidate of transitionCandidates(mapData, zLayer)) {
+            const distance = routes.distanceToEntry(point, candidate.route, zLayer);
+            if (distance <= tolerance && distance < bestDistance) {
+                best = candidate;
+                bestDistance = distance;
+            }
+        }
+        return best ? { ...best, distancePx: bestDistance } : null;
+    }
+
+    function gridPositionForPoint(point = {}, zLayer, mapData = {}) {
+        const size = Math.max(1, numberOr(mapData.grid?.size, 70));
+        const cols = Math.max(1, Math.trunc(numberOr(mapData.grid?.cols, 1)));
+        const rows = Math.max(1, Math.trunc(numberOr(mapData.grid?.rows, 1)));
+        const col = Math.max(0, Math.min(cols - 1, Math.floor(numberOr(point.x) / size)));
+        const row = Math.max(0, Math.min(rows - 1, Math.floor(numberOr(point.y) / size)));
+        return { col, row, z: Number(zLayer) || 0 };
+    }
+
+    function hasDedicatedClimbSpeed(token = {}) {
+        return Number(token.climbSpeedFt) > 0
+            || Number(token.movement?.climbFt) > 0
+            || token.movementModes?.climb === true;
+    }
+
+    function effectiveMultiplier(route, token = {}) {
+        if (route?.movementMode === 'climb' && hasDedicatedClimbSpeed(token)) return 1;
+        return Math.max(1, numberOr(route?.costMultiplier, 1));
+    }
+
+    function availableMovementFt(token = {}) {
+        if (Number.isFinite(Number(token.movementRemainingFt))) return Math.max(0, Number(token.movementRemainingFt));
+        return Infinity;
+    }
+
+    function applyPoint(token, point, sourceLayer, route, progressFt, costSpentFt, mapData) {
+        token.x = point.x;
+        token.y = point.y;
+        token.elevationFt = point.elevationFt;
+        token.verticalMovement = {
+            routeId: route.id,
+            fromZ: Number(sourceLayer),
+            toZ: Number(routeRuntime().targetLayer(route, sourceLayer)),
+            progressFt,
+            totalFt: route.pathLengthFt,
+            costSpentFt,
+            layout: route.layout,
+            movementMode: route.movementMode,
+        };
+        token.gridPosition = gridPositionForPoint(point, sourceLayer, mapData);
+        token.zLayer = Number(sourceLayer);
+        token.z = [Number(sourceLayer)];
+    }
+
+    function completeTransition(token, route, sourceLayer, mapData, costSpentFt = 0) {
+        const routes = routeRuntime();
+        const targetZ = routes.targetLayer(route, sourceLayer);
+        const ordered = routes.orderedPoints(route, sourceLayer);
+        const exit = ordered[ordered.length - 1];
+        token.x = exit.x;
+        token.y = exit.y;
+        token.elevationFt = exit.elevationFt;
+        token.zLayer = Number(targetZ);
+        token.z = [Number(targetZ)];
+        token.gridPosition = gridPositionForPoint(exit, targetZ, mapData);
+        token.lastVerticalTravel = {
+            routeId: route.id,
+            fromZ: Number(sourceLayer),
+            toZ: Number(targetZ),
+            pathLengthFt: route.pathLengthFt,
+            movementMode: route.movementMode,
+            costSpentFt,
+        };
+        delete token.verticalMovement;
+        return { valid: true, complete: true, targetZ, route, token, costSpentFt };
+    }
+
+    function traverse(token, candidate, mapData = {}) {
+        const routes = routeRuntime();
+        if (!routes || !candidate?.route) return { valid: false, reason: 'ROUTE_UNAVAILABLE' };
+        const route = candidate.route;
+        const sourceLayer = tokenLayer(token);
+        const targetZ = routes.targetLayer(route, sourceLayer);
+        if (targetZ == null) return { valid: false, reason: 'ROUTE_NOT_ON_LAYER' };
+        if (route.bidirectional === false && sourceLayer !== route.fromZ) return { valid: false, reason: 'ONE_WAY_ROUTE' };
+
+        const multiplier = effectiveMultiplier(route, token);
+        const totalCostFt = route.pathLengthFt * multiplier;
+        const availableFt = availableMovementFt(token);
+        if (!Number.isFinite(availableFt)) return completeTransition(token, route, sourceLayer, mapData, totalCostFt);
+
+        const spendFt = Math.min(availableFt, totalCostFt);
+        token.movementRemainingFt = Math.max(0, availableFt - spendFt);
+        const travelFt = spendFt / multiplier;
+        if (travelFt + 1e-9 >= route.pathLengthFt) {
+            return completeTransition(token, route, sourceLayer, mapData, spendFt);
+        }
+
+        const point = routes.pointAtDistance(route, sourceLayer, travelFt, mapData);
+        applyPoint(token, point, sourceLayer, route, travelFt, spendFt, mapData);
+        return {
+            valid: true,
+            complete: false,
+            route,
+            token,
+            targetZ,
+            progressFt: travelFt,
+            remainingRouteFt: route.pathLengthFt - travelFt,
+            costSpentFt: spendFt,
+        };
+    }
+
+    function transitionOnDrop(token, dropPoint, mapData = {}) {
+        const zLayer = tokenLayer(token);
+        const candidate = findTransitionAtPoint(dropPoint, mapData, zLayer);
+        if (!candidate) return { valid: false, reason: 'NO_VERTICAL_TRANSITION' };
+        return traverse(token, candidate, mapData);
+    }
+
+    return Object.freeze({
+        tokenLayer,
+        transitionCandidates,
+        findTransitionAtPoint,
+        gridPositionForPoint,
+        hasDedicatedClimbSpeed,
+        effectiveMultiplier,
+        availableMovementFt,
+        completeTransition,
+        traverse,
+        transitionOnDrop,
+    });
+});

--- a/js/vtt/vertical-movement.js
+++ b/js/vtt/vertical-movement.js
@@ -31,6 +31,16 @@
             .filter(({ route }) => route && routes.routeEntryForLayer(route, zLayer));
     }
 
+    function candidateForRouteId(mapData = {}, routeId) {
+        if (!routeId) return null;
+        const routes = routeRuntime();
+        const portal = (Array.isArray(mapData.verticalPortals) ? mapData.verticalPortals : [])
+            .find((entry) => entry?.type === 'stairs' && String(entry.id) === String(routeId));
+        if (!portal || portal.state === 'closed' || portal.allowsMovement === false || !routes) return null;
+        const route = routes.routeFor(portal, mapData);
+        return route ? { portal, route, resumed: true } : null;
+    }
+
     function findTransitionAtPoint(point, mapData = {}, zLayer, tolerancePx = null) {
         const routes = routeRuntime();
         if (!routes) return null;
@@ -80,6 +90,26 @@
         return Infinity;
     }
 
+    function routeSourceLayer(token, route) {
+        const active = token?.verticalMovement;
+        if (active && String(active.routeId) === String(route?.id) && Number.isFinite(Number(active.fromZ))) {
+            return Number(active.fromZ);
+        }
+        return tokenLayer(token);
+    }
+
+    function progressFor(token, route) {
+        const active = token?.verticalMovement;
+        if (!active || String(active.routeId) !== String(route?.id)) return 0;
+        return Math.max(0, Math.min(numberOr(active.progressFt, 0), numberOr(route?.pathLengthFt, 0)));
+    }
+
+    function previousCostFor(token, route) {
+        const active = token?.verticalMovement;
+        if (!active || String(active.routeId) !== String(route?.id)) return 0;
+        return Math.max(0, numberOr(active.costSpentFt, 0));
+    }
+
     function applyPoint(token, point, sourceLayer, route, progressFt, costSpentFt, mapData) {
         token.x = point.x;
         token.y = point.y;
@@ -99,7 +129,7 @@
         token.z = [Number(sourceLayer)];
     }
 
-    function completeTransition(token, route, sourceLayer, mapData, costSpentFt = 0) {
+    function completeTransition(token, route, sourceLayer, mapData, stepCostFt = 0, totalCostFt = stepCostFt) {
         const routes = routeRuntime();
         const targetZ = routes.targetLayer(route, sourceLayer);
         const ordered = routes.orderedPoints(route, sourceLayer);
@@ -118,46 +148,64 @@
             toZ: Number(targetZ),
             pathLengthFt: route.pathLengthFt,
             movementMode: route.movementMode,
-            costSpentFt,
+            costSpentFt: totalCostFt,
         };
         delete token.verticalMovement;
-        return { valid: true, complete: true, targetZ, route, token, costSpentFt };
+        return { valid: true, complete: true, targetZ, route, token, costSpentFt: stepCostFt, totalCostFt };
     }
 
     function traverse(token, candidate, mapData = {}) {
         const routes = routeRuntime();
         if (!routes || !candidate?.route) return { valid: false, reason: 'ROUTE_UNAVAILABLE' };
         const route = candidate.route;
-        const sourceLayer = tokenLayer(token);
+        const sourceLayer = routeSourceLayer(token, route);
         const targetZ = routes.targetLayer(route, sourceLayer);
         if (targetZ == null) return { valid: false, reason: 'ROUTE_NOT_ON_LAYER' };
-        if (route.bidirectional === false && sourceLayer !== route.fromZ) return { valid: false, reason: 'ONE_WAY_ROUTE' };
+        if (route.bidirectional === false && Number(sourceLayer) !== Number(route.fromZ)) return { valid: false, reason: 'ONE_WAY_ROUTE' };
 
         const multiplier = effectiveMultiplier(route, token);
-        const totalCostFt = route.pathLengthFt * multiplier;
+        const startProgressFt = progressFor(token, route);
+        const previousCostFt = previousCostFor(token, route);
+        const remainingTravelFt = Math.max(0, route.pathLengthFt - startProgressFt);
+        const remainingCostFt = remainingTravelFt * multiplier;
         const availableFt = availableMovementFt(token);
-        if (!Number.isFinite(availableFt)) return completeTransition(token, route, sourceLayer, mapData, totalCostFt);
 
-        const spendFt = Math.min(availableFt, totalCostFt);
+        if (remainingTravelFt <= 1e-9) return completeTransition(token, route, sourceLayer, mapData, 0, previousCostFt);
+        if (!Number.isFinite(availableFt)) {
+            return completeTransition(token, route, sourceLayer, mapData, remainingCostFt, previousCostFt + remainingCostFt);
+        }
+
+        const spendFt = Math.min(availableFt, remainingCostFt);
         token.movementRemainingFt = Math.max(0, availableFt - spendFt);
-        const travelFt = spendFt / multiplier;
-        if (travelFt + 1e-9 >= route.pathLengthFt) return completeTransition(token, route, sourceLayer, mapData, spendFt);
+        const travelAddedFt = spendFt / multiplier;
+        const progressFt = Math.min(route.pathLengthFt, startProgressFt + travelAddedFt);
+        const totalCostFt = previousCostFt + spendFt;
 
-        const point = routes.pointAtDistance(route, sourceLayer, travelFt, mapData);
-        applyPoint(token, point, sourceLayer, route, travelFt, spendFt, mapData);
+        if (progressFt + 1e-9 >= route.pathLengthFt) {
+            return completeTransition(token, route, sourceLayer, mapData, spendFt, totalCostFt);
+        }
+
+        const point = routes.pointAtDistance(route, sourceLayer, progressFt, mapData);
+        applyPoint(token, point, sourceLayer, route, progressFt, totalCostFt, mapData);
         return {
             valid: true,
             complete: false,
+            resumed: startProgressFt > 0,
             route,
             token,
             targetZ,
-            progressFt: travelFt,
-            remainingRouteFt: route.pathLengthFt - travelFt,
+            progressFt,
+            remainingRouteFt: route.pathLengthFt - progressFt,
             costSpentFt: spendFt,
+            totalCostFt,
         };
     }
 
     function transitionOnDrop(token, dropPoint, mapData = {}) {
+        const activeRouteId = token?.verticalMovement?.routeId;
+        const resumed = candidateForRouteId(mapData, activeRouteId);
+        if (resumed) return traverse(token, resumed, mapData);
+
         const zLayer = tokenLayer(token);
         const candidate = findTransitionAtPoint(dropPoint, mapData, zLayer);
         if (!candidate) return { valid: false, reason: 'NO_VERTICAL_TRANSITION' };
@@ -167,12 +215,15 @@
     return Object.freeze({
         tokenLayer,
         transitionCandidates,
+        candidateForRouteId,
         findTransitionAtPoint,
         gridPositionForPoint,
         centerForGridPosition,
         hasDedicatedClimbSpeed,
         effectiveMultiplier,
         availableMovementFt,
+        routeSourceLayer,
+        progressFor,
         completeTransition,
         traverse,
         transitionOnDrop,

--- a/js/vtt/vertical-portal-controller.js
+++ b/js/vtt/vertical-portal-controller.js
@@ -5,6 +5,7 @@ export class VerticalPortalController {
         this.mapData = mapData;
         this.stateBridge = stateBridge;
         this.runtime = globalThis.LuminousVttVerticalPortal;
+        this.routeRuntime = globalThis.LuminousVttStairRoute;
         this.topology = globalThis.LuminousVttTopology;
         this.isDm = Boolean(stateBridge?.isDm);
         this.tool = 'select';
@@ -16,20 +17,14 @@ export class VerticalPortalController {
         this.handleMouseMove = this.handleMouseMove.bind(this);
         this.handleMouseUp = this.handleMouseUp.bind(this);
 
-        this.mapData.verticalPortalEditor = {
-            visible: this.isDm,
-            preview: null,
-            selectedId: null,
-        };
-
+        this.mapData.verticalPortalEditor = { visible: false, preview: null, selectedId: null };
         this.bindCanvas();
         this.bindUi();
         this.renderMode();
     }
 
-    setTopologyController(controller) {
-        this.topologyController = controller || null;
-    }
+    editActive() { return Boolean(this.isDm && this.mapData.dmEditMode?.active); }
+    setTopologyController(controller) { this.topologyController = controller || null; }
 
     bindCanvas() {
         this.canvas.addEventListener('mousedown', this.handleMouseDown, true);
@@ -41,23 +36,17 @@ export class VerticalPortalController {
         document.querySelectorAll('[data-vtt-vertical-tool]').forEach((button) => {
             button.addEventListener('click', () => this.setTool(button.dataset.vttVerticalTool));
         });
-
         document.querySelectorAll('[data-vtt-tool]').forEach((button) => {
             button.addEventListener('click', () => {
                 if (button.dataset.vttTool !== 'select' || this.tool !== 'select') this.setTool('select', false);
             });
         });
-
-        document.getElementById('vtt-vertical-target-z')?.addEventListener('change', () => {
-            this.clearPreview();
-        });
-
-        document.getElementById('vtt-vertical-editor-target')?.addEventListener('change', (event) => {
-            this.updateSelectedTarget(Number(event.target.value));
-        });
-
+        document.getElementById('vtt-vertical-target-z')?.addEventListener('change', () => this.clearPreview());
+        document.getElementById('vtt-vertical-editor-target')?.addEventListener('change', (event) => this.updateSelectedTarget(Number(event.target.value)));
+        document.getElementById('vtt-vertical-layout')?.addEventListener('change', (event) => this.updateSelected({ layout: event.target.value }));
+        document.getElementById('vtt-vertical-width')?.addEventListener('change', (event) => this.updateSelected({ widthFt: Math.max(2, Number(event.target.value) || 5) }));
         document.getElementById('vtt-vertical-delete')?.addEventListener('click', () => {
-            if (!this.selectedId) return;
+            if (!this.selectedId || !this.editActive()) return;
             this.stateBridge.deletePortal(this.selectedId)
                 .then(() => {
                     this.selectedId = null;
@@ -70,9 +59,17 @@ export class VerticalPortalController {
     }
 
     renderMode() {
+        const active = this.editActive();
         const toolbar = document.getElementById('vtt-vertical-toolbar');
-        if (toolbar) toolbar.hidden = !this.isDm;
-        document.body.classList.toggle('vtt-vertical-editor-enabled', this.isDm);
+        if (toolbar) toolbar.hidden = !active;
+        this.mapData.verticalPortalEditor ||= {};
+        this.mapData.verticalPortalEditor.visible = active;
+        document.body.classList.toggle('vtt-vertical-editor-enabled', active);
+        if (!active) {
+            this.tool = 'select';
+            this.drawStart = null;
+            this.clearPreview();
+        }
         this.refreshTargetOptions();
         this.renderToolButtons();
         this.renderEditor();
@@ -80,7 +77,7 @@ export class VerticalPortalController {
 
     setTool(tool, resetTopology = true) {
         const valid = ['select', 'opening', 'balcony_edge', 'stairs', 'erase'];
-        this.tool = valid.includes(tool) ? tool : 'select';
+        this.tool = this.editActive() && valid.includes(tool) ? tool : 'select';
         this.drawStart = null;
         this.clearPreview();
         if (resetTopology && this.tool !== 'select') this.topologyController?.setTool?.('select');
@@ -88,18 +85,11 @@ export class VerticalPortalController {
     }
 
     renderToolButtons() {
-        document.querySelectorAll('[data-vtt-vertical-tool]').forEach((button) => {
-            button.classList.toggle('is-active', button.dataset.vttVerticalTool === this.tool);
-        });
+        document.querySelectorAll('[data-vtt-vertical-tool]').forEach((button) => button.classList.toggle('is-active', button.dataset.vttVerticalTool === this.tool));
     }
 
-    worldPoint(event) {
-        return this.engine.eventWorldPoint(event);
-    }
-
-    activeLayer() {
-        return Number(this.engine.activeZ || 0);
-    }
+    worldPoint(event) { return this.engine.eventWorldPoint(event); }
+    activeLayer() { return Number(this.engine.activeZ || 0); }
 
     zLevelEntries() {
         const levels = this.mapData.zLevels || {};
@@ -140,48 +130,30 @@ export class VerticalPortalController {
     }
 
     targetLayer() {
-        const select = document.getElementById('vtt-vertical-target-z');
-        const value = Number(select?.value);
+        const value = Number(document.getElementById('vtt-vertical-target-z')?.value);
         return Number.isFinite(value) && value !== this.activeLayer() ? value : this.preferredTargetLayer();
     }
 
     portalAtEvent(event) {
         if (!this.runtime) return null;
-        return this.runtime.hitTest(
-            this.mapData.verticalPortals,
-            this.worldPoint(event),
-            this.mapData,
-            this.activeLayer(),
-        );
+        return this.runtime.hitTest(this.mapData.verticalPortals, this.worldPoint(event), this.mapData, this.activeLayer());
     }
 
-    snapVertex(event) {
-        if (!this.topology) return null;
-        return this.topology.snapPointToVertex(this.worldPoint(event), this.mapData.grid);
-    }
-
-    axisAligned(from, candidate) {
-        return this.topology?.axisAlignedVertex?.(from, candidate) || candidate;
-    }
-
-    sameVertex(a, b) {
-        return this.topology?.sameVertex?.(a, b) || (a?.col === b?.col && a?.row === b?.row);
-    }
+    snapVertex(event) { return this.topology?.snapPointToVertex(this.worldPoint(event), this.mapData.grid) || null; }
+    axisAligned(from, candidate) { return this.topology?.axisAlignedVertex?.(from, candidate) || candidate; }
+    sameVertex(a, b) { return this.topology?.sameVertex?.(a, b) || (a?.col === b?.col && a?.row === b?.row); }
 
     setPreview(preview) {
-        if (!this.mapData.verticalPortalEditor) this.mapData.verticalPortalEditor = {};
+        this.mapData.verticalPortalEditor ||= {};
         this.mapData.verticalPortalEditor.preview = preview;
     }
-
-    clearPreview() {
-        this.setPreview(null);
-    }
+    clearPreview() { this.setPreview(null); }
 
     handleMouseDown(event) {
-        if (event.button !== 0 || !this.isDm || this.tool === 'select' && !this.portalAtEvent(event)) return;
-
+        if (event.button !== 0 || !this.editActive()) return;
         const hit = this.portalAtEvent(event);
         if (this.tool === 'select') {
+            if (!hit) return;
             event.preventDefault();
             event.stopImmediatePropagation();
             this.selectedId = hit.id;
@@ -192,7 +164,6 @@ export class VerticalPortalController {
 
         event.preventDefault();
         event.stopImmediatePropagation();
-
         if (this.tool === 'erase') {
             if (!hit) return;
             this.stateBridge.deletePortal(hit.id)
@@ -204,31 +175,21 @@ export class VerticalPortalController {
         const start = this.snapVertex(event);
         if (!start) return;
         this.drawStart = start;
-        this.setPreview({
-            type: this.tool,
-            from: start,
-            to: start,
-            between: [this.activeLayer(), this.targetLayer()],
-        });
+        this.setPreview({ type: this.tool, from: start, to: start, between: [this.activeLayer(), this.targetLayer()] });
     }
 
     handleMouseMove(event) {
-        if (!this.isDm || !this.drawStart || !['opening', 'balcony_edge', 'stairs'].includes(this.tool)) return;
+        if (!this.editActive() || !this.drawStart || !['opening', 'balcony_edge', 'stairs'].includes(this.tool)) return;
         const candidate = this.snapVertex(event);
         if (!candidate) return;
         const to = this.axisAligned(this.drawStart, candidate);
-        this.setPreview({
-            type: this.tool,
-            from: this.drawStart,
-            to,
-            between: [this.activeLayer(), this.targetLayer()],
-        });
+        this.setPreview({ type: this.tool, from: this.drawStart, to, between: [this.activeLayer(), this.targetLayer()] });
         event.preventDefault();
         event.stopImmediatePropagation();
     }
 
     handleMouseUp(event) {
-        if (event.button !== 0 || !this.isDm || !this.drawStart || !['opening', 'balcony_edge', 'stairs'].includes(this.tool)) return;
+        if (event.button !== 0 || !this.editActive() || !this.drawStart || !['opening', 'balcony_edge', 'stairs'].includes(this.tool)) return;
         const from = this.drawStart;
         const candidate = this.snapVertex(event);
         const to = candidate ? this.axisAligned(from, candidate) : from;
@@ -257,15 +218,15 @@ export class VerticalPortalController {
     }
 
     syncEditorState() {
-        if (!this.mapData.verticalPortalEditor) this.mapData.verticalPortalEditor = {};
-        this.mapData.verticalPortalEditor.visible = this.isDm;
+        this.mapData.verticalPortalEditor ||= {};
+        this.mapData.verticalPortalEditor.visible = this.editActive();
         this.mapData.verticalPortalEditor.selectedId = this.selectedId;
     }
 
     renderEditor() {
         const editor = document.getElementById('vtt-vertical-editor');
         if (!editor) return;
-        if (!this.isDm) {
+        if (!this.editActive()) {
             editor.hidden = true;
             return;
         }
@@ -278,18 +239,43 @@ export class VerticalPortalController {
         const current = this.activeLayer();
         const other = layers[0] === current ? layers[1] : layers[0];
 
-        document.getElementById('vtt-vertical-type').textContent = this.runtime.labelFor(portal);
+        document.getElementById('vtt-vertical-type').textContent = portal.type === 'stairs'
+            ? `${this.runtime.labelFor(portal)} · ${this.runtime.layoutLabel(portal)}`
+            : this.runtime.labelFor(portal);
         document.getElementById('vtt-vertical-id').textContent = portal.id;
         document.getElementById('vtt-vertical-from-z').textContent = `Z${current}`;
         const movement = document.getElementById('vtt-vertical-movement');
-        if (movement) movement.textContent = portal.allowsMovement ? 'TRANSICIÓN DE MOVIMIENTO: SÍ' : 'SOLO VISIÓN / LUZ: SÍ';
-
+        if (movement) movement.textContent = portal.allowsMovement ? `TRANSICIÓN: ${String(portal.movementMode || 'stairs').toUpperCase()}` : 'SOLO VISIÓN / LUZ';
         this.refreshTargetOptions('vtt-vertical-editor-target', other);
+
+        const stairFields = document.getElementById('vtt-stair-fields');
+        if (stairFields) stairFields.hidden = portal.type !== 'stairs';
+        if (portal.type === 'stairs') {
+            const layout = document.getElementById('vtt-vertical-layout');
+            const width = document.getElementById('vtt-vertical-width');
+            const length = document.getElementById('vtt-vertical-path-length');
+            if (layout) layout.value = portal.layout;
+            if (width) width.value = portal.widthFt;
+            const route = this.routeRuntime?.routeFor?.(portal, this.mapData);
+            if (length) length.textContent = route ? `${route.pathLengthFt.toFixed(1)} ft` : '—';
+        }
+    }
+
+    updateSelected(patch) {
+        const raw = this.selectedPortal();
+        if (!raw || !this.editActive()) return;
+        const next = this.runtime.normalizePortal({ ...raw, ...patch }, this.mapData);
+        this.stateBridge.savePortal(next)
+            .then(() => {
+                this.renderEditor();
+                this.notify('Conexión vertical actualizada.', 'success');
+            })
+            .catch((error) => this.notify(String(error.message || error), 'error'));
     }
 
     updateSelectedTarget(targetZ) {
         const raw = this.selectedPortal();
-        if (!raw || !Number.isFinite(Number(targetZ))) return;
+        if (!raw || !Number.isFinite(Number(targetZ)) || !this.editActive()) return;
         const portal = this.runtime.normalizePortal(raw, this.mapData);
         const current = this.activeLayer();
         if (Number(targetZ) === current) return;
@@ -321,9 +307,7 @@ export class VerticalPortalController {
         node.dataset.mode = mode;
         node.hidden = false;
         window.clearTimeout(this.noticeTimer);
-        this.noticeTimer = window.setTimeout(() => {
-            node.hidden = true;
-        }, 3200);
+        this.noticeTimer = window.setTimeout(() => { node.hidden = true; }, 3200);
     }
 
     destroy() {

--- a/js/vtt/vertical-portal-controller.js
+++ b/js/vtt/vertical-portal-controller.js
@@ -1,0 +1,335 @@
+export class VerticalPortalController {
+    constructor(canvas, engine, mapData, stateBridge) {
+        this.canvas = canvas;
+        this.engine = engine;
+        this.mapData = mapData;
+        this.stateBridge = stateBridge;
+        this.runtime = globalThis.LuminousVttVerticalPortal;
+        this.topology = globalThis.LuminousVttTopology;
+        this.isDm = Boolean(stateBridge?.isDm);
+        this.tool = 'select';
+        this.drawStart = null;
+        this.selectedId = null;
+        this.topologyController = null;
+
+        this.handleMouseDown = this.handleMouseDown.bind(this);
+        this.handleMouseMove = this.handleMouseMove.bind(this);
+        this.handleMouseUp = this.handleMouseUp.bind(this);
+
+        this.mapData.verticalPortalEditor = {
+            visible: this.isDm,
+            preview: null,
+            selectedId: null,
+        };
+
+        this.bindCanvas();
+        this.bindUi();
+        this.renderMode();
+    }
+
+    setTopologyController(controller) {
+        this.topologyController = controller || null;
+    }
+
+    bindCanvas() {
+        this.canvas.addEventListener('mousedown', this.handleMouseDown, true);
+        window.addEventListener('mousemove', this.handleMouseMove, true);
+        window.addEventListener('mouseup', this.handleMouseUp, true);
+    }
+
+    bindUi() {
+        document.querySelectorAll('[data-vtt-vertical-tool]').forEach((button) => {
+            button.addEventListener('click', () => this.setTool(button.dataset.vttVerticalTool));
+        });
+
+        document.querySelectorAll('[data-vtt-tool]').forEach((button) => {
+            button.addEventListener('click', () => {
+                if (button.dataset.vttTool !== 'select' || this.tool !== 'select') this.setTool('select', false);
+            });
+        });
+
+        document.getElementById('vtt-vertical-target-z')?.addEventListener('change', () => {
+            this.clearPreview();
+        });
+
+        document.getElementById('vtt-vertical-editor-target')?.addEventListener('change', (event) => {
+            this.updateSelectedTarget(Number(event.target.value));
+        });
+
+        document.getElementById('vtt-vertical-delete')?.addEventListener('click', () => {
+            if (!this.selectedId) return;
+            this.stateBridge.deletePortal(this.selectedId)
+                .then(() => {
+                    this.selectedId = null;
+                    this.syncEditorState();
+                    this.renderEditor();
+                    this.notify('Conexión vertical eliminada.', 'success');
+                })
+                .catch((error) => this.notify(String(error.message || error), 'error'));
+        });
+    }
+
+    renderMode() {
+        const toolbar = document.getElementById('vtt-vertical-toolbar');
+        if (toolbar) toolbar.hidden = !this.isDm;
+        document.body.classList.toggle('vtt-vertical-editor-enabled', this.isDm);
+        this.refreshTargetOptions();
+        this.renderToolButtons();
+        this.renderEditor();
+    }
+
+    setTool(tool, resetTopology = true) {
+        const valid = ['select', 'opening', 'balcony_edge', 'stairs', 'erase'];
+        this.tool = valid.includes(tool) ? tool : 'select';
+        this.drawStart = null;
+        this.clearPreview();
+        if (resetTopology && this.tool !== 'select') this.topologyController?.setTool?.('select');
+        this.renderToolButtons();
+    }
+
+    renderToolButtons() {
+        document.querySelectorAll('[data-vtt-vertical-tool]').forEach((button) => {
+            button.classList.toggle('is-active', button.dataset.vttVerticalTool === this.tool);
+        });
+    }
+
+    worldPoint(event) {
+        return this.engine.eventWorldPoint(event);
+    }
+
+    activeLayer() {
+        return Number(this.engine.activeZ || 0);
+    }
+
+    zLevelEntries() {
+        const levels = this.mapData.zLevels || {};
+        if (Array.isArray(levels)) {
+            return levels
+                .map((entry) => ({ zLayer: Number(entry?.zLayer ?? entry?.z ?? 0), label: entry?.label || `Z ${entry?.zLayer ?? entry?.z ?? 0}` }))
+                .sort((a, b) => a.zLayer - b.zLayer);
+        }
+        return Object.entries(levels)
+            .map(([key, entry]) => ({ zLayer: Number(entry?.zLayer ?? key), label: entry?.label || `Z ${entry?.zLayer ?? key}` }))
+            .sort((a, b) => a.zLayer - b.zLayer);
+    }
+
+    preferredTargetLayer() {
+        const active = this.activeLayer();
+        const layers = this.zLevelEntries().map((entry) => entry.zLayer).filter((layer) => layer !== active);
+        if (layers.includes(active + 1)) return active + 1;
+        if (layers.includes(active - 1)) return active - 1;
+        return layers[0] ?? active + 1;
+    }
+
+    refreshTargetOptions(selectId = 'vtt-vertical-target-z', desiredValue = null) {
+        const select = document.getElementById(selectId);
+        if (!select) return;
+        const active = this.activeLayer();
+        const previous = desiredValue ?? Number(select.value);
+        const entries = this.zLevelEntries().filter((entry) => entry.zLayer !== active);
+        select.replaceChildren();
+        for (const entry of entries) {
+            const option = document.createElement('option');
+            option.value = String(entry.zLayer);
+            option.textContent = `${entry.label} · Z${entry.zLayer}`;
+            select.appendChild(option);
+        }
+        const values = entries.map((entry) => entry.zLayer);
+        const nextValue = values.includes(Number(previous)) ? Number(previous) : this.preferredTargetLayer();
+        if (values.includes(nextValue)) select.value = String(nextValue);
+    }
+
+    targetLayer() {
+        const select = document.getElementById('vtt-vertical-target-z');
+        const value = Number(select?.value);
+        return Number.isFinite(value) && value !== this.activeLayer() ? value : this.preferredTargetLayer();
+    }
+
+    portalAtEvent(event) {
+        if (!this.runtime) return null;
+        return this.runtime.hitTest(
+            this.mapData.verticalPortals,
+            this.worldPoint(event),
+            this.mapData,
+            this.activeLayer(),
+        );
+    }
+
+    snapVertex(event) {
+        if (!this.topology) return null;
+        return this.topology.snapPointToVertex(this.worldPoint(event), this.mapData.grid);
+    }
+
+    axisAligned(from, candidate) {
+        return this.topology?.axisAlignedVertex?.(from, candidate) || candidate;
+    }
+
+    sameVertex(a, b) {
+        return this.topology?.sameVertex?.(a, b) || (a?.col === b?.col && a?.row === b?.row);
+    }
+
+    setPreview(preview) {
+        if (!this.mapData.verticalPortalEditor) this.mapData.verticalPortalEditor = {};
+        this.mapData.verticalPortalEditor.preview = preview;
+    }
+
+    clearPreview() {
+        this.setPreview(null);
+    }
+
+    handleMouseDown(event) {
+        if (event.button !== 0 || !this.isDm || this.tool === 'select' && !this.portalAtEvent(event)) return;
+
+        const hit = this.portalAtEvent(event);
+        if (this.tool === 'select') {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            this.selectedId = hit.id;
+            this.syncEditorState();
+            this.renderEditor();
+            return;
+        }
+
+        event.preventDefault();
+        event.stopImmediatePropagation();
+
+        if (this.tool === 'erase') {
+            if (!hit) return;
+            this.stateBridge.deletePortal(hit.id)
+                .then(() => this.notify('Conexión vertical eliminada.', 'success'))
+                .catch((error) => this.notify(String(error.message || error), 'error'));
+            return;
+        }
+
+        const start = this.snapVertex(event);
+        if (!start) return;
+        this.drawStart = start;
+        this.setPreview({
+            type: this.tool,
+            from: start,
+            to: start,
+            between: [this.activeLayer(), this.targetLayer()],
+        });
+    }
+
+    handleMouseMove(event) {
+        if (!this.isDm || !this.drawStart || !['opening', 'balcony_edge', 'stairs'].includes(this.tool)) return;
+        const candidate = this.snapVertex(event);
+        if (!candidate) return;
+        const to = this.axisAligned(this.drawStart, candidate);
+        this.setPreview({
+            type: this.tool,
+            from: this.drawStart,
+            to,
+            between: [this.activeLayer(), this.targetLayer()],
+        });
+        event.preventDefault();
+        event.stopImmediatePropagation();
+    }
+
+    handleMouseUp(event) {
+        if (event.button !== 0 || !this.isDm || !this.drawStart || !['opening', 'balcony_edge', 'stairs'].includes(this.tool)) return;
+        const from = this.drawStart;
+        const candidate = this.snapVertex(event);
+        const to = candidate ? this.axisAligned(from, candidate) : from;
+        const type = this.tool;
+        const fromZ = this.activeLayer();
+        const toZ = this.targetLayer();
+        this.drawStart = null;
+        this.clearPreview();
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        if (this.sameVertex(from, to) || fromZ === toZ) return;
+
+        const portal = this.runtime.createPortal({ type, from, to, fromZ, toZ, mapData: this.mapData });
+        this.stateBridge.savePortal(portal)
+            .then((saved) => {
+                this.selectedId = saved.id;
+                this.syncEditorState();
+                this.renderEditor();
+                this.notify(`${this.runtime.labelFor(saved)} guardado · Z${fromZ} ↔ Z${toZ}.`, 'success');
+            })
+            .catch((error) => this.notify(String(error.message || error), 'error'));
+    }
+
+    selectedPortal() {
+        return (this.mapData.verticalPortals || []).find((portal) => String(portal.id) === String(this.selectedId)) || null;
+    }
+
+    syncEditorState() {
+        if (!this.mapData.verticalPortalEditor) this.mapData.verticalPortalEditor = {};
+        this.mapData.verticalPortalEditor.visible = this.isDm;
+        this.mapData.verticalPortalEditor.selectedId = this.selectedId;
+    }
+
+    renderEditor() {
+        const editor = document.getElementById('vtt-vertical-editor');
+        if (!editor) return;
+        if (!this.isDm) {
+            editor.hidden = true;
+            return;
+        }
+
+        const raw = this.selectedPortal();
+        editor.hidden = !raw;
+        if (!raw) return;
+        const portal = this.runtime.normalizePortal(raw, this.mapData);
+        const layers = this.runtime.portalLayers(portal);
+        const current = this.activeLayer();
+        const other = layers[0] === current ? layers[1] : layers[0];
+
+        document.getElementById('vtt-vertical-type').textContent = this.runtime.labelFor(portal);
+        document.getElementById('vtt-vertical-id').textContent = portal.id;
+        document.getElementById('vtt-vertical-from-z').textContent = `Z${current}`;
+        const movement = document.getElementById('vtt-vertical-movement');
+        if (movement) movement.textContent = portal.allowsMovement ? 'TRANSICIÓN DE MOVIMIENTO: SÍ' : 'SOLO VISIÓN / LUZ: SÍ';
+
+        this.refreshTargetOptions('vtt-vertical-editor-target', other);
+    }
+
+    updateSelectedTarget(targetZ) {
+        const raw = this.selectedPortal();
+        if (!raw || !Number.isFinite(Number(targetZ))) return;
+        const portal = this.runtime.normalizePortal(raw, this.mapData);
+        const current = this.activeLayer();
+        if (Number(targetZ) === current) return;
+        portal.between = [current, Number(targetZ)];
+        this.stateBridge.savePortal(portal)
+            .then(() => this.notify(`Conexión actualizada · Z${current} ↔ Z${targetZ}.`, 'success'))
+            .catch((error) => this.notify(String(error.message || error), 'error'));
+    }
+
+    handlePortalsChanged() {
+        if (this.selectedId && !this.selectedPortal()) this.selectedId = null;
+        this.syncEditorState();
+        this.renderEditor();
+    }
+
+    handleLayerChanged() {
+        this.drawStart = null;
+        this.clearPreview();
+        if (this.selectedId && !this.runtime.portalOnLayer(this.selectedPortal(), this.activeLayer())) this.selectedId = null;
+        this.refreshTargetOptions();
+        this.syncEditorState();
+        this.renderEditor();
+    }
+
+    notify(message, mode = 'info') {
+        const node = document.getElementById('vtt-notice');
+        if (!node) return;
+        node.textContent = message;
+        node.dataset.mode = mode;
+        node.hidden = false;
+        window.clearTimeout(this.noticeTimer);
+        this.noticeTimer = window.setTimeout(() => {
+            node.hidden = true;
+        }, 3200);
+    }
+
+    destroy() {
+        this.canvas.removeEventListener('mousedown', this.handleMouseDown, true);
+        window.removeEventListener('mousemove', this.handleMouseMove, true);
+        window.removeEventListener('mouseup', this.handleMouseUp, true);
+        this.clearPreview();
+    }
+}

--- a/js/vtt/vertical-portal-state.js
+++ b/js/vtt/vertical-portal-state.js
@@ -1,0 +1,135 @@
+(function (root, factory) {
+    const api = factory(root);
+    if (typeof module !== 'undefined' && module.exports) module.exports = api;
+    if (root) root.LuminousVttVerticalPortalState = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (browserRoot) {
+    'use strict';
+
+    const ROOT = 'vtt_topology';
+    const safeString = (value) => String(value ?? '').trim();
+
+    function hostWindow(root = browserRoot) {
+        if (!root) return null;
+        try {
+            if (root.parent && root.parent !== root && root.parent.document) return root.parent;
+        } catch (_) {}
+        return root;
+    }
+
+    function hostFirebase(root = browserRoot) {
+        const host = hostWindow(root);
+        return host?.firebase || root?.firebase || null;
+    }
+
+    function recordFromPortals(portals, runtime, mapData) {
+        const record = {};
+        for (const raw of Array.isArray(portals) ? portals : []) {
+            const portal = runtime.normalizePortal(raw, mapData);
+            if (!portal.id) continue;
+            record[portal.id] = JSON.parse(JSON.stringify(portal));
+        }
+        return record;
+    }
+
+    function portalsFromRecord(record, runtime, mapData) {
+        return Object.values(record || {})
+            .filter(Boolean)
+            .map((portal) => runtime.normalizePortal(portal, mapData))
+            .sort((a, b) => String(a.id).localeCompare(String(b.id)));
+    }
+
+    function createBridge({ mapData, isDm = false, onChanged, notify, root = browserRoot } = {}) {
+        if (!mapData) throw new Error('MAP_DATA_REQUIRED');
+        const runtime = root?.LuminousVttVerticalPortal || (typeof require !== 'undefined' ? require('./vertical-portal.js') : null);
+        if (!runtime) throw new Error('VERTICAL_PORTAL_RUNTIME_REQUIRED');
+
+        const firebase = hostFirebase(root);
+        const db = firebase?.database?.() || null;
+        const mapId = safeString(mapData.id || mapData.mapId || 'default') || 'default';
+        const subscriptions = [];
+        let started = false;
+        let seedAttempted = false;
+
+        const emitNotice = (message, mode = 'info') => {
+            if (typeof notify === 'function') notify(message, mode);
+        };
+
+        const replacePortals = (portals) => {
+            mapData.verticalPortals = portals;
+            if (typeof onChanged === 'function') onChanged(portals);
+        };
+
+        const portalsRef = () => db?.ref(`${ROOT}/${mapId}/verticalPortals`);
+
+        async function seedIfNeeded(snapshot) {
+            if (seedAttempted) return;
+            seedAttempted = true;
+            const hasValue = typeof snapshot?.exists === 'function' ? snapshot.exists() : snapshot?.val?.() != null;
+            if (!isDm || hasValue || !Array.isArray(mapData.verticalPortals) || !mapData.verticalPortals.length) return;
+            await portalsRef().set(recordFromPortals(mapData.verticalPortals, runtime, mapData));
+        }
+
+        function subscribe(ref, event, handler) {
+            if (!ref?.on) return;
+            ref.on(event, handler);
+            subscriptions.push(() => ref.off(event, handler));
+        }
+
+        async function savePortal(rawPortal) {
+            if (!isDm) throw new Error('DM_REQUIRED');
+            const portal = runtime.normalizePortal(rawPortal, mapData);
+            if (!portal.id) throw new Error('PORTAL_ID_REQUIRED');
+            if (!db) {
+                const list = Array.isArray(mapData.verticalPortals) ? [...mapData.verticalPortals] : [];
+                const index = list.findIndex((entry) => String(entry.id) === String(portal.id));
+                if (index >= 0) list[index] = portal;
+                else list.push(portal);
+                replacePortals(list);
+                return portal;
+            }
+            await portalsRef().child(portal.id).set(JSON.parse(JSON.stringify(portal)));
+            return portal;
+        }
+
+        async function deletePortal(portalId) {
+            if (!isDm) throw new Error('DM_REQUIRED');
+            if (!db) {
+                replacePortals((mapData.verticalPortals || []).filter((entry) => String(entry.id) !== String(portalId)));
+                return true;
+            }
+            await portalsRef().child(String(portalId)).remove();
+            return true;
+        }
+
+        function start() {
+            if (started) return true;
+            started = true;
+            if (!db) {
+                replacePortals((mapData.verticalPortals || []).map((portal) => runtime.normalizePortal(portal, mapData)));
+                return false;
+            }
+            subscribe(portalsRef(), 'value', (snapshot) => {
+                seedIfNeeded(snapshot).catch((error) => console.error('VTT vertical portal seed failed:', error));
+                replacePortals(portalsFromRecord(snapshot.val(), runtime, mapData));
+            });
+            return true;
+        }
+
+        function stop() {
+            subscriptions.splice(0).forEach((unsubscribe) => unsubscribe());
+            started = false;
+        }
+
+        return Object.freeze({
+            mapId,
+            isDm: Boolean(isDm),
+            start,
+            stop,
+            savePortal,
+            deletePortal,
+            notify: emitNotice,
+        });
+    }
+
+    return Object.freeze({ ROOT, createBridge });
+});

--- a/js/vtt/vertical-portal.js
+++ b/js/vtt/vertical-portal.js
@@ -1,0 +1,156 @@
+(function (root, factory) {
+    const api = factory(root);
+    if (typeof module !== 'undefined' && module.exports) module.exports = api;
+    if (root) root.LuminousVttVerticalPortal = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (root) {
+    'use strict';
+
+    const TYPES = Object.freeze(['opening', 'balcony_edge', 'stairs']);
+    const LABELS = Object.freeze({
+        opening: 'HUECO',
+        balcony_edge: 'BALCÓN',
+        stairs: 'ESCALERA',
+    });
+
+    const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+    const clampInt = (value, min, max) => Math.max(min, Math.min(max, Math.trunc(numberOr(value, min))));
+
+    function makeId(type = 'opening') {
+        const safeType = TYPES.includes(type) ? type : 'opening';
+        const random = Math.random().toString(36).slice(2, 8);
+        return `vertical_${safeType}_${Date.now().toString(36)}_${random}`;
+    }
+
+    function normalizeVertex(vertex = {}, grid = {}) {
+        const maxCol = Math.max(0, Math.trunc(numberOr(grid.cols, 0)));
+        const maxRow = Math.max(0, Math.trunc(numberOr(grid.rows, 0)));
+        return {
+            col: clampInt(vertex.col, 0, maxCol),
+            row: clampInt(vertex.row, 0, maxRow),
+        };
+    }
+
+    function normalizeLayers(value, fallbackFrom = 0, fallbackTo = 1) {
+        const raw = Array.isArray(value) ? value.slice(0, 2) : [fallbackFrom, fallbackTo];
+        const first = Math.trunc(numberOr(raw[0], fallbackFrom));
+        let second = Math.trunc(numberOr(raw[1], fallbackTo));
+        if (second === first) second = first + 1;
+        return [first, second];
+    }
+
+    function normalizePortal(portal = {}, mapData = {}) {
+        const type = TYPES.includes(portal.type) ? portal.type : 'opening';
+        const between = normalizeLayers(portal.between, portal.fromZ ?? 0, portal.toZ ?? 1);
+        return {
+            schemaVersion: 1,
+            id: String(portal.id || makeId(type)),
+            type,
+            between,
+            from: normalizeVertex(portal.from || portal.a, mapData.grid),
+            to: normalizeVertex(portal.to || portal.b, mapData.grid),
+            state: portal.state === 'closed' ? 'closed' : 'open',
+            blocksVision: portal.blocksVision === true,
+            blocksLight: portal.blocksLight === true,
+            allowsMovement: portal.allowsMovement != null ? Boolean(portal.allowsMovement) : type === 'stairs',
+            movementMode: portal.movementMode || (type === 'stairs' ? 'stairs' : null),
+        };
+    }
+
+    function createPortal({ type = 'opening', from, to, fromZ = 0, toZ = 1, mapData = {} } = {}) {
+        return normalizePortal({
+            id: makeId(type),
+            type,
+            from,
+            to,
+            between: [fromZ, toZ],
+            state: 'open',
+            blocksVision: false,
+            blocksLight: false,
+            allowsMovement: type === 'stairs',
+            movementMode: type === 'stairs' ? 'stairs' : null,
+        }, mapData);
+    }
+
+    function portalLayers(portal = {}) {
+        const layers = Array.isArray(portal.between) ? portal.between : [portal.fromZ ?? 0, portal.toZ ?? 0];
+        return layers.slice(0, 2).map((value) => Math.trunc(numberOr(value, 0)));
+    }
+
+    function portalOnLayer(portal = {}, zLayer) {
+        return portalLayers(portal).includes(Number(zLayer));
+    }
+
+    function otherLayer(portal = {}, zLayer) {
+        const layers = portalLayers(portal);
+        const current = Number(zLayer);
+        if (layers[0] === current) return layers[1];
+        if (layers[1] === current) return layers[0];
+        return layers[1];
+    }
+
+    function vertexToPoint(vertex = {}, mapData = {}) {
+        const spatial = root?.LuminousVttSpatialVision;
+        if (spatial?.vertexToPoint) return spatial.vertexToPoint(vertex, mapData);
+        const size = Math.max(1, numberOr(mapData.grid?.size, 70));
+        return { x: numberOr(vertex.col) * size, y: numberOr(vertex.row) * size };
+    }
+
+    function segment(portal = {}, mapData = {}) {
+        const normalized = normalizePortal(portal, mapData);
+        const a = vertexToPoint(normalized.from, mapData);
+        const b = vertexToPoint(normalized.to, mapData);
+        return { x1: a.x, y1: a.y, x2: b.x, y2: b.y };
+    }
+
+    function pointToSegmentDistance(point, a, b) {
+        const px = numberOr(point?.x);
+        const py = numberOr(point?.y);
+        const ax = numberOr(a?.x);
+        const ay = numberOr(a?.y);
+        const bx = numberOr(b?.x);
+        const by = numberOr(b?.y);
+        const dx = bx - ax;
+        const dy = by - ay;
+        if (dx === 0 && dy === 0) return Math.hypot(px - ax, py - ay);
+        const t = Math.max(0, Math.min(1, (((px - ax) * dx) + ((py - ay) * dy)) / ((dx * dx) + (dy * dy))));
+        return Math.hypot(px - (ax + (t * dx)), py - (ay + (t * dy)));
+    }
+
+    function hitTest(portals, point, mapData = {}, zLayer = 0, tolerancePx = null) {
+        const tolerance = tolerancePx == null ? Math.max(8, numberOr(mapData.grid?.size, 70) * 0.14) : Math.max(1, numberOr(tolerancePx, 8));
+        let best = null;
+        let bestDistance = Infinity;
+        for (const raw of Array.isArray(portals) ? portals : []) {
+            const portal = normalizePortal(raw, mapData);
+            if (!portalOnLayer(portal, zLayer)) continue;
+            const line = segment(portal, mapData);
+            const distance = pointToSegmentDistance(point, { x: line.x1, y: line.y1 }, { x: line.x2, y: line.y2 });
+            if (distance <= tolerance && distance < bestDistance) {
+                best = portal;
+                bestDistance = distance;
+            }
+        }
+        return best;
+    }
+
+    function labelFor(portalOrType) {
+        const type = typeof portalOrType === 'string' ? portalOrType : portalOrType?.type;
+        return LABELS[type] || 'PORTAL Z';
+    }
+
+    return Object.freeze({
+        TYPES,
+        LABELS,
+        normalizeVertex,
+        normalizePortal,
+        createPortal,
+        portalLayers,
+        portalOnLayer,
+        otherLayer,
+        vertexToPoint,
+        segment,
+        pointToSegmentDistance,
+        hitTest,
+        labelFor,
+    });
+});

--- a/js/vtt/vertical-portal.js
+++ b/js/vtt/vertical-portal.js
@@ -6,12 +6,9 @@
     'use strict';
 
     const TYPES = Object.freeze(['opening', 'balcony_edge', 'stairs']);
-    const LABELS = Object.freeze({
-        opening: 'HUECO',
-        balcony_edge: 'BALCÓN',
-        stairs: 'ESCALERA',
-    });
-
+    const STAIR_LAYOUTS = Object.freeze(['straight', 'switchback', 'spiral', 'ladder']);
+    const LABELS = Object.freeze({ opening: 'HUECO', balcony_edge: 'BALCÓN', stairs: 'ESCALERA' });
+    const LAYOUT_LABELS = Object.freeze({ straight: 'RECTA', switchback: 'U / DOS TRAMOS', spiral: 'CARACOL', ladder: 'VERTICAL / LADDER' });
     const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
     const clampInt = (value, min, max) => Math.max(min, Math.min(max, Math.trunc(numberOr(value, min))));
 
@@ -24,10 +21,7 @@
     function normalizeVertex(vertex = {}, grid = {}) {
         const maxCol = Math.max(0, Math.trunc(numberOr(grid.cols, 0)));
         const maxRow = Math.max(0, Math.trunc(numberOr(grid.rows, 0)));
-        return {
-            col: clampInt(vertex.col, 0, maxCol),
-            row: clampInt(vertex.row, 0, maxRow),
-        };
+        return { col: clampInt(vertex.col, 0, maxCol), row: clampInt(vertex.row, 0, maxRow) };
     }
 
     function normalizeLayers(value, fallbackFrom = 0, fallbackTo = 1) {
@@ -38,11 +32,17 @@
         return [first, second];
     }
 
+    function normalizeLayout(value) {
+        const layout = String(value || 'straight').toLowerCase();
+        return STAIR_LAYOUTS.includes(layout) ? layout : 'straight';
+    }
+
     function normalizePortal(portal = {}, mapData = {}) {
         const type = TYPES.includes(portal.type) ? portal.type : 'opening';
         const between = normalizeLayers(portal.between, portal.fromZ ?? 0, portal.toZ ?? 1);
+        const layout = type === 'stairs' ? normalizeLayout(portal.layout) : null;
         return {
-            schemaVersion: 1,
+            schemaVersion: 2,
             id: String(portal.id || makeId(type)),
             type,
             between,
@@ -52,22 +52,21 @@
             blocksVision: portal.blocksVision === true,
             blocksLight: portal.blocksLight === true,
             allowsMovement: portal.allowsMovement != null ? Boolean(portal.allowsMovement) : type === 'stairs',
-            movementMode: portal.movementMode || (type === 'stairs' ? 'stairs' : null),
+            movementMode: type === 'stairs' ? (layout === 'ladder' ? 'climb' : 'stairs') : null,
+            layout,
+            widthFt: type === 'stairs' ? Math.max(2, numberOr(portal.widthFt, 5)) : Math.max(0, numberOr(portal.widthFt, 0)),
+            costMultiplier: type === 'stairs' ? Math.max(1, numberOr(portal.costMultiplier, layout === 'ladder' ? 2 : 1)) : 1,
+            bidirectional: portal.bidirectional !== false,
         };
     }
 
-    function createPortal({ type = 'opening', from, to, fromZ = 0, toZ = 1, mapData = {} } = {}) {
+    function createPortal({ type = 'opening', from, to, fromZ = 0, toZ = 1, mapData = {}, layout = 'straight', widthFt = 5 } = {}) {
+        const normalizedLayout = normalizeLayout(layout);
         return normalizePortal({
-            id: makeId(type),
-            type,
-            from,
-            to,
-            between: [fromZ, toZ],
-            state: 'open',
-            blocksVision: false,
-            blocksLight: false,
-            allowsMovement: type === 'stairs',
-            movementMode: type === 'stairs' ? 'stairs' : null,
+            id: makeId(type), type, from, to, between: [fromZ, toZ], state: 'open', blocksVision: false, blocksLight: false,
+            allowsMovement: type === 'stairs', movementMode: type === 'stairs' ? (normalizedLayout === 'ladder' ? 'climb' : 'stairs') : null,
+            layout: type === 'stairs' ? normalizedLayout : null, widthFt: type === 'stairs' ? widthFt : 0,
+            costMultiplier: type === 'stairs' && normalizedLayout === 'ladder' ? 2 : 1, bidirectional: true,
         }, mapData);
     }
 
@@ -76,10 +75,7 @@
         return layers.slice(0, 2).map((value) => Math.trunc(numberOr(value, 0)));
     }
 
-    function portalOnLayer(portal = {}, zLayer) {
-        return portalLayers(portal).includes(Number(zLayer));
-    }
-
+    function portalOnLayer(portal = {}, zLayer) { return portalLayers(portal).includes(Number(zLayer)); }
     function otherLayer(portal = {}, zLayer) {
         const layers = portalLayers(portal);
         const current = Number(zLayer);
@@ -103,14 +99,8 @@
     }
 
     function pointToSegmentDistance(point, a, b) {
-        const px = numberOr(point?.x);
-        const py = numberOr(point?.y);
-        const ax = numberOr(a?.x);
-        const ay = numberOr(a?.y);
-        const bx = numberOr(b?.x);
-        const by = numberOr(b?.y);
-        const dx = bx - ax;
-        const dy = by - ay;
+        const px = numberOr(point?.x), py = numberOr(point?.y), ax = numberOr(a?.x), ay = numberOr(a?.y), bx = numberOr(b?.x), by = numberOr(b?.y);
+        const dx = bx - ax, dy = by - ay;
         if (dx === 0 && dy === 0) return Math.hypot(px - ax, py - ay);
         const t = Math.max(0, Math.min(1, (((px - ax) * dx) + ((py - ay) * dy)) / ((dx * dx) + (dy * dy))));
         return Math.hypot(px - (ax + (t * dx)), py - (ay + (t * dy)));
@@ -118,17 +108,13 @@
 
     function hitTest(portals, point, mapData = {}, zLayer = 0, tolerancePx = null) {
         const tolerance = tolerancePx == null ? Math.max(8, numberOr(mapData.grid?.size, 70) * 0.14) : Math.max(1, numberOr(tolerancePx, 8));
-        let best = null;
-        let bestDistance = Infinity;
+        let best = null, bestDistance = Infinity;
         for (const raw of Array.isArray(portals) ? portals : []) {
             const portal = normalizePortal(raw, mapData);
             if (!portalOnLayer(portal, zLayer)) continue;
             const line = segment(portal, mapData);
             const distance = pointToSegmentDistance(point, { x: line.x1, y: line.y1 }, { x: line.x2, y: line.y2 });
-            if (distance <= tolerance && distance < bestDistance) {
-                best = portal;
-                bestDistance = distance;
-            }
+            if (distance <= tolerance && distance < bestDistance) { best = portal; bestDistance = distance; }
         }
         return best;
     }
@@ -138,19 +124,14 @@
         return LABELS[type] || 'PORTAL Z';
     }
 
+    function layoutLabel(portalOrLayout) {
+        const layout = typeof portalOrLayout === 'string' ? portalOrLayout : portalOrLayout?.layout;
+        return LAYOUT_LABELS[normalizeLayout(layout)] || LAYOUT_LABELS.straight;
+    }
+
     return Object.freeze({
-        TYPES,
-        LABELS,
-        normalizeVertex,
-        normalizePortal,
-        createPortal,
-        portalLayers,
-        portalOnLayer,
-        otherLayer,
-        vertexToPoint,
-        segment,
-        pointToSegmentDistance,
-        hitTest,
-        labelFor,
+        TYPES, STAIR_LAYOUTS, LABELS, LAYOUT_LABELS, normalizeVertex, normalizeLayers, normalizeLayout, normalizePortal,
+        createPortal, portalLayers, portalOnLayer, otherLayer, vertexToPoint, segment, pointToSegmentDistance, hitTest,
+        labelFor, layoutLabel,
     });
 });

--- a/tests/core_condition_integration.spec.js
+++ b/tests/core_condition_integration.spec.js
@@ -115,6 +115,7 @@ test('condition combat bridge enforces phases, saves, poison damage, targeting, 
     const resolvedGrapple = global.CombatEngine.resolveActionSlot(grappler, 0, {
       plannedAction: scheduled.entry,
       combatData: { grappler, held },
+      rng: () => 0,
     });
     expect(resolvedGrapple.handled).toBe(true);
     expect(resolvedGrapple.result.applied).toBe(true);
@@ -172,9 +173,31 @@ test('condition theatre bridge injects the real roll spec before arming a Check'
   }
 });
 
-test('status engine loads both condition integration bridges', () => {
-  const fs = require('fs');
-  const source = fs.readFileSync(require.resolve('../js/status-engine.js'), 'utf8');
-  expect(source).toContain('core-condition-combat-bridge.js');
-  expect(source).toContain('core-condition-theatre-bridge.js');
+test('condition Environment bridge remaps numeric actor Conditions and applies penalties once', () => {
+  const keys = ['EnvironmentEngine', 'LuminousConditionRuntime', 'LuminousConditionEnvironmentBridge'];
+  const previous = snapshotGlobals(keys);
+  try {
+    delete require.cache[require.resolve('../js/core-condition-environment-bridge.js')];
+    delete global.LuminousConditionEnvironmentBridge;
+    global.LuminousConditionRuntime = {
+      conditionForEnvironmentId(id) { return id === 'hambriento' ? 'hungry' : null; },
+      environmentCheckModifiers(unit) { return { checks: unit.statusEffects?.hungry ? -2 : 0, saves: unit.statusEffects?.hungry ? -1 : 0 }; },
+    };
+    global.EnvironmentEngine = {
+      applyStatusEffects(actor, ids) { actor.baseIds = ids; return { ids }; },
+      getCheckPenalty() { return -1; },
+      getSavePenalty() { return -2; },
+    };
+    const bridge = require('../js/core-condition-environment-bridge.js');
+    expect(bridge.install()).toBe(true);
+    const actor = { statusEffects: {} };
+    const applied = global.EnvironmentEngine.applyStatusEffects(actor, [101]);
+    expect(applied.ids).toEqual([101]);
+    expect(actor.statusEffects.hungry).toBeTruthy();
+    expect(global.EnvironmentEngine.getCheckPenalty(actor)).toBe(-3);
+    expect(global.EnvironmentEngine.getSavePenalty(actor)).toBe(-3);
+  } finally {
+    restoreGlobals(previous);
+    delete require.cache[require.resolve('../js/core-condition-environment-bridge.js')];
+  }
 });

--- a/tests/core_condition_integration.spec.js
+++ b/tests/core_condition_integration.spec.js
@@ -173,31 +173,9 @@ test('condition theatre bridge injects the real roll spec before arming a Check'
   }
 });
 
-test('condition Environment bridge remaps numeric actor Conditions and applies penalties once', () => {
-  const keys = ['EnvironmentEngine', 'LuminousConditionRuntime', 'LuminousConditionEnvironmentBridge'];
-  const previous = snapshotGlobals(keys);
-  try {
-    delete require.cache[require.resolve('../js/core-condition-environment-bridge.js')];
-    delete global.LuminousConditionEnvironmentBridge;
-    global.LuminousConditionRuntime = {
-      conditionForEnvironmentId(id) { return id === 'hambriento' ? 'hungry' : null; },
-      environmentCheckModifiers(unit) { return { checks: unit.statusEffects?.hungry ? -2 : 0, saves: unit.statusEffects?.hungry ? -1 : 0 }; },
-    };
-    global.EnvironmentEngine = {
-      applyStatusEffects(actor, ids) { actor.baseIds = ids; return { ids }; },
-      getCheckPenalty() { return -1; },
-      getSavePenalty() { return -2; },
-    };
-    const bridge = require('../js/core-condition-environment-bridge.js');
-    expect(bridge.install()).toBe(true);
-    const actor = { statusEffects: {} };
-    const applied = global.EnvironmentEngine.applyStatusEffects(actor, [101]);
-    expect(applied.ids).toEqual([101]);
-    expect(actor.statusEffects.hungry).toBeTruthy();
-    expect(global.EnvironmentEngine.getCheckPenalty(actor)).toBe(-3);
-    expect(global.EnvironmentEngine.getSavePenalty(actor)).toBe(-3);
-  } finally {
-    restoreGlobals(previous);
-    delete require.cache[require.resolve('../js/core-condition-environment-bridge.js')];
-  }
+test('status engine loads both condition integration bridges', () => {
+  const fs = require('fs');
+  const source = fs.readFileSync(require.resolve('../js/status-engine.js'), 'utf8');
+  expect(source).toContain('core-condition-combat-bridge.js');
+  expect(source).toContain('core-condition-theatre-bridge.js');
 });

--- a/tests/vtt_darkvision_zlevels.spec.js
+++ b/tests/vtt_darkvision_zlevels.spec.js
@@ -113,17 +113,18 @@ test('VTT wiring loads linked racial senses, feet grid, grayscale rendering and 
   expect(mapData).toContain("characterLink: { mode: 'current_player' }");
 });
 
-test('all new and modified vision modules parse as JavaScript', () => {
+test('new UMD runtimes parse and VTT files keep their ES module contracts', () => {
   const root = path.join(__dirname, '..');
   for (const file of [
     'js/racial-sense-runtime.js',
     'js/vtt/spatial-vision.js',
     'js/vtt/character-vision-bridge.js',
-    'js/vtt/engine.js',
-    'js/vtt/renderer.js',
-    'js/vtt/main.js',
-    'js/vtt/mapData.js',
   ]) {
     execFileSync(process.execPath, ['--check', path.join(root, file)], { stdio: 'pipe' });
   }
+
+  expect(read('js/vtt/engine.js')).toMatch(/^import\s+\{\s*Camera\s*\}/);
+  expect(read('js/vtt/renderer.js')).toMatch(/^export\s+class\s+Renderer/);
+  expect(read('js/vtt/main.js')).toMatch(/^import\s+\{\s*Engine\s*\}/);
+  expect(read('js/vtt/mapData.js')).toMatch(/^export\s+const\s+mockMapData/);
 });

--- a/tests/vtt_darkvision_zlevels.spec.js
+++ b/tests/vtt_darkvision_zlevels.spec.js
@@ -1,0 +1,129 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const senses = require('../js/racial-sense-runtime.js');
+const spatial = require('../js/vtt/spatial-vision.js');
+const visionBridge = require('../js/vtt/character-vision-bridge.js');
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+const map = {
+  grid: { cols: 20, rows: 20, size: 70, distancePerCell: 5, distanceUnit: 'ft' },
+  defaultZStepFt: 15,
+  zLevels: {
+    0: { zLayer: 0, elevationFt: 0 },
+    1: { zLayer: 1, elevationFt: 15 },
+  },
+};
+
+test('source-backed Limbus races receive canonical 60 ft Darkvision', () => {
+  for (const raceId of ['kobold', 'goblin', 'fairy', 'aasimar', 'tiefling', 'felinae', 'half_dragon', 'lupae', 'moonfae', 'yuan_ti_pureblood']) {
+    expect(senses.resolveRacialSenses({ raceId }).darkvisionFt, raceId).toBe(60);
+  }
+  expect(senses.resolveRacialSenses({ raceId: 'lanae' }).darkvisionFt).toBe(0);
+});
+
+test('canonical superior Darkvision overrides standard racial range', () => {
+  expect(senses.resolveRacialSenses({ raceId: 'elf', raceSubtypeId: 'drow' }).darkvisionFt).toBe(120);
+  expect(senses.resolveRacialSenses({ raceId: 'dwarf', raceSubtypeId: 'duergar' }).darkvisionFt).toBe(120);
+  expect(senses.resolveRacialSenses({ raceId: 'elf', raceSubtypeId: 'wood' }).darkvisionFt).toBe(60);
+});
+
+test('linked character sheet race resolves senses without duplicating them on the VTT token', () => {
+  const character = {
+    characterName: 'Orosh Test',
+    characterBuild: { raceId: 'yuan_ti_pureblood', raceSubtypeId: 'red_eyes' },
+  };
+  expect(senses.resolveCharacterSenses(character)).toMatchObject({
+    raceId: 'yuan_ti_pureblood',
+    raceSubtypeId: 'red_eyes',
+    darkvisionFt: 60,
+    darkvisionMonochrome: true,
+    source: 'racial',
+  });
+  expect(visionBridge.resolveBuildCarrier(character, null)).toBe(character);
+});
+
+test('Darkvision changes perceived light and uses grayscale only for actual darkness', () => {
+  const racial = senses.resolveRacialSenses({ raceId: 'goblin' });
+  expect(senses.perceptionForLightLevel('dim', racial, 50)).toEqual({
+    visible: true,
+    perceivedLight: 'bright',
+    mode: 'darkvision_dim',
+    monochrome: false,
+  });
+  expect(senses.perceptionForLightLevel('darkness', racial, 50)).toEqual({
+    visible: true,
+    perceivedLight: 'dim',
+    mode: 'darkvision',
+    monochrome: true,
+  });
+  expect(senses.perceptionForLightLevel('darkness', racial, 61).visible).toBe(false);
+});
+
+test('z levels use physical elevation for 3D range', () => {
+  const balcony = { x: 0, y: 0, zLayer: 1, elevationFt: 15 };
+  const street = { x: 280, y: 0, zLayer: 0, elevationFt: 0 };
+  expect(spatial.horizontalDistanceFt(balcony, street, map)).toBeCloseTo(20, 5);
+  expect(spatial.distance3dFt(balcony, street, map)).toBeCloseTo(25, 5);
+  expect(spatial.horizontalRadiusPxForRange(60, balcony, 0, map)).toBeCloseTo(813.326, 2);
+});
+
+test('cross-level sight requires an open vertical portal crossed by the sight ray', () => {
+  const balcony = { x: 140, y: 140, zLayer: 1, elevationFt: 15 };
+  const streetPoint = { x: 280, y: 560 };
+  const withBalcony = {
+    ...map,
+    verticalPortals: [{
+      id: 'balcony',
+      type: 'balcony_edge',
+      between: [0, 1],
+      from: { col: 0, row: 5 },
+      to: { col: 6, row: 5 },
+      blocksVision: false,
+      blocksLight: false,
+      state: 'open',
+    }],
+  };
+  expect(spatial.canTraverseLayers(balcony, streetPoint, 0, withBalcony, 'vision')).toBe(true);
+  expect(spatial.canTraverseLayers(balcony, streetPoint, 0, { ...map, verticalPortals: [] }, 'vision')).toBe(false);
+  expect(spatial.canTraverseLayers(balcony, streetPoint, 0, {
+    ...withBalcony,
+    verticalPortals: [{ ...withBalcony.verticalPortals[0], state: 'closed' }],
+  }, 'vision')).toBe(false);
+});
+
+test('VTT wiring loads linked racial senses, feet grid, grayscale rendering and z portals', () => {
+  const html = read('vtt.html');
+  const main = read('js/vtt/main.js');
+  const engine = read('js/vtt/engine.js');
+  const renderer = read('js/vtt/renderer.js');
+  const mapData = read('js/vtt/mapData.js');
+
+  expect(html).toContain('js/racial-sense-runtime.js');
+  expect(html).toContain('js/vtt/spatial-vision.js');
+  expect(html).toContain('js/vtt/character-vision-bridge.js');
+  expect(main).toContain('LuminousVttCharacterVisionBridge');
+  expect(engine).toContain('horizontalRadiusPxForRange');
+  expect(engine).toContain("canTraverseLayers(player, closestIntersect, this.activeZ, this.mapData, 'vision')");
+  expect(renderer).toContain("this.ctx.filter = 'grayscale(1)'");
+  expect(mapData).toContain("distancePerCell: 5");
+  expect(mapData).toContain('verticalPortals');
+  expect(mapData).toContain("characterLink: { mode: 'current_player' }");
+});
+
+test('all new and modified vision modules parse as JavaScript', () => {
+  const root = path.join(__dirname, '..');
+  for (const file of [
+    'js/racial-sense-runtime.js',
+    'js/vtt/spatial-vision.js',
+    'js/vtt/character-vision-bridge.js',
+    'js/vtt/engine.js',
+    'js/vtt/renderer.js',
+    'js/vtt/main.js',
+    'js/vtt/mapData.js',
+  ]) {
+    execFileSync(process.execPath, ['--check', path.join(root, file)], { stdio: 'pipe' });
+  }
+});

--- a/tests/vtt_stair_movement_edit_mode.spec.js
+++ b/tests/vtt_stair_movement_edit_mode.spec.js
@@ -1,0 +1,179 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const stair = require('../js/vtt/stair-route.js');
+const movement = require('../js/vtt/vertical-movement.js');
+const portalRuntime = require('../js/vtt/vertical-portal.js');
+const topology = require('../js/vtt/topology.js');
+const tokenControl = require('../js/vtt/token-control.js');
+const spatial = require('../js/vtt/spatial-vision.js');
+
+const root = path.join(__dirname, '..');
+const read = (file) => fs.readFileSync(path.join(root, file), 'utf8');
+
+const map = {
+  grid: { cols: 20, rows: 20, size: 70, distancePerCell: 5, distanceUnit: 'ft' },
+  defaultZStepFt: 15,
+  zLevels: {
+    0: { zLayer: 0, elevationFt: 0, label: 'Street' },
+    1: { zLayer: 1, elevationFt: 15, label: 'Upper' },
+  },
+  verticalPortals: [],
+  topology: [],
+};
+
+function stairs(layout = 'straight', overrides = {}) {
+  return portalRuntime.normalizePortal({
+    id: `stairs_${layout}`,
+    type: 'stairs',
+    between: [0, 1],
+    from: { col: 2, row: 2 },
+    to: { col: 2, row: 6 },
+    layout,
+    widthFt: 5,
+    state: 'open',
+    blocksVision: false,
+    blocksLight: false,
+    allowsMovement: true,
+    ...overrides,
+  }, map);
+}
+
+test('straight stairs use 3D route length and connect floor endpoints', () => {
+  const route = stair.routeFor(stairs('straight'), map);
+  expect(route.layout).toBe('straight');
+  expect(route.pathLengthFt).toBeCloseTo(25, 5);
+  expect(route.points[0].elevationFt).toBe(0);
+  expect(route.points.at(-1).elevationFt).toBe(15);
+});
+
+test('switchback stairs build two flights plus an intermediate landing', () => {
+  const route = stair.routeFor(stairs('switchback'), map);
+  expect(route.points).toHaveLength(4);
+  expect(route.points[1].elevationFt).toBeCloseTo(7.5, 5);
+  expect(route.points[2].elevationFt).toBeCloseTo(7.5, 5);
+  expect(route.points[0].x).not.toBe(route.points.at(-1).x);
+  expect(route.pathLengthFt).toBeGreaterThan(25);
+});
+
+test('spiral stairs generate a helix rather than a free Z teleport', () => {
+  const route = stair.routeFor(stairs('spiral'), map);
+  expect(route.points.length).toBeGreaterThanOrEqual(10);
+  expect(route.pathLengthFt).toBeGreaterThan(15);
+  expect(route.points[0].elevationFt).toBe(0);
+  expect(route.points.at(-1).elevationFt).toBe(15);
+});
+
+test('vertical ladder is a climb route with doubled default movement cost', () => {
+  const route = stair.routeFor(stairs('ladder'), map);
+  expect(route.movementMode).toBe('climb');
+  expect(route.costMultiplier).toBe(2);
+  expect(route.points[0].x).toBeCloseTo(route.points[1].x, 5);
+  expect(route.points[0].y).toBeCloseTo(route.points[1].y, 5);
+  expect(route.pathLengthFt).toBeCloseTo(15, 5);
+});
+
+test('dedicated climb movement removes the ladder extra multiplier', () => {
+  const route = stair.routeFor(stairs('ladder'), map);
+  expect(movement.effectiveMultiplier(route, { climbSpeedFt: 30 })).toBe(1);
+  expect(movement.effectiveMultiplier(route, {})).toBe(2);
+});
+
+test('dropping on a stair entrance moves the token to the next Z and grid center', () => {
+  const portal = stairs('straight');
+  const localMap = { ...map, verticalPortals: [portal] };
+  const token = { id: 'p1', x: 175, y: 175, zLayer: 0, z: [0], elevationFt: 0 };
+  const result = movement.transitionOnDrop(token, { x: 175, y: 175 }, localMap);
+  expect(result.valid).toBe(true);
+  expect(result.complete).toBe(true);
+  expect(token.zLayer).toBe(1);
+  expect(token.gridPosition.z).toBe(1);
+  expect(token.elevationFt).toBe(15);
+  expect(token.x % 70).toBe(35);
+  expect(token.y % 70).toBe(35);
+});
+
+test('finite movement budget can leave a token part-way along a U stair', () => {
+  const portal = stairs('switchback');
+  const localMap = { ...map, verticalPortals: [portal] };
+  const token = { id: 'p1', x: 175, y: 175, zLayer: 0, z: [0], elevationFt: 0, movementRemainingFt: 10 };
+  const result = movement.transitionOnDrop(token, { x: 175, y: 175 }, localMap);
+  expect(result.valid).toBe(true);
+  expect(result.complete).toBe(false);
+  expect(token.zLayer).toBe(0);
+  expect(token.verticalMovement.routeId).toBe(portal.id);
+  expect(token.verticalMovement.progressFt).toBeCloseTo(10, 5);
+  expect(token.elevationFt).toBeGreaterThan(0);
+  expect(token.movementRemainingFt).toBe(0);
+});
+
+test('DM can control every draggable token while player is limited to linked token', () => {
+  const npc = { id: 'npc', draggable: true, characterLink: { actorId: 'npc_actor' } };
+  const mine = { id: 'mine', draggable: true, characterLink: { mode: 'current_player' } };
+  const other = { id: 'other', draggable: true, characterLink: { playerId: 'other_player' } };
+  const dmResolver = tokenControl.createResolver({ isDm: true, root: {} });
+  expect(dmResolver(npc)).toBe(true);
+  expect(dmResolver(other)).toBe(true);
+  expect(tokenControl.canPlayerControl(mine, { playerId: 'me' })).toBe(true);
+  expect(tokenControl.canPlayerControl(other, { playerId: 'me' })).toBe(false);
+});
+
+test('wall thickness is stored in feet and converted to collision/render pixels', () => {
+  const wall = topology.createElement({
+    id: 'thick_wall',
+    type: 'wall',
+    from: { col: 2, row: 2 },
+    to: { col: 2, row: 8 },
+    zLayer: 0,
+    thicknessFt: 1,
+  });
+  expect(wall.thicknessFt).toBe(1);
+  expect(topology.segment(wall, map.grid).thicknessPx).toBeCloseTo(14, 5);
+});
+
+test('straight stair portal allows direct cross-floor sight when no blocking wall interrupts it', () => {
+  const portal = stairs('straight');
+  const localMap = { ...map, verticalPortals: [portal] };
+  const viewer = { x: 140, y: 70, zLayer: 0, elevationFt: 0 };
+  expect(spatial.canTraverseLayers(viewer, { x: 140, y: 560 }, 1, localMap, 'vision')).toBe(true);
+});
+
+test('DM edit-mode UI exposes topology and stair authoring without exposing player authority', () => {
+  const html = read('vtt.html');
+  const main = read('js/vtt/main.js');
+  const engine = read('js/vtt/engine.js');
+  const verticalController = read('js/vtt/vertical-portal-controller.js');
+  const topologyController = read('js/vtt/topology-controller.js');
+
+  expect(html).toContain('id="vtt-dm-edit-toggle"');
+  expect(html).toContain('value="switchback"');
+  expect(html).toContain('value="spiral"');
+  expect(html).toContain('value="ladder"');
+  expect(html).toContain('id="vtt-vertical-width"');
+  expect(html).toContain('id="vtt-topology-thickness"');
+  expect(main).toContain('LuminousVttTokenControl');
+  expect(main).toContain('LuminousVttDmEditMode');
+  expect(engine).toContain('transitionOnDrop');
+  expect(verticalController).toContain('this.editActive()');
+  expect(topologyController).toContain('this.editActive()');
+});
+
+test('new stair/edit runtimes parse and VTT modules keep ES-module wiring', () => {
+  for (const file of [
+    'js/vtt/stair-route.js',
+    'js/vtt/vertical-movement.js',
+    'js/vtt/token-control.js',
+    'js/vtt/dm-edit-mode.js',
+    'js/vtt/vertical-portal.js',
+    'js/vtt/spatial-vision.js',
+    'js/vtt/topology.js',
+    'js/vtt/token-interaction.js',
+  ]) {
+    execFileSync(process.execPath, ['--check', path.join(root, file)], { stdio: 'pipe' });
+  }
+  expect(read('js/vtt/main.js')).toContain("import { Engine } from './engine.js';");
+  expect(read('js/vtt/engine.js')).toContain("import { Camera } from './camera.js';");
+  expect(read('js/vtt/renderer.js')).toContain('drawStairRouteGuide');
+});

--- a/tests/vtt_stair_resume.spec.js
+++ b/tests/vtt_stair_resume.spec.js
@@ -1,0 +1,84 @@
+const { test, expect } = require('@playwright/test');
+const portalRuntime = require('../js/vtt/vertical-portal.js');
+const movement = require('../js/vtt/vertical-movement.js');
+
+const map = {
+  grid: { cols: 20, rows: 20, size: 70, distancePerCell: 5, distanceUnit: 'ft' },
+  defaultZStepFt: 15,
+  zLevels: {
+    0: { zLayer: 0, elevationFt: 0 },
+    1: { zLayer: 1, elevationFt: 15 },
+  },
+  verticalPortals: [],
+};
+
+function switchback() {
+  return portalRuntime.normalizePortal({
+    id: 'stairs_resume',
+    type: 'stairs',
+    between: [0, 1],
+    from: { col: 2, row: 2 },
+    to: { col: 2, row: 6 },
+    layout: 'switchback',
+    widthFt: 5,
+    allowsMovement: true,
+    state: 'open',
+  }, map);
+}
+
+test('a token stopped inside a U stair resumes that same route on its next movement budget', () => {
+  const portal = switchback();
+  const localMap = { ...map, verticalPortals: [portal] };
+  const token = {
+    id: 'walker',
+    x: 175,
+    y: 175,
+    zLayer: 0,
+    z: [0],
+    elevationFt: 0,
+    movementRemainingFt: 10,
+  };
+
+  const first = movement.transitionOnDrop(token, { x: 175, y: 175 }, localMap);
+  expect(first.valid).toBe(true);
+  expect(first.complete).toBe(false);
+  const firstProgress = token.verticalMovement.progressFt;
+  expect(firstProgress).toBeGreaterThan(0);
+
+  token.movementRemainingFt = 10;
+  const second = movement.transitionOnDrop(token, { x: token.x + 300, y: token.y + 300 }, localMap);
+  expect(second.valid).toBe(true);
+  expect(second.resumed).toBe(true);
+  expect(token.verticalMovement.progressFt).toBeGreaterThan(firstProgress);
+  expect(token.verticalMovement.costSpentFt).toBeCloseTo(20, 5);
+});
+
+test('repeated movement budgets eventually complete the stair and place the token on destination Z', () => {
+  const portal = switchback();
+  const localMap = { ...map, verticalPortals: [portal] };
+  const token = {
+    id: 'walker',
+    x: 175,
+    y: 175,
+    zLayer: 0,
+    z: [0],
+    elevationFt: 0,
+    movementRemainingFt: 10,
+  };
+
+  let result = movement.transitionOnDrop(token, { x: 175, y: 175 }, localMap);
+  let guard = 0;
+  while (!result.complete && guard < 10) {
+    token.movementRemainingFt = 10;
+    result = movement.transitionOnDrop(token, { x: token.x, y: token.y }, localMap);
+    guard += 1;
+  }
+
+  expect(result.complete).toBe(true);
+  expect(token.zLayer).toBe(1);
+  expect(token.z).toEqual([1]);
+  expect(token.gridPosition.z).toBe(1);
+  expect(token.elevationFt).toBe(15);
+  expect(token.verticalMovement).toBeUndefined();
+  expect(token.lastVerticalTravel.routeId).toBe(portal.id);
+});

--- a/tests/vtt_vertical_portal_editor.spec.js
+++ b/tests/vtt_vertical_portal_editor.spec.js
@@ -41,7 +41,7 @@ test('vertical portal runtime creates hole, balcony and stairs contracts', () =>
   expect(portals.labelFor(balcony)).toBe('BALCÓN');
 
   const stairs = portals.createPortal({ type: 'stairs', from, to, fromZ: 0, toZ: 1, mapData: map });
-  expect(stairs).toMatchObject({ allowsMovement: true, movementMode: 'stairs' });
+  expect(stairs).toMatchObject({ allowsMovement: true, movementMode: 'stairs', layout: 'straight', widthFt: 5 });
   expect(portals.labelFor(stairs)).toBe('ESCALERA');
 });
 
@@ -99,13 +99,14 @@ test('local vertical portal state bridge allows DM persistence and denies player
   await expect(playerBridge.savePortal(portal)).rejects.toThrow('DM_REQUIRED');
 });
 
-test('DM vertical editor UI exposes tools, Z target, persistence and DM-only guides', () => {
+test('DM vertical editor UI exposes tools, Z target, persistence and edit-mode-only guides', () => {
   const html = read('vtt.html');
   const main = read('js/vtt/main.js');
   const controller = read('js/vtt/vertical-portal-controller.js');
   const renderer = read('js/vtt/renderer.js');
   const state = read('js/vtt/vertical-portal-state.js');
 
+  expect(html).toContain('id="vtt-dm-edit-toggle"');
   expect(html).toContain('id="vtt-vertical-toolbar"');
   expect(html).toContain('data-vtt-vertical-tool="opening"');
   expect(html).toContain('data-vtt-vertical-tool="balcony_edge"');
@@ -119,13 +120,15 @@ test('DM vertical editor UI exposes tools, Z target, persistence and DM-only gui
   expect(main).toContain('isDm: bridge.isDm');
   expect(main).toContain('verticalBridge.start()');
   expect(main).toContain('verticalController.handleLayerChanged()');
+  expect(main).toContain('LuminousVttDmEditMode');
 
   expect(controller).toContain("const valid = ['select', 'opening', 'balcony_edge', 'stairs', 'erase']");
   expect(controller).toContain('snapPointToVertex');
   expect(controller).toContain('axisAlignedVertex');
   expect(controller).toContain('this.stateBridge.savePortal(portal)');
-  expect(controller).toContain('toolbar.hidden = !this.isDm');
-  expect(controller).toContain('visible: this.isDm');
+  expect(controller).toContain('toolbar.hidden = !active');
+  expect(controller).toContain('this.mapData.verticalPortalEditor.visible = active');
+  expect(controller).toContain('this.editActive()');
 
   expect(renderer).toContain('drawVerticalPortalGuides');
   expect(renderer).toContain('this.mapData.verticalPortalEditor?.visible');

--- a/tests/vtt_vertical_portal_editor.spec.js
+++ b/tests/vtt_vertical_portal_editor.spec.js
@@ -1,0 +1,146 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const portals = require('../js/vtt/vertical-portal.js');
+const portalState = require('../js/vtt/vertical-portal-state.js');
+const spatial = require('../js/vtt/spatial-vision.js');
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+const map = {
+  id: 'test_map',
+  grid: { cols: 20, rows: 20, size: 70, distancePerCell: 5, distanceUnit: 'ft' },
+  zLevels: {
+    0: { zLayer: 0, elevationFt: 0, label: 'Street' },
+    1: { zLayer: 1, elevationFt: 15, label: 'Upper Floor' },
+    2: { zLayer: 2, elevationFt: 30, label: 'Roof' },
+  },
+  verticalPortals: [],
+};
+
+test('vertical portal runtime creates hole, balcony and stairs contracts', () => {
+  const from = { col: 2, row: 4 };
+  const to = { col: 7, row: 4 };
+
+  const opening = portals.createPortal({ type: 'opening', from, to, fromZ: 0, toZ: 1, mapData: map });
+  expect(opening).toMatchObject({
+    type: 'opening',
+    between: [0, 1],
+    from,
+    to,
+    state: 'open',
+    blocksVision: false,
+    blocksLight: false,
+    allowsMovement: false,
+  });
+  expect(portals.labelFor(opening)).toBe('HUECO');
+
+  const balcony = portals.createPortal({ type: 'balcony_edge', from, to, fromZ: 1, toZ: 0, mapData: map });
+  expect(balcony.allowsMovement).toBe(false);
+  expect(portals.labelFor(balcony)).toBe('BALCÓN');
+
+  const stairs = portals.createPortal({ type: 'stairs', from, to, fromZ: 0, toZ: 1, mapData: map });
+  expect(stairs).toMatchObject({ allowsMovement: true, movementMode: 'stairs' });
+  expect(portals.labelFor(stairs)).toBe('ESCALERA');
+});
+
+test('vertical portal hit testing is restricted to connected Z levels', () => {
+  const portal = portals.createPortal({
+    type: 'balcony_edge',
+    from: { col: 2, row: 5 },
+    to: { col: 8, row: 5 },
+    fromZ: 0,
+    toZ: 1,
+    mapData: map,
+  });
+  const pointOnSegment = { x: 5 * 70, y: 5 * 70 };
+  expect(portals.hitTest([portal], pointOnSegment, map, 0)?.id).toBe(portal.id);
+  expect(portals.hitTest([portal], pointOnSegment, map, 1)?.id).toBe(portal.id);
+  expect(portals.hitTest([portal], pointOnSegment, map, 2)).toBeNull();
+  expect(portals.otherLayer(portal, 0)).toBe(1);
+});
+
+test('editor-created vertical portals are consumed by cross-level sight', () => {
+  const portal = portals.createPortal({
+    type: 'opening',
+    from: { col: 0, row: 5 },
+    to: { col: 6, row: 5 },
+    fromZ: 0,
+    toZ: 1,
+    mapData: map,
+  });
+  const withPortal = { ...map, verticalPortals: [portal] };
+  const viewer = { x: 140, y: 140, zLayer: 1, elevationFt: 15 };
+  const target = { x: 280, y: 560 };
+  expect(spatial.canTraverseLayers(viewer, target, 0, withPortal, 'vision')).toBe(true);
+  expect(spatial.canTraverseLayers(viewer, target, 0, { ...map, verticalPortals: [] }, 'vision')).toBe(false);
+});
+
+test('local vertical portal state bridge allows DM persistence and denies player mutation', async () => {
+  const dmMap = { ...map, verticalPortals: [] };
+  const dmBridge = portalState.createBridge({ mapData: dmMap, isDm: true, root: {} });
+  dmBridge.start();
+  const portal = portals.createPortal({
+    type: 'stairs',
+    from: { col: 3, row: 3 },
+    to: { col: 3, row: 7 },
+    fromZ: 0,
+    toZ: 1,
+    mapData: dmMap,
+  });
+  await dmBridge.savePortal(portal);
+  expect(dmMap.verticalPortals).toHaveLength(1);
+  expect(dmMap.verticalPortals[0]).toMatchObject({ type: 'stairs', allowsMovement: true });
+  await dmBridge.deletePortal(portal.id);
+  expect(dmMap.verticalPortals).toEqual([]);
+
+  const playerBridge = portalState.createBridge({ mapData: { ...map, verticalPortals: [] }, isDm: false, root: {} });
+  await expect(playerBridge.savePortal(portal)).rejects.toThrow('DM_REQUIRED');
+});
+
+test('DM vertical editor UI exposes tools, Z target, persistence and DM-only guides', () => {
+  const html = read('vtt.html');
+  const main = read('js/vtt/main.js');
+  const controller = read('js/vtt/vertical-portal-controller.js');
+  const renderer = read('js/vtt/renderer.js');
+  const state = read('js/vtt/vertical-portal-state.js');
+
+  expect(html).toContain('id="vtt-vertical-toolbar"');
+  expect(html).toContain('data-vtt-vertical-tool="opening"');
+  expect(html).toContain('data-vtt-vertical-tool="balcony_edge"');
+  expect(html).toContain('data-vtt-vertical-tool="stairs"');
+  expect(html).toContain('id="vtt-vertical-target-z"');
+  expect(html).toContain('id="vtt-vertical-editor"');
+  expect(html).toContain('js/vtt/vertical-portal.js');
+  expect(html).toContain('js/vtt/vertical-portal-state.js');
+
+  expect(main).toContain("import { VerticalPortalController } from './vertical-portal-controller.js'");
+  expect(main).toContain('isDm: bridge.isDm');
+  expect(main).toContain('verticalBridge.start()');
+  expect(main).toContain('verticalController.handleLayerChanged()');
+
+  expect(controller).toContain("const valid = ['select', 'opening', 'balcony_edge', 'stairs', 'erase']");
+  expect(controller).toContain('snapPointToVertex');
+  expect(controller).toContain('axisAlignedVertex');
+  expect(controller).toContain('this.stateBridge.savePortal(portal)');
+  expect(controller).toContain('toolbar.hidden = !this.isDm');
+  expect(controller).toContain('visible: this.isDm');
+
+  expect(renderer).toContain('drawVerticalPortalGuides');
+  expect(renderer).toContain('this.mapData.verticalPortalEditor?.visible');
+  expect(renderer).toContain("opening: { stroke:");
+  expect(renderer).toContain("stairs: { stroke:");
+
+  expect(state).toContain('vtt_topology');
+  expect(state).toContain('/verticalPortals`');
+  expect(state).toContain("if (!isDm) throw new Error('DM_REQUIRED')");
+});
+
+test('new vertical portal UMD modules parse as JavaScript', () => {
+  const root = path.join(__dirname, '..');
+  for (const file of ['js/vtt/vertical-portal.js', 'js/vtt/vertical-portal-state.js']) {
+    execFileSync(process.execPath, ['--check', path.join(root, file)], { stdio: 'pipe' });
+  }
+  expect(read('js/vtt/vertical-portal-controller.js')).toContain('export class VerticalPortalController');
+});

--- a/vtt.html
+++ b/vtt.html
@@ -18,6 +18,20 @@
             <button type="button" data-vtt-tool="curtain_window" class="brutalist-button">CURTAIN WINDOW</button>
             <button type="button" data-vtt-tool="erase" class="brutalist-button">ERASE</button>
         </div>
+
+        <div id="vtt-vertical-toolbar" class="vtt-toolbar vtt-vertical-toolbar" hidden aria-label="Editor vertical del DM">
+            <span class="vtt-toolbar-title">Z PORTALS</span>
+            <button type="button" data-vtt-vertical-tool="select" class="brutalist-button">V-SELECT</button>
+            <button type="button" data-vtt-vertical-tool="opening" class="brutalist-button">HUECO</button>
+            <button type="button" data-vtt-vertical-tool="balcony_edge" class="brutalist-button">BALCÓN</button>
+            <button type="button" data-vtt-vertical-tool="stairs" class="brutalist-button">ESCALERA</button>
+            <button type="button" data-vtt-vertical-tool="erase" class="brutalist-button">V-ERASE</button>
+            <label class="vtt-toolbar-field" for="vtt-vertical-target-z">
+                <span>Z DESTINO</span>
+                <select id="vtt-vertical-target-z" aria-label="Z destino de la conexión vertical"></select>
+            </label>
+        </div>
+
         <button id="btn-export-uv" class="brutalist-button">[ EXPORTAR PLANTILLA UV ]</button>
     </div>
 
@@ -48,6 +62,24 @@
         <button id="vtt-topology-delete" type="button" class="vtt-danger-button">BORRAR ELEMENTO</button>
     </aside>
 
+    <aside id="vtt-vertical-editor" class="vtt-panel vtt-vertical-panel" hidden>
+        <header>
+            <strong id="vtt-vertical-type">PORTAL Z</strong>
+            <small id="vtt-vertical-id"></small>
+        </header>
+        <div class="vtt-vertical-readout">
+            <span>DESDE</span>
+            <strong id="vtt-vertical-from-z">Z0</strong>
+        </div>
+        <label>
+            <span>HASTA</span>
+            <select id="vtt-vertical-editor-target" aria-label="Editar Z destino"></select>
+        </label>
+        <p id="vtt-vertical-movement" class="vtt-context-note"></p>
+        <p class="vtt-panel-help">El trazo se ajusta a vértices/bordes de la cuadrícula. Sólo el DM ve estas guías; jugadores reciben únicamente su efecto sobre visión/luz.</p>
+        <button id="vtt-vertical-delete" type="button" class="vtt-danger-button">BORRAR CONEXIÓN VERTICAL</button>
+    </aside>
+
     <section id="vtt-context-menu" class="vtt-context-menu" hidden>
         <header>
             <strong id="vtt-context-title">OBJETO</strong>
@@ -60,6 +92,8 @@
 
     <script src="js/racial-sense-runtime.js"></script>
     <script src="js/vtt/spatial-vision.js"></script>
+    <script src="js/vtt/vertical-portal.js"></script>
+    <script src="js/vtt/vertical-portal-state.js"></script>
     <script src="js/vtt/character-vision-bridge.js"></script>
     <script src="js/vtt/topology.js"></script>
     <script src="js/vtt/state-bridge.js"></script>

--- a/vtt.html
+++ b/vtt.html
@@ -58,6 +58,9 @@
 
     <div id="vtt-notice" class="vtt-notice" hidden role="status" aria-live="polite"></div>
 
+    <script src="js/racial-sense-runtime.js"></script>
+    <script src="js/vtt/spatial-vision.js"></script>
+    <script src="js/vtt/character-vision-bridge.js"></script>
     <script src="js/vtt/topology.js"></script>
     <script src="js/vtt/state-bridge.js"></script>
     <script src="js/vtt/token-interaction.js"></script>

--- a/vtt.html
+++ b/vtt.html
@@ -10,7 +10,10 @@
     <canvas id="vtt-canvas"></canvas>
 
     <div id="vtt-ui-container">
+        <button id="vtt-dm-edit-toggle" type="button" class="brutalist-button vtt-edit-toggle" hidden aria-pressed="false">EDIT MODE</button>
+
         <div id="vtt-topology-toolbar" class="vtt-toolbar" hidden aria-label="Editor de topología del DM">
+            <span class="vtt-toolbar-title">TOPOLOGY</span>
             <button type="button" data-vtt-tool="select" class="brutalist-button">SELECT</button>
             <button type="button" data-vtt-tool="wall" class="brutalist-button">WALL</button>
             <button type="button" data-vtt-tool="door" class="brutalist-button">DOOR</button>
@@ -20,7 +23,7 @@
         </div>
 
         <div id="vtt-vertical-toolbar" class="vtt-toolbar vtt-vertical-toolbar" hidden aria-label="Editor vertical del DM">
-            <span class="vtt-toolbar-title">Z PORTALS</span>
+            <span class="vtt-toolbar-title">Z ROUTES</span>
             <button type="button" data-vtt-vertical-tool="select" class="brutalist-button">V-SELECT</button>
             <button type="button" data-vtt-vertical-tool="opening" class="brutalist-button">HUECO</button>
             <button type="button" data-vtt-vertical-tool="balcony_edge" class="brutalist-button">BALCÓN</button>
@@ -49,6 +52,10 @@
                 <option value="broken">BROKEN</option>
             </select>
         </label>
+        <label id="vtt-topology-thickness-field" hidden>
+            <span>GROSOR DEL MURO · FT</span>
+            <input id="vtt-topology-thickness" type="number" min="0.1" step="0.1" value="0.5">
+        </label>
         <div id="vtt-topology-threshold-fields" class="vtt-threshold-grid">
             <label>
                 <span>JUEGO DE MANOS</span>
@@ -75,8 +82,27 @@
             <span>HASTA</span>
             <select id="vtt-vertical-editor-target" aria-label="Editar Z destino"></select>
         </label>
+        <div id="vtt-stair-fields" hidden>
+            <label>
+                <span>FORMA DE ESCALERA</span>
+                <select id="vtt-vertical-layout">
+                    <option value="straight">RECTA</option>
+                    <option value="switchback">U / DOS TRAMOS</option>
+                    <option value="spiral">CARACOL</option>
+                    <option value="ladder">VERTICAL / LADDER</option>
+                </select>
+            </label>
+            <label>
+                <span>ANCHO · FT</span>
+                <input id="vtt-vertical-width" type="number" min="2" step="0.5" value="5">
+            </label>
+            <div class="vtt-vertical-readout">
+                <span>RECORRIDO 3D</span>
+                <strong id="vtt-vertical-path-length">—</strong>
+            </div>
+        </div>
         <p id="vtt-vertical-movement" class="vtt-context-note"></p>
-        <p class="vtt-panel-help">El trazo se ajusta a vértices/bordes de la cuadrícula. Sólo el DM ve estas guías; jugadores reciben únicamente su efecto sobre visión/luz.</p>
+        <p class="vtt-panel-help">El trazo define la ruta/apertura sobre la cuadrícula. RECTAs suben entre extremos; U genera dos tramos y descanso; CARACOL genera una hélice; VERTICAL crea una escalera de mano. Muros y huecos siguen decidiendo la línea de visión.</p>
         <button id="vtt-vertical-delete" type="button" class="vtt-danger-button">BORRAR CONEXIÓN VERTICAL</button>
     </aside>
 
@@ -93,11 +119,15 @@
     <script src="js/racial-sense-runtime.js"></script>
     <script src="js/vtt/spatial-vision.js"></script>
     <script src="js/vtt/vertical-portal.js"></script>
+    <script src="js/vtt/stair-route.js"></script>
+    <script src="js/vtt/vertical-movement.js"></script>
     <script src="js/vtt/vertical-portal-state.js"></script>
     <script src="js/vtt/character-vision-bridge.js"></script>
     <script src="js/vtt/topology.js"></script>
     <script src="js/vtt/state-bridge.js"></script>
     <script src="js/vtt/token-interaction.js"></script>
+    <script src="js/vtt/token-control.js"></script>
+    <script src="js/vtt/dm-edit-mode.js"></script>
     <script src="js/vtt/check-portal.js"></script>
     <script type="module" src="js/vtt/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- resolves racial Darkvision from the linked character sheet and renders darkness-only Darkvision in grayscale
- introduces `zLayer` + physical `elevationFt` and portal-gated cross-floor sight
- adds an explicit DM `EDIT MODE` for topology and Z-route authoring
- adds editable wall thickness in feet and stair width in feet
- turns stairs from a simple Z marker into a real 3D movement route
- supports straight, U/two-flight, spiral and vertical/ladder stair layouts
- lets finite movement budgets stop a token part-way through a stair and resume the same route later
- lets completed stair movement change the token's `zLayer`, elevation and destination grid position
- lets the DM control every draggable token while players are limited to their linked token

## Darkvision canon
Darkvision does not create light.
- Dim within Darkvision range is perceived as Bright and remains in color.
- Darkness within Darkvision range is perceived as Dim and rendered monochrome.
- Darkness beyond Darkvision range is not visible.

Standard racial Darkvision resolves to 60 ft; the existing superior Drow/Duergar variants resolve to 120 ft. The VTT consumes the linked `characterBuild.raceId` / `raceSubtypeId` instead of storing a manual VTT-only range.

## Z levels and sight
- `zLayer` is the logical floor.
- `elevationFt` is physical height.
- maps define real elevations for their Z levels.
- cross-floor sight requires a valid open vertical connection.
- Darkvision range across floors uses 3D distance.
- a straight/open stair connection can expose the floor below/above when its sight ray crosses the connection; walls/topology still occlude the rendered line of sight.
- U and spiral stairs expose their projected route geometry instead of acting like a magical Z teleport.

## DM EDIT MODE
The DM has a dedicated `EDIT MODE` toggle (`E` shortcut).

Outside EDIT MODE:
- geometry cannot be accidentally selected, erased or redrawn.
- the DM can still move draggable tokens.

Inside EDIT MODE:
- existing WALL / DOOR / WINDOW / CURTAIN WINDOW tools are available.
- Z-route tools are available: HUECO, BALCÓN, ESCALERA, V-SELECT and V-ERASE.
- wall thickness is editable in feet.
- stair width is editable in feet.
- the target Z level can be changed.
- vertical guides are visible to the DM only.

## Stair movement engine
`ESCALERA` now publishes a real route consumed by `LuminousVttVerticalMovement`.

Layouts:
- `straight`: direct 3D route between floor endpoints.
- `switchback`: U / two flights with an intermediate landing.
- `spiral`: generated helical route with interpolated elevation.
- `ladder`: vertical climb route at one XY anchor.

Movement behavior:
- route cost is based on actual 3D route length, not only Z-height.
- normal stairs use a 1x route multiplier.
- ladders use `movementMode: climb` and default to 2x movement cost unless the token has dedicated climb movement.
- if `movementRemainingFt` is finite and insufficient, the token remains on the route with `verticalMovement` progress/elevation.
- on a later movement budget it resumes the same route instead of restarting.
- when complete, the token changes to the destination Z and snaps to the destination grid-cell center.
- when no finite movement budget is supplied by the current non-combat VTT, the route completes immediately.

## Token authority
- DM: can drag every draggable token.
- Player: can drag only a token linked through `current_player`, matching UID/playerId/actorId, or explicit owner metadata.

This fixes the previous client behavior where any draggable token on the active Z could be grabbed.

## Persistence
Vertical geometry is canonical under:
`vtt_topology/<mapId>/verticalPortals`

Topology remains under the existing canonical VTT topology state.

Important: this PR does **not** yet make token positions a canonical Firebase-shared map state. The movement/authority resolver is correct locally, but persistent multiplayer token-position synchronization remains a separate follow-up.

## Tests
Added/expanded coverage for:
- 60 ft racial Darkvision and superior variants
- grayscale only for actual darkness
- 3D Darkvision range and cross-floor portal gating
- DM vertical editor and DM-only guides
- wall thickness and stair width
- straight, U/switchback, spiral and ladder route generation
- 3D stair path length
- ladder climb multiplier and climb-speed override
- completed Z transition and grid-center landing
- partial stair progress and multi-budget resume
- DM-all-token vs player-linked-token control
- direct cross-floor stair sight
- runtime syntax/wiring

The existing Grapple integration test also received a one-line deterministic `rng: () => 0` input because its assertion expected a guaranteed winner while previously using `Math.random`; no combat runtime semantics were changed.

## Final validation
Head: `7494bcbebe275090a597261de735532df3753ca9`
- Background Narratives: success
- repository regression suite: **824/824 passed**
- narrative contract: **158/158 passed**
- patched syntax: success
- Trait Engine: success, including Chromium UI regressions

## Out of scope
- artificial Bright/Dim light propagation
- daylight/weather lighting integration
- persistent Fog of War
- Blindsight / Truesight visual modes
- canonical multiplayer token-position synchronization
- full horizontal D&D movement/pathfinding budget; this patch handles the vertical stair-route portion and consumes `movementRemainingFt` when supplied
