### PR TITLE
feat(vtt): token PoV controls and 3D Look Up

### DIFF
--- a/js/vtt/dynamic-lighting-bootstrap.js
+++ b/js/vtt/dynamic-lighting-bootstrap.js
@@ -3,6 +3,10 @@ import './lighting-engine.js';
 import './environment-light-bridge.js';
 import './lighting-state.js';
 import './lighting-controller.js';
+import './pov-engine.js';
+import './pov-state.js';
+import './pov-controller.js';
+import './pov-renderer.js';
 
 const ready = (fn) => {
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', () => queueMicrotask(fn), { once: true });
@@ -25,7 +29,11 @@ ready(() => {
   const stateApi = window.LuminousVttLightingState;
   const envApi = window.LuminousVttEnvironmentLightBridge;
   const controllerApi = window.LuminousVttLightingController;
-  if (!light || !stateApi || !envApi || !controllerApi) {
+  const pov = window.LuminousVttPovEngine;
+  const povStateApi = window.LuminousVttPovState;
+  const povControllerApi = window.LuminousVttPovController;
+  const povRenderer = window.LuminousVttPovRenderer;
+  if (!light || !stateApi || !envApi || !controllerApi || !pov || !povStateApi || !povControllerApi || !povRenderer) {
     console.error('Dynamic Lighting: one or more runtimes are unavailable.');
     return;
   }
@@ -33,19 +41,58 @@ ready(() => {
   mapData.lighting ||= {};
   mapData.lighting.daylightHours ||= { start: 6, end: 18 };
   mapData.lighting.visionSamplingFt ||= 2.5;
+  mapData.defaultCeilingHeightFt ||= pov.DEFAULT_CEILING_HEIGHT_FT;
   mapData.tokens?.forEach((token) => {
     if (!Number.isFinite(Number(token.facingDeg))) token.facingDeg = 0;
+    if (!Number.isFinite(Number(token.lookDeg))) token.lookDeg = token.facingDeg;
+    if (!Number.isFinite(Number(token.eyeHeightFt))) token.eyeHeightFt = pov.DEFAULT_EYE_HEIGHT_FT;
     if (!Number.isFinite(Number(token.visionConeDeg))) token.visionConeDeg = light.DEFAULT_VISION_CONE_DEG;
   });
 
+  const perceptionCache = { key: '', tiles: [] };
   let lightingController = null;
+  let povController = null;
+
   const lightingStateBridge = stateApi.createBridge({
     mapData,
     isDm: bridge.isDm,
     notify: (message, mode) => runtime.controller?.notify?.(message, mode),
-    onChanged: () => lightingController?.handleSceneChanged?.(),
+    onChanged: () => {
+      perceptionCache.key = '';
+      lightingController?.handleSceneChanged?.();
+      povController?.handleSceneChanged?.();
+    },
   });
-  const environmentLightBridge = envApi.createBridge({ mapData, onChanged: () => { perceptionCache.key = ''; } });
+
+  const povStateBridge = povStateApi.createBridge({
+    mapData,
+    isDm: bridge.isDm,
+    onChanged: () => { perceptionCache.key = ''; },
+  });
+
+  const environmentLightBridge = envApi.createBridge({
+    mapData,
+    onChanged: () => { perceptionCache.key = ''; },
+  });
+
+  function controlledViewers() {
+    if (bridge.isDm) {
+      const previewId = mapData.lighting?.dmPreviewTokenId;
+      if (!previewId) return [];
+      const token = (mapData.tokens || []).find((entry) => String(entry.id) === String(previewId));
+      if (token) povStateBridge.applyDefaults(token);
+      return token ? [token] : [];
+    }
+    const tokenControl = window.LuminousVttTokenControl;
+    const identity = tokenControl?.identity?.() || lightingStateBridge.identity || {};
+    const controlled = (mapData.tokens || []).filter((token) => token.viewer === true || tokenControl?.canPlayerControl?.(token, identity));
+    controlled.forEach((token) => povStateBridge.applyDefaults(token));
+    if (controlled.length) return controlled;
+    const fallback = (mapData.tokens || []).find((token) => token.characterLink?.mode === 'current_player');
+    if (fallback) povStateBridge.applyDefaults(fallback);
+    return fallback ? [fallback] : [];
+  }
+
   lightingController = controllerApi.createController({
     canvas,
     engine,
@@ -54,36 +101,56 @@ ready(() => {
     isDm: bridge.isDm,
     notify: (message, mode) => runtime.controller?.notify?.(message, mode),
   });
+
+  povController = povControllerApi.createController({
+    canvas,
+    engine,
+    mapData,
+    stateBridge: povStateBridge,
+    isDm: bridge.isDm,
+    getControlledViewers: controlledViewers,
+    notify: (message, mode) => runtime.controller?.notify?.(message, mode),
+  });
+
   lightingStateBridge.start();
+  povStateBridge.start();
   environmentLightBridge.start();
 
   const originalRender = renderer.render.bind(renderer);
-  const perceptionCache = { key: '', tiles: [] };
 
-  function controlledViewers() {
-    if (bridge.isDm) {
-      const previewId = mapData.lighting?.dmPreviewTokenId;
-      if (!previewId) return [];
-      const token = (mapData.tokens || []).find((entry) => String(entry.id) === String(previewId));
-      return token ? [token] : [];
-    }
-    const tokenControl = window.LuminousVttTokenControl;
-    const identity = tokenControl?.identity?.() || lightingStateBridge.identity || {};
-    const controlled = (mapData.tokens || []).filter((token) => token.viewer === true || tokenControl?.canPlayerControl?.(token, identity));
-    if (controlled.length) return controlled;
-    const fallback = (mapData.tokens || []).find((token) => token.characterLink?.mode === 'current_player');
-    return fallback ? [fallback] : [];
+  function scene() {
+    const current = mapData.lighting?.scene || { sources: [], interiors: [], transformers: [], switches: [] };
+    current.roofs ||= [];
+    return current;
   }
 
-  function scene() { return mapData.lighting?.scene || { sources: [], interiors: [], transformers: [], switches: [] }; }
   function environment() { return mapData.lighting?.environment || { state: { light: mapData.ambientLight?.level || 'bright' } }; }
 
-  function mapFingerprint(viewers, activeZ, now) {
-    const tokens = (mapData.tokens || []).map((token) => [token.id, Number(token.x)||0, Number(token.y)||0, light.layerOf(token), light.elevationFt(token, mapData), Number(token.facingDeg)||0]);
+  function mapFingerprint(viewers, viewZ, lookUp, now) {
+    const tokens = (mapData.tokens || []).map((token) => [
+      token.id,
+      Number(token.x) || 0,
+      Number(token.y) || 0,
+      light.layerOf(token),
+      light.elevationFt(token, mapData),
+      Number(token.lookDeg ?? token.facingDeg) || 0,
+      Number(token.eyeHeightFt) || pov.DEFAULT_EYE_HEIGHT_FT,
+    ]);
     const moving = (scene().sources || []).some((source) => source.motion && !light.interpolateMotion(source.motion, now).complete);
     return JSON.stringify({
-      z: activeZ,
-      viewers: viewers.map((viewer) => [viewer.id, viewer.x, viewer.y, light.layerOf(viewer), light.elevationFt(viewer, mapData), viewer.facingDeg, viewer.visionConeDeg, viewer.senses?.darkvisionFt]),
+      z: viewZ,
+      lookUp: Boolean(lookUp),
+      viewers: viewers.map((viewer) => [
+        viewer.id,
+        viewer.x,
+        viewer.y,
+        light.layerOf(viewer),
+        light.elevationFt(viewer, mapData),
+        viewer.lookDeg ?? viewer.facingDeg,
+        viewer.eyeHeightFt,
+        viewer.visionConeDeg,
+        viewer.senses?.darkvisionFt,
+      ]),
       tokens,
       scene: scene(),
       env: environment()?.state,
@@ -91,12 +158,12 @@ ready(() => {
     });
   }
 
-  function bestPerception(viewers, point, now) {
+  function bestPerception(viewers, point, now, lookUp) {
     let darkvision = null;
     let dim = null;
     for (const viewer of viewers) {
-      const result = light.perceptionAtPoint(viewer, point, scene(), mapData, environment(), now);
-      if (!result.visible) continue;
+      const result = pov.perceptionAtPoint(viewer, point, scene(), mapData, environment(), now, { lookUp });
+      if (!result?.visible) continue;
       if (!result.monochrome && result.level === 'bright') return result;
       if (!result.monochrome) dim ||= result;
       else darkvision ||= result;
@@ -104,19 +171,19 @@ ready(() => {
     return dim || darkvision || null;
   }
 
-  function computeTiles(viewers, activeZ, now) {
+  function computeTiles(viewers, viewZ, now, lookUp) {
     if (!viewers.length) return [];
     const stepFt = Math.max(1, Number(mapData.lighting?.visionSamplingFt) || 2.5);
     const step = light.feetToPixels(stepFt, mapData);
     const width = (mapData.grid?.cols || 1) * (mapData.grid?.size || 70);
     const height = (mapData.grid?.rows || 1) * (mapData.grid?.size || 70);
-    const elevationFt = light.elevationForLayer(mapData, activeZ);
+    const elevationFt = light.elevationForLayer(mapData, viewZ);
     const tiles = [];
     for (let y = 0; y < height; y += step) {
       for (let x = 0; x < width; x += step) {
         const w = Math.min(step, width - x), h = Math.min(step, height - y);
-        const point = { x: x + w / 2, y: y + h / 2, zLayer: activeZ, elevationFt };
-        const perception = bestPerception(viewers, point, now);
+        const point = { x: x + w / 2, y: y + h / 2, zLayer: viewZ, elevationFt };
+        const perception = bestPerception(viewers, point, now, lookUp);
         if (!perception) continue;
         tiles.push({ x, y, w, h, perception });
       }
@@ -124,11 +191,11 @@ ready(() => {
     return tiles;
   }
 
-  function perceptionTiles(viewers, activeZ, now) {
-    const key = mapFingerprint(viewers, activeZ, now);
+  function perceptionTiles(viewers, viewZ, now, lookUp) {
+    const key = mapFingerprint(viewers, viewZ, lookUp, now);
     if (key !== perceptionCache.key) {
       perceptionCache.key = key;
-      perceptionCache.tiles = computeTiles(viewers, activeZ, now);
+      perceptionCache.tiles = computeTiles(viewers, viewZ, now, lookUp);
     }
     return perceptionCache.tiles;
   }
@@ -172,7 +239,7 @@ ready(() => {
     ctx.restore();
   }
 
-  function drawBaseScene(targetCanvas, targetCtx, activeZ, now, includeGuides = false) {
+  function drawBaseScene(targetCanvas, targetCtx, renderZ, now, includeGuides = false, options = {}) {
     withRendererContext(targetCanvas, targetCtx, () => {
       renderer.clear(false);
       targetCtx.save();
@@ -180,11 +247,16 @@ ready(() => {
       targetCtx.fillStyle = '#111';
       targetCtx.fillRect(0, 0, (mapData.grid?.cols || 1) * (mapData.grid?.size || 70), (mapData.grid?.rows || 1) * (mapData.grid?.size || 70));
       renderer.drawGrid();
-      renderer.drawWalls(activeZ, false);
-      renderer.drawTopology(activeZ, false);
-      renderer.drawTokens(activeZ);
-      drawLightEffects(targetCtx, activeZ, now, bridge.isDm && !mapData.lighting?.dmPreviewTokenId);
-      if (includeGuides) lightingController.renderEditorGuides(targetCtx);
+      renderer.drawWalls(renderZ, false);
+      renderer.drawTopology(renderZ, false);
+      renderer.drawTokens(renderZ);
+      povRenderer.drawIndicators(renderer, renderZ);
+      drawLightEffects(targetCtx, renderZ, now, bridge.isDm && !mapData.lighting?.dmPreviewTokenId);
+      if (options.lookUp) (options.viewers || []).forEach((viewer) => povRenderer.drawLookUpAnchor(targetCtx, viewer, mapData));
+      if (includeGuides) {
+        lightingController.renderEditorGuides(targetCtx);
+        povController.renderEditorGuides(targetCtx, renderZ);
+      }
       targetCtx.restore();
     });
   }
@@ -199,14 +271,18 @@ ready(() => {
   }
 
   function renderTokenVision(activeZ, viewers, now) {
+    const requestedLookUp = povController.lookUpHeld();
+    const viewZ = povController.viewLayer(activeZ);
+    const lookUp = requestedLookUp && Number(viewZ) !== Number(activeZ);
     const offscreen = document.createElement('canvas');
     offscreen.width = canvas.width; offscreen.height = canvas.height;
     const offctx = offscreen.getContext('2d');
-    drawBaseScene(offscreen, offctx, activeZ, now, false);
+    drawBaseScene(offscreen, offctx, viewZ, now, false, { lookUp, viewers });
 
     renderer.ctx.clearRect(0, 0, canvas.width, canvas.height);
     renderer.ctx.fillStyle = '#000'; renderer.ctx.fillRect(0, 0, canvas.width, canvas.height);
-    const tiles = perceptionTiles(viewers, activeZ, now);
+    const tiles = perceptionTiles(viewers, viewZ, now, lookUp);
+    povController.setLookUpBlocked(requestedLookUp && (!lookUp || tiles.length === 0));
     const zoom = camera.zoom;
     for (const tile of tiles) {
       const sx = (tile.x + camera.x) * zoom;
@@ -237,39 +313,7 @@ ready(() => {
     if (bridge.isDm && !mapData.lighting?.dmPreviewTokenId) renderFullMap(activeZ, now);
     else renderTokenVision(activeZ, viewers, now);
   };
-  engine.calculateVision = () => ({ dynamicLighting: true });
-
-  function tokenFromMoveEvent(event) {
-    const id = event.detail?.tokenId;
-    return (mapData.tokens || []).find((token) => String(token.id) === String(id)) || null;
-  }
-
-  function updateFacingFromMove(event) {
-    const token = tokenFromMoveEvent(event);
-    const from = event.detail?.from || {}, to = event.detail?.to || {};
-    if (!token || !Number.isFinite(Number(from.x)) || !Number.isFinite(Number(to.x))) return;
-    const dx = Number(to.x) - Number(from.x), dy = Number(to.y) - Number(from.y);
-    if (Math.hypot(dx, dy) < 1) return;
-    token.facingDeg = light.normalizeAngleDeg((Math.atan2(dy, dx) * 180) / Math.PI);
-    perceptionCache.key = '';
-    lightingStateBridge.saveFacing(token).catch((error) => console.error('VTT facing persistence failed:', error));
-  }
-  canvas.addEventListener('vtt:token-moved', updateFacingFromMove);
-
-  function rotatableToken() {
-    if (bridge.isDm && mapData.lighting?.dmPreviewTokenId) return (mapData.tokens || []).find((token) => String(token.id) === String(mapData.lighting.dmPreviewTokenId)) || null;
-    return controlledViewers()[0] || null;
-  }
-  const keyHandler = (event) => {
-    if (!['[', ']'].includes(event.key) || event.ctrlKey || event.metaKey || event.altKey) return;
-    const token = rotatableToken();
-    if (!token) return;
-    token.facingDeg = light.normalizeAngleDeg(Number(token.facingDeg || 0) + (event.key === '[' ? -15 : 15));
-    perceptionCache.key = '';
-    lightingStateBridge.saveFacing(token).catch((error) => console.error('VTT facing persistence failed:', error));
-    event.preventDefault();
-  };
-  window.addEventListener('keydown', keyHandler);
+  engine.calculateVision = () => ({ dynamicLighting: true, directionalPov: true });
 
   const previousRuntime = window.LuminousVttRuntime;
   window.LuminousVttRuntime = Object.freeze({
@@ -280,15 +324,22 @@ ready(() => {
       environmentBridge: environmentLightBridge,
       controller: lightingController,
       controlledViewers,
-      perceptionAtPoint: (viewer, point) => light.perceptionAtPoint(viewer, point, scene(), mapData, environment()),
+      perceptionAtPoint: (viewer, point) => pov.perceptionAtPoint(viewer, point, scene(), mapData, environment()),
+    }),
+    pov: Object.freeze({
+      engine: pov,
+      stateBridge: povStateBridge,
+      controller: povController,
+      controlledViewers,
+      lookUpPerceptionAtPoint: (viewer, point) => pov.perceptionAtPoint(viewer, point, scene(), mapData, environment(), Date.now(), { lookUp: true }),
     }),
   });
 
   window.addEventListener('beforeunload', () => {
-    canvas.removeEventListener('vtt:token-moved', updateFacingFromMove);
-    window.removeEventListener('keydown', keyHandler);
+    povController.stop();
     lightingController.stop();
     environmentLightBridge.stop();
+    povStateBridge.stop();
     lightingStateBridge.stop();
     renderer.render = originalRender;
   }, { once: true });

--- a/js/vtt/dynamic-lighting-bootstrap.js
+++ b/js/vtt/dynamic-lighting-bootstrap.js
@@ -315,6 +315,33 @@ ready(() => {
   };
   engine.calculateVision = () => ({ dynamicLighting: true, directionalPov: true });
 
+  // Body-facing compatibility remains canonical, but PoV no longer reads this value once lookDeg exists.
+  function tokenFromMoveEvent(event) {
+    const id = event.detail?.tokenId;
+    return (mapData.tokens || []).find((token) => String(token.id) === String(id)) || null;
+  }
+
+  function updateFacingFromMove(event) {
+    const token = tokenFromMoveEvent(event);
+    const from = event.detail?.from || {}, to = event.detail?.to || {};
+    if (!token || !Number.isFinite(Number(from.x)) || !Number.isFinite(Number(to.x))) return;
+    const dx = Number(to.x) - Number(from.x), dy = Number(to.y) - Number(from.y);
+    if (Math.hypot(dx, dy) < 1) return;
+    token.facingDeg = light.normalizeAngleDeg((Math.atan2(dy, dx) * 180) / Math.PI);
+    lightingStateBridge.saveFacing(token).catch((error) => console.error('VTT body facing persistence failed:', error));
+  }
+  canvas.addEventListener('vtt:token-moved', updateFacingFromMove);
+
+  const bodyFacingKeyHandler = (event) => {
+    if (!['[', ']'].includes(event.key) || event.ctrlKey || event.metaKey || event.altKey) return;
+    const token = controlledViewers()[0] || null;
+    if (!token) return;
+    token.facingDeg = light.normalizeAngleDeg(Number(token.facingDeg || 0) + (event.key === '[' ? -15 : 15));
+    lightingStateBridge.saveFacing(token).catch((error) => console.error('VTT body facing persistence failed:', error));
+    event.preventDefault();
+  };
+  window.addEventListener('keydown', bodyFacingKeyHandler);
+
   const previousRuntime = window.LuminousVttRuntime;
   window.LuminousVttRuntime = Object.freeze({
     ...previousRuntime,
@@ -336,6 +363,8 @@ ready(() => {
   });
 
   window.addEventListener('beforeunload', () => {
+    canvas.removeEventListener('vtt:token-moved', updateFacingFromMove);
+    window.removeEventListener('keydown', bodyFacingKeyHandler);
     povController.stop();
     lightingController.stop();
     environmentLightBridge.stop();

--- a/js/vtt/dynamic-lighting-bootstrap.js
+++ b/js/vtt/dynamic-lighting-bootstrap.js
@@ -107,6 +107,7 @@ ready(() => {
     engine,
     mapData,
     stateBridge: povStateBridge,
+    sceneBridge: lightingStateBridge,
     isDm: bridge.isDm,
     getControlledViewers: controlledViewers,
     notify: (message, mode) => runtime.controller?.notify?.(message, mode),

--- a/js/vtt/main.js
+++ b/js/vtt/main.js
@@ -133,7 +133,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (event.key === '0') applyLayer(0);
         else if (event.key === '1') applyLayer(1);
         else if (event.key === '2') applyLayer(2);
-        else if ((event.key === 'e' || event.key === 'E') && bridge.isDm && !event.ctrlKey && !event.metaKey && !event.altKey) editMode?.toggle?.();
+        // E belongs exclusively to token PoV Look Lock/Unlock. DM Edit Mode remains available via its button.
         else if (event.key === 'Escape') {
             controller.hideContextMenu();
             controller.setTool('select');

--- a/js/vtt/pov-controller.js
+++ b/js/vtt/pov-controller.js
@@ -1,0 +1,355 @@
+(function (root, factory) {
+  const api = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttPovController = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (browserRoot) {
+  'use strict';
+
+  const clean = (value) => String(value ?? '').trim();
+  const num = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+  function uid(prefix) { return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`; }
+
+  function createController({ canvas, engine, mapData, stateBridge, isDm = false, getControlledViewers, notify, root = browserRoot } = {}) {
+    if (!canvas || !engine || !mapData || !stateBridge) throw new Error('POV_CONTROLLER_INPUT_REQUIRED');
+    const doc = root?.document;
+    const pov = root?.LuminousVttPovEngine;
+    if (!pov) throw new Error('POV_ENGINE_REQUIRED');
+    const listeners = [];
+    mapData.pov ||= {};
+    if (typeof mapData.pov.lookLocked !== 'boolean') mapData.pov.lookLocked = false;
+    if (typeof mapData.pov.lookUpHeld !== 'boolean') mapData.pov.lookUpHeld = false;
+    mapData.pov.lookUpBlocked = false;
+    mapData.lighting ||= {};
+    mapData.lighting.scene ||= { sources: [], interiors: [], transformers: [], switches: [] };
+    mapData.lighting.scene.roofs ||= [];
+
+    let saveTimer = null;
+    let roofToolActive = false;
+    let roofDragStart = null;
+    let selectedRoofId = null;
+
+    function emit(message, mode = 'info') { if (typeof notify === 'function') notify(message, mode); }
+    function scene() { mapData.lighting.scene.roofs ||= []; return mapData.lighting.scene; }
+    function editActive() { return Boolean(isDm && mapData.dmEditMode?.active); }
+    function activeZ() { return Number(engine.activeZ) || 0; }
+    function controlled() { return typeof getControlledViewers === 'function' ? (getControlledViewers() || []) : []; }
+    function activeLookToken() { return controlled()[0] || null; }
+    function lookLocked() { return Boolean(mapData.pov.lookLocked); }
+    function lookUpHeld() { return Boolean(mapData.pov.lookUpHeld); }
+
+    function eventWorldPoint(event) {
+      if (typeof engine.eventWorldPoint === 'function') return engine.eventWorldPoint(event);
+      const rect = canvas.getBoundingClientRect();
+      return engine.camera?.screenToWorld?.(event.clientX - rect.left, event.clientY - rect.top) || { x: 0, y: 0 };
+    }
+
+    function snapVertex(point) {
+      const size = Math.max(1, num(mapData.grid?.size, 70));
+      const cols = Math.max(1, num(mapData.grid?.cols, 1));
+      const rows = Math.max(1, num(mapData.grid?.rows, 1));
+      return {
+        x: Math.max(0, Math.min(cols * size, Math.round(num(point.x) / size) * size)),
+        y: Math.max(0, Math.min(rows * size, Math.round(num(point.y) / size) * size)),
+      };
+    }
+
+    function injectUi() {
+      if (!doc) return;
+      if (!doc.getElementById('vtt-pov-runtime-style')) {
+        const style = doc.createElement('style');
+        style.id = 'vtt-pov-runtime-style';
+        style.textContent = `
+          .vtt-pov-status{position:fixed;left:50%;bottom:18px;transform:translateX(-50%);z-index:30020;background:#0b0b0b;border:1px solid #aaa;color:#fff;padding:6px 10px;font:700 11px monospace;pointer-events:none;box-shadow:3px 3px 0 #000}
+          .vtt-pov-status[data-mode="blocked"]{border-color:#ff6b6b}.vtt-pov-status[data-mode="up"]{border-color:#8bd8ff}.vtt-pov-status[data-mode="locked"]{border-color:#ffe38b}
+          .vtt-pov-roof-panel{position:fixed;right:18px;top:86px;z-index:31500;width:280px;background:#111;border:2px solid #fff;color:#fff;padding:12px;font:12px monospace;box-shadow:6px 6px 0 #000}
+          .vtt-pov-roof-panel[hidden]{display:none}.vtt-pov-roof-panel label{display:grid;gap:4px;margin:8px 0}.vtt-pov-roof-panel input{background:#080808;color:#fff;border:1px solid #777;padding:6px}
+        `;
+        doc.head.appendChild(style);
+      }
+      if (!doc.getElementById('vtt-pov-status')) {
+        const badge = doc.createElement('div');
+        badge.id = 'vtt-pov-status';
+        badge.className = 'vtt-pov-status';
+        doc.body.appendChild(badge);
+      }
+      if (isDm && !doc.getElementById('vtt-pov-roof-editor')) {
+        const panel = doc.createElement('aside');
+        panel.id = 'vtt-pov-roof-editor';
+        panel.className = 'vtt-pov-roof-panel';
+        panel.hidden = true;
+        doc.body.appendChild(panel);
+      }
+      installRoofButton();
+      updateStatus();
+    }
+
+    function installRoofButton() {
+      if (!isDm || !doc) return;
+      const toolbar = doc.getElementById('vtt-lighting-toolbar');
+      if (!toolbar || doc.getElementById('vtt-pov-roof-tool')) return;
+      const button = doc.createElement('button');
+      button.id = 'vtt-pov-roof-tool';
+      button.type = 'button';
+      button.className = 'brutalist-button';
+      button.textContent = 'ROOF';
+      button.addEventListener('click', () => {
+        roofToolActive = !roofToolActive;
+        button.classList.toggle('is-active', roofToolActive);
+        if (!roofToolActive) { roofDragStart = null; closeRoofEditor(); }
+      });
+      toolbar.appendChild(button);
+    }
+
+    function updateStatus() {
+      const badge = doc?.getElementById('vtt-pov-status');
+      if (!badge) return;
+      if (lookUpHeld() && mapData.pov.lookUpBlocked) {
+        badge.textContent = 'Q · LOOK UP · BLOCKED';
+        badge.dataset.mode = 'blocked';
+        return;
+      }
+      if (lookUpHeld()) {
+        const target = pov.nextLayer(activeLookToken() || activeZ(), mapData);
+        badge.textContent = target == null ? 'Q · LOOK UP · NO FLOOR' : `Q · LOOK UP · Z${target}`;
+        badge.dataset.mode = target == null ? 'blocked' : 'up';
+        return;
+      }
+      badge.textContent = lookLocked() ? 'E · LOOK LOCKED' : 'E · LOOK FREE';
+      badge.dataset.mode = lookLocked() ? 'locked' : 'free';
+    }
+
+    function scheduleSave(token) {
+      if (!token) return;
+      if (saveTimer != null) root.clearTimeout?.(saveTimer);
+      saveTimer = root.setTimeout?.(() => {
+        saveTimer = null;
+        stateBridge.saveLook(token).catch((error) => console.error('VTT PoV save failed:', error));
+      }, 120) || null;
+    }
+
+    function updateLookFromPoint(point) {
+      if (lookLocked() || editActive()) return false;
+      const token = activeLookToken();
+      if (!token) return false;
+      token.lookDeg = pov.angleToPointDeg(token, point);
+      scheduleSave(token);
+      return true;
+    }
+
+    function toggleLookLock() {
+      mapData.pov.lookLocked = !lookLocked();
+      const token = activeLookToken();
+      if (token) stateBridge.saveLook(token).catch((error) => console.error('VTT PoV lock save failed:', error));
+      updateStatus();
+      return lookLocked();
+    }
+
+    function setLookUpHeld(value) {
+      mapData.pov.lookUpHeld = Boolean(value);
+      if (!mapData.pov.lookUpHeld) mapData.pov.lookUpBlocked = false;
+      updateStatus();
+      return mapData.pov.lookUpHeld;
+    }
+
+    function setLookUpBlocked(value) {
+      mapData.pov.lookUpBlocked = Boolean(value);
+      updateStatus();
+    }
+
+    function viewLayer(baseZ = activeZ()) {
+      if (!lookUpHeld()) return Number(baseZ) || 0;
+      const next = pov.nextLayer(activeLookToken() || baseZ, mapData);
+      return next == null ? Number(baseZ) || 0 : next;
+    }
+
+    function isTypingTarget(target) {
+      const tag = String(target?.tagName || '').toLowerCase();
+      return ['input', 'textarea', 'select'].includes(tag) || target?.isContentEditable === true;
+    }
+
+    function onPointerMove(event) {
+      if (event.buttons) return;
+      if (roofToolActive && editActive()) return;
+      if (updateLookFromPoint(eventWorldPoint(event))) mapData.pov.dirty = true;
+    }
+
+    function onKeyDown(event) {
+      if (isTypingTarget(event.target) || event.ctrlKey || event.metaKey || event.altKey) return;
+      const key = String(event.key || '').toLowerCase();
+      if (key === 'e' && !event.repeat) {
+        toggleLookLock();
+        event.preventDefault();
+        return;
+      }
+      if (key === 'q') {
+        if (!event.repeat) setLookUpHeld(true);
+        event.preventDefault();
+      }
+    }
+
+    function onKeyUp(event) {
+      if (String(event.key || '').toLowerCase() !== 'q') return;
+      setLookUpHeld(false);
+      event.preventDefault();
+    }
+
+    function roofAtPoint(point) {
+      const roofs = scene().roofs || [];
+      return roofs.find((roof) => Number(roof.zLayer ?? 0) === activeZ() && pov.pointInRect(point, roof, 1)) || null;
+    }
+
+    function placeRoof(from, to) {
+      const a = snapVertex(from), b = snapVertex(to);
+      if (Math.abs(a.x - b.x) < 1 || Math.abs(a.y - b.y) < 1) return null;
+      const zLayer = activeZ();
+      const roof = {
+        id: uid('roof'),
+        label: 'ROOF',
+        zLayer,
+        x1: Math.min(a.x, b.x), y1: Math.min(a.y, b.y), x2: Math.max(a.x, b.x), y2: Math.max(a.y, b.y),
+        elevationFt: pov.elevationForLayer(mapData, zLayer) + num(mapData.defaultCeilingHeightFt, pov.DEFAULT_CEILING_HEIGHT_FT),
+        transparent: false,
+      };
+      scene().roofs.push(roof);
+      selectedRoofId = roof.id;
+      persistScene();
+      openRoofEditor(roof);
+      return roof;
+    }
+
+    async function persistScene() {
+      try { await stateBridge.saveScene?.(scene()); }
+      catch (error) { console.error('VTT roof save failed:', error); emit('No se pudo guardar el techo.', 'error'); }
+    }
+
+    function openRoofEditor(roof) {
+      if (!isDm || !roof) return;
+      selectedRoofId = roof.id;
+      const panel = doc?.getElementById('vtt-pov-roof-editor');
+      if (!panel) return;
+      panel.innerHTML = `<header><strong>ROOF</strong><small>${clean(roof.id)}</small></header>
+        <label>LABEL<input data-roof-field="label" value="${clean(roof.label || 'ROOF')}"></label>
+        <label>ELEVATION FT<input type="number" step="1" data-roof-field="elevationFt" value="${num(roof.elevationFt)}"></label>
+        <label><input type="checkbox" data-roof-field="transparent" ${roof.transparent ? 'checked' : ''}> TRANSPARENT</label>
+        <button type="button" class="vtt-danger-button" data-roof-delete>DELETE ROOF</button>`;
+      panel.hidden = false;
+      panel.addEventListener('change', onRoofEditorChange);
+      panel.querySelector('[data-roof-delete]')?.addEventListener('click', () => {
+        scene().roofs = (scene().roofs || []).filter((entry) => clean(entry.id) !== clean(selectedRoofId));
+        selectedRoofId = null;
+        closeRoofEditor();
+        persistScene();
+      }, { once: true });
+    }
+
+    function closeRoofEditor() {
+      const panel = doc?.getElementById('vtt-pov-roof-editor');
+      if (!panel) return;
+      panel.removeEventListener('change', onRoofEditorChange);
+      panel.hidden = true;
+    }
+
+    function onRoofEditorChange(event) {
+      const roof = (scene().roofs || []).find((entry) => clean(entry.id) === clean(selectedRoofId));
+      const field = event.target?.dataset?.roofField;
+      if (!roof || !field) return;
+      if (field === 'transparent') roof.transparent = Boolean(event.target.checked);
+      else if (field === 'elevationFt') roof.elevationFt = num(event.target.value, roof.elevationFt);
+      else roof[field] = event.target.value;
+      persistScene();
+    }
+
+    function onRoofMouseDown(event) {
+      if (!roofToolActive || !editActive() || event.button !== 0) return;
+      const point = eventWorldPoint(event);
+      const existing = roofAtPoint(point);
+      if (existing) {
+        openRoofEditor(existing);
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        return;
+      }
+      roofDragStart = point;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+
+    function onRoofMouseUp(event) {
+      if (!roofToolActive || !editActive() || !roofDragStart) return;
+      const start = roofDragStart;
+      roofDragStart = null;
+      placeRoof(start, eventWorldPoint(event));
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+
+    function renderEditorGuides(ctx, zLayer = activeZ()) {
+      if (!ctx || !editActive()) return;
+      ctx.save();
+      ctx.lineWidth = 3;
+      ctx.strokeStyle = '#ffffff';
+      ctx.fillStyle = 'rgba(255,255,255,.08)';
+      ctx.setLineDash([8, 6]);
+      for (const roof of scene().roofs || []) {
+        if (Number(roof.zLayer ?? 0) !== Number(zLayer)) continue;
+        const r = pov.normalizeRect(roof);
+        ctx.fillRect(r.x1, r.y1, r.x2 - r.x1, r.y2 - r.y1);
+        ctx.strokeRect(r.x1, r.y1, r.x2 - r.x1, r.y2 - r.y1);
+      }
+      if (roofDragStart) {
+        const current = mapData.pov.roofPreviewPoint;
+        if (current) {
+          const a = snapVertex(roofDragStart), b = snapVertex(current);
+          ctx.strokeRect(Math.min(a.x,b.x), Math.min(a.y,b.y), Math.abs(a.x-b.x), Math.abs(a.y-b.y));
+        }
+      }
+      ctx.restore();
+    }
+
+    function onRoofPreviewMove(event) {
+      if (!roofToolActive || !editActive() || !roofDragStart) return;
+      mapData.pov.roofPreviewPoint = eventWorldPoint(event);
+    }
+
+    function handleSceneChanged() {
+      scene().roofs ||= [];
+      if (selectedRoofId) {
+        const current = scene().roofs.find((entry) => clean(entry.id) === clean(selectedRoofId));
+        if (current) openRoofEditor(current); else closeRoofEditor();
+      }
+    }
+
+    injectUi();
+    canvas.addEventListener('mousemove', onPointerMove); listeners.push(() => canvas.removeEventListener('mousemove', onPointerMove));
+    canvas.addEventListener('mousemove', onRoofPreviewMove, true); listeners.push(() => canvas.removeEventListener('mousemove', onRoofPreviewMove, true));
+    canvas.addEventListener('mousedown', onRoofMouseDown, true); listeners.push(() => canvas.removeEventListener('mousedown', onRoofMouseDown, true));
+    root.addEventListener('mouseup', onRoofMouseUp, true); listeners.push(() => root.removeEventListener('mouseup', onRoofMouseUp, true));
+    root.addEventListener('keydown', onKeyDown, true); listeners.push(() => root.removeEventListener('keydown', onKeyDown, true));
+    root.addEventListener('keyup', onKeyUp, true); listeners.push(() => root.removeEventListener('keyup', onKeyUp, true));
+
+    function stop() {
+      listeners.splice(0).forEach((fn) => fn());
+      if (saveTimer != null) root.clearTimeout?.(saveTimer);
+      saveTimer = null;
+      closeRoofEditor();
+    }
+
+    return Object.freeze({
+      activeLookToken,
+      lookLocked,
+      lookUpHeld,
+      toggleLookLock,
+      setLookUpHeld,
+      setLookUpBlocked,
+      viewLayer,
+      updateLookFromPoint,
+      renderEditorGuides,
+      handleSceneChanged,
+      installRoofButton,
+      stop,
+    });
+  }
+
+  return Object.freeze({ createController });
+});

--- a/js/vtt/pov-controller.js
+++ b/js/vtt/pov-controller.js
@@ -10,7 +10,7 @@
 
   function uid(prefix) { return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`; }
 
-  function createController({ canvas, engine, mapData, stateBridge, isDm = false, getControlledViewers, notify, root = browserRoot } = {}) {
+  function createController({ canvas, engine, mapData, stateBridge, sceneBridge = null, isDm = false, getControlledViewers, notify, root = browserRoot } = {}) {
     if (!canvas || !engine || !mapData || !stateBridge) throw new Error('POV_CONTROLLER_INPUT_REQUIRED');
     const doc = root?.document;
     const pov = root?.LuminousVttPovEngine;
@@ -194,6 +194,12 @@
       event.preventDefault();
     }
 
+    function onWindowBlur() {
+      if (lookUpHeld()) setLookUpHeld(false);
+      roofDragStart = null;
+      mapData.pov.roofPreviewPoint = null;
+    }
+
     function roofAtPoint(point) {
       const roofs = scene().roofs || [];
       return roofs.find((roof) => Number(roof.zLayer ?? 0) === activeZ() && pov.pointInRect(point, roof, 1)) || null;
@@ -219,7 +225,13 @@
     }
 
     async function persistScene() {
-      try { await stateBridge.saveScene?.(scene()); }
+      const bridge = sceneBridge || stateBridge;
+      if (typeof bridge?.saveScene !== 'function') {
+        console.error('VTT roof persistence failed: scene bridge is unavailable.');
+        emit('No se pudo guardar el techo.', 'error');
+        return;
+      }
+      try { await bridge.saveScene(scene()); }
       catch (error) { console.error('VTT roof save failed:', error); emit('No se pudo guardar el techo.', 'error'); }
     }
 
@@ -327,11 +339,13 @@
     root.addEventListener('mouseup', onRoofMouseUp, true); listeners.push(() => root.removeEventListener('mouseup', onRoofMouseUp, true));
     root.addEventListener('keydown', onKeyDown, true); listeners.push(() => root.removeEventListener('keydown', onKeyDown, true));
     root.addEventListener('keyup', onKeyUp, true); listeners.push(() => root.removeEventListener('keyup', onKeyUp, true));
+    root.addEventListener('blur', onWindowBlur); listeners.push(() => root.removeEventListener('blur', onWindowBlur));
 
     function stop() {
       listeners.splice(0).forEach((fn) => fn());
       if (saveTimer != null) root.clearTimeout?.(saveTimer);
       saveTimer = null;
+      setLookUpHeld(false);
       closeRoofEditor();
     }
 

--- a/js/vtt/pov-engine.js
+++ b/js/vtt/pov-engine.js
@@ -196,14 +196,25 @@
   }
 
   function blockingSegmentsForLayer(mapData = {}, zLayer = 0) {
-    const topology = topologyRuntime();
-    if (!topology) return [];
+    const lighting = lightingRuntime();
+    if (lighting?.blockersForLayer) return lighting.blockersForLayer(mapData, zLayer);
+
     const result = [];
-    for (const raw of Array.isArray(mapData.topology) ? mapData.topology : []) {
-      const element = topology.normalizeElement(raw);
-      if (!topology.elementOnLayer(element, zLayer)) continue;
-      if (!topology.effectiveFlags(element).blocksVision) continue;
-      result.push(topology.segment(element, mapData.grid));
+    const topology = topologyRuntime();
+    if (topology) {
+      for (const raw of Array.isArray(mapData.topology) ? mapData.topology : []) {
+        const element = topology.normalizeElement(raw);
+        if (!topology.elementOnLayer(element, zLayer)) continue;
+        if (!topology.effectiveFlags(element).blocksVision) continue;
+        result.push(topology.segment(element, mapData.grid));
+      }
+    }
+    for (const wall of Array.isArray(mapData.walls) ? mapData.walls : []) {
+      const onLayer = Array.isArray(wall.z)
+        ? wall.z.map(Number).includes(Number(zLayer))
+        : Number(wall.z ?? wall.zLayer ?? 0) === Number(zLayer);
+      if (!onLayer || wall.blocksVision === false) continue;
+      result.push({ x1: num(wall.x1), y1: num(wall.y1), x2: num(wall.x2), y2: num(wall.y2), blocksVision: true });
     }
     return result;
   }

--- a/js/vtt/pov-engine.js
+++ b/js/vtt/pov-engine.js
@@ -1,0 +1,324 @@
+(function (root, factory) {
+  const api = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttPovEngine = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (browserRoot) {
+  'use strict';
+
+  const DEFAULT_EYE_HEIGHT_FT = 5;
+  const DEFAULT_CEILING_HEIGHT_FT = 10;
+  const LOOK_UP_INTERIOR_DEPTH_FT = 5;
+  const EPSILON = 1e-9;
+
+  const num = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const clean = (value) => String(value ?? '').trim();
+  const clamp = (value, min, max) => Math.max(min, Math.min(max, num(value, min)));
+
+  function lightingRuntime() {
+    if (browserRoot?.LuminousVttLightingEngine) return browserRoot.LuminousVttLightingEngine;
+    if (typeof require !== 'undefined') {
+      try { return require('./lighting-engine.js'); } catch (_) {}
+    }
+    return null;
+  }
+
+  function topologyRuntime() {
+    if (browserRoot?.LuminousVttTopology) return browserRoot.LuminousVttTopology;
+    if (typeof require !== 'undefined') {
+      try { return require('./topology.js'); } catch (_) {}
+    }
+    return null;
+  }
+
+  function normalizeAngleDeg(value) {
+    const lighting = lightingRuntime();
+    if (lighting?.normalizeAngleDeg) return lighting.normalizeAngleDeg(value);
+    const angle = num(value, 0) % 360;
+    return angle < 0 ? angle + 360 : angle;
+  }
+
+  function angleToPointDeg(origin = {}, point = {}) {
+    const lighting = lightingRuntime();
+    if (lighting?.angleToPointDeg) return lighting.angleToPointDeg(origin, point);
+    return normalizeAngleDeg((Math.atan2(num(point.y) - num(origin.y), num(point.x) - num(origin.x)) * 180) / Math.PI);
+  }
+
+  function layerOf(entity = {}) {
+    const lighting = lightingRuntime();
+    if (lighting?.layerOf) return lighting.layerOf(entity);
+    if (Number.isFinite(Number(entity.zLayer))) return Number(entity.zLayer);
+    if (Number.isFinite(Number(entity.gridPosition?.z))) return Number(entity.gridPosition.z);
+    if (Array.isArray(entity.z) && entity.z.length) return Number(entity.z[0]) || 0;
+    return 0;
+  }
+
+  function elevationForLayer(mapData = {}, zLayer = 0) {
+    const lighting = lightingRuntime();
+    if (lighting?.elevationForLayer) return lighting.elevationForLayer(mapData, zLayer);
+    const record = mapData.zLevels?.[String(zLayer)] || mapData.zLevels?.[zLayer];
+    if (Number.isFinite(Number(record?.elevationFt))) return Number(record.elevationFt);
+    return Number(zLayer) * num(mapData.defaultZStepFt, 15);
+  }
+
+  function feetToPixels(feet, mapData = {}) {
+    const lighting = lightingRuntime();
+    if (lighting?.feetToPixels) return lighting.feetToPixels(feet, mapData);
+    const size = Math.max(1, num(mapData.grid?.size, 70));
+    const distancePerCell = Math.max(0.001, num(mapData.grid?.distancePerCell, 5));
+    return (Math.max(0, num(feet)) / distancePerCell) * size;
+  }
+
+  function eyeHeightFt(viewer = {}) {
+    return Math.max(0, num(viewer.eyeHeightFt, DEFAULT_EYE_HEIGHT_FT));
+  }
+
+  function eyePoint(viewer = {}, mapData = {}) {
+    const lighting = lightingRuntime();
+    const base = lighting?.elevationFt ? lighting.elevationFt(viewer, mapData) : num(viewer.elevationFt, elevationForLayer(mapData, layerOf(viewer)));
+    return {
+      x: num(viewer.x),
+      y: num(viewer.y),
+      zLayer: layerOf(viewer),
+      elevationFt: base + eyeHeightFt(viewer),
+    };
+  }
+
+  function normalizeRect(raw = {}) {
+    const x1 = Math.min(num(raw.x1 ?? raw.x), num(raw.x2 ?? raw.x) + Math.max(0, num(raw.width)));
+    const x2 = Math.max(num(raw.x1 ?? raw.x), num(raw.x2 ?? raw.x) + Math.max(0, num(raw.width)));
+    const y1 = Math.min(num(raw.y1 ?? raw.y), num(raw.y2 ?? raw.y) + Math.max(0, num(raw.height)));
+    const y2 = Math.max(num(raw.y1 ?? raw.y), num(raw.y2 ?? raw.y) + Math.max(0, num(raw.height)));
+    return { x1, y1, x2, y2 };
+  }
+
+  function pointInRect(point = {}, rect = {}, tolerance = 0) {
+    const r = normalizeRect(rect);
+    return num(point.x) >= r.x1 - tolerance && num(point.x) <= r.x2 + tolerance
+      && num(point.y) >= r.y1 - tolerance && num(point.y) <= r.y2 + tolerance;
+  }
+
+  function ceilingHeightFt(raw = {}, mapData = {}) {
+    return Math.max(0.1, num(raw.ceilingHeightFt ?? raw.roof?.ceilingHeightFt ?? mapData.defaultCeilingHeightFt, DEFAULT_CEILING_HEIGHT_FT));
+  }
+
+  function normalizeRoof(raw = {}, mapData = {}) {
+    const rect = normalizeRect(raw);
+    const zLayer = Number.isFinite(Number(raw.zLayer)) ? Number(raw.zLayer) : 0;
+    const baseElevation = elevationForLayer(mapData, zLayer);
+    const elevationFt = Number.isFinite(Number(raw.elevationFt))
+      ? Number(raw.elevationFt)
+      : baseElevation + ceilingHeightFt(raw, mapData);
+    return {
+      ...raw,
+      id: clean(raw.id || 'roof'),
+      zLayer,
+      x1: rect.x1,
+      y1: rect.y1,
+      x2: rect.x2,
+      y2: rect.y2,
+      elevationFt,
+      transparent: raw.transparent === true,
+    };
+  }
+
+  function roofsForScene(scene = {}, mapData = {}) {
+    const result = [];
+    for (const raw of Array.isArray(scene.roofs) ? scene.roofs : []) result.push(normalizeRoof(raw, mapData));
+    for (const interior of Array.isArray(scene.interiors) ? scene.interiors : []) {
+      if (interior?.roof?.present === false || interior?.roof == null) continue;
+      const rect = normalizeRect(interior);
+      result.push(normalizeRoof({
+        id: `${clean(interior.id || 'interior')}:roof`,
+        zLayer: Number.isFinite(Number(interior.zLayer)) ? Number(interior.zLayer) : 0,
+        x1: rect.x1, y1: rect.y1, x2: rect.x2, y2: rect.y2,
+        elevationFt: interior.roof?.elevationFt,
+        ceilingHeightFt: interior.roof?.ceilingHeightFt ?? interior.ceilingHeightFt,
+        transparent: interior.roof?.transparent === true,
+        sourceInteriorId: clean(interior.id),
+      }, mapData));
+    }
+    return result;
+  }
+
+  function rayPlaneIntersection(from = {}, to = {}, planeElevationFt = 0) {
+    const z0 = num(from.elevationFt);
+    const z1 = num(to.elevationFt);
+    const dz = z1 - z0;
+    if (Math.abs(dz) <= EPSILON) return null;
+    const t = (num(planeElevationFt) - z0) / dz;
+    if (t <= EPSILON || t >= 1 - EPSILON) return null;
+    return {
+      t,
+      x: num(from.x) + ((num(to.x) - num(from.x)) * t),
+      y: num(from.y) + ((num(to.y) - num(from.y)) * t),
+      elevationFt: num(planeElevationFt),
+    };
+  }
+
+  function roofOcclusion(viewer = {}, target = {}, scene = {}, mapData = {}) {
+    const from = eyePoint(viewer, mapData);
+    const targetElevation = Number.isFinite(Number(target.elevationFt)) ? Number(target.elevationFt) : elevationForLayer(mapData, layerOf(target));
+    const to = { x: num(target.x), y: num(target.y), zLayer: layerOf(target), elevationFt: targetElevation };
+    if (to.elevationFt <= from.elevationFt + EPSILON) return { blocked: false, roof: null, intersection: null };
+    for (const roof of roofsForScene(scene, mapData)) {
+      if (roof.transparent) continue;
+      const hit = rayPlaneIntersection(from, to, roof.elevationFt);
+      if (!hit) continue;
+      if (pointInRect(hit, roof, EPSILON)) return { blocked: true, roof, intersection: hit };
+    }
+    return { blocked: false, roof: null, intersection: null };
+  }
+
+  function projectedShadowWidthFt(roofWidthFt, eyeToRoofFt, eyeToTargetFt) {
+    const width = Math.max(0, num(roofWidthFt));
+    const near = Math.max(EPSILON, num(eyeToRoofFt));
+    const far = Math.max(0, num(eyeToTargetFt));
+    return width * (far / near);
+  }
+
+  function segmentDistancePx(point = {}, segment = {}) {
+    const px = num(point.x), py = num(point.y), ax = num(segment.x1), ay = num(segment.y1), bx = num(segment.x2), by = num(segment.y2);
+    const dx = bx - ax, dy = by - ay;
+    const len2 = (dx * dx) + (dy * dy);
+    if (len2 <= EPSILON) return Math.hypot(px - ax, py - ay);
+    const t = clamp((((px - ax) * dx) + ((py - ay) * dy)) / len2, 0, 1);
+    return Math.hypot(px - (ax + dx * t), py - (ay + dy * t));
+  }
+
+  function boundaryCandidates(point = {}, interior = {}) {
+    const rect = normalizeRect(interior);
+    return [
+      { side: 'left', distance: Math.abs(num(point.x) - rect.x1), point: { x: rect.x1, y: clamp(point.y, rect.y1, rect.y2) } },
+      { side: 'right', distance: Math.abs(rect.x2 - num(point.x)), point: { x: rect.x2, y: clamp(point.y, rect.y1, rect.y2) } },
+      { side: 'top', distance: Math.abs(num(point.y) - rect.y1), point: { x: clamp(point.x, rect.x1, rect.x2), y: rect.y1 } },
+      { side: 'bottom', distance: Math.abs(rect.y2 - num(point.y)), point: { x: clamp(point.x, rect.x1, rect.x2), y: rect.y2 } },
+    ].sort((a, b) => a.distance - b.distance);
+  }
+
+  function blockingSegmentsForLayer(mapData = {}, zLayer = 0) {
+    const topology = topologyRuntime();
+    if (!topology) return [];
+    const result = [];
+    for (const raw of Array.isArray(mapData.topology) ? mapData.topology : []) {
+      const element = topology.normalizeElement(raw);
+      if (!topology.elementOnLayer(element, zLayer)) continue;
+      if (!topology.effectiveFlags(element).blocksVision) continue;
+      result.push(topology.segment(element, mapData.grid));
+    }
+    return result;
+  }
+
+  function boundaryIsOpen(boundaryPoint = {}, zLayer = 0, mapData = {}) {
+    const tolerance = Math.max(3, num(mapData.grid?.size, 70) * 0.12);
+    return !blockingSegmentsForLayer(mapData, zLayer)
+      .some((segment) => segmentDistancePx(boundaryPoint, segment) <= tolerance);
+  }
+
+  function nearVisualOpening(point = {}, interior = {}, mapData = {}, depthFt = LOOK_UP_INTERIOR_DEPTH_FT) {
+    const lighting = lightingRuntime();
+    const maxPx = feetToPixels(depthFt, mapData);
+    if (lighting?.openingSegments) {
+      const explicit = lighting.openingSegments(mapData, Number(interior.zLayer ?? layerOf(point))) || [];
+      if (explicit.some((segment) => segmentDistancePx(point, segment) <= maxPx + EPSILON)) return true;
+    }
+    return boundaryCandidates(point, interior)
+      .some((candidate) => candidate.distance <= maxPx + EPSILON && boundaryIsOpen(candidate.point, Number(interior.zLayer ?? layerOf(point)), mapData));
+  }
+
+  function hasInternalLight(point = {}, scene = {}, mapData = {}, environment = {}, now = Date.now()) {
+    const lighting = lightingRuntime();
+    if (!lighting) return false;
+    const ambient = lighting.ambientAtPoint?.(point, scene, mapData, environment);
+    if (ambient && ambient.origin === 'interior' && ambient.level !== 'darkness') return true;
+    for (const source of Array.isArray(scene.sources) ? scene.sources : []) {
+      const level = lighting.sourceLevelAtPoint?.(source, point, scene, mapData, now);
+      if (level && level !== 'darkness') return true;
+    }
+    return false;
+  }
+
+  function lookUpInteriorGate(viewer = {}, target = {}, scene = {}, mapData = {}, environment = {}, now = Date.now()) {
+    const lighting = lightingRuntime();
+    const interior = lighting?.interiorAtPoint?.(target, scene, mapData) || null;
+    if (!interior) return { allowed: true, reason: 'EXTERIOR', interior: null };
+    if (hasInternalLight(target, scene, mapData, environment, now)) return { allowed: true, reason: 'INTERNAL_LIGHT', interior };
+    if (nearVisualOpening(target, interior, mapData, num(interior.lookUpPenetrationFt, LOOK_UP_INTERIOR_DEPTH_FT))) {
+      return { allowed: true, reason: 'OPENING_5FT', interior };
+    }
+    return { allowed: false, reason: 'INTERIOR_DEPTH_LIMIT', interior };
+  }
+
+  function sceneForLookUp(scene = {}) {
+    return {
+      ...scene,
+      interiors: (Array.isArray(scene.interiors) ? scene.interiors : []).map((interior) => ({
+        ...interior,
+        roof: interior.roof ? { ...interior.roof, transparent: true } : interior.roof,
+      })),
+    };
+  }
+
+  function lookDeg(viewer = {}) {
+    if (Number.isFinite(Number(viewer.lookDeg))) return normalizeAngleDeg(viewer.lookDeg);
+    if (Number.isFinite(Number(viewer.facingDeg))) return normalizeAngleDeg(viewer.facingDeg);
+    return 0;
+  }
+
+  function perceptionAtPoint(viewer = {}, target = {}, scene = {}, mapData = {}, environment = {}, now = Date.now(), options = {}) {
+    const lighting = lightingRuntime();
+    if (!lighting?.perceptionAtPoint) return { visible: false, reason: 'LIGHTING_RUNTIME_REQUIRED' };
+    const observer = { ...viewer, facingDeg: lookDeg(viewer) };
+    if (!options.lookUp || layerOf(target) <= layerOf(viewer)) return lighting.perceptionAtPoint(observer, target, scene, mapData, environment, now);
+
+    const roof = roofOcclusion(observer, target, scene, mapData);
+    if (roof.blocked) return { visible: false, reason: 'ROOF_OCCLUSION', roofId: roof.roof?.id || null };
+    const gate = lookUpInteriorGate(observer, target, scene, mapData, environment, now);
+    if (!gate.allowed) return { visible: false, reason: gate.reason, interiorId: gate.interior?.id || null };
+
+    const result = lighting.perceptionAtPoint(observer, target, sceneForLookUp(scene), mapData, environment, now);
+    return result?.visible ? { ...result, lookUp: true, lookUpReason: gate.reason } : result;
+  }
+
+  function availableLayers(mapData = {}) {
+    const levels = mapData.zLevels || {};
+    if (Array.isArray(levels)) return levels.map((entry) => Number(entry?.zLayer ?? entry?.z)).filter(Number.isFinite).sort((a, b) => a - b);
+    return Object.entries(levels).map(([key, entry]) => Number(entry?.zLayer ?? entry?.z ?? key)).filter(Number.isFinite).sort((a, b) => a - b);
+  }
+
+  function nextLayer(viewerOrLayer = 0, mapData = {}) {
+    const current = typeof viewerOrLayer === 'object' ? layerOf(viewerOrLayer) : Number(viewerOrLayer) || 0;
+    const next = availableLayers(mapData).find((value) => value > current);
+    return Number.isFinite(next) ? next : null;
+  }
+
+  return Object.freeze({
+    DEFAULT_EYE_HEIGHT_FT,
+    DEFAULT_CEILING_HEIGHT_FT,
+    LOOK_UP_INTERIOR_DEPTH_FT,
+    normalizeAngleDeg,
+    angleToPointDeg,
+    layerOf,
+    elevationForLayer,
+    feetToPixels,
+    eyeHeightFt,
+    eyePoint,
+    normalizeRect,
+    pointInRect,
+    normalizeRoof,
+    roofsForScene,
+    rayPlaneIntersection,
+    roofOcclusion,
+    projectedShadowWidthFt,
+    segmentDistancePx,
+    boundaryCandidates,
+    boundaryIsOpen,
+    nearVisualOpening,
+    hasInternalLight,
+    lookUpInteriorGate,
+    sceneForLookUp,
+    lookDeg,
+    perceptionAtPoint,
+    availableLayers,
+    nextLayer,
+  });
+});

--- a/js/vtt/pov-eye-height-patch.js
+++ b/js/vtt/pov-eye-height-patch.js
@@ -1,0 +1,23 @@
+import './pov-engine.js';
+
+const base = window.LuminousVttPovEngine;
+if (base && !base.__eyePointDistancePatched) {
+  function perceptionAtPoint(viewer = {}, target = {}, scene = {}, mapData = {}, environment = {}, now = Date.now(), options = {}) {
+    if (!options.lookUp || base.layerOf(target) <= base.layerOf(viewer)) {
+      return base.perceptionAtPoint(viewer, target, scene, mapData, environment, now, options);
+    }
+
+    // Look Up originates at the creature's eyes, not at the token's feet/base elevation.
+    // Set eyeHeightFt to zero after lifting elevationFt so the base PoV engine does not
+    // apply eye height a second time for roof rays or 3D lighting distance.
+    const eye = base.eyePoint(viewer, mapData);
+    const eyeViewer = { ...viewer, elevationFt: eye.elevationFt, eyeHeightFt: 0 };
+    return base.perceptionAtPoint(eyeViewer, target, scene, mapData, environment, now, options);
+  }
+
+  window.LuminousVttPovEngine = Object.freeze({
+    ...base,
+    __eyePointDistancePatched: true,
+    perceptionAtPoint,
+  });
+}

--- a/js/vtt/pov-renderer.js
+++ b/js/vtt/pov-renderer.js
@@ -1,0 +1,84 @@
+(function (root, factory) {
+  const api = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttPovRenderer = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (browserRoot) {
+  'use strict';
+
+  const num = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+  function tokenLayer(token = {}) {
+    const pov = browserRoot?.LuminousVttPovEngine;
+    if (pov?.layerOf) return pov.layerOf(token);
+    return Number(token.zLayer ?? token.gridPosition?.z ?? token.z?.[0] ?? 0) || 0;
+  }
+
+  function tokenRadius(token = {}, mapData = {}) {
+    const rules = browserRoot?.LuminousVttTokenInteraction;
+    return rules?.tokenRadius?.(token, mapData.grid) || num(token.radius, num(mapData.grid?.size, 70) * 0.4);
+  }
+
+  function lookDeg(token = {}) {
+    const pov = browserRoot?.LuminousVttPovEngine;
+    if (pov?.lookDeg) return pov.lookDeg(token);
+    return Number.isFinite(Number(token.lookDeg)) ? Number(token.lookDeg) : num(token.facingDeg, 0);
+  }
+
+  function drawLookIndicator(ctx, token = {}, radius = 20) {
+    if (!ctx || !token) return;
+    const angle = (lookDeg(token) * Math.PI) / 180;
+    const ringRadius = radius + Math.max(2, radius * 0.08);
+    const tipRadius = ringRadius + Math.max(7, radius * 0.2);
+    const baseRadius = ringRadius + 1;
+    const spread = Math.max(0.13, Math.min(0.24, 5 / Math.max(10, radius)));
+
+    ctx.save();
+    ctx.strokeStyle = 'rgba(255,255,255,.78)';
+    ctx.lineWidth = Math.max(1.5, radius * 0.045);
+    ctx.beginPath();
+    ctx.arc(token.x, token.y, ringRadius, 0, Math.PI * 2);
+    ctx.stroke();
+
+    const tip = { x: token.x + Math.cos(angle) * tipRadius, y: token.y + Math.sin(angle) * tipRadius };
+    const left = { x: token.x + Math.cos(angle - spread) * baseRadius, y: token.y + Math.sin(angle - spread) * baseRadius };
+    const right = { x: token.x + Math.cos(angle + spread) * baseRadius, y: token.y + Math.sin(angle + spread) * baseRadius };
+    ctx.fillStyle = '#ffffff';
+    ctx.beginPath();
+    ctx.moveTo(tip.x, tip.y);
+    ctx.lineTo(left.x, left.y);
+    ctx.lineTo(right.x, right.y);
+    ctx.closePath();
+    ctx.fill();
+    ctx.restore();
+  }
+
+  function drawIndicators(renderer, zLayer) {
+    const ctx = renderer?.ctx;
+    const mapData = renderer?.mapData;
+    if (!ctx || !mapData) return;
+    const tokenRules = browserRoot?.LuminousVttTokenInteraction;
+    for (const token of mapData.tokens || []) {
+      const onLayer = tokenRules?.tokenOnLayer ? tokenRules.tokenOnLayer(token, zLayer) : tokenLayer(token) === Number(zLayer);
+      if (!onLayer) continue;
+      drawLookIndicator(ctx, token, tokenRadius(token, mapData));
+    }
+  }
+
+  function drawLookUpAnchor(ctx, viewer = {}, mapData = {}) {
+    if (!ctx || !viewer) return;
+    const radius = tokenRadius(viewer, mapData);
+    ctx.save();
+    ctx.globalAlpha = 0.62;
+    ctx.strokeStyle = '#ffffff';
+    ctx.lineWidth = Math.max(2, radius * 0.06);
+    ctx.setLineDash([5, 5]);
+    ctx.beginPath();
+    ctx.arc(viewer.x, viewer.y, radius + 5, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.setLineDash([]);
+    drawLookIndicator(ctx, viewer, radius);
+    ctx.restore();
+  }
+
+  return Object.freeze({ tokenLayer, tokenRadius, lookDeg, drawLookIndicator, drawIndicators, drawLookUpAnchor });
+});

--- a/js/vtt/pov-state.js
+++ b/js/vtt/pov-state.js
@@ -57,7 +57,6 @@
     const subscriptions = [];
     let playerRecords = {};
     let worldRecords = {};
-    let timer = null;
     let started = false;
 
     const playersRef = () => db?.ref(PLAYER_ROOT);
@@ -114,16 +113,15 @@
       started = true;
       applyRecords();
       if (!db) return false;
+      // Firebase subscriptions are the single remote authority. Avoid polling stale cached
+      // records while the local mouse is actively changing lookDeg.
       subscribe(playersRef(), (snapshot) => { playerRecords = snapshot.val() || {}; applyRecords(); });
       subscribe(worldRef(), (snapshot) => { worldRecords = snapshot.val() || {}; applyRecords(); });
-      timer = root?.setInterval?.(applyRecords, 750) || null;
       return true;
     }
 
     function stop() {
       subscriptions.splice(0).forEach((unsubscribe) => unsubscribe());
-      if (timer != null) root?.clearInterval?.(timer);
-      timer = null;
       started = false;
     }
 

--- a/js/vtt/pov-state.js
+++ b/js/vtt/pov-state.js
@@ -1,0 +1,154 @@
+(function (root, factory) {
+  const api = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttPovState = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (browserRoot) {
+  'use strict';
+
+  const DM_UID = 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1';
+  const PLAYER_ROOT = 'campaña/jugadores';
+  const WORLD_ROOT = 'campaña/estado_mundo/vttPov';
+  const clean = (value) => String(value ?? '').trim();
+
+  function hostWindow(root = browserRoot) {
+    if (!root) return null;
+    try { if (root.parent && root.parent !== root && root.parent.document) return root.parent; } catch (_) {}
+    return root;
+  }
+
+  function hostFirebase(root = browserRoot) {
+    const host = hostWindow(root);
+    return host?.firebase || root?.firebase || null;
+  }
+
+  function identity(root = browserRoot) {
+    const host = hostWindow(root);
+    const data = host?.datosJugador || {};
+    let uid = '';
+    try { uid = clean(hostFirebase(root)?.auth?.().currentUser?.uid); } catch (_) {}
+    return {
+      uid,
+      playerId: clean(host?.localStorage?.getItem?.('playerId') || data.playerId || data.id),
+      actorId: clean(data.actorId || data.vinculo_jugador),
+    };
+  }
+
+  function firebaseKey(value, fallback = 'default') {
+    return clean(value).replace(/[.#$\[\]\/]/g, '_') || fallback;
+  }
+
+  function normalizeLookDeg(value, root = browserRoot) {
+    const pov = root?.LuminousVttPovEngine;
+    if (pov?.normalizeAngleDeg) return pov.normalizeAngleDeg(value);
+    const angle = Number(value) || 0;
+    return ((angle % 360) + 360) % 360;
+  }
+
+  function playerKeyForToken(token = {}, current = {}) {
+    return clean(token.canonicalPlayerKey || token.playerId || (token.characterLink?.mode === 'current_player' ? current.playerId : ''));
+  }
+
+  function createBridge({ mapData, isDm = false, onChanged, root = browserRoot } = {}) {
+    if (!mapData) throw new Error('MAP_DATA_REQUIRED');
+    const firebase = hostFirebase(root);
+    const db = firebase?.database?.() || null;
+    const mapId = firebaseKey(mapData.id || mapData.mapId || 'default');
+    const current = identity(root);
+    const subscriptions = [];
+    let playerRecords = {};
+    let worldRecords = {};
+    let timer = null;
+    let started = false;
+
+    const playersRef = () => db?.ref(PLAYER_ROOT);
+    const playerPovRef = (playerId) => db?.ref(`${PLAYER_ROOT}/${firebaseKey(playerId, 'player')}/vttPov/${mapId}`);
+    const worldRef = () => db?.ref(`${WORLD_ROOT}/${mapId}`);
+
+    function subscribe(ref, handler) {
+      if (!ref?.on) return;
+      ref.on('value', handler);
+      subscriptions.push(() => ref.off('value', handler));
+    }
+
+    function applyDefaults(token) {
+      if (!token) return;
+      if (!Number.isFinite(Number(token.lookDeg))) token.lookDeg = normalizeLookDeg(token.facingDeg || 0, root);
+      if (!Number.isFinite(Number(token.eyeHeightFt))) token.eyeHeightFt = 5;
+    }
+
+    function applyRecords() {
+      for (const token of Array.isArray(mapData.tokens) ? mapData.tokens : []) {
+        applyDefaults(token);
+        const playerKey = playerKeyForToken(token, current);
+        if (playerKey) {
+          const value = playerRecords?.[playerKey]?.vttPov?.[mapId]?.lookDeg;
+          if (Number.isFinite(Number(value))) token.lookDeg = normalizeLookDeg(value, root);
+          continue;
+        }
+        const worldValue = worldRecords?.[firebaseKey(token.id, 'token')]?.lookDeg;
+        if (Number.isFinite(Number(worldValue))) token.lookDeg = normalizeLookDeg(worldValue, root);
+      }
+      if (typeof onChanged === 'function') onChanged({ type: 'look' });
+    }
+
+    async function saveLook(token) {
+      if (!token) throw new Error('TOKEN_REQUIRED');
+      applyDefaults(token);
+      const lookDeg = normalizeLookDeg(token.lookDeg, root);
+      token.lookDeg = lookDeg;
+      const playerKey = playerKeyForToken(token, current);
+      if (playerKey) {
+        const ownerUid = clean(token.canonicalOwnerUid || token.ownerUid);
+        if (!isDm && playerKey !== current.playerId && ownerUid !== current.uid) throw new Error('PLAYER_TOKEN_OWNERSHIP_REQUIRED');
+        if (db) await playerPovRef(playerKey).child('lookDeg').set(lookDeg);
+        return { valid: true, scope: 'player', key: playerKey, lookDeg };
+      }
+      if (!isDm) throw new Error('DM_REQUIRED');
+      const key = firebaseKey(token.id, 'token');
+      if (db) await worldRef().child(key).set({ lookDeg, updatedByUid: current.uid || DM_UID, updatedAt: firebase.database.ServerValue.TIMESTAMP });
+      return { valid: true, scope: 'world', key, lookDeg };
+    }
+
+    function start() {
+      if (started) return true;
+      started = true;
+      applyRecords();
+      if (!db) return false;
+      subscribe(playersRef(), (snapshot) => { playerRecords = snapshot.val() || {}; applyRecords(); });
+      subscribe(worldRef(), (snapshot) => { worldRecords = snapshot.val() || {}; applyRecords(); });
+      timer = root?.setInterval?.(applyRecords, 750) || null;
+      return true;
+    }
+
+    function stop() {
+      subscriptions.splice(0).forEach((unsubscribe) => unsubscribe());
+      if (timer != null) root?.clearInterval?.(timer);
+      timer = null;
+      started = false;
+    }
+
+    return Object.freeze({
+      mapId,
+      isDm: Boolean(isDm),
+      identity: current,
+      start,
+      stop,
+      saveLook,
+      applyRecords,
+      applyDefaults,
+    });
+  }
+
+  return Object.freeze({
+    DM_UID,
+    PLAYER_ROOT,
+    WORLD_ROOT,
+    hostWindow,
+    hostFirebase,
+    identity,
+    firebaseKey,
+    normalizeLookDeg,
+    playerKeyForToken,
+    createBridge,
+  });
+});

--- a/tests/vtt_pov_eye_height_hardening.spec.js
+++ b/tests/vtt_pov_eye_height_hardening.spec.js
@@ -1,0 +1,22 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+test('Look Up hardening lifts the lighting observer to eye elevation exactly once', () => {
+  const patch = read('js/vtt/pov-eye-height-patch.js');
+  expect(patch).toContain("import './pov-engine.js'");
+  expect(patch).toContain('const eye = base.eyePoint(viewer, mapData)');
+  expect(patch).toContain('elevationFt: eye.elevationFt');
+  expect(patch).toContain('eyeHeightFt: 0');
+  expect(patch).toContain('base.perceptionAtPoint(eyeViewer');
+});
+
+test('eye-point hardening loads before dynamic lighting captures the PoV runtime', () => {
+  const html = read('vtt.html');
+  const patch = html.indexOf('pov-eye-height-patch.js');
+  const lighting = html.indexOf('dynamic-lighting-bootstrap.js');
+  expect(patch).toBeGreaterThan(-1);
+  expect(lighting).toBeGreaterThan(patch);
+});

--- a/tests/vtt_pov_subscription_sync.spec.js
+++ b/tests/vtt_pov_subscription_sync.spec.js
@@ -1,0 +1,13 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+test('PoV remote sync is subscription driven and never polls cached look records', () => {
+  const state = read('js/vtt/pov-state.js');
+  expect(state).toContain('subscribe(playersRef()');
+  expect(state).toContain('subscribe(worldRef()');
+  expect(state).not.toContain('setInterval');
+  expect(state).not.toContain('clearInterval');
+});

--- a/tests/vtt_token_pov_look_up.spec.js
+++ b/tests/vtt_token_pov_look_up.spec.js
@@ -1,0 +1,201 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const pov = require('../js/vtt/pov-engine.js');
+const povState = require('../js/vtt/pov-state.js');
+const lighting = require('../js/vtt/lighting-engine.js');
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+function map(overrides = {}) {
+  return {
+    id: 'alpha',
+    grid: { cols: 20, rows: 20, size: 70, distancePerCell: 5, distanceUnit: 'ft' },
+    defaultZStepFt: 15,
+    defaultCeilingHeightFt: 10,
+    zLevels: {
+      0: { zLayer: 0, elevationFt: 0 },
+      1: { zLayer: 1, elevationFt: 15 },
+      2: { zLayer: 2, elevationFt: 30 },
+    },
+    walls: [],
+    topology: [],
+    verticalPortals: [],
+    tokens: [],
+    ambientLight: { level: 'darkness' },
+    ...overrides,
+  };
+}
+
+function scene(overrides = {}) {
+  return { sources: [], interiors: [], roofs: [], transformers: [], switches: [], ...overrides };
+}
+
+function viewer(overrides = {}) {
+  return {
+    id: 'viewer', x: 0, y: 0, zLayer: 0, elevationFt: 0,
+    facingDeg: 180, lookDeg: 0, eyeHeightFt: 5, visionConeDeg: 120,
+    senses: { darkvisionFt: 0 },
+    ...overrides,
+  };
+}
+
+const brightEnv = () => ({ state: { light: 'bright', visibility: 'clear' } });
+const darkEnv = () => ({ state: { light: 'darkness', visibility: 'clear' } });
+
+function fakeRoot({ uid = 'uid-a', playerId = 'alice' } = {}) {
+  const writes = [];
+  const handlers = [];
+  const makeRef = (value) => ({
+    path: value,
+    child(key) { return makeRef(`${value}/${key}`); },
+    async set(payload) { writes.push({ type: 'set', path: value, value: payload }); },
+    on(event, handler) { handlers.push({ value, event, handler }); },
+    off() {},
+  });
+  const database = () => ({ ref: (value) => makeRef(value) });
+  database.ServerValue = { TIMESTAMP: 123456 };
+  const root = {
+    document: {},
+    datosJugador: { id: playerId, playerId },
+    localStorage: { getItem: (key) => key === 'playerId' ? playerId : null },
+    firebase: { auth: () => ({ currentUser: { uid } }), database },
+    setInterval: () => 1,
+    clearInterval() {},
+    LuminousVttPovEngine: pov,
+  };
+  return { root, writes };
+}
+
+test('look direction is independent from body facing and drives the vision cone', () => {
+  const m = map();
+  const v = viewer({ facingDeg: 180, lookDeg: 0 });
+  const ahead = { x: lighting.feetToPixels(10, m), y: 0, zLayer: 0, elevationFt: 0 };
+  const behind = { x: -lighting.feetToPixels(10, m), y: 0, zLayer: 0, elevationFt: 0 };
+  expect(pov.lookDeg(v)).toBe(0);
+  expect(pov.perceptionAtPoint(v, ahead, scene(), m, brightEnv()).visible).toBe(true);
+  expect(pov.perceptionAtPoint(v, behind, scene(), m, brightEnv()).visible).toBe(false);
+});
+
+test('default eye height is 5 ft and default roof plane is 10 ft over its floor', () => {
+  const m = map();
+  expect(pov.eyePoint(viewer({ eyeHeightFt: undefined }), m).elevationFt).toBe(5);
+  const roof = pov.normalizeRoof({ id: 'awning', zLayer: 0, x1: 0, y1: 0, x2: 70, y2: 70 }, m);
+  expect(roof.elevationFt).toBe(10);
+});
+
+test('a 5 ft roof casts a perspective shadow instead of blocking the whole upper floor', () => {
+  const m = map();
+  const halfRoof = lighting.feetToPixels(2.5, m);
+  const s = scene({ roofs: [{ id: 'small-roof', zLayer: 0, elevationFt: 10, x1: -halfRoof, y1: -halfRoof, x2: halfRoof, y2: halfRoof, transparent: false }] });
+  const v = viewer();
+  const blocked = { x: 0, y: 0, zLayer: 1, elevationFt: 15 };
+  const clear = { x: lighting.feetToPixels(6, m), y: 0, zLayer: 1, elevationFt: 15 };
+
+  expect(pov.roofOcclusion(v, blocked, s, m)).toMatchObject({ blocked: true, roof: { id: 'small-roof' } });
+  expect(pov.roofOcclusion(v, clear, s, m).blocked).toBe(false);
+  expect(pov.perceptionAtPoint(v, blocked, s, m, brightEnv(), 1000, { lookUp: true }).reason).toBe('ROOF_OCCLUSION');
+  expect(pov.perceptionAtPoint(v, clear, s, m, brightEnv(), 1000, { lookUp: true }).visible).toBe(true);
+});
+
+test('perspective math gives 10 ft shadow at Z15 and 15 ft shadow at Z20 for the example geometry', () => {
+  expect(pov.projectedShadowWidthFt(5, 5, 10)).toBeCloseTo(10, 6);
+  expect(pov.projectedShadowWidthFt(5, 5, 15)).toBeCloseTo(15, 6);
+});
+
+test('transparent roofs do not occlude Look Up rays', () => {
+  const m = map();
+  const s = scene({ roofs: [{ id: 'glass', zLayer: 0, elevationFt: 10, x1: -70, y1: -70, x2: 70, y2: 70, transparent: true }] });
+  expect(pov.roofOcclusion(viewer(), { x: 0, y: 0, zLayer: 1, elevationFt: 15 }, s, m).blocked).toBe(false);
+});
+
+test('an upper dark interior is visible only 5 ft through an un-walled boundary', () => {
+  const m = map();
+  const interior = { id: 'upper-room', zLayer: 1, x1: 0, y1: 0, x2: 700, y2: 700, baseLight: 'darkness', roof: { present: true, transparent: false } };
+  const s = scene({ interiors: [interior] });
+  const near = { x: lighting.feetToPixels(4, m), y: 350, zLayer: 1, elevationFt: 15 };
+  const deep = { x: lighting.feetToPixels(6, m), y: 350, zLayer: 1, elevationFt: 15 };
+  expect(pov.lookUpInteriorGate(viewer(), near, s, m, brightEnv())).toMatchObject({ allowed: true, reason: 'OPENING_5FT' });
+  expect(pov.lookUpInteriorGate(viewer(), deep, s, m, brightEnv())).toMatchObject({ allowed: false, reason: 'INTERIOR_DEPTH_LIMIT' });
+});
+
+test('a closed wall removes the implicit open-boundary Look Up window', () => {
+  const m = map({ topology: [{ id: 'left-wall', type: 'wall', from: { col: 0, row: 0 }, to: { col: 0, row: 10 }, z: [1] }] });
+  const s = scene({ interiors: [{ id: 'upper-room', zLayer: 1, x1: 0, y1: 0, x2: 700, y2: 700, baseLight: 'darkness', roof: { present: true, transparent: false } }] });
+  const near = { x: lighting.feetToPixels(4, m), y: 350, zLayer: 1, elevationFt: 15 };
+  expect(pov.lookUpInteriorGate(viewer(), near, s, m, brightEnv())).toMatchObject({ allowed: false, reason: 'INTERIOR_DEPTH_LIMIT' });
+});
+
+test('a normal closed window counts as a valid 5 ft Look Up opening', () => {
+  const m = map({ topology: [{ id: 'window', type: 'window', from: { col: 0, row: 0 }, to: { col: 0, row: 10 }, z: [1], state: 'closed', thresholds: { lockpick: 12, break: 10 } }] });
+  const s = scene({ interiors: [{ id: 'upper-room', zLayer: 1, x1: 0, y1: 0, x2: 700, y2: 700, baseLight: 'darkness', roof: { present: true, transparent: false } }] });
+  const near = { x: lighting.feetToPixels(4, m), y: 350, zLayer: 1, elevationFt: 15 };
+  expect(pov.lookUpInteriorGate(viewer(), near, s, m, brightEnv())).toMatchObject({ allowed: true, reason: 'OPENING_5FT' });
+});
+
+test('real interior illumination can reveal deeper than the 5 ft ambient Look Up limit', () => {
+  const m = map();
+  const deep = { x: lighting.feetToPixels(12, m), y: 350, zLayer: 1, elevationFt: 15 };
+  const s = scene({
+    interiors: [{ id: 'upper-room', zLayer: 1, x1: 0, y1: 0, x2: 700, y2: 700, baseLight: 'darkness', roof: { present: true, transparent: false } }],
+    sources: [{ id: 'lamp', x: deep.x, y: deep.y, zLayer: 1, elevationFt: 15, brightFt: 15, dimAdditionalFt: 15, enabled: true }],
+  });
+  expect(pov.lookUpInteriorGate(viewer(), deep, s, m, darkEnv())).toMatchObject({ allowed: true, reason: 'INTERNAL_LIGHT' });
+});
+
+test('Look Up resolves the next logical floor without changing the token physical Z', () => {
+  const m = map();
+  const token = viewer({ zLayer: 0, elevationFt: 0 });
+  const before = { zLayer: token.zLayer, elevationFt: token.elevationFt };
+  expect(pov.nextLayer(token, m)).toBe(1);
+  expect(token).toMatchObject(before);
+  expect(pov.nextLayer(1, m)).toBe(2);
+  expect(pov.nextLayer(2, m)).toBeNull();
+});
+
+test('player Look direction persists only under their canonical player node', async () => {
+  const { root, writes } = fakeRoot({ uid: 'uid-a', playerId: 'alice' });
+  const token = { id: 'player-template', characterLink: { mode: 'current_player' }, lookDeg: 37 };
+  const bridge = povState.createBridge({ mapData: { id: 'alpha', tokens: [token] }, isDm: false, root });
+  await bridge.saveLook(token);
+  expect(writes).toHaveLength(1);
+  expect(writes[0]).toMatchObject({ path: 'campaña/jugadores/alice/vttPov/alpha/lookDeg', value: 37 });
+});
+
+test('a player cannot persist another token look direction while DM can persist world PoV', async () => {
+  const player = fakeRoot({ uid: 'uid-a', playerId: 'alice' });
+  const playerBridge = povState.createBridge({ mapData: { id: 'alpha', tokens: [] }, isDm: false, root: player.root });
+  await expect(playerBridge.saveLook({ id: 'player:bob', canonicalPlayerKey: 'bob', canonicalOwnerUid: 'uid-b', lookDeg: 90 })).rejects.toThrow('PLAYER_TOKEN_OWNERSHIP_REQUIRED');
+
+  const dm = fakeRoot({ uid: povState.DM_UID, playerId: 'dm' });
+  const dmBridge = povState.createBridge({ mapData: { id: 'alpha', tokens: [] }, isDm: true, root: dm.root });
+  await dmBridge.saveLook({ id: 'npc-1', lookDeg: 270 });
+  expect(dm.writes[0].path).toBe('campaña/estado_mundo/vttPov/alpha/npc-1');
+  expect(dm.writes[0].value.lookDeg).toBe(270);
+});
+
+test('runtime wiring uses mouse Look, E lock, hold-Q Look Up, white direction marker and roof authoring', () => {
+  const bootstrap = read('js/vtt/dynamic-lighting-bootstrap.js');
+  const controller = read('js/vtt/pov-controller.js');
+  const renderer = read('js/vtt/pov-renderer.js');
+
+  expect(bootstrap).toContain("import './pov-engine.js'");
+  expect(bootstrap).toContain('pov.perceptionAtPoint');
+  expect(bootstrap).toContain('povController.viewLayer(activeZ)');
+  expect(bootstrap).not.toContain('updateFacingFromMove');
+  expect(controller).toContain("key === 'e'");
+  expect(controller).toContain("key === 'q'");
+  expect(controller).toContain("canvas.addEventListener('mousemove', onPointerMove)");
+  expect(controller).toContain("button.textContent = 'ROOF'");
+  expect(controller).toContain('mapData.pov.lookUpHeld');
+  expect(renderer).toContain("ctx.fillStyle = '#ffffff'");
+  expect(renderer).toContain('token.lookDeg');
+  expect(renderer).not.toContain('ctx.rotate(');
+});
+
+test('new PoV runtimes parse as JavaScript', () => {
+  for (const file of ['js/vtt/pov-engine.js', 'js/vtt/pov-state.js', 'js/vtt/pov-controller.js', 'js/vtt/pov-renderer.js', 'js/vtt/dynamic-lighting-bootstrap.js']) {
+    execFileSync(process.execPath, ['--check', path.join(__dirname, '..', file)], { stdio: 'pipe' });
+  }
+});

--- a/tests/vtt_token_pov_look_up.spec.js
+++ b/tests/vtt_token_pov_look_up.spec.js
@@ -6,6 +6,7 @@ const { execFileSync } = require('node:child_process');
 const pov = require('../js/vtt/pov-engine.js');
 const povState = require('../js/vtt/pov-state.js');
 const lighting = require('../js/vtt/lighting-engine.js');
+const lightingState = require('../js/vtt/lighting-state.js');
 const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
 
 function map(overrides = {}) {
@@ -120,8 +121,15 @@ test('an upper dark interior is visible only 5 ft through an un-walled boundary'
   expect(pov.lookUpInteriorGate(viewer(), deep, s, m, brightEnv())).toMatchObject({ allowed: false, reason: 'INTERIOR_DEPTH_LIMIT' });
 });
 
-test('a closed wall removes the implicit open-boundary Look Up window', () => {
+test('a closed topology wall removes the implicit open-boundary Look Up window', () => {
   const m = map({ topology: [{ id: 'left-wall', type: 'wall', from: { col: 0, row: 0 }, to: { col: 0, row: 10 }, z: [1] }] });
+  const s = scene({ interiors: [{ id: 'upper-room', zLayer: 1, x1: 0, y1: 0, x2: 700, y2: 700, baseLight: 'darkness', roof: { present: true, transparent: false } }] });
+  const near = { x: lighting.feetToPixels(4, m), y: 350, zLayer: 1, elevationFt: 15 };
+  expect(pov.lookUpInteriorGate(viewer(), near, s, m, brightEnv())).toMatchObject({ allowed: false, reason: 'INTERIOR_DEPTH_LIMIT' });
+});
+
+test('legacy walls also remove the implicit Look Up opening', () => {
+  const m = map({ walls: [{ x1: 0, y1: 0, x2: 0, y2: 700, z: [1], blocksVision: true }] });
   const s = scene({ interiors: [{ id: 'upper-room', zLayer: 1, x1: 0, y1: 0, x2: 700, y2: 700, baseLight: 'darkness', roof: { present: true, transparent: false } }] });
   const near = { x: lighting.feetToPixels(4, m), y: 350, zLayer: 1, elevationFt: 15 };
   expect(pov.lookUpInteriorGate(viewer(), near, s, m, brightEnv())).toMatchObject({ allowed: false, reason: 'INTERIOR_DEPTH_LIMIT' });
@@ -175,22 +183,33 @@ test('a player cannot persist another token look direction while DM can persist 
   expect(dm.writes[0].value.lookDeg).toBe(270);
 });
 
-test('runtime wiring uses mouse Look, E lock, hold-Q Look Up, white direction marker and roof authoring', () => {
+test('lighting canonical scene normalization preserves authored roofs', () => {
+  const normalized = lightingState.normalizeScene({ roofs: [{ id: 'roof-a', x1: 0, y1: 0, x2: 70, y2: 70, elevationFt: 10 }] });
+  expect(normalized.roofs).toEqual([{ id: 'roof-a', x1: 0, y1: 0, x2: 70, y2: 70, elevationFt: 10 }]);
+});
+
+test('runtime wiring uses mouse Look, E lock, hold-Q Look Up, white direction marker and canonical roof authoring', () => {
   const bootstrap = read('js/vtt/dynamic-lighting-bootstrap.js');
   const controller = read('js/vtt/pov-controller.js');
   const renderer = read('js/vtt/pov-renderer.js');
+  const main = read('js/vtt/main.js');
 
   expect(bootstrap).toContain("import './pov-engine.js'");
   expect(bootstrap).toContain('pov.perceptionAtPoint');
   expect(bootstrap).toContain('povController.viewLayer(activeZ)');
+  expect(bootstrap).toContain('sceneBridge: lightingStateBridge');
   expect(controller).toContain("key === 'e'");
   expect(controller).toContain("key === 'q'");
   expect(controller).toContain("canvas.addEventListener('mousemove', onPointerMove)");
+  expect(controller).toContain("root.addEventListener('blur', onWindowBlur)");
+  expect(controller).toContain('bridge.saveScene(scene())');
   expect(controller).toContain("button.textContent = 'ROOF'");
   expect(controller).toContain('mapData.pov.lookUpHeld');
   expect(renderer).toContain("ctx.fillStyle = '#ffffff'");
   expect(renderer).toContain('token.lookDeg');
   expect(renderer).not.toContain('ctx.rotate(');
+  expect(main).not.toContain("(event.key === 'e' || event.key === 'E')");
+  expect(main).toContain('E belongs exclusively to token PoV Look Lock/Unlock');
 });
 
 test('new PoV UMD runtimes parse as JavaScript and the ESM bootstrap imports them', () => {

--- a/tests/vtt_token_pov_look_up.spec.js
+++ b/tests/vtt_token_pov_look_up.spec.js
@@ -183,7 +183,6 @@ test('runtime wiring uses mouse Look, E lock, hold-Q Look Up, white direction ma
   expect(bootstrap).toContain("import './pov-engine.js'");
   expect(bootstrap).toContain('pov.perceptionAtPoint');
   expect(bootstrap).toContain('povController.viewLayer(activeZ)');
-  expect(bootstrap).not.toContain('updateFacingFromMove');
   expect(controller).toContain("key === 'e'");
   expect(controller).toContain("key === 'q'");
   expect(controller).toContain("canvas.addEventListener('mousemove', onPointerMove)");
@@ -194,8 +193,13 @@ test('runtime wiring uses mouse Look, E lock, hold-Q Look Up, white direction ma
   expect(renderer).not.toContain('ctx.rotate(');
 });
 
-test('new PoV runtimes parse as JavaScript', () => {
-  for (const file of ['js/vtt/pov-engine.js', 'js/vtt/pov-state.js', 'js/vtt/pov-controller.js', 'js/vtt/pov-renderer.js', 'js/vtt/dynamic-lighting-bootstrap.js']) {
+test('new PoV UMD runtimes parse as JavaScript and the ESM bootstrap imports them', () => {
+  for (const file of ['js/vtt/pov-engine.js', 'js/vtt/pov-state.js', 'js/vtt/pov-controller.js', 'js/vtt/pov-renderer.js']) {
     execFileSync(process.execPath, ['--check', path.join(__dirname, '..', file)], { stdio: 'pipe' });
   }
+  const bootstrap = read('js/vtt/dynamic-lighting-bootstrap.js');
+  expect(bootstrap).toContain("import './pov-engine.js';");
+  expect(bootstrap).toContain("import './pov-state.js';");
+  expect(bootstrap).toContain("import './pov-controller.js';");
+  expect(bootstrap).toContain("import './pov-renderer.js';");
 });

--- a/vtt.html
+++ b/vtt.html
@@ -133,6 +133,7 @@
     <script src="js/vtt/multiplayer-senses-bridge.js"></script>
     <script type="module" src="js/vtt/main.js"></script>
     <script type="module" src="js/vtt/lighting-defaults-patch.js"></script>
+    <script type="module" src="js/vtt/pov-eye-height-patch.js"></script>
     <script type="module" src="js/vtt/dynamic-lighting-bootstrap.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- adds independent token Look direction (`lookDeg`) without rotating the token sprite
- mouse controls horizontal Look while unlocked
- `E` toggles Look Lock / Unlock
- holding `Q` enters Look Up toward the next logical Z layer without changing token `zLayer` or physical elevation
- renders a white outer orientation ring + small white triangle so other players can see where a token is looking
- keeps the map North-Up; only the token Look indicator changes direction
- adds configurable `eyeHeightFt` with 5 ft default
- adds explicit partial `ROOF` geometry with a 10 ft default ceiling plane above its floor
- resolves Look Up roof occlusion through true 3D ray/plane intersections instead of blocking an entire floor
- preserves the perspective-shadow rule: a 5 ft roof 5 ft above the eyes projects a 10 ft shadow on a plane 10 ft above the eyes and 15 ft on a plane 15 ft above the eyes
- upper exterior/open areas use normal LoS
- upper dark interiors are visible only within 5 ft of a valid visual opening or an un-walled boundary
- closed walls/doors/curtain windows block that opening; normal windows and open geometry permit it
- real interior illumination can reveal farther than the 5 ft ambient penetration rule
- transparent roofs do not block Look Up
- DM Lighting edit mode gains a `ROOF` authoring tool for grid-aligned roof rectangles, elevation and transparency

## Controls
- Mouse: turn Look direction toward cursor while Look is free
- `E`: toggle `LOOK FREE` / `LOOK LOCKED`
- hold `Q`: `LOOK UP` at the next logical floor
- releasing `Q`: return to normal current-floor PoV

`Q` is perception-only. It never changes movement, collision, `zLayer`, grid position or elevation.

DM Edit Mode remains available through its existing button; `E` is now reserved exclusively for Look Lock/Unlock to avoid the previous shortcut collision.

## Integration hardening
A post-CI integration audit found and fixed four runtime issues that static feature tests did not expose:
- removed the DM Edit Mode `E` shortcut conflict
- wired ROOF authoring to the canonical lighting scene bridge so roofs actually persist
- clears held `Q`/roof drag on window blur so Look Up cannot become stuck
- includes legacy `mapData.walls` in implicit upper-interior opening checks

PoV Firebase synchronization is now subscription-driven only; the previous 750 ms cached-record poll was removed so stale remote `lookDeg` cannot fight live mouse input.

## Canonical state
Player Look direction:
`campaña/jugadores/<playerId>/vttPov/<mapId>/lookDeg`

World/NPC Look direction:
`campaña/estado_mundo/vttPov/<mapId>/<tokenId>`

ROOF geometry is persisted as part of the existing canonical lighting scene under:
`campaña/estado_mundo/vttLighting/<mapId>/scene`

Look Lock and held-Q are local input state; only `lookDeg` is shared because other clients need the orientation marker.

## Final validation
Head: `9abf1627ec38d84c220f54f8457b6def86dd168f`
- Background Narratives workflow run 122: **success**
- repository regression suite: **877/877 passed**
- narrative contract: **158/158 passed**
- patched syntax: **success**
- branch comparison: **15 commits ahead / 0 behind `main`**
- base / merge-base: `4d27eeb253d9636a956181bc7278b70e92947ec3`

Added regression coverage specifically for shortcut ownership, canonical roof persistence, focus-loss cleanup, legacy walls and subscription-only PoV synchronization.

## Out of scope
- Look Down
- advanced creature-size-derived eye height defaults
- persistent Fog of War
- magical Darkness
- full 3D mesh roofs; roofs are horizontal rectangular authoring regions in this patch
