### PR TITLE
feat(vtt): surface materials, sparse floor grid and DM painter

### DIFF
--- a/.github/workflows/vtt-surface-foundation.yml
+++ b/.github/workflows/vtt-surface-foundation.yml
@@ -1,0 +1,37 @@
+name: VTT Surface Foundation
+
+on:
+  pull_request:
+    paths:
+      - 'js/vtt/surface-*.js'
+      - 'js/vtt/main.js'
+      - 'js/vtt/map-authoring*.js'
+      - 'js/vtt/pathfinding.js'
+      - 'tests/vtt_surface_foundation.spec.js'
+      - '.github/workflows/vtt-surface-foundation.yml'
+  workflow_dispatch:
+
+jobs:
+  surface-foundation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Syntax
+        run: |
+          node --check js/vtt/surface-core.js
+          node --check js/vtt/surface-renderer.js
+          node --check js/vtt/surface-authoring-patch.js
+          node --input-type=module --check < js/vtt/surface-bootstrap.js
+          node --input-type=module --check < js/vtt/main.js
+          node --check tests/vtt_surface_foundation.spec.js
+      - name: Focused contracts
+        run: npx playwright test tests/vtt_surface_foundation.spec.js tests/vtt_map_hud_physical.spec.js --workers=1
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Repository regression
+        run: npx playwright test --workers=1

--- a/js/vtt/main.js
+++ b/js/vtt/main.js
@@ -3,6 +3,9 @@ import { TopologyController } from './topology-controller.js';
 import { VerticalPortalController } from './vertical-portal-controller.js';
 import { mockMapData } from './mapData.js';
 import './map-authoring.js';
+import './surface-core.js';
+import './surface-renderer.js';
+import './surface-authoring-patch.js';
 import './map-authoring-state.js';
 import './map-switch-guard.js';
 import './actor-library.js';
@@ -30,6 +33,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     } catch (error) {
         console.warn('VTT map authoring: falling back to bundled map.', error);
     }
+    globalThis.LuminousVttSurfaceCore?.ensureMapState?.(mockMapData);
 
     mockMapData.dmEditMode ||= { active: false };
     const engine = new Engine(canvas, mockMapData);
@@ -175,8 +179,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     }) || (() => {});
 
     import('./map-authoring-bootstrap.js')
-        .then((module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }))
-        .catch((error) => console.error('VTT map authoring bootstrap failed:', error));
+        .then(async (module) => {
+            module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
+            const surfaceModule = await import('./surface-bootstrap.js');
+            return surfaceModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
+        })
+        .catch((error) => console.error('VTT map authoring / surfaces bootstrap failed:', error));
     import('./actor-library-bootstrap.js')
         .then((module) => {
             const actorLibrary = module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
@@ -209,6 +217,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     window.addEventListener('beforeunload', () => {
         stopMapWatch();
+        window.LuminousVttSurfaceRuntime?.stop?.();
         window.LuminousVttMapHudRuntime?.stop?.();
         window.LuminousVttRuntime?.movement?.stop?.();
         window.LuminousVttRuntime?.worldObjects?.stop?.();

--- a/js/vtt/surface-authoring-patch.js
+++ b/js/vtt/surface-authoring-patch.js
@@ -1,0 +1,82 @@
+(function (root, factory) {
+  const api = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttSurfaceAuthoringPatch = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (root) {
+  'use strict';
+
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+  function install() {
+    const base = root?.LuminousVttMapAuthoring;
+    const core = root?.LuminousVttSurfaceCore;
+    if (!base || !core) return null;
+    if (base.__surfaceAware === true) return base;
+
+    function surfacePayload(raw = {}, fallback = {}) {
+      const materials = core.normalizeMaterialCatalog(raw.surfaceMaterials || fallback.surfaceMaterials || null);
+      const grid = raw.grid || fallback.grid || base.DEFAULT_GRID || {};
+      const layers = core.normalizeLayers(raw.surfaceLayers || fallback.surfaceLayers || {}, grid, materials);
+      return { surfaceMaterials: materials, surfaceLayers: layers };
+    }
+
+    function attachSurfaces(definition, raw = {}, fallback = {}) {
+      return { ...definition, ...surfacePayload(raw, fallback) };
+    }
+
+    function normalizeDefinition(raw = {}, fallback = {}) {
+      return attachSurfaces(base.normalizeDefinition(raw, fallback), raw, fallback);
+    }
+
+    function definitionFromMapData(mapData = {}) {
+      return attachSurfaces(base.definitionFromMapData(mapData), mapData, mapData);
+    }
+
+    function applyDefinition(mapData, rawDefinition, options = {}) {
+      const normalized = normalizeDefinition(rawDefinition, mapData || {});
+      base.applyDefinition(mapData, normalized, options);
+      mapData.surfaceMaterials = clone(normalized.surfaceMaterials);
+      mapData.surfaceLayers = clone(normalized.surfaceLayers);
+      core.ensureMapState(mapData);
+      return mapData;
+    }
+
+    function preserveSurfaces(fn) {
+      return function wrapped(rawDefinition, ...args) {
+        const result = fn(rawDefinition, ...args);
+        return attachSurfaces(result, rawDefinition || {}, rawDefinition || {});
+      };
+    }
+
+    function canDeleteLevel(mapData = {}, zLayer = 0) {
+      const gate = base.canDeleteLevel(mapData, zLayer);
+      if (!gate.valid) return gate;
+      const surfaces = core.cellsOnLayer(mapData, zLayer);
+      if (surfaces.length) return { valid:false, reason:'FLOOR_IN_USE', dependencies:{ ...(gate.dependencies || {}), surfaces } };
+      return { ...gate, dependencies:{ ...(gate.dependencies || {}), surfaces:[] } };
+    }
+
+    function createDefinition(options = {}) {
+      const definition = base.createDefinition(options);
+      return attachSurfaces(definition, options, { grid: definition.grid });
+    }
+
+    const patched = Object.freeze({
+      ...base,
+      __surfaceAware: true,
+      normalizeDefinition,
+      definitionFromMapData,
+      applyDefinition,
+      addLevel: preserveSurfaces(base.addLevel),
+      updateLevel: preserveSurfaces(base.updateLevel),
+      removeLevel: preserveSurfaces(base.removeLevel),
+      canDeleteLevel,
+      createDefinition,
+    });
+    root.LuminousVttMapAuthoring = patched;
+    return patched;
+  }
+
+  const installed = install();
+  return Object.freeze({ install, installed });
+});

--- a/js/vtt/surface-bootstrap.js
+++ b/js/vtt/surface-bootstrap.js
@@ -1,0 +1,244 @@
+import './surface-core.js';
+import './surface-renderer.js';
+
+const TOOLBAR_ID = 'vtt-surface-toolbar';
+const STYLE_ID = 'vtt-surface-style';
+const clean = (value) => String(value ?? '').trim();
+
+function ensureStyles() {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+    #${TOOLBAR_ID}{border-color:#476b55!important}
+    #${TOOLBAR_ID} .vtt-surface-material{display:grid;gap:4px;padding-top:6px;border-top:1px solid #3c4147;color:#9eabb3;font:9px monospace}
+    #${TOOLBAR_ID} .vtt-surface-material select{width:100%;min-width:0;box-sizing:border-box;background:#090c0e;color:#e6ecef;border:1px solid #59636c;padding:5px;font:10px monospace}
+    #${TOOLBAR_ID} .vtt-surface-status{padding:5px;border:1px solid #38434a;background:#0b0e11;color:#9eabb3;font:9px monospace;line-height:1.35}
+    #${TOOLBAR_ID} button.is-active{border-color:#82c696!important;color:#82c696!important}
+  `;
+  document.head.appendChild(style);
+}
+
+function ensureToolbar(core, mapData) {
+  let toolbar = document.getElementById(TOOLBAR_ID);
+  if (toolbar) return toolbar;
+  ensureStyles();
+  toolbar = document.createElement('div');
+  toolbar.id = TOOLBAR_ID;
+  toolbar.className = 'vtt-toolbar vtt-surface-toolbar';
+  toolbar.setAttribute('aria-label', 'Surface painter');
+  const materials = Object.values(mapData.surfaceMaterials || core.defaultMaterialCatalog());
+  toolbar.innerHTML = `
+    <span class="vtt-toolbar-title">SURFACES</span>
+    <button type="button" class="brutalist-button" data-surface-tool="select">SELECT</button>
+    <button type="button" class="brutalist-button" data-surface-tool="brush">BRUSH</button>
+    <button type="button" class="brutalist-button" data-surface-tool="rect">RECTANGLE</button>
+    <button type="button" class="brutalist-button" data-surface-tool="erase">ERASE</button>
+    <label class="vtt-surface-material"><span>MATERIAL</span><select data-surface-material>${materials.map((material) => `<option value="${material.id}">${material.name.toUpperCase()} · ×${Number(material.movement?.costMultiplier || 1).toFixed(2)}</option>`).join('')}</select></label>
+    <div class="vtt-surface-status" data-surface-status>READY</div>
+  `;
+  const host = document.getElementById('vtt-edit-sidebar') || document.getElementById('vtt-ui-container') || document.body;
+  host.appendChild(toolbar);
+  return toolbar;
+}
+
+export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.engine?.mapData } = {}) {
+  if (!runtime?.engine || !mapData) return null;
+  if (window.LuminousVttSurfaceRuntime?.api) return window.LuminousVttSurfaceRuntime.api;
+  const core = window.LuminousVttSurfaceCore;
+  if (!core) throw new Error('SURFACE_CORE_REQUIRED');
+  core.ensureMapState(mapData);
+
+  const engine = runtime.engine;
+  const canvas = engine.canvas;
+  const isDm = Boolean(runtime.bridge?.isDm);
+  let stopped = false;
+  let tool = isDm ? 'brush' : 'select';
+  let materialId = Object.keys(mapData.surfaceMaterials || {})[0] || 'concrete';
+  let painting = false;
+  let rectStart = null;
+  let lastCellKey = null;
+  let saveTimer = null;
+  let saveInFlight = Promise.resolve();
+  const toolbar = isDm ? ensureToolbar(core, mapData) : null;
+
+  const currentRuntime = () => window.LuminousVttRuntime || runtime;
+  const activeZ = () => Number(engine.activeZ) || 0;
+  const painterEnabled = () => isDm && mapData.dmEditMode?.active === true && tool !== 'select';
+
+  function cellAtEvent(event) {
+    const rect = canvas.getBoundingClientRect();
+    const point = engine.camera.screenToWorld(event.clientX - rect.left, event.clientY - rect.top);
+    const size = Math.max(1, Number(mapData.grid?.size) || 70);
+    const cols = Math.max(1, Number(mapData.grid?.cols) || 1);
+    const rows = Math.max(1, Number(mapData.grid?.rows) || 1);
+    const col = Math.floor(point.x / size), row = Math.floor(point.y / size);
+    if (col < 0 || row < 0 || col >= cols || row >= rows) return null;
+    return { col, row };
+  }
+
+  function statusText() {
+    const material = core.materialFor(mapData, materialId);
+    const count = core.cellsOnLayer(mapData, activeZ()).length;
+    return `${tool.toUpperCase()} · ${clean(material?.name || materialId).toUpperCase()} · Z${activeZ()} · ${count} CELLS`;
+  }
+
+  function syncUi() {
+    if (!toolbar) return;
+    toolbar.querySelectorAll('[data-surface-tool]').forEach((button) => button.classList.toggle('is-active', button.dataset.surfaceTool === tool));
+    const select = toolbar.querySelector('[data-surface-material]');
+    if (select && select.value !== materialId && [...select.options].some((option) => option.value === materialId)) select.value = materialId;
+    const status = toolbar.querySelector('[data-surface-status]');
+    if (status) status.textContent = statusText();
+  }
+
+  function emit(reason, cells = []) {
+    canvas.dispatchEvent(new CustomEvent('vtt:surface-changed', {
+      detail: { reason, zLayer: activeZ(), materialId, cells },
+    }));
+    syncUi();
+  }
+
+  function paintCell(cell) {
+    if (!cell) return false;
+    const key = core.cellKey(cell.col, cell.row);
+    if (painting && key === lastCellKey) return false;
+    lastCellKey = key;
+    if (tool === 'erase') {
+      const changed = core.eraseCell(mapData, activeZ(), cell.col, cell.row);
+      if (changed) emit('erase', [cell]);
+      return changed;
+    }
+    const changed = Boolean(core.setCell(mapData, activeZ(), cell.col, cell.row, materialId));
+    if (changed) emit('paint', [cell]);
+    return changed;
+  }
+
+  async function persistNow() {
+    if (!isDm || stopped) return false;
+    const authoring = window.LuminousVttMapAuthoring;
+    const bridge = currentRuntime()?.mapAuthoring?.bridge;
+    if (!authoring?.definitionFromMapData || !bridge?.saveDefinition) return false;
+    const definition = authoring.definitionFromMapData(mapData);
+    await bridge.saveDefinition(definition);
+    return true;
+  }
+
+  function schedulePersist(delay = 180) {
+    if (!isDm) return;
+    if (saveTimer != null) window.clearTimeout(saveTimer);
+    saveTimer = window.setTimeout(() => {
+      saveTimer = null;
+      saveInFlight = saveInFlight.then(() => persistNow()).catch((error) => {
+        console.error('VTT surface persistence failed:', error);
+        currentRuntime()?.controller?.notify?.('No se pudo guardar la superficie del mapa.', 'error');
+      });
+    }, Math.max(0, Number(delay) || 0));
+  }
+
+  function finishStroke(event = null) {
+    if (!painting && !rectStart) return;
+    if (tool === 'rect' && rectStart && event) {
+      const end = cellAtEvent(event);
+      if (end) {
+        const changed = core.paintRect(mapData, activeZ(), rectStart, end, materialId);
+        if (changed) emit('paint-rect', [rectStart, end]);
+      }
+    }
+    painting = false;
+    rectStart = null;
+    lastCellKey = null;
+    schedulePersist();
+  }
+
+  function setTool(nextTool) {
+    const next = ['select','brush','rect','erase'].includes(nextTool) ? nextTool : 'select';
+    tool = next;
+    painting = false;
+    rectStart = null;
+    lastCellKey = null;
+    if (next !== 'select') {
+      currentRuntime()?.controller?.setTool?.('select');
+      currentRuntime()?.verticalController?.setTool?.('select', false);
+    }
+    syncUi();
+    return tool;
+  }
+
+  function setMaterial(nextId) {
+    if (!core.materialFor(mapData, nextId)) throw new Error('SURFACE_MATERIAL_NOT_FOUND');
+    materialId = nextId;
+    syncUi();
+    return materialId;
+  }
+
+  const onPointerDown = (event) => {
+    if (!painterEnabled() || event.button !== 0) return;
+    const cell = cellAtEvent(event);
+    if (!cell) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    painting = true;
+    lastCellKey = null;
+    if (tool === 'rect') rectStart = cell;
+    else paintCell(cell);
+  };
+
+  const onPointerMove = (event) => {
+    if (!painting || !painterEnabled() || tool === 'rect') return;
+    const cell = cellAtEvent(event);
+    if (!cell) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    paintCell(cell);
+  };
+
+  const onPointerUp = (event) => {
+    if ((!painting && !rectStart) || event.button !== 0) return;
+    if (painterEnabled()) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+    finishStroke(event);
+  };
+
+  const onExternalTool = (event) => {
+    const target = event.target?.closest?.('[data-vtt-tool],[data-vtt-vertical-tool],[data-light-tool]');
+    if (target) setTool('select');
+  };
+
+  canvas.addEventListener('mousedown', onPointerDown, true);
+  window.addEventListener('mousemove', onPointerMove, true);
+  window.addEventListener('mouseup', onPointerUp, true);
+  document.addEventListener('click', onExternalTool, true);
+
+  if (toolbar) {
+    toolbar.addEventListener('click', (event) => {
+      const nextTool = event.target.closest?.('[data-surface-tool]')?.dataset?.surfaceTool;
+      if (nextTool) setTool(nextTool);
+    });
+    toolbar.querySelector('[data-surface-material]')?.addEventListener('change', (event) => setMaterial(event.target.value));
+  }
+
+  const uiTimer = window.setInterval(syncUi, 300);
+  syncUi();
+
+  function stop() {
+    if (stopped) return;
+    stopped = true;
+    if (saveTimer != null) window.clearTimeout(saveTimer);
+    window.clearInterval(uiTimer);
+    canvas.removeEventListener('mousedown', onPointerDown, true);
+    window.removeEventListener('mousemove', onPointerMove, true);
+    window.removeEventListener('mouseup', onPointerUp, true);
+    document.removeEventListener('click', onExternalTool, true);
+    toolbar?.remove();
+    document.getElementById(STYLE_ID)?.remove();
+  }
+
+  const api = Object.freeze({ core, setTool, setMaterial, getTool: () => tool, getMaterialId: () => materialId, persistNow, syncUi, stop });
+  window.LuminousVttSurfaceRuntime = Object.freeze({ api, stop });
+  const current = currentRuntime();
+  window.LuminousVttRuntime = Object.freeze({ ...current, surfaces: api });
+  return api;
+}

--- a/js/vtt/surface-bootstrap.js
+++ b/js/vtt/surface-bootstrap.js
@@ -46,11 +46,13 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   if (!runtime?.engine || !mapData) return null;
   if (window.LuminousVttSurfaceRuntime?.api) return window.LuminousVttSurfaceRuntime.api;
   const core = window.LuminousVttSurfaceCore;
-  if (!core) throw new Error('SURFACE_CORE_REQUIRED');
+  const surfaceRenderer = window.LuminousVttSurfaceRenderer;
+  if (!core || !surfaceRenderer) throw new Error('SURFACE_RUNTIME_REQUIRED');
   core.ensureMapState(mapData);
 
   const engine = runtime.engine;
   const canvas = engine.canvas;
+  const renderer = engine.renderer;
   const isDm = Boolean(runtime.bridge?.isDm);
   let stopped = false;
   let tool = isDm ? 'brush' : 'select';
@@ -64,7 +66,17 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
 
   const currentRuntime = () => window.LuminousVttRuntime || runtime;
   const activeZ = () => Number(engine.activeZ) || 0;
+  const renderZ = () => Number(currentRuntime()?.pov?.controller?.viewLayer?.(engine.activeZ) ?? engine.activeZ) || 0;
   const painterEnabled = () => isDm && mapData.dmEditMode?.active === true && tool !== 'select';
+
+  const originalDrawGrid = renderer.drawGrid.bind(renderer);
+  const surfaceDrawGrid = function surfaceDrawGrid(...args) {
+    const result = originalDrawGrid(...args);
+    surfaceRenderer.drawSurfaceLayer(renderer.ctx, mapData, renderZ());
+    surfaceRenderer.drawGridOverlay(renderer.ctx, mapData, Boolean(args[0]));
+    return result;
+  };
+  renderer.drawGrid = surfaceDrawGrid;
 
   function cellAtEvent(event) {
     const rect = canvas.getBoundingClientRect();
@@ -232,6 +244,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     window.removeEventListener('mousemove', onPointerMove, true);
     window.removeEventListener('mouseup', onPointerUp, true);
     document.removeEventListener('click', onExternalTool, true);
+    if (renderer.drawGrid === surfaceDrawGrid) renderer.drawGrid = originalDrawGrid;
     toolbar?.remove();
     document.getElementById(STYLE_ID)?.remove();
   }

--- a/js/vtt/surface-core.js
+++ b/js/vtt/surface-core.js
@@ -1,0 +1,260 @@
+(function (root, factory) {
+  const api = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttSurfaceCore = api;
+})(typeof window !== 'undefined' ? window : globalThis, function () {
+  'use strict';
+
+  const SCHEMA_VERSION = 1;
+  const clean = (value) => String(value ?? '').trim();
+  const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+  const DEFAULT_MATERIALS = Object.freeze([
+    { id:'concrete', name:'Concrete', visual:{ color:'#5b5e61', image:'', opacity:1, scale:1 }, movement:{ costMultiplier:1, difficultTerrain:false }, tags:['urban','hard_surface','interior'] },
+    { id:'asphalt', name:'Asphalt', visual:{ color:'#282b2f', image:'', opacity:1, scale:1 }, movement:{ costMultiplier:1, difficultTerrain:false }, tags:['urban','road','hard_surface'] },
+    { id:'sidewalk', name:'Sidewalk', visual:{ color:'#7a7d80', image:'', opacity:1, scale:1 }, movement:{ costMultiplier:1, difficultTerrain:false }, tags:['urban','sidewalk','hard_surface'] },
+    { id:'tile', name:'Tile', visual:{ color:'#6e665d', image:'', opacity:1, scale:1 }, movement:{ costMultiplier:1, difficultTerrain:false }, tags:['interior','hard_surface'] },
+    { id:'metal', name:'Metal', visual:{ color:'#4e5960', image:'', opacity:1, scale:1 }, movement:{ costMultiplier:1, difficultTerrain:false }, tags:['industrial','hard_surface'] },
+    { id:'wood', name:'Wood', visual:{ color:'#6a4c35', image:'', opacity:1, scale:1 }, movement:{ costMultiplier:1, difficultTerrain:false }, tags:['interior','wood'] },
+    { id:'dirt', name:'Dirt', visual:{ color:'#58412f', image:'', opacity:1, scale:1 }, movement:{ costMultiplier:1, difficultTerrain:false }, tags:['outdoor','soil'] },
+    { id:'mud', name:'Mud', visual:{ color:'#3d3328', image:'', opacity:1, scale:1 }, movement:{ costMultiplier:2, difficultTerrain:true }, tags:['outdoor','soil','wet'] },
+    { id:'grass', name:'Grass', visual:{ color:'#334b31', image:'', opacity:1, scale:1 }, movement:{ costMultiplier:1, difficultTerrain:false }, tags:['outdoor','vegetation'] },
+    { id:'shallow_water', name:'Shallow Water', visual:{ color:'#315a6a', image:'', opacity:0.9, scale:1 }, movement:{ costMultiplier:2, difficultTerrain:true }, tags:['water','wet','shallow'] },
+    { id:'deep_water', name:'Deep Water', visual:{ color:'#193c50', image:'', opacity:0.92, scale:1 }, movement:{ costMultiplier:1, difficultTerrain:false, requiredMode:'swim' }, tags:['water','wet','deep'] },
+  ]);
+
+  function safeId(value, fallback = 'surface') {
+    return clean(value).toLowerCase().replace(/[^a-z0-9_-]+/g, '_').replace(/^_+|_+$/g, '') || fallback;
+  }
+
+  function normalizeMaterial(raw = {}) {
+    const id = safeId(raw.id || raw.materialId || raw.name);
+    const visual = raw.visual || {};
+    const movement = raw.movement || {};
+    const requiredMode = clean(movement.requiredMode || raw.requiredMode).toLowerCase();
+    const allowedModes = Array.isArray(movement.allowedModes || raw.allowedModes)
+      ? [...new Set((movement.allowedModes || raw.allowedModes).map((mode) => clean(mode).toLowerCase()).filter(Boolean))]
+      : [];
+    const difficultTerrain = Boolean(movement.difficultTerrain ?? movement.difficult ?? raw.difficultTerrain ?? raw.difficult);
+    return {
+      schemaVersion: SCHEMA_VERSION,
+      id,
+      name: clean(raw.name || raw.label || id) || id,
+      visual: {
+        color: clean(visual.color || raw.color || '#444444') || '#444444',
+        image: clean(visual.image || visual.url || raw.image || ''),
+        opacity: Math.max(0, Math.min(1, finite(visual.opacity, 1))),
+        scale: Math.max(0.05, finite(visual.scale, 1)),
+      },
+      movement: {
+        costMultiplier: Math.max(0.05, finite(movement.costMultiplier ?? movement.multiplier ?? raw.costMultiplier, difficultTerrain ? 2 : 1)),
+        difficultTerrain,
+        blocked: Boolean(movement.blocked ?? raw.blocked),
+        requiredMode: requiredMode || null,
+        allowedModes,
+      },
+      tags: [...new Set((Array.isArray(raw.tags) ? raw.tags : []).map((tag) => clean(tag).toLowerCase()).filter(Boolean))],
+    };
+  }
+
+  function defaultMaterialCatalog() {
+    const record = {};
+    DEFAULT_MATERIALS.forEach((entry) => { const material = normalizeMaterial(entry); record[material.id] = material; });
+    return record;
+  }
+
+  function normalizeMaterialCatalog(raw = null) {
+    const record = {};
+    const rows = Array.isArray(raw) ? raw : Object.values(raw || {});
+    rows.forEach((entry) => {
+      if (!entry) return;
+      const material = normalizeMaterial(entry);
+      record[material.id] = material;
+    });
+    const defaults = defaultMaterialCatalog();
+    Object.entries(defaults).forEach(([id, material]) => { if (!record[id]) record[id] = material; });
+    return record;
+  }
+
+  function cellKey(col, row) {
+    return `${Math.trunc(finite(col, 0))}_${Math.trunc(finite(row, 0))}`;
+  }
+
+  function parseCellKey(key) {
+    const [col, row] = String(key || '').split('_').map(Number);
+    return Number.isFinite(col) && Number.isFinite(row) ? { col, row } : null;
+  }
+
+  function normalizeCell(raw = {}, fallbackMaterialId = 'concrete') {
+    if (typeof raw === 'string') raw = { materialId: raw };
+    return {
+      materialId: safeId(raw.materialId || raw.material || fallbackMaterialId, fallbackMaterialId),
+      elevationOffsetFt: finite(raw.elevationOffsetFt ?? raw.elevationFt, 0),
+    };
+  }
+
+  function normalizeLayers(raw = {}, grid = {}, catalog = {}) {
+    const result = {};
+    const cols = Math.max(1, Math.trunc(finite(grid.cols, 1)));
+    const rows = Math.max(1, Math.trunc(finite(grid.rows, 1)));
+    Object.entries(raw || {}).forEach(([zKey, layer]) => {
+      if (!layer || typeof layer !== 'object' || Array.isArray(layer)) return;
+      const target = {};
+      Object.entries(layer).forEach(([key, value]) => {
+        const cell = parseCellKey(key);
+        if (!cell || cell.col < 0 || cell.row < 0 || cell.col >= cols || cell.row >= rows) return;
+        const normalized = normalizeCell(value);
+        if (!catalog[normalized.materialId]) return;
+        target[cellKey(cell.col, cell.row)] = normalized;
+      });
+      if (Object.keys(target).length) result[String(Number(zKey) || 0)] = target;
+    });
+    return result;
+  }
+
+  function ensureMapState(mapData = {}) {
+    mapData.surfaceMaterials = normalizeMaterialCatalog(mapData.surfaceMaterials);
+    mapData.surfaceLayers = normalizeLayers(mapData.surfaceLayers || {}, mapData.grid || {}, mapData.surfaceMaterials);
+    mapData.movement ||= {};
+    mapData.movement.terrain ||= {};
+    syncMovementTerrain(mapData);
+    return mapData;
+  }
+
+  function materialFor(mapData = {}, materialId) {
+    const catalog = mapData.surfaceMaterials || defaultMaterialCatalog();
+    return catalog[safeId(materialId)] || null;
+  }
+
+  function layerRecord(mapData = {}, zLayer = 0, create = false) {
+    mapData.surfaceLayers ||= {};
+    const key = String(Number(zLayer) || 0);
+    if (!mapData.surfaceLayers[key] && create) mapData.surfaceLayers[key] = {};
+    return mapData.surfaceLayers[key] || null;
+  }
+
+  function getCell(mapData = {}, zLayer = 0, col = 0, row = 0) {
+    const layer = layerRecord(mapData, zLayer, false);
+    return layer?.[cellKey(col, row)] || null;
+  }
+
+  function terrainRecordForCell(mapData = {}, cell = null) {
+    if (!cell) return null;
+    const material = materialFor(mapData, cell.materialId);
+    if (!material) return null;
+    const movement = material.movement || {};
+    return {
+      multiplier: Math.max(0.05, finite(movement.costMultiplier, movement.difficultTerrain ? 2 : 1)),
+      costMultiplier: Math.max(0.05, finite(movement.costMultiplier, movement.difficultTerrain ? 2 : 1)),
+      difficult: Boolean(movement.difficultTerrain),
+      blocked: Boolean(movement.blocked),
+      requiredMode: movement.requiredMode || null,
+      allowedModes: Array.isArray(movement.allowedModes) ? [...movement.allowedModes] : [],
+      surfaceMaterialId: material.id,
+      surfaceTags: [...(material.tags || [])],
+      elevationOffsetFt: finite(cell.elevationOffsetFt, 0),
+      _surface: true,
+    };
+  }
+
+  function terrainLayer(mapData = {}, zLayer = 0, create = false) {
+    mapData.movement ||= {};
+    mapData.movement.terrain ||= {};
+    const key = String(Number(zLayer) || 0);
+    if (!mapData.movement.terrain[key] && create) mapData.movement.terrain[key] = {};
+    return mapData.movement.terrain[key] || null;
+  }
+
+  function projectCell(mapData, zLayer, col, row) {
+    const key = cellKey(col, row);
+    const terrain = terrainLayer(mapData, zLayer, true);
+    const cell = getCell(mapData, zLayer, col, row);
+    if (!cell) {
+      if (terrain[key]?._surface) delete terrain[key];
+      return null;
+    }
+    const record = terrainRecordForCell(mapData, cell);
+    terrain[key] = record;
+    return record;
+  }
+
+  function syncMovementTerrain(mapData = {}) {
+    mapData.movement ||= {};
+    mapData.movement.terrain ||= {};
+    Object.values(mapData.movement.terrain).forEach((layer) => {
+      if (!layer || typeof layer !== 'object' || Array.isArray(layer)) return;
+      Object.keys(layer).forEach((key) => { if (layer[key]?._surface) delete layer[key]; });
+    });
+    Object.entries(mapData.surfaceLayers || {}).forEach(([zKey, layer]) => {
+      Object.keys(layer || {}).forEach((key) => {
+        const cell = parseCellKey(key);
+        if (cell) projectCell(mapData, Number(zKey) || 0, cell.col, cell.row);
+      });
+    });
+    return mapData.movement.terrain;
+  }
+
+  function setCell(mapData = {}, zLayer = 0, col = 0, row = 0, materialId = 'concrete', patch = {}) {
+    ensureMapState(mapData);
+    const cols = Math.max(1, Math.trunc(finite(mapData.grid?.cols, 1)));
+    const rows = Math.max(1, Math.trunc(finite(mapData.grid?.rows, 1)));
+    const c = Math.trunc(finite(col, -1)), r = Math.trunc(finite(row, -1));
+    if (c < 0 || r < 0 || c >= cols || r >= rows) return null;
+    const material = materialFor(mapData, materialId);
+    if (!material) throw new Error('SURFACE_MATERIAL_NOT_FOUND');
+    const layer = layerRecord(mapData, zLayer, true);
+    const key = cellKey(c, r);
+    layer[key] = normalizeCell({ ...(layer[key] || {}), ...patch, materialId: material.id }, material.id);
+    projectCell(mapData, zLayer, c, r);
+    return clone(layer[key]);
+  }
+
+  function eraseCell(mapData = {}, zLayer = 0, col = 0, row = 0) {
+    ensureMapState(mapData);
+    const layer = layerRecord(mapData, zLayer, false);
+    const key = cellKey(col, row);
+    if (!layer?.[key]) return false;
+    delete layer[key];
+    if (!Object.keys(layer).length) delete mapData.surfaceLayers[String(Number(zLayer) || 0)];
+    projectCell(mapData, zLayer, col, row);
+    return true;
+  }
+
+  function paintRect(mapData = {}, zLayer = 0, from = {}, to = {}, materialId = 'concrete') {
+    const minCol = Math.min(Math.trunc(finite(from.col)), Math.trunc(finite(to.col)));
+    const maxCol = Math.max(Math.trunc(finite(from.col)), Math.trunc(finite(to.col)));
+    const minRow = Math.min(Math.trunc(finite(from.row)), Math.trunc(finite(to.row)));
+    const maxRow = Math.max(Math.trunc(finite(from.row)), Math.trunc(finite(to.row)));
+    let changed = 0;
+    for (let row = minRow; row <= maxRow; row += 1) {
+      for (let col = minCol; col <= maxCol; col += 1) {
+        if (setCell(mapData, zLayer, col, row, materialId)) changed += 1;
+      }
+    }
+    return changed;
+  }
+
+  function eraseRect(mapData = {}, zLayer = 0, from = {}, to = {}) {
+    const minCol = Math.min(Math.trunc(finite(from.col)), Math.trunc(finite(to.col)));
+    const maxCol = Math.max(Math.trunc(finite(from.col)), Math.trunc(finite(to.col)));
+    const minRow = Math.min(Math.trunc(finite(from.row)), Math.trunc(finite(to.row)));
+    const maxRow = Math.max(Math.trunc(finite(from.row)), Math.trunc(finite(to.row)));
+    let changed = 0;
+    for (let row = minRow; row <= maxRow; row += 1) {
+      for (let col = minCol; col <= maxCol; col += 1) if (eraseCell(mapData, zLayer, col, row)) changed += 1;
+    }
+    return changed;
+  }
+
+  function cellsOnLayer(mapData = {}, zLayer = 0) {
+    const layer = layerRecord(mapData, zLayer, false) || {};
+    return Object.entries(layer).map(([key, value]) => ({ ...parseCellKey(key), ...clone(value) })).filter((entry) => Number.isFinite(entry.col) && Number.isFinite(entry.row));
+  }
+
+  return Object.freeze({
+    SCHEMA_VERSION, DEFAULT_MATERIALS, safeId, normalizeMaterial, defaultMaterialCatalog, normalizeMaterialCatalog,
+    cellKey, parseCellKey, normalizeCell, normalizeLayers, ensureMapState, materialFor, layerRecord, getCell,
+    terrainRecordForCell, projectCell, syncMovementTerrain, setCell, eraseCell, paintRect, eraseRect, cellsOnLayer,
+  });
+});

--- a/js/vtt/surface-renderer.js
+++ b/js/vtt/surface-renderer.js
@@ -59,7 +59,7 @@
   function drawSurfaceLayer(ctx, mapData = {}, zLayer = 0) {
     const core = coreRuntime();
     if (!core || !ctx) return 0;
-    core.ensureMapState(mapData);
+    if (!mapData.surfaceMaterials || !mapData.surfaceLayers || !mapData.movement?.terrain) core.ensureMapState(mapData);
     let count = 0;
     for (const cell of core.cellsOnLayer(mapData, zLayer)) if (drawCell(ctx, mapData, cell)) count += 1;
     return count;

--- a/js/vtt/surface-renderer.js
+++ b/js/vtt/surface-renderer.js
@@ -65,5 +65,22 @@
     return count;
   }
 
-  return Object.freeze({ imageFor, drawCell, drawSurfaceLayer });
+  function drawGridOverlay(ctx, mapData = {}, isExporting = false) {
+    if (!ctx || !mapData.grid) return false;
+    const cols = Math.max(1, Math.trunc(finite(mapData.grid.cols, 1)));
+    const rows = Math.max(1, Math.trunc(finite(mapData.grid.rows, 1)));
+    const size = Math.max(1, finite(mapData.grid.size, 70));
+    const width = cols * size, height = rows * size;
+    ctx.save();
+    ctx.strokeStyle = isExporting ? 'rgba(0, 0, 0, 0.2)' : 'rgba(255, 255, 255, 0.2)';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    for (let x = 0; x <= cols; x += 1) { ctx.moveTo(x * size, 0); ctx.lineTo(x * size, height); }
+    for (let y = 0; y <= rows; y += 1) { ctx.moveTo(0, y * size); ctx.lineTo(width, y * size); }
+    ctx.stroke();
+    ctx.restore();
+    return true;
+  }
+
+  return Object.freeze({ imageFor, drawCell, drawSurfaceLayer, drawGridOverlay });
 });

--- a/js/vtt/surface-renderer.js
+++ b/js/vtt/surface-renderer.js
@@ -1,0 +1,69 @@
+(function (root, factory) {
+  const api = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttSurfaceRenderer = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (root) {
+  'use strict';
+
+  const imageCache = new Map();
+  const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+  function coreRuntime() {
+    if (root?.LuminousVttSurfaceCore) return root.LuminousVttSurfaceCore;
+    if (typeof require !== 'undefined') {
+      try { return require('./surface-core.js'); } catch (_) {}
+    }
+    return null;
+  }
+
+  function imageFor(url) {
+    if (!url || typeof Image === 'undefined') return null;
+    let entry = imageCache.get(url);
+    if (!entry) {
+      const image = new Image();
+      entry = { image, ready:false, failed:false };
+      image.decoding = 'async';
+      image.onload = () => { entry.ready = true; };
+      image.onerror = () => { entry.failed = true; };
+      image.src = url;
+      imageCache.set(url, entry);
+    }
+    return entry.ready && !entry.failed ? entry.image : null;
+  }
+
+  function drawCell(ctx, mapData, cell) {
+    const core = coreRuntime();
+    if (!core || !ctx || !cell) return false;
+    const material = core.materialFor(mapData, cell.materialId);
+    if (!material) return false;
+    const size = Math.max(1, finite(mapData.grid?.size, 70));
+    const x = cell.col * size, y = cell.row * size;
+    const visual = material.visual || {};
+    const opacity = Math.max(0, Math.min(1, finite(visual.opacity, 1)));
+    ctx.save();
+    ctx.globalAlpha *= opacity;
+    const image = imageFor(visual.image);
+    if (image) {
+      const scale = Math.max(0.05, finite(visual.scale, 1));
+      const dw = size * scale, dh = size * scale;
+      const dx = x + ((size - dw) / 2), dy = y + ((size - dh) / 2);
+      ctx.drawImage(image, dx, dy, dw, dh);
+    } else {
+      ctx.fillStyle = visual.color || '#444444';
+      ctx.fillRect(x, y, size, size);
+    }
+    ctx.restore();
+    return true;
+  }
+
+  function drawSurfaceLayer(ctx, mapData = {}, zLayer = 0) {
+    const core = coreRuntime();
+    if (!core || !ctx) return 0;
+    core.ensureMapState(mapData);
+    let count = 0;
+    for (const cell of core.cellsOnLayer(mapData, zLayer)) if (drawCell(ctx, mapData, cell)) count += 1;
+    return count;
+  }
+
+  return Object.freeze({ imageFor, drawCell, drawSurfaceLayer });
+});

--- a/tests/vtt_surface_foundation.spec.js
+++ b/tests/vtt_surface_foundation.spec.js
@@ -1,0 +1,142 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+function loadCore() {
+  delete require.cache[require.resolve('../js/vtt/surface-core.js')];
+  return require('../js/vtt/surface-core.js');
+}
+
+function baseMap(cols = 6, rows = 4) {
+  return {
+    id: 'surface_test',
+    grid: { cols, rows, size: 70, distancePerCell: 5, distanceUnit: 'ft' },
+    zLevels: { 0:{ zLayer:0, elevationFt:0, label:'Ground' } },
+    movement: { terrain: { '0': { '5_3': { multiplier:3, legacy:true } } }, blockTokens:false },
+    tokens: [],
+  };
+}
+
+test('surface grid stays sparse and projects only painted cells into canonical movement terrain', () => {
+  const core = loadCore();
+  const mapData = baseMap();
+  core.ensureMapState(mapData);
+  expect(Object.keys(mapData.surfaceMaterials)).toEqual(expect.arrayContaining(['concrete','asphalt','mud','deep_water']));
+  expect(mapData.surfaceLayers).toEqual({});
+
+  core.setCell(mapData, 0, 2, 1, 'mud');
+  expect(mapData.surfaceLayers['0']).toEqual({ '2_1': { materialId:'mud', elevationOffsetFt:0 } });
+  expect(mapData.movement.terrain['0']['2_1']).toMatchObject({ multiplier:2, difficult:true, surfaceMaterialId:'mud', _surface:true });
+  expect(mapData.movement.terrain['0']['5_3']).toMatchObject({ multiplier:3, legacy:true });
+
+  core.eraseCell(mapData, 0, 2, 1);
+  expect(mapData.surfaceLayers['0']).toBeUndefined();
+  expect(mapData.movement.terrain['0']['2_1']).toBeUndefined();
+  expect(mapData.movement.terrain['0']['5_3']).toMatchObject({ multiplier:3, legacy:true });
+});
+
+test('surface material movement contract blocks walk on deep water but permits swim', () => {
+  const core = loadCore();
+  global.LuminousVttSurfaceCore = core;
+  delete require.cache[require.resolve('../js/vtt/pathfinding.js')];
+  const pathfinding = require('../js/vtt/pathfinding.js');
+  const mapData = baseMap(3, 3);
+  core.ensureMapState(mapData);
+  core.setCell(mapData, 0, 1, 1, 'deep_water');
+  const token = { id:'p', x:35, y:105, radius:20, zLayer:0 };
+  const point = pathfinding.pointForCell({ col:1, row:1 }, mapData, 0);
+  expect(pathfinding.pointPassable(token, point, mapData, 0, { movementMode:'walk', blockTokens:false })).toMatchObject({ valid:false, reason:'TERRAIN_MODE_BLOCKED' });
+  expect(pathfinding.pointPassable(token, point, mapData, 0, { movementMode:'swim', blockTokens:false }).valid).toBe(true);
+});
+
+test('A* consumes painted surface costs and routes around expensive mud when cheaper pavement exists', () => {
+  const core = loadCore();
+  global.LuminousVttSurfaceCore = core;
+  delete require.cache[require.resolve('../js/vtt/pathfinding.js')];
+  const pathfinding = require('../js/vtt/pathfinding.js');
+  const mapData = baseMap(5, 3);
+  mapData.movement.terrain = {};
+  core.ensureMapState(mapData);
+  core.setCell(mapData, 0, 1, 1, 'mud');
+  core.setCell(mapData, 0, 2, 1, 'mud');
+  core.setCell(mapData, 0, 3, 1, 'mud');
+  const token = { id:'p', x:35, y:105, radius:10, zLayer:0 };
+  const route = pathfinding.findPath({
+    token,
+    start:pathfinding.pointForCell({ col:0,row:1 }, mapData, 0),
+    target:pathfinding.pointForCell({ col:4,row:1 }, mapData, 0),
+    mapData,
+    movementMode:'walk',
+    blockTokens:false,
+  });
+  expect(route.valid).toBe(true);
+  expect(route.costFt).toBeLessThan(35);
+  expect(route.cells).not.toContainEqual({ col:2, row:1 });
+});
+
+test('surface-aware MapDefinition persists surfaces across normalization and floor edits', () => {
+  delete global.LuminousVttMapAuthoring;
+  delete global.LuminousVttSurfaceCore;
+  delete require.cache[require.resolve('../js/vtt/map-authoring.js')];
+  delete require.cache[require.resolve('../js/vtt/surface-core.js')];
+  delete require.cache[require.resolve('../js/vtt/surface-authoring-patch.js')];
+  require('../js/vtt/map-authoring.js');
+  const core = require('../js/vtt/surface-core.js');
+  require('../js/vtt/surface-authoring-patch.js');
+  const authoring = global.LuminousVttMapAuthoring;
+  expect(authoring.__surfaceAware).toBe(true);
+
+  const raw = {
+    id:'painted_map', name:'Painted Map', grid:{ cols:4,rows:4,size:70,distancePerCell:5 },
+    zLevels:{ 0:{zLayer:0,elevationFt:0,label:'Ground'} },
+    surfaceMaterials:core.defaultMaterialCatalog(),
+    surfaceLayers:{ '0':{ '1_1':{ materialId:'asphalt', elevationOffsetFt:0 } } },
+  };
+  const normalized = authoring.normalizeDefinition(raw);
+  expect(normalized.surfaceLayers['0']['1_1']).toMatchObject({ materialId:'asphalt' });
+  const withFloor = authoring.addLevel(normalized, 0, 1);
+  expect(withFloor.surfaceLayers['0']['1_1']).toMatchObject({ materialId:'asphalt' });
+
+  const mapData = { id:'old', grid:{cols:2,rows:2,size:70,distancePerCell:5}, zLevels:{0:{zLayer:0,elevationFt:0}}, movement:{terrain:{}}, tokens:[] };
+  authoring.applyDefinition(mapData, withFloor);
+  expect(mapData.surfaceLayers['0']['1_1']).toMatchObject({ materialId:'asphalt' });
+  expect(mapData.movement.terrain['0']['1_1']).toMatchObject({ surfaceMaterialId:'asphalt' });
+  expect(authoring.definitionFromMapData(mapData).surfaceLayers['0']['1_1']).toMatchObject({ materialId:'asphalt' });
+});
+
+test('floor deletion is blocked while the floor contains painted surfaces', () => {
+  const authoring = global.LuminousVttMapAuthoring;
+  const core = global.LuminousVttSurfaceCore;
+  const mapData = {
+    id:'floors', grid:{cols:3,rows:3,size:70,distancePerCell:5},
+    zLevels:{0:{zLayer:0,elevationFt:0,label:'Ground'},1:{zLayer:1,elevationFt:15,label:'Upper'}},
+    walls:[], topology:[], verticalPortals:[], tokens:[], lighting:{scene:{roofs:[],sources:[]}}, movement:{terrain:{}},
+    surfaceMaterials:core.defaultMaterialCatalog(), surfaceLayers:{'1':{'1_1':{materialId:'tile',elevationOffsetFt:0}}},
+  };
+  core.ensureMapState(mapData);
+  expect(authoring.canDeleteLevel(mapData, 1)).toMatchObject({ valid:false, reason:'FLOOR_IN_USE' });
+});
+
+test('surface painter composes background then surface then grid and captures paint input before token dragging', () => {
+  const source = fs.readFileSync(path.join(__dirname,'..','js','vtt','surface-bootstrap.js'),'utf8');
+  const original = source.indexOf('const result = originalDrawGrid(...args)');
+  const surface = source.indexOf('surfaceRenderer.drawSurfaceLayer');
+  const overlay = source.indexOf('surfaceRenderer.drawGridOverlay');
+  expect(original).toBeGreaterThan(-1);
+  expect(surface).toBeGreaterThan(original);
+  expect(overlay).toBeGreaterThan(surface);
+  expect(source).toContain("canvas.addEventListener('mousedown', onPointerDown, true)");
+  expect(source).toContain("window.addEventListener('mousemove', onPointerMove, true)");
+  expect(source).toContain('bridge?.saveDefinition');
+  expect(source).toContain('data-surface-tool="brush"');
+  expect(source).toContain('data-surface-tool="rect"');
+  expect(source).toContain('data-surface-tool="erase"');
+});
+
+test('main bootstrap installs the surface authoring patch before active map lookup and starts painter after map authoring', () => {
+  const source = fs.readFileSync(path.join(__dirname,'..','js','vtt','main.js'),'utf8');
+  expect(source.indexOf("import './surface-authoring-patch.js';")).toBeLessThan(source.indexOf("import './map-authoring-state.js';"));
+  expect(source).toContain("const surfaceModule = await import('./surface-bootstrap.js')");
+  expect(source).toContain('LuminousVttSurfaceCore?.ensureMapState?.(mockMapData)');
+  expect(source).toContain('window.LuminousVttSurfaceRuntime?.stop?.()');
+});


### PR DESCRIPTION
## Summary
- Adds canonical `SurfaceMaterialDefinition` records with visual metadata, movement cost/mode rules and environment tags.
- Adds sparse per-Z `surfaceLayers` instead of one entity per grid cell.
- Projects painted surfaces into the existing `movement.terrain` contract so current A* and movement budgets consume the same terrain data without a second pathfinding engine.
- Seeds concrete, asphalt, sidewalk, tile, metal, wood, dirt, mud, grass, shallow water and deep water materials.
- Adds DM Surface Painter tools for SELECT / BRUSH / RECTANGLE / ERASE with material selection.
- Captures painter input before token dragging while a surface tool is active.
- Persists surfaces through the existing `MapDefinition` authoring/save path and preserves them across floor edits.
- Prevents floor deletion while painted surface cells still exist on that Z layer.
- Keeps painted surfaces under topology/tokens while restoring a visible grid overlay.

## Validation already completed on superseded Draft #638
The identical head SHA passed:
- VTT Surface Foundation focused contracts + full Chromium repository regression;
- VTT Map HUD and Physical World contracts + regression;
- VTT World Objects contracts + regression;
- Background Narratives non-browser repository regression.

#638 was closed only because the connector's Draft -> Ready GraphQL mutation is currently broken. This non-Draft PR contains the identical tested tree.

## Scope
Wall Builder, auto-tiling, door/window construction, pillars/railings and Stair Builder remain follow-up PRs after this surface foundation lands.