### PR TITLE
feat(vtt): atomic wall edge door and window replacement

### DIFF
--- a/.github/workflows/vtt-opening-edge-replacement.yml
+++ b/.github/workflows/vtt-opening-edge-replacement.yml
@@ -1,0 +1,37 @@
+name: VTT Opening Edge Replacement
+
+on:
+  pull_request:
+    paths:
+      - 'js/vtt/topology-opening-edge*.js'
+      - 'js/vtt/topology-replace-state-patch.js'
+      - 'js/vtt/wall-builder-bootstrap.js'
+      - 'js/vtt/main.js'
+      - 'tests/vtt_opening_edge_replacement.spec.js'
+      - '.github/workflows/vtt-opening-edge-replacement.yml'
+  workflow_dispatch:
+
+jobs:
+  opening-edge-replacement:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Syntax
+        run: |
+          node --check js/vtt/topology-opening-edge.js
+          node --check js/vtt/topology-replace-state-patch.js
+          node --input-type=module --check < js/vtt/topology-opening-edge-bootstrap.js
+          node --input-type=module --check < js/vtt/wall-builder-bootstrap.js
+          node --input-type=module --check < js/vtt/main.js
+          node --check tests/vtt_opening_edge_replacement.spec.js
+      - name: Focused contracts
+        run: npx playwright test tests/vtt_opening_edge_replacement.spec.js tests/vtt_wall_autotiling.spec.js tests/vtt_wall_builder_foundation.spec.js tests/vtt_surface_foundation.spec.js tests/vtt_map_hud_physical.spec.js --workers=1
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Repository regression
+        run: npx playwright test --workers=1

--- a/js/vtt/main.js
+++ b/js/vtt/main.js
@@ -8,6 +8,7 @@ import './surface-renderer.js';
 import './surface-authoring-patch.js';
 import './map-authoring-state.js';
 import './map-switch-guard.js';
+import './topology-replace-state-patch.js';
 import './actor-library.js';
 import './actor-library-state.js';
 import './token-appearance.js';

--- a/js/vtt/topology-opening-edge-bootstrap.js
+++ b/js/vtt/topology-opening-edge-bootstrap.js
@@ -1,0 +1,152 @@
+import './topology-opening-edge.js';
+
+const PANEL_ID = 'vtt-opening-edge-actions';
+const STYLE_ID = 'vtt-opening-edge-style';
+
+function labelFor(type) {
+  return ({ door:'DOOR', window:'WINDOW', curtain_window:'CURTAIN WINDOW' })[type] || String(type || '').toUpperCase();
+}
+
+function ensureUi() {
+  const editor = document.getElementById('vtt-topology-editor');
+  if (!editor) return null;
+  let panel = document.getElementById(PANEL_ID);
+  if (panel) return panel;
+
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+    #${PANEL_ID}{display:grid;gap:6px;padding:8px 0;border-top:1px solid #3c4147;border-bottom:1px solid #3c4147;margin:6px 0}
+    #${PANEL_ID}[hidden]{display:none}
+    #${PANEL_ID} small{font:9px monospace;color:#8d9aa2;line-height:1.35}
+    #${PANEL_ID} .vtt-opening-actions{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:4px}
+    #${PANEL_ID} button{min-width:0;padding:6px 4px;font-size:9px}
+    #${PANEL_ID} [data-opening-restore]{grid-column:1/-1}
+  `;
+  document.head.appendChild(style);
+
+  panel = document.createElement('section');
+  panel.id = PANEL_ID;
+  panel.hidden = true;
+  panel.innerHTML = `
+    <small data-opening-status>OPENING EDGE</small>
+    <div class="vtt-opening-actions">
+      <button type="button" class="brutalist-button" data-opening-type="door">DOOR</button>
+      <button type="button" class="brutalist-button" data-opening-type="window">WINDOW</button>
+      <button type="button" class="brutalist-button" data-opening-type="curtain_window">CURTAIN</button>
+      <button type="button" class="vtt-danger-button" data-opening-restore hidden>RESTORE WALL</button>
+    </div>
+  `;
+  const deleteButton = document.getElementById('vtt-topology-delete');
+  editor.insertBefore(panel, deleteButton || null);
+  return panel;
+}
+
+export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.engine?.mapData } = {}) {
+  if (!runtime?.controller || !runtime?.bridge || !mapData) return null;
+  if (window.LuminousVttOpeningEdgeRuntime?.api) return window.LuminousVttOpeningEdgeRuntime.api;
+
+  const controller = runtime.controller;
+  const bridge = runtime.bridge;
+  const core = window.LuminousVttOpeningEdge;
+  const builder = window.LuminousVttWallBuilder;
+  if (!core || !builder) throw new Error('OPENING_EDGE_DEPENDENCY_REQUIRED');
+  if (typeof bridge.replaceElement !== 'function') throw new Error('ATOMIC_TOPOLOGY_REPLACE_REQUIRED');
+
+  const panel = controller.isDm ? ensureUi() : null;
+  const originalRenderEditor = controller.renderEditor.bind(controller);
+  let stopped = false;
+
+  function elementById(id) {
+    return (mapData.topology || []).find((entry) => String(entry?.id || '') === String(id || '')) || null;
+  }
+
+  async function replaceWithOpening(elementOrId, type) {
+    const element = typeof elementOrId === 'object' ? elementOrId : elementById(elementOrId);
+    if (!element) throw new Error('ELEMENT_NOT_FOUND');
+    const plan = core.replacementPlan(element, type);
+    const saved = await bridge.replaceElement(plan.oldId, plan.next);
+    controller.selectedId = saved.id;
+    controller.handleTopologyChanged?.();
+    controller.renderEditor?.();
+    controller.notify?.(`${labelFor(saved.type)} INSERTED ON WALL EDGE`, 'success');
+    return { ...plan, saved };
+  }
+
+  async function restoreOpening(elementOrId) {
+    const element = typeof elementOrId === 'object' ? elementOrId : elementById(elementOrId);
+    if (!element) throw new Error('ELEMENT_NOT_FOUND');
+    const wall = core.restoreWall(element);
+    const saved = await bridge.replaceElement(String(element.id), wall);
+    controller.selectedId = saved.id;
+    controller.handleTopologyChanged?.();
+    controller.renderEditor?.();
+    controller.notify?.('WALL EDGE RESTORED', 'success');
+    return saved;
+  }
+
+  async function placeOnElement(rawElement, type) {
+    if (!controller.isDm || !controller.editActive?.()) throw new Error('DM_EDIT_MODE_REQUIRED');
+    if (!rawElement) throw new Error('WALL_EDGE_REQUIRED');
+    if (!core.isUnitWall(rawElement) && !core.isOpening(rawElement)) throw new Error('UNIT_WALL_EDGE_REQUIRED');
+    return replaceWithOpening(rawElement, type);
+  }
+
+  function renderInspector() {
+    if (!panel) return;
+    const selected = controller.selectedElement?.();
+    const isWall = core.isUnitWall(selected);
+    const isOpening = core.isOpening(selected) && Boolean(selected?.openingEdge?.sourceWall);
+    panel.hidden = !(controller.editActive?.() && (isWall || isOpening));
+    if (panel.hidden) return;
+
+    const status = panel.querySelector('[data-opening-status]');
+    const restore = panel.querySelector('[data-opening-restore]');
+    if (status) {
+      status.textContent = isWall
+        ? `UNIT WALL · ${String(selected.wallProfileId || selected.wall?.profileId || 'WALL').toUpperCase()} · REPLACE EDGE`
+        : `${labelFor(selected.type)} · SOURCE WALL SAVED`;
+    }
+    if (restore) restore.hidden = !isOpening;
+    panel.querySelectorAll('[data-opening-type]').forEach((button) => {
+      button.disabled = isOpening && button.dataset.openingType === selected.type;
+    });
+  }
+
+  controller.renderEditor = function openingEdgeRenderEditor(...args) {
+    const result = originalRenderEditor(...args);
+    renderInspector();
+    return result;
+  };
+
+  panel?.querySelectorAll('[data-opening-type]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const selected = controller.selectedElement?.();
+      if (!selected) return;
+      void replaceWithOpening(selected, button.dataset.openingType)
+        .catch((error) => controller.notify?.(String(error.message || error), 'error'));
+    });
+  });
+
+  panel?.querySelector('[data-opening-restore]')?.addEventListener('click', () => {
+    const selected = controller.selectedElement?.();
+    if (!selected) return;
+    void restoreOpening(selected)
+      .catch((error) => controller.notify?.(String(error.message || error), 'error'));
+  });
+
+  renderInspector();
+
+  function stop() {
+    if (stopped) return;
+    stopped = true;
+    controller.renderEditor = originalRenderEditor;
+    panel?.remove();
+    document.getElementById(STYLE_ID)?.remove();
+  }
+
+  const api = Object.freeze({ core, placeOnElement, replaceWithOpening, restoreOpening, renderInspector, stop });
+  window.LuminousVttOpeningEdgeRuntime = Object.freeze({ api, stop });
+  window.LuminousVttRuntime = Object.freeze({ ...window.LuminousVttRuntime, openingEdges:api });
+  return api;
+}

--- a/js/vtt/topology-opening-edge.js
+++ b/js/vtt/topology-opening-edge.js
@@ -1,0 +1,188 @@
+(function (root, factory) {
+  const api = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttOpeningEdge = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (root) {
+  'use strict';
+
+  const OPENING_TYPES = Object.freeze(['door', 'window', 'curtain_window']);
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+  function topologyRuntime() {
+    if (root?.LuminousVttTopology) return root.LuminousVttTopology;
+    if (typeof require !== 'undefined') {
+      try { return require('./topology.js'); } catch (_) {}
+    }
+    return null;
+  }
+
+  function builderRuntime() {
+    if (root?.LuminousVttWallBuilder) return root.LuminousVttWallBuilder;
+    if (typeof require !== 'undefined') {
+      try { return require('./wall-builder.js'); } catch (_) {}
+    }
+    return null;
+  }
+
+  function normalizeOpeningType(type) {
+    const value = String(type || '').trim().toLowerCase();
+    if (!OPENING_TYPES.includes(value)) throw new Error('OPENING_TYPE_REQUIRED');
+    return value;
+  }
+
+  function layerOf(element = {}) {
+    const topology = topologyRuntime();
+    return Number(topology?.elementLayers?.(element)?.[0] || 0);
+  }
+
+  function openingId(from, to, zLayer = 0) {
+    const builder = builderRuntime();
+    if (!builder) throw new Error('WALL_BUILDER_REQUIRED');
+    const edge = builder.canonicalEdge(from, to);
+    const z = Number(zLayer) || 0;
+    return `opening_z${String(z).replace(/-/g, 'n')}_c${edge.from.col}r${edge.from.row}_c${edge.to.col}r${edge.to.row}`;
+  }
+
+  function isOpening(element = {}) {
+    return OPENING_TYPES.includes(String(element?.type || ''));
+  }
+
+  function isUnitWall(element = {}) {
+    const topology = topologyRuntime();
+    const builder = builderRuntime();
+    if (!topology || !builder) return false;
+    const normalized = topology.normalizeElement(element);
+    return normalized.type === 'wall' && builder.isUnitEdge(normalized.from, normalized.to);
+  }
+
+  function exactEdgeMatch(a = {}, b = {}, zLayer = null) {
+    const topology = topologyRuntime();
+    const builder = builderRuntime();
+    if (!topology || !builder || !a || !b) return false;
+    const az = zLayer == null ? layerOf(a) : Number(zLayer) || 0;
+    if (!topology.elementOnLayer(a, az) || !topology.elementOnLayer(b, az)) return false;
+    const left = topology.normalizeElement(a);
+    const right = topology.normalizeElement(b);
+    if (!builder.isUnitEdge(left.from, left.to) || !builder.isUnitEdge(right.from, right.to)) return false;
+    return builder.edgeKey(left.from, left.to, az) === builder.edgeKey(right.from, right.to, az);
+  }
+
+  function sourceWallSnapshot(rawWall = {}) {
+    if (!isUnitWall(rawWall)) throw new Error('UNIT_WALL_REQUIRED');
+    const topology = topologyRuntime();
+    const wall = topology.normalizeElement(rawWall);
+    return clone({
+      ...rawWall,
+      ...wall,
+      state: null,
+      thresholds: undefined,
+    });
+  }
+
+  function createOpeningFromWall(rawWall, type) {
+    const topology = topologyRuntime();
+    const openingType = normalizeOpeningType(type);
+    if (!topology || !isUnitWall(rawWall)) throw new Error('UNIT_WALL_REQUIRED');
+    const wall = topology.normalizeElement(rawWall);
+    const zLayer = layerOf(wall);
+    const opening = topology.createElement({
+      id: openingId(wall.from, wall.to, zLayer),
+      type: openingType,
+      from: wall.from,
+      to: wall.to,
+      zLayer,
+    });
+    return {
+      ...opening,
+      openingEdge: {
+        schemaVersion: 1,
+        sourceWall: sourceWallSnapshot(rawWall),
+      },
+    };
+  }
+
+  function retypeOpening(rawOpening, type) {
+    const topology = topologyRuntime();
+    const openingType = normalizeOpeningType(type);
+    if (!topology || !isOpening(rawOpening)) throw new Error('OPENING_REQUIRED');
+    const current = topology.normalizeElement(rawOpening);
+    const sourceWall = clone(rawOpening.openingEdge?.sourceWall || null);
+    if (!sourceWall || !isUnitWall(sourceWall)) throw new Error('SOURCE_WALL_REQUIRED');
+    const zLayer = layerOf(current);
+    return {
+      ...topology.createElement({
+        id: String(current.id || openingId(current.from, current.to, zLayer)),
+        type: openingType,
+        from: current.from,
+        to: current.to,
+        zLayer,
+      }),
+      openingEdge: {
+        schemaVersion: 1,
+        sourceWall,
+      },
+    };
+  }
+
+  function restoreWall(rawOpening) {
+    const topology = topologyRuntime();
+    const builder = builderRuntime();
+    if (!topology || !builder || !isOpening(rawOpening)) throw new Error('OPENING_REQUIRED');
+    const source = clone(rawOpening.openingEdge?.sourceWall || null);
+    if (!source || !isUnitWall(source)) throw new Error('SOURCE_WALL_REQUIRED');
+    const normalized = topology.normalizeElement(source);
+    const zLayer = layerOf(normalized);
+    const id = String(source.id || builder.wallId(normalized.from, normalized.to, zLayer));
+    return {
+      ...source,
+      ...normalized,
+      id,
+      type: 'wall',
+      state: null,
+      thresholds: undefined,
+      wallProfileId: source.wallProfileId || source.wall?.profileId || 'concrete',
+      wall: clone(source.wall || null),
+      heightFt: Number(source.heightFt ?? source.wall?.heightFt ?? 10),
+    };
+  }
+
+  function exactElementAtEdge(elements = [], from, to, zLayer = 0) {
+    const topology = topologyRuntime();
+    const builder = builderRuntime();
+    if (!topology || !builder) return null;
+    const key = builder.edgeKey(from, to, zLayer);
+    return (Array.isArray(elements) ? elements : []).find((raw) => {
+      if (!topology.elementOnLayer(raw, zLayer)) return false;
+      const element = topology.normalizeElement(raw);
+      if (!builder.isUnitEdge(element.from, element.to)) return false;
+      return builder.edgeKey(element.from, element.to, zLayer) === key;
+    }) || null;
+  }
+
+  function replacementPlan(rawElement, type) {
+    const openingType = normalizeOpeningType(type);
+    if (isUnitWall(rawElement)) {
+      return { oldId:String(rawElement.id), next:createOpeningFromWall(rawElement, openingType), mode:'wall_to_opening' };
+    }
+    if (isOpening(rawElement)) {
+      return { oldId:String(rawElement.id), next:retypeOpening(rawElement, openingType), mode:'opening_retype' };
+    }
+    throw new Error('REPLACEABLE_EDGE_REQUIRED');
+  }
+
+  return Object.freeze({
+    OPENING_TYPES,
+    normalizeOpeningType,
+    layerOf,
+    openingId,
+    isOpening,
+    isUnitWall,
+    exactEdgeMatch,
+    sourceWallSnapshot,
+    createOpeningFromWall,
+    retypeOpening,
+    restoreWall,
+    exactElementAtEdge,
+    replacementPlan,
+  });
+});

--- a/js/vtt/topology-replace-state-patch.js
+++ b/js/vtt/topology-replace-state-patch.js
@@ -1,0 +1,64 @@
+(function (root) {
+  'use strict';
+
+  const base = root?.LuminousVttStateBridge;
+  if (!base || base.__atomicReplacePatch) return;
+
+  const originalCreateBridge = base.createBridge.bind(base);
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+  function hostFirebase(runtimeRoot = root) {
+    const host = base.hostWindow?.(runtimeRoot) || runtimeRoot;
+    return host?.firebase || runtimeRoot?.firebase || null;
+  }
+
+  function createBridge(options = {}) {
+    const bridge = originalCreateBridge(options);
+    if (bridge?.replaceElement) return bridge;
+
+    const mapData = options.mapData;
+    const topology = root?.LuminousVttTopology;
+    const firebase = hostFirebase(options.root || root);
+    const db = firebase?.database?.() || null;
+
+    async function replaceElement(oldElementId, nextElement) {
+      if (!bridge?.isDm) throw new Error('DM_REQUIRED');
+      if (!mapData || !topology) throw new Error('TOPOLOGY_REPLACE_DEPENDENCY_REQUIRED');
+
+      const oldId = String(oldElementId || '').trim();
+      const normalized = topology.normalizeElement(nextElement);
+      const nextId = String(normalized.id || '').trim();
+      if (!oldId) throw new Error('OLD_ELEMENT_ID_REQUIRED');
+      if (!nextId) throw new Error('ELEMENT_ID_REQUIRED');
+      if (!(mapData.topology || []).some((entry) => String(entry?.id || '') === oldId)) {
+        throw new Error('ELEMENT_NOT_FOUND');
+      }
+
+      if (!db) {
+        const next = (Array.isArray(mapData.topology) ? mapData.topology : [])
+          .filter((entry) => {
+            const id = String(entry?.id || '');
+            return id !== oldId && id !== nextId;
+          });
+        next.push(clone(normalized));
+        next.sort((a, b) => String(a.id).localeCompare(String(b.id)));
+        mapData.topology = next;
+        if (typeof options.onTopologyChanged === 'function') options.onTopologyChanged(next);
+        return normalized;
+      }
+
+      const updates = { [nextId]: clone(normalized) };
+      if (oldId !== nextId) updates[oldId] = null;
+      await db.ref(`${base.TOPOLOGY_ROOT}/${bridge.mapId}/elements`).update(updates);
+      return normalized;
+    }
+
+    return Object.freeze({ ...bridge, replaceElement });
+  }
+
+  root.LuminousVttStateBridge = Object.freeze({
+    ...base,
+    __atomicReplacePatch: true,
+    createBridge,
+  });
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/vtt/wall-builder-bootstrap.js
+++ b/js/vtt/wall-builder-bootstrap.js
@@ -1,8 +1,10 @@
 import './wall-builder.js';
 import { start as startWallAutoTile } from './wall-auto-tile-bootstrap.js';
+import { start as startOpeningEdges } from './topology-opening-edge-bootstrap.js';
 
 const PROFILE_FIELD_ID = 'vtt-wall-builder-profile-field';
 const STYLE_ID = 'vtt-wall-builder-style';
+const OPENING_TOOLS = Object.freeze(['door', 'window', 'curtain_window']);
 
 function ensureProfileUi(builder, controller) {
   const toolbar = document.getElementById('vtt-topology-toolbar');
@@ -57,9 +59,14 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   let profileId = profileField?.querySelector('[data-wall-profile]')?.value || 'concrete';
   let stopped = false;
   let autoTileApi = null;
+  let openingApi = null;
 
   function editWallActive() {
     return Boolean(controller.isDm && controller.editActive?.() && controller.tool === 'wall');
+  }
+
+  function editOpeningActive() {
+    return Boolean(controller.isDm && controller.editActive?.() && OPENING_TOOLS.includes(controller.tool));
   }
 
   function activeProfile() {
@@ -77,6 +84,26 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   }
 
   function onMouseDown(event) {
+    if (editOpeningActive()) {
+      if (event.button !== 0) return;
+      if (engine.tokenAtEvent(event)) return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      controller.hideContextMenu?.();
+      const hit = controller.topologyAtEvent?.(event);
+      if (!hit) {
+        controller.notify?.('Selecciona un WALL EDGE existente para insertar la apertura.', 'error');
+        return;
+      }
+      if (!openingApi) {
+        controller.notify?.('Opening Edge runtime no disponible.', 'error');
+        return;
+      }
+      void openingApi.placeOnElement(hit, controller.tool)
+        .catch((error) => controller.notify?.(String(error.message || error), 'error'));
+      return;
+    }
+
     if (!editWallActive()) return original.down(event);
     if (event.button !== 0) return;
     if (engine.tokenAtEvent(event)) return;
@@ -159,6 +186,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   function stop() {
     if (stopped) return;
     stopped = true;
+    openingApi?.stop?.();
     autoTileApi?.stop?.();
     canvas.removeEventListener('mousedown', onMouseDown, true);
     window.removeEventListener('mousemove', onMouseMove, true);
@@ -171,11 +199,20 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     document.getElementById(STYLE_ID)?.remove();
   }
 
-  const api = Object.freeze({ builder, saveRun, setProfile, getProfile:activeProfile, getAutoTile:() => autoTileApi, stop });
+  const api = Object.freeze({
+    builder,
+    saveRun,
+    setProfile,
+    getProfile:activeProfile,
+    getAutoTile:() => autoTileApi,
+    getOpeningEdges:() => openingApi,
+    stop,
+  });
   window.LuminousVttWallBuilderRuntime = Object.freeze({ api, stop });
   window.LuminousVttRuntime = Object.freeze({ ...window.LuminousVttRuntime, wallBuilder:api });
   try {
     autoTileApi = startWallAutoTile({ runtime:window.LuminousVttRuntime, mapData });
+    openingApi = startOpeningEdges({ runtime:window.LuminousVttRuntime, mapData });
   } catch (error) {
     stop();
     throw error;

--- a/tests/vtt_opening_edge_replacement.spec.js
+++ b/tests/vtt_opening_edge_replacement.spec.js
@@ -1,0 +1,152 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+const topology = require('../js/vtt/topology.js');
+const builder = require('../js/vtt/wall-builder.js');
+const openingEdges = require('../js/vtt/topology-opening-edge.js');
+const autoTile = require('../js/vtt/wall-auto-tile.js');
+const tokenInteraction = require('../js/vtt/token-interaction.js');
+const lighting = require('../js/vtt/lighting-engine.js');
+
+test('wall edge -> opening -> wall round trip preserves canonical wall profile and geometry', () => {
+  const [wall] = builder.createWallRun({
+    from:{ col:1, row:1 }, to:{ col:2, row:1 }, zLayer:1, profileId:'brick',
+  });
+  const door = openingEdges.createOpeningFromWall(wall, 'door');
+
+  expect(door.id).toBe('opening_z1_c1r1_c2r1');
+  expect(door.type).toBe('door');
+  expect(door.from).toEqual(wall.from);
+  expect(door.to).toEqual(wall.to);
+  expect(door.z).toEqual([1]);
+  expect(door.openingEdge.sourceWall.id).toBe(wall.id);
+  expect(door.openingEdge.sourceWall.wallProfileId).toBe('brick');
+
+  const restored = openingEdges.restoreWall(door);
+  expect(restored.id).toBe(wall.id);
+  expect(restored.type).toBe('wall');
+  expect(restored.from).toEqual(wall.from);
+  expect(restored.to).toEqual(wall.to);
+  expect(restored.z).toEqual([1]);
+  expect(restored.wallProfileId).toBe('brick');
+  expect(restored.wall.materialId).toBe('brick');
+  expect(restored.thicknessFt).toBe(wall.thicknessFt);
+  expect(restored.heightFt).toBe(wall.heightFt);
+});
+
+test('retyping an opening keeps one stable edge identity and its source wall snapshot', () => {
+  const [wall] = builder.createWallRun({
+    from:{ col:0, row:0 }, to:{ col:1, row:0 }, zLayer:0, profileId:'metal',
+  });
+  const door = openingEdges.createOpeningFromWall(wall, 'door');
+  const window = openingEdges.retypeOpening(door, 'window');
+  const curtain = openingEdges.retypeOpening(window, 'curtain_window');
+
+  expect(window.id).toBe(door.id);
+  expect(curtain.id).toBe(door.id);
+  expect(window.openingEdge.sourceWall.wallProfileId).toBe('metal');
+  expect(curtain.openingEdge.sourceWall.id).toBe(wall.id);
+  expect(openingEdges.restoreWall(curtain).id).toBe(wall.id);
+});
+
+test('door and window replacements inherit existing topology physics without a parallel collision system', () => {
+  const [wall] = builder.createWallRun({
+    from:{ col:1, row:0 }, to:{ col:1, row:1 }, zLayer:0, profileId:'concrete',
+  });
+  const door = openingEdges.createOpeningFromWall(wall, 'door');
+  const window = openingEdges.createOpeningFromWall(wall, 'window');
+  const grid = { size:70, cols:4, rows:3, distancePerCell:5 };
+  const token = { id:'t1', x:35, y:35, zLayer:0, radius:20 };
+  const destination = { x:105, y:35 };
+
+  const doorMap = { grid, topology:[door] };
+  expect(tokenInteraction.isPathClear(token, { x:35, y:35 }, destination, doorMap).valid).toBe(false);
+  expect(lighting.lineBlocked2d({ x:35, y:35 }, destination, doorMap, 0)).toBe(true);
+
+  const openDoor = topology.applyAction(door, 'open').element;
+  const openDoorMap = { grid, topology:[openDoor] };
+  expect(tokenInteraction.isPathClear(token, { x:35, y:35 }, destination, openDoorMap).valid).toBe(true);
+  expect(lighting.lineBlocked2d({ x:35, y:35 }, destination, openDoorMap, 0)).toBe(false);
+
+  const windowMap = { grid, topology:[window] };
+  expect(tokenInteraction.isPathClear(token, { x:35, y:35 }, destination, windowMap).valid).toBe(false);
+  expect(lighting.lineBlocked2d({ x:35, y:35 }, destination, windowMap, 0)).toBe(false);
+});
+
+test('replacing a middle wall edge with an opening auto-caps its adjacent walls', () => {
+  const walls = builder.createWallRun({
+    from:{ col:0, row:1 }, to:{ col:3, row:1 }, zLayer:0, profileId:'wood',
+  });
+  const before = { topology:walls };
+  expect(autoTile.junctionAt(before, 0, { col:1, row:1 }).shape).toBe('straight');
+  expect(autoTile.junctionAt(before, 0, { col:2, row:1 }).shape).toBe('straight');
+
+  const door = openingEdges.createOpeningFromWall(walls[1], 'door');
+  const after = { topology:[walls[0], door, walls[2]] };
+  expect(autoTile.junctionAt(after, 0, { col:1, row:1 }).shape).toBe('end');
+  expect(autoTile.junctionAt(after, 0, { col:2, row:1 }).shape).toBe('end');
+  expect(autoTile.tileForEdge(walls[0], after, 0).shape).toBe('isolated');
+  expect(autoTile.tileForEdge(walls[2], after, 0).shape).toBe('isolated');
+});
+
+test('opening replacement remains isolated by Z layer', () => {
+  const [wallZ0] = builder.createWallRun({ from:{ col:0, row:0 }, to:{ col:1, row:0 }, zLayer:0 });
+  const [wallZ1] = builder.createWallRun({ from:{ col:0, row:0 }, to:{ col:1, row:0 }, zLayer:1 });
+  const doorZ0 = openingEdges.createOpeningFromWall(wallZ0, 'door');
+  const mapData = { topology:[doorZ0, wallZ1] };
+
+  expect(openingEdges.exactElementAtEdge(mapData.topology, wallZ0.from, wallZ0.to, 0).id).toBe(doorZ0.id);
+  expect(openingEdges.exactElementAtEdge(mapData.topology, wallZ1.from, wallZ1.to, 1).id).toBe(wallZ1.id);
+  expect(autoTile.wallsOnLayer(mapData, 0)).toHaveLength(0);
+  expect(autoTile.wallsOnLayer(mapData, 1)).toHaveLength(1);
+});
+
+test('atomic topology replacement bridge emits one Firebase multipath update', async () => {
+  const statePath = require.resolve('../js/vtt/state-bridge.js');
+  const patchPath = require.resolve('../js/vtt/topology-replace-state-patch.js');
+  delete require.cache[statePath];
+  delete require.cache[patchPath];
+  require(statePath);
+  require(patchPath);
+
+  const [wall] = builder.createWallRun({ from:{ col:0, row:0 }, to:{ col:1, row:0 }, zLayer:0 });
+  const door = openingEdges.createOpeningFromWall(wall, 'door');
+  const writes = [];
+  const db = {
+    ref(refPath) {
+      return {
+        update: async (payload) => writes.push({ refPath, payload }),
+      };
+    },
+  };
+  const fakeRoot = {
+    document: { body: { classList:{ contains:(name) => name === 'on-game-dashboard' }, dataset:{} } },
+    firebase: { database:() => db },
+  };
+  const mapData = { id:'atomic-map', topology:[wall] };
+  const bridge = global.LuminousVttStateBridge.createBridge({ mapData, root:fakeRoot });
+
+  await bridge.replaceElement(wall.id, door);
+  expect(writes).toHaveLength(1);
+  expect(writes[0].refPath).toBe('vtt_topology/atomic-map/elements');
+  expect(writes[0].payload[wall.id]).toBeNull();
+  expect(writes[0].payload[door.id].type).toBe('door');
+  expect(writes[0].payload[door.id].openingEdge.sourceWall.id).toBe(wall.id);
+});
+
+test('opening authoring contracts enforce edge replacement UX and inspector restore', () => {
+  const main = fs.readFileSync(path.join(__dirname, '../js/vtt/main.js'), 'utf8');
+  const wallBootstrap = fs.readFileSync(path.join(__dirname, '../js/vtt/wall-builder-bootstrap.js'), 'utf8');
+  const openingBootstrap = fs.readFileSync(path.join(__dirname, '../js/vtt/topology-opening-edge-bootstrap.js'), 'utf8');
+  const replacePatch = fs.readFileSync(path.join(__dirname, '../js/vtt/topology-replace-state-patch.js'), 'utf8');
+
+  expect(main).toContain("import './topology-replace-state-patch.js'");
+  expect(wallBootstrap).toContain("OPENING_TOOLS.includes(controller.tool)");
+  expect(wallBootstrap).toContain('openingApi.placeOnElement(hit, controller.tool)');
+  expect(openingBootstrap).toContain('data-opening-restore');
+  expect(openingBootstrap).toContain('bridge.replaceElement(plan.oldId, plan.next)');
+  expect(openingBootstrap).toContain('bridge.replaceElement(String(element.id), wall)');
+  expect(replacePatch).toContain("updates[oldId] = null");
+  expect(replacePatch).toContain('.update(updates)');
+});


### PR DESCRIPTION
## Summary
- Replaces canonical unit wall edges atomically with `door`, `window`, or `curtain_window` topology elements instead of drawing openings on top of walls.
- Stores the replaced wall snapshot inside `openingEdge.sourceWall`, preserving wall id, profile, material, height, thickness and visual metadata for exact restoration.
- Adds `RESTORE WALL` plus retype actions to the topology inspector.
- Routes the existing DOOR / WINDOW / CURTAIN WINDOW tools through click-on-edge replacement; arbitrary floating/long opening drawing is no longer used while Wall Builder runtime is active.
- Supports opening-to-opening retyping while retaining one stable opening id and the original source wall snapshot.
- Adds an atomic `replaceElement(oldId, nextElement)` composition to the canonical topology state bridge using one Firebase multipath update (`old=null`, `next=value`).
- Keeps all physical rules in the existing topology engine: closed doors block movement+vision, windows block movement but not vision, open doors stop blocking both.
- Auto-tiling continues to treat openings as gaps, so adjacent wall edges recalculate their caps automatically.
- Keeps Z layers isolated.

## Architecture
`unit wall edge -> atomic topology replacement -> opening edge`

`opening edge -> stored sourceWall -> atomic restore -> original wall edge`

No parallel collision, vision or lighting model is introduced.

## Tests
Focused contracts cover wall/opening round-trip, profile preservation, opening retyping, Movement/vision/light behavior, auto-tile neighbor caps, Z isolation, Firebase atomic multipath replacement, inspector actions and tool routing. CI also runs Wall Auto-Tiling, Wall Builder, Surface Foundation, Map/HUD and the full repository regression suite.