### PR TITLE
feat(vtt): dynamic lighting, directional sight and powered interiors

### DIFF
--- a/js/vtt/dynamic-lighting-bootstrap.js
+++ b/js/vtt/dynamic-lighting-bootstrap.js
@@ -1,0 +1,295 @@
+import '../environment-engine.js';
+import './lighting-engine.js';
+import './environment-light-bridge.js';
+import './lighting-state.js';
+import './lighting-controller.js';
+
+const ready = (fn) => {
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', () => queueMicrotask(fn), { once: true });
+  else queueMicrotask(fn);
+};
+
+ready(() => {
+  const runtime = window.LuminousVttRuntime;
+  if (!runtime?.engine || !runtime?.bridge) {
+    console.error('Dynamic Lighting: VTT runtime is unavailable.');
+    return;
+  }
+
+  const { engine, bridge } = runtime;
+  const canvas = engine.canvas;
+  const renderer = engine.renderer;
+  const camera = engine.camera;
+  const mapData = engine.mapData;
+  const light = window.LuminousVttLightingEngine;
+  const stateApi = window.LuminousVttLightingState;
+  const envApi = window.LuminousVttEnvironmentLightBridge;
+  const controllerApi = window.LuminousVttLightingController;
+  if (!light || !stateApi || !envApi || !controllerApi) {
+    console.error('Dynamic Lighting: one or more runtimes are unavailable.');
+    return;
+  }
+
+  mapData.lighting ||= {};
+  mapData.lighting.daylightHours ||= { start: 6, end: 18 };
+  mapData.lighting.visionSamplingFt ||= 2.5;
+  mapData.tokens?.forEach((token) => {
+    if (!Number.isFinite(Number(token.facingDeg))) token.facingDeg = 0;
+    if (!Number.isFinite(Number(token.visionConeDeg))) token.visionConeDeg = light.DEFAULT_VISION_CONE_DEG;
+  });
+
+  let lightingController = null;
+  const lightingStateBridge = stateApi.createBridge({
+    mapData,
+    isDm: bridge.isDm,
+    notify: (message, mode) => runtime.controller?.notify?.(message, mode),
+    onChanged: () => lightingController?.handleSceneChanged?.(),
+  });
+  const environmentLightBridge = envApi.createBridge({ mapData, onChanged: () => { perceptionCache.key = ''; } });
+  lightingController = controllerApi.createController({
+    canvas,
+    engine,
+    mapData,
+    bridge: lightingStateBridge,
+    isDm: bridge.isDm,
+    notify: (message, mode) => runtime.controller?.notify?.(message, mode),
+  });
+  lightingStateBridge.start();
+  environmentLightBridge.start();
+
+  const originalRender = renderer.render.bind(renderer);
+  const perceptionCache = { key: '', tiles: [] };
+
+  function controlledViewers() {
+    if (bridge.isDm) {
+      const previewId = mapData.lighting?.dmPreviewTokenId;
+      if (!previewId) return [];
+      const token = (mapData.tokens || []).find((entry) => String(entry.id) === String(previewId));
+      return token ? [token] : [];
+    }
+    const tokenControl = window.LuminousVttTokenControl;
+    const identity = tokenControl?.identity?.() || lightingStateBridge.identity || {};
+    const controlled = (mapData.tokens || []).filter((token) => token.viewer === true || tokenControl?.canPlayerControl?.(token, identity));
+    if (controlled.length) return controlled;
+    const fallback = (mapData.tokens || []).find((token) => token.characterLink?.mode === 'current_player');
+    return fallback ? [fallback] : [];
+  }
+
+  function scene() { return mapData.lighting?.scene || { sources: [], interiors: [], transformers: [], switches: [] }; }
+  function environment() { return mapData.lighting?.environment || { state: { light: mapData.ambientLight?.level || 'bright' } }; }
+
+  function mapFingerprint(viewers, activeZ, now) {
+    const tokens = (mapData.tokens || []).map((token) => [token.id, Number(token.x)||0, Number(token.y)||0, light.layerOf(token), light.elevationFt(token, mapData), Number(token.facingDeg)||0]);
+    const moving = (scene().sources || []).some((source) => source.motion && !light.interpolateMotion(source.motion, now).complete);
+    return JSON.stringify({
+      z: activeZ,
+      viewers: viewers.map((viewer) => [viewer.id, viewer.x, viewer.y, light.layerOf(viewer), light.elevationFt(viewer, mapData), viewer.facingDeg, viewer.visionConeDeg, viewer.senses?.darkvisionFt]),
+      tokens,
+      scene: scene(),
+      env: environment()?.state,
+      motionTick: moving ? Math.floor(now / 50) : 0,
+    });
+  }
+
+  function bestPerception(viewers, point, now) {
+    let darkvision = null;
+    let dim = null;
+    for (const viewer of viewers) {
+      const result = light.perceptionAtPoint(viewer, point, scene(), mapData, environment(), now);
+      if (!result.visible) continue;
+      if (!result.monochrome && result.level === 'bright') return result;
+      if (!result.monochrome) dim ||= result;
+      else darkvision ||= result;
+    }
+    return dim || darkvision || null;
+  }
+
+  function computeTiles(viewers, activeZ, now) {
+    if (!viewers.length) return [];
+    const stepFt = Math.max(1, Number(mapData.lighting?.visionSamplingFt) || 2.5);
+    const step = light.feetToPixels(stepFt, mapData);
+    const width = (mapData.grid?.cols || 1) * (mapData.grid?.size || 70);
+    const height = (mapData.grid?.rows || 1) * (mapData.grid?.size || 70);
+    const elevationFt = light.elevationForLayer(mapData, activeZ);
+    const tiles = [];
+    for (let y = 0; y < height; y += step) {
+      for (let x = 0; x < width; x += step) {
+        const w = Math.min(step, width - x), h = Math.min(step, height - y);
+        const point = { x: x + w / 2, y: y + h / 2, zLayer: activeZ, elevationFt };
+        const perception = bestPerception(viewers, point, now);
+        if (!perception) continue;
+        tiles.push({ x, y, w, h, perception });
+      }
+    }
+    return tiles;
+  }
+
+  function perceptionTiles(viewers, activeZ, now) {
+    const key = mapFingerprint(viewers, activeZ, now);
+    if (key !== perceptionCache.key) {
+      perceptionCache.key = key;
+      perceptionCache.tiles = computeTiles(viewers, activeZ, now);
+    }
+    return perceptionCache.tiles;
+  }
+
+  function withRendererContext(targetCanvas, targetCtx, fn) {
+    const prevCanvas = renderer.canvas, prevCtx = renderer.ctx;
+    renderer.canvas = targetCanvas; renderer.ctx = targetCtx;
+    try { fn(); } finally { renderer.canvas = prevCanvas; renderer.ctx = prevCtx; }
+  }
+
+  function drawLightEffects(ctx, activeZ, now, subtle = false) {
+    const s = scene();
+    const targetElevation = light.elevationForLayer(mapData, activeZ);
+    ctx.save();
+    ctx.globalCompositeOperation = 'screen';
+    for (const raw of s.sources || []) {
+      const source = light.sourcePosition(raw, mapData, now);
+      if (!light.sourcePowered(source, s).powered) continue;
+      const totalFt = Number(source.brightFt || 0) + Number(source.dimAdditionalFt || 0);
+      const vertical = Math.abs(Number(source.elevationFt || 0) - targetElevation);
+      if (vertical >= totalFt || totalFt <= 0) continue;
+      const targetAtSource = { x: source.x, y: source.y, zLayer: activeZ, elevationFt: targetElevation };
+      if (!light.canTraverseLayers(source, targetAtSource, s, mapData, 'light')) continue;
+      const horizontalFt = Math.sqrt(Math.max(0, totalFt * totalFt - vertical * vertical));
+      const radius = light.feetToPixels(horizontalFt, mapData) * light.lightVisualIntensity(source, now);
+      if (radius <= 0) continue;
+      ctx.save();
+      if (source.shape === 'cone') {
+        const angle = (Number(source.directionDeg || 0) * Math.PI) / 180;
+        const half = ((Number(source.coneDeg || 90) / 2) * Math.PI) / 180;
+        ctx.beginPath(); ctx.moveTo(source.x, source.y); ctx.arc(source.x, source.y, radius, angle - half, angle + half); ctx.closePath(); ctx.clip();
+      }
+      const gradient = ctx.createRadialGradient(source.x, source.y, 0, source.x, source.y, radius);
+      const alpha = subtle ? 0.08 : 0.18;
+      gradient.addColorStop(0, `${source.color || '#ffd27a'}${Math.round(alpha * 255).toString(16).padStart(2,'0')}`);
+      gradient.addColorStop(0.55, `${source.color || '#ffd27a'}${Math.round(alpha * 0.65 * 255).toString(16).padStart(2,'0')}`);
+      gradient.addColorStop(1, `${source.color || '#ffd27a'}00`);
+      ctx.fillStyle = gradient; ctx.beginPath(); ctx.arc(source.x, source.y, radius, 0, Math.PI * 2); ctx.fill();
+      ctx.restore();
+    }
+    ctx.restore();
+  }
+
+  function drawBaseScene(targetCanvas, targetCtx, activeZ, now, includeGuides = false) {
+    withRendererContext(targetCanvas, targetCtx, () => {
+      renderer.clear(false);
+      targetCtx.save();
+      camera.applyTransformSimple(targetCtx);
+      targetCtx.fillStyle = '#111';
+      targetCtx.fillRect(0, 0, (mapData.grid?.cols || 1) * (mapData.grid?.size || 70), (mapData.grid?.rows || 1) * (mapData.grid?.size || 70));
+      renderer.drawGrid();
+      renderer.drawWalls(activeZ, false);
+      renderer.drawTopology(activeZ, false);
+      renderer.drawTokens(activeZ);
+      drawLightEffects(targetCtx, activeZ, now, bridge.isDm && !mapData.lighting?.dmPreviewTokenId);
+      if (includeGuides) lightingController.renderEditorGuides(targetCtx);
+      targetCtx.restore();
+    });
+  }
+
+  function renderFullMap(activeZ, now) {
+    drawBaseScene(canvas, renderer.ctx, activeZ, now, true);
+  }
+
+  function sourceForPerception(perception) {
+    if (!perception?.light?.sourceId) return null;
+    return (scene().sources || []).find((source) => String(source.id) === String(perception.light.sourceId)) || null;
+  }
+
+  function renderTokenVision(activeZ, viewers, now) {
+    const offscreen = document.createElement('canvas');
+    offscreen.width = canvas.width; offscreen.height = canvas.height;
+    const offctx = offscreen.getContext('2d');
+    drawBaseScene(offscreen, offctx, activeZ, now, false);
+
+    renderer.ctx.clearRect(0, 0, canvas.width, canvas.height);
+    renderer.ctx.fillStyle = '#000'; renderer.ctx.fillRect(0, 0, canvas.width, canvas.height);
+    const tiles = perceptionTiles(viewers, activeZ, now);
+    const zoom = camera.zoom;
+    for (const tile of tiles) {
+      const sx = (tile.x + camera.x) * zoom;
+      const sy = (tile.y + camera.y) * zoom;
+      const sw = tile.w * zoom + 1;
+      const sh = tile.h * zoom + 1;
+      if (sx + sw < 0 || sy + sh < 0 || sx > canvas.width || sy > canvas.height) continue;
+      const mode = tile.perception.mode;
+      renderer.ctx.save();
+      if (tile.perception.monochrome) renderer.ctx.filter = 'grayscale(1) brightness(.58)';
+      else if (mode === 'normal_dim') renderer.ctx.filter = 'brightness(.68) contrast(.92)';
+      else if (mode === 'near_dim') renderer.ctx.filter = 'brightness(.45) contrast(.88)';
+      else renderer.ctx.filter = 'none';
+      renderer.ctx.drawImage(offscreen, sx, sy, sw, sh, sx, sy, sw, sh);
+      const source = sourceForPerception(tile.perception);
+      if (source && !tile.perception.monochrome) {
+        renderer.ctx.globalCompositeOperation = 'screen'; renderer.ctx.globalAlpha = tile.perception.level === 'bright' ? 0.10 : 0.06;
+        renderer.ctx.fillStyle = source.color || '#ffd27a'; renderer.ctx.fillRect(sx, sy, sw, sh);
+      }
+      renderer.ctx.restore();
+    }
+  }
+
+  renderer.render = function dynamicLightingRender(activeCamera, activeZ, renderData, isExporting = false) {
+    if (isExporting) return originalRender(activeCamera, activeZ, renderData, true);
+    const now = Date.now();
+    const viewers = controlledViewers();
+    if (bridge.isDm && !mapData.lighting?.dmPreviewTokenId) renderFullMap(activeZ, now);
+    else renderTokenVision(activeZ, viewers, now);
+  };
+  engine.calculateVision = () => ({ dynamicLighting: true });
+
+  function tokenFromMoveEvent(event) {
+    const id = event.detail?.tokenId;
+    return (mapData.tokens || []).find((token) => String(token.id) === String(id)) || null;
+  }
+
+  function updateFacingFromMove(event) {
+    const token = tokenFromMoveEvent(event);
+    const from = event.detail?.from || {}, to = event.detail?.to || {};
+    if (!token || !Number.isFinite(Number(from.x)) || !Number.isFinite(Number(to.x))) return;
+    const dx = Number(to.x) - Number(from.x), dy = Number(to.y) - Number(from.y);
+    if (Math.hypot(dx, dy) < 1) return;
+    token.facingDeg = light.normalizeAngleDeg((Math.atan2(dy, dx) * 180) / Math.PI);
+    perceptionCache.key = '';
+    lightingStateBridge.saveFacing(token).catch((error) => console.error('VTT facing persistence failed:', error));
+  }
+  canvas.addEventListener('vtt:token-moved', updateFacingFromMove);
+
+  function rotatableToken() {
+    if (bridge.isDm && mapData.lighting?.dmPreviewTokenId) return (mapData.tokens || []).find((token) => String(token.id) === String(mapData.lighting.dmPreviewTokenId)) || null;
+    return controlledViewers()[0] || null;
+  }
+  const keyHandler = (event) => {
+    if (!['[', ']'].includes(event.key) || event.ctrlKey || event.metaKey || event.altKey) return;
+    const token = rotatableToken();
+    if (!token) return;
+    token.facingDeg = light.normalizeAngleDeg(Number(token.facingDeg || 0) + (event.key === '[' ? -15 : 15));
+    perceptionCache.key = '';
+    lightingStateBridge.saveFacing(token).catch((error) => console.error('VTT facing persistence failed:', error));
+    event.preventDefault();
+  };
+  window.addEventListener('keydown', keyHandler);
+
+  const previousRuntime = window.LuminousVttRuntime;
+  window.LuminousVttRuntime = Object.freeze({
+    ...previousRuntime,
+    lighting: Object.freeze({
+      engine: light,
+      stateBridge: lightingStateBridge,
+      environmentBridge: environmentLightBridge,
+      controller: lightingController,
+      controlledViewers,
+      perceptionAtPoint: (viewer, point) => light.perceptionAtPoint(viewer, point, scene(), mapData, environment()),
+    }),
+  });
+
+  window.addEventListener('beforeunload', () => {
+    canvas.removeEventListener('vtt:token-moved', updateFacingFromMove);
+    window.removeEventListener('keydown', keyHandler);
+    lightingController.stop();
+    environmentLightBridge.stop();
+    lightingStateBridge.stop();
+    renderer.render = originalRender;
+  }, { once: true });
+});

--- a/js/vtt/environment-light-bridge.js
+++ b/js/vtt/environment-light-bridge.js
@@ -1,0 +1,67 @@
+(function (root, factory) {
+  const api = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttEnvironmentLightBridge = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (browserRoot) {
+  'use strict';
+
+  function hostWindow(root = browserRoot) {
+    if (!root) return null;
+    try {
+      if (root.parent && root.parent !== root && root.parent.document) return root.parent;
+    } catch (_) {}
+    return root;
+  }
+
+  function createBridge({ mapData, onChanged, root = browserRoot } = {}) {
+    if (!mapData) throw new Error('MAP_DATA_REQUIRED');
+    const host = hostWindow(root);
+    let unsubscribe = null;
+    let started = false;
+
+    function resolve() {
+      const lighting = root?.LuminousVttLightingEngine || browserRoot?.LuminousVttLightingEngine;
+      if (!lighting) return null;
+      const weatherEngine = host?.LuminousWeatherEngine || root?.LuminousWeatherEngine;
+      const environmentEngine = host?.LuminousEnvironmentEngine || root?.LuminousEnvironmentEngine;
+      const weatherState = weatherEngine?.getState?.() || null;
+      const calendar = weatherEngine?.getCalendar?.() || {};
+      const daylightHours = mapData.lighting?.daylightHours || lighting.DEFAULT_DAYLIGHT_HOURS;
+      const overrideLevel = mapData.lighting?.ambientOverride || null;
+      const environment = lighting.exteriorEnvironment({
+        weatherState,
+        calendar,
+        environmentEngine,
+        daylightHours,
+        overrideLevel,
+      });
+      mapData.lighting ||= {};
+      mapData.lighting.environment = environment;
+      mapData.lighting.weatherState = weatherState;
+      mapData.lighting.calendar = calendar;
+      mapData.ambientLight ||= {};
+      mapData.ambientLight.level = environment?.state?.light || mapData.ambientLight.level || 'bright';
+      if (typeof onChanged === 'function') onChanged(environment);
+      return environment;
+    }
+
+    function start() {
+      if (started) return true;
+      started = true;
+      const weatherEngine = host?.LuminousWeatherEngine || root?.LuminousWeatherEngine;
+      if (weatherEngine?.onChange) unsubscribe = weatherEngine.onChange(() => resolve());
+      resolve();
+      return Boolean(weatherEngine);
+    }
+
+    function stop() {
+      try { unsubscribe?.(); } catch (_) {}
+      unsubscribe = null;
+      started = false;
+    }
+
+    return Object.freeze({ start, stop, resolve, getEnvironment: () => mapData.lighting?.environment || null });
+  }
+
+  return Object.freeze({ hostWindow, createBridge });
+});

--- a/js/vtt/environment-light-bridge.js
+++ b/js/vtt/environment-light-bridge.js
@@ -18,6 +18,7 @@
     const host = hostWindow(root);
     let unsubscribe = null;
     let started = false;
+    let resolveQueued = false;
 
     function resolve() {
       const lighting = root?.LuminousVttLightingEngine || browserRoot?.LuminousVttLightingEngine;
@@ -45,22 +46,33 @@
       return environment;
     }
 
+    function scheduleResolve() {
+      if (resolveQueued) return;
+      resolveQueued = true;
+      const schedule = typeof queueMicrotask === 'function' ? queueMicrotask : (fn) => Promise.resolve().then(fn);
+      schedule(() => {
+        resolveQueued = false;
+        if (started) resolve();
+      });
+    }
+
     function start() {
       if (started) return true;
       started = true;
       const weatherEngine = host?.LuminousWeatherEngine || root?.LuminousWeatherEngine;
-      if (weatherEngine?.onChange) unsubscribe = weatherEngine.onChange(() => resolve());
-      resolve();
+      if (weatherEngine?.onChange) unsubscribe = weatherEngine.onChange(scheduleResolve);
+      scheduleResolve();
       return Boolean(weatherEngine);
     }
 
     function stop() {
       try { unsubscribe?.(); } catch (_) {}
       unsubscribe = null;
+      resolveQueued = false;
       started = false;
     }
 
-    return Object.freeze({ start, stop, resolve, getEnvironment: () => mapData.lighting?.environment || null });
+    return Object.freeze({ start, stop, resolve, scheduleResolve, getEnvironment: () => mapData.lighting?.environment || null });
   }
 
   return Object.freeze({ hostWindow, createBridge });

--- a/js/vtt/lighting-controller.js
+++ b/js/vtt/lighting-controller.js
@@ -1,0 +1,385 @@
+(function (root, factory) {
+  const api = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttLightingController = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (browserRoot) {
+  'use strict';
+
+  const clean = (value) => String(value ?? '').trim();
+  const num = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+  function uid(prefix) { return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`; }
+
+  function createController({ canvas, engine, mapData, bridge, isDm = false, notify, root = browserRoot } = {}) {
+    if (!canvas || !engine || !mapData || !bridge) throw new Error('LIGHTING_CONTROLLER_INPUT_REQUIRED');
+    const doc = root?.document;
+    const lighting = root?.LuminousVttLightingEngine;
+    const current = bridge.identity || {};
+    let tool = 'select';
+    let dragStart = null;
+    let selected = null;
+    let selectingPreview = false;
+    let throwSourceId = null;
+    const listeners = [];
+
+    function emit(message, mode = 'info') { if (typeof notify === 'function') notify(message, mode); }
+    function scene() { return mapData.lighting?.scene || { sources: [], interiors: [], transformers: [], switches: [] }; }
+    function editActive() { return Boolean(isDm && mapData.dmEditMode?.active); }
+    function worldPoint(event) { return engine.eventWorldPoint(event); }
+    function activeZ() { return Number(engine.activeZ) || 0; }
+    function elevationForActiveZ() { return lighting?.elevationForLayer?.(mapData, activeZ()) ?? activeZ() * 15; }
+    function pxForFt(ft) { return lighting?.feetToPixels?.(ft, mapData) ?? (Number(ft) / 5) * (mapData.grid?.size || 70); }
+
+    function injectUi() {
+      if (!doc) return;
+      if (!doc.getElementById('vtt-lighting-runtime-style')) {
+        const style = doc.createElement('style');
+        style.id = 'vtt-lighting-runtime-style';
+        style.textContent = `
+          .vtt-light-toolbar{display:none;gap:6px;align-items:center;flex-wrap:wrap}
+          body.vtt-dm-edit-active .vtt-light-toolbar{display:flex}
+          .vtt-light-panel{position:fixed;right:18px;top:86px;z-index:31000;width:min(330px,calc(100vw - 36px));max-height:calc(100vh - 110px);overflow:auto;background:#111;border:2px solid #eee;padding:12px;color:#fff;font:12px monospace;box-shadow:6px 6px 0 #000}
+          .vtt-light-panel[hidden]{display:none}.vtt-light-panel label{display:grid;gap:4px;margin:8px 0}.vtt-light-panel input,.vtt-light-panel select{background:#080808;color:#fff;border:1px solid #777;padding:6px}
+          .vtt-light-panel .row{display:grid;grid-template-columns:1fr 1fr;gap:8px}.vtt-light-panel button{margin-top:8px}
+          .vtt-view-token{position:fixed;right:18px;bottom:18px;z-index:30000}.vtt-view-token.is-active{outline:3px solid #fff}
+          .vtt-portable-lights{position:fixed;left:18px;bottom:18px;z-index:30000;display:flex;gap:6px;flex-wrap:wrap;max-width:70vw}.vtt-portable-lights:empty{display:none}
+          .vtt-light-chip{display:flex;gap:4px;background:#101010;border:1px solid #777;padding:4px}
+        `;
+        doc.head.appendChild(style);
+      }
+
+      if (isDm && !doc.getElementById('vtt-lighting-toolbar')) {
+        const toolbar = doc.createElement('div');
+        toolbar.id = 'vtt-lighting-toolbar';
+        toolbar.className = 'vtt-toolbar vtt-light-toolbar';
+        toolbar.innerHTML = `<span class="vtt-toolbar-title">LIGHTING</span>
+          <button type="button" class="brutalist-button" data-light-tool="select">L-SELECT</button>
+          <button type="button" class="brutalist-button" data-light-tool="light">LIGHT</button>
+          <button type="button" class="brutalist-button" data-light-tool="interior">INTERIOR</button>
+          <button type="button" class="brutalist-button" data-light-tool="transformer">TRANSFORMER</button>
+          <button type="button" class="brutalist-button" data-light-tool="switch">SWITCH</button>
+          <button type="button" class="brutalist-button" data-light-tool="erase">L-ERASE</button>`;
+        doc.getElementById('vtt-ui-container')?.appendChild(toolbar);
+        toolbar.addEventListener('click', (event) => {
+          const button = event.target.closest('[data-light-tool]');
+          if (!button) return;
+          setTool(button.dataset.lightTool);
+        });
+      }
+
+      if (isDm && !doc.getElementById('vtt-light-editor')) {
+        const panel = doc.createElement('aside');
+        panel.id = 'vtt-light-editor';
+        panel.className = 'vtt-light-panel';
+        panel.hidden = true;
+        doc.body.appendChild(panel);
+      }
+
+      if (isDm && !doc.getElementById('vtt-view-as-token')) {
+        const button = doc.createElement('button');
+        button.id = 'vtt-view-as-token';
+        button.className = 'brutalist-button vtt-view-token';
+        button.textContent = 'VIEW AS TOKEN';
+        doc.body.appendChild(button);
+        button.addEventListener('click', () => {
+          if (mapData.lighting?.dmPreviewTokenId) {
+            clearPreview();
+            return;
+          }
+          selectingPreview = !selectingPreview;
+          button.classList.toggle('is-active', selectingPreview);
+          button.textContent = selectingPreview ? 'CLICK TOKEN…' : 'VIEW AS TOKEN';
+        });
+      }
+
+      if (!isDm && !doc.getElementById('vtt-portable-lights')) {
+        const bar = doc.createElement('div');
+        bar.id = 'vtt-portable-lights';
+        bar.className = 'vtt-portable-lights';
+        doc.body.appendChild(bar);
+      }
+    }
+
+    function setTool(next) {
+      tool = ['select', 'light', 'interior', 'transformer', 'switch', 'erase'].includes(next) ? next : 'select';
+      doc?.querySelectorAll?.('[data-light-tool]')?.forEach((button) => button.classList.toggle('is-active', button.dataset.lightTool === tool));
+      if (tool !== 'select') closeEditor();
+      return tool;
+    }
+
+    function clearPreview() {
+      mapData.lighting ||= {};
+      mapData.lighting.dmPreviewTokenId = null;
+      selectingPreview = false;
+      const button = doc?.getElementById('vtt-view-as-token');
+      if (button) { button.textContent = 'VIEW AS TOKEN'; button.classList.remove('is-active'); }
+    }
+
+    function setPreviewToken(token) {
+      mapData.lighting ||= {};
+      mapData.lighting.dmPreviewTokenId = token?.id || null;
+      selectingPreview = false;
+      const button = doc?.getElementById('vtt-view-as-token');
+      if (button) { button.textContent = token ? `FULL MAP · ${token.id}` : 'VIEW AS TOKEN'; button.classList.toggle('is-active', Boolean(token)); }
+    }
+
+    function nearestToken(point, maxPx = (mapData.grid?.size || 70) * 0.55) {
+      let best = null, bestDist = Infinity;
+      for (const token of mapData.tokens || []) {
+        if (Number(lighting?.layerOf?.(token) ?? token.zLayer ?? 0) !== activeZ()) continue;
+        const distance = Math.hypot(num(token.x) - point.x, num(token.y) - point.y);
+        if (distance <= maxPx && distance < bestDist) { best = token; bestDist = distance; }
+      }
+      return best;
+    }
+
+    function nearestEntity(point, maxPx = (mapData.grid?.size || 70) * 0.45) {
+      const candidates = [];
+      const add = (kind, list) => (list || []).forEach((item) => {
+        if (kind !== 'interior' && Number(item.zLayer ?? 0) !== activeZ()) return;
+        if (kind === 'interior') {
+          if (Number(item.zLayer ?? 0) !== activeZ()) return;
+          const cx = (num(item.x1) + num(item.x2)) / 2, cy = (num(item.y1) + num(item.y2)) / 2;
+          const inside = point.x >= Math.min(item.x1, item.x2) && point.x <= Math.max(item.x1, item.x2) && point.y >= Math.min(item.y1, item.y2) && point.y <= Math.max(item.y1, item.y2);
+          if (inside) candidates.push({ kind, item, distance: Math.hypot(point.x - cx, point.y - cy) * 0.1 });
+          return;
+        }
+        const position = kind === 'source' ? lighting?.sourcePosition?.(item, mapData) || item : item;
+        candidates.push({ kind, item, distance: Math.hypot(point.x - num(position.x), point.y - num(position.y)) });
+      });
+      const s = scene();
+      add('source', s.sources); add('switch', s.switches); add('transformer', s.transformers); add('interior', s.interiors);
+      return candidates.filter((candidate) => candidate.distance <= maxPx).sort((a, b) => a.distance - b.distance)[0] || null;
+    }
+
+    async function persist() {
+      try { await bridge.saveScene(scene()); }
+      catch (error) { console.error('VTT lighting save failed:', error); emit('No se pudo guardar la iluminación.', 'error'); }
+    }
+
+    function placeSource(point) {
+      const source = {
+        id: uid('light'), label: 'LIGHT', x: point.x, y: point.y, zLayer: activeZ(), elevationFt: elevationForActiveZ(),
+        brightFt: 20, dimAdditionalFt: 20, shape: 'radius', directionDeg: 0, coneDeg: 90,
+        enabled: true, functional: true, color: '#ffd27a', flicker: null, circuitId: '', attachedToTokenId: null,
+      };
+      scene().sources.push(source); selected = { kind: 'source', item: source }; persist(); openEditor(selected);
+    }
+
+    function placeTransformer(point) {
+      const transformer = { id: uid('transformer'), label: 'TRANSFORMER', x: point.x, y: point.y, zLayer: activeZ(), elevationFt: elevationForActiveZ(), powered: true, damaged: false, circuits: ['main'], repair: null };
+      scene().transformers.push(transformer); selected = { kind: 'transformer', item: transformer }; persist(); openEditor(selected);
+    }
+
+    function placeSwitch(point) {
+      const item = { id: uid('switch'), label: 'SWITCH', x: point.x, y: point.y, zLayer: activeZ(), elevationFt: elevationForActiveZ(), circuitId: 'main', state: 'on', interactable: true, interactionFt: 5 };
+      scene().switches.push(item); selected = { kind: 'switch', item }; persist(); openEditor(selected);
+    }
+
+    function placeInterior(from, to) {
+      if (Math.hypot(to.x - from.x, to.y - from.y) < 8) return;
+      const interior = { id: uid('interior'), label: 'INTERIOR', zLayer: activeZ(), x1: Math.min(from.x, to.x), y1: Math.min(from.y, to.y), x2: Math.max(from.x, to.x), y2: Math.max(from.y, to.y), baseLight: 'darkness', exteriorPenetrationFt: 5, roof: { present: true, transparent: false } };
+      scene().interiors.push(interior); selected = { kind: 'interior', item: interior }; persist(); openEditor(selected);
+    }
+
+    function removeEntity(entity) {
+      if (!entity) return;
+      const map = { source: 'sources', switch: 'switches', transformer: 'transformers', interior: 'interiors' };
+      const key = map[entity.kind];
+      if (!key) return;
+      scene()[key] = (scene()[key] || []).filter((item) => item !== entity.item && clean(item.id) !== clean(entity.item.id));
+      selected = null; closeEditor(); persist();
+    }
+
+    function checkbox(value) { return value ? 'checked' : ''; }
+    function esc(value) { return String(value ?? '').replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;'); }
+
+    function openEditor(entity) {
+      if (!isDm || !entity) return;
+      selected = entity;
+      const panel = doc?.getElementById('vtt-light-editor');
+      if (!panel) return;
+      const item = entity.item;
+      let body = `<header><strong>${entity.kind.toUpperCase()}</strong><small>${esc(item.id)}</small></header>`;
+      if (entity.kind === 'source') body += `
+        <label>LABEL<input data-field="label" value="${esc(item.label || '')}"></label>
+        <div class="row"><label>BRIGHT FT<input type="number" min="0" step="1" data-field="brightFt" value="${num(item.brightFt,20)}"></label><label>DIM +FT<input type="number" min="0" step="1" data-field="dimAdditionalFt" value="${num(item.dimAdditionalFt,20)}"></label></div>
+        <div class="row"><label>SHAPE<select data-field="shape"><option value="radius" ${item.shape !== 'cone'?'selected':''}>RADIUS</option><option value="cone" ${item.shape === 'cone'?'selected':''}>CONE</option></select></label><label>CONE °<input type="number" min="1" max="360" data-field="coneDeg" value="${num(item.coneDeg,90)}"></label></div>
+        <div class="row"><label>DIRECTION °<input type="number" step="15" data-field="directionDeg" value="${num(item.directionDeg,0)}"></label><label>ELEVATION FT<input type="number" step="1" data-field="elevationFt" value="${num(item.elevationFt,0)}"></label></div>
+        <label>CIRCUIT<input data-field="circuitId" value="${esc(item.circuitId || '')}" placeholder="none"></label>
+        <label>COLOR<input type="color" data-field="color" value="${esc(item.color || '#ffd27a')}"></label>
+        <label><input type="checkbox" data-field="enabled" ${checkbox(item.enabled !== false)}> ENABLED</label>
+        <label><input type="checkbox" data-field="functional" ${checkbox(item.functional !== false)}> FUNCTIONAL</label>
+        <label><input type="checkbox" data-field="flicker.enabled" ${checkbox(item.flicker?.enabled)}> VISUAL FLICKER</label>
+        <div class="row"><label>ATTACH TOKEN<input data-field="attachedToTokenId" value="${esc(item.attachedToTokenId || '')}"></label><label>OWNER PLAYER<input data-field="ownerPlayerId" value="${esc(item.ownerPlayerId || '')}"></label></div>
+        <label>THROW RANGE FT (optional)<input type="number" min="0" step="1" data-field="throwRangeFt" value="${Number.isFinite(Number(item.throwRangeFt))?Number(item.throwRangeFt):''}"></label>`;
+      if (entity.kind === 'interior') body += `
+        <label>LABEL<input data-field="label" value="${esc(item.label || '')}"></label>
+        <div class="row"><label>BASE LIGHT<select data-field="baseLight"><option value="darkness" ${item.baseLight!=='dim'?'selected':''}>DARKNESS</option><option value="dim" ${item.baseLight==='dim'?'selected':''}>DIM</option></select></label><label>EXTERIOR PENETRATION FT<input type="number" min="0" step="1" data-field="exteriorPenetrationFt" value="${num(item.exteriorPenetrationFt,5)}"></label></div>
+        <label><input type="checkbox" data-field="roof.present" ${checkbox(item.roof?.present !== false)}> HAS ROOF / CEILING</label>
+        <label><input type="checkbox" data-field="roof.transparent" ${checkbox(item.roof?.transparent)}> TRANSPARENT ROOF</label>`;
+      if (entity.kind === 'transformer') body += `
+        <label>LABEL<input data-field="label" value="${esc(item.label || '')}"></label>
+        <label>CIRCUITS (comma)<input data-field="circuits" value="${esc((item.circuits || []).join(','))}"></label>
+        <label><input type="checkbox" data-field="powered" ${checkbox(item.powered !== false)}> POWERED</label><label><input type="checkbox" data-field="damaged" ${checkbox(item.damaged)}> DAMAGED</label>
+        <hr><strong>REPAIR CHECK · optional, no defaults</strong>
+        <label>REQUIRED ITEM<input data-field="repair.requiredItem" value="${esc(item.repair?.requiredItem || '')}"></label>
+        <div class="row"><label>THRESHOLD<input type="number" min="0" data-field="repair.threshold" value="${Number.isFinite(Number(item.repair?.threshold))?Number(item.repair.threshold):''}"></label><label>ABILITY<input data-field="repair.abilityId" value="${esc(item.repair?.rollSpec?.abilityId || '')}" placeholder="int"></label></div>
+        <label>SKILL ID (optional)<input data-field="repair.skillId" value="${esc(item.repair?.rollSpec?.skillId || '')}"></label>`;
+      if (entity.kind === 'switch') body += `
+        <label>LABEL<input data-field="label" value="${esc(item.label || '')}"></label><label>CIRCUIT<input data-field="circuitId" value="${esc(item.circuitId || 'main')}"></label>
+        <div class="row"><label>STATE<select data-field="state"><option value="on" ${item.state!=='off'?'selected':''}>ON</option><option value="off" ${item.state==='off'?'selected':''}>OFF</option></select></label><label>REACH FT<input type="number" min="0" step="1" data-field="interactionFt" value="${num(item.interactionFt,5)}"></label></div>
+        <label><input type="checkbox" data-field="interactable" ${checkbox(item.interactable !== false)}> INTERACTABLE</label>`;
+      body += `<button type="button" class="brutalist-button" data-light-save>SAVE</button> <button type="button" class="vtt-danger-button" data-light-delete>DELETE</button>`;
+      panel.innerHTML = body;
+      panel.hidden = false;
+      panel.querySelector('[data-light-save]')?.addEventListener('click', saveEditor);
+      panel.querySelector('[data-light-delete]')?.addEventListener('click', () => removeEntity(selected));
+    }
+
+    function fieldValue(panel, name) {
+      const input = panel.querySelector(`[data-field="${name}"]`);
+      if (!input) return undefined;
+      if (input.type === 'checkbox') return input.checked;
+      if (input.type === 'number') return input.value === '' ? null : Number(input.value);
+      return input.value;
+    }
+
+    function saveEditor() {
+      const panel = doc?.getElementById('vtt-light-editor');
+      if (!panel || !selected) return;
+      const item = selected.item;
+      panel.querySelectorAll('[data-field]')?.forEach((input) => {
+        const path = input.dataset.field;
+        let value = input.type === 'checkbox' ? input.checked : input.type === 'number' ? (input.value === '' ? null : Number(input.value)) : input.value;
+        if (path === 'circuits') { item.circuits = String(value).split(',').map(clean).filter(Boolean); return; }
+        if (path.startsWith('flicker.')) { item.flicker ||= {}; item.flicker[path.split('.')[1]] = value; return; }
+        if (path.startsWith('roof.')) { item.roof ||= {}; item.roof[path.split('.')[1]] = value; return; }
+        if (path.startsWith('repair.')) {
+          item.repair ||= { rollSpec: {} };
+          const key = path.split('.')[1];
+          if (key === 'abilityId') item.repair.rollSpec.abilityId = clean(value);
+          else if (key === 'skillId') item.repair.rollSpec.skillId = clean(value) || null;
+          else item.repair[key] = value;
+          const ability = clean(item.repair.rollSpec.abilityId);
+          const skill = clean(item.repair.rollSpec.skillId);
+          if (ability) item.repair.rollSpec = { kind: skill ? 'skill' : 'ability', abilityId: ability, skillId: skill || null, label: skill || ability.toUpperCase() };
+          if (!item.repair.requiredItem && !Number.isFinite(Number(item.repair.threshold)) && !ability) item.repair = null;
+          return;
+        }
+        item[path] = value;
+      });
+      persist(); openEditor(selected);
+    }
+
+    function closeEditor() { const panel = doc?.getElementById('vtt-light-editor'); if (panel) panel.hidden = true; selected = null; }
+
+    function onMouseDown(event) {
+      if (selectingPreview && isDm) {
+        const token = nearestToken(worldPoint(event));
+        if (token) { setPreviewToken(token); event.preventDefault(); event.stopImmediatePropagation(); }
+        return;
+      }
+      if (throwSourceId && !isDm) {
+        const point = worldPoint(event);
+        const target = { x: point.x, y: point.y, zLayer: activeZ(), elevationFt: elevationForActiveZ() };
+        bridge.requestSourceThrow(throwSourceId, target).catch((error) => emit(error.message || 'No se pudo lanzar la luz.', 'error'));
+        throwSourceId = null; renderPortableBar(); event.preventDefault(); event.stopImmediatePropagation(); return;
+      }
+      if (!editActive()) return;
+      const point = worldPoint(event);
+      if (tool === 'interior') { dragStart = point; event.preventDefault(); event.stopImmediatePropagation(); return; }
+      if (tool === 'light') placeSource(point);
+      else if (tool === 'transformer') placeTransformer(point);
+      else if (tool === 'switch') placeSwitch(point);
+      else if (tool === 'erase') removeEntity(nearestEntity(point));
+      else if (tool === 'select') {
+        const entity = nearestEntity(point);
+        if (entity) openEditor(entity);
+        else closeEditor();
+        return;
+      } else return;
+      event.preventDefault(); event.stopImmediatePropagation();
+    }
+
+    function onMouseUp(event) {
+      if (!dragStart || !editActive() || tool !== 'interior') return;
+      const end = worldPoint(event); placeInterior(dragStart, end); dragStart = null;
+      event.preventDefault(); event.stopImmediatePropagation();
+    }
+
+    function onDoubleClick(event) {
+      if (isDm || editActive()) return;
+      const point = worldPoint(event);
+      const entity = nearestEntity(point, pxForFt(6));
+      if (!entity) return;
+      if (entity.kind === 'switch' && entity.item.interactable !== false) {
+        bridge.requestSwitchToggle(entity.item.id).catch((error) => emit(error.message || 'No se pudo usar el switch.', 'error'));
+      } else if (entity.kind === 'transformer' && entity.item.damaged) {
+        bridge.requestTransformerRepair(entity.item.id).catch((error) => emit(error.message || 'No se pudo solicitar la reparación.', 'error'));
+      } else return;
+      event.preventDefault(); event.stopImmediatePropagation();
+    }
+
+    function ownedPortableSources() {
+      const viewer = (mapData.tokens || []).find((token) => token.viewer === true) || (mapData.tokens || []).find((token) => token.characterLink?.mode === 'current_player');
+      return (scene().sources || []).filter((source) => clean(source.ownerPlayerId) === clean(current.playerId) || (viewer && clean(source.attachedToTokenId) === clean(viewer.id)));
+    }
+
+    function renderPortableBar() {
+      if (isDm) return;
+      const bar = doc?.getElementById('vtt-portable-lights');
+      if (!bar) return;
+      bar.innerHTML = '';
+      for (const source of ownedPortableSources()) {
+        const chip = doc.createElement('div'); chip.className = 'vtt-light-chip';
+        const label = doc.createElement('span'); label.textContent = source.label || source.id; chip.appendChild(label);
+        if (source.attachedToTokenId) {
+          const drop = doc.createElement('button'); drop.className = 'brutalist-button'; drop.textContent = 'DROP'; drop.onclick = () => bridge.requestSourceDrop(source.id); chip.appendChild(drop);
+          const thr = doc.createElement('button'); thr.className = 'brutalist-button'; thr.textContent = 'THROW'; thr.disabled = !Number.isFinite(Number(source.throwRangeFt)); thr.title = thr.disabled ? 'Esta fuente no tiene throwRangeFt configurado.' : 'Haz clic en el destino.'; thr.onclick = () => { throwSourceId = source.id; renderPortableBar(); emit('Haz clic donde quieres lanzar la fuente.', 'pending'); }; chip.appendChild(thr);
+        } else {
+          const attach = doc.createElement('button'); attach.className = 'brutalist-button'; attach.textContent = 'PICK UP'; attach.onclick = () => bridge.requestSourceAttach(source.id); chip.appendChild(attach);
+        }
+        if (throwSourceId === source.id) chip.style.outline = '2px solid white';
+        bar.appendChild(chip);
+      }
+    }
+
+    function renderEditorGuides(ctx) {
+      if (!isDm || !editActive() || !ctx) return;
+      const s = scene();
+      ctx.save();
+      ctx.font = 'bold 10px monospace'; ctx.textAlign = 'center';
+      for (const interior of s.interiors || []) {
+        if (Number(interior.zLayer || 0) !== activeZ()) continue;
+        ctx.strokeStyle = '#00e5ff'; ctx.setLineDash([8, 5]); ctx.lineWidth = 2;
+        ctx.strokeRect(interior.x1, interior.y1, interior.x2 - interior.x1, interior.y2 - interior.y1);
+        ctx.fillStyle = '#00e5ff'; ctx.fillText('INTERIOR', (interior.x1 + interior.x2) / 2, interior.y1 + 12);
+      }
+      ctx.setLineDash([]);
+      const drawPoint = (item, color, label) => { if (Number(item.zLayer || 0) !== activeZ()) return; ctx.fillStyle = color; ctx.beginPath(); ctx.arc(item.x, item.y, 9, 0, Math.PI * 2); ctx.fill(); ctx.fillText(label, item.x, item.y - 14); };
+      (s.transformers || []).forEach((item) => drawPoint(item, '#ff3bd5', item.damaged ? 'TRANSFORMER · DAMAGED' : 'TRANSFORMER'));
+      (s.switches || []).forEach((item) => drawPoint(item, '#7dff6b', `SWITCH · ${String(item.state || 'on').toUpperCase()}`));
+      (s.sources || []).forEach((item) => {
+        const p = lighting?.sourcePosition?.(item, mapData) || item;
+        if (Number(p.zLayer || 0) !== activeZ()) return;
+        ctx.strokeStyle = item.color || '#ffd27a'; ctx.lineWidth = 2; ctx.beginPath(); ctx.arc(p.x, p.y, 7, 0, Math.PI * 2); ctx.stroke();
+      });
+      ctx.restore();
+    }
+
+    function handleSceneChanged() { renderPortableBar(); if (selected) { const id = selected.item?.id, kind = selected.kind; const map = { source: 'sources', switch: 'switches', transformer: 'transformers', interior: 'interiors' }; const currentItem = (scene()[map[kind]] || []).find((item) => clean(item.id) === clean(id)); if (currentItem) openEditor({ kind, item: currentItem }); else closeEditor(); } }
+
+    injectUi();
+    canvas.addEventListener('mousedown', onMouseDown, true); listeners.push(() => canvas.removeEventListener('mousedown', onMouseDown, true));
+    root.addEventListener('mouseup', onMouseUp, true); listeners.push(() => root.removeEventListener('mouseup', onMouseUp, true));
+    canvas.addEventListener('dblclick', onDoubleClick, true); listeners.push(() => canvas.removeEventListener('dblclick', onDoubleClick, true));
+    renderPortableBar(); setTool('select');
+
+    function stop() { listeners.splice(0).forEach((fn) => fn()); closeEditor(); }
+
+    return Object.freeze({ setTool, clearPreview, setPreviewToken, renderEditorGuides, renderPortableBar, handleSceneChanged, stop, getTool: () => tool, getSelected: () => selected });
+  }
+
+  return Object.freeze({ createController });
+});

--- a/js/vtt/lighting-defaults-patch.js
+++ b/js/vtt/lighting-defaults-patch.js
@@ -1,0 +1,30 @@
+import './lighting-engine.js';
+
+const base = window.LuminousVttLightingEngine;
+if (base) {
+  const finite = (value) => Number.isFinite(Number(value));
+  const withViewerDefaults = (viewer = {}) => ({
+    ...viewer,
+    visionConeDeg: finite(viewer.visionConeDeg) ? Number(viewer.visionConeDeg) : base.DEFAULT_VISION_CONE_DEG,
+  });
+  const withSourceDefaults = (source = {}) => ({
+    ...source,
+    coneDeg: finite(source.coneDeg) ? Number(source.coneDeg) : 90,
+  });
+  const withSceneDefaults = (scene = {}) => ({
+    ...scene,
+    sources: (scene.sources || []).map(withSourceDefaults),
+  });
+
+  window.LuminousVttLightingEngine = Object.freeze({
+    ...base,
+    visionConeDeg: (viewer = {}) => finite(viewer.visionConeDeg)
+      ? Math.max(1, Math.min(360, Number(viewer.visionConeDeg)))
+      : base.DEFAULT_VISION_CONE_DEG,
+    normalizeSource: (source, mapData) => base.normalizeSource(withSourceDefaults(source), mapData),
+    sourcePosition: (source, mapData, nowMs) => base.sourcePosition(withSourceDefaults(source), mapData, nowMs),
+    sourceLevelAtPoint: (source, point, scene, mapData, nowMs) => base.sourceLevelAtPoint(withSourceDefaults(source), point, withSceneDefaults(scene), mapData, nowMs),
+    lightAtPoint: (point, scene, mapData, environment, nowMs) => base.lightAtPoint(point, withSceneDefaults(scene), mapData, environment, nowMs),
+    perceptionAtPoint: (viewer, point, scene, mapData, environment, nowMs) => base.perceptionAtPoint(withViewerDefaults(viewer), point, withSceneDefaults(scene), mapData, environment, nowMs),
+  });
+}

--- a/js/vtt/lighting-engine.js
+++ b/js/vtt/lighting-engine.js
@@ -1,0 +1,500 @@
+(function (root, factory) {
+  const api = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttLightingEngine = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (root) {
+  'use strict';
+
+  const LEVELS = Object.freeze({ BRIGHT: 'bright', DIM: 'dim', DARKNESS: 'darkness' });
+  const RANK = Object.freeze({ darkness: 0, dim: 1, bright: 2 });
+  const DEFAULT_VISION_CONE_DEG = 120;
+  const DARK_NEAR_DIM_FT = 3;
+  const EXTERIOR_INTERIOR_PENETRATION_FT = 5;
+  const DEFAULT_DAYLIGHT_HOURS = Object.freeze({ start: 6, end: 18 });
+
+  const num = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const clean = (value) => String(value ?? '').trim();
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const clamp = (value, min, max) => Math.max(min, Math.min(max, num(value, min)));
+
+  function topologyRuntime() {
+    if (root?.LuminousVttTopology) return root.LuminousVttTopology;
+    if (typeof require !== 'undefined') {
+      try { return require('./topology.js'); } catch (_) {}
+    }
+    return null;
+  }
+
+  function spatialRuntime() {
+    if (root?.LuminousVttSpatialVision) return root.LuminousVttSpatialVision;
+    if (typeof require !== 'undefined') {
+      try { return require('./spatial-vision.js'); } catch (_) {}
+    }
+    return null;
+  }
+
+  function feetPerPixel(mapData = {}) {
+    const size = Math.max(1, num(mapData.grid?.size, 70));
+    return Math.max(0.001, num(mapData.grid?.distancePerCell, 5)) / size;
+  }
+
+  function feetToPixels(feet, mapData = {}) { return Math.max(0, num(feet)) / feetPerPixel(mapData); }
+  function pixelsToFeet(px, mapData = {}) { return Math.max(0, num(px)) * feetPerPixel(mapData); }
+
+  function layerOf(entity = {}) {
+    const spatial = spatialRuntime();
+    if (spatial?.layerOf) return spatial.layerOf(entity);
+    if (Number.isFinite(Number(entity.zLayer))) return Number(entity.zLayer);
+    if (Number.isFinite(Number(entity.gridPosition?.z))) return Number(entity.gridPosition.z);
+    if (Array.isArray(entity.z) && entity.z.length) return Number(entity.z[0]) || 0;
+    return 0;
+  }
+
+  function elevationForLayer(mapData = {}, zLayer = 0) {
+    const spatial = spatialRuntime();
+    if (spatial?.elevationForLayer) return spatial.elevationForLayer(mapData, zLayer);
+    const record = mapData.zLevels?.[String(zLayer)] || mapData.zLevels?.[zLayer];
+    if (Number.isFinite(Number(record?.elevationFt))) return Number(record.elevationFt);
+    return Number(zLayer) * num(mapData.defaultZStepFt, 15);
+  }
+
+  function elevationFt(entity = {}, mapData = {}) {
+    if (Number.isFinite(Number(entity.elevationFt))) return Number(entity.elevationFt);
+    return elevationForLayer(mapData, layerOf(entity));
+  }
+
+  function distance3dFt(a = {}, b = {}, mapData = {}) {
+    const horizontalFt = Math.hypot(num(b.x) - num(a.x), num(b.y) - num(a.y)) * feetPerPixel(mapData);
+    return Math.hypot(horizontalFt, elevationFt(b, mapData) - elevationFt(a, mapData));
+  }
+
+  function normalizeAngleDeg(value) {
+    const angle = num(value, 0) % 360;
+    return angle < 0 ? angle + 360 : angle;
+  }
+
+  function signedAngleDeltaDeg(a, b) {
+    let delta = normalizeAngleDeg(a) - normalizeAngleDeg(b);
+    if (delta > 180) delta -= 360;
+    if (delta < -180) delta += 360;
+    return delta;
+  }
+
+  function angleToPointDeg(origin = {}, point = {}) {
+    return normalizeAngleDeg((Math.atan2(num(point.y) - num(origin.y), num(point.x) - num(origin.x)) * 180) / Math.PI);
+  }
+
+  function pointInCone(origin = {}, point = {}, facingDeg = 0, coneDeg = DEFAULT_VISION_CONE_DEG) {
+    const cone = clamp(coneDeg, 1, 360);
+    if (cone >= 359.999) return true;
+    return Math.abs(signedAngleDeltaDeg(angleToPointDeg(origin, point), facingDeg)) <= (cone / 2) + 1e-9;
+  }
+
+  function normalizeLevel(value, fallback = LEVELS.DARKNESS) {
+    const id = clean(value).toLowerCase();
+    return Object.values(LEVELS).includes(id) ? id : fallback;
+  }
+
+  function strongerLevel(a, b) {
+    const left = normalizeLevel(a);
+    const right = normalizeLevel(b);
+    return RANK[right] > RANK[left] ? right : left;
+  }
+
+  function normalizeRect(rect = {}) {
+    const x1 = Math.min(num(rect.x1 ?? rect.x), num(rect.x2 ?? rect.x) + Math.max(0, num(rect.width)));
+    const x2 = Math.max(num(rect.x1 ?? rect.x), num(rect.x2 ?? rect.x) + Math.max(0, num(rect.width)));
+    const y1 = Math.min(num(rect.y1 ?? rect.y), num(rect.y2 ?? rect.y) + Math.max(0, num(rect.height)));
+    const y2 = Math.max(num(rect.y1 ?? rect.y), num(rect.y2 ?? rect.y) + Math.max(0, num(rect.height)));
+    return { x1, y1, x2, y2 };
+  }
+
+  function normalizeInterior(raw = {}, mapData = {}) {
+    const rect = normalizeRect(raw);
+    return {
+      ...raw,
+      id: clean(raw.id),
+      zLayer: Number.isFinite(Number(raw.zLayer)) ? Number(raw.zLayer) : 0,
+      x1: rect.x1,
+      y1: rect.y1,
+      x2: rect.x2,
+      y2: rect.y2,
+      baseLight: normalizeLevel(raw.baseLight, LEVELS.DARKNESS),
+      exteriorPenetrationFt: Math.max(0, num(raw.exteriorPenetrationFt, EXTERIOR_INTERIOR_PENETRATION_FT)),
+      roof: {
+        present: raw.roof?.present !== false,
+        transparent: raw.roof?.transparent === true,
+      },
+      label: clean(raw.label || raw.id || 'INTERIOR'),
+    };
+  }
+
+  function pointInInterior(point = {}, interior = {}) {
+    if (Number(layerOf(point)) !== Number(interior.zLayer ?? 0)) return false;
+    return num(point.x) >= num(interior.x1) && num(point.x) <= num(interior.x2)
+      && num(point.y) >= num(interior.y1) && num(point.y) <= num(interior.y2);
+  }
+
+  function interiorAtPoint(point = {}, scene = {}, mapData = {}) {
+    return (Array.isArray(scene.interiors) ? scene.interiors : [])
+      .map((item) => normalizeInterior(item, mapData))
+      .find((item) => pointInInterior(point, item)) || null;
+  }
+
+  function segmentDistancePx(point, segment) {
+    const px = num(point.x), py = num(point.y), ax = num(segment.x1), ay = num(segment.y1), bx = num(segment.x2), by = num(segment.y2);
+    const dx = bx - ax, dy = by - ay;
+    const len2 = (dx * dx) + (dy * dy);
+    if (!len2) return Math.hypot(px - ax, py - ay);
+    const t = Math.max(0, Math.min(1, (((px - ax) * dx) + ((py - ay) * dy)) / len2));
+    return Math.hypot(px - (ax + dx * t), py - (ay + dy * t));
+  }
+
+  function topologySegments(mapData = {}, zLayer = 0, blocking = true) {
+    const topology = topologyRuntime();
+    if (!topology) return [];
+    const list = [];
+    for (const raw of Array.isArray(mapData.topology) ? mapData.topology : []) {
+      const element = topology.normalizeElement(raw);
+      if (!topology.elementOnLayer(element, zLayer)) continue;
+      const flags = topology.effectiveFlags(element);
+      const blocksLight = flags.blocksVision === true;
+      if (blocking !== blocksLight) continue;
+      list.push({ ...topology.segment(element, mapData.grid), blocksLight });
+    }
+    return list;
+  }
+
+  function legacySegments(mapData = {}, zLayer = 0) {
+    return (Array.isArray(mapData.walls) ? mapData.walls : [])
+      .filter((wall) => (Array.isArray(wall.z) ? wall.z.map(Number).includes(Number(zLayer)) : Number(wall.z ?? 0) === Number(zLayer)))
+      .filter((wall) => wall.blocksVision !== false)
+      .map((wall) => ({ x1: num(wall.x1), y1: num(wall.y1), x2: num(wall.x2), y2: num(wall.y2), blocksLight: true }));
+  }
+
+  function openingSegments(mapData = {}, zLayer = 0) {
+    const topology = topologyRuntime();
+    const result = [];
+    if (topology) {
+      for (const raw of Array.isArray(mapData.topology) ? mapData.topology : []) {
+        const element = topology.normalizeElement(raw);
+        if (!topology.elementOnLayer(element, zLayer)) continue;
+        if (topology.effectiveFlags(element).blocksVision) continue;
+        if (!['door', 'window', 'curtain_window'].includes(element.type)) continue;
+        result.push(topology.segment(element, mapData.grid));
+      }
+    }
+    const spatial = spatialRuntime();
+    for (const portal of Array.isArray(mapData.verticalPortals) ? mapData.verticalPortals : []) {
+      const layers = spatial?.portalLayers?.(portal) || portal.between || [];
+      if (!layers.map(Number).includes(Number(zLayer))) continue;
+      if (spatial?.portalAllows && !spatial.portalAllows(portal, 'light')) continue;
+      const a = spatial?.vertexToPoint?.(portal.from || portal.a, mapData);
+      const b = spatial?.vertexToPoint?.(portal.to || portal.b, mapData);
+      if (a && b) result.push({ x1: a.x, y1: a.y, x2: b.x, y2: b.y, vertical: true });
+    }
+    return result;
+  }
+
+  function nearExteriorOpening(point = {}, interior = {}, mapData = {}) {
+    const maxPx = feetToPixels(interior.exteriorPenetrationFt, mapData);
+    return openingSegments(mapData, interior.zLayer).some((segment) => segmentDistancePx(point, segment) <= maxPx + 1e-9);
+  }
+
+  function calendarHour(calendar = {}) {
+    if (Number.isFinite(Number(calendar.hora ?? calendar.hour))) return ((Number(calendar.hora ?? calendar.hour) % 24) + 24) % 24;
+    if (calendar.timestamp) {
+      const parsed = new Date(calendar.timestamp);
+      if (!Number.isNaN(parsed.getTime())) return parsed.getUTCHours();
+    }
+    return 12;
+  }
+
+  function isDayFromCalendar(calendar = {}, daylightHours = DEFAULT_DAYLIGHT_HOURS) {
+    const hour = calendarHour(calendar);
+    const start = clamp(daylightHours?.start, 0, 23.999);
+    const end = clamp(daylightHours?.end, 0, 24);
+    if (start <= end) return hour >= start && hour < end;
+    return hour >= start || hour < end;
+  }
+
+  function exteriorEnvironment({ weatherState, calendar, environmentEngine, daylightHours, overrideLevel } = {}) {
+    if (overrideLevel) return { state: { light: normalizeLevel(overrideLevel, LEVELS.BRIGHT) }, isDay: true, source: 'override' };
+    const isDay = isDayFromCalendar(calendar || {}, daylightHours || DEFAULT_DAYLIGHT_HOURS);
+    if (environmentEngine?.resolveEnvironment) {
+      const resolved = environmentEngine.resolveEnvironment({ encounterType: 'outdoor', weather: weatherState, isDay });
+      return { ...resolved, source: 'environment-engine' };
+    }
+    return { state: { light: isDay ? LEVELS.BRIGHT : LEVELS.DARKNESS }, isDay, source: 'fallback' };
+  }
+
+  function ambientAtPoint(point = {}, scene = {}, mapData = {}, environment = {}) {
+    const exterior = normalizeLevel(environment?.state?.light ?? mapData.ambientLight?.level, LEVELS.BRIGHT);
+    const interior = interiorAtPoint(point, scene, mapData);
+    if (!interior) return { level: exterior, origin: 'exterior', interior: null };
+    if (nearExteriorOpening(point, interior, mapData)) return { level: exterior, origin: 'exterior_penetration', interior };
+    return { level: interior.baseLight, origin: 'interior', interior };
+  }
+
+  function normalizeTransformer(raw = {}) {
+    const repair = raw.repair && typeof raw.repair === 'object' ? clone(raw.repair) : null;
+    return {
+      ...raw,
+      id: clean(raw.id),
+      powered: raw.powered !== false,
+      damaged: raw.damaged === true,
+      circuits: Array.isArray(raw.circuits) ? raw.circuits.map(clean).filter(Boolean) : [],
+      repair,
+    };
+  }
+
+  function normalizeSwitch(raw = {}) {
+    return {
+      ...raw,
+      id: clean(raw.id),
+      circuitId: clean(raw.circuitId || 'main') || 'main',
+      state: raw.state === 'off' ? 'off' : 'on',
+      interactable: raw.interactable !== false,
+      interactionFt: Math.max(0, num(raw.interactionFt, 5)),
+      x: num(raw.x), y: num(raw.y), zLayer: num(raw.zLayer, 0), elevationFt: num(raw.elevationFt, 0),
+    };
+  }
+
+  function circuitPower(scene = {}, circuitId = '') {
+    const id = clean(circuitId);
+    if (!id) return { powered: true, reason: 'NO_CIRCUIT' };
+    const transformers = (Array.isArray(scene.transformers) ? scene.transformers : []).map(normalizeTransformer)
+      .filter((transformer) => transformer.circuits.includes(id));
+    if (transformers.length && !transformers.some((transformer) => transformer.powered && !transformer.damaged)) {
+      return { powered: false, reason: 'TRANSFORMER_OFFLINE' };
+    }
+    const switches = (Array.isArray(scene.switches) ? scene.switches : []).map(normalizeSwitch).filter((entry) => entry.circuitId === id);
+    if (switches.length && !switches.some((entry) => entry.state === 'on')) return { powered: false, reason: 'SWITCH_OFF' };
+    return { powered: true, reason: 'POWERED' };
+  }
+
+  function normalizeSource(raw = {}, mapData = {}) {
+    const shape = raw.shape === 'cone' ? 'cone' : 'radius';
+    const zLayer = Number.isFinite(Number(raw.zLayer)) ? Number(raw.zLayer) : 0;
+    return {
+      ...raw,
+      id: clean(raw.id),
+      label: clean(raw.label || raw.id || 'LIGHT'),
+      x: num(raw.x), y: num(raw.y), zLayer,
+      elevationFt: Number.isFinite(Number(raw.elevationFt)) ? Number(raw.elevationFt) : elevationForLayer(mapData, zLayer),
+      brightFt: Math.max(0, num(raw.brightFt, 0)),
+      dimAdditionalFt: Math.max(0, num(raw.dimAdditionalFt, 0)),
+      shape,
+      directionDeg: normalizeAngleDeg(raw.directionDeg),
+      coneDeg: clamp(raw.coneDeg, 1, 360) || 90,
+      enabled: raw.enabled !== false,
+      functional: raw.functional !== false,
+      circuitId: clean(raw.circuitId),
+      color: clean(raw.color || '#ffd27a') || '#ffd27a',
+      flicker: raw.flicker && typeof raw.flicker === 'object' ? clone(raw.flicker) : (raw.flicker ? { enabled: true } : null),
+      attachedToTokenId: clean(raw.attachedToTokenId) || null,
+      ownerPlayerId: clean(raw.ownerPlayerId) || null,
+      throwRangeFt: Number.isFinite(Number(raw.throwRangeFt)) ? Math.max(0, Number(raw.throwRangeFt)) : null,
+      motion: raw.motion && typeof raw.motion === 'object' ? clone(raw.motion) : null,
+    };
+  }
+
+  function sourcePowered(source = {}, scene = {}) {
+    if (!source.enabled) return { powered: false, reason: 'DISABLED' };
+    if (!source.functional) return { powered: false, reason: 'BROKEN' };
+    return circuitPower(scene, source.circuitId);
+  }
+
+  function tokenById(tokens = [], id) { return (Array.isArray(tokens) ? tokens : []).find((token) => clean(token.id) === clean(id)) || null; }
+
+  function interpolateMotion(motion = {}, nowMs = Date.now()) {
+    const startedAt = num(motion.startedAt, nowMs);
+    const durationMs = Math.max(1, num(motion.durationMs, 1));
+    const t = clamp((num(nowMs, startedAt) - startedAt) / durationMs, 0, 1);
+    const from = motion.from || {};
+    const to = motion.to || {};
+    const arcHeightFt = Math.max(0, num(motion.arcHeightFt, 0));
+    return {
+      x: num(from.x) + (num(to.x) - num(from.x)) * t,
+      y: num(from.y) + (num(to.y) - num(from.y)) * t,
+      zLayer: t >= 1 ? num(to.zLayer, num(from.zLayer)) : num(from.zLayer),
+      elevationFt: num(from.elevationFt) + (num(to.elevationFt) - num(from.elevationFt)) * t + (4 * arcHeightFt * t * (1 - t)),
+      progress: t,
+      complete: t >= 1,
+    };
+  }
+
+  function sourcePosition(rawSource = {}, mapData = {}, nowMs = Date.now()) {
+    const source = normalizeSource(rawSource, mapData);
+    if (source.attachedToTokenId) {
+      const token = tokenById(mapData.tokens, source.attachedToTokenId);
+      if (token) return { ...source, x: num(token.x), y: num(token.y), zLayer: layerOf(token), elevationFt: elevationFt(token, mapData), attachment: true };
+    }
+    if (source.motion) return { ...source, ...interpolateMotion(source.motion, nowMs), attachment: false };
+    return { ...source, attachment: false };
+  }
+
+  function orientation(a, b, c) { return ((num(b.y) - num(a.y)) * (num(c.x) - num(b.x))) - ((num(b.x) - num(a.x)) * (num(c.y) - num(b.y))); }
+  function onSegment(a, b, c) { return num(b.x) <= Math.max(num(a.x), num(c.x)) + 1e-9 && num(b.x) + 1e-9 >= Math.min(num(a.x), num(c.x)) && num(b.y) <= Math.max(num(a.y), num(c.y)) + 1e-9 && num(b.y) + 1e-9 >= Math.min(num(a.y), num(c.y)); }
+  function segmentsIntersect(a, b, c, d) {
+    const o1 = orientation(a, b, c), o2 = orientation(a, b, d), o3 = orientation(c, d, a), o4 = orientation(c, d, b);
+    if (((o1 > 0 && o2 < 0) || (o1 < 0 && o2 > 0)) && ((o3 > 0 && o4 < 0) || (o3 < 0 && o4 > 0))) return true;
+    if (Math.abs(o1) < 1e-9 && onSegment(a, c, b)) return true;
+    if (Math.abs(o2) < 1e-9 && onSegment(a, d, b)) return true;
+    if (Math.abs(o3) < 1e-9 && onSegment(c, a, d)) return true;
+    if (Math.abs(o4) < 1e-9 && onSegment(c, b, d)) return true;
+    return false;
+  }
+
+  function blockersForLayer(mapData = {}, zLayer = 0) { return [...legacySegments(mapData, zLayer), ...topologySegments(mapData, zLayer, true)]; }
+
+  function lineBlocked2d(from = {}, to = {}, mapData = {}, zLayer = 0) {
+    return blockersForLayer(mapData, zLayer).some((wall) => segmentsIntersect(from, to, { x: wall.x1, y: wall.y1 }, { x: wall.x2, y: wall.y2 }));
+  }
+
+  function roofBlocksDirectCrossLayer(from = {}, to = {}, scene = {}, mapData = {}) {
+    const fromInterior = interiorAtPoint(from, scene, mapData);
+    const toInterior = interiorAtPoint(to, scene, mapData);
+    const blocks = (interior) => interior?.roof?.present === true && interior?.roof?.transparent !== true;
+    return blocks(fromInterior) || blocks(toInterior);
+  }
+
+  function canTraverseLayers(from = {}, to = {}, scene = {}, mapData = {}, kind = 'light') {
+    const fromZ = layerOf(from), toZ = layerOf(to);
+    if (fromZ === toZ) return true;
+    const spatial = spatialRuntime();
+    if (spatial?.canTraverseLayers?.(from, to, toZ, mapData, kind)) return true;
+    return !roofBlocksDirectCrossLayer(from, to, scene, mapData);
+  }
+
+  function lineOfEffect(from = {}, to = {}, scene = {}, mapData = {}, kind = 'light') {
+    const fromZ = layerOf(from), toZ = layerOf(to);
+    if (!canTraverseLayers(from, to, scene, mapData, kind)) return false;
+    if (lineBlocked2d(from, to, mapData, fromZ)) return false;
+    if (toZ !== fromZ && lineBlocked2d(from, to, mapData, toZ)) return false;
+    return true;
+  }
+
+  function sourceLevelAtPoint(rawSource, point = {}, scene = {}, mapData = {}, nowMs = Date.now()) {
+    const source = sourcePosition(rawSource, mapData, nowMs);
+    if (!sourcePowered(source, scene).powered) return LEVELS.DARKNESS;
+    if (source.shape === 'cone' && !pointInCone(source, point, source.directionDeg, source.coneDeg)) return LEVELS.DARKNESS;
+    const distance = distance3dFt(source, point, mapData);
+    if (distance > source.brightFt + source.dimAdditionalFt + 1e-9) return LEVELS.DARKNESS;
+    if (!lineOfEffect(source, point, scene, mapData, 'light')) return LEVELS.DARKNESS;
+    return distance <= source.brightFt + 1e-9 ? LEVELS.BRIGHT : LEVELS.DIM;
+  }
+
+  function lightAtPoint(point = {}, scene = {}, mapData = {}, environment = {}, nowMs = Date.now()) {
+    const ambient = ambientAtPoint(point, scene, mapData, environment);
+    let level = ambient.level;
+    let sourceId = null;
+    for (const rawSource of Array.isArray(scene.sources) ? scene.sources : []) {
+      const candidate = sourceLevelAtPoint(rawSource, point, scene, mapData, nowMs);
+      if (RANK[candidate] > RANK[level]) {
+        level = candidate;
+        sourceId = rawSource.id || null;
+        if (level === LEVELS.BRIGHT) break;
+      }
+    }
+    return { level, ambient, sourceId };
+  }
+
+  function visionConeDeg(viewer = {}) { return clamp(viewer.visionConeDeg, 1, 360) || DEFAULT_VISION_CONE_DEG; }
+  function facingDeg(viewer = {}) { return normalizeAngleDeg(viewer.facingDeg); }
+
+  function darkvisionRangeFt(viewer = {}) {
+    return Math.max(0, num(viewer.senses?.darkvisionFt ?? viewer.darkvisionFt, 0));
+  }
+
+  function perceptionAtPoint(viewer = {}, point = {}, scene = {}, mapData = {}, environment = {}, nowMs = Date.now()) {
+    if (!pointInCone(viewer, point, facingDeg(viewer), visionConeDeg(viewer))) return { visible: false, mode: 'outside_cone', level: LEVELS.DARKNESS, monochrome: false };
+    if (!lineOfEffect(viewer, point, scene, mapData, 'vision')) return { visible: false, mode: 'occluded', level: LEVELS.DARKNESS, monochrome: false };
+    const light = lightAtPoint(point, scene, mapData, environment, nowMs);
+    const distanceFt = distance3dFt(viewer, point, mapData);
+    if (light.level !== LEVELS.DARKNESS) return { visible: true, mode: light.level === LEVELS.BRIGHT ? 'normal_bright' : 'normal_dim', level: light.level, monochrome: false, distanceFt, light };
+    if (distanceFt <= DARK_NEAR_DIM_FT + 1e-9) return { visible: true, mode: 'near_dim', level: LEVELS.DIM, monochrome: false, distanceFt, light };
+    const range = darkvisionRangeFt(viewer);
+    if (range > 0 && distanceFt <= range + 1e-9) return { visible: true, mode: 'darkvision', level: LEVELS.DIM, monochrome: true, distanceFt, light };
+    return { visible: false, mode: 'darkness', level: LEVELS.DARKNESS, monochrome: false, distanceFt, light };
+  }
+
+  function lightVisualIntensity(source = {}, nowMs = Date.now()) {
+    const normalized = normalizeSource(source);
+    const flicker = normalized.flicker;
+    if (!flicker?.enabled) return 1;
+    const amount = clamp(flicker.amount, 0, 0.45) || 0.08;
+    const speed = Math.max(0.1, num(flicker.speed, 7));
+    const seed = clean(normalized.id).split('').reduce((sum, char) => sum + char.charCodeAt(0), 0);
+    const wave = (Math.sin((nowMs / 1000) * speed + seed) + Math.sin((nowMs / 1000) * speed * 1.73 + seed * 0.13)) / 2;
+    return clamp(1 + wave * amount, 1 - amount, 1 + amount);
+  }
+
+  function createThrowMotion(source = {}, target = {}, mapData = {}, options = {}) {
+    const from = sourcePosition(source, mapData, options.startedAt ?? Date.now());
+    const toZ = Number.isFinite(Number(target.zLayer)) ? Number(target.zLayer) : from.zLayer;
+    const to = {
+      x: num(target.x, from.x), y: num(target.y, from.y), zLayer: toZ,
+      elevationFt: Number.isFinite(Number(target.elevationFt)) ? Number(target.elevationFt) : elevationForLayer(mapData, toZ),
+    };
+    const distanceFt = distance3dFt(from, to, mapData);
+    const speedFtPerSecond = Math.max(1, num(options.speedFtPerSecond, 30));
+    return {
+      from: { x: from.x, y: from.y, zLayer: from.zLayer, elevationFt: from.elevationFt },
+      to,
+      startedAt: num(options.startedAt, Date.now()),
+      durationMs: Math.max(120, num(options.durationMs, (distanceFt / speedFtPerSecond) * 1000)),
+      arcHeightFt: Math.max(0, num(options.arcHeightFt, Math.min(8, distanceFt * 0.25))),
+    };
+  }
+
+  return Object.freeze({
+    LEVELS,
+    RANK,
+    DEFAULT_VISION_CONE_DEG,
+    DARK_NEAR_DIM_FT,
+    EXTERIOR_INTERIOR_PENETRATION_FT,
+    DEFAULT_DAYLIGHT_HOURS,
+    feetPerPixel,
+    feetToPixels,
+    pixelsToFeet,
+    layerOf,
+    elevationForLayer,
+    elevationFt,
+    distance3dFt,
+    normalizeAngleDeg,
+    signedAngleDeltaDeg,
+    angleToPointDeg,
+    pointInCone,
+    normalizeLevel,
+    strongerLevel,
+    normalizeInterior,
+    pointInInterior,
+    interiorAtPoint,
+    openingSegments,
+    nearExteriorOpening,
+    calendarHour,
+    isDayFromCalendar,
+    exteriorEnvironment,
+    ambientAtPoint,
+    normalizeTransformer,
+    normalizeSwitch,
+    circuitPower,
+    normalizeSource,
+    sourcePowered,
+    interpolateMotion,
+    sourcePosition,
+    blockersForLayer,
+    lineBlocked2d,
+    canTraverseLayers,
+    lineOfEffect,
+    sourceLevelAtPoint,
+    lightAtPoint,
+    visionConeDeg,
+    facingDeg,
+    darkvisionRangeFt,
+    perceptionAtPoint,
+    lightVisualIntensity,
+    createThrowMotion,
+  });
+});

--- a/js/vtt/lighting-state.js
+++ b/js/vtt/lighting-state.js
@@ -1,0 +1,368 @@
+(function (root, factory) {
+  const api = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttLightingState = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (browserRoot) {
+  'use strict';
+
+  const DM_UID = 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1';
+  const WORLD_ROOT = 'campaña/estado_mundo/vttLighting';
+  const PLAYER_ROOT = 'campaña/jugadores';
+  const CHECK_COMMAND_ROOT = 'theatre_check_commands';
+  const CHECK_LIVE_ROOT = 'theatre_check_live';
+  const clean = (value) => String(value ?? '').trim();
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+  function hostWindow(root = browserRoot) {
+    if (!root) return null;
+    try { if (root.parent && root.parent !== root && root.parent.document) return root.parent; } catch (_) {}
+    return root;
+  }
+
+  function hostFirebase(root = browserRoot) {
+    const host = hostWindow(root);
+    return host?.firebase || root?.firebase || null;
+  }
+
+  function identity(root = browserRoot) {
+    const host = hostWindow(root);
+    const data = host?.datosJugador || {};
+    let uid = '';
+    try { uid = clean(hostFirebase(root)?.auth?.().currentUser?.uid); } catch (_) {}
+    return {
+      uid,
+      playerId: clean(host?.localStorage?.getItem?.('playerId') || data.playerId || data.id),
+      actorId: clean(data.actorId || data.vinculo_jugador),
+      name: clean(data.characterName || data.nombre || data.name || 'PLAYER') || 'PLAYER',
+    };
+  }
+
+  function firebaseKey(value, fallback = 'default') {
+    return clean(value).replace(/[.#$\[\]\/]/g, '_') || fallback;
+  }
+
+  function emptyScene() {
+    return { schemaVersion: 1, sources: [], interiors: [], transformers: [], switches: [] };
+  }
+
+  function normalizeScene(raw = {}) {
+    const input = raw && typeof raw === 'object' ? raw : {};
+    return {
+      ...emptyScene(),
+      ...clone(input),
+      schemaVersion: 1,
+      sources: Array.isArray(input.sources) ? clone(input.sources) : [],
+      interiors: Array.isArray(input.interiors) ? clone(input.interiors) : [],
+      transformers: Array.isArray(input.transformers) ? clone(input.transformers) : [],
+      switches: Array.isArray(input.switches) ? clone(input.switches) : [],
+    };
+  }
+
+  function createBridge({ mapData, isDm = false, onChanged, notify, root = browserRoot } = {}) {
+    if (!mapData) throw new Error('MAP_DATA_REQUIRED');
+    const host = hostWindow(root);
+    const firebase = hostFirebase(root);
+    const db = firebase?.database?.() || null;
+    const mapId = firebaseKey(mapData.id || mapData.mapId || 'default');
+    const current = identity(root);
+    const subscriptions = [];
+    const liveWatchers = new Map();
+    let started = false;
+    let seeded = false;
+
+    mapData.lighting ||= {};
+    mapData.lighting.scene = normalizeScene(mapData.lighting.scene || mapData.lightingScene || {});
+
+    const sceneRef = () => db?.ref(`${WORLD_ROOT}/${mapId}/scene`);
+    const worldFacingRef = () => db?.ref(`${WORLD_ROOT}/${mapId}/tokenFacing`);
+    const playersRef = () => db?.ref(PLAYER_ROOT);
+    const playerLightingRef = (playerId) => db?.ref(`${PLAYER_ROOT}/${firebaseKey(playerId, 'player')}/vttLighting/${mapId}`);
+    const playerRequestsRef = (playerId) => db?.ref(`${PLAYER_ROOT}/${firebaseKey(playerId, 'player')}/vttLightingRequests/${mapId}`);
+
+    function emit(message, mode = 'info') { if (typeof notify === 'function') notify(message, mode); }
+    function subscribe(ref, event, handler) {
+      if (!ref?.on) return;
+      ref.on(event, handler);
+      subscriptions.push(() => ref.off(event, handler));
+    }
+
+    function replaceScene(raw) {
+      mapData.lighting.scene = normalizeScene(raw || {});
+      if (typeof onChanged === 'function') onChanged({ type: 'scene', scene: mapData.lighting.scene });
+    }
+
+    function applyFacingRecord(rawPlayers = {}, worldFacing = null) {
+      const byPlayer = {};
+      Object.entries(rawPlayers || {}).forEach(([playerKey, data]) => {
+        const value = data?.vttLighting?.[mapId]?.facingDeg;
+        if (Number.isFinite(Number(value))) byPlayer[playerKey] = Number(value);
+      });
+      for (const token of Array.isArray(mapData.tokens) ? mapData.tokens : []) {
+        const playerKey = clean(token.canonicalPlayerKey || token.playerId);
+        if (playerKey && Number.isFinite(Number(byPlayer[playerKey]))) token.facingDeg = Number(byPlayer[playerKey]);
+      }
+      const world = worldFacing || mapData.lighting.worldFacing || {};
+      mapData.lighting.worldFacing = world;
+      for (const token of Array.isArray(mapData.tokens) ? mapData.tokens : []) {
+        if (token.canonicalScope === 'player' || token.characterLink?.mode === 'current_player') continue;
+        const key = firebaseKey(token.id, 'token');
+        if (Number.isFinite(Number(world[key]))) token.facingDeg = Number(world[key]);
+      }
+      if (typeof onChanged === 'function') onChanged({ type: 'facing' });
+    }
+
+    async function seedIfNeeded(snapshot) {
+      if (seeded) return;
+      seeded = true;
+      const exists = typeof snapshot?.exists === 'function' ? snapshot.exists() : snapshot?.val?.() != null;
+      if (!isDm || exists || !db) return;
+      await sceneRef().set(normalizeScene(mapData.lighting.scene));
+    }
+
+    async function saveScene(scene = mapData.lighting.scene) {
+      const normalized = normalizeScene(scene);
+      replaceScene(normalized);
+      if (!db) return { valid: true, offline: true, scene: normalized };
+      if (!isDm) throw new Error('DM_REQUIRED');
+      await sceneRef().set(normalized);
+      return { valid: true, scene: normalized };
+    }
+
+    function playerToken(playerId) {
+      return (mapData.tokens || []).find((token) => clean(token.canonicalPlayerKey || token.playerId) === clean(playerId))
+        || (mapData.tokens || []).find((token) => token.characterLink?.mode === 'current_player' && clean(playerId) === clean(current.playerId))
+        || null;
+    }
+
+    async function saveFacing(token) {
+      if (!token) throw new Error('TOKEN_REQUIRED');
+      const facing = Number(token.facingDeg) || 0;
+      const playerKey = clean(token.canonicalPlayerKey || token.playerId || (token.characterLink?.mode === 'current_player' ? current.playerId : ''));
+      if (playerKey) {
+        const ownerUid = clean(token.canonicalOwnerUid || token.ownerUid);
+        if (!isDm && playerKey !== current.playerId && ownerUid !== current.uid) throw new Error('PLAYER_TOKEN_OWNERSHIP_REQUIRED');
+        if (db) await playerLightingRef(playerKey).child('facingDeg').set(facing);
+        return { valid: true, scope: 'player', key: playerKey, facingDeg: facing };
+      }
+      if (!isDm) throw new Error('DM_REQUIRED');
+      const key = firebaseKey(token.id, 'token');
+      if (db) await worldFacingRef().child(key).set(facing);
+      return { valid: true, scope: 'world', key, facingDeg: facing };
+    }
+
+    function sourceById(id) { return (mapData.lighting.scene.sources || []).find((entry) => clean(entry.id) === clean(id)) || null; }
+    function switchById(id) { return (mapData.lighting.scene.switches || []).find((entry) => clean(entry.id) === clean(id)) || null; }
+    function transformerById(id) { return (mapData.lighting.scene.transformers || []).find((entry) => clean(entry.id) === clean(id)) || null; }
+
+    function requesterCanUseSource(source, playerId) {
+      if (!source) return false;
+      if (clean(source.ownerPlayerId) && clean(source.ownerPlayerId) === clean(playerId)) return true;
+      const token = playerToken(playerId);
+      return Boolean(token && clean(source.attachedToTokenId) === clean(token.id));
+    }
+
+    function playerHasConfiguredItem(playerData, itemId) {
+      if (!itemId) return true;
+      return Boolean(root?.LuminousVttStateBridge?.inventoryHasItem?.(playerData || {}, itemId));
+    }
+
+    async function persistRequestResult(ref, patch) {
+      if (!ref?.update) return;
+      await ref.update({ ...patch, decidedAt: firebase.database.ServerValue.TIMESTAMP });
+    }
+
+    async function applySwitchRequest(request, requestRef) {
+      const light = root?.LuminousVttLightingEngine;
+      const item = switchById(request.switchId);
+      const token = playerToken(request.playerId);
+      if (!item || item.interactable === false || !token) return persistRequestResult(requestRef, { status: 'denied', reason: 'SWITCH_UNAVAILABLE' });
+      const distance = light?.distance3dFt?.(token, item, mapData) ?? Infinity;
+      if (distance > Number(item.interactionFt || 5) + 1e-9) return persistRequestResult(requestRef, { status: 'denied', reason: 'OUT_OF_REACH' });
+      item.state = item.state === 'off' ? 'on' : 'off';
+      await saveScene(mapData.lighting.scene);
+      return persistRequestResult(requestRef, { status: 'applied', resultState: item.state });
+    }
+
+    async function applySourceRequest(request, requestRef) {
+      const light = root?.LuminousVttLightingEngine;
+      const source = sourceById(request.sourceId);
+      const token = playerToken(request.playerId);
+      if (!source || !token || !requesterCanUseSource(source, request.playerId)) return persistRequestResult(requestRef, { status: 'denied', reason: 'SOURCE_OWNERSHIP_REQUIRED' });
+      if (request.action === 'source_drop') {
+        source.attachedToTokenId = null;
+        source.motion = null;
+        source.x = Number(token.x) || 0;
+        source.y = Number(token.y) || 0;
+        source.zLayer = light?.layerOf?.(token) ?? 0;
+        source.elevationFt = light?.elevationFt?.(token, mapData) ?? 0;
+      } else if (request.action === 'source_attach') {
+        source.attachedToTokenId = token.id;
+        source.motion = null;
+      } else if (request.action === 'source_throw') {
+        if (!Number.isFinite(Number(source.throwRangeFt))) return persistRequestResult(requestRef, { status: 'denied', reason: 'THROW_RANGE_UNCONFIGURED' });
+        const target = request.target || {};
+        const from = light?.sourcePosition?.(source, mapData) || token;
+        const distance = light?.distance3dFt?.(from, target, mapData) ?? Infinity;
+        if (distance > Number(source.throwRangeFt) + 1e-9) return persistRequestResult(requestRef, { status: 'denied', reason: 'THROW_OUT_OF_RANGE' });
+        source.attachedToTokenId = null;
+        source.motion = light.createThrowMotion(source, target, mapData, { startedAt: Date.now(), speedFtPerSecond: Number(request.speedFtPerSecond) || 30 });
+        source.x = Number(target.x) || source.x || 0;
+        source.y = Number(target.y) || source.y || 0;
+        source.zLayer = Number.isFinite(Number(target.zLayer)) ? Number(target.zLayer) : source.zLayer;
+        source.elevationFt = Number.isFinite(Number(target.elevationFt)) ? Number(target.elevationFt) : light.elevationForLayer(mapData, source.zLayer);
+      } else return persistRequestResult(requestRef, { status: 'denied', reason: 'ACTION_NOT_ALLOWED' });
+      await saveScene(mapData.lighting.scene);
+      return persistRequestResult(requestRef, { status: 'applied' });
+    }
+
+    async function watchRepair(commandRef, requestRef, transformerId, uid) {
+      const key = `${uid}/${commandRef.key}`;
+      if (liveWatchers.has(key)) return;
+      const liveRef = db.ref(`${CHECK_LIVE_ROOT}/${uid}/${commandRef.key}`);
+      const handler = async (snapshot) => {
+        const live = snapshot.val() || {};
+        if (live.status !== 'complete') return;
+        liveRef.off('value', handler);
+        liveWatchers.delete(key);
+        const transformer = transformerById(transformerId);
+        const passed = live.outcome === 'passed';
+        if (passed && transformer) {
+          transformer.damaged = false;
+          transformer.powered = true;
+          await saveScene(mapData.lighting.scene);
+        }
+        await persistRequestResult(requestRef, { status: passed ? 'applied' : 'failed', checkOutcome: live.outcome || null });
+      };
+      liveWatchers.set(key, { ref: liveRef, handler });
+      liveRef.on('value', handler);
+    }
+
+    async function applyRepairRequest(request, requestRef, playerData) {
+      const transformer = transformerById(request.transformerId);
+      const repair = transformer?.repair;
+      if (!transformer || !repair?.rollSpec || !Number.isFinite(Number(repair.threshold))) return persistRequestResult(requestRef, { status: 'denied', reason: 'REPAIR_UNCONFIGURED' });
+      if (!transformer.damaged) return persistRequestResult(requestRef, { status: 'denied', reason: 'NOT_DAMAGED' });
+      if (repair.requiredItem && !playerHasConfiguredItem(playerData, repair.requiredItem)) return persistRequestResult(requestRef, { status: 'denied', reason: 'REQUIRED_ITEM_MISSING' });
+      const uid = clean(request.requesterUid);
+      if (!uid) return persistRequestResult(requestRef, { status: 'denied', reason: 'AUTH_REQUIRED' });
+      const commandRef = db.ref(`${CHECK_COMMAND_ROOT}/${uid}`).push();
+      await commandRef.set({
+        schemaVersion: 1,
+        targetUid: uid,
+        targetPlayerId: request.playerId || null,
+        targetName: request.playerName || 'PLAYER',
+        roomKey: request.roomKey || 'default',
+        requestedBy: 'player',
+        rollSpec: clone(repair.rollSpec),
+        check: { thresholdRaw: Number(repair.threshold), hiddenThreshold: repair.hiddenThreshold !== false, modifierType: 'neutral', modifierValue: 0, tipText: clean(repair.tipText) },
+        status: 'issued',
+        issuedAt: firebase.database.ServerValue.TIMESTAMP,
+        clientIssuedAt: Date.now(),
+      });
+      await requestRef.update({ status: 'check_issued', commandId: commandRef.key, decidedAt: firebase.database.ServerValue.TIMESTAMP });
+      await watchRepair(commandRef, requestRef, transformer.id, uid);
+    }
+
+    async function processRequest(playerId, playerData, requestId, request) {
+      if (!isDm || !db || !request || request.status !== 'pending' || clean(request.mapId) !== mapId) return;
+      const requestRef = playerRequestsRef(playerId).child(requestId);
+      const normalized = { ...request, playerId: clean(request.playerId || playerId) };
+      if (normalized.action === 'switch_toggle') return applySwitchRequest(normalized, requestRef);
+      if (['source_drop', 'source_attach', 'source_throw'].includes(normalized.action)) return applySourceRequest(normalized, requestRef);
+      if (normalized.action === 'transformer_repair') return applyRepairRequest(normalized, requestRef, playerData);
+      return persistRequestResult(requestRef, { status: 'denied', reason: 'ACTION_NOT_ALLOWED' });
+    }
+
+    function processPlayerRequests(snapshot) {
+      if (!isDm || !db) return;
+      const players = snapshot.val() || {};
+      Object.entries(players).forEach(([playerId, data]) => {
+        const requests = data?.vttLightingRequests?.[mapId] || {};
+        Object.entries(requests).forEach(([requestId, request]) => {
+          processRequest(playerId, data, requestId, request).catch((error) => console.error('VTT lighting request failed:', error));
+        });
+      });
+    }
+
+    async function requestAction(action, payload = {}) {
+      if (!db) return { valid: false, reason: 'FIREBASE_UNAVAILABLE' };
+      if (isDm) throw new Error('PLAYER_REQUEST_ONLY');
+      if (!current.playerId || !current.uid) throw new Error('AUTH_NOT_READY');
+      const ref = playerRequestsRef(current.playerId).push();
+      await ref.set({
+        schemaVersion: 1,
+        mapId,
+        action,
+        requesterUid: current.uid,
+        playerId: current.playerId,
+        actorId: current.actorId || null,
+        playerName: current.name,
+        roomKey: clean(host?.document?.body?.dataset?.theatreRoomId || 'default') || 'default',
+        ...clone(payload),
+        status: 'pending',
+        createdAt: firebase.database.ServerValue.TIMESTAMP,
+        clientCreatedAt: Date.now(),
+      });
+      emit('Interacción enviada.', 'pending');
+      return { valid: true, pending: true, requestId: ref.key };
+    }
+
+    function start() {
+      if (started) return true;
+      started = true;
+      if (!db) return false;
+      subscribe(sceneRef(), 'value', (snapshot) => {
+        seedIfNeeded(snapshot).catch((error) => console.error('VTT lighting seed failed:', error));
+        replaceScene(snapshot.val() || {});
+      });
+      subscribe(worldFacingRef(), 'value', (snapshot) => {
+        mapData.lighting.worldFacing = snapshot.val() || {};
+        playersRef().once('value').then((players) => applyFacingRecord(players.val() || {}, mapData.lighting.worldFacing));
+      });
+      subscribe(playersRef(), 'value', (snapshot) => {
+        applyFacingRecord(snapshot.val() || {}, mapData.lighting.worldFacing || {});
+        if (isDm) processPlayerRequests(snapshot);
+      });
+      return true;
+    }
+
+    function stop() {
+      subscriptions.splice(0).forEach((fn) => fn());
+      liveWatchers.forEach(({ ref, handler }) => ref.off('value', handler));
+      liveWatchers.clear();
+      started = false;
+    }
+
+    return Object.freeze({
+      mapId,
+      isDm: Boolean(isDm),
+      identity: current,
+      start,
+      stop,
+      saveScene,
+      saveFacing,
+      requestAction,
+      requestSwitchToggle: (switchId) => requestAction('switch_toggle', { switchId }),
+      requestSourceDrop: (sourceId) => requestAction('source_drop', { sourceId }),
+      requestSourceAttach: (sourceId) => requestAction('source_attach', { sourceId }),
+      requestSourceThrow: (sourceId, target, options = {}) => requestAction('source_throw', { sourceId, target, speedFtPerSecond: options.speedFtPerSecond }),
+      requestTransformerRepair: (transformerId) => requestAction('transformer_repair', { transformerId }),
+      getScene: () => mapData.lighting.scene,
+    });
+  }
+
+  return Object.freeze({
+    DM_UID,
+    WORLD_ROOT,
+    PLAYER_ROOT,
+    CHECK_COMMAND_ROOT,
+    CHECK_LIVE_ROOT,
+    hostWindow,
+    hostFirebase,
+    identity,
+    firebaseKey,
+    emptyScene,
+    normalizeScene,
+    createBridge,
+  });
+});

--- a/js/vtt/multiplayer-senses-bridge.js
+++ b/js/vtt/multiplayer-senses-bridge.js
@@ -1,0 +1,40 @@
+(function (root) {
+  'use strict';
+  function hostWindow() {
+    try { if (root.parent && root.parent !== root && root.parent.document) return root.parent; } catch (_) {}
+    return root;
+  }
+  function start() {
+    const host = hostWindow();
+    const runtime = root.LuminousVttRuntime;
+    const racial = root.LuminousRacialSenseRuntime;
+    const db = host?.firebase?.database?.();
+    const mapData = runtime?.engine?.mapData;
+    if (!db || !mapData || !racial?.resolveCharacterSenses) return null;
+    const ref = db.ref('campaña/jugadores');
+    let records = {};
+    const apply = () => {
+      for (const token of mapData.tokens || []) {
+        const playerId = String(token.canonicalPlayerKey || token.playerId || '').trim();
+        if (!playerId || !records[playerId]) continue;
+        token.senses = racial.resolveCharacterSenses(records[playerId]);
+        token.characterVision = {
+          raceId: token.senses.raceId,
+          raceSubtypeId: token.senses.raceSubtypeId,
+          darkvisionFt: token.senses.darkvisionFt,
+          source: token.senses.source,
+        };
+      }
+    };
+    const handler = (snapshot) => { records = snapshot.val() || {}; apply(); setTimeout(apply, 0); };
+    ref.on('value', handler);
+    const timer = setInterval(apply, 1000);
+    return () => { ref.off('value', handler); clearInterval(timer); };
+  }
+  const boot = () => {
+    const stop = start();
+    if (stop) root.addEventListener('beforeunload', stop, { once: true });
+  };
+  if (root.document?.readyState === 'loading') root.document.addEventListener('DOMContentLoaded', () => setTimeout(boot, 0), { once: true });
+  else setTimeout(boot, 0);
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/vtt/multiplayer-senses-bridge.js
+++ b/js/vtt/multiplayer-senses-bridge.js
@@ -8,6 +8,7 @@
     const host = hostWindow();
     const runtime = root.LuminousVttRuntime;
     const racial = root.LuminousRacialSenseRuntime;
+    const lighting = root.LuminousVttLightingEngine;
     const db = host?.firebase?.database?.();
     const mapData = runtime?.engine?.mapData;
     if (!db || !mapData || !racial?.resolveCharacterSenses) return null;
@@ -17,6 +18,8 @@
       for (const token of mapData.tokens || []) {
         const playerId = String(token.canonicalPlayerKey || token.playerId || '').trim();
         if (!playerId || !records[playerId]) continue;
+        if (!Number.isFinite(Number(token.visionConeDeg))) token.visionConeDeg = lighting?.DEFAULT_VISION_CONE_DEG || 120;
+        if (!Number.isFinite(Number(token.facingDeg))) token.facingDeg = 0;
         token.senses = racial.resolveCharacterSenses(records[playerId]);
         token.characterVision = {
           raceId: token.senses.raceId,

--- a/tests/vtt_dynamic_lighting.spec.js
+++ b/tests/vtt_dynamic_lighting.spec.js
@@ -1,0 +1,304 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const lighting = require('../js/vtt/lighting-engine.js');
+const environmentEngine = require('../js/environment-engine.js');
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+function map(overrides = {}) {
+  return {
+    id: 'test-map',
+    grid: { cols: 20, rows: 20, size: 70, distancePerCell: 5, distanceUnit: 'ft' },
+    defaultZStepFt: 15,
+    zLevels: {
+      0: { zLayer: 0, elevationFt: 0 },
+      1: { zLayer: 1, elevationFt: 15 },
+      2: { zLayer: 2, elevationFt: 30 },
+    },
+    walls: [],
+    topology: [],
+    verticalPortals: [],
+    tokens: [],
+    ambientLight: { level: 'darkness' },
+    ...overrides,
+  };
+}
+
+function darkEnv() { return { state: { light: 'darkness', visibility: 'clear' } }; }
+function brightEnv() { return { state: { light: 'bright', visibility: 'clear' } }; }
+function scene(overrides = {}) { return { sources: [], interiors: [], transformers: [], switches: [], ...overrides }; }
+
+function viewer(overrides = {}) {
+  return {
+    id: 'viewer', x: 70, y: 70, zLayer: 0, elevationFt: 0,
+    facingDeg: 0, visionConeDeg: 120, senses: { darkvisionFt: 0 },
+    ...overrides,
+  };
+}
+
+test('vision is directional with a configurable 120 degree default cone', () => {
+  expect(lighting.DEFAULT_VISION_CONE_DEG).toBe(120);
+  const origin = { x: 0, y: 0 };
+  expect(lighting.pointInCone(origin, { x: 100, y: 0 }, 0, 120)).toBe(true);
+  expect(lighting.pointInCone(origin, { x: 50, y: 86.6 }, 0, 120)).toBe(true);
+  expect(lighting.pointInCone(origin, { x: 0, y: 100 }, 0, 120)).toBe(false);
+  expect(lighting.pointInCone(origin, { x: -100, y: 0 }, 0, 120)).toBe(false);
+});
+
+test('normal vision in darkness only gets a 3 ft dim pocket', () => {
+  const m = map();
+  const v = viewer({ x: 0, y: 0 });
+  const near = { x: lighting.feetToPixels(2.9, m), y: 0, zLayer: 0, elevationFt: 0 };
+  const far = { x: lighting.feetToPixels(3.1, m), y: 0, zLayer: 0, elevationFt: 0 };
+  const nearResult = lighting.perceptionAtPoint(v, near, scene(), m, darkEnv());
+  const farResult = lighting.perceptionAtPoint(v, far, scene(), m, darkEnv());
+  expect(nearResult).toMatchObject({ visible: true, mode: 'near_dim', level: 'dim', monochrome: false });
+  expect(farResult.visible).toBe(false);
+});
+
+test('Darkvision is grayscale only when darkness itself is being perceived', () => {
+  const m = map();
+  const v = viewer({ x: 0, y: 0, senses: { darkvisionFt: 60 } });
+  const point = { x: lighting.feetToPixels(20, m), y: 0, zLayer: 0, elevationFt: 0 };
+  const dark = lighting.perceptionAtPoint(v, point, scene(), m, darkEnv());
+  expect(dark).toMatchObject({ visible: true, mode: 'darkvision', monochrome: true, level: 'dim' });
+
+  const litScene = scene({ sources: [{ id: 'torch', x: point.x, y: point.y, zLayer: 0, elevationFt: 0, brightFt: 10, dimAdditionalFt: 10, enabled: true }] });
+  const lit = lighting.perceptionAtPoint(v, point, litScene, m, darkEnv());
+  expect(lit.visible).toBe(true);
+  expect(lit.monochrome).toBe(false);
+  expect(lit.mode).toBe('normal_bright');
+});
+
+test('outside weather and calendar drive natural ambient light through EnvironmentEngine', () => {
+  const noon = lighting.exteriorEnvironment({
+    weatherState: { actual: { tipo: 'nublado' } },
+    calendar: { hora: 12 },
+    environmentEngine,
+  });
+  const midnight = lighting.exteriorEnvironment({
+    weatherState: { actual: { tipo: 'soleado' } },
+    calendar: { hora: 0 },
+    environmentEngine,
+  });
+  expect(noon.source).toBe('environment-engine');
+  expect(noon.state.light).toBe('bright');
+  expect(noon.state.sunlight).toBe('diffuse');
+  expect(midnight.state.light).toBe('darkness');
+  expect(midnight.state.sunlight).toBe('none');
+});
+
+test('daylight hours are configurable instead of hard-coded as a universal sunrise', () => {
+  expect(lighting.isDayFromCalendar({ hora: 12 }, { start: 6, end: 18 })).toBe(true);
+  expect(lighting.isDayFromCalendar({ hora: 20 }, { start: 6, end: 18 })).toBe(false);
+  expect(lighting.isDayFromCalendar({ hora: 20 }, { start: 18, end: 6 })).toBe(true);
+});
+
+test('interiors are dark beyond 5 ft of an opening but receive exterior light near a window', () => {
+  const m = map({
+    topology: [{ id: 'window', type: 'window', from: { col: 0, row: 0 }, to: { col: 0, row: 2 }, z: [0], state: 'closed', thresholds: { lockpick: 12, break: 10 } }],
+  });
+  const s = scene({ interiors: [{ id: 'room', zLayer: 0, x1: 0, y1: 0, x2: 700, y2: 700, baseLight: 'darkness', exteriorPenetrationFt: 5, roof: { present: true, transparent: false } }] });
+  const near = { x: lighting.feetToPixels(4, m), y: 35, zLayer: 0, elevationFt: 0 };
+  const deep = { x: lighting.feetToPixels(8, m), y: 140, zLayer: 0, elevationFt: 0 };
+  expect(lighting.ambientAtPoint(near, s, m, brightEnv()).origin).toBe('exterior_penetration');
+  expect(lighting.ambientAtPoint(near, s, m, brightEnv()).level).toBe('bright');
+  expect(lighting.ambientAtPoint(deep, s, m, brightEnv()).level).toBe('darkness');
+});
+
+test('closed windows pass light while walls and closed doors block it', () => {
+  const source = { id: 'lamp', x: 35, y: 105, zLayer: 0, elevationFt: 0, brightFt: 30, dimAdditionalFt: 0, enabled: true };
+  const target = { x: 175, y: 105, zLayer: 0, elevationFt: 0 };
+  const windowMap = map({ topology: [{ id: 'w', type: 'window', from: { col: 1, row: 0 }, to: { col: 1, row: 3 }, z: [0], state: 'closed', thresholds: { lockpick: 12, break: 10 } }] });
+  const wallMap = map({ topology: [{ id: 'wall', type: 'wall', from: { col: 1, row: 0 }, to: { col: 1, row: 3 }, z: [0] }] });
+  const doorMap = map({ topology: [{ id: 'door', type: 'door', from: { col: 1, row: 0 }, to: { col: 1, row: 3 }, z: [0], state: 'closed', thresholds: { lockpick: 15, break: 15 } }] });
+  expect(lighting.sourceLevelAtPoint(source, target, scene(), windowMap)).toBe('bright');
+  expect(lighting.sourceLevelAtPoint(source, target, scene(), wallMap)).toBe('darkness');
+  expect(lighting.sourceLevelAtPoint(source, target, scene(), doorMap)).toBe('darkness');
+});
+
+test('open or broken doors stop blocking light and closed curtain windows block it', () => {
+  const source = { id: 'lamp', x: 35, y: 105, zLayer: 0, elevationFt: 0, brightFt: 30, dimAdditionalFt: 0, enabled: true };
+  const target = { x: 175, y: 105, zLayer: 0, elevationFt: 0 };
+  const mk = (type, state) => map({ topology: [{ id: 'x', type, from: { col: 1, row: 0 }, to: { col: 1, row: 3 }, z: [0], state, thresholds: { lockpick: 12, break: 10 } }] });
+  expect(lighting.sourceLevelAtPoint(source, target, scene(), mk('door', 'open'))).toBe('bright');
+  expect(lighting.sourceLevelAtPoint(source, target, scene(), mk('door', 'broken'))).toBe('bright');
+  expect(lighting.sourceLevelAtPoint(source, target, scene(), mk('curtain_window', 'closed'))).toBe('darkness');
+});
+
+test('artificial light uses real 3D distance between Z levels', () => {
+  const m = map();
+  const source = { id: 'street', x: 70, y: 70, zLayer: 0, elevationFt: 0, brightFt: 20, dimAdditionalFt: 20, enabled: true };
+  const directlyAbove = { x: 70, y: 70, zLayer: 1, elevationFt: 15 };
+  const fartherAbove = { x: lighting.feetToPixels(20, m) + 70, y: 70, zLayer: 1, elevationFt: 15 };
+  expect(lighting.distance3dFt(source, directlyAbove, m)).toBeCloseTo(15, 6);
+  expect(lighting.sourceLevelAtPoint(source, directlyAbove, scene(), m)).toBe('bright');
+  expect(lighting.distance3dFt(source, fartherAbove, m)).toBeCloseTo(25, 6);
+  expect(lighting.sourceLevelAtPoint(source, fartherAbove, scene(), m)).toBe('dim');
+});
+
+test('opaque roofs block cross-floor light while transparent roofs permit it', () => {
+  const m = map();
+  const source = { id: 'below', x: 140, y: 140, zLayer: 0, elevationFt: 0, brightFt: 30, dimAdditionalFt: 0, enabled: true };
+  const target = { x: 140, y: 140, zLayer: 1, elevationFt: 15 };
+  const opaque = scene({ interiors: [{ id: 'upper', zLayer: 1, x1: 0, y1: 0, x2: 300, y2: 300, roof: { present: true, transparent: false } }] });
+  const transparent = scene({ interiors: [{ id: 'upper', zLayer: 1, x1: 0, y1: 0, x2: 300, y2: 300, roof: { present: true, transparent: true } }] });
+  expect(lighting.sourceLevelAtPoint(source, target, opaque, m)).toBe('darkness');
+  expect(lighting.sourceLevelAtPoint(source, target, transparent, m)).toBe('bright');
+});
+
+test('vertical openings permit cross-floor light even when an interior roof exists', () => {
+  const m = map({ verticalPortals: [{ id: 'opening', type: 'opening', between: [0, 1], from: { col: 1, row: 1 }, to: { col: 3, row: 1 }, blocksLight: false, blocksVision: false, state: 'open' }] });
+  const source = { id: 'below', x: 70, y: 140, zLayer: 0, elevationFt: 0, brightFt: 30, dimAdditionalFt: 0, enabled: true };
+  const target = { x: 210, y: 0, zLayer: 1, elevationFt: 15 };
+  const s = scene({ interiors: [{ id: 'upper', zLayer: 1, x1: 0, y1: 0, x2: 400, y2: 400, roof: { present: true, transparent: false } }] });
+  expect(lighting.canTraverseLayers(source, target, s, m, 'light')).toBe(true);
+});
+
+test('strongest illumination wins and overlapping Dim sources do not become Bright', () => {
+  expect(lighting.strongerLevel('dim', 'dim')).toBe('dim');
+  expect(lighting.strongerLevel('darkness', 'dim')).toBe('dim');
+  expect(lighting.strongerLevel('dim', 'bright')).toBe('bright');
+  const m = map();
+  const point = { x: 140, y: 70, zLayer: 0, elevationFt: 0 };
+  const s = scene({ sources: [
+    { id: 'a', x: 0, y: 70, zLayer: 0, elevationFt: 0, brightFt: 5, dimAdditionalFt: 20, enabled: true },
+    { id: 'b', x: 280, y: 70, zLayer: 0, elevationFt: 0, brightFt: 5, dimAdditionalFt: 20, enabled: true },
+  ] });
+  expect(lighting.lightAtPoint(point, s, m, darkEnv()).level).toBe('dim');
+});
+
+test('radius and cone light sources share the same mechanical level rules', () => {
+  const m = map();
+  const ahead = { x: lighting.feetToPixels(10, m), y: 0, zLayer: 0, elevationFt: 0 };
+  const behind = { x: -lighting.feetToPixels(10, m), y: 0, zLayer: 0, elevationFt: 0 };
+  const cone = { id: 'phone', x: 0, y: 0, zLayer: 0, elevationFt: 0, brightFt: 15, dimAdditionalFt: 15, enabled: true, shape: 'cone', directionDeg: 0, coneDeg: 60 };
+  expect(lighting.sourceLevelAtPoint(cone, ahead, scene(), m)).toBe('bright');
+  expect(lighting.sourceLevelAtPoint(cone, behind, scene(), m)).toBe('darkness');
+});
+
+test('attached lights follow canonical token X/Y/Z/elevation', () => {
+  const m = map({ tokens: [{ id: 'p1', x: 210, y: 350, zLayer: 1, elevationFt: 17 }] });
+  const position = lighting.sourcePosition({ id: 'torch', attachedToTokenId: 'p1', brightFt: 20, dimAdditionalFt: 20 }, m, 1000);
+  expect(position).toMatchObject({ x: 210, y: 350, zLayer: 1, elevationFt: 17, attachment: true });
+});
+
+test('transformers and switches gate a circuit without affecting unrelated circuits', () => {
+  const s = scene({
+    transformers: [
+      { id: 't-main', powered: true, damaged: false, circuits: ['lobby'] },
+      { id: 't-side', powered: true, damaged: false, circuits: ['stairs'] },
+    ],
+    switches: [
+      { id: 's-lobby', circuitId: 'lobby', state: 'off' },
+      { id: 's-stairs', circuitId: 'stairs', state: 'on' },
+    ],
+  });
+  expect(lighting.circuitPower(s, 'lobby')).toMatchObject({ powered: false, reason: 'SWITCH_OFF' });
+  expect(lighting.circuitPower(s, 'stairs')).toMatchObject({ powered: true });
+  s.transformers[1].damaged = true;
+  expect(lighting.circuitPower(s, 'stairs')).toMatchObject({ powered: false, reason: 'TRANSFORMER_OFFLINE' });
+});
+
+test('transformer repair has no invented item skill or DC defaults', () => {
+  const transformer = lighting.normalizeTransformer({ id: 't', powered: false, damaged: true, circuits: ['main'] });
+  expect(transformer.repair).toBeNull();
+  const controllerSource = read('js/vtt/lighting-controller.js');
+  expect(controllerSource).toContain('REPAIR CHECK · optional, no defaults');
+  expect(controllerSource).not.toContain('repair: { requiredItem:');
+});
+
+test('flicker changes presentation intensity without changing mechanical light level', () => {
+  const m = map();
+  const source = { id: 'fire', x: 0, y: 0, zLayer: 0, elevationFt: 0, brightFt: 20, dimAdditionalFt: 20, enabled: true, flicker: { enabled: true, amount: 0.2, speed: 9 } };
+  const point = { x: lighting.feetToPixels(10, m), y: 0, zLayer: 0, elevationFt: 0 };
+  expect(lighting.sourceLevelAtPoint(source, point, scene(), m, 1000)).toBe('bright');
+  expect(lighting.sourceLevelAtPoint(source, point, scene(), m, 1800)).toBe('bright');
+  expect(lighting.lightVisualIntensity(source, 1000)).not.toBe(lighting.lightVisualIntensity(source, 1800));
+});
+
+test('thrown light motion interpolates in real time instead of teleporting', () => {
+  const m = map();
+  const source = { id: 'flare', x: 0, y: 0, zLayer: 0, elevationFt: 0, brightFt: 10, dimAdditionalFt: 10 };
+  const motion = lighting.createThrowMotion(source, { x: 280, y: 0, zLayer: 0, elevationFt: 0 }, m, { startedAt: 1000, durationMs: 1000, arcHeightFt: 5 });
+  const start = lighting.interpolateMotion(motion, 1000);
+  const middle = lighting.interpolateMotion(motion, 1500);
+  const end = lighting.interpolateMotion(motion, 2000);
+  expect(start.x).toBe(0);
+  expect(middle.x).toBe(140);
+  expect(middle.elevationFt).toBeCloseTo(5, 6);
+  expect(end.x).toBe(280);
+  expect(end.complete).toBe(true);
+});
+
+test('lighting state reuses existing campaign authority and canonical Check UI roots', () => {
+  const state = read('js/vtt/lighting-state.js');
+  const rules = JSON.parse(read('database.rules.json')).rules;
+  expect(state).toContain("const WORLD_ROOT = 'campaña/estado_mundo/vttLighting'");
+  expect(state).toContain("const PLAYER_ROOT = 'campaña/jugadores'");
+  expect(state).toContain("const CHECK_COMMAND_ROOT = 'theatre_check_commands'");
+  expect(state).toContain("const CHECK_LIVE_ROOT = 'theatre_check_live'");
+  expect(rules.campaña.estado_mundo['.write']).toContain('e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1');
+  expect(rules.campaña.jugadores['$nombre_personaje']['.write']).toContain("data.child('uid').val() === auth.uid");
+  expect(rules.vtt_lighting).toBeUndefined();
+});
+
+test('DM editor and view-as-token integration are wired into EDIT MODE', () => {
+  const controller = read('js/vtt/lighting-controller.js');
+  const bootstrap = read('js/vtt/dynamic-lighting-bootstrap.js');
+  const html = read('vtt.html');
+  expect(controller).toContain('body.vtt-dm-edit-active .vtt-light-toolbar');
+  expect(controller).toContain('LIGHTING');
+  expect(controller).toContain('INTERIOR');
+  expect(controller).toContain('TRANSFORMER');
+  expect(controller).toContain('SWITCH');
+  expect(controller).toContain('VIEW AS TOKEN');
+  expect(bootstrap).toContain("if (bridge.isDm && !mapData.lighting?.dmPreviewTokenId) renderFullMap");
+  expect(bootstrap).toContain('renderTokenVision');
+  expect(html).toContain('js/vtt/dynamic-lighting-bootstrap.js');
+});
+
+test('players combine only tokens they control; there is no party-wide vision flag', () => {
+  const bootstrap = read('js/vtt/dynamic-lighting-bootstrap.js');
+  expect(bootstrap).toContain('canPlayerControl?.(token, identity)');
+  expect(bootstrap).not.toContain('partyVision');
+  expect(bootstrap).not.toContain('sharedVision');
+});
+
+test('facing rotates separately and movement updates the vision direction', () => {
+  const bootstrap = read('js/vtt/dynamic-lighting-bootstrap.js');
+  const state = read('js/vtt/lighting-state.js');
+  expect(bootstrap).toContain("if (!['[', ']'].includes(event.key)");
+  expect(bootstrap).toContain("canvas.addEventListener('vtt:token-moved', updateFacingFromMove)");
+  expect(bootstrap).toContain('lightingStateBridge.saveFacing(token)');
+  expect(state).toContain("child('facingDeg').set(facing)");
+});
+
+test('portable sources expose drop pickup and configured throw actions', () => {
+  const controller = read('js/vtt/lighting-controller.js');
+  const state = read('js/vtt/lighting-state.js');
+  expect(controller).toContain("drop.textContent = 'DROP'");
+  expect(controller).toContain("thr.textContent = 'THROW'");
+  expect(controller).toContain("attach.textContent = 'PICK UP'");
+  expect(controller).toContain('thr.disabled = !Number.isFinite(Number(source.throwRangeFt))');
+  expect(state).toContain("reason: 'THROW_RANGE_UNCONFIGURED'");
+  expect(state).toContain("requestSourceThrow: (sourceId, target");
+});
+
+test('dynamic lighting files parse and the module bootstrap parses as ESM', () => {
+  for (const file of [
+    'js/vtt/lighting-engine.js',
+    'js/vtt/environment-light-bridge.js',
+    'js/vtt/lighting-state.js',
+    'js/vtt/lighting-controller.js',
+    'js/vtt/multiplayer-senses-bridge.js',
+  ]) execFileSync(process.execPath, ['--check', path.join(__dirname, '..', file)], { stdio: 'pipe' });
+
+  const tmp = path.join(os.tmpdir(), `luminous-lighting-${process.pid}.mjs`);
+  fs.writeFileSync(tmp, read('js/vtt/dynamic-lighting-bootstrap.js'));
+  try { execFileSync(process.execPath, ['--check', tmp], { stdio: 'pipe' }); }
+  finally { fs.unlinkSync(tmp); }
+});

--- a/tests/vtt_dynamic_lighting_runtime.spec.js
+++ b/tests/vtt_dynamic_lighting_runtime.spec.js
@@ -1,0 +1,57 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const lighting = require('../js/vtt/lighting-engine.js');
+const environmentEngine = require('../js/environment-engine.js');
+const environmentBridgeApi = require('../js/vtt/environment-light-bridge.js');
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+test('weather bridge defers immediate WeatherEngine callbacks until bootstrap initialization completes', async () => {
+  let changes = 0;
+  const fakeRoot = {
+    document: {},
+    LuminousVttLightingEngine: lighting,
+    LuminousEnvironmentEngine: environmentEngine,
+    LuminousWeatherEngine: {
+      getState: () => ({ actual: { tipo: 'nublado' } }),
+      getCalendar: () => ({ hora: 12 }),
+      onChange(listener) { listener({}); return () => {}; },
+    },
+  };
+  const mapData = { ambientLight: { level: 'darkness' }, lighting: { daylightHours: { start: 6, end: 18 } } };
+  const bridge = environmentBridgeApi.createBridge({ mapData, root: fakeRoot, onChanged: () => { changes += 1; } });
+  bridge.start();
+  expect(changes).toBe(0);
+  await Promise.resolve();
+  expect(changes).toBe(1);
+  expect(mapData.ambientLight.level).toBe('bright');
+  bridge.stop();
+});
+
+test('browser defaults patch runs before dynamic bootstrap and preserves 120 degree fallback', () => {
+  const html = read('vtt.html');
+  const patchIndex = html.indexOf('js/vtt/lighting-defaults-patch.js');
+  const bootstrapIndex = html.indexOf('js/vtt/dynamic-lighting-bootstrap.js');
+  expect(patchIndex).toBeGreaterThan(0);
+  expect(bootstrapIndex).toBeGreaterThan(patchIndex);
+  const patch = read('js/vtt/lighting-defaults-patch.js');
+  expect(patch).toContain('base.DEFAULT_VISION_CONE_DEG');
+  expect(patch).toContain('coneDeg: finite(source.coneDeg) ? Number(source.coneDeg) : 90');
+});
+
+test('dynamic multiplayer player tokens refresh their own racial senses and cone defaults', () => {
+  const source = read('js/vtt/multiplayer-senses-bridge.js');
+  expect(source).toContain('racial.resolveCharacterSenses(records[playerId])');
+  expect(source).toContain('token.visionConeDeg = lighting?.DEFAULT_VISION_CONE_DEG || 120');
+  expect(source).toContain('token.facingDeg = 0');
+});
+
+test('lighting defaults patch parses as an ES module', () => {
+  const tmp = path.join(os.tmpdir(), `luminous-lighting-defaults-${process.pid}.mjs`);
+  fs.writeFileSync(tmp, read('js/vtt/lighting-defaults-patch.js'));
+  try { execFileSync(process.execPath, ['--check', tmp], { stdio: 'pipe' }); }
+  finally { fs.unlinkSync(tmp); }
+});

--- a/vtt.html
+++ b/vtt.html
@@ -130,6 +130,7 @@
     <script src="js/vtt/token-state.js"></script>
     <script src="js/vtt/dm-edit-mode.js"></script>
     <script src="js/vtt/check-portal.js"></script>
+    <script src="js/vtt/multiplayer-senses-bridge.js"></script>
     <script type="module" src="js/vtt/main.js"></script>
     <script type="module" src="js/vtt/dynamic-lighting-bootstrap.js"></script>
 </body>

--- a/vtt.html
+++ b/vtt.html
@@ -132,6 +132,7 @@
     <script src="js/vtt/check-portal.js"></script>
     <script src="js/vtt/multiplayer-senses-bridge.js"></script>
     <script type="module" src="js/vtt/main.js"></script>
+    <script type="module" src="js/vtt/lighting-defaults-patch.js"></script>
     <script type="module" src="js/vtt/dynamic-lighting-bootstrap.js"></script>
 </body>
 </html>

--- a/vtt.html
+++ b/vtt.html
@@ -131,5 +131,6 @@
     <script src="js/vtt/dm-edit-mode.js"></script>
     <script src="js/vtt/check-portal.js"></script>
     <script type="module" src="js/vtt/main.js"></script>
+    <script type="module" src="js/vtt/dynamic-lighting-bootstrap.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replaces the runtime's circular prototype vision with directional token perception
- normal sight in Darkness gets only a 3 ft Dim pocket inside the vision cone
- racial Darkvision remains linked to the character sheet and is grayscale only for darkness perceived through Darkvision
- genuinely lit areas remain in color for everyone, including Darkvision users
- reuses `LuminousEnvironmentEngine` + `LuminousWeatherEngine` calendar/weather for exterior Bright/Dim/Darkness
- adds explicit interior zones with 5 ft natural-light penetration through valid openings
- adds 3D artificial lights with Bright + additional Dim range, radius or cone shapes, Z/elevation, color and visual flicker
- reuses canonical wall/door/window/curtain topology for light blocking
- allows cross-Z light/vision through vertical openings or direct open-air connections when no opaque roof is marked
- adds transformer/circuit/switch power state and interactable player switch requests
- adds configurable transformer repair Checks without inventing an Item, Skill or DC
- adds portable light attachment, Drop/Pick Up and configured Throw transitions with real-time interpolation
- DM sees the full map by default and can use `VIEW AS TOKEN` to inspect a token's exact perception
- players combine sight only from tokens they themselves control; no party-wide shared vision

## Vision canon
Default authoring value is a configurable 120° cone (`visionConeDeg`), not a hard universal lock.

In Darkness:
- normal sight: 3 ft perceived as Dim, in color
- racial Darkvision: Darkness is perceived as Dim within racial range and rendered grayscale
- real Bright/Dim illumination overrides the grayscale presentation and is shown in color

Facing is canonical per map. Movement turns the token toward its travel direction; `[` / `]` rotate facing by 15° without movement.

## Natural light and interiors
Exterior light is resolved from existing weather + calendar state through `LuminousEnvironmentEngine`.

`daylightHours` is map-configurable (authoring default 06:00–18:00) so sunrise/sunset is not hard-coded as setting canon.

An `INTERIOR` zone:
- defaults to Darkness unless explicitly changed
- receives exterior ambient light only within 5 ft of a valid opening
- can mark an opaque or transparent roof/ceiling
- blocks direct cross-floor light/sight when the roof is opaque

Windows and other topology reuse existing semantics:
- normal closed window passes vision/light but blocks movement
- closed door / wall / closed curtain window block light
- open/broken topology passes light

## Artificial lights
Sources support:
- `brightFt`
- `dimAdditionalFt`
- radius or cone
- direction + cone angle
- x/y, `zLayer`, `elevationFt`
- 3D distance
- enabled / functional
- optional circuit
- color
- visual-only flicker
- token attachment
- optional `ownerPlayerId`
- optional `throwRangeFt`
- interpolated motion

Strongest category wins (`Bright > Dim > Darkness`). Multiple Dim sources do not combine into Bright.

## Electrical system
Lighting scene state supports:
- transformers
- named circuits
- switches
- light sources attached to circuits

A circuit light requires a functional/enabled source plus available transformer/switch power.

Player switches are intents stored under their existing player campaign node; the DM-authoritative bridge applies the canonical scene change under `campaña/estado_mundo/vttLighting/<map>`.

Transformer repair is intentionally configuration-driven. A transformer may define `repair.requiredItem`, `repair.rollSpec`, and `repair.threshold`. Without those values, repair returns `REPAIR_UNCONFIGURED`; this PR does not invent an electrical tool, Skill or DC. Configured repairs reuse the existing theatre Check command/live UI.

## Portable sources
Player-owned/attached sources expose Drop, Pick Up and Throw. Throw is available only when the source/item defines `throwRangeFt`; no generic throw range is invented. The canonical source stores a motion transition (`from`, `to`, `startedAt`, `durationMs`, arc), so clients interpolate the moving light rather than teleporting it.

`Pick Up` currently reattaches a player-owned source. A generalized physical pickup/retrieval reach rule is intentionally not invented here; the configured throw range is enforced canonically.

## DM editor
Inside existing `EDIT MODE`, a LIGHTING toolbar adds:
- L-SELECT
- LIGHT
- INTERIOR
- TRANSFORMER
- SWITCH
- L-ERASE

The editor exposes Bright/Dim range, radius/cone, direction, elevation, circuit, color, enabled/functional, flicker, attachment/owner, throw range, interior roof/transparency, circuits, switch reach/state, and optional repair Check configuration.

Outside edit mode, DM remains in full-map view. `VIEW AS TOKEN` enters token-inspection mode and returns to FULL MAP from the same control.

## Canonical state
DM scene:
`campaña/estado_mundo/vttLighting/<mapId>/scene`

World/NPC facing:
`campaña/estado_mundo/vttLighting/<mapId>/tokenFacing`

Player facing:
`campaña/jugadores/<playerId>/vttLighting/<mapId>/facingDeg`

Player interaction intents:
`campaña/jugadores/<playerId>/vttLightingRequests/<mapId>`

This reuses current Firebase campaign authority; `database.rules.json` is not broadened.

## Tests
`tests/vtt_dynamic_lighting.spec.js` and `tests/vtt_dynamic_lighting_runtime.spec.js` cover:
- directional cone
- 3 ft normal Darkness sight
- Darkvision grayscale vs real-light color
- weather/calendar exterior light
- deferred weather initialization ordering
- configurable daylight hours
- 5 ft interior penetration
- wall/door/window/curtain light blocking
- 3D cross-Z distance
- opaque vs transparent roofs
- vertical openings
- strongest-light semantics
- radius/cone sources
- dynamic-token vision defaults
- remote player racial senses
- attached token sources
- transformer/switch circuits
- no invented repair defaults
- visual-only flicker
- real-time throw interpolation
- canonical Firebase authority roots
- DM editor / VIEW AS TOKEN wiring
- no party-wide vision
- canonical facing controls
- portable Drop/Pick Up/Throw contracts
- UMD/ESM syntax and bootstrap ordering

## Final validation
Head: `65a5475e267ce48ac2aee79a32cbbb4c8a2b7fdd`
- Background Narratives workflow run 111: **success**
- repository regression suite: **860/860 passed**
- narrative contract: **158/158 passed**
- patched syntax: **success**
- branch comparison: **14 commits ahead / 0 behind `main`**
- base commit / merge-base: `1f4106f518d6eccb610eaa12b81e13bdd3c7d8e9`

## Out of scope
- Magical Darkness and magical-light suppression
- persistent Fog of War
- generic inventory/equipment activation rules beyond portable-light integration points
- generalized physical pickup/retrieval reach for dropped light sources
- horizontal combat movement-budget/pathfinding rules
