### PR TITLE
feat(vtt): canonical multiplayer token positions

### DIFF
--- a/js/vtt/main.js
+++ b/js/vtt/main.js
@@ -59,8 +59,34 @@ document.addEventListener('DOMContentLoaded', () => {
         verticalPortalController: verticalController,
     }) || null;
 
+    const applyLayer = (zLayer) => {
+        engine.setZLayer(zLayer);
+        controller.handleTopologyChanged();
+        verticalController.handleLayerChanged();
+    };
+
+    const tokenStateApi = globalThis.LuminousVttTokenState;
+    if (!tokenStateApi) {
+        console.error('VTT canonical token state bridge not found.');
+        return;
+    }
+
+    const tokenStateBridge = tokenStateApi.createBridge({
+        mapData: mockMapData,
+        isDm: bridge.isDm,
+        notify: (message, mode) => controller?.notify(message, mode),
+        onTokensChanged: () => {
+            if (bridge.isDm) return;
+            const viewer = (mockMapData.tokens || []).find((token) => token.viewer === true)
+                || (mockMapData.tokens || []).find((token) => token.characterLink?.mode === 'current_player');
+            const zLayer = Number(viewer?.zLayer ?? viewer?.gridPosition?.z ?? viewer?.z?.[0]);
+            if (Number.isFinite(zLayer) && zLayer !== engine.activeZ) applyLayer(zLayer);
+        },
+    });
+
     bridge.start();
     verticalBridge.start();
+    tokenStateBridge.start();
 
     const characterVisionApi = globalThis.LuminousVttCharacterVisionBridge;
     const characterVisionBridge = characterVisionApi?.createBridge?.({
@@ -74,11 +100,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const exportBtn = document.getElementById('btn-export-uv');
     exportBtn?.addEventListener('click', () => engine.exportUVTemplate());
 
-    const applyLayer = (zLayer) => {
-        engine.setZLayer(zLayer);
-        controller.handleTopologyChanged();
-        verticalController.handleLayerChanged();
-    };
+    canvas.addEventListener('vtt:token-moved', (event) => {
+        const detail = event.detail || {};
+        const token = (mockMapData.tokens || []).find((entry) => String(entry.id) === String(detail.tokenId));
+        if (!token) return;
+        tokenStateBridge.saveToken(token).catch((error) => {
+            console.error('VTT token persistence failed:', error);
+            controller?.notify?.('No se pudo sincronizar la posición de la ficha.', 'error');
+        });
+    });
 
     canvas.addEventListener('vtt:token-z-transition', (event) => {
         const detail = event.detail || {};
@@ -94,6 +124,7 @@ document.addEventListener('DOMContentLoaded', () => {
         bridge,
         verticalController,
         verticalBridge,
+        tokenStateBridge,
         editMode,
         characterVisionBridge,
     });
@@ -113,6 +144,7 @@ document.addEventListener('DOMContentLoaded', () => {
     window.addEventListener('beforeunload', () => {
         editMode?.stop?.();
         characterVisionBridge?.stop?.();
+        tokenStateBridge.stop();
         verticalController.destroy();
         verticalBridge.stop();
         bridge.stop();

--- a/js/vtt/token-state.js
+++ b/js/vtt/token-state.js
@@ -5,7 +5,8 @@
 })(typeof window !== 'undefined' ? window : globalThis, function (browserRoot) {
     'use strict';
 
-    const ROOT = 'vtt_token_state';
+    const PLAYER_ROOT = 'campaña/jugadores';
+    const WORLD_ROOT = 'campaña/estado_mundo/vttTokens';
     const DM_UID = 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1';
     const clean = (value) => String(value ?? '').trim();
     const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
@@ -91,11 +92,11 @@
     }
 
     function playerRecordFromToken(token, owner = {}) {
-        if (!clean(owner.uid)) throw new Error('PLAYER_UID_REQUIRED');
+        if (!clean(owner.playerId)) throw new Error('PLAYER_ID_REQUIRED');
         return {
             schemaVersion: 1,
-            ownerUid: clean(owner.uid),
-            playerId: clean(owner.playerId) || null,
+            ownerUid: clean(owner.uid) || null,
+            playerId: clean(owner.playerId),
             actorId: clean(owner.actorId) || null,
             baseTokenId: clean(token?.baseTokenId || token?.id || 'player'),
             position: positionFromToken(token),
@@ -111,21 +112,36 @@
         };
     }
 
-    function playerTokenFromRecord(template, uid, record = {}, currentUid = '') {
+    function playerTokenFromRecord(template, playerKey, record = {}, current = {}) {
         const token = clone(template || {});
-        const ownerUid = clean(record.ownerUid || uid);
-        token.id = `player:${firebaseKey(ownerUid, 'unknown')}`;
+        const playerId = clean(record.playerId || playerKey);
+        const ownerUid = clean(record.ownerUid);
+        token.id = `player:${firebaseKey(playerId || ownerUid, 'unknown')}`;
         token.baseTokenId = clean(record.baseTokenId || template?.id || 'player');
-        token.ownerUid = ownerUid;
-        token.playerId = clean(record.playerId) || null;
+        token.ownerUid = ownerUid || null;
+        token.playerId = playerId || null;
         token.actorId = clean(record.actorId) || null;
-        token.characterLink = { mode: 'uid', uid: ownerUid, playerId: token.playerId, actorId: token.actorId };
+        token.characterLink = { mode: 'player', uid: token.ownerUid, playerId: token.playerId, actorId: token.actorId };
         token.canonicalScope = 'player';
-        token.canonicalOwnerUid = ownerUid;
-        token.viewer = Boolean(ownerUid && ownerUid === clean(currentUid));
+        token.canonicalPlayerKey = clean(playerKey || playerId);
+        token.canonicalOwnerUid = ownerUid || null;
+        token.viewer = Boolean((ownerUid && ownerUid === clean(current.uid)) || (playerId && playerId === clean(current.playerId)));
         token.draggable = template?.draggable !== false;
         applyPosition(token, record.position || {});
         return token;
+    }
+
+    function extractPlayerRecords(rawPlayers = {}, mapId = 'default') {
+        const records = {};
+        Object.entries(rawPlayers || {}).forEach(([playerKey, playerData]) => {
+            const record = playerData?.vttTokenState?.[mapId];
+            if (!record?.position) return;
+            records[playerKey] = {
+                ...record,
+                playerId: clean(record.playerId || playerKey),
+            };
+        });
+        return records;
     }
 
     function createBridge({ mapData, isDm = false, onTokensChanged, notify, root = browserRoot } = {}) {
@@ -138,16 +154,16 @@
         const template = clone((mapData.tokens || []).find(isCurrentPlayerTemplate) || null);
         const fixedTokenIds = new Set((mapData.tokens || []).filter((token) => !isCurrentPlayerTemplate(token)).map((token) => clean(token.id)).filter(Boolean));
         let started = false;
-        let seedingPlayers = false;
+        let seedingPlayer = false;
         let seedingWorld = false;
 
         const emitNotice = (message, mode = 'info') => {
             if (typeof notify === 'function') notify(message, mode);
         };
 
-        const rootRef = () => db?.ref(`${ROOT}/${mapId}`);
-        const playersRef = () => rootRef()?.child('players');
-        const worldRef = () => rootRef()?.child('tokens');
+        const playersRootRef = () => db?.ref(PLAYER_ROOT);
+        const playerStateRef = (playerKey) => db?.ref(`${PLAYER_ROOT}/${firebaseKey(playerKey, 'player')}/vttTokenState/${mapId}`);
+        const worldRef = () => db?.ref(`${WORLD_ROOT}/${mapId}`);
 
         function subscribe(ref, event, handler) {
             if (!ref?.on) return;
@@ -161,47 +177,54 @@
                 || null;
         }
 
+        function isOwnRecord(record = {}, playerKey = '') {
+            const uidMatch = clean(record.ownerUid) && clean(record.ownerUid) === clean(current.uid);
+            const playerMatch = clean(record.playerId || playerKey) && clean(record.playerId || playerKey) === clean(current.playerId);
+            return Boolean(uidMatch || playerMatch);
+        }
+
         function syncPlayerRecords(rawRecord = {}) {
             const records = rawRecord || {};
             const keepIds = new Set();
-            const ownUid = clean(current.uid);
             const ownTemplate = !isDm ? (mapData.tokens || []).find(isCurrentPlayerTemplate) : null;
 
             if (isDm && template) {
                 mapData.tokens = (mapData.tokens || []).filter((token) => !isCurrentPlayerTemplate(token));
             }
 
-            Object.entries(records).forEach(([uid, record]) => {
-                if (!record || !record.position) return;
-                const ownerUid = clean(record.ownerUid || uid);
-                if (!ownerUid) return;
+            Object.entries(records).forEach(([playerKey, record]) => {
+                if (!record?.position) return;
+                const playerId = clean(record.playerId || playerKey);
+                const ownerUid = clean(record.ownerUid);
 
-                if (!isDm && ownerUid === ownUid && ownTemplate) {
-                    ownTemplate.ownerUid = ownerUid;
-                    ownTemplate.playerId = clean(record.playerId) || ownTemplate.playerId || null;
+                if (!isDm && isOwnRecord(record, playerKey) && ownTemplate) {
+                    ownTemplate.ownerUid = ownerUid || ownTemplate.ownerUid || null;
+                    ownTemplate.playerId = playerId || ownTemplate.playerId || current.playerId || null;
                     ownTemplate.actorId = clean(record.actorId) || ownTemplate.actorId || null;
                     ownTemplate.canonicalScope = 'player';
-                    ownTemplate.canonicalOwnerUid = ownerUid;
+                    ownTemplate.canonicalPlayerKey = clean(playerKey || playerId || current.playerId);
+                    ownTemplate.canonicalOwnerUid = ownerUid || current.uid || null;
                     ownTemplate.viewer = true;
                     applyPosition(ownTemplate, record.position);
                     keepIds.add(clean(ownTemplate.id));
                     return;
                 }
 
-                const id = `player:${firebaseKey(ownerUid, 'unknown')}`;
+                const id = `player:${firebaseKey(playerId || ownerUid || playerKey, 'unknown')}`;
                 keepIds.add(id);
                 let token = (mapData.tokens || []).find((entry) => clean(entry.id) === id);
                 if (!token) {
-                    token = playerTokenFromRecord(template || ownTemplate || {}, ownerUid, record, ownUid);
+                    token = playerTokenFromRecord(template || ownTemplate || {}, playerKey, record, current);
                     mapData.tokens ||= [];
                     mapData.tokens.push(token);
                 } else {
-                    token.ownerUid = ownerUid;
-                    token.playerId = clean(record.playerId) || token.playerId || null;
+                    token.ownerUid = ownerUid || null;
+                    token.playerId = playerId || null;
                     token.actorId = clean(record.actorId) || token.actorId || null;
                     token.canonicalScope = 'player';
-                    token.canonicalOwnerUid = ownerUid;
-                    token.viewer = Boolean(!isDm && ownerUid === ownUid);
+                    token.canonicalPlayerKey = clean(playerKey || playerId);
+                    token.canonicalOwnerUid = ownerUid || null;
+                    token.viewer = Boolean(!isDm && isOwnRecord(record, playerKey));
                     applyPosition(token, record.position);
                 }
             });
@@ -217,8 +240,7 @@
         }
 
         function syncWorldRecords(rawRecord = {}) {
-            const records = rawRecord || {};
-            Object.entries(records).forEach(([key, record]) => {
+            Object.entries(rawRecord || {}).forEach(([key, record]) => {
                 if (!record?.position) return;
                 const tokenId = clean(record.tokenId || key);
                 const token = (mapData.tokens || []).find((entry) => clean(entry.id) === tokenId);
@@ -231,20 +253,19 @@
         }
 
         async function seedOwnPlayerIfNeeded() {
-            if (seedingPlayers || isDm || !db || !current.uid || !template) return;
-            seedingPlayers = true;
+            if (seedingPlayer || isDm || !db || !current.playerId || !template) return;
+            seedingPlayer = true;
             try {
-                const ref = playersRef().child(current.uid);
+                const ref = playerStateRef(current.playerId);
                 const snapshot = await ref.once('value');
                 const exists = typeof snapshot.exists === 'function' ? snapshot.exists() : snapshot.val() != null;
                 if (exists) return;
-                const liveToken = localViewerToken() || template;
-                const record = playerRecordFromToken(liveToken, current);
-                record.updatedByUid = current.uid;
+                const record = playerRecordFromToken(localViewerToken() || template, current);
+                record.updatedByUid = current.uid || null;
                 record.updatedAt = firebase.database.ServerValue.TIMESTAMP;
                 await ref.set(record);
             } finally {
-                seedingPlayers = false;
+                seedingPlayer = false;
             }
         }
 
@@ -274,21 +295,22 @@
             if (!token) throw new Error('TOKEN_REQUIRED');
             if (!db) return { valid: true, offline: true, position: positionFromToken(token) };
 
-            const playerScope = token.canonicalScope === 'player' || isCurrentPlayerTemplate(token) || Boolean(token.canonicalOwnerUid);
+            const playerScope = token.canonicalScope === 'player' || isCurrentPlayerTemplate(token) || Boolean(token.canonicalPlayerKey);
             if (playerScope) {
-                const ownerUid = clean(token.canonicalOwnerUid || token.ownerUid || (isCurrentPlayerTemplate(token) ? current.uid : ''));
-                if (!ownerUid) throw new Error('PLAYER_UID_REQUIRED');
-                if (!isDm && ownerUid !== current.uid) throw new Error('PLAYER_TOKEN_OWNERSHIP_REQUIRED');
+                const playerKey = clean(token.canonicalPlayerKey || token.playerId || (isCurrentPlayerTemplate(token) ? current.playerId : ''));
+                if (!playerKey) throw new Error('PLAYER_ID_REQUIRED');
+                const ownerUid = clean(token.canonicalOwnerUid || token.ownerUid || (playerKey === current.playerId ? current.uid : ''));
+                if (!isDm && playerKey !== current.playerId && ownerUid !== current.uid) throw new Error('PLAYER_TOKEN_OWNERSHIP_REQUIRED');
                 const owner = {
-                    uid: ownerUid,
-                    playerId: token.playerId || (ownerUid === current.uid ? current.playerId : ''),
-                    actorId: token.actorId || (ownerUid === current.uid ? current.actorId : ''),
+                    uid: ownerUid || (playerKey === current.playerId ? current.uid : ''),
+                    playerId: playerKey,
+                    actorId: token.actorId || (playerKey === current.playerId ? current.actorId : ''),
                 };
                 const record = playerRecordFromToken(token, owner);
                 record.updatedByUid = current.uid || DM_UID;
                 record.updatedAt = firebase.database.ServerValue.TIMESTAMP;
-                await playersRef().child(ownerUid).set(record);
-                return { valid: true, scope: 'player', key: ownerUid, record };
+                await playerStateRef(playerKey).set(record);
+                return { valid: true, scope: 'player', key: playerKey, record };
             }
 
             if (!isDm) throw new Error('DM_REQUIRED');
@@ -305,7 +327,7 @@
             started = true;
             if (!db) return false;
 
-            subscribe(playersRef(), 'value', (snapshot) => syncPlayerRecords(snapshot.val() || {}));
+            subscribe(playersRootRef(), 'value', (snapshot) => syncPlayerRecords(extractPlayerRecords(snapshot.val() || {}, mapId)));
             subscribe(worldRef(), 'value', (snapshot) => syncWorldRecords(snapshot.val() || {}));
             seedOwnPlayerIfNeeded().catch((error) => console.error('VTT player token seed failed:', error));
             seedWorldIfNeeded().catch((error) => console.error('VTT world token seed failed:', error));
@@ -331,7 +353,8 @@
     }
 
     return Object.freeze({
-        ROOT,
+        PLAYER_ROOT,
+        WORLD_ROOT,
         DM_UID,
         hostWindow,
         hostFirebase,
@@ -344,6 +367,7 @@
         playerRecordFromToken,
         worldRecordFromToken,
         playerTokenFromRecord,
+        extractPlayerRecords,
         createBridge,
     });
 });

--- a/js/vtt/token-state.js
+++ b/js/vtt/token-state.js
@@ -1,0 +1,349 @@
+(function (root, factory) {
+    const api = factory(root);
+    if (typeof module !== 'undefined' && module.exports) module.exports = api;
+    if (root) root.LuminousVttTokenState = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (browserRoot) {
+    'use strict';
+
+    const ROOT = 'vtt_token_state';
+    const DM_UID = 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1';
+    const clean = (value) => String(value ?? '').trim();
+    const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+    function hostWindow(root = browserRoot) {
+        if (!root) return null;
+        try {
+            if (root.parent && root.parent !== root && root.parent.document) return root.parent;
+        } catch (_) {}
+        return root;
+    }
+
+    function hostFirebase(root = browserRoot) {
+        const host = hostWindow(root);
+        return host?.firebase || root?.firebase || null;
+    }
+
+    function identity(root = browserRoot) {
+        const host = hostWindow(root);
+        const data = host?.datosJugador || {};
+        let uid = '';
+        try { uid = clean(hostFirebase(root)?.auth?.().currentUser?.uid); } catch (_) {}
+        return {
+            uid,
+            playerId: clean(host?.localStorage?.getItem?.('playerId') || data.playerId || data.id),
+            actorId: clean(data.actorId || data.vinculo_jugador),
+        };
+    }
+
+    function firebaseKey(value, fallback = 'token') {
+        return clean(value).replace(/[.#$\[\]\/]/g, '_') || fallback;
+    }
+
+    function isCurrentPlayerTemplate(token = {}) {
+        return token.characterLink?.mode === 'current_player';
+    }
+
+    function tokenLayer(token = {}) {
+        if (Number.isFinite(Number(token.zLayer))) return Number(token.zLayer);
+        if (Number.isFinite(Number(token.gridPosition?.z))) return Number(token.gridPosition.z);
+        if (Array.isArray(token.z) && token.z.length) return Number(token.z[0]) || 0;
+        return 0;
+    }
+
+    function positionFromToken(token = {}) {
+        const zLayer = tokenLayer(token);
+        const grid = token.gridPosition || {};
+        const position = {
+            x: Number(token.x) || 0,
+            y: Number(token.y) || 0,
+            zLayer,
+            elevationFt: Number(token.elevationFt) || 0,
+            gridPosition: {
+                col: Number.isFinite(Number(grid.col)) ? Number(grid.col) : 0,
+                row: Number.isFinite(Number(grid.row)) ? Number(grid.row) : 0,
+                z: Number.isFinite(Number(grid.z)) ? Number(grid.z) : zLayer,
+            },
+        };
+        if (token.verticalMovement) position.verticalMovement = clone(token.verticalMovement);
+        if (token.lastVerticalTravel) position.lastVerticalTravel = clone(token.lastVerticalTravel);
+        return position;
+    }
+
+    function applyPosition(token, rawPosition = {}) {
+        if (!token || !rawPosition || typeof rawPosition !== 'object') return token;
+        const zLayer = Number.isFinite(Number(rawPosition.zLayer)) ? Number(rawPosition.zLayer) : tokenLayer(token);
+        if (Number.isFinite(Number(rawPosition.x))) token.x = Number(rawPosition.x);
+        if (Number.isFinite(Number(rawPosition.y))) token.y = Number(rawPosition.y);
+        token.zLayer = zLayer;
+        token.z = [zLayer];
+        token.elevationFt = Number.isFinite(Number(rawPosition.elevationFt)) ? Number(rawPosition.elevationFt) : Number(token.elevationFt) || 0;
+        const grid = rawPosition.gridPosition || {};
+        token.gridPosition = {
+            col: Number.isFinite(Number(grid.col)) ? Number(grid.col) : Number(token.gridPosition?.col) || 0,
+            row: Number.isFinite(Number(grid.row)) ? Number(grid.row) : Number(token.gridPosition?.row) || 0,
+            z: Number.isFinite(Number(grid.z)) ? Number(grid.z) : zLayer,
+        };
+        if (rawPosition.verticalMovement) token.verticalMovement = clone(rawPosition.verticalMovement);
+        else delete token.verticalMovement;
+        if (rawPosition.lastVerticalTravel) token.lastVerticalTravel = clone(rawPosition.lastVerticalTravel);
+        else delete token.lastVerticalTravel;
+        return token;
+    }
+
+    function playerRecordFromToken(token, owner = {}) {
+        if (!clean(owner.uid)) throw new Error('PLAYER_UID_REQUIRED');
+        return {
+            schemaVersion: 1,
+            ownerUid: clean(owner.uid),
+            playerId: clean(owner.playerId) || null,
+            actorId: clean(owner.actorId) || null,
+            baseTokenId: clean(token?.baseTokenId || token?.id || 'player'),
+            position: positionFromToken(token),
+        };
+    }
+
+    function worldRecordFromToken(token) {
+        if (!clean(token?.id)) throw new Error('TOKEN_ID_REQUIRED');
+        return {
+            schemaVersion: 1,
+            tokenId: clean(token.id),
+            position: positionFromToken(token),
+        };
+    }
+
+    function playerTokenFromRecord(template, uid, record = {}, currentUid = '') {
+        const token = clone(template || {});
+        const ownerUid = clean(record.ownerUid || uid);
+        token.id = `player:${firebaseKey(ownerUid, 'unknown')}`;
+        token.baseTokenId = clean(record.baseTokenId || template?.id || 'player');
+        token.ownerUid = ownerUid;
+        token.playerId = clean(record.playerId) || null;
+        token.actorId = clean(record.actorId) || null;
+        token.characterLink = { mode: 'uid', uid: ownerUid, playerId: token.playerId, actorId: token.actorId };
+        token.canonicalScope = 'player';
+        token.canonicalOwnerUid = ownerUid;
+        token.viewer = Boolean(ownerUid && ownerUid === clean(currentUid));
+        token.draggable = template?.draggable !== false;
+        applyPosition(token, record.position || {});
+        return token;
+    }
+
+    function createBridge({ mapData, isDm = false, onTokensChanged, notify, root = browserRoot } = {}) {
+        if (!mapData) throw new Error('MAP_DATA_REQUIRED');
+        const firebase = hostFirebase(root);
+        const db = firebase?.database?.() || null;
+        const mapId = firebaseKey(mapData.id || mapData.mapId || 'default', 'default');
+        const current = identity(root);
+        const subscriptions = [];
+        const template = clone((mapData.tokens || []).find(isCurrentPlayerTemplate) || null);
+        const fixedTokenIds = new Set((mapData.tokens || []).filter((token) => !isCurrentPlayerTemplate(token)).map((token) => clean(token.id)).filter(Boolean));
+        let started = false;
+        let seedingPlayers = false;
+        let seedingWorld = false;
+
+        const emitNotice = (message, mode = 'info') => {
+            if (typeof notify === 'function') notify(message, mode);
+        };
+
+        const rootRef = () => db?.ref(`${ROOT}/${mapId}`);
+        const playersRef = () => rootRef()?.child('players');
+        const worldRef = () => rootRef()?.child('tokens');
+
+        function subscribe(ref, event, handler) {
+            if (!ref?.on) return;
+            ref.on(event, handler);
+            subscriptions.push(() => ref.off(event, handler));
+        }
+
+        function localViewerToken() {
+            return (mapData.tokens || []).find((token) => token.viewer === true)
+                || (mapData.tokens || []).find(isCurrentPlayerTemplate)
+                || null;
+        }
+
+        function syncPlayerRecords(rawRecord = {}) {
+            const records = rawRecord || {};
+            const keepIds = new Set();
+            const ownUid = clean(current.uid);
+            const ownTemplate = !isDm ? (mapData.tokens || []).find(isCurrentPlayerTemplate) : null;
+
+            if (isDm && template) {
+                mapData.tokens = (mapData.tokens || []).filter((token) => !isCurrentPlayerTemplate(token));
+            }
+
+            Object.entries(records).forEach(([uid, record]) => {
+                if (!record || !record.position) return;
+                const ownerUid = clean(record.ownerUid || uid);
+                if (!ownerUid) return;
+
+                if (!isDm && ownerUid === ownUid && ownTemplate) {
+                    ownTemplate.ownerUid = ownerUid;
+                    ownTemplate.playerId = clean(record.playerId) || ownTemplate.playerId || null;
+                    ownTemplate.actorId = clean(record.actorId) || ownTemplate.actorId || null;
+                    ownTemplate.canonicalScope = 'player';
+                    ownTemplate.canonicalOwnerUid = ownerUid;
+                    ownTemplate.viewer = true;
+                    applyPosition(ownTemplate, record.position);
+                    keepIds.add(clean(ownTemplate.id));
+                    return;
+                }
+
+                const id = `player:${firebaseKey(ownerUid, 'unknown')}`;
+                keepIds.add(id);
+                let token = (mapData.tokens || []).find((entry) => clean(entry.id) === id);
+                if (!token) {
+                    token = playerTokenFromRecord(template || ownTemplate || {}, ownerUid, record, ownUid);
+                    mapData.tokens ||= [];
+                    mapData.tokens.push(token);
+                } else {
+                    token.ownerUid = ownerUid;
+                    token.playerId = clean(record.playerId) || token.playerId || null;
+                    token.actorId = clean(record.actorId) || token.actorId || null;
+                    token.canonicalScope = 'player';
+                    token.canonicalOwnerUid = ownerUid;
+                    token.viewer = Boolean(!isDm && ownerUid === ownUid);
+                    applyPosition(token, record.position);
+                }
+            });
+
+            mapData.tokens = (mapData.tokens || []).filter((token) => {
+                if (fixedTokenIds.has(clean(token.id))) return true;
+                if (!isDm && isCurrentPlayerTemplate(token)) return true;
+                if (token.canonicalScope === 'player') return keepIds.has(clean(token.id));
+                return true;
+            });
+
+            if (typeof onTokensChanged === 'function') onTokensChanged({ scope: 'players', tokens: mapData.tokens });
+        }
+
+        function syncWorldRecords(rawRecord = {}) {
+            const records = rawRecord || {};
+            Object.entries(records).forEach(([key, record]) => {
+                if (!record?.position) return;
+                const tokenId = clean(record.tokenId || key);
+                const token = (mapData.tokens || []).find((entry) => clean(entry.id) === tokenId);
+                if (!token) return;
+                token.canonicalScope = 'world';
+                token.canonicalTokenKey = firebaseKey(tokenId);
+                applyPosition(token, record.position);
+            });
+            if (typeof onTokensChanged === 'function') onTokensChanged({ scope: 'world', tokens: mapData.tokens });
+        }
+
+        async function seedOwnPlayerIfNeeded() {
+            if (seedingPlayers || isDm || !db || !current.uid || !template) return;
+            seedingPlayers = true;
+            try {
+                const ref = playersRef().child(current.uid);
+                const snapshot = await ref.once('value');
+                const exists = typeof snapshot.exists === 'function' ? snapshot.exists() : snapshot.val() != null;
+                if (exists) return;
+                const liveToken = localViewerToken() || template;
+                const record = playerRecordFromToken(liveToken, current);
+                record.updatedByUid = current.uid;
+                record.updatedAt = firebase.database.ServerValue.TIMESTAMP;
+                await ref.set(record);
+            } finally {
+                seedingPlayers = false;
+            }
+        }
+
+        async function seedWorldIfNeeded() {
+            if (seedingWorld || !isDm || !db) return;
+            seedingWorld = true;
+            try {
+                const snapshot = await worldRef().once('value');
+                const existing = snapshot.val() || {};
+                const updates = {};
+                for (const token of (mapData.tokens || [])) {
+                    if (isCurrentPlayerTemplate(token) || token.canonicalScope === 'player' || !clean(token.id)) continue;
+                    const key = firebaseKey(token.id);
+                    if (existing[key]) continue;
+                    const record = worldRecordFromToken(token);
+                    record.updatedByUid = current.uid || DM_UID;
+                    record.updatedAt = firebase.database.ServerValue.TIMESTAMP;
+                    updates[key] = record;
+                }
+                if (Object.keys(updates).length) await worldRef().update(updates);
+            } finally {
+                seedingWorld = false;
+            }
+        }
+
+        async function saveToken(token) {
+            if (!token) throw new Error('TOKEN_REQUIRED');
+            if (!db) return { valid: true, offline: true, position: positionFromToken(token) };
+
+            const playerScope = token.canonicalScope === 'player' || isCurrentPlayerTemplate(token) || Boolean(token.canonicalOwnerUid);
+            if (playerScope) {
+                const ownerUid = clean(token.canonicalOwnerUid || token.ownerUid || (isCurrentPlayerTemplate(token) ? current.uid : ''));
+                if (!ownerUid) throw new Error('PLAYER_UID_REQUIRED');
+                if (!isDm && ownerUid !== current.uid) throw new Error('PLAYER_TOKEN_OWNERSHIP_REQUIRED');
+                const owner = {
+                    uid: ownerUid,
+                    playerId: token.playerId || (ownerUid === current.uid ? current.playerId : ''),
+                    actorId: token.actorId || (ownerUid === current.uid ? current.actorId : ''),
+                };
+                const record = playerRecordFromToken(token, owner);
+                record.updatedByUid = current.uid || DM_UID;
+                record.updatedAt = firebase.database.ServerValue.TIMESTAMP;
+                await playersRef().child(ownerUid).set(record);
+                return { valid: true, scope: 'player', key: ownerUid, record };
+            }
+
+            if (!isDm) throw new Error('DM_REQUIRED');
+            const key = firebaseKey(token.id);
+            const record = worldRecordFromToken(token);
+            record.updatedByUid = current.uid || DM_UID;
+            record.updatedAt = firebase.database.ServerValue.TIMESTAMP;
+            await worldRef().child(key).set(record);
+            return { valid: true, scope: 'world', key, record };
+        }
+
+        function start() {
+            if (started) return true;
+            started = true;
+            if (!db) return false;
+
+            subscribe(playersRef(), 'value', (snapshot) => syncPlayerRecords(snapshot.val() || {}));
+            subscribe(worldRef(), 'value', (snapshot) => syncWorldRecords(snapshot.val() || {}));
+            seedOwnPlayerIfNeeded().catch((error) => console.error('VTT player token seed failed:', error));
+            seedWorldIfNeeded().catch((error) => console.error('VTT world token seed failed:', error));
+            return true;
+        }
+
+        function stop() {
+            subscriptions.splice(0).forEach((unsubscribe) => unsubscribe());
+            started = false;
+        }
+
+        return Object.freeze({
+            mapId,
+            isDm: Boolean(isDm),
+            identity: current,
+            start,
+            stop,
+            saveToken,
+            syncPlayerRecords,
+            syncWorldRecords,
+            notify: emitNotice,
+        });
+    }
+
+    return Object.freeze({
+        ROOT,
+        DM_UID,
+        hostWindow,
+        hostFirebase,
+        identity,
+        firebaseKey,
+        isCurrentPlayerTemplate,
+        tokenLayer,
+        positionFromToken,
+        applyPosition,
+        playerRecordFromToken,
+        worldRecordFromToken,
+        playerTokenFromRecord,
+        createBridge,
+    });
+});

--- a/tests/vtt_canonical_token_state.spec.js
+++ b/tests/vtt_canonical_token_state.spec.js
@@ -1,0 +1,208 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const tokenState = require('../js/vtt/token-state.js');
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+function fakeRoot({ uid = 'uid-player', playerId = 'player-key', actorId = 'actor-1' } = {}) {
+  const writes = [];
+  const makeRef = (pathValue) => ({
+    path: pathValue,
+    child(childKey) { return makeRef(`${pathValue}/${childKey}`); },
+    async set(value) { writes.push({ type: 'set', path: pathValue, value }); },
+    async update(value) { writes.push({ type: 'update', path: pathValue, value }); },
+    async once() { return { exists: () => true, val: () => ({}) }; },
+    on() {},
+    off() {},
+  });
+  const database = () => ({ ref: (value) => makeRef(value) });
+  database.ServerValue = { TIMESTAMP: 123456 };
+  const root = {
+    document: {},
+    datosJugador: { id: playerId, playerId, actorId },
+    localStorage: { getItem: (key) => key === 'playerId' ? playerId : null },
+    firebase: {
+      auth: () => ({ currentUser: { uid } }),
+      database,
+    },
+  };
+  return { root, writes };
+}
+
+function playerToken(overrides = {}) {
+  return {
+    id: 'player-template',
+    x: 245,
+    y: 315,
+    draggable: true,
+    characterLink: { mode: 'current_player' },
+    zLayer: 0,
+    elevationFt: 0,
+    gridPosition: { col: 3, row: 4, z: 0 },
+    z: [0],
+    ...overrides,
+  };
+}
+
+test('canonical position preserves Z elevation grid and partial stair progress', () => {
+  const token = playerToken({
+    x: 350,
+    y: 420,
+    zLayer: 1,
+    elevationFt: 9.5,
+    gridPosition: { col: 5, row: 6, z: 1 },
+    z: [1],
+    verticalMovement: {
+      routeId: 'stairs_u_1',
+      fromZ: 0,
+      toZ: 1,
+      progressFt: 12,
+      totalFt: 24,
+      costSpentFt: 12,
+      layout: 'switchback',
+      movementMode: 'stairs',
+    },
+  });
+
+  const position = tokenState.positionFromToken(token);
+  expect(position).toMatchObject({
+    x: 350,
+    y: 420,
+    zLayer: 1,
+    elevationFt: 9.5,
+    gridPosition: { col: 5, row: 6, z: 1 },
+    verticalMovement: { routeId: 'stairs_u_1', progressFt: 12, layout: 'switchback' },
+  });
+
+  const target = playerToken({ x: 1, y: 1 });
+  tokenState.applyPosition(target, position);
+  expect(target.x).toBe(350);
+  expect(target.y).toBe(420);
+  expect(target.zLayer).toBe(1);
+  expect(target.z).toEqual([1]);
+  expect(target.elevationFt).toBe(9.5);
+  expect(target.gridPosition).toEqual({ col: 5, row: 6, z: 1 });
+  expect(target.verticalMovement.progressFt).toBe(12);
+});
+
+test('campaign player records expose only the selected map token state', () => {
+  const records = tokenState.extractPlayerRecords({
+    alice: {
+      uid: 'uid-a',
+      vttTokenState: {
+        alpha: { ownerUid: 'uid-a', position: { x: 10, y: 20 } },
+        beta: { ownerUid: 'uid-a', position: { x: 30, y: 40 } },
+      },
+    },
+    bob: { uid: 'uid-b' },
+  }, 'alpha');
+
+  expect(Object.keys(records)).toEqual(['alice']);
+  expect(records.alice.playerId).toBe('alice');
+  expect(records.alice.position).toEqual({ x: 10, y: 20 });
+});
+
+test('remote player records become distinct player tokens and only the owner is viewer', () => {
+  const template = playerToken();
+  const own = tokenState.playerTokenFromRecord(template, 'alice', {
+    ownerUid: 'uid-a',
+    playerId: 'alice',
+    actorId: 'actor-a',
+    position: { x: 100, y: 200, zLayer: 1, elevationFt: 15, gridPosition: { col: 1, row: 2, z: 1 } },
+  }, { uid: 'uid-a', playerId: 'alice' });
+  const other = tokenState.playerTokenFromRecord(template, 'bob', {
+    ownerUid: 'uid-b',
+    playerId: 'bob',
+    position: { x: 300, y: 400, zLayer: 0, elevationFt: 0, gridPosition: { col: 4, row: 5, z: 0 } },
+  }, { uid: 'uid-a', playerId: 'alice' });
+
+  expect(own.id).toBe('player:alice');
+  expect(own.viewer).toBe(true);
+  expect(own.canonicalScope).toBe('player');
+  expect(own.canonicalPlayerKey).toBe('alice');
+  expect(other.id).toBe('player:bob');
+  expect(other.viewer).toBe(false);
+  expect(other.characterLink.uid).toBe('uid-b');
+});
+
+test('player writes only their campaign player token path and cannot persist world tokens', async () => {
+  const { root, writes } = fakeRoot({ uid: 'uid-a', playerId: 'alice' });
+  const mapData = { id: 'alpha', tokens: [playerToken()] };
+  const bridge = tokenState.createBridge({ mapData, isDm: false, root });
+
+  await bridge.saveToken(mapData.tokens[0]);
+  expect(writes).toHaveLength(1);
+  expect(writes[0].path).toBe('campaña/jugadores/alice/vttTokenState/alpha');
+  expect(writes[0].value.ownerUid).toBe('uid-a');
+  expect(writes[0].value.playerId).toBe('alice');
+
+  await expect(bridge.saveToken({
+    id: 'npc-1', x: 10, y: 10, zLayer: 0, elevationFt: 0,
+    gridPosition: { col: 0, row: 0, z: 0 }, z: [0],
+  })).rejects.toThrow('DM_REQUIRED');
+});
+
+test('player cannot persist another player canonical token', async () => {
+  const { root } = fakeRoot({ uid: 'uid-a', playerId: 'alice' });
+  const bridge = tokenState.createBridge({ mapData: { id: 'alpha', tokens: [playerToken()] }, isDm: false, root });
+  const other = playerToken({
+    id: 'player:bob',
+    characterLink: { mode: 'player', uid: 'uid-b', playerId: 'bob' },
+    canonicalScope: 'player',
+    canonicalPlayerKey: 'bob',
+    canonicalOwnerUid: 'uid-b',
+    playerId: 'bob',
+    ownerUid: 'uid-b',
+  });
+  await expect(bridge.saveToken(other)).rejects.toThrow('PLAYER_TOKEN_OWNERSHIP_REQUIRED');
+});
+
+test('DM can persist both a player token and a world token to canonical campaign roots', async () => {
+  const { root, writes } = fakeRoot({ uid: tokenState.DM_UID, playerId: 'dm' });
+  const bridge = tokenState.createBridge({ mapData: { id: 'alpha', tokens: [] }, isDm: true, root });
+
+  await bridge.saveToken({
+    ...playerToken(),
+    id: 'player:alice',
+    characterLink: { mode: 'player', uid: 'uid-a', playerId: 'alice' },
+    canonicalScope: 'player',
+    canonicalPlayerKey: 'alice',
+    canonicalOwnerUid: 'uid-a',
+    ownerUid: 'uid-a',
+    playerId: 'alice',
+  });
+  await bridge.saveToken({
+    id: 'npc-1', x: 70, y: 70, zLayer: 0, elevationFt: 0,
+    gridPosition: { col: 1, row: 1, z: 0 }, z: [0], draggable: true,
+  });
+
+  expect(writes[0].path).toBe('campaña/jugadores/alice/vttTokenState/alpha');
+  expect(writes[1].path).toBe('campaña/estado_mundo/vttTokens/alpha/npc-1');
+});
+
+test('VTT runtime wires canonical token state to movement events and existing Firebase authority', () => {
+  const html = read('vtt.html');
+  const main = read('js/vtt/main.js');
+  const rules = read('database.rules.json');
+  const stateSource = read('js/vtt/token-state.js');
+
+  expect(html).toContain('js/vtt/token-state.js');
+  expect(main).toContain('LuminousVttTokenState');
+  expect(main).toContain("canvas.addEventListener('vtt:token-moved'");
+  expect(main).toContain('tokenStateBridge.saveToken(token)');
+  expect(main).toContain('tokenStateBridge.stop()');
+  expect(stateSource).toContain("const PLAYER_ROOT = 'campaña/jugadores'");
+  expect(stateSource).toContain("const WORLD_ROOT = 'campaña/estado_mundo/vttTokens'");
+
+  const parsedRules = JSON.parse(rules).rules;
+  expect(parsedRules['campaña']['.read']).toBe('auth != null');
+  expect(parsedRules['campaña'].jugadores['$nombre_personaje']['.write']).toContain("data.child('uid').val() === auth.uid");
+  expect(parsedRules['campaña'].estado_mundo['.write']).toContain(tokenState.DM_UID);
+});
+
+test('canonical token state UMD module parses as JavaScript', () => {
+  execFileSync(process.execPath, ['--check', path.join(__dirname, '..', 'js/vtt/token-state.js')], { stdio: 'pipe' });
+  expect(read('js/vtt/main.js')).toContain('tokenStateBridge');
+});

--- a/vtt.html
+++ b/vtt.html
@@ -127,6 +127,7 @@
     <script src="js/vtt/state-bridge.js"></script>
     <script src="js/vtt/token-interaction.js"></script>
     <script src="js/vtt/token-control.js"></script>
+    <script src="js/vtt/token-state.js"></script>
     <script src="js/vtt/dm-edit-mode.js"></script>
     <script src="js/vtt/check-portal.js"></script>
     <script type="module" src="js/vtt/main.js"></script>


### PR DESCRIPTION
## Summary
- persists VTT player-token positions inside each existing `campaña/jugadores/<player>/vttTokenState/<map>` record
- persists DM/world token positions under `campaña/estado_mundo/vttTokens/<map>`
- reuses existing Firebase authority instead of opening a new database root
- synchronizes x/y, grid position, `zLayer`, physical `elevationFt`, partial stair progress and last vertical travel
- lets the DM move canonical player tokens and world/NPC tokens
- keeps players limited to their own canonical player token while still receiving other players' positions for rendering
- updates a player's active Z automatically when the canonical viewer token is moved between floors

## Authority
Player token state uses the existing `campaña/jugadores/$nombre_personaje` rule, which allows the DM or the UID already bound to that player record.

World/NPC token state uses the existing DM-only `campaña/estado_mundo` authority.

No Firebase rules are broadened by this patch.

## Canonical paths
Player:
`campaña/jugadores/<playerKey>/vttTokenState/<mapId>`

World/NPC:
`campaña/estado_mundo/vttTokens/<mapId>/<tokenId>`

## Vertical movement
Canonical position includes:
- x/y
- logical Z
- physical elevation
- grid cell
- `verticalMovement` partial route state
- `lastVerticalTravel`

This means a stair climb that stops part-way can be observed by the other clients and later resumed from the same canonical route progress.

## Runtime flow
`vtt:token-moved`
→ `LuminousVttTokenState.saveToken()`
→ existing campaign Firebase authority
→ all VTT clients subscribe
→ local `mapData.tokens` is updated

DM receives player records as dynamic player-token instances cloned from the current player token template. Players keep their own `current_player` token as the viewer and receive the other player records as non-viewer tokens.

## Tests
`tests/vtt_canonical_token_state.spec.js` covers:
- Z/elevation/grid/vertical progress round-trip
- map-specific player record extraction
- distinct remote player token instances
- player-owned persistence path
- player rejection for world tokens
- player rejection for another player's token
- DM writes for both player and world token scopes
- VTT movement-event wiring
- reuse of existing Firebase authority
- UMD syntax

## Final validation
Head: `94dd51f702a59091b3f611256c9d5a2325fee6b5`
- Background Narratives workflow: success
- repository regression suite: **832/832 passed**
- narrative contract: **158/158 passed**
- patched syntax: success
- branch is 5 commits ahead / 0 behind the merged #616 `main`

## Out of scope
- dynamic light sources
- Fog of War
- horizontal combat movement-budget enforcement
- token creation/deletion UI
- map-specific token appearance persistence
