### PR TITLE
fix(vtt): prevent DM map bootstrap crash and reload loops

### DIFF
--- a/hoja_de_DM.html
+++ b/hoja_de_DM.html
@@ -81,35 +81,35 @@
             <div style="display: grid; grid-template-columns: 1fr; gap: 8px; margin-bottom: 10px;">
               <input id="theatre-scenario-name" type="text" placeholder="Nombre del escenario" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; width: 100%; box-sizing: border-box;">
               <input id="theatre-background-input" type="url" placeholder="URL del fondo" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; width: 100%; box-sizing: border-box;">
-              <input id="theatre-location-input" type="text" placeholder="Localización" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; width: 100%; box-sizing: border-box;">
+              <input id="theatre-location-input" type="text" placeholder="Localización" style="padding: 6px; background:#121820; color:white; border:1px solid #53606d; width:100%; box-sizing:border-box;">
               <input id="theatre-scenario-tags" type="text" placeholder="Sub-etiquetas (separadas por coma)" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; width: 100%; box-sizing: border-box;">
             </div>
 
             <div style="display: flex; gap: 8px; flex-wrap: wrap;">
-              <button id="btn-save-scenario" type="button" style="padding: 8px; background: #1a222c; color: #a37c35; border: 1px solid #a37c35; cursor: pointer;">GUARDAR ESCENARIO</button>
-              <button id="btn-use-scenario" type="button" style="padding: 8px; background: #8a1c1c; color: white; border: 1px solid #ff6575; cursor: pointer; flex: 1;">USAR EN TEATRO</button>
-              <button id="btn-delete-scenario" type="button" style="padding: 8px; background: #3a0c0c; color: #ff6575; border: 1px solid #ff6575; cursor: pointer;">BORRAR</button>
-              <button id="btn-update-scene" type="button" style="padding: 8px; background: #222; color: white; border: 1px solid #555; cursor: pointer;">APLICAR MANUAL</button>
+              <button id="btn-save-scenario" type="button" style="padding: 8px; background: #1a222c; color: #a37c35; border: 1px solid #a37c35; cursor:pointer;">GUARDAR ESCENARIO</button>
+              <button id="btn-use-scenario" type="button" style="padding: 8px; background: #8a1c1c; color:white; border:1px solid #ff6575; cursor:pointer; flex:1;">USAR EN TEATRO</button>
+              <button id="btn-delete-scenario" type="button" style="padding: 8px; background: #3a0c0c; color:#ff6575; border:1px solid #ff6575; cursor:pointer;">BORRAR</button>
+              <button id="btn-update-scene" type="button" style="padding: 8px; background:#222; color:white; border:1px solid #555; cursor:pointer;">APLICAR MANUAL</button>
             </div>
           </div>
 
-          <div class="theatre-controls" style="display: flex; flex-direction: column; gap: 10px;">
-            <h4 style="color: #a37c35; margin: 0; font-family: 'Cinzel', serif;">Compositor de Diálogo</h4>
-            <div style="display: flex; gap: 8px;">
-              <select id="theatre-speaker-select" style="flex: 1; padding: 9px; background: #121820; color: white; border: 1px solid #53606d;">
+          <div class="theatre-controls" style="display:flex; flex-direction:column; gap:10px;">
+            <h4 style="color:#a37c35; margin:0; font-family:'Cinzel', serif;">Compositor de Diálogo</h4>
+            <div style="display:flex; gap:8px;">
+              <select id="theatre-speaker-select" style="flex:1; padding:9px; background:#121820; color:white; border:1px solid #53606d;">
                 <option value="narrador">Narrador</option>
               </select>
-              <select id="dm-tipo-dialogo-select" style="flex: 1; padding: 9px; background: #121820; color: white; border: 1px solid #53606d;">
+              <select id="dm-tipo-dialogo-select" style="flex:1; padding:9px; background:#121820; color:white; border:1px solid #53606d;">
                 <option value="dialogo">Diálogo</option>
                 <option value="narracion">Narración</option>
                 <option value="pensamiento">Pensamiento</option>
               </select>
-              <select id="theatre-expression-select" style="flex: 1; padding: 9px; background: #121820; color: white; border: 1px solid #53606d;">
+              <select id="theatre-expression-select" style="flex:1; padding:9px; background:#121820; color:white; border:1px solid #53606d;">
                 <option value="Neutral">Neutral</option>
               </select>
             </div>
 
-            <textarea id="theatre-dialogue-input" placeholder="Diálogo en vivo" style="min-height: 80px;"></textarea>
+            <textarea id="theatre-dialogue-input" placeholder="Diálogo en vivo" style="min-height:80px;"></textarea>
             <button id="btn-send-dialogue" type="button">ENVIAR DIÁLOGO</button>
           </div>
         </div>
@@ -117,7 +117,7 @@
     </section>
 
     <section id="modulo-mapa" class="game-module hidden" aria-hidden="true">
-      <iframe src="vtt.html" title="Mapa táctico D&amp;D"></iframe>
+      <iframe data-vtt-src="vtt.html" title="Mapa táctico D&amp;D"></iframe>
     </section>
 
     <section id="modulo-combate" class="game-module hidden" aria-hidden="true">
@@ -138,6 +138,7 @@
   <script src="js/weather-readonly-engine.js"></script>
   <script src="js/weather-fx.js"></script>
   <script src="js/instance-control.js"></script>
+  <script src="js/vtt/dm-map-lazy-loader.js"></script>
   <script src="js/dm-managed-effect-engine.js"></script>
   <script src="js/language-catalog-engine.js"></script>
   <script src="js/bond-engine.js"></script>

--- a/hoja_de_DM.html
+++ b/hoja_de_DM.html
@@ -81,35 +81,35 @@
             <div style="display: grid; grid-template-columns: 1fr; gap: 8px; margin-bottom: 10px;">
               <input id="theatre-scenario-name" type="text" placeholder="Nombre del escenario" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; width: 100%; box-sizing: border-box;">
               <input id="theatre-background-input" type="url" placeholder="URL del fondo" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; width: 100%; box-sizing: border-box;">
-              <input id="theatre-location-input" type="text" placeholder="Localización" style="padding: 6px; background:#121820; color:white; border:1px solid #53606d; width:100%; box-sizing:border-box;">
+              <input id="theatre-location-input" type="text" placeholder="Localización" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; width: 100%; box-sizing: border-box;">
               <input id="theatre-scenario-tags" type="text" placeholder="Sub-etiquetas (separadas por coma)" style="padding: 6px; background: #121820; color: white; border: 1px solid #53606d; width: 100%; box-sizing: border-box;">
             </div>
 
             <div style="display: flex; gap: 8px; flex-wrap: wrap;">
-              <button id="btn-save-scenario" type="button" style="padding: 8px; background: #1a222c; color: #a37c35; border: 1px solid #a37c35; cursor:pointer;">GUARDAR ESCENARIO</button>
-              <button id="btn-use-scenario" type="button" style="padding: 8px; background: #8a1c1c; color:white; border:1px solid #ff6575; cursor:pointer; flex:1;">USAR EN TEATRO</button>
-              <button id="btn-delete-scenario" type="button" style="padding: 8px; background: #3a0c0c; color:#ff6575; border:1px solid #ff6575; cursor:pointer;">BORRAR</button>
-              <button id="btn-update-scene" type="button" style="padding: 8px; background:#222; color:white; border:1px solid #555; cursor:pointer;">APLICAR MANUAL</button>
+              <button id="btn-save-scenario" type="button" style="padding: 8px; background: #1a222c; color: #a37c35; border: 1px solid #a37c35; cursor: pointer;">GUARDAR ESCENARIO</button>
+              <button id="btn-use-scenario" type="button" style="padding: 8px; background: #8a1c1c; color: white; border: 1px solid #ff6575; cursor: pointer; flex: 1;">USAR EN TEATRO</button>
+              <button id="btn-delete-scenario" type="button" style="padding: 8px; background: #3a0c0c; color: #ff6575; border: 1px solid #ff6575; cursor: pointer;">BORRAR</button>
+              <button id="btn-update-scene" type="button" style="padding: 8px; background: #222; color: white; border: 1px solid #555; cursor: pointer;">APLICAR MANUAL</button>
             </div>
           </div>
 
-          <div class="theatre-controls" style="display:flex; flex-direction:column; gap:10px;">
-            <h4 style="color:#a37c35; margin:0; font-family:'Cinzel', serif;">Compositor de Diálogo</h4>
-            <div style="display:flex; gap:8px;">
-              <select id="theatre-speaker-select" style="flex:1; padding:9px; background:#121820; color:white; border:1px solid #53606d;">
+          <div class="theatre-controls" style="display: flex; flex-direction: column; gap: 10px;">
+            <h4 style="color: #a37c35; margin: 0; font-family: 'Cinzel', serif;">Compositor de Diálogo</h4>
+            <div style="display: flex; gap: 8px;">
+              <select id="theatre-speaker-select" style="flex: 1; padding: 9px; background: #121820; color: white; border: 1px solid #53606d;">
                 <option value="narrador">Narrador</option>
               </select>
-              <select id="dm-tipo-dialogo-select" style="flex:1; padding:9px; background:#121820; color:white; border:1px solid #53606d;">
+              <select id="dm-tipo-dialogo-select" style="flex: 1; padding: 9px; background: #121820; color: white; border: 1px solid #53606d;">
                 <option value="dialogo">Diálogo</option>
                 <option value="narracion">Narración</option>
                 <option value="pensamiento">Pensamiento</option>
               </select>
-              <select id="theatre-expression-select" style="flex:1; padding:9px; background:#121820; color:white; border:1px solid #53606d;">
+              <select id="theatre-expression-select" style="flex: 1; padding: 9px; background: #121820; color: white; border: 1px solid #53606d;">
                 <option value="Neutral">Neutral</option>
               </select>
             </div>
 
-            <textarea id="theatre-dialogue-input" placeholder="Diálogo en vivo" style="min-height:80px;"></textarea>
+            <textarea id="theatre-dialogue-input" placeholder="Diálogo en vivo" style="min-height: 80px;"></textarea>
             <button id="btn-send-dialogue" type="button">ENVIAR DIÁLOGO</button>
           </div>
         </div>

--- a/js/vtt/dm-map-lazy-loader.js
+++ b/js/vtt/dm-map-lazy-loader.js
@@ -1,0 +1,46 @@
+(function (root, factory) {
+  const api = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttDmMapLazyLoader = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (browserRoot) {
+  'use strict';
+
+  function ensureLoaded(documentRef = browserRoot?.document) {
+    const section = documentRef?.getElementById?.('modulo-mapa');
+    const frame = section?.querySelector?.('iframe[data-vtt-src]');
+    if (!section || !frame || !section.classList?.contains?.('active-module')) return false;
+    if (frame.getAttribute?.('src')) return true;
+
+    const src = String(frame.dataset?.vttSrc || frame.getAttribute?.('data-vtt-src') || '').trim();
+    if (!src) return false;
+    frame.setAttribute?.('src', src);
+    return true;
+  }
+
+  function start({ documentRef = browserRoot?.document, MutationObserverCtor = browserRoot?.MutationObserver } = {}) {
+    const section = documentRef?.getElementById?.('modulo-mapa');
+    if (!section) return () => {};
+
+    const check = () => ensureLoaded(documentRef);
+    check();
+
+    if (typeof MutationObserverCtor !== 'function') return () => {};
+    const observer = new MutationObserverCtor(check);
+    observer.observe(section, { attributes: true, attributeFilter: ['class', 'aria-hidden'] });
+    return () => observer.disconnect();
+  }
+
+  function autoStart() {
+    const documentRef = browserRoot?.document;
+    if (!documentRef) return;
+    const boot = () => {
+      if (browserRoot.__luminousVttDmMapLazyLoaderStop) return;
+      browserRoot.__luminousVttDmMapLazyLoaderStop = start({ documentRef });
+    };
+    if (documentRef.readyState === 'loading') documentRef.addEventListener('DOMContentLoaded', boot, { once: true });
+    else boot();
+  }
+
+  autoStart();
+  return Object.freeze({ ensureLoaded, start });
+});

--- a/js/vtt/main.js
+++ b/js/vtt/main.js
@@ -4,6 +4,7 @@ import { VerticalPortalController } from './vertical-portal-controller.js';
 import { mockMapData } from './mapData.js';
 import './map-authoring.js';
 import './map-authoring-state.js';
+import './map-switch-guard.js';
 import './actor-library.js';
 import './actor-library-state.js';
 import './token-state-dynamic-patch.js';
@@ -149,9 +150,22 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
 
     const initialMapId = String(mockMapData.id || mockMapData.mapId || 'default');
+    const mapSwitchGuard = globalThis.LuminousVttMapSwitchGuard?.createGuard?.({
+        currentMapId: initialMapId,
+        resolveActiveDefinition: () => mapAuthoringState?.resolveActiveDefinition?.({ fallback: mockMapData }),
+        reload: () => window.location.reload(),
+        notify: (message, mode) => controller?.notify?.(message, mode),
+        log: console,
+    }) || null;
     const stopMapWatch = mapAuthoringState?.watchActiveMap?.({
         onChanged: (mapId) => {
-            if (mapId && String(mapId) !== initialMapId) window.location.reload();
+            if (!mapId || String(mapId) === initialMapId) return;
+            if (!mapSwitchGuard) {
+                console.error('VTT map switch guard unavailable; refusing blind reload.', { initialMapId, mapId });
+                controller?.notify?.('No se pudo validar el cambio de mapa. Se mantiene el mapa actual.', 'error');
+                return;
+            }
+            void mapSwitchGuard(mapId);
         },
     }) || (() => {});
 

--- a/js/vtt/map-switch-guard.js
+++ b/js/vtt/map-switch-guard.js
@@ -1,0 +1,60 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttMapSwitchGuard = api;
+})(typeof window !== 'undefined' ? window : globalThis, function () {
+  'use strict';
+
+  const clean = (value) => String(value ?? '').trim();
+
+  function createGuard({ currentMapId, resolveActiveDefinition, reload, notify, log = console } = {}) {
+    const current = clean(currentMapId) || 'default';
+    let reloadPending = false;
+
+    return async function handleMapChanged(mapId) {
+      const target = clean(mapId);
+      if (!target || target === current) return { action: 'ignore', reason: 'SAME_OR_EMPTY' };
+      if (reloadPending) return { action: 'ignore', reason: 'RELOAD_PENDING' };
+
+      reloadPending = true;
+      try {
+        const definition = typeof resolveActiveDefinition === 'function'
+          ? await resolveActiveDefinition()
+          : null;
+        const resolvedId = clean(definition?.id || definition?.mapId);
+
+        if (!definition || resolvedId !== target) {
+          reloadPending = false;
+          log?.error?.('VTT map switch blocked: active map definition unavailable.', {
+            currentMapId: current,
+            targetMapId: target,
+            resolvedMapId: resolvedId || null,
+          });
+          notify?.(`No se pudo activar el mapa "${target}". Se mantiene el mapa actual.`, 'error');
+          return {
+            action: 'blocked',
+            reason: 'MAP_DEFINITION_UNAVAILABLE',
+            targetMapId: target,
+            resolvedMapId: resolvedId || null,
+          };
+        }
+
+        if (typeof reload !== 'function') {
+          reloadPending = false;
+          notify?.('No se pudo recargar el VTT para completar el cambio de mapa.', 'error');
+          return { action: 'blocked', reason: 'RELOAD_UNAVAILABLE', targetMapId: target };
+        }
+
+        reload();
+        return { action: 'reload', targetMapId: target };
+      } catch (error) {
+        reloadPending = false;
+        log?.error?.('VTT map switch validation failed.', error);
+        notify?.(`No se pudo validar el mapa "${target}". Se mantiene el mapa actual.`, 'error');
+        return { action: 'blocked', reason: 'VALIDATION_FAILED', targetMapId: target, error };
+      }
+    };
+  }
+
+  return Object.freeze({ createGuard });
+});

--- a/tests/vtt_instance_activation.spec.js
+++ b/tests/vtt_instance_activation.spec.js
@@ -10,7 +10,8 @@ const dashboardCss = read('css/on-game-dashboard.css');
 test('DM game controls expose the tactical map as a canonical instance', () => {
     expect(dashboardHtml).toContain('name="instancia" value="mapa"');
     expect(dashboardHtml).toContain('id="modulo-mapa"');
-    expect(dashboardHtml).toContain('<iframe src="vtt.html" title="Mapa táctico D&amp;D"></iframe>');
+    expect(dashboardHtml).toContain('<iframe data-vtt-src="vtt.html" title="Mapa táctico D&amp;D"></iframe>');
+    expect(dashboardHtml).toContain('js/vtt/dm-map-lazy-loader.js');
     expect(instanceSource).toContain('activeInstance === "mapa"');
     expect(instanceSource).toContain('activeModuleId = "modulo-mapa"');
     expect(instanceSource).toContain('SALIDA ACTUAL: MAPA TÁCTICO');

--- a/tests/vtt_map_switch_bootstrap.spec.js
+++ b/tests/vtt_map_switch_bootstrap.spec.js
@@ -1,0 +1,86 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+const mapSwitchGuard = require('../js/vtt/map-switch-guard.js');
+const dmMapLazyLoader = require('../js/vtt/dm-map-lazy-loader.js');
+
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+function fakeDmMapDom(initiallyActive = false) {
+  let active = initiallyActive;
+  const attributes = new Map([['data-vtt-src', 'vtt.html']]);
+  const frame = {
+    dataset: { vttSrc: 'vtt.html' },
+    getAttribute(name) { return attributes.get(name) || null; },
+    setAttribute(name, value) { attributes.set(name, String(value)); },
+  };
+  const section = {
+    classList: { contains(name) { return name === 'active-module' && active; } },
+    querySelector(selector) { return selector === 'iframe[data-vtt-src]' ? frame : null; },
+  };
+  const documentRef = {
+    getElementById(id) { return id === 'modulo-mapa' ? section : null; },
+  };
+  return { documentRef, frame, setActive(value) { active = Boolean(value); } };
+}
+
+test('DM VTT iframe remains unloaded until MAPA is the active module', () => {
+  const dom = fakeDmMapDom(false);
+  expect(dmMapLazyLoader.ensureLoaded(dom.documentRef)).toBe(false);
+  expect(dom.frame.getAttribute('src')).toBeNull();
+
+  dom.setActive(true);
+  expect(dmMapLazyLoader.ensureLoaded(dom.documentRef)).toBe(true);
+  expect(dom.frame.getAttribute('src')).toBe('vtt.html');
+});
+
+test('invalid active-map definition is blocked instead of causing a reload loop', async () => {
+  let reloads = 0;
+  const notices = [];
+  const guard = mapSwitchGuard.createGuard({
+    currentMapId: 'map_a',
+    resolveActiveDefinition: async () => null,
+    reload: () => { reloads += 1; },
+    notify: (message, mode) => notices.push({ message, mode }),
+    log: { error() {} },
+  });
+
+  const result = await guard('map_b');
+  expect(result.action).toBe('blocked');
+  expect(result.reason).toBe('MAP_DEFINITION_UNAVAILABLE');
+  expect(reloads).toBe(0);
+  expect(notices.at(-1)?.mode).toBe('error');
+});
+
+test('valid map switch reloads exactly once while navigation is pending', async () => {
+  let reloads = 0;
+  const guard = mapSwitchGuard.createGuard({
+    currentMapId: 'map_a',
+    resolveActiveDefinition: async () => ({ id: 'map_b' }),
+    reload: () => { reloads += 1; },
+    log: { error() {} },
+  });
+
+  const first = await guard('map_b');
+  const second = await guard('map_b');
+  expect(first.action).toBe('reload');
+  expect(second).toEqual({ action: 'ignore', reason: 'RELOAD_PENDING' });
+  expect(reloads).toBe(1);
+});
+
+test('DM dashboard uses lazy VTT source and loads the lazy bootstrap before dashboard binding', () => {
+  const html = read('hoja_de_DM.html');
+  expect(html).toContain('<iframe data-vtt-src="vtt.html" title="Mapa táctico D&amp;D"></iframe>');
+  expect(html).not.toContain('<iframe src="vtt.html" title="Mapa táctico D&amp;D"></iframe>');
+  expect(html.indexOf('js/vtt/dm-map-lazy-loader.js')).toBeGreaterThan(-1);
+  expect(html.indexOf('js/vtt/dm-map-lazy-loader.js')).toBeLessThan(html.indexOf('js/on-game-dashboard.js'));
+});
+
+test('VTT main routes active-map changes through the validated switch guard', () => {
+  const source = read('js/vtt/main.js');
+  expect(source).toContain("import './map-switch-guard.js';");
+  expect(source).toContain('LuminousVttMapSwitchGuard?.createGuard?.');
+  expect(source).toContain('resolveActiveDefinition: () => mapAuthoringState?.resolveActiveDefinition?.');
+  expect(source).toContain('void mapSwitchGuard(mapId);');
+  expect(source).toContain('refusing blind reload');
+});


### PR DESCRIPTION
## Summary
- Defers the DM `vtt.html` iframe until `MAPA TÁCTICO` is actually the active dashboard module, preventing the hidden VTT from capturing an unavailable parent Firebase runtime during page bootstrap.
- Adds a guarded active-map switch path: a client validates that the new `vttMapActive` resolves to the requested canonical map definition before reloading.
- Blocks invalid/unavailable map definitions with an in-VTT error instead of blindly reloading, preventing infinite reload loops for both DM and player clients.
- Keeps the current map running when validation fails.

## Regression coverage
- DM map iframe has no eager `src` and is loaded only after the map module becomes active.
- Missing active-map definitions never call reload.
- Valid map changes reload exactly once while navigation is pending.
- `js/vtt/main.js` is wired through the validated map-switch guard.

## Scope
This patch does not change map schemas, token persistence, movement, lighting, Fog/Memory, or map authoring semantics. It only hardens VTT bootstrap and active-map transitions.