### PR TITLE
feat(vtt): canonical unit-edge wall builder foundation

### DIFF
--- a/.github/workflows/vtt-wall-builder-foundation.yml
+++ b/.github/workflows/vtt-wall-builder-foundation.yml
@@ -1,0 +1,36 @@
+name: VTT Wall Builder Foundation
+
+on:
+  pull_request:
+    paths:
+      - 'js/vtt/wall-builder*.js'
+      - 'js/vtt/topology*.js'
+      - 'js/vtt/token-interaction.js'
+      - 'js/vtt/lighting-engine.js'
+      - 'js/vtt/main.js'
+      - 'tests/vtt_wall_builder_foundation.spec.js'
+      - '.github/workflows/vtt-wall-builder-foundation.yml'
+  workflow_dispatch:
+
+jobs:
+  wall-builder-foundation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Syntax
+        run: |
+          node --check js/vtt/wall-builder.js
+          node --input-type=module --check < js/vtt/wall-builder-bootstrap.js
+          node --input-type=module --check < js/vtt/main.js
+          node --check tests/vtt_wall_builder_foundation.spec.js
+      - name: Focused contracts
+        run: npx playwright test tests/vtt_wall_builder_foundation.spec.js tests/vtt_surface_foundation.spec.js tests/vtt_map_hud_physical.spec.js --workers=1
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Repository regression
+        run: npx playwright test --workers=1

--- a/js/vtt/main.js
+++ b/js/vtt/main.js
@@ -185,6 +185,9 @@ document.addEventListener('DOMContentLoaded', async () => {
             return surfaceModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
         })
         .catch((error) => console.error('VTT map authoring / surfaces bootstrap failed:', error));
+    import('./wall-builder-bootstrap.js')
+        .then((module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }))
+        .catch((error) => console.error('VTT wall builder bootstrap failed:', error));
     import('./actor-library-bootstrap.js')
         .then((module) => {
             const actorLibrary = module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
@@ -217,6 +220,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     window.addEventListener('beforeunload', () => {
         stopMapWatch();
+        window.LuminousVttWallBuilderRuntime?.stop?.();
         window.LuminousVttSurfaceRuntime?.stop?.();
         window.LuminousVttMapHudRuntime?.stop?.();
         window.LuminousVttRuntime?.movement?.stop?.();

--- a/js/vtt/wall-builder-bootstrap.js
+++ b/js/vtt/wall-builder-bootstrap.js
@@ -1,0 +1,175 @@
+import './wall-builder.js';
+
+const PROFILE_FIELD_ID = 'vtt-wall-builder-profile-field';
+const STYLE_ID = 'vtt-wall-builder-style';
+
+function ensureProfileUi(builder, controller) {
+  const toolbar = document.getElementById('vtt-topology-toolbar');
+  if (!toolbar) return null;
+  let field = document.getElementById(PROFILE_FIELD_ID);
+  if (field) return field;
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+    #${PROFILE_FIELD_ID}{display:grid;gap:4px;padding-top:6px;border-top:1px solid #3c4147;color:#9eabb3;font:9px monospace}
+    #${PROFILE_FIELD_ID} select{width:100%;min-width:0;box-sizing:border-box;background:#090c0e;color:#e6ecef;border:1px solid #59636c;padding:5px;font:10px monospace}
+    #${PROFILE_FIELD_ID} small{color:#7f8b93;line-height:1.3}
+  `;
+  document.head.appendChild(style);
+  const catalog = builder.defaultProfileCatalog();
+  field = document.createElement('label');
+  field.id = PROFILE_FIELD_ID;
+  field.className = 'vtt-toolbar-field';
+  field.innerHTML = `<span>WALL PROFILE</span><select data-wall-profile>${Object.values(catalog).map((profile) => `<option value="${profile.id}">${profile.name.toUpperCase()} · ${profile.thicknessFt}FT</option>`).join('')}</select><small data-wall-profile-status>UNIT EDGES · FULL BLOCKER</small>`;
+  toolbar.appendChild(field);
+  const syncVisibility = () => { field.hidden = controller.tool !== 'wall'; };
+  toolbar.addEventListener('click', () => queueMicrotask(syncVisibility));
+  syncVisibility();
+  return field;
+}
+
+export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.engine?.mapData } = {}) {
+  if (!runtime?.controller || !runtime?.engine || !mapData) return null;
+  if (window.LuminousVttWallBuilderRuntime?.api) return window.LuminousVttWallBuilderRuntime.api;
+  const builder = window.LuminousVttWallBuilder;
+  if (!builder) throw new Error('WALL_BUILDER_REQUIRED');
+
+  const controller = runtime.controller;
+  const engine = runtime.engine;
+  const canvas = engine.canvas;
+  const renderer = engine.renderer;
+  const bridge = controller.stateBridge || runtime.bridge;
+  if (!bridge?.saveElement) throw new Error('TOPOLOGY_STATE_BRIDGE_REQUIRED');
+
+  const original = {
+    down: controller.handleMouseDown,
+    move: controller.handleMouseMove,
+    up: controller.handleMouseUp,
+    topologyStyle: renderer.topologyStyle.bind(renderer),
+  };
+
+  canvas.removeEventListener('mousedown', original.down, true);
+  window.removeEventListener('mousemove', original.move, true);
+  window.removeEventListener('mouseup', original.up, true);
+
+  const profileField = controller.isDm ? ensureProfileUi(builder, controller) : null;
+  let profileId = profileField?.querySelector('[data-wall-profile]')?.value || 'concrete';
+  let stopped = false;
+
+  function editWallActive() {
+    return Boolean(controller.isDm && controller.editActive?.() && controller.tool === 'wall');
+  }
+
+  function activeProfile() {
+    return builder.profileFor(profileId);
+  }
+
+  function preview(from, to) {
+    const profile = activeProfile();
+    mapData.topologyPreview = {
+      type: 'wall', from, to, z: [engine.activeZ], thicknessFt: profile.thicknessFt,
+      wallProfileId: profile.id,
+      heightFt: profile.heightFt,
+      wall: { profileId:profile.id, materialId:profile.materialId, heightFt:profile.heightFt, visual:{ ...profile.visual } },
+    };
+  }
+
+  function onMouseDown(event) {
+    if (!editWallActive()) return original.down(event);
+    if (event.button !== 0) return;
+    if (engine.tokenAtEvent(event)) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    controller.hideContextMenu?.();
+    controller.drawStart = controller.topology.snapPointToVertex(controller.worldPoint(event), mapData.grid);
+    preview(controller.drawStart, controller.drawStart);
+  }
+
+  function onMouseMove(event) {
+    if (!editWallActive() || !controller.drawStart) return original.move(event);
+    const candidate = controller.topology.snapPointToVertex(controller.worldPoint(event), mapData.grid);
+    const to = controller.topology.axisAlignedVertex(controller.drawStart, candidate);
+    preview(controller.drawStart, to);
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  }
+
+  async function saveRun(from, to) {
+    const incoming = builder.createWallRun({ from, to, zLayer:engine.activeZ, profileId });
+    const reconciliation = builder.reconcileRun(mapData.topology || [], incoming);
+    if (!reconciliation.save.length) {
+      const reason = reconciliation.skipped.some((entry) => entry.reason === 'EDGE_OCCUPIED_BY_OPENING')
+        ? 'El tramo ya contiene una puerta o ventana.'
+        : 'El tramo ya está cubierto por topología existente.';
+      controller.notify?.(reason, 'error');
+      return { saved:[], skipped:reconciliation.skipped };
+    }
+    const saved = await Promise.all(reconciliation.save.map((element) => bridge.saveElement(element)));
+    controller.selectedId = saved[saved.length - 1]?.id || controller.selectedId;
+    controller.renderEditor?.();
+    const suffix = reconciliation.skipped.length ? ` · ${reconciliation.skipped.length} OMITIDOS` : '';
+    controller.notify?.(`${saved.length} WALL EDGES GUARDADOS${suffix}`, 'success');
+    return { saved, skipped:reconciliation.skipped };
+  }
+
+  function onMouseUp(event) {
+    if (!editWallActive() || !controller.drawStart) return original.up(event);
+    if (event.button !== 0) return;
+    const from = controller.drawStart;
+    const candidate = controller.topology.snapPointToVertex(controller.worldPoint(event), mapData.grid);
+    const to = controller.topology.axisAlignedVertex(from, candidate);
+    controller.drawStart = null;
+    mapData.topologyPreview = null;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    if (controller.topology.sameVertex(from, to)) return;
+    void saveRun(from, to).catch((error) => controller.notify?.(String(error.message || error), 'error'));
+  }
+
+  canvas.addEventListener('mousedown', onMouseDown, true);
+  window.addEventListener('mousemove', onMouseMove, true);
+  window.addEventListener('mouseup', onMouseUp, true);
+
+  profileField?.querySelector('[data-wall-profile]')?.addEventListener('change', (event) => {
+    profileId = event.target.value;
+    const profile = activeProfile();
+    const status = profileField.querySelector('[data-wall-profile-status]');
+    if (status) status.textContent = `${profile.materialId.toUpperCase()} · ${profile.heightFt}FT HIGH · UNIT EDGES`;
+  });
+
+  renderer.topologyStyle = function wallBuilderTopologyStyle(element, isPreview = false) {
+    const base = original.topologyStyle(element, isPreview);
+    if (!isPreview && element?.type === 'wall') {
+      const color = element.wall?.visual?.color;
+      if (color) return { ...base, stroke:color };
+    }
+    return base;
+  };
+
+  function setProfile(nextId) {
+    const profile = builder.profileFor(nextId);
+    profileId = profile.id;
+    const select = profileField?.querySelector('[data-wall-profile]');
+    if (select) select.value = profile.id;
+    return profile;
+  }
+
+  function stop() {
+    if (stopped) return;
+    stopped = true;
+    canvas.removeEventListener('mousedown', onMouseDown, true);
+    window.removeEventListener('mousemove', onMouseMove, true);
+    window.removeEventListener('mouseup', onMouseUp, true);
+    canvas.addEventListener('mousedown', original.down, true);
+    window.addEventListener('mousemove', original.move, true);
+    window.addEventListener('mouseup', original.up, true);
+    renderer.topologyStyle = original.topologyStyle;
+    profileField?.remove();
+    document.getElementById(STYLE_ID)?.remove();
+  }
+
+  const api = Object.freeze({ builder, saveRun, setProfile, getProfile:activeProfile, stop });
+  window.LuminousVttWallBuilderRuntime = Object.freeze({ api, stop });
+  window.LuminousVttRuntime = Object.freeze({ ...window.LuminousVttRuntime, wallBuilder:api });
+  return api;
+}

--- a/js/vtt/wall-builder.js
+++ b/js/vtt/wall-builder.js
@@ -1,0 +1,196 @@
+(function (root, factory) {
+  const api = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttWallBuilder = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (root) {
+  'use strict';
+
+  const clean = (value) => String(value ?? '').trim();
+  const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+  const DEFAULT_PROFILES = Object.freeze([
+    Object.freeze({ id:'concrete', name:'Concrete Wall', materialId:'concrete', thicknessFt:0.75, heightFt:10, visual:Object.freeze({ color:'#8b8f93' }) }),
+    Object.freeze({ id:'brick', name:'Brick Wall', materialId:'brick', thicknessFt:0.5, heightFt:10, visual:Object.freeze({ color:'#9a5848' }) }),
+    Object.freeze({ id:'metal', name:'Metal Wall', materialId:'metal', thicknessFt:0.5, heightFt:10, visual:Object.freeze({ color:'#64727a' }) }),
+    Object.freeze({ id:'wood', name:'Wood Wall', materialId:'wood', thicknessFt:0.5, heightFt:10, visual:Object.freeze({ color:'#7b583d' }) }),
+  ]);
+
+  function topologyRuntime() {
+    if (root?.LuminousVttTopology) return root.LuminousVttTopology;
+    if (typeof require !== 'undefined') {
+      try { return require('./topology.js'); } catch (_) {}
+    }
+    return null;
+  }
+
+  function safeId(value, fallback = 'wall') {
+    return clean(value).toLowerCase().replace(/[^a-z0-9_-]+/g, '_').replace(/^_+|_+$/g, '') || fallback;
+  }
+
+  function normalizeProfile(raw = {}) {
+    const id = safeId(raw.id || raw.profileId || raw.name, 'concrete');
+    return {
+      id,
+      name: clean(raw.name || raw.label || id) || id,
+      materialId: safeId(raw.materialId || raw.material || id, id),
+      thicknessFt: Math.max(0.1, finite(raw.thicknessFt, 0.5)),
+      heightFt: Math.max(0.5, finite(raw.heightFt, 10)),
+      visual: {
+        color: clean(raw.visual?.color || raw.color || '#8b8f93') || '#8b8f93',
+      },
+    };
+  }
+
+  function defaultProfileCatalog() {
+    const result = {};
+    DEFAULT_PROFILES.forEach((profile) => { const normalized = normalizeProfile(profile); result[normalized.id] = normalized; });
+    return result;
+  }
+
+  function profileFor(profileId = 'concrete', catalog = null) {
+    const profiles = catalog && typeof catalog === 'object' ? catalog : defaultProfileCatalog();
+    return normalizeProfile(profiles[safeId(profileId, 'concrete')] || profiles.concrete || DEFAULT_PROFILES[0]);
+  }
+
+  function normalizeVertex(vertex = {}) {
+    return { col: Math.trunc(finite(vertex.col, 0)), row: Math.trunc(finite(vertex.row, 0)) };
+  }
+
+  function compareVertex(a, b) {
+    const left = normalizeVertex(a), right = normalizeVertex(b);
+    if (left.col !== right.col) return left.col - right.col;
+    return left.row - right.row;
+  }
+
+  function canonicalEdge(from, to) {
+    const a = normalizeVertex(from), b = normalizeVertex(to);
+    return compareVertex(a, b) <= 0 ? { from:a, to:b } : { from:b, to:a };
+  }
+
+  function isUnitEdge(from, to) {
+    const a = normalizeVertex(from), b = normalizeVertex(to);
+    return Math.abs(a.col - b.col) + Math.abs(a.row - b.row) === 1;
+  }
+
+  function edgeKey(from, to, zLayer = 0) {
+    const edge = canonicalEdge(from, to);
+    return `z${Number(zLayer) || 0}:${edge.from.col},${edge.from.row}>${edge.to.col},${edge.to.row}`;
+  }
+
+  function wallId(from, to, zLayer = 0) {
+    const edge = canonicalEdge(from, to);
+    const z = Number(zLayer) || 0;
+    return `wall_z${String(z).replace(/-/g, 'n')}_c${edge.from.col}r${edge.from.row}_c${edge.to.col}r${edge.to.row}`;
+  }
+
+  function runEdges(from, to) {
+    const start = normalizeVertex(from), end = normalizeVertex(to);
+    const horizontal = start.row === end.row;
+    const vertical = start.col === end.col;
+    if (!horizontal && !vertical) throw new Error('WALL_RUN_MUST_BE_AXIS_ALIGNED');
+    if (start.col === end.col && start.row === end.row) return [];
+    const edges = [];
+    if (horizontal) {
+      const direction = end.col > start.col ? 1 : -1;
+      for (let col = start.col; col !== end.col; col += direction) {
+        edges.push(canonicalEdge({ col, row:start.row }, { col:col + direction, row:start.row }));
+      }
+    } else {
+      const direction = end.row > start.row ? 1 : -1;
+      for (let row = start.row; row !== end.row; row += direction) {
+        edges.push(canonicalEdge({ col:start.col, row }, { col:start.col, row:row + direction }));
+      }
+    }
+    return edges;
+  }
+
+  function createWallRun({ from, to, zLayer = 0, profileId = 'concrete', catalog = null } = {}) {
+    const topology = topologyRuntime();
+    if (!topology) throw new Error('TOPOLOGY_RUNTIME_REQUIRED');
+    const profile = profileFor(profileId, catalog);
+    return runEdges(from, to).map((edge) => topology.createElement({
+      id: wallId(edge.from, edge.to, zLayer),
+      type: 'wall',
+      from: edge.from,
+      to: edge.to,
+      zLayer,
+      thicknessFt: profile.thicknessFt,
+    })).map((element) => ({
+      ...element,
+      wallProfileId: profile.id,
+      heightFt: profile.heightFt,
+      wall: {
+        profileId: profile.id,
+        materialId: profile.materialId,
+        heightFt: profile.heightFt,
+        visual: clone(profile.visual),
+      },
+    }));
+  }
+
+  function layerOf(element = {}) {
+    const topology = topologyRuntime();
+    const layers = topology?.elementLayers?.(element) || (Array.isArray(element.z) ? element.z : [finite(element.z, 0)]);
+    return layers.map(Number);
+  }
+
+  function orientationOf(from, to) {
+    const a = normalizeVertex(from), b = normalizeVertex(to);
+    if (a.row === b.row) return 'horizontal';
+    if (a.col === b.col) return 'vertical';
+    return 'other';
+  }
+
+  function elementCoversEdge(rawElement, edge, zLayer = 0) {
+    const topology = topologyRuntime();
+    if (!rawElement || !topology?.elementOnLayer?.(rawElement, zLayer)) return false;
+    const element = topology.normalizeElement(rawElement);
+    const target = canonicalEdge(edge.from, edge.to);
+    const eo = orientationOf(element.from, element.to), to = orientationOf(target.from, target.to);
+    if (eo !== to || eo === 'other') return false;
+    if (eo === 'horizontal') {
+      if (element.from.row !== target.from.row || element.to.row !== target.to.row) return false;
+      const min = Math.min(element.from.col, element.to.col), max = Math.max(element.from.col, element.to.col);
+      return target.from.col >= min && target.to.col <= max;
+    }
+    if (element.from.col !== target.from.col || element.to.col !== target.to.col) return false;
+    const min = Math.min(element.from.row, element.to.row), max = Math.max(element.from.row, element.to.row);
+    return target.from.row >= min && target.to.row <= max;
+  }
+
+  function exactUnitElement(rawElement, edge, zLayer = 0) {
+    const topology = topologyRuntime();
+    if (!rawElement || !topology?.elementOnLayer?.(rawElement, zLayer)) return false;
+    const element = topology.normalizeElement(rawElement);
+    if (!isUnitEdge(element.from, element.to)) return false;
+    return edgeKey(element.from, element.to, zLayer) === edgeKey(edge.from, edge.to, zLayer);
+  }
+
+  function reconcileRun(existing = [], incoming = []) {
+    const save = [], skipped = [];
+    for (const candidate of Array.isArray(incoming) ? incoming : []) {
+      const zLayer = layerOf(candidate)[0] || 0;
+      const edge = canonicalEdge(candidate.from, candidate.to);
+      const occupants = (Array.isArray(existing) ? existing : []).filter((entry) => elementCoversEdge(entry, edge, zLayer));
+      const opening = occupants.find((entry) => String(entry.type) !== 'wall');
+      if (opening) {
+        skipped.push({ element:candidate, reason:'EDGE_OCCUPIED_BY_OPENING', occupantId:opening.id || null, occupantType:opening.type || null });
+        continue;
+      }
+      const wall = occupants.find((entry) => String(entry.type) === 'wall');
+      if (wall && !exactUnitElement(wall, edge, zLayer)) {
+        skipped.push({ element:candidate, reason:'EDGE_COVERED_BY_LEGACY_WALL', occupantId:wall.id || null, occupantType:'wall' });
+        continue;
+      }
+      save.push(wall ? { ...candidate, id:String(wall.id || candidate.id) } : candidate);
+    }
+    return { save, skipped };
+  }
+
+  return Object.freeze({
+    DEFAULT_PROFILES, safeId, normalizeProfile, defaultProfileCatalog, profileFor,
+    normalizeVertex, canonicalEdge, isUnitEdge, edgeKey, wallId, runEdges, createWallRun,
+    orientationOf, elementCoversEdge, exactUnitElement, reconcileRun,
+  });
+});

--- a/tests/vtt_wall_builder_foundation.spec.js
+++ b/tests/vtt_wall_builder_foundation.spec.js
@@ -1,0 +1,94 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+const topology = require('../js/vtt/topology.js');
+global.LuminousVttTopology = topology;
+const builder = require('../js/vtt/wall-builder.js');
+const interaction = require('../js/vtt/token-interaction.js');
+global.LuminousVttTokenInteraction = interaction;
+const pathfinding = require('../js/vtt/pathfinding.js');
+const lighting = require('../js/vtt/lighting-engine.js');
+
+const repo = path.resolve(__dirname, '..');
+const text = (file) => fs.readFileSync(path.join(repo, file), 'utf8');
+
+function mapWith(topologyElements = []) {
+  return {
+    grid: { cols:5, rows:3, size:70, distancePerCell:5, distanceUnit:'ft' },
+    zLevels: { 0:{ zLayer:0, elevationFt:0 }, 1:{ zLayer:1, elevationFt:15 } },
+    defaultZStepFt: 15,
+    topology: topologyElements,
+    walls: [],
+    tokens: [],
+    movement: { blockTokens:false },
+    lighting: { scene:{ sources:[], interiors:[], transformers:[], switches:[], roofs:[] } },
+  };
+}
+
+test('wall drag is decomposed into deterministic unit edges', () => {
+  const forward = builder.createWallRun({ from:{ col:1,row:1 }, to:{ col:4,row:1 }, zLayer:0, profileId:'brick' });
+  const reverse = builder.createWallRun({ from:{ col:4,row:1 }, to:{ col:1,row:1 }, zLayer:0, profileId:'brick' });
+  expect(forward).toHaveLength(3);
+  expect(forward.every((wall) => builder.isUnitEdge(wall.from, wall.to))).toBeTruthy();
+  expect(forward.map((wall) => wall.id).sort()).toEqual(reverse.map((wall) => wall.id).sort());
+  expect(forward[0].wallProfileId).toBe('brick');
+  expect(forward[0].wall.materialId).toBe('brick');
+  expect(forward[0].heightFt).toBe(10);
+});
+
+test('wall builder never overwrites an opening edge', () => {
+  const door = topology.createElement({ id:'door_a', type:'door', from:{ col:2,row:1 }, to:{ col:3,row:1 }, zLayer:0 });
+  const incoming = builder.createWallRun({ from:{ col:1,row:1 }, to:{ col:4,row:1 }, zLayer:0, profileId:'concrete' });
+  const result = builder.reconcileRun([door], incoming);
+  expect(result.save).toHaveLength(2);
+  expect(result.skipped).toHaveLength(1);
+  expect(result.skipped[0].reason).toBe('EDGE_OCCUPIED_BY_OPENING');
+  expect(result.skipped[0].occupantId).toBe('door_a');
+});
+
+test('legacy long walls are not duplicated by new unit-edge authoring', () => {
+  const legacy = topology.createElement({ id:'legacy_wall', type:'wall', from:{ col:1,row:0 }, to:{ col:1,row:3 }, zLayer:0 });
+  const incoming = builder.createWallRun({ from:{ col:1,row:1 }, to:{ col:1,row:2 }, zLayer:0, profileId:'metal' });
+  const result = builder.reconcileRun([legacy], incoming);
+  expect(result.save).toHaveLength(0);
+  expect(result.skipped[0].reason).toBe('EDGE_COVERED_BY_LEGACY_WALL');
+});
+
+test('unit walls remain canonical movement, A*, vision and light blockers', () => {
+  const walls = builder.createWallRun({ from:{ col:2,row:1 }, to:{ col:2,row:2 }, zLayer:0, profileId:'concrete' });
+  const map = mapWith(walls);
+  const token = { id:'p1', x:35, y:105, radius:28, zLayer:0, z:[0] };
+
+  const blocking = topology.blockingSegments(map.topology, 'vision', 0, map.grid);
+  expect(blocking).toHaveLength(1);
+  expect(interaction.isPathClear(token, { x:35,y:105 }, { x:315,y:105 }, map).valid).toBeFalsy();
+  expect(lighting.lineBlocked2d({ x:35,y:105,zLayer:0 }, { x:315,y:105,zLayer:0 }, map, 0)).toBeTruthy();
+
+  const route = pathfinding.findPath({ token, start:{ col:0,row:1 }, target:{ col:4,row:1 }, mapData:map, zLayer:0, blockTokens:false });
+  expect(route.valid).toBeTruthy();
+  expect(route.cells.some((cell) => cell.row !== 1)).toBeTruthy();
+});
+
+test('wall blockers are isolated to their authored Z layer', () => {
+  const walls = builder.createWallRun({ from:{ col:2,row:1 }, to:{ col:2,row:2 }, zLayer:1, profileId:'metal' });
+  const map = mapWith(walls);
+  const token0 = { id:'p0', x:35, y:105, radius:28, zLayer:0, z:[0] };
+  const token1 = { id:'p1', x:35, y:105, radius:28, zLayer:1, z:[1] };
+  expect(interaction.isPathClear(token0, { x:35,y:105 }, { x:315,y:105 }, map).valid).toBeTruthy();
+  expect(interaction.isPathClear(token1, { x:35,y:105 }, { x:315,y:105 }, map).valid).toBeFalsy();
+  expect(lighting.lineBlocked2d({ x:35,y:105 }, { x:315,y:105 }, map, 0)).toBeFalsy();
+  expect(lighting.lineBlocked2d({ x:35,y:105 }, { x:315,y:105 }, map, 1)).toBeTruthy();
+});
+
+test('wall builder bootstrap composes with the existing topology controller', () => {
+  const bootstrap = text('js/vtt/wall-builder-bootstrap.js');
+  const main = text('js/vtt/main.js');
+  expect(bootstrap).toContain("controller.tool === 'wall'");
+  expect(bootstrap).toContain("return original.down(event)");
+  expect(bootstrap).toContain('builder.reconcileRun');
+  expect(bootstrap).toContain('bridge.saveElement');
+  expect(bootstrap).toContain("EDGE_OCCUPIED_BY_OPENING");
+  expect(main).toContain("import('./wall-builder-bootstrap.js')");
+  expect(main).toContain('window.LuminousVttWallBuilderRuntime?.stop?.()');
+});


### PR DESCRIPTION
## Summary
- Converts DM `WALL` drawing from one long topology segment into canonical one-cell edge segments.
- Uses deterministic per-edge wall IDs so reverse-direction authoring resolves to the same physical edges.
- Adds reusable wall profiles for concrete, brick, metal and wood with thickness, height metadata and simple profile colors.
- Preserves the existing `TopologyController` for SELECT / DOOR / WINDOW / CURTAIN WINDOW / ERASE; the new runtime intercepts input only while `WALL` is active.
- Keeps each authored edge as `topology.type = wall`, so current Movement, A*, PoV and Dynamic Lighting continue to consume the same canonical physics.
- Refuses to overwrite door/window edges and refuses to duplicate legacy long wall segments that already cover an edge.
- Adds lifecycle cleanup and restores the original controller handlers on teardown.

## Why unit edges
Auto-tiling, placing an opening in the middle of a wall, chunk indexing and later procedural generation all require addressable wall edges. A 6-cell drag now yields 6 canonical edges instead of one indivisible segment.

## Scope
This is the Wall Builder foundation only. It intentionally does not implement visual auto-tiling, wall junction sprites, automatic door/window replacement, pillars/railings, or Stair Builder yet.

## Tests
Focused contracts cover deterministic edge decomposition, reverse-direction stability, opening protection, legacy-wall protection, Movement/A* blocking and rerouting, vision/light blocking, Z isolation, and bootstrap composition. Dedicated CI also runs Surface Foundation + Map/HUD focused contracts and the full repository regression suite.