### PR TITLE
feat(vtt): wall auto-tiling junction resolver and renderer

### DIFF
--- a/.github/workflows/vtt-wall-autotiling.yml
+++ b/.github/workflows/vtt-wall-autotiling.yml
@@ -1,0 +1,36 @@
+name: VTT Wall Auto-Tiling
+
+on:
+  pull_request:
+    paths:
+      - 'js/vtt/wall-auto-tile*.js'
+      - 'js/vtt/wall-builder*.js'
+      - 'js/vtt/topology*.js'
+      - 'js/vtt/renderer.js'
+      - 'tests/vtt_wall_autotiling.spec.js'
+      - '.github/workflows/vtt-wall-autotiling.yml'
+  workflow_dispatch:
+
+jobs:
+  wall-autotiling:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Syntax
+        run: |
+          node --check js/vtt/wall-auto-tile.js
+          node --check js/vtt/wall-auto-tile-renderer.js
+          node --input-type=module --check < js/vtt/wall-auto-tile-bootstrap.js
+          node --input-type=module --check < js/vtt/wall-builder-bootstrap.js
+          node --check tests/vtt_wall_autotiling.spec.js
+      - name: Focused contracts
+        run: npx playwright test tests/vtt_wall_autotiling.spec.js tests/vtt_wall_builder_foundation.spec.js tests/vtt_surface_foundation.spec.js tests/vtt_map_hud_physical.spec.js --workers=1
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Repository regression
+        run: npx playwright test --workers=1

--- a/js/vtt/wall-auto-tile-bootstrap.js
+++ b/js/vtt/wall-auto-tile-bootstrap.js
@@ -1,0 +1,100 @@
+import './wall-auto-tile.js';
+import './wall-auto-tile-renderer.js';
+
+const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.engine?.mapData } = {}) {
+  if (!runtime?.engine?.renderer || !runtime?.controller || !mapData) return null;
+  if (window.LuminousVttWallAutoTileRuntime?.api) return window.LuminousVttWallAutoTileRuntime.api;
+
+  const autoTile = window.LuminousVttWallAutoTile;
+  const tileRenderer = window.LuminousVttWallAutoTileRenderer;
+  const topology = window.LuminousVttTopology;
+  if (!autoTile || !tileRenderer || !topology) throw new Error('WALL_AUTO_TILE_DEPENDENCY_REQUIRED');
+
+  const renderer = runtime.engine.renderer;
+  const controller = runtime.controller;
+  const originalDrawTopologyElement = renderer.drawTopologyElement.bind(renderer);
+  const originalHandleTopologyChanged = controller.handleTopologyChanged.bind(controller);
+  const cache = new Map();
+  let topologySnapshot = clone(mapData.topology || []);
+  let stopped = false;
+
+  const cacheKey = (element, zLayer) => `${Number(zLayer) || 0}:${String(element?.id || '')}`;
+
+  function layersOf(element = {}) {
+    return (topology.elementLayers?.(element) || [0]).map(Number);
+  }
+
+  function descriptorFor(rawElement, zLayer = null) {
+    if (!rawElement || String(rawElement.type) !== 'wall') return null;
+    const layer = zLayer == null ? Number(layersOf(rawElement)[0] || 0) : Number(zLayer) || 0;
+    const key = cacheKey(rawElement, layer);
+    if (!cache.has(key)) cache.set(key, autoTile.tileForEdge(rawElement, mapData, layer));
+    return cache.get(key) || null;
+  }
+
+  function invalidateAll() {
+    cache.clear();
+  }
+
+  function invalidateChanges(previous = [], next = []) {
+    const changed = autoTile.changedElements(previous, next);
+    if (!changed.length) return [];
+    const layers = new Set();
+    changed.forEach((element) => layersOf(element).forEach((z) => layers.add(Number(z) || 0)));
+    const affected = new Set();
+
+    for (const layer of layers) {
+      for (const id of autoTile.affectedWallIds(mapData, layer, changed)) {
+        affected.add(`${layer}:${id}`);
+        cache.delete(`${layer}:${id}`);
+      }
+    }
+
+    for (const raw of changed) {
+      if (!raw?.id) continue;
+      layersOf(raw).forEach((layer) => {
+        affected.add(`${layer}:${String(raw.id)}`);
+        cache.delete(`${layer}:${String(raw.id)}`);
+      });
+    }
+    return [...affected].sort();
+  }
+
+  renderer.drawTopologyElement = function wallAutoTileDrawTopologyElement(element, isOnionSkin = false, preview = false) {
+    if (preview || String(element?.type) !== 'wall') return originalDrawTopologyElement(element, isOnionSkin, preview);
+    const normalized = topology.normalizeElement(element);
+    const builder = window.LuminousVttWallBuilder;
+    if (!builder?.isUnitEdge?.(normalized.from, normalized.to)) return originalDrawTopologyElement(element, isOnionSkin, preview);
+    const layer = Number(topology.elementLayers(normalized)[0] || 0);
+    const tile = descriptorFor(element, layer);
+    if (!tile) return originalDrawTopologyElement(element, isOnionSkin, preview);
+    return tileRenderer.drawWallTile(renderer.ctx, mapData, element, tile, { onion:isOnionSkin });
+  };
+
+  controller.handleTopologyChanged = function wallAutoTileTopologyChanged(...args) {
+    const next = clone(mapData.topology || []);
+    invalidateChanges(topologySnapshot, next);
+    topologySnapshot = next;
+    return originalHandleTopologyChanged(...args);
+  };
+
+  function inspectWall(elementId, zLayer = runtime.engine.activeZ) {
+    const wall = (mapData.topology || []).find((entry) => String(entry.id) === String(elementId));
+    return wall ? descriptorFor(wall, zLayer) : null;
+  }
+
+  function stop() {
+    if (stopped) return;
+    stopped = true;
+    renderer.drawTopologyElement = originalDrawTopologyElement;
+    controller.handleTopologyChanged = originalHandleTopologyChanged;
+    cache.clear();
+  }
+
+  const api = Object.freeze({ autoTile, descriptorFor, inspectWall, invalidateAll, invalidateChanges, cache, stop });
+  window.LuminousVttWallAutoTileRuntime = Object.freeze({ api, stop });
+  window.LuminousVttRuntime = Object.freeze({ ...window.LuminousVttRuntime, wallAutoTile:api });
+  return api;
+}

--- a/js/vtt/wall-auto-tile-renderer.js
+++ b/js/vtt/wall-auto-tile-renderer.js
@@ -1,0 +1,109 @@
+(function (root, factory) {
+  const api = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttWallAutoTileRenderer = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (root) {
+  'use strict';
+
+  const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+  function topologyRuntime() {
+    if (root?.LuminousVttTopology) return root.LuminousVttTopology;
+    if (typeof require !== 'undefined') {
+      try { return require('./topology.js'); } catch (_) {}
+    }
+    return null;
+  }
+
+  function tileRuntime() {
+    if (root?.LuminousVttWallAutoTile) return root.LuminousVttWallAutoTile;
+    if (typeof require !== 'undefined') {
+      try { return require('./wall-auto-tile.js'); } catch (_) {}
+    }
+    return null;
+  }
+
+  function shade(hex, amount = -28) {
+    const value = String(hex || '#8b8f93').replace('#', '');
+    if (!/^[0-9a-f]{6}$/i.test(value)) return '#303438';
+    const rgb = [0,2,4].map((index) => Math.max(0, Math.min(255, parseInt(value.slice(index, index + 2), 16) + amount)));
+    return `#${rgb.map((part) => part.toString(16).padStart(2, '0')).join('')}`;
+  }
+
+  function pointForVertex(vertex, mapData = {}) {
+    const size = Math.max(1, finite(mapData.grid?.size, 70));
+    return { x:finite(vertex?.col) * size, y:finite(vertex?.row) * size };
+  }
+
+  function widthFor(element, mapData = {}) {
+    const topology = topologyRuntime();
+    const line = topology?.segment?.(element, mapData.grid || {});
+    return Math.max(4, finite(line?.thicknessPx, 4));
+  }
+
+  function drawJunction(ctx, point, junction, width, color, onion = false) {
+    if (!junction || !ctx) return;
+    const shape = junction.shape || 'end';
+    const radius = Math.max(width * 0.52, shape === 't' || shape === 'cross' ? width * 0.68 : width * 0.56);
+    ctx.save();
+    ctx.globalAlpha *= onion ? 0.55 : 1;
+    ctx.fillStyle = color;
+    ctx.strokeStyle = shade(color, -34);
+    ctx.lineWidth = Math.max(1, width * 0.16);
+
+    if (shape === 'end') {
+      ctx.beginPath();
+      ctx.arc(point.x, point.y, radius * 0.72, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.stroke();
+    } else if (shape === 'straight') {
+      ctx.fillRect(point.x - radius * 0.72, point.y - radius * 0.72, radius * 1.44, radius * 1.44);
+    } else {
+      ctx.beginPath();
+      ctx.arc(point.x, point.y, radius, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.stroke();
+    }
+    ctx.restore();
+  }
+
+  function drawWallTile(ctx, mapData = {}, rawElement = {}, tile = null, options = {}) {
+    const topology = topologyRuntime();
+    const autoTile = tileRuntime();
+    if (!ctx || !topology || !autoTile) return false;
+    const element = topology.normalizeElement(rawElement);
+    const descriptor = tile || autoTile.tileForEdge(rawElement, mapData);
+    if (!descriptor) return false;
+    const line = topology.segment(element, mapData.grid || {});
+    const width = widthFor(element, mapData);
+    const color = options.onion ? '#666666' : descriptor.color || rawElement.wall?.visual?.color || '#8b8f93';
+    const outline = options.onion ? '#4d4d4d' : shade(color, -38);
+
+    ctx.save();
+    ctx.globalAlpha = options.onion ? 0.3 : 1;
+    ctx.lineCap = 'butt';
+    ctx.lineJoin = 'round';
+    ctx.setLineDash([]);
+
+    ctx.strokeStyle = outline;
+    ctx.lineWidth = width + Math.max(2, width * 0.24);
+    ctx.beginPath();
+    ctx.moveTo(line.x1, line.y1);
+    ctx.lineTo(line.x2, line.y2);
+    ctx.stroke();
+
+    ctx.strokeStyle = color;
+    ctx.lineWidth = width;
+    ctx.beginPath();
+    ctx.moveTo(line.x1, line.y1);
+    ctx.lineTo(line.x2, line.y2);
+    ctx.stroke();
+
+    drawJunction(ctx, pointForVertex(element.from, mapData), descriptor.from, width, color, options.onion);
+    drawJunction(ctx, pointForVertex(element.to, mapData), descriptor.to, width, color, options.onion);
+    ctx.restore();
+    return true;
+  }
+
+  return Object.freeze({ shade, pointForVertex, widthFor, drawJunction, drawWallTile });
+});

--- a/js/vtt/wall-auto-tile.js
+++ b/js/vtt/wall-auto-tile.js
@@ -1,0 +1,232 @@
+(function (root, factory) {
+  const api = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttWallAutoTile = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (root) {
+  'use strict';
+
+  const DIRECTIONS = Object.freeze({ N:'N', E:'E', S:'S', W:'W' });
+  const DIRECTION_ORDER = Object.freeze(['N','E','S','W']);
+  const ANGLES = Object.freeze({ E:0, S:90, W:180, N:270 });
+  const SHAPE_PRIORITY = Object.freeze({ isolated:0, end:1, straight:2, corner:3, t:4, cross:5 });
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+  function topologyRuntime() {
+    if (root?.LuminousVttTopology) return root.LuminousVttTopology;
+    if (typeof require !== 'undefined') {
+      try { return require('./topology.js'); } catch (_) {}
+    }
+    return null;
+  }
+
+  function builderRuntime() {
+    if (root?.LuminousVttWallBuilder) return root.LuminousVttWallBuilder;
+    if (typeof require !== 'undefined') {
+      try { return require('./wall-builder.js'); } catch (_) {}
+    }
+    return null;
+  }
+
+  function vertex(value = {}) {
+    return { col:Math.trunc(finite(value.col, 0)), row:Math.trunc(finite(value.row, 0)) };
+  }
+
+  function vertexKey(value = {}) {
+    const v = vertex(value);
+    return `${v.col},${v.row}`;
+  }
+
+  function sameVertex(a, b) { return vertexKey(a) === vertexKey(b); }
+
+  function directionBetween(from, to) {
+    const a = vertex(from), b = vertex(to);
+    const dc = b.col - a.col, dr = b.row - a.row;
+    if (dc === 1 && dr === 0) return DIRECTIONS.E;
+    if (dc === -1 && dr === 0) return DIRECTIONS.W;
+    if (dc === 0 && dr === 1) return DIRECTIONS.S;
+    if (dc === 0 && dr === -1) return DIRECTIONS.N;
+    return null;
+  }
+
+  function opposite(direction) {
+    return ({ N:'S', S:'N', E:'W', W:'E' })[direction] || null;
+  }
+
+  function normalizedWall(raw = null) {
+    const topology = topologyRuntime();
+    const builder = builderRuntime();
+    if (!raw || !topology) return null;
+    const element = topology.normalizeElement(raw);
+    if (element.type !== 'wall' || !builder?.isUnitEdge?.(element.from, element.to)) return null;
+    return { ...element, wallProfileId:raw.wallProfileId, wall:clone(raw.wall) };
+  }
+
+  function wallsOnLayer(mapData = {}, zLayer = 0) {
+    const topology = topologyRuntime();
+    if (!topology) return [];
+    return (Array.isArray(mapData.topology) ? mapData.topology : [])
+      .filter((entry) => topology.elementOnLayer(entry, zLayer))
+      .map(normalizedWall)
+      .filter(Boolean);
+  }
+
+  function otherVertex(edge, atVertex) {
+    if (sameVertex(edge.from, atVertex)) return vertex(edge.to);
+    if (sameVertex(edge.to, atVertex)) return vertex(edge.from);
+    return null;
+  }
+
+  function incidentWalls(mapData = {}, zLayer = 0, atVertex = {}) {
+    return wallsOnLayer(mapData, zLayer).filter((edge) => sameVertex(edge.from, atVertex) || sameVertex(edge.to, atVertex));
+  }
+
+  function directionsAtVertex(mapData = {}, zLayer = 0, atVertex = {}) {
+    const result = [];
+    for (const edge of incidentWalls(mapData, zLayer, atVertex)) {
+      const other = otherVertex(edge, atVertex);
+      const direction = directionBetween(atVertex, other);
+      if (direction && !result.includes(direction)) result.push(direction);
+    }
+    return result.sort((a, b) => DIRECTION_ORDER.indexOf(a) - DIRECTION_ORDER.indexOf(b));
+  }
+
+  function cornerOrientation(directions) {
+    const key = [...directions].sort().join('');
+    if (key === 'ES') return 0;
+    if (key === 'SW') return 90;
+    if (key === 'NW') return 180;
+    if (key === 'EN') return 270;
+    return 0;
+  }
+
+  function classifyDirections(rawDirections = []) {
+    const directions = [...new Set(rawDirections.filter((entry) => DIRECTION_ORDER.includes(entry)))]
+      .sort((a, b) => DIRECTION_ORDER.indexOf(a) - DIRECTION_ORDER.indexOf(b));
+    const degree = directions.length;
+    if (degree <= 0) return { shape:'isolated', degree:0, orientationDeg:0, directions };
+    if (degree === 1) return { shape:'end', degree, orientationDeg:ANGLES[directions[0]], directions };
+    if (degree === 2) {
+      const isStraight = opposite(directions[0]) === directions[1];
+      if (isStraight) {
+        const horizontal = directions.includes('E') || directions.includes('W');
+        return { shape:'straight', degree, orientationDeg:horizontal ? 0 : 90, directions };
+      }
+      return { shape:'corner', degree, orientationDeg:cornerOrientation(directions), directions };
+    }
+    if (degree === 3) {
+      const missing = DIRECTION_ORDER.find((direction) => !directions.includes(direction)) || 'N';
+      return { shape:'t', degree, orientationDeg:ANGLES[missing], directions, missingDirection:missing };
+    }
+    return { shape:'cross', degree:4, orientationDeg:0, directions:DIRECTION_ORDER.slice() };
+  }
+
+  function junctionAt(mapData = {}, zLayer = 0, atVertex = {}) {
+    const directions = directionsAtVertex(mapData, zLayer, atVertex);
+    const walls = incidentWalls(mapData, zLayer, atVertex);
+    const profiles = [...new Set(walls.map((wall) => String(wall.wallProfileId || wall.wall?.profileId || 'legacy')).filter(Boolean))];
+    return {
+      vertex:vertex(atVertex),
+      vertexKey:vertexKey(atVertex),
+      ...classifyDirections(directions),
+      wallIds:walls.map((wall) => String(wall.id || '')).filter(Boolean).sort(),
+      profileIds:profiles.sort(),
+      mixedProfiles:profiles.length > 1,
+    };
+  }
+
+  function dominantShape(a, b) {
+    const left = a?.shape || 'isolated', right = b?.shape || 'isolated';
+    return SHAPE_PRIORITY[right] > SHAPE_PRIORITY[left] ? right : left;
+  }
+
+  function edgeOrientation(element = {}) {
+    const builder = builderRuntime();
+    const orientation = builder?.orientationOf?.(element.from, element.to);
+    return orientation === 'vertical' ? 90 : 0;
+  }
+
+  function tileForEdge(rawElement, mapData = {}, zLayer = null) {
+    const topology = topologyRuntime();
+    const edge = normalizedWall(rawElement);
+    if (!edge || !topology) return null;
+    const layer = zLayer == null ? Number(topology.elementLayers(edge)[0] || 0) : Number(zLayer) || 0;
+    const fromJunction = junctionAt(mapData, layer, edge.from);
+    const toJunction = junctionAt(mapData, layer, edge.to);
+    const bothEnds = fromJunction.shape === 'end' && toJunction.shape === 'end';
+    const shape = bothEnds ? 'isolated' : dominantShape(fromJunction, toJunction);
+    return {
+      id:String(edge.id || ''),
+      zLayer:layer,
+      shape,
+      orientationDeg:edgeOrientation(edge),
+      variantKey:`wall.${shape}`,
+      from:fromJunction,
+      to:toJunction,
+      profileId:String(edge.wallProfileId || edge.wall?.profileId || 'legacy'),
+      materialId:String(edge.wall?.materialId || edge.wallProfileId || 'wall'),
+      color:String(edge.wall?.visual?.color || '#8b8f93'),
+      thicknessFt:finite(edge.thicknessFt, 0.5),
+      heightFt:finite(edge.heightFt ?? edge.wall?.heightFt, 10),
+    };
+  }
+
+  function elementFingerprint(raw = {}) {
+    const topology = topologyRuntime();
+    if (!topology) return '';
+    const element = topology.normalizeElement(raw);
+    return JSON.stringify({
+      id:String(element.id || ''), type:element.type, from:element.from, to:element.to, z:element.z,
+      state:element.state, thicknessFt:element.thicknessFt,
+      wallProfileId:raw.wallProfileId || null, wall:raw.wall || null,
+    });
+  }
+
+  function changedElements(previous = [], next = []) {
+    const before = new Map((Array.isArray(previous) ? previous : []).map((entry) => [String(entry.id || ''), entry]));
+    const after = new Map((Array.isArray(next) ? next : []).map((entry) => [String(entry.id || ''), entry]));
+    const ids = new Set([...before.keys(), ...after.keys()]);
+    const changed = [];
+    for (const id of ids) {
+      const a = before.get(id), b = after.get(id);
+      if (!a || !b || elementFingerprint(a) !== elementFingerprint(b)) {
+        if (a) changed.push(a);
+        if (b) changed.push(b);
+      }
+    }
+    return changed;
+  }
+
+  function touchedVertices(elements = []) {
+    const result = new Map();
+    for (const raw of Array.isArray(elements) ? elements : []) {
+      const topology = topologyRuntime();
+      const element = topology?.normalizeElement?.(raw);
+      if (!element || !['wall','door','window','curtain_window'].includes(element.type)) continue;
+      result.set(vertexKey(element.from), vertex(element.from));
+      result.set(vertexKey(element.to), vertex(element.to));
+    }
+    return [...result.values()];
+  }
+
+  function affectedWallIds(mapData = {}, zLayer = 0, changed = []) {
+    const touched = touchedVertices(changed);
+    const ids = new Set();
+    for (const at of touched) {
+      for (const wall of incidentWalls(mapData, zLayer, at)) if (wall.id) ids.add(String(wall.id));
+    }
+    for (const raw of changed) {
+      const topology = topologyRuntime();
+      if (!topology?.elementOnLayer?.(raw, zLayer)) continue;
+      if (String(raw.type) === 'wall' && raw.id) ids.add(String(raw.id));
+    }
+    return [...ids].sort();
+  }
+
+  return Object.freeze({
+    DIRECTIONS, DIRECTION_ORDER, ANGLES, SHAPE_PRIORITY,
+    vertex, vertexKey, sameVertex, directionBetween, opposite, normalizedWall, wallsOnLayer,
+    otherVertex, incidentWalls, directionsAtVertex, classifyDirections, junctionAt, dominantShape,
+    edgeOrientation, tileForEdge, elementFingerprint, changedElements, touchedVertices, affectedWallIds,
+  });
+});

--- a/js/vtt/wall-builder-bootstrap.js
+++ b/js/vtt/wall-builder-bootstrap.js
@@ -1,4 +1,5 @@
 import './wall-builder.js';
+import { start as startWallAutoTile } from './wall-auto-tile-bootstrap.js';
 
 const PROFILE_FIELD_ID = 'vtt-wall-builder-profile-field';
 const STYLE_ID = 'vtt-wall-builder-style';
@@ -20,7 +21,7 @@ function ensureProfileUi(builder, controller) {
   field = document.createElement('label');
   field.id = PROFILE_FIELD_ID;
   field.className = 'vtt-toolbar-field';
-  field.innerHTML = `<span>WALL PROFILE</span><select data-wall-profile>${Object.values(catalog).map((profile) => `<option value="${profile.id}">${profile.name.toUpperCase()} · ${profile.thicknessFt}FT</option>`).join('')}</select><small data-wall-profile-status>UNIT EDGES · FULL BLOCKER</small>`;
+  field.innerHTML = `<span>WALL PROFILE</span><select data-wall-profile>${Object.values(catalog).map((profile) => `<option value="${profile.id}">${profile.name.toUpperCase()} · ${profile.thicknessFt}FT</option>`).join('')}</select><small data-wall-profile-status>UNIT EDGES · AUTO-TILE READY</small>`;
   toolbar.appendChild(field);
   const syncVisibility = () => { field.hidden = controller.tool !== 'wall'; };
   toolbar.addEventListener('click', () => queueMicrotask(syncVisibility));
@@ -55,6 +56,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   const profileField = controller.isDm ? ensureProfileUi(builder, controller) : null;
   let profileId = profileField?.querySelector('[data-wall-profile]')?.value || 'concrete';
   let stopped = false;
+  let autoTileApi = null;
 
   function editWallActive() {
     return Boolean(controller.isDm && controller.editActive?.() && controller.tool === 'wall');
@@ -134,7 +136,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     profileId = event.target.value;
     const profile = activeProfile();
     const status = profileField.querySelector('[data-wall-profile-status]');
-    if (status) status.textContent = `${profile.materialId.toUpperCase()} · ${profile.heightFt}FT HIGH · UNIT EDGES`;
+    if (status) status.textContent = `${profile.materialId.toUpperCase()} · ${profile.heightFt}FT HIGH · AUTO-TILE`;
   });
 
   renderer.topologyStyle = function wallBuilderTopologyStyle(element, isPreview = false) {
@@ -157,6 +159,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   function stop() {
     if (stopped) return;
     stopped = true;
+    autoTileApi?.stop?.();
     canvas.removeEventListener('mousedown', onMouseDown, true);
     window.removeEventListener('mousemove', onMouseMove, true);
     window.removeEventListener('mouseup', onMouseUp, true);
@@ -168,8 +171,14 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     document.getElementById(STYLE_ID)?.remove();
   }
 
-  const api = Object.freeze({ builder, saveRun, setProfile, getProfile:activeProfile, stop });
+  const api = Object.freeze({ builder, saveRun, setProfile, getProfile:activeProfile, getAutoTile:() => autoTileApi, stop });
   window.LuminousVttWallBuilderRuntime = Object.freeze({ api, stop });
   window.LuminousVttRuntime = Object.freeze({ ...window.LuminousVttRuntime, wallBuilder:api });
+  try {
+    autoTileApi = startWallAutoTile({ runtime:window.LuminousVttRuntime, mapData });
+  } catch (error) {
+    stop();
+    throw error;
+  }
   return api;
 }

--- a/tests/vtt_wall_autotiling.spec.js
+++ b/tests/vtt_wall_autotiling.spec.js
@@ -1,0 +1,122 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+require('../js/vtt/topology.js');
+const topology = globalThis.LuminousVttTopology;
+const builder = require('../js/vtt/wall-builder.js');
+const autoTile = require('../js/vtt/wall-auto-tile.js');
+const autoRenderer = require('../js/vtt/wall-auto-tile-renderer.js');
+
+function wall(from, to, zLayer = 0, profileId = 'brick') {
+  return builder.createWallRun({ from, to, zLayer, profileId })[0];
+}
+
+function map(topologyElements = []) {
+  return { grid:{ size:70, cols:20, rows:20, distancePerCell:5 }, topology:topologyElements };
+}
+
+test('junction classifier covers end, straight, corner, T and cross orientations', () => {
+  expect(autoTile.classifyDirections(['E'])).toMatchObject({ shape:'end', orientationDeg:0, degree:1 });
+  expect(autoTile.classifyDirections(['W','E'])).toMatchObject({ shape:'straight', orientationDeg:0, degree:2 });
+  expect(autoTile.classifyDirections(['N','S'])).toMatchObject({ shape:'straight', orientationDeg:90, degree:2 });
+  expect(autoTile.classifyDirections(['E','S'])).toMatchObject({ shape:'corner', orientationDeg:0, degree:2 });
+  expect(autoTile.classifyDirections(['N','E','S'])).toMatchObject({ shape:'t', missingDirection:'W', orientationDeg:180, degree:3 });
+  expect(autoTile.classifyDirections(['N','E','S','W'])).toMatchObject({ shape:'cross', orientationDeg:0, degree:4 });
+});
+
+test('neighbor resolver derives a corner from canonical wall edges', () => {
+  const center = { col:2, row:2 };
+  const east = wall(center, { col:3, row:2 });
+  const south = wall(center, { col:2, row:3 });
+  const data = map([east, south]);
+  const junction = autoTile.junctionAt(data, 0, center);
+  expect(junction.shape).toBe('corner');
+  expect(junction.directions).toEqual(['E','S']);
+  expect(junction.wallIds).toEqual([east.id, south.id].sort());
+});
+
+test('single wall edge resolves as isolated while retaining endpoint metadata', () => {
+  const edge = wall({ col:1, row:1 }, { col:2, row:1 });
+  const data = map([edge]);
+  const tile = autoTile.tileForEdge(edge, data, 0);
+  expect(tile.shape).toBe('isolated');
+  expect(tile.variantKey).toBe('wall.isolated');
+  expect(tile.orientationDeg).toBe(0);
+  expect(tile.from.shape).toBe('end');
+  expect(tile.to.shape).toBe('end');
+  expect(edge.autoTile).toBeUndefined();
+});
+
+test('doors and windows are openings, not visual wall neighbors', () => {
+  const center = { col:5, row:5 };
+  const east = wall(center, { col:6, row:5 });
+  const door = topology.createElement({ id:'door_south', type:'door', from:center, to:{ col:5, row:6 }, zLayer:0 });
+  const data = map([east, door]);
+  const junction = autoTile.junctionAt(data, 0, center);
+  expect(junction.shape).toBe('end');
+  expect(junction.directions).toEqual(['E']);
+});
+
+test('wall connections are isolated by Z layer', () => {
+  const center = { col:7, row:7 };
+  const z0East = wall(center, { col:8, row:7 }, 0);
+  const z1South = wall(center, { col:7, row:8 }, 1);
+  const data = map([z0East, z1South]);
+  expect(autoTile.junctionAt(data, 0, center).directions).toEqual(['E']);
+  expect(autoTile.junctionAt(data, 1, center).directions).toEqual(['S']);
+});
+
+test('mixed wall profiles connect physically while reporting a mixed visual junction', () => {
+  const center = { col:4, row:4 };
+  const concrete = wall(center, { col:5, row:4 }, 0, 'concrete');
+  const wood = wall(center, { col:4, row:5 }, 0, 'wood');
+  const junction = autoTile.junctionAt(map([concrete, wood]), 0, center);
+  expect(junction.shape).toBe('corner');
+  expect(junction.mixedProfiles).toBe(true);
+  expect(junction.profileIds).toEqual(['concrete','wood']);
+});
+
+test('dirty-neighbor invalidation touches only walls incident to changed vertices', () => {
+  const west = wall({ col:1, row:2 }, { col:2, row:2 });
+  const east = wall({ col:2, row:2 }, { col:3, row:2 });
+  const far = wall({ col:8, row:8 }, { col:9, row:8 });
+  const previous = [west, far];
+  const next = [west, east, far];
+  const changed = autoTile.changedElements(previous, next);
+  expect(changed.map((entry) => entry.id)).toContain(east.id);
+  const affected = autoTile.affectedWallIds(map(next), 0, changed);
+  expect(affected).toContain(west.id);
+  expect(affected).toContain(east.id);
+  expect(affected).not.toContain(far.id);
+});
+
+test('vector renderer draws derived wall tile without changing physical topology', () => {
+  const edge = wall({ col:1, row:1 }, { col:2, row:1 });
+  const data = map([edge]);
+  const calls = [];
+  const ctx = {
+    globalAlpha:1,
+    save(){ calls.push('save'); }, restore(){ calls.push('restore'); },
+    beginPath(){}, moveTo(){}, lineTo(){}, stroke(){ calls.push('stroke'); },
+    arc(){}, fill(){ calls.push('fill'); }, fillRect(){ calls.push('fillRect'); }, setLineDash(){},
+    set fillStyle(value){ this._fillStyle = value; }, set strokeStyle(value){ this._strokeStyle = value; },
+    set lineWidth(value){ this._lineWidth = value; }, set lineCap(value){ this._lineCap = value; }, set lineJoin(value){ this._lineJoin = value; },
+  };
+  const before = JSON.stringify(data.topology);
+  expect(autoRenderer.drawWallTile(ctx, data, edge, autoTile.tileForEdge(edge, data))).toBe(true);
+  expect(calls.filter((entry) => entry === 'stroke').length).toBeGreaterThanOrEqual(2);
+  expect(JSON.stringify(data.topology)).toBe(before);
+});
+
+test('bootstrap composes renderer/controller and restores both on teardown', () => {
+  const source = fs.readFileSync(path.join(__dirname, '../js/vtt/wall-auto-tile-bootstrap.js'), 'utf8');
+  const builderBootstrap = fs.readFileSync(path.join(__dirname, '../js/vtt/wall-builder-bootstrap.js'), 'utf8');
+  expect(source).toContain('renderer.drawTopologyElement = function wallAutoTileDrawTopologyElement');
+  expect(source).toContain('controller.handleTopologyChanged = function wallAutoTileTopologyChanged');
+  expect(source).toContain('invalidateChanges(topologySnapshot, next)');
+  expect(source).toContain('renderer.drawTopologyElement = originalDrawTopologyElement');
+  expect(source).toContain('controller.handleTopologyChanged = originalHandleTopologyChanged');
+  expect(builderBootstrap).toContain("startWallAutoTile({ runtime:window.LuminousVttRuntime, mapData })");
+  expect(builderBootstrap).toContain('autoTileApi?.stop?.()');
+});


### PR DESCRIPTION
## Summary
- Adds derived wall auto-tiling over the canonical unit-edge Wall Builder merged in #640.
- Classifies each wall vertex as END / STRAIGHT / CORNER / T / CROSS with stable orientation metadata.
- Resolves every unit wall edge into a derived tile descriptor with `from` and `to` junctions plus a dominant variant key.
- Keeps auto-tile state non-persistent: `MapDefinition` continues to store only canonical topology edges and wall profile metadata.
- Treats doors/windows as openings rather than wall neighbors, preparing exact edge replacement without visual seams.
- Keeps Z layers isolated during neighbor resolution.
- Supports mixed wall profiles at a junction while reporting `mixedProfiles` for future atlas/material policy.
- Adds a vector auto-tile renderer for current profiles and preserves previews, openings and legacy long walls through the existing topology renderer.
- Adds local cache invalidation: topology changes only invalidate wall edges incident to changed vertices rather than rebuilding every wall descriptor.
- Integrates auto-tiling into the Wall Builder lifecycle and restores renderer/controller wrappers on teardown.

## Architecture
`canonical topology wall edges -> neighbor graph -> derived junction/tile descriptors -> renderer`

Physics remains upstream and unchanged: Movement, A*, PoV and Dynamic Lighting continue reading canonical `topology.type = wall`; visuals never become authoritative.

## Scope
This PR does not add texture atlases or image sprite sheets yet. The descriptor already exposes stable `variantKey` + orientation so a later appearance/atlas layer can map `wall.end`, `wall.straight`, `wall.corner`, `wall.t`, and `wall.cross` without changing persisted map data.

## Tests
Focused contracts cover shape/orientation classification, canonical neighbor resolution, isolated edges, opening behavior, Z isolation, mixed profiles, dirty-neighbor invalidation, renderer purity and lifecycle composition. CI also runs Wall Builder, Surface Foundation, Map/HUD contracts and the full repository regression suite.