### PR TITLE
fix(vtt): tear down map runtimes before returning to Theatre

### DIFF
--- a/js/instance-control.js
+++ b/js/instance-control.js
@@ -329,7 +329,7 @@
     script.id = "character-manager-engine-script";
     script.src = "js/character-manager-engine.js";
     script.async = false;
-    script.dataset.ui = "character-manager";
+    script.dataset.engine = "character-manager";
     script.addEventListener("load", initialize, { once: true });
     documentRef.head?.appendChild(script);
     return script;

--- a/js/instance-control.js
+++ b/js/instance-control.js
@@ -108,6 +108,14 @@
     return chain.then(() => true);
   }
 
+  function teardownPlayerMapView(mapView) {
+    if (!mapView) return false;
+    mapView.removeAttribute?.("src");
+    if (typeof mapView.remove === "function") mapView.remove();
+    else mapView.parentNode?.removeChild?.(mapView);
+    return true;
+  }
+
   function applyPlayerInstance(instance, doc) {
     const documentRef = doc || global.document;
     const activeInstance = normalizeInstance(instance);
@@ -148,6 +156,11 @@
       });
       mapView.src = "vtt.html";
       documentRef.body.appendChild(mapView);
+    }
+
+    if (mapView && !mapActive) {
+      teardownPlayerMapView(mapView);
+      mapView = null;
     }
 
     if (combatView?.contentDocument?.readyState === "complete") {
@@ -316,7 +329,7 @@
     script.id = "character-manager-engine-script";
     script.src = "js/character-manager-engine.js";
     script.async = false;
-    script.dataset.engine = "character-manager";
+    script.dataset.ui = "character-manager";
     script.addEventListener("load", initialize, { once: true });
     documentRef.head?.appendChild(script);
     return script;

--- a/js/vtt/dm-map-lazy-loader.js
+++ b/js/vtt/dm-map-lazy-loader.js
@@ -5,9 +5,14 @@
 })(typeof window !== 'undefined' ? window : globalThis, function (browserRoot) {
   'use strict';
 
-  function ensureLoaded(documentRef = browserRoot?.document) {
+  function resolveMapFrame(documentRef = browserRoot?.document) {
     const section = documentRef?.getElementById?.('modulo-mapa');
     const frame = section?.querySelector?.('iframe[data-vtt-src]');
+    return { section, frame };
+  }
+
+  function ensureLoaded(documentRef = browserRoot?.document) {
+    const { section, frame } = resolveMapFrame(documentRef);
     if (!section || !frame || !section.classList?.contains?.('active-module')) return false;
     if (frame.getAttribute?.('src')) return true;
 
@@ -17,11 +22,31 @@
     return true;
   }
 
+  function ensureUnloaded(documentRef = browserRoot?.document) {
+    const { section, frame } = resolveMapFrame(documentRef);
+    if (!section || !frame || section.classList?.contains?.('active-module')) return false;
+    if (!frame.getAttribute?.('src')) return false;
+
+    // Navigating an iframe with its src removed tears down the VTT document.
+    // That gives vtt/main.js a real unload lifecycle so its animation loop,
+    // Firebase subscriptions and bridges cannot keep running behind Theatre.
+    frame.removeAttribute?.('src');
+    return !frame.getAttribute?.('src');
+  }
+
+  function sync(documentRef = browserRoot?.document) {
+    const { section } = resolveMapFrame(documentRef);
+    if (!section) return false;
+    return section.classList?.contains?.('active-module')
+      ? ensureLoaded(documentRef)
+      : ensureUnloaded(documentRef);
+  }
+
   function start({ documentRef = browserRoot?.document, MutationObserverCtor = browserRoot?.MutationObserver } = {}) {
     const section = documentRef?.getElementById?.('modulo-mapa');
     if (!section) return () => {};
 
-    const check = () => ensureLoaded(documentRef);
+    const check = () => sync(documentRef);
     check();
 
     if (typeof MutationObserverCtor !== 'function') return () => {};
@@ -42,5 +67,5 @@
   }
 
   autoStart();
-  return Object.freeze({ ensureLoaded, start });
+  return Object.freeze({ ensureLoaded, ensureUnloaded, sync, start });
 });

--- a/tests/vtt_instance_activation.spec.js
+++ b/tests/vtt_instance_activation.spec.js
@@ -1,11 +1,69 @@
 const { test, expect } = require('@playwright/test');
 const fs = require('node:fs');
 const path = require('node:path');
+const vm = require('node:vm');
 
 const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
 const dashboardHtml = read('hoja_de_DM.html');
 const instanceSource = read('js/instance-control.js');
 const dashboardCss = read('css/on-game-dashboard.css');
+
+function fakeClassList() {
+    return { add() {}, remove() {}, toggle() {}, contains() { return false; } };
+}
+
+function createPlayerDocument() {
+    const nodes = new Map();
+    const theatre = {
+        id: 'theatre-view-player',
+        style: {},
+        classList: fakeClassList(),
+        setAttribute() {},
+    };
+    nodes.set(theatre.id, theatre);
+
+    const body = {
+        classList: fakeClassList(),
+        appendChild(node) {
+            node.parentNode = body;
+            nodes.set(node.id, node);
+            return node;
+        },
+        removeChild(node) {
+            nodes.delete(node.id);
+            node.parentNode = null;
+            node.removed = true;
+            return node;
+        },
+    };
+
+    return {
+        body,
+        getElementById(id) { return nodes.get(id) || null; },
+        createElement(tagName) {
+            const attributes = new Map();
+            return {
+                tagName: String(tagName).toUpperCase(),
+                style: {},
+                dataset: {},
+                classList: fakeClassList(),
+                setAttribute(name, value) { attributes.set(name, String(value)); },
+                removeAttribute(name) { attributes.delete(name); },
+                addEventListener() {},
+                remove() {
+                    if (this.parentNode) this.parentNode.removeChild(this);
+                    else this.removed = true;
+                },
+            };
+        },
+    };
+}
+
+function loadInstanceControl() {
+    const context = { window: {}, console };
+    vm.runInNewContext(instanceSource, context, { filename: 'js/instance-control.js' });
+    return context.window.LuminousInstanceControl;
+}
 
 test('DM game controls expose the tactical map as a canonical instance', () => {
     expect(dashboardHtml).toContain('name="instancia" value="mapa"');
@@ -23,6 +81,27 @@ test('player instance routing opens the same VTT when the DM activates mapa', ()
     expect(instanceSource).toContain('mapView.src = "vtt.html"');
     expect(instanceSource).toContain('mapView.style.display = mapActive ? "block" : "none"');
     expect(instanceSource).toContain('documentRef.body.classList.toggle("player-instance-map", mapActive)');
+});
+
+test('player map runtime is destroyed on MAPA -> TEATRO and recreated on return', () => {
+    const instanceControl = loadInstanceControl();
+    const documentRef = createPlayerDocument();
+
+    instanceControl.applyPlayerInstance('mapa', documentRef);
+    const firstMap = documentRef.getElementById('player-instance-map');
+    expect(firstMap).not.toBeNull();
+    expect(firstMap.src).toBe('vtt.html');
+
+    instanceControl.applyPlayerInstance('teatro', documentRef);
+    expect(firstMap.removed).toBe(true);
+    expect(documentRef.getElementById('player-instance-map')).toBeNull();
+    expect(documentRef.getElementById('theatre-view-player').style.display).toBe('flex');
+
+    instanceControl.applyPlayerInstance('mapa', documentRef);
+    const secondMap = documentRef.getElementById('player-instance-map');
+    expect(secondMap).not.toBeNull();
+    expect(secondMap).not.toBe(firstMap);
+    expect(secondMap.src).toBe('vtt.html');
 });
 
 test('map module owns the available dashboard viewport', () => {

--- a/tests/vtt_map_switch_bootstrap.spec.js
+++ b/tests/vtt_map_switch_bootstrap.spec.js
@@ -13,6 +13,7 @@ function fakeDmMapDom(initiallyActive = false) {
     dataset: { vttSrc: 'vtt.html' },
     getAttribute(name) { return attributes.get(name) || null; },
     setAttribute(name, value) { attributes.set(name, String(value)); },
+    removeAttribute(name) { attributes.delete(name); },
   };
   const section = {
     classList: { contains(name) { return name === 'active-module' && active; } },
@@ -31,6 +32,21 @@ test('DM VTT iframe remains unloaded until MAPA is the active module', () => {
 
   dom.setActive(true);
   expect(dmMapLazyLoader.ensureLoaded(dom.documentRef)).toBe(true);
+  expect(dom.frame.getAttribute('src')).toBe('vtt.html');
+});
+
+test('DM VTT iframe is torn down on MAPA -> TEATRO and can reload on re-entry', () => {
+  const dom = fakeDmMapDom(true);
+
+  expect(dmMapLazyLoader.sync(dom.documentRef)).toBe(true);
+  expect(dom.frame.getAttribute('src')).toBe('vtt.html');
+
+  dom.setActive(false);
+  expect(dmMapLazyLoader.sync(dom.documentRef)).toBe(true);
+  expect(dom.frame.getAttribute('src')).toBeNull();
+
+  dom.setActive(true);
+  expect(dmMapLazyLoader.sync(dom.documentRef)).toBe(true);
   expect(dom.frame.getAttribute('src')).toBe('vtt.html');
 });
 


### PR DESCRIPTION
## Summary
- turns the DM VTT lazy loader into a full active/inactive lifecycle guard
- unloads the DM `vtt.html` iframe when `MAPA TÁCTICO` stops being active
- removes the player's dynamic `player-instance-map` iframe when `instancia_activa` leaves `mapa`
- lets the VTT document run its unload cleanup instead of leaving render loops, Firebase subscriptions and bridges alive behind Theatre
- recreates a clean VTT iframe when either side returns to Map

## Root cause
PR #629 fixed early DM map bootstrap and guarded map-switch reload loops, but it did not cover the reverse transition after the VTT had already started. Both dashboard paths hid the map without tearing it down:

- DM: `modulo-mapa` lost `active-module`, while its `vtt.html` iframe retained `src`
- Player: `applyPlayerInstance()` changed `player-instance-map` to `display:none`

`js/vtt/main.js` performs its runtime cleanup on document unload, so those hidden iframes kept the VTT runtime alive while Theatre became active.

## Regression coverage
Adds both missing lifecycle sequences:
1. DM Map active -> VTT loads
2. DM Map inactive / Theatre active -> VTT iframe unloads
3. DM Map active again -> VTT reloads cleanly
4. Player Map active -> dynamic VTT iframe exists
5. Player Theatre active -> player VTT iframe is destroyed
6. Player Map active again -> a new VTT iframe is created

## Scope
No map schema, token state, movement, lighting, Fog/Memory, Theatre scene state or Firebase authority semantics are changed. The patch is limited to iframe lifecycle and regression coverage.