### PR TITLE
Item runtime + realtime DM/player inventory sync

### DIFF
--- a/.github/workflows/item-runtime-validation.yml
+++ b/.github/workflows/item-runtime-validation.yml
@@ -8,9 +8,11 @@ on:
       - "js/workshop-runtime.js"
       - "js/item-magic-runtime.js"
       - "js/item-persistence-runtime.js"
+      - "js/item-realtime-sync.js"
       - "js/item-augmentation-runtime.js"
       - "js/item-salvage-runtime.js"
-      - "js/status-engine.js"
+      - "hoja_personaje.js"
+      - "pantalla_dm.html"
       - "tests/item_runtime_engine.spec.js"
       - "tests/item_runtime_catalog_profile.spec.js"
       - "tests/item_inventory_runtime.spec.js"
@@ -18,6 +20,7 @@ on:
       - "tests/workshop_runtime.spec.js"
       - "tests/item_magic_runtime.spec.js"
       - "tests/item_persistence_runtime.spec.js"
+      - "tests/item_realtime_sync.spec.js"
       - "tests/item_augmentation_runtime.spec.js"
       - "tests/item_salvage_runtime.spec.js"
       - ".github/workflows/item-runtime-validation.yml"
@@ -33,4 +36,4 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
-      - run: npx playwright test tests/item_runtime_engine.spec.js tests/item_runtime_catalog_profile.spec.js tests/item_inventory_runtime.spec.js tests/item_inventory_regression.spec.js tests/workshop_runtime.spec.js tests/item_magic_runtime.spec.js tests/item_persistence_runtime.spec.js tests/item_augmentation_runtime.spec.js tests/item_salvage_runtime.spec.js
+      - run: npx playwright test tests/item_runtime_engine.spec.js tests/item_runtime_catalog_profile.spec.js tests/item_inventory_runtime.spec.js tests/item_inventory_regression.spec.js tests/workshop_runtime.spec.js tests/item_magic_runtime.spec.js tests/item_persistence_runtime.spec.js tests/item_realtime_sync.spec.js tests/item_augmentation_runtime.spec.js tests/item_salvage_runtime.spec.js

--- a/.github/workflows/item-runtime-validation.yml
+++ b/.github/workflows/item-runtime-validation.yml
@@ -1,0 +1,36 @@
+name: Item Runtime Validation
+
+on:
+  pull_request:
+    paths:
+      - "js/item-runtime-engine.js"
+      - "js/item-inventory-runtime.js"
+      - "js/workshop-runtime.js"
+      - "js/item-magic-runtime.js"
+      - "js/item-persistence-runtime.js"
+      - "js/item-augmentation-runtime.js"
+      - "js/item-salvage-runtime.js"
+      - "js/status-engine.js"
+      - "tests/item_runtime_engine.spec.js"
+      - "tests/item_runtime_catalog_profile.spec.js"
+      - "tests/item_inventory_runtime.spec.js"
+      - "tests/item_inventory_regression.spec.js"
+      - "tests/workshop_runtime.spec.js"
+      - "tests/item_magic_runtime.spec.js"
+      - "tests/item_persistence_runtime.spec.js"
+      - "tests/item_augmentation_runtime.spec.js"
+      - "tests/item_salvage_runtime.spec.js"
+      - ".github/workflows/item-runtime-validation.yml"
+
+jobs:
+  item-runtime-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx playwright test tests/item_runtime_engine.spec.js tests/item_runtime_catalog_profile.spec.js tests/item_inventory_runtime.spec.js tests/item_inventory_regression.spec.js tests/workshop_runtime.spec.js tests/item_magic_runtime.spec.js tests/item_persistence_runtime.spec.js tests/item_augmentation_runtime.spec.js tests/item_salvage_runtime.spec.js

--- a/js/item-augmentation-runtime.js
+++ b/js/item-augmentation-runtime.js
@@ -1,0 +1,247 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousItemAugmentationRuntime) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousItemAugmentationRuntime;
+    return;
+  }
+
+  function safeRequire(path) {
+    if (typeof require !== "function") return null;
+    try { return require(path); } catch (_) { return null; }
+  }
+
+  const items = () => global.LuminousItemRuntime || global.LuminousItemInventoryRuntime || safeRequire("./item-inventory-runtime.js") || safeRequire("./item-runtime-engine.js");
+  const anatomy = () => global.LuminousAnatomyEquipmentEngine || safeRequire("./anatomy-equipment-engine.js");
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const asArray = (value) => value == null ? [] : (Array.isArray(value) ? value : [value]);
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  const intOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Math.trunc(Number(value)) : fallback;
+
+  function emit(name, detail) {
+    try {
+      if (typeof global.dispatchEvent === "function" && typeof global.CustomEvent === "function") {
+        global.dispatchEvent(new global.CustomEvent(name, { detail }));
+      }
+    } catch (_) {}
+    return detail;
+  }
+
+  function instanceIdOf(item = {}) {
+    return String(item.instanceId || item.instance_id || items()?.itemId?.(item) || "").trim();
+  }
+
+  function categoryOf(item = {}) {
+    return normalizeId(items()?.categoryOf?.(item) || item.category || item.itemType || item.type || item.tipo_categoria || "");
+  }
+
+  function augmentationProfile(item = {}) {
+    const runtime = item.runtime && typeof item.runtime === "object" ? item.runtime : {};
+    const explicit = runtime.augmentation || runtime.augment || item.augmentation || item.augment || item.augmentationProfile || {};
+    return explicit && typeof explicit === "object" ? clone(explicit) : {};
+  }
+
+  function isAugmentation(item = {}) {
+    return ["augmentation", "augment", "aumento", "alteracion_corporal"].includes(categoryOf(item)) || augmentationProfile(item).enabled === true;
+  }
+
+  function installedAugments(unit = {}, create = false) {
+    const keys = ["augmentations", "augments", "bodyAugmentations"];
+    for (const key of keys) {
+      if (Array.isArray(unit[key])) return { key, value: unit[key] };
+    }
+    if (!create) return { key: "augmentations", value: [] };
+    unit.augmentations = [];
+    return { key: "augmentations", value: unit.augmentations };
+  }
+
+  function findInstalledAugment(unit, ref) {
+    const wanted = String(typeof ref === "object" ? instanceIdOf(ref) : ref || "");
+    return installedAugments(unit).value.find((entry) => {
+      if (!entry) return false;
+      if (entry === ref) return true;
+      return String(entry.instanceId || entry.instance_id || entry.id || "") === wanted;
+    }) || null;
+  }
+
+  function resolveAnatomy(unit = {}, options = {}) {
+    const engine = anatomy();
+    if (!engine?.resolveCharacterAnatomy) return null;
+    return engine.resolveCharacterAnatomy(unit, options);
+  }
+
+  function requirementProfile(item = {}) {
+    const profile = augmentationProfile(item);
+    return {
+      targetPartIds: asArray(profile.targetPartIds || profile.targetParts || profile.partIds).map(normalizeId).filter(Boolean),
+      targetPartTypes: asArray(profile.targetPartTypes || profile.partTypes || profile.slots).map(normalizeId).filter(Boolean),
+      requiredPartCount: Math.max(1, intOr(profile.requiredPartCount || profile.partCount, 1)),
+      allowedSubstrates: asArray(profile.allowedSubstrates || profile.substrates).map(normalizeId).filter(Boolean),
+      replaceBodyPart: clone(profile.replaceBodyPart || profile.replacesBodyPart || profile.replaces || null),
+      addBodyParts: clone(profile.addBodyParts || profile.addBodyPart || profile.addsBodyParts || null),
+      removable: profile.removable !== false && item.removable !== false,
+      installationDifficulty: profile.installationDifficulty ?? item.installationDifficulty ?? null,
+      removalDifficulty: profile.removalDifficulty ?? item.removalDifficulty ?? null,
+    };
+  }
+
+  function validateBodyRequirements(unit, item, options = {}) {
+    const engine = anatomy();
+    const resolved = resolveAnatomy(unit, options);
+    if (!resolved || !engine) return { allowed: false, reason: "anatomy_engine_unavailable" };
+    const requirements = requirementProfile(item);
+    const matchedPartIds = [];
+
+    if (requirements.targetPartIds.length) {
+      for (const partId of requirements.targetPartIds) {
+        const part = resolved.parts?.[partId];
+        if (!part || !engine.isPartUsable?.(part)) return { allowed: false, reason: "required_body_part_unavailable", partId };
+        if (requirements.allowedSubstrates.length && !requirements.allowedSubstrates.includes(normalizeId(part.substrate))) {
+          return { allowed: false, reason: "body_part_substrate_incompatible", partId, substrate: part.substrate };
+        }
+        matchedPartIds.push(partId);
+      }
+    }
+
+    if (requirements.targetPartTypes.length) {
+      for (const type of requirements.targetPartTypes) {
+        const parts = engine.partsByType?.(resolved, type, { usableOnly: true }) || [];
+        const compatible = requirements.allowedSubstrates.length
+          ? parts.filter((part) => requirements.allowedSubstrates.includes(normalizeId(part.substrate)))
+          : parts;
+        if (compatible.length < requirements.requiredPartCount) return { allowed: false, reason: "required_body_part_type_unavailable", partType: type, required: requirements.requiredPartCount, available: compatible.length };
+        compatible.slice(0, requirements.requiredPartCount).forEach((part) => matchedPartIds.push(part.id));
+      }
+    }
+
+    return { allowed: true, anatomy: resolved, requirements, matchedPartIds: [...new Set(matchedPartIds)] };
+  }
+
+  function canInstallAugment(unit, itemInput, options = {}) {
+    const item = typeof itemInput === "object" ? itemInput : items()?.findItem?.(unit, itemInput, { container: options.container || "active" });
+    if (!unit || !item) return { allowed: false, reason: "missing_unit_or_item" };
+    if (!isAugmentation(item)) return { allowed: false, reason: "item_not_augmentation", item };
+    const id = instanceIdOf(item);
+    if (!id) return { allowed: false, reason: "missing_item_instance_id", item };
+    if (findInstalledAugment(unit, id)) return { allowed: false, reason: "augmentation_already_installed", item };
+    const body = validateBodyRequirements(unit, item, options);
+    if (!body.allowed) return { ...body, item };
+    if (typeof options.checkInstallation === "function") {
+      const check = options.checkInstallation(unit, item, body.requirements);
+      if (check === false || check?.allowed === false) return { allowed: false, reason: check?.reason || "augmentation_installation_check_failed", item, body };
+    }
+    return { allowed: true, item, body };
+  }
+
+  function installAugment(unit, itemInput, options = {}) {
+    const gate = canInstallAugment(unit, itemInput, options);
+    if (!gate.allowed) return { installed: false, ...gate };
+    const item = gate.item;
+    const store = installedAugments(unit, true).value;
+
+    // AnatomyEquipmentEngine reads augmentation.mechanics/anatomy/bodyModification.
+    // Canonical item data keeps the augment profile under runtime.augmentation,
+    // so project it into mechanics on the installed instance instead of creating
+    // a parallel anatomy implementation.
+    const profile = augmentationProfile(item);
+    if (Object.keys(profile).length) item.mechanics = { ...clone(item.mechanics || {}), ...clone(profile) };
+
+    item.installed = true;
+    item.equipped = true;
+    item.installedBodyPartIds = clone(gate.body.matchedPartIds || []);
+    item.installedByWorkshopId = options.installedByWorkshopId || item.installedByWorkshopId || null;
+    item.installedAt = options.installedAt || item.installedAt || null;
+    store.push(item);
+    const resolved = resolveAnatomy(unit, options);
+    const result = { installed: true, item, installedBodyPartIds: clone(item.installedBodyPartIds), anatomy: resolved };
+    emit("luminous:augmentation-installed", { unit, ...result });
+    return result;
+  }
+
+  function canRemoveAugment(unit, itemInput, options = {}) {
+    const item = typeof itemInput === "object" ? itemInput : findInstalledAugment(unit, itemInput);
+    if (!unit || !item) return { allowed: false, reason: "augmentation_not_installed" };
+    const profile = requirementProfile(item);
+    if (!profile.removable && options.force !== true) return { allowed: false, reason: "augmentation_not_removable", item, profile };
+    if (typeof options.checkRemoval === "function") {
+      const check = options.checkRemoval(unit, item, profile);
+      if (check === false || check?.allowed === false) return { allowed: false, reason: check?.reason || "augmentation_removal_check_failed", item, profile };
+    }
+    return { allowed: true, item, profile };
+  }
+
+  function removeAugment(unit, itemInput, options = {}) {
+    const gate = canRemoveAugment(unit, itemInput, options);
+    if (!gate.allowed) return { removed: false, ...gate };
+    const store = installedAugments(unit, true);
+    const id = instanceIdOf(gate.item);
+    unit[store.key] = store.value.filter((entry) => instanceIdOf(entry) !== id);
+    gate.item.installed = false;
+    gate.item.equipped = false;
+    gate.item.installedBodyPartIds = [];
+    const result = { removed: true, item: gate.item, anatomy: resolveAnatomy(unit, options) };
+    emit("luminous:augmentation-removed", { unit, ...result });
+    return result;
+  }
+
+  function collectAugmentModifierTraits(unit = {}) {
+    const traits = [];
+    installedAugments(unit).value.forEach((item) => {
+      const source = `augmentation:${instanceIdOf(item) || item.id || "item"}`;
+      const raw = item.modifiers || item.modifierTraits || item.runtime?.modifiers || augmentationProfile(item).modifiers;
+      asArray(raw).forEach((modifier, index) => {
+        if (!modifier || typeof modifier !== "object") return;
+        traits.push({
+          id: `${source}:modifier:${index}`,
+          name: item.displayName || item.name || item.nombre || "Augmentation",
+          enabled: true,
+          mechanics: { modifiers: [clone(modifier)] },
+          sourceType: "augmentation",
+          sourceItemInstanceId: instanceIdOf(item),
+        });
+      });
+    });
+    return traits;
+  }
+
+  let modifierBridgeBase = null;
+  function installModifierBridge() {
+    const current = global.LuminousUniversalModifiers || safeRequire("./universal-modifier-engine.js");
+    if (!current) return false;
+    if (current.__luminousAugmentationBridge) return true;
+    modifierBridgeBase = current;
+    const mergeTraits = (options = {}) => {
+      const unit = options.unit || options.character || {};
+      return { ...options, traits: [...asArray(options.traits), ...collectAugmentModifierTraits(unit)] };
+    };
+    global.LuminousUniversalModifiers = Object.freeze({
+      ...current,
+      __luminousAugmentationBridge: true,
+      __luminousAugmentationBase: current,
+      resolveTraitModifiers(options = {}) { return current.resolveTraitModifiers(mergeTraits(options)); },
+      resolveStats(options = {}) { return current.resolveStats(mergeTraits(options)); },
+    });
+    return true;
+  }
+
+  const api = Object.freeze({
+    version: 1,
+    augmentationProfile,
+    isAugmentation,
+    installedAugments,
+    findInstalledAugment,
+    resolveAnatomy,
+    requirementProfile,
+    validateBodyRequirements,
+    canInstallAugment,
+    installAugment,
+    canRemoveAugment,
+    removeAugment,
+    collectAugmentModifierTraits,
+    installModifierBridge,
+  });
+
+  global.LuminousItemAugmentationRuntime = api;
+  installModifierBridge();
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/item-inventory-runtime.js
+++ b/js/item-inventory-runtime.js
@@ -1,0 +1,665 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousItemInventoryRuntime) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousItemInventoryRuntime;
+    return;
+  }
+
+  function safeRequire(path) {
+    if (typeof require !== "function") return null;
+    try { return require(path); } catch (_) { return null; }
+  }
+
+  // Capture the original functional item runtime before this module extends
+  // global.LuminousItemRuntime. Keeping this reference stable prevents a
+  // missing-item lookup from delegating back into this same findItem().
+  const baseRuntime = global.LuminousItemRuntime || safeRequire("./item-runtime-engine.js");
+  const base = () => baseRuntime;
+  const registry = () => global.LuminousContentRegistry || safeRequire("./content-registry.js");
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const intOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Math.trunc(Number(value)) : fallback;
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+  const asArray = (value) => value == null ? [] : (Array.isArray(value) ? value : [value]);
+  const normalizeId = (value) => base()?.normalizeId?.(value) || String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+
+  const SCHEMA_VERSION = 2;
+  const DEFAULT_ACTIVE_SLOT_LIMIT = 10;
+  const DEFAULT_ACTIVE_STACK_LIMIT = 2;
+  const DEFAULT_STASH_STACK_LIMIT = 99;
+  let instanceCounter = 0;
+
+  function emit(name, detail) {
+    try {
+      if (typeof global.dispatchEvent === "function" && typeof global.CustomEvent === "function") {
+        global.dispatchEvent(new global.CustomEvent(name, { detail }));
+      }
+    } catch (_) {}
+    return detail;
+  }
+
+  function createInstanceId(prefix = "item") {
+    instanceCounter += 1;
+    const entropy = Math.random().toString(36).slice(2, 8);
+    return `${normalizeId(prefix) || "item"}_${Date.now()}_${instanceCounter}_${entropy}`;
+  }
+
+  function definitionIdOf(item = {}) {
+    return base()?.definitionId?.(item) || String(item.definitionId || item.definition_id || item.canonicalId || item.itemId || item.item_id || item.id || item.key || "").trim();
+  }
+
+  function itemIdOf(item = {}) {
+    return base()?.itemId?.(item) || String(item.instanceId || item.instance_id || definitionIdOf(item) || item.key || "").trim();
+  }
+
+  function quantityOf(item = {}) {
+    return base()?.quantityOf?.(item) ?? Math.max(0, intOr(item.quantity ?? item.qty ?? item.cantidad ?? item.stack ?? item.count, 1));
+  }
+
+  function setQuantity(item = {}, value) {
+    if (base()?.setQuantity) return base().setQuantity(item, value);
+    item.quantity = Math.max(0, intOr(value, 0));
+    return item.quantity;
+  }
+
+  function resolveDefinition(ref, options = {}) {
+    if (ref && typeof ref === "object" && !ref.instanceId && !ref.instance_id) return clone(ref);
+    const id = typeof ref === "object" ? definitionIdOf(ref) : String(ref ?? "").trim();
+    if (!id) return null;
+
+    if (options.catalog) {
+      if (Array.isArray(options.catalog)) {
+        const found = options.catalog.find((entry) => definitionIdOf(entry) === id || entry?.canonicalId === id || entry?.id === id);
+        if (found) return clone(found.definition || found);
+      } else if (typeof options.catalog === "object") {
+        const found = options.catalog[id];
+        if (found) return clone(found.definition || found);
+      }
+    }
+
+    const content = registry();
+    if (content?.get) {
+      const canonical = content.get(id) || content.get("item", id);
+      if (canonical) return clone(canonical.definition || canonical);
+    }
+    return null;
+  }
+
+  function compactInstance(input = {}, definition = null, options = {}) {
+    const def = definition || resolveDefinition(input, options) || {};
+    const definitionId = definitionIdOf(input) || definitionIdOf(def) || String(options.definitionId || "").trim();
+    const maxCondition = Math.max(0, numberOr(input.conditionMax ?? input.maxCondition ?? input.maxDurability ?? def.conditionMax ?? def.condition_max, 100));
+    const currentCondition = clamp(numberOr(input.condition ?? input.currentCondition ?? input.durability, maxCondition), 0, maxCondition);
+    const qualityTier = clamp(intOr(input.qualityTier ?? input.quality_tier ?? input.quality ?? options.qualityTier ?? options.quality, 1), 1, 5);
+    const chargesMax = input.chargesMax ?? input.maxCharges ?? input.charges_max ?? def.chargesMax ?? def.maxCharges ?? null;
+    const chargesCurrent = input.chargesCurrent ?? input.charges_current ?? input.charges ?? options.charges ?? chargesMax;
+
+    return {
+      schemaVersion: SCHEMA_VERSION,
+      instanceId: String(input.instanceId || input.instance_id || options.instanceId || createInstanceId(definitionId || "item")),
+      definitionId,
+      quantity: Math.max(1, intOr(input.quantity ?? input.qty ?? input.cantidad ?? input.stack ?? input.count ?? options.quantity, 1)),
+      qualityTier,
+      conditionMax: maxCondition,
+      condition: currentCondition,
+      manufacturerId: input.manufacturerId ?? input.manufacturer_id ?? options.manufacturerId ?? null,
+      currentOwnerId: input.currentOwnerId ?? input.current_owner_id ?? options.currentOwnerId ?? null,
+      sellerId: input.sellerId ?? input.seller_id ?? options.sellerId ?? null,
+      previousOwnerIds: clone(input.previousOwnerIds || input.previous_owner_ids || options.previousOwnerIds || []),
+      productLineId: input.productLineId ?? input.product_line_id ?? options.productLineId ?? null,
+      modelName: input.modelName ?? input.model_name ?? options.modelName ?? null,
+      commissionName: input.commissionName ?? input.commission_name ?? options.commissionName ?? null,
+      productSerial: input.productSerial ?? input.product_serial ?? options.productSerial ?? null,
+      installedModuleIds: clone(input.installedModuleIds || input.installed_module_ids || options.installedModuleIds || []),
+      installedModules: clone(input.installedModules || options.installedModules || []),
+      signatureTechnologyIds: clone(input.signatureTechnologyIds || input.signature_technology_ids || options.signatureTechnologyIds || []),
+      signatureComponents: clone(input.signatureComponents || input.signature_components || options.signatureComponents || []),
+      chargesCurrent: chargesCurrent == null ? null : Math.max(0, intOr(chargesCurrent, 0)),
+      chargesMax: chargesMax == null ? null : Math.max(0, intOr(chargesMax, 0)),
+      rechargeRule: input.rechargeRule ?? input.recharge_rule ?? def.rechargeRule ?? def.recharge_rule ?? null,
+      stolen: input.stolen === true || options.stolen === true,
+      originMarketId: input.originMarketId ?? input.origin_market_id ?? options.originMarketId ?? null,
+      equipped: input.equipped === true,
+      equippedPartIds: clone(input.equippedPartIds || input.assignedBodyParts || []),
+      runtimeState: clone(input.runtimeState || input.runtime_state || {}),
+      customData: clone(input.customData || input.custom_data || {}),
+    };
+  }
+
+  function createItemInstance(definitionOrId, options = {}) {
+    const definition = resolveDefinition(definitionOrId, options) || (typeof definitionOrId === "object" ? clone(definitionOrId) : { id: definitionOrId, definitionId: definitionOrId });
+    const instance = compactInstance({ ...options, definitionId: definitionIdOf(definition) || String(definitionOrId || "") }, definition, options);
+    emit("luminous:item-instance-created", { instance: clone(instance), definition: clone(definition) });
+    return instance;
+  }
+
+  function serializeItemInstance(instance) {
+    return compactInstance(instance || {}, null, {});
+  }
+
+  function deserializeItemInstance(data, options = {}) {
+    return compactInstance(data || {}, resolveDefinition(data, options), options);
+  }
+
+  function hydrateItemInstance(instance, options = {}) {
+    if (!instance || typeof instance !== "object") return null;
+    const definition = resolveDefinition(instance, options) || {};
+    const compact = compactInstance(instance, definition, options);
+    const hydrated = { ...clone(definition), ...clone(compact) };
+    hydrated.quality = compact.qualityTier;
+    hydrated.charges = compact.chargesCurrent;
+    if (!hydrated.nombre && hydrated.name) hydrated.nombre = hydrated.name;
+    if (!hydrated.name && hydrated.nombre) hydrated.name = hydrated.nombre;
+    return base()?.hydrateForEquipment?.(hydrated) || hydrated;
+  }
+
+  function getRawWorkshopName(manufacturer, options = {}) {
+    if (!manufacturer) return null;
+    if (typeof manufacturer === "object") return String(manufacturer.workshopName || manufacturer.name || manufacturer.nombre || "").trim() || null;
+    const id = String(manufacturer);
+    const source = options.workshops || options.workshopCatalog || global.LuminousWorkshopRuntime;
+    if (source?.getWorkshop) {
+      const found = source.getWorkshop(id);
+      return found ? getRawWorkshopName(found, options) : null;
+    }
+    if (source && typeof source === "object" && source[id]) return getRawWorkshopName(source[id], options);
+    return id;
+  }
+
+  function getProductLineName(item = {}, options = {}) {
+    if (item.productLineName) return String(item.productLineName);
+    if (options.productLineName) return String(options.productLineName);
+    const lineId = item.productLineId || item.product_line_id;
+    if (!lineId) return null;
+    const source = options.workshops || options.workshopCatalog || global.LuminousWorkshopRuntime;
+    const workshop = source?.getWorkshop?.(item.manufacturerId) || (source && typeof source === "object" ? source[item.manufacturerId] : null);
+    const line = asArray(workshop?.productLines).find((entry) => String(entry?.productLineId || entry?.id || "") === String(lineId));
+    return line?.productLineName || line?.name || null;
+  }
+
+  function formatWorkshopProductName(item, options = {}) {
+    const hydrated = hydrateItemInstance(item, options) || item || {};
+    const manufacturerRaw = getRawWorkshopName(hydrated.manufacturerId, options);
+    const baseName = String(hydrated.baseItemName || hydrated.displayName || hydrated.name || hydrated.nombre || definitionIdOf(hydrated) || "Item").trim();
+    if (!manufacturerRaw) return baseName;
+    const cleanWorkshopName = manufacturerRaw.replace(/\s+Workshop$/i, "").trim();
+    let display = `${cleanWorkshopName} Workshop ${baseName}`;
+    const productLineName = getProductLineName(hydrated, options);
+    if (productLineName) display += ` — ${productLineName}`;
+    const commissionName = hydrated.commissionName || hydrated.modelName || null;
+    if (commissionName) display += ` “${commissionName}”`;
+    return display;
+  }
+
+  function resolveItem(instance, options = {}) {
+    const hydrated = hydrateItemInstance(instance, options);
+    if (!hydrated) return null;
+    hydrated.displayName = hydrated.manufacturerId
+      ? formatWorkshopProductName(hydrated, options)
+      : String(hydrated.displayName || hydrated.name || hydrated.nombre || hydrated.definitionId || "Item");
+    hydrated.conditionState = getConditionState(hydrated);
+    return hydrated;
+  }
+
+  function activeContainer(unit = {}, create = false) {
+    const candidates = ["inventario_activo", "activeInventory", "inventory", "inventario"];
+    for (const key of candidates) if (unit[key] && typeof unit[key] === "object") return { key, value: unit[key] };
+    if (!create) return { key: "inventario_activo", value: null };
+    unit.inventario_activo = {};
+    return { key: "inventario_activo", value: unit.inventario_activo };
+  }
+
+  function stashContainer(unit = {}, create = false) {
+    const candidates = ["inventario_stash", "stashInventory", "stash"];
+    for (const key of candidates) if (unit[key] && typeof unit[key] === "object") return { key, value: unit[key] };
+    if (!create) return { key: "inventario_stash", value: null };
+    unit.inventario_stash = {};
+    return { key: "inventario_stash", value: unit.inventario_stash };
+  }
+
+  function objectEntries(container) {
+    if (Array.isArray(container)) return container.map((item, index) => [String(index), item]);
+    return container && typeof container === "object" ? Object.entries(container) : [];
+  }
+
+  function findInContainer(container, ref) {
+    const wanted = String(typeof ref === "object" ? itemIdOf(ref) : ref ?? "").trim();
+    if (!wanted) return null;
+    for (const [key, item] of objectEntries(container)) {
+      if (!item || typeof item !== "object") continue;
+      const ids = [key, itemIdOf(item), definitionIdOf(item), item.id, item.key, item.itemId, item.canonicalId].map((value) => String(value ?? "").trim()).filter(Boolean);
+      if (ids.includes(wanted)) return { key, item };
+    }
+    return null;
+  }
+
+  function findItem(unit, ref, options = {}) {
+    if (ref && typeof ref === "object") return ref;
+    const preferred = normalizeId(options.container || "");
+    const order = preferred === "stash"
+      ? [stashContainer(unit).value, activeContainer(unit).value, unit.equipment]
+      : [activeContainer(unit).value, stashContainer(unit).value, unit.equipment];
+    for (const container of order.filter(Boolean)) {
+      const found = findInContainer(container, ref);
+      if (found) return found.item;
+    }
+    return base()?.findItem?.(unit, ref) || null;
+  }
+
+  function containerCount(container) {
+    return objectEntries(container).filter(([, item]) => item && quantityOf(item) > 0).length;
+  }
+
+  function activeSlotLimit(unit = {}) {
+    return Math.max(0, intOr(unit.activeSlotLimit ?? unit.inventoryRules?.activeSlotLimit, DEFAULT_ACTIVE_SLOT_LIMIT));
+  }
+
+  function stackLimit(item, containerType = "active") {
+    const type = normalizeId(containerType);
+    if (type === "stash") return Math.max(1, intOr(item?.stashStackLimit ?? item?.limite_alijo, DEFAULT_STASH_STACK_LIMIT));
+    return Math.max(1, intOr(item?.activeStackLimit ?? item?.limite_activo, DEFAULT_ACTIVE_STACK_LIMIT));
+  }
+
+  function stackSignature(item = {}) {
+    return JSON.stringify({
+      definitionId: definitionIdOf(item),
+      qualityTier: intOr(item.qualityTier ?? item.quality, 1),
+      condition: numberOr(item.condition, 100),
+      conditionMax: numberOr(item.conditionMax, 100),
+      manufacturerId: item.manufacturerId || null,
+      productLineId: item.productLineId || null,
+      modelName: item.modelName || null,
+      commissionName: item.commissionName || null,
+      installedModuleIds: asArray(item.installedModuleIds).map(String).sort(),
+      signatureTechnologyIds: asArray(item.signatureTechnologyIds).map(String).sort(),
+      chargesCurrent: item.chargesCurrent ?? item.charges ?? null,
+      chargesMax: item.chargesMax ?? null,
+      stolen: item.stolen === true,
+    });
+  }
+
+  function canStack(a, b) {
+    if (!a || !b) return false;
+    if (a.equipped || b.equipped) return false;
+    return stackSignature(a) === stackSignature(b);
+  }
+
+  function insertIntoContainer(container, item, containerType, options = {}) {
+    const limit = stackLimit(item, containerType);
+    let remaining = quantityOf(item);
+    const insertedKeys = [];
+
+    for (const [key, existing] of objectEntries(container)) {
+      if (remaining <= 0) break;
+      if (!canStack(existing, item)) continue;
+      const available = Math.max(0, limit - quantityOf(existing));
+      if (!available) continue;
+      const moved = Math.min(available, remaining);
+      setQuantity(existing, quantityOf(existing) + moved);
+      remaining -= moved;
+      insertedKeys.push(key);
+    }
+
+    while (remaining > 0) {
+      if (normalizeId(containerType) === "active" && containerCount(container) >= (options.activeSlotLimit ?? DEFAULT_ACTIVE_SLOT_LIMIT)) {
+        return { inserted: false, partial: remaining !== quantityOf(item), reason: "active_inventory_full", remaining, insertedKeys };
+      }
+      const moved = Math.min(limit, remaining);
+      const copy = clone(item);
+      copy.instanceId = remaining === quantityOf(item) ? item.instanceId : createInstanceId(definitionIdOf(item));
+      setQuantity(copy, moved);
+      if (Array.isArray(container)) {
+        container.push(copy);
+        insertedKeys.push(String(container.length - 1));
+      } else {
+        const key = copy.instanceId || createInstanceId(definitionIdOf(copy));
+        copy.instanceId = key;
+        container[key] = copy;
+        insertedKeys.push(key);
+      }
+      remaining -= moved;
+    }
+    return { inserted: true, remaining: 0, insertedKeys };
+  }
+
+  function deleteFromContainer(container, key) {
+    if (Array.isArray(container)) {
+      const index = intOr(key, -1);
+      if (index >= 0 && index < container.length) container.splice(index, 1);
+    } else if (container && typeof container === "object") delete container[key];
+  }
+
+  function moveItem(unit, ref, fromType, toType, amount = null, options = {}) {
+    const from = normalizeId(fromType) === "stash" ? stashContainer(unit, true) : activeContainer(unit, true);
+    const to = normalizeId(toType) === "stash" ? stashContainer(unit, true) : activeContainer(unit, true);
+    const found = findInContainer(from.value, ref);
+    if (!found) return { moved: false, reason: "item_not_found_in_source", from: from.key, to: to.key };
+
+    const before = quantityOf(found.item);
+    const requested = amount == null ? before : Math.max(1, intOr(amount, 1));
+    const movedQty = Math.min(before, requested);
+    const moving = clone(found.item);
+    if (movedQty < before) moving.instanceId = createInstanceId(definitionIdOf(moving));
+    setQuantity(moving, movedQty);
+
+    const result = insertIntoContainer(to.value, moving, toType, { activeSlotLimit: activeSlotLimit(unit), ...options });
+    const actuallyMoved = movedQty - Math.max(0, result.remaining || 0);
+    if (actuallyMoved <= 0) return { moved: false, reason: result.reason || "target_rejected_item", from: from.key, to: to.key };
+
+    setQuantity(found.item, before - actuallyMoved);
+    if (quantityOf(found.item) <= 0) deleteFromContainer(from.value, found.key);
+    const output = { moved: true, amount: actuallyMoved, from: from.key, to: to.key, instanceId: itemIdOf(moving), partial: actuallyMoved < requested, reason: result.reason || null };
+    emit("luminous:item-moved", { unit, ...output });
+    return output;
+  }
+
+  function moveToActive(unit, ref, amount, options = {}) { return moveItem(unit, ref, "stash", "active", amount, options); }
+  function moveToStash(unit, ref, amount, options = {}) { return moveItem(unit, ref, "active", "stash", amount, options); }
+
+  function splitStack(unit, ref, amount, options = {}) {
+    const container = normalizeId(options.container) === "stash" ? stashContainer(unit, true) : activeContainer(unit, true);
+    const found = findInContainer(container.value, ref);
+    if (!found) return { split: false, reason: "item_not_found" };
+    const before = quantityOf(found.item);
+    const qty = Math.max(1, intOr(amount, 1));
+    if (qty >= before) return { split: false, reason: "split_amount_must_be_less_than_stack" };
+    const created = clone(found.item);
+    created.instanceId = createInstanceId(definitionIdOf(created));
+    setQuantity(created, qty);
+    setQuantity(found.item, before - qty);
+    if (Array.isArray(container.value)) container.value.push(created);
+    else container.value[created.instanceId] = created;
+    return { split: true, source: found.item, created };
+  }
+
+  function mergeStacks(unit, sourceRef, targetRef, options = {}) {
+    const container = normalizeId(options.container) === "stash" ? stashContainer(unit, true) : activeContainer(unit, true);
+    const source = findInContainer(container.value, sourceRef);
+    const target = findInContainer(container.value, targetRef);
+    if (!source || !target) return { merged: false, reason: "stack_not_found" };
+    if (source.key === target.key) return { merged: false, reason: "same_stack" };
+    if (!canStack(source.item, target.item)) return { merged: false, reason: "stack_incompatible" };
+    const limit = stackLimit(target.item, options.container || "active");
+    const room = Math.max(0, limit - quantityOf(target.item));
+    if (!room) return { merged: false, reason: "target_stack_full" };
+    const moved = Math.min(room, quantityOf(source.item));
+    setQuantity(target.item, quantityOf(target.item) + moved);
+    setQuantity(source.item, quantityOf(source.item) - moved);
+    if (quantityOf(source.item) <= 0) deleteFromContainer(container.value, source.key);
+    return { merged: true, amount: moved, source: source.item, target: target.item };
+  }
+
+  function getCondition(item = {}) {
+    const max = Math.max(0, numberOr(item.conditionMax ?? item.maxCondition ?? item.maxDurability, 100));
+    return { current: clamp(numberOr(item.condition ?? item.currentCondition ?? item.durability, max), 0, max), max };
+  }
+
+  function getConditionState(item = {}) {
+    const state = getCondition(item);
+    const pct = state.max > 0 ? (state.current / state.max) * 100 : 0;
+    const id = pct <= 0 ? "broken" : pct <= 25 ? "critical" : pct <= 50 ? "damaged" : pct <= 75 ? "worn" : "good";
+    return { ...state, percent: pct, id };
+  }
+
+  function damageCondition(item, amount) {
+    if (!item || typeof item !== "object") return { changed: false, reason: "missing_item" };
+    const state = getCondition(item);
+    const after = clamp(state.current - Math.max(0, numberOr(amount, 0)), 0, state.max);
+    item.condition = after;
+    const result = { changed: after !== state.current, before: state.current, after, max: state.max, state: getConditionState(item) };
+    emit("luminous:item-condition-changed", { item, ...result });
+    return result;
+  }
+
+  function setQualityTier(item, tier) {
+    if (!item || typeof item !== "object") return null;
+    item.qualityTier = clamp(intOr(tier, 1), 1, 5);
+    item.quality = item.qualityTier;
+    return item.qualityTier;
+  }
+
+  function getQualityTier(item = {}) { return clamp(intOr(item.qualityTier ?? item.quality, 1), 1, 5); }
+
+  function installedModuleIds(item = {}) {
+    const explicit = asArray(item.installedModuleIds).map(String).filter(Boolean);
+    const legacy = asArray(item.installedModules).map((entry) => typeof entry === "string" ? entry : (entry?.definitionId || entry?.id || entry?.instanceId)).filter(Boolean).map(String);
+    return [...new Set([...explicit, ...legacy])];
+  }
+
+  function moduleClass(module = {}) {
+    return normalizeId(module.technologyClass || module.moduleClass || module.class || module.runtime?.technologyClass || "module");
+  }
+
+  function canRemoveModule(module = {}) {
+    return !["structural_tech", "structural_technology"].includes(moduleClass(module)) && module.removable !== false;
+  }
+
+  function removeInstalledModule(host, moduleRef, options = {}) {
+    if (!host) return { removed: false, reason: "missing_host" };
+    const wanted = String(typeof moduleRef === "object" ? (definitionIdOf(moduleRef) || itemIdOf(moduleRef)) : moduleRef || "");
+    const legacyEntry = asArray(host.installedModules).find((entry) => String(typeof entry === "string" ? entry : (entry?.definitionId || entry?.id || entry?.instanceId || "")) === wanted);
+    const moduleDefinition = options.moduleDefinition || resolveDefinition(wanted, { ...options, type: "module" }) || legacyEntry || {};
+    if (!canRemoveModule(moduleDefinition)) return { removed: false, reason: "structural_technology_not_removable" };
+
+    if (Array.isArray(host.installedModuleIds)) host.installedModuleIds = host.installedModuleIds.filter((id) => String(id) !== wanted);
+    if (Array.isArray(host.installedModules)) host.installedModules = host.installedModules.filter((entry) => String(typeof entry === "string" ? entry : (entry?.definitionId || entry?.id || entry?.instanceId || "")) !== wanted);
+    return { removed: true, host, moduleRef: wanted, installedModuleIds: installedModuleIds(host) };
+  }
+
+  function getCharges(item = {}) {
+    const max = item.chargesMax ?? item.maxCharges ?? item.charges_max ?? null;
+    const current = item.chargesCurrent ?? item.charges_current ?? item.charges ?? max;
+    return {
+      current: current == null ? null : Math.max(0, intOr(current, 0)),
+      max: max == null ? null : Math.max(0, intOr(max, 0)),
+    };
+  }
+
+  function canSpendCharges(item, amount = 1) {
+    const state = getCharges(item);
+    const cost = Math.max(0, intOr(amount, 1));
+    return state.current != null && state.current >= cost;
+  }
+
+  function spendCharges(item, amount = 1) {
+    if (!item) return { spent: false, reason: "missing_item" };
+    const state = getCharges(item);
+    const cost = Math.max(0, intOr(amount, 1));
+    if (state.current == null) return { spent: false, reason: "item_has_no_charges" };
+    if (state.current < cost) return { spent: false, reason: "insufficient_charges", before: state.current, after: state.current };
+    const after = state.current - cost;
+    item.chargesCurrent = after;
+    item.charges = after;
+    return { spent: true, before: state.current, after, amount: cost };
+  }
+
+  function restoreCharges(item, amount) {
+    if (!item) return { restored: false, reason: "missing_item" };
+    const state = getCharges(item);
+    if (state.current == null || state.max == null) return { restored: false, reason: "item_has_no_charge_capacity" };
+    const after = clamp(state.current + Math.max(0, intOr(amount, 0)), 0, state.max);
+    item.chargesCurrent = after;
+    item.charges = after;
+    return { restored: after > state.current, before: state.current, after, amount: after - state.current };
+  }
+
+  function processRecharge(item, trigger, options = {}) {
+    if (!item) return { recharged: false, reason: "missing_item" };
+    const rule = item.rechargeRule || item.recharge_rule || options.rechargeRule;
+    if (!rule) return { recharged: false, reason: "no_recharge_rule" };
+    const normalizedTrigger = normalizeId(trigger);
+    const ruleTrigger = normalizeId(typeof rule === "string" ? rule : rule.trigger);
+    if (ruleTrigger && ruleTrigger !== normalizedTrigger) return { recharged: false, reason: "trigger_mismatch" };
+    const state = getCharges(item);
+    if (state.max == null) return { recharged: false, reason: "item_has_no_charge_capacity" };
+    const amount = typeof rule === "object" && Number.isFinite(Number(rule.amount)) ? Number(rule.amount) : state.max;
+    const result = restoreCharges(item, amount);
+    return { recharged: result.restored, trigger: normalizedTrigger, ...result };
+  }
+
+  function transferOwnership(item, newOwnerId, options = {}) {
+    if (!item || typeof item !== "object") return { transferred: false, reason: "missing_item" };
+    const previous = item.currentOwnerId ?? item.current_owner_id ?? null;
+    if (previous && previous !== newOwnerId) {
+      if (!Array.isArray(item.previousOwnerIds)) item.previousOwnerIds = [];
+      if (!item.previousOwnerIds.includes(previous)) item.previousOwnerIds.push(previous);
+    }
+    item.currentOwnerId = newOwnerId || null;
+    if (options.sellerId !== undefined) item.sellerId = options.sellerId;
+    const result = { transferred: true, previousOwnerId: previous, currentOwnerId: item.currentOwnerId, manufacturerId: item.manufacturerId || null };
+    emit("luminous:item-ownership-transferred", { item, ...result });
+    return result;
+  }
+
+  function migrateLegacyItem(item, key = null, options = {}) {
+    if (!item || typeof item !== "object") return null;
+    if (intOr(item.schemaVersion, 0) >= SCHEMA_VERSION && item.instanceId && item.definitionId) return item;
+    const definitionId = definitionIdOf(item) || String(key || normalizeId(item.name || item.nombre || "item"));
+    const migrated = compactInstance({ ...item, instanceId: item.instanceId || key || createInstanceId(definitionId), definitionId }, resolveDefinition(definitionId, options), options);
+    const legacyFields = ["nombre", "name", "displayName", "tipo_categoria", "category", "tags", "tag", "keywords", "limite_activo", "limite_alijo", "precio", "cost", "tier", "weapon_details", "armor_details", "shield_details", "accessory_details", "consumable_details", "upgrade_details", "runtime", "function", "functions"];
+    legacyFields.forEach((field) => {
+      if (item[field] === undefined) return;
+      migrated.customData[field] = clone(item[field]);
+      migrated[field] = clone(item[field]);
+    });
+    return migrated;
+  }
+
+  function migrateContainer(container, options = {}) {
+    if (!container || typeof container !== "object") return container;
+    if (Array.isArray(container)) return container.map((item, index) => migrateLegacyItem(item, String(index), options)).filter(Boolean);
+    const next = {};
+    Object.entries(container).forEach(([key, item]) => {
+      const migrated = migrateLegacyItem(item, key, options);
+      if (!migrated) return;
+      next[migrated.instanceId || key] = migrated;
+    });
+    return next;
+  }
+
+  function migrateLegacyInventory(unit, options = {}) {
+    if (!unit || typeof unit !== "object") return { migrated: false, reason: "missing_unit" };
+    const active = activeContainer(unit, true);
+    const stash = stashContainer(unit, true);
+    unit[active.key] = migrateContainer(active.value, options);
+    unit[stash.key] = migrateContainer(stash.value, options);
+    unit.itemInventorySchemaVersion = SCHEMA_VERSION;
+    const result = {
+      migrated: true,
+      schemaVersion: SCHEMA_VERSION,
+      activeContainer: active.key,
+      stashContainer: stash.key,
+      activeCount: containerCount(unit[active.key]),
+      stashCount: containerCount(unit[stash.key]),
+    };
+    emit("luminous:inventory-migrated", { unit, ...result });
+    return result;
+  }
+
+  function inventorySnapshot(unit, options = {}) {
+    const active = activeContainer(unit).value || {};
+    const stash = stashContainer(unit).value || {};
+    const mapItem = (item) => options.hydrate === false ? clone(item) : resolveItem(item, options);
+    return {
+      schemaVersion: intOr(unit?.itemInventorySchemaVersion, SCHEMA_VERSION),
+      activeSlotLimit: activeSlotLimit(unit),
+      active: objectEntries(active).map(([key, item]) => ({ key, item: mapItem(item) })),
+      stash: objectEntries(stash).map(([key, item]) => ({ key, item: mapItem(item) })),
+    };
+  }
+
+  function describeInventory(unit) {
+    const active = activeContainer(unit).value || {};
+    const stash = stashContainer(unit).value || {};
+    return {
+      activeSlots: containerCount(active),
+      activeSlotLimit: activeSlotLimit(unit),
+      stashSlots: containerCount(stash),
+      activeQuantity: objectEntries(active).reduce((sum, [, item]) => sum + quantityOf(item), 0),
+      stashQuantity: objectEntries(stash).reduce((sum, [, item]) => sum + quantityOf(item), 0),
+    };
+  }
+
+  const inventoryApi = Object.freeze({
+    version: 1,
+    schemaVersion: SCHEMA_VERSION,
+    DEFAULT_ACTIVE_SLOT_LIMIT,
+    DEFAULT_ACTIVE_STACK_LIMIT,
+    DEFAULT_STASH_STACK_LIMIT,
+    createInstanceId,
+    resolveDefinition,
+    createItemInstance,
+    serializeItemInstance,
+    deserializeItemInstance,
+    hydrateItemInstance,
+    resolveItem,
+    formatWorkshopProductName,
+    activeContainer,
+    stashContainer,
+    findItem,
+    activeSlotLimit,
+    stackLimit,
+    canStack,
+    splitStack,
+    mergeStacks,
+    moveItem,
+    moveToActive,
+    moveToStash,
+    getCondition,
+    getConditionState,
+    damageCondition,
+    getQualityTier,
+    setQualityTier,
+    installedModuleIds,
+    moduleClass,
+    canRemoveModule,
+    removeInstalledModule,
+    getCharges,
+    canSpendCharges,
+    spendCharges,
+    restoreCharges,
+    processRecharge,
+    transferOwnership,
+    migrateLegacyItem,
+    migrateLegacyInventory,
+    inventorySnapshot,
+    describeInventory,
+  });
+
+  global.LuminousItemInventoryRuntime = inventoryApi;
+  if (baseRuntime) {
+    global.LuminousItemRuntime = Object.freeze({ ...baseRuntime, ...inventoryApi, __luminousInventoryRuntimeBridge: true, __luminousItemRuntimeBase: baseRuntime });
+  }
+
+  function loadExtension(globalName, scriptId, src, next) {
+    if (!global.document) return;
+    if (global[globalName]) {
+      if (typeof next === "function") next();
+      return;
+    }
+    const existing = global.document.getElementById(scriptId);
+    if (existing) {
+      existing.addEventListener?.("load", () => next?.(), { once: true });
+      return;
+    }
+    const script = global.document.createElement("script");
+    script.id = scriptId;
+    script.src = src;
+    script.async = false;
+    script.addEventListener?.("load", () => next?.(), { once: true });
+    global.document.head?.appendChild(script);
+  }
+
+  function ensureRuntimeExtensions() {
+    if (!global.document) return;
+    loadExtension("LuminousWorkshopRuntime", "workshop-runtime-script", "js/workshop-runtime.js", () => {
+      loadExtension("LuminousItemMagicRuntime", "item-magic-runtime-script", "js/item-magic-runtime.js", () => {
+        loadExtension("LuminousItemPersistenceRuntime", "item-persistence-runtime-script", "js/item-persistence-runtime.js");
+      });
+    });
+  }
+
+  ensureRuntimeExtensions();
+  if (typeof module !== "undefined" && module.exports) module.exports = inventoryApi;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/item-magic-runtime.js
+++ b/js/item-magic-runtime.js
@@ -11,15 +11,25 @@
     try { return require(path); } catch (_) { return null; }
   }
 
-  const items = () => global.LuminousItemInventoryRuntime || global.LuminousItemRuntime || safeRequire("./item-inventory-runtime.js") || safeRequire("./item-runtime-engine.js");
-  const spells = () => global.LuminousSpellcastingRuntime || safeRequire("./spellcasting-runtime.js");
   const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
   const intOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Math.trunc(Number(value)) : fallback;
-  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
   const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
   const asArray = (value) => value == null ? [] : (Array.isArray(value) ? value : [value]);
-
   const DEFAULT_ATTUNEMENT_CAPACITY = 3;
+
+  function itemRuntimeFor(method) {
+    const candidates = [
+      global.LuminousItemInventoryRuntime,
+      global.LuminousItemRuntime,
+      safeRequire("./item-inventory-runtime.js"),
+      safeRequire("./item-runtime-engine.js"),
+    ];
+    return candidates.find((candidate) => candidate && typeof candidate[method] === "function") || null;
+  }
+
+  function spellRuntime() {
+    return global.LuminousSpellcastingRuntime || safeRequire("./spellcasting-runtime.js");
+  }
 
   function emit(name, detail) {
     try {
@@ -38,17 +48,42 @@
   }
 
   function instanceIdOf(item = {}) {
-    return String(item.instanceId || item.instance_id || items()?.itemId?.(item) || "").trim();
+    const runtime = itemRuntimeFor("itemId");
+    return String(item.instanceId || item.instance_id || runtime?.itemId?.(item) || "").trim();
   }
 
   function definitionIdOf(item = {}) {
-    return String(item.definitionId || item.definition_id || items()?.definitionId?.(item) || "").trim();
+    const runtime = itemRuntimeFor("definitionId");
+    return String(item.definitionId || item.definition_id || runtime?.definitionId?.(item) || "").trim();
   }
 
   function magicProfile(item = {}) {
     const runtime = runtimeOf(item);
     const explicit = runtime.magic || runtime.magicItem || runtime.magic_item || item.magic || item.magicItem || item.magic_item || {};
     return explicit && typeof explicit === "object" ? explicit : {};
+  }
+
+  function requiresAttunement(item = {}) {
+    const profile = magicProfile(item);
+    const runtime = runtimeOf(item);
+    return item.requiresAttunement === true || item.requires_attunement === true ||
+      profile.requiresAttunement === true || profile.requires_attunement === true ||
+      runtime.requiresAttunement === true || runtime.requires_attunement === true;
+  }
+
+  function spellProfiles(item = {}) {
+    const runtime = runtimeOf(item);
+    const profile = magicProfile(item);
+    const raw = profile.spells || profile.itemSpells || runtime.itemSpells || runtime.spells || item.itemSpells || item.spells ||
+      (profile.spellId || runtime.spellId || item.spellId ? [{ spellId: profile.spellId || runtime.spellId || item.spellId }] : []);
+    return asArray(raw).map((entry) => {
+      if (typeof entry === "string") return { spellId: entry, chargeCost: 1 };
+      return {
+        ...clone(entry),
+        spellId: entry?.spellId || entry?.spell_id || entry?.id || null,
+        chargeCost: Math.max(0, intOr(entry?.chargeCost ?? entry?.charge_cost, 1)),
+      };
+    }).filter((entry) => entry.spellId);
   }
 
   function isMagicItem(item = {}) {
@@ -59,14 +94,6 @@
       requiresAttunement(item) || spellProfiles(item).length ||
       runtime.curse || runtime.cursed === true || item.cursed === true
     );
-  }
-
-  function requiresAttunement(item = {}) {
-    const profile = magicProfile(item);
-    const runtime = runtimeOf(item);
-    return item.requiresAttunement === true || item.requires_attunement === true ||
-      profile.requiresAttunement === true || profile.requires_attunement === true ||
-      runtime.requiresAttunement === true || runtime.requires_attunement === true;
   }
 
   function attunementStore(unit = {}, create = false) {
@@ -139,32 +166,16 @@
   function unattuneItem(unit, item) {
     if (!unit || !item) return { unattuned: false, reason: "missing_unit_or_item" };
     const id = typeof item === "string" ? item : instanceIdOf(item);
-    const store = attunementStore(unit, true).value;
-    const before = store.length;
-    const next = store.filter((entry) => String(entry) !== String(id));
-    unit[attunementStore(unit, true).key] = next;
+    const store = attunementStore(unit, true);
+    const before = store.value.length;
+    unit[store.key] = store.value.filter((entry) => String(entry) !== String(id));
     if (typeof item === "object") {
       item.attuned = false;
       item.attunedToId = null;
     }
-    const result = { unattuned: next.length < before, itemInstanceId: id };
+    const result = { unattuned: unit[store.key].length < before, itemInstanceId: id };
     if (result.unattuned) emit("luminous:item-unattuned", { unit, item, ...result });
     return result;
-  }
-
-  function spellProfiles(item = {}) {
-    const runtime = runtimeOf(item);
-    const profile = magicProfile(item);
-    const raw = profile.spells || profile.itemSpells || runtime.itemSpells || runtime.spells || item.itemSpells || item.spells ||
-      (profile.spellId || runtime.spellId || item.spellId ? [{ spellId: profile.spellId || runtime.spellId || item.spellId }] : []);
-    return asArray(raw).map((entry) => {
-      if (typeof entry === "string") return { spellId: entry, chargeCost: 1 };
-      return {
-        ...clone(entry),
-        spellId: entry?.spellId || entry?.spell_id || entry?.id || null,
-        chargeCost: Math.max(0, intOr(entry?.chargeCost ?? entry?.charge_cost, 1)),
-      };
-    }).filter((entry) => entry.spellId);
   }
 
   function findSpellProfile(item, spellRef = null) {
@@ -177,10 +188,10 @@
   function resolveItemSpellcasting(user, item, spellRef, options = {}) {
     const profile = findSpellProfile(item, spellRef);
     if (!profile) return { resolved: false, reason: "spell_not_granted_by_item" };
-    const spellRuntime = spells();
+    const spells = spellRuntime();
     const classId = profile.classId || profile.class_id || magicProfile(item).classId || options.classId || null;
-    const inherited = classId && spellRuntime?.resolveSpellcasting
-      ? spellRuntime.resolveSpellcasting(user || {}, classId, options.runtime || {}, options.variables || {})
+    const inherited = classId && spells?.resolveSpellcasting
+      ? spells.resolveSpellcasting(user || {}, classId, options.runtime || {}, options.variables || {})
       : null;
     const spellAttack = Number.isFinite(Number(profile.spellAttack ?? profile.spell_attack))
       ? Number(profile.spellAttack ?? profile.spell_attack)
@@ -201,6 +212,14 @@
     };
   }
 
+  function chargeState(item) {
+    const runtime = itemRuntimeFor("getCharges");
+    if (runtime) return runtime.getCharges(item);
+    const max = item.chargesMax ?? item.maxCharges ?? null;
+    const current = item.chargesCurrent ?? item.charges ?? max;
+    return { current: current == null ? null : Math.max(0, intOr(current, 0)), max: max == null ? null : Math.max(0, intOr(max, 0)) };
+  }
+
   function canActivateSpellFromItem(user, item, spellRef, options = {}) {
     if (!item) return { allowed: false, reason: "missing_item" };
     const casting = resolveItemSpellcasting(user, item, spellRef, options);
@@ -208,9 +227,9 @@
     if (requiresAttunement(item) && !isAttuned(user || {}, item)) return { allowed: false, reason: "item_not_attuned", casting };
     const chargeCost = Math.max(0, intOr(options.chargeCost ?? casting.chargeCost, 0));
     if (chargeCost > 0) {
-      const chargeState = items()?.getCharges?.(item) || { current: item.chargesCurrent ?? item.charges ?? null };
-      if (chargeState.current == null) return { allowed: false, reason: "item_has_no_charges", casting };
-      if (Number(chargeState.current) < chargeCost) return { allowed: false, reason: "insufficient_charges", casting, chargeCost };
+      const charges = chargeState(item);
+      if (charges.current == null) return { allowed: false, reason: "item_has_no_charges", casting };
+      if (Number(charges.current) < chargeCost) return { allowed: false, reason: "insufficient_charges", casting, chargeCost };
     }
     return { allowed: true, casting, chargeCost };
   }
@@ -233,7 +252,9 @@
       return { executed: false, prepared: true, reason: "spell_executor_unavailable", payload };
     }
     const result = executor(payload);
-    if (result === false || result?.executed === false || result?.cast === false) return { executed: false, prepared: true, reason: result?.reason || "spell_execution_failed", result, payload };
+    if (result === false || result?.executed === false || result?.cast === false) {
+      return { executed: false, prepared: true, reason: result?.reason || "spell_execution_failed", result, payload };
+    }
     return { executed: true, prepared: true, result, payload };
   }
 
@@ -242,9 +263,11 @@
     if (!gate.allowed) return { cast: false, ...gate };
     const execution = executeSpellHook(user, item, gate.casting, options);
     if (!execution.executed) return { cast: false, ...gate, ...execution };
+
     let charges = null;
     if (gate.chargeCost > 0) {
-      charges = items()?.spendCharges?.(item, gate.chargeCost);
+      const runtime = itemRuntimeFor("spendCharges");
+      charges = runtime?.spendCharges?.(item, gate.chargeCost) || null;
       if (!charges?.spent) return { cast: false, reason: charges?.reason || "charge_spend_failed", execution, charges };
     }
     const result = { cast: true, casting: gate.casting, execution, charges };
@@ -263,8 +286,9 @@
     const spellRef = options.spellId || item.runtimeState?.spellId || item.customData?.spellId || spellProfiles(item)[0]?.spellId;
     const result = castSpellFromItem(user, item, spellRef, { ...options, chargeCost: 0 });
     if (!result.cast) return { used: false, ...result };
-    const consumed = items()?.consumeQuantity?.(item, 1);
-    return { used: Boolean(consumed?.consumed), consumed, ...result };
+    const runtime = itemRuntimeFor("consumeQuantity");
+    const consumed = runtime?.consumeQuantity?.(item, 1) || { consumed: false, reason: "quantity_runtime_unavailable" };
+    return { used: consumed.consumed === true, consumed, ...result };
   }
 
   function isCursed(item = {}) {

--- a/js/item-magic-runtime.js
+++ b/js/item-magic-runtime.js
@@ -1,0 +1,340 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousItemMagicRuntime) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousItemMagicRuntime;
+    return;
+  }
+
+  function safeRequire(path) {
+    if (typeof require !== "function") return null;
+    try { return require(path); } catch (_) { return null; }
+  }
+
+  const items = () => global.LuminousItemInventoryRuntime || global.LuminousItemRuntime || safeRequire("./item-inventory-runtime.js") || safeRequire("./item-runtime-engine.js");
+  const spells = () => global.LuminousSpellcastingRuntime || safeRequire("./spellcasting-runtime.js");
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const intOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Math.trunc(Number(value)) : fallback;
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  const asArray = (value) => value == null ? [] : (Array.isArray(value) ? value : [value]);
+
+  const DEFAULT_ATTUNEMENT_CAPACITY = 3;
+
+  function emit(name, detail) {
+    try {
+      if (typeof global.dispatchEvent === "function" && typeof global.CustomEvent === "function") {
+        global.dispatchEvent(new global.CustomEvent(name, { detail }));
+      }
+    } catch (_) {}
+    return detail;
+  }
+
+  function runtimeOf(item = {}) {
+    return item.runtime && typeof item.runtime === "object" ? item.runtime
+      : item.itemRuntime && typeof item.itemRuntime === "object" ? item.itemRuntime
+        : item.item_runtime && typeof item.item_runtime === "object" ? item.item_runtime
+          : {};
+  }
+
+  function instanceIdOf(item = {}) {
+    return String(item.instanceId || item.instance_id || items()?.itemId?.(item) || "").trim();
+  }
+
+  function definitionIdOf(item = {}) {
+    return String(item.definitionId || item.definition_id || items()?.definitionId?.(item) || "").trim();
+  }
+
+  function magicProfile(item = {}) {
+    const runtime = runtimeOf(item);
+    const explicit = runtime.magic || runtime.magicItem || runtime.magic_item || item.magic || item.magicItem || item.magic_item || {};
+    return explicit && typeof explicit === "object" ? explicit : {};
+  }
+
+  function isMagicItem(item = {}) {
+    const profile = magicProfile(item);
+    const runtime = runtimeOf(item);
+    return Boolean(
+      item.isMagicItem === true || item.magic === true || profile.enabled === true ||
+      requiresAttunement(item) || spellProfiles(item).length ||
+      runtime.curse || runtime.cursed === true || item.cursed === true
+    );
+  }
+
+  function requiresAttunement(item = {}) {
+    const profile = magicProfile(item);
+    const runtime = runtimeOf(item);
+    return item.requiresAttunement === true || item.requires_attunement === true ||
+      profile.requiresAttunement === true || profile.requires_attunement === true ||
+      runtime.requiresAttunement === true || runtime.requires_attunement === true;
+  }
+
+  function attunementStore(unit = {}, create = false) {
+    const candidates = ["attunedItemInstanceIds", "attunedItems", "itemAttunements"];
+    for (const key of candidates) {
+      if (Array.isArray(unit[key])) return { key, value: unit[key] };
+    }
+    if (!create) return { key: "attunedItemInstanceIds", value: [] };
+    unit.attunedItemInstanceIds = [];
+    return { key: "attunedItemInstanceIds", value: unit.attunedItemInstanceIds };
+  }
+
+  function getAttunementCapacity(unit = {}, options = {}) {
+    const explicit = options.capacity ?? unit.attunementCapacity ?? unit.itemRules?.attunementCapacity ?? unit.magicItemRules?.attunementCapacity;
+    return Math.max(0, intOr(explicit, DEFAULT_ATTUNEMENT_CAPACITY));
+  }
+
+  function getAttunedItems(unit = {}) {
+    return [...new Set(attunementStore(unit).value.map(String).filter(Boolean))];
+  }
+
+  function isAttuned(unit, item) {
+    const id = typeof item === "string" ? item : instanceIdOf(item);
+    return Boolean(id) && getAttunedItems(unit).includes(String(id));
+  }
+
+  function attunementRequirements(item = {}) {
+    const profile = magicProfile(item);
+    return clone(profile.attunementRequirements || profile.attunement_requirements || item.attunementRequirements || []);
+  }
+
+  function canAttune(unit, item, options = {}) {
+    if (!unit || !item) return { allowed: false, reason: "missing_unit_or_item" };
+    if (!requiresAttunement(item)) return { allowed: false, reason: "item_does_not_require_attunement" };
+    const id = instanceIdOf(item);
+    if (!id) return { allowed: false, reason: "missing_item_instance_id" };
+    if (isAttuned(unit, item)) return { allowed: true, alreadyAttuned: true, capacity: getAttunementCapacity(unit, options) };
+    const capacity = getAttunementCapacity(unit, options);
+    const current = getAttunedItems(unit).length;
+    if (current >= capacity) return { allowed: false, reason: "attunement_capacity_reached", current, capacity };
+
+    const requirements = attunementRequirements(item);
+    if (typeof options.checkRequirement === "function") {
+      for (const requirement of requirements) {
+        const result = options.checkRequirement(unit, requirement, item);
+        if (result === false || result?.allowed === false) {
+          return { allowed: false, reason: result?.reason || "attunement_requirement_failed", requirement };
+        }
+      }
+    } else if (requirements.length && options.ignoreRequirements !== true) {
+      return { allowed: false, reason: "attunement_requirement_resolver_unavailable", requirements };
+    }
+    return { allowed: true, current, capacity, requirements };
+  }
+
+  function attuneItem(unit, item, options = {}) {
+    const gate = canAttune(unit, item, options);
+    if (!gate.allowed) return { attuned: false, ...gate };
+    if (gate.alreadyAttuned) return { attuned: true, alreadyAttuned: true, itemInstanceId: instanceIdOf(item) };
+    const store = attunementStore(unit, true).value;
+    const id = instanceIdOf(item);
+    store.push(id);
+    item.attuned = true;
+    item.attunedToId = options.attunedToId || unit.id || unit.characterId || unit.playerId || null;
+    const result = { attuned: true, itemInstanceId: id, current: store.length, capacity: gate.capacity };
+    emit("luminous:item-attuned", { unit, item, ...result });
+    return result;
+  }
+
+  function unattuneItem(unit, item) {
+    if (!unit || !item) return { unattuned: false, reason: "missing_unit_or_item" };
+    const id = typeof item === "string" ? item : instanceIdOf(item);
+    const store = attunementStore(unit, true).value;
+    const before = store.length;
+    const next = store.filter((entry) => String(entry) !== String(id));
+    unit[attunementStore(unit, true).key] = next;
+    if (typeof item === "object") {
+      item.attuned = false;
+      item.attunedToId = null;
+    }
+    const result = { unattuned: next.length < before, itemInstanceId: id };
+    if (result.unattuned) emit("luminous:item-unattuned", { unit, item, ...result });
+    return result;
+  }
+
+  function spellProfiles(item = {}) {
+    const runtime = runtimeOf(item);
+    const profile = magicProfile(item);
+    const raw = profile.spells || profile.itemSpells || runtime.itemSpells || runtime.spells || item.itemSpells || item.spells ||
+      (profile.spellId || runtime.spellId || item.spellId ? [{ spellId: profile.spellId || runtime.spellId || item.spellId }] : []);
+    return asArray(raw).map((entry) => {
+      if (typeof entry === "string") return { spellId: entry, chargeCost: 1 };
+      return {
+        ...clone(entry),
+        spellId: entry?.spellId || entry?.spell_id || entry?.id || null,
+        chargeCost: Math.max(0, intOr(entry?.chargeCost ?? entry?.charge_cost, 1)),
+      };
+    }).filter((entry) => entry.spellId);
+  }
+
+  function findSpellProfile(item, spellRef = null) {
+    const list = spellProfiles(item);
+    if (!spellRef) return list.length === 1 ? list[0] : null;
+    const wanted = normalizeId(typeof spellRef === "object" ? (spellRef.spellId || spellRef.id) : spellRef);
+    return list.find((entry) => normalizeId(entry.spellId) === wanted) || null;
+  }
+
+  function resolveItemSpellcasting(user, item, spellRef, options = {}) {
+    const profile = findSpellProfile(item, spellRef);
+    if (!profile) return { resolved: false, reason: "spell_not_granted_by_item" };
+    const spellRuntime = spells();
+    const classId = profile.classId || profile.class_id || magicProfile(item).classId || options.classId || null;
+    const inherited = classId && spellRuntime?.resolveSpellcasting
+      ? spellRuntime.resolveSpellcasting(user || {}, classId, options.runtime || {}, options.variables || {})
+      : null;
+    const spellAttack = Number.isFinite(Number(profile.spellAttack ?? profile.spell_attack))
+      ? Number(profile.spellAttack ?? profile.spell_attack)
+      : inherited?.spellAttack ?? null;
+    const spellDC = Number.isFinite(Number(profile.spellDC ?? profile.spell_dc))
+      ? Number(profile.spellDC ?? profile.spell_dc)
+      : inherited?.spellDC ?? null;
+    return {
+      resolved: true,
+      spellId: profile.spellId,
+      spellLevel: Math.max(0, intOr(profile.spellLevel ?? profile.spell_level, 0)),
+      chargeCost: profile.chargeCost,
+      classId,
+      abilityId: inherited?.abilityId || profile.abilityId || null,
+      spellAttack,
+      spellDC,
+      profile,
+    };
+  }
+
+  function canActivateSpellFromItem(user, item, spellRef, options = {}) {
+    if (!item) return { allowed: false, reason: "missing_item" };
+    const casting = resolveItemSpellcasting(user, item, spellRef, options);
+    if (!casting.resolved) return { allowed: false, reason: casting.reason };
+    if (requiresAttunement(item) && !isAttuned(user || {}, item)) return { allowed: false, reason: "item_not_attuned", casting };
+    const chargeCost = Math.max(0, intOr(options.chargeCost ?? casting.chargeCost, 0));
+    if (chargeCost > 0) {
+      const chargeState = items()?.getCharges?.(item) || { current: item.chargesCurrent ?? item.charges ?? null };
+      if (chargeState.current == null) return { allowed: false, reason: "item_has_no_charges", casting };
+      if (Number(chargeState.current) < chargeCost) return { allowed: false, reason: "insufficient_charges", casting, chargeCost };
+    }
+    return { allowed: true, casting, chargeCost };
+  }
+
+  function executeSpellHook(user, item, casting, options = {}) {
+    const executor = options.executeSpell || options.spellExecutor || global.LuminousSpellExecutor?.castSpell;
+    const payload = {
+      user,
+      item,
+      spellId: casting.spellId,
+      spellLevel: casting.spellLevel,
+      spellAttack: casting.spellAttack,
+      spellDC: casting.spellDC,
+      target: options.target || null,
+      context: options.context || {},
+      source: "item",
+    };
+    if (typeof executor !== "function") {
+      emit("luminous:item-spell-cast-requested", payload);
+      return { executed: false, prepared: true, reason: "spell_executor_unavailable", payload };
+    }
+    const result = executor(payload);
+    if (result === false || result?.executed === false || result?.cast === false) return { executed: false, prepared: true, reason: result?.reason || "spell_execution_failed", result, payload };
+    return { executed: true, prepared: true, result, payload };
+  }
+
+  function castSpellFromItem(user, item, spellRef, options = {}) {
+    const gate = canActivateSpellFromItem(user, item, spellRef, options);
+    if (!gate.allowed) return { cast: false, ...gate };
+    const execution = executeSpellHook(user, item, gate.casting, options);
+    if (!execution.executed) return { cast: false, ...gate, ...execution };
+    let charges = null;
+    if (gate.chargeCost > 0) {
+      charges = items()?.spendCharges?.(item, gate.chargeCost);
+      if (!charges?.spent) return { cast: false, reason: charges?.reason || "charge_spend_failed", execution, charges };
+    }
+    const result = { cast: true, casting: gate.casting, execution, charges };
+    emit("luminous:item-spell-cast", { user, item, ...result });
+    return result;
+  }
+
+  function isSpellScroll(item = {}) {
+    const category = normalizeId(item.category || item.type || item.itemType || "");
+    const tags = asArray(item.tags).map(normalizeId);
+    return item.isSpellScroll === true || category === "spell_scroll" || tags.includes("spell_scroll") || normalizeId(magicProfile(item).kind) === "spell_scroll";
+  }
+
+  function useSpellScroll(user, item, options = {}) {
+    if (!isSpellScroll(item)) return { used: false, reason: "item_not_spell_scroll" };
+    const spellRef = options.spellId || item.runtimeState?.spellId || item.customData?.spellId || spellProfiles(item)[0]?.spellId;
+    const result = castSpellFromItem(user, item, spellRef, { ...options, chargeCost: 0 });
+    if (!result.cast) return { used: false, ...result };
+    const consumed = items()?.consumeQuantity?.(item, 1);
+    return { used: Boolean(consumed?.consumed), consumed, ...result };
+  }
+
+  function isCursed(item = {}) {
+    const runtime = runtimeOf(item);
+    const profile = magicProfile(item);
+    return item.cursed === true || runtime.cursed === true || Boolean(runtime.curse || profile.curse || item.curse);
+  }
+
+  function revealCurse(item) {
+    if (!item || !isCursed(item)) return { revealed: false, reason: "item_not_cursed" };
+    if (!item.runtimeState || typeof item.runtimeState !== "object") item.runtimeState = {};
+    item.runtimeState.curseRevealed = true;
+    emit("luminous:item-curse-revealed", { item });
+    return { revealed: true, itemInstanceId: instanceIdOf(item) };
+  }
+
+  function curseProfile(item = {}) {
+    return clone(runtimeOf(item).curse || magicProfile(item).curse || item.curse || null);
+  }
+
+  function applyCurse(user, item, options = {}) {
+    if (!user || !item || !isCursed(item)) return { applied: false, reason: "missing_or_uncursed_item" };
+    if (!Array.isArray(user.itemCurses)) user.itemCurses = [];
+    const sourceItemInstanceId = instanceIdOf(item);
+    const existing = user.itemCurses.find((entry) => entry.sourceItemInstanceId === sourceItemInstanceId);
+    if (existing) return { applied: true, alreadyApplied: true, curse: clone(existing) };
+    const curse = { sourceItemInstanceId, sourceDefinitionId: definitionIdOf(item), profile: curseProfile(item), active: true };
+    user.itemCurses.push(curse);
+    if (typeof options.onApply === "function") options.onApply(user, item, curse);
+    emit("luminous:item-curse-applied", { user, item, curse: clone(curse) });
+    return { applied: true, curse };
+  }
+
+  function removeCurse(user, itemOrRef, options = {}) {
+    if (!user || !Array.isArray(user.itemCurses)) return { removed: false, reason: "no_item_curses" };
+    const id = typeof itemOrRef === "string" ? itemOrRef : instanceIdOf(itemOrRef);
+    const before = user.itemCurses.length;
+    const removedEntries = user.itemCurses.filter((entry) => entry.sourceItemInstanceId === id);
+    user.itemCurses = user.itemCurses.filter((entry) => entry.sourceItemInstanceId !== id);
+    if (removedEntries.length && typeof options.onRemove === "function") options.onRemove(user, itemOrRef, removedEntries);
+    return { removed: user.itemCurses.length < before, removedEntries };
+  }
+
+  const api = Object.freeze({
+    version: 1,
+    DEFAULT_ATTUNEMENT_CAPACITY,
+    magicProfile,
+    isMagicItem,
+    requiresAttunement,
+    getAttunementCapacity,
+    getAttunedItems,
+    isAttuned,
+    attunementRequirements,
+    canAttune,
+    attuneItem,
+    unattuneItem,
+    spellProfiles,
+    findSpellProfile,
+    resolveItemSpellcasting,
+    canActivateSpellFromItem,
+    castSpellFromItem,
+    isSpellScroll,
+    useSpellScroll,
+    isCursed,
+    revealCurse,
+    curseProfile,
+    applyCurse,
+    removeCurse,
+  });
+
+  global.LuminousItemMagicRuntime = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/item-persistence-runtime.js
+++ b/js/item-persistence-runtime.js
@@ -1,0 +1,326 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousItemPersistenceRuntime) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousItemPersistenceRuntime;
+    return;
+  }
+
+  function safeRequire(path) {
+    if (typeof require !== "function") return null;
+    try { return require(path); } catch (_) { return null; }
+  }
+
+  const inventory = () => global.LuminousItemInventoryRuntime || safeRequire("./item-inventory-runtime.js");
+  const workshopRuntime = () => global.LuminousWorkshopRuntime || safeRequire("./workshop-runtime.js");
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const intOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Math.trunc(Number(value)) : fallback;
+  const SCHEMA_VERSION = 2;
+  const LEGACY_HUD_FIELDS = Object.freeze([
+    "nombre", "name", "displayName", "tipo_categoria", "category", "itemType", "type",
+    "tags", "tag", "keywords", "limite_activo", "limite_alijo", "precio", "price", "cost",
+    "tier", "tierRoman", "icon", "imagen", "image", "description", "descripcion",
+    "weapon_details", "armor_details", "shield_details", "accessory_details", "consumable_details",
+    "upgrade_details", "runtime", "function", "functions", "carga_actual", "carga_maxima",
+  ]);
+
+  function emit(name, detail) {
+    try {
+      if (typeof global.dispatchEvent === "function" && typeof global.CustomEvent === "function") {
+        global.dispatchEvent(new global.CustomEvent(name, { detail }));
+      }
+    } catch (_) {}
+    return detail;
+  }
+
+  function objectEntries(container) {
+    if (Array.isArray(container)) return container.map((item, index) => [String(index), item]);
+    return container && typeof container === "object" ? Object.entries(container) : [];
+  }
+
+  function preserveLegacyHudFields(target, source = {}) {
+    if (!target || typeof target !== "object") return target;
+    const custom = source.customData && typeof source.customData === "object" ? source.customData : {};
+    LEGACY_HUD_FIELDS.forEach((field) => {
+      const value = source[field] !== undefined ? source[field] : custom[field];
+      if (value !== undefined) target[field] = clone(value);
+    });
+    return target;
+  }
+
+  function serializeContainer(container) {
+    const runtime = inventory();
+    const out = {};
+    objectEntries(container).forEach(([key, item]) => {
+      if (!item || typeof item !== "object") return;
+      const serialized = runtime?.serializeItemInstance?.(item) || clone(item);
+      preserveLegacyHudFields(serialized, item);
+      const instanceId = String(serialized.instanceId || key);
+      serialized.instanceId = instanceId;
+      out[instanceId] = serialized;
+    });
+    return out;
+  }
+
+  function equipmentRefs(unit = {}) {
+    const equipment = unit.equipment && typeof unit.equipment === "object" ? unit.equipment : {};
+    const refOf = (item) => item && typeof item === "object" ? (item.instanceId || item.instance_id || null) : (typeof item === "string" ? item : null);
+    return {
+      mainHand: refOf(equipment.mainHand),
+      offHand: refOf(equipment.offHand),
+      armor: refOf(equipment.armor),
+      shield: refOf(equipment.shield),
+      accessoryIds: Array.isArray(equipment.accessories) ? equipment.accessories.map(refOf).filter(Boolean) : [],
+    };
+  }
+
+  function serializeInventoryState(unit = {}) {
+    const runtime = inventory();
+    const active = runtime?.activeContainer?.(unit)?.value || unit.inventario_activo || {};
+    const stash = runtime?.stashContainer?.(unit)?.value || unit.inventario_stash || {};
+    return {
+      schemaVersion: SCHEMA_VERSION,
+      inventario_activo: serializeContainer(active),
+      inventario_stash: serializeContainer(stash),
+      equipmentRefs: equipmentRefs(unit),
+      attunedItemInstanceIds: [...new Set((unit.attunedItemInstanceIds || []).map(String).filter(Boolean))],
+    };
+  }
+
+  function deserializeContainer(raw, options = {}) {
+    const runtime = inventory();
+    if (!raw || typeof raw !== "object") return {};
+    const out = {};
+    objectEntries(raw).forEach(([key, item]) => {
+      if (!item || typeof item !== "object") return;
+      const instance = intOr(item.schemaVersion, 0) >= SCHEMA_VERSION && item.instanceId && item.definitionId
+        ? (runtime?.deserializeItemInstance?.(item, options) || clone(item))
+        : (runtime?.migrateLegacyItem?.(item, key, options) || clone(item));
+      preserveLegacyHudFields(instance, item);
+      const instanceId = String(instance.instanceId || key);
+      instance.instanceId = instanceId;
+      out[instanceId] = instance;
+    });
+    return out;
+  }
+
+  function deserializeInventoryState(snapshot = {}, options = {}) {
+    return {
+      schemaVersion: SCHEMA_VERSION,
+      inventario_activo: deserializeContainer(snapshot.inventario_activo || snapshot.activeInventory || snapshot.inventory || {}, options),
+      inventario_stash: deserializeContainer(snapshot.inventario_stash || snapshot.stashInventory || snapshot.stash || {}, options),
+      equipmentRefs: clone(snapshot.equipmentRefs || snapshot.itemEquipmentRefs || {}),
+      attunedItemInstanceIds: [...new Set((snapshot.attunedItemInstanceIds || snapshot.attunedItems || []).map(String).filter(Boolean))],
+      migratedFromVersion: intOr(snapshot.schemaVersion, 0),
+    };
+  }
+
+  function findInstance(state, instanceId) {
+    const id = String(instanceId || "");
+    return state?.inventario_activo?.[id] || state?.inventario_stash?.[id] || null;
+  }
+
+  function restoreEquipmentRefs(unit, state) {
+    const refs = state?.equipmentRefs || {};
+    if (!unit.equipment || typeof unit.equipment !== "object" || Array.isArray(unit.equipment)) unit.equipment = {};
+    ["mainHand", "offHand", "armor", "shield"].forEach((slot) => {
+      const id = refs[slot];
+      if (!id) return;
+      const item = findInstance(state, id);
+      if (item) unit.equipment[slot] = item;
+    });
+    if (Array.isArray(refs.accessoryIds)) unit.equipment.accessories = refs.accessoryIds.map((id) => findInstance(state, id)).filter(Boolean);
+    return unit.equipment;
+  }
+
+  function applyInventoryState(unit, snapshot, options = {}) {
+    if (!unit || typeof unit !== "object") return { applied: false, reason: "missing_unit" };
+    const state = deserializeInventoryState(snapshot, options);
+    unit.inventario_activo = state.inventario_activo;
+    unit.inventario_stash = state.inventario_stash;
+    unit.itemInventorySchemaVersion = SCHEMA_VERSION;
+    unit.attunedItemInstanceIds = state.attunedItemInstanceIds;
+    restoreEquipmentRefs(unit, state);
+    const result = { applied: true, state, activeCount: Object.keys(state.inventario_activo).length, stashCount: Object.keys(state.inventario_stash).length };
+    emit("luminous:inventory-state-applied", { unit, ...result });
+    return result;
+  }
+
+  function playerPaths(playerId, options = {}) {
+    const root = String(options.playerRoot || "campaña/jugadores").replace(/\/+$/g, "");
+    const id = String(playerId || "").trim();
+    if (!id) return null;
+    const base = `${root}/${id}`;
+    return {
+      base,
+      active: `${base}/inventario_activo`,
+      stash: `${base}/inventario_stash`,
+      schemaVersion: `${base}/itemInventorySchemaVersion`,
+      equipmentRefs: `${base}/itemEquipmentRefs`,
+      attunement: `${base}/attunedItemInstanceIds`,
+    };
+  }
+
+  function requireDb(db) {
+    return Boolean(db && typeof db.ref === "function");
+  }
+
+  async function loadPlayerInventory(db, playerId, options = {}) {
+    if (!requireDb(db)) return { loaded: false, reason: "firebase_db_unavailable" };
+    const paths = playerPaths(playerId, options);
+    if (!paths) return { loaded: false, reason: "missing_player_id" };
+    const [activeSnap, stashSnap, versionSnap, equipmentSnap, attunementSnap] = await Promise.all([
+      db.ref(paths.active).once("value"),
+      db.ref(paths.stash).once("value"),
+      db.ref(paths.schemaVersion).once("value"),
+      db.ref(paths.equipmentRefs).once("value"),
+      db.ref(paths.attunement).once("value"),
+    ]);
+    const raw = {
+      schemaVersion: versionSnap?.val?.() || 0,
+      inventario_activo: activeSnap?.val?.() || {},
+      inventario_stash: stashSnap?.val?.() || {},
+      equipmentRefs: equipmentSnap?.val?.() || {},
+      attunedItemInstanceIds: attunementSnap?.val?.() || [],
+    };
+    const state = deserializeInventoryState(raw, options);
+    const migrated = intOr(raw.schemaVersion, 0) < SCHEMA_VERSION;
+    if (migrated && options.writeBackMigration === true) await saveInventoryState(db, playerId, state, options);
+    const result = { loaded: true, playerId: String(playerId), migrated, state };
+    emit("luminous:inventory-loaded", result);
+    return result;
+  }
+
+  function normalizeStateForSave(unitOrState = {}, options = {}) {
+    const looksLikeState = unitOrState.schemaVersion != null && unitOrState.equipmentRefs !== undefined && !unitOrState.equipment;
+    if (!looksLikeState) return serializeInventoryState(unitOrState);
+    return {
+      schemaVersion: SCHEMA_VERSION,
+      inventario_activo: serializeContainer(unitOrState.inventario_activo || {}),
+      inventario_stash: serializeContainer(unitOrState.inventario_stash || {}),
+      equipmentRefs: clone(unitOrState.equipmentRefs || {}),
+      attunedItemInstanceIds: clone(unitOrState.attunedItemInstanceIds || []),
+    };
+  }
+
+  async function saveInventoryState(db, playerId, unitOrState, options = {}) {
+    if (!requireDb(db)) return { saved: false, reason: "firebase_db_unavailable" };
+    const paths = playerPaths(playerId, options);
+    if (!paths) return { saved: false, reason: "missing_player_id" };
+    const state = normalizeStateForSave(unitOrState || {}, options);
+    const updates = {
+      inventario_activo: serializeContainer(state.inventario_activo),
+      inventario_stash: serializeContainer(state.inventario_stash),
+      itemInventorySchemaVersion: SCHEMA_VERSION,
+      itemEquipmentRefs: clone(state.equipmentRefs || {}),
+      attunedItemInstanceIds: clone(state.attunedItemInstanceIds || []),
+    };
+    const ref = db.ref(paths.base);
+    if (typeof ref.update === "function") await ref.update(updates);
+    else if (typeof ref.set === "function") await Promise.all(Object.entries(updates).map(([key, value]) => db.ref(`${paths.base}/${key}`).set(value)));
+    else return { saved: false, reason: "firebase_write_unavailable" };
+    const result = { saved: true, playerId: String(playerId), schemaVersion: SCHEMA_VERSION, state: updates };
+    emit("luminous:inventory-saved", result);
+    return result;
+  }
+
+  function subscribePlayerInventory(db, playerId, callback, options = {}) {
+    if (!requireDb(db) || typeof callback !== "function") return () => {};
+    const paths = playerPaths(playerId, options);
+    if (!paths) return () => {};
+    let active = {};
+    let stash = {};
+    let schemaVersion = 0;
+    let equipment = {};
+    let attunement = [];
+    let scheduled = false;
+    const publish = () => {
+      if (scheduled) return;
+      scheduled = true;
+      Promise.resolve().then(() => {
+        scheduled = false;
+        callback(deserializeInventoryState({ schemaVersion, inventario_activo: active, inventario_stash: stash, equipmentRefs: equipment, attunedItemInstanceIds: attunement }, options));
+      });
+    };
+    const handlers = [
+      [paths.active, (snap) => { active = snap?.val?.() || {}; publish(); }],
+      [paths.stash, (snap) => { stash = snap?.val?.() || {}; publish(); }],
+      [paths.schemaVersion, (snap) => { schemaVersion = snap?.val?.() || 0; publish(); }],
+      [paths.equipmentRefs, (snap) => { equipment = snap?.val?.() || {}; publish(); }],
+      [paths.attunement, (snap) => { attunement = snap?.val?.() || []; publish(); }],
+    ];
+    handlers.forEach(([path, handler]) => db.ref(path).on("value", handler));
+    return () => handlers.forEach(([path, handler]) => db.ref(path).off?.("value", handler));
+  }
+
+  async function readStashAccess(db, options = {}) {
+    if (!requireDb(db)) return { loaded: false, reason: "firebase_db_unavailable", unlocked: false };
+    const path = options.stashAccessPath || "campaña/ajustes_globales/alijo_desbloqueado";
+    const snap = await db.ref(path).once("value");
+    return { loaded: true, path, unlocked: snap?.val?.() === true };
+  }
+
+  function serializeWorkshopState(runtime = workshopRuntime()) {
+    const list = runtime?.listWorkshops?.() || [];
+    const workshopMap = {};
+    list.forEach((workshop) => {
+      if (workshop?.workshopId) workshopMap[workshop.workshopId] = runtime?.serializeWorkshop?.(workshop) || clone(workshop);
+    });
+    return { schemaVersion: 1, workshops: workshopMap };
+  }
+
+  function hydrateWorkshopState(snapshot = {}, runtime = workshopRuntime()) {
+    if (!runtime?.registerWorkshop) return { hydrated: false, reason: "workshop_runtime_unavailable" };
+    const source = snapshot.workshops || snapshot;
+    const results = [];
+    Object.values(source || {}).forEach((workshop) => {
+      if (!workshop?.workshopId) return;
+      results.push(runtime.registerWorkshop(workshop));
+    });
+    return { hydrated: true, count: results.filter((entry) => entry.registered).length, results };
+  }
+
+  async function saveWorkshopState(db, path, runtime = workshopRuntime()) {
+    if (!requireDb(db)) return { saved: false, reason: "firebase_db_unavailable" };
+    if (!path) return { saved: false, reason: "workshop_path_required" };
+    const state = serializeWorkshopState(runtime);
+    const ref = db.ref(String(path));
+    if (typeof ref.set === "function") await ref.set(state);
+    else if (typeof ref.update === "function") await ref.update(state);
+    else return { saved: false, reason: "firebase_write_unavailable" };
+    return { saved: true, path: String(path), count: Object.keys(state.workshops).length };
+  }
+
+  async function loadWorkshopState(db, path, runtime = workshopRuntime()) {
+    if (!requireDb(db)) return { loaded: false, reason: "firebase_db_unavailable" };
+    if (!path) return { loaded: false, reason: "workshop_path_required" };
+    const snap = await db.ref(String(path)).once("value");
+    const state = snap?.val?.() || { schemaVersion: 1, workshops: {} };
+    const hydrated = hydrateWorkshopState(state, runtime);
+    return { loaded: true, path: String(path), state, ...hydrated };
+  }
+
+  const api = Object.freeze({
+    version: 1,
+    schemaVersion: SCHEMA_VERSION,
+    LEGACY_HUD_FIELDS,
+    preserveLegacyHudFields,
+    serializeContainer,
+    serializeInventoryState,
+    deserializeInventoryState,
+    restoreEquipmentRefs,
+    applyInventoryState,
+    playerPaths,
+    loadPlayerInventory,
+    saveInventoryState,
+    subscribePlayerInventory,
+    readStashAccess,
+    serializeWorkshopState,
+    hydrateWorkshopState,
+    saveWorkshopState,
+    loadWorkshopState,
+  });
+
+  global.LuminousItemPersistenceRuntime = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/item-realtime-sync.js
+++ b/js/item-realtime-sync.js
@@ -1,0 +1,188 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousItemRealtimeSync) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousItemRealtimeSync;
+    return;
+  }
+
+  function safeRequire(path) {
+    if (typeof require !== "function") return null;
+    try { return require(path); } catch (_) { return null; }
+  }
+
+  const persistence = () => global.LuminousItemPersistenceRuntime || safeRequire("./item-persistence-runtime.js");
+  const inventory = () => global.LuminousItemInventoryRuntime || safeRequire("./item-inventory-runtime.js");
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const STASH_ACCESS_PATH = "campaña/ajustes_globales/alijo_desbloqueado";
+
+  function emit(name, detail) {
+    try {
+      if (typeof global.dispatchEvent === "function" && typeof global.CustomEvent === "function") {
+        global.dispatchEvent(new global.CustomEvent(name, { detail }));
+      }
+    } catch (_) {}
+    return detail;
+  }
+
+  function normalizeRole(value) {
+    const role = String(value || "player").trim().toLowerCase();
+    return role === "dm" ? "dm" : "player";
+  }
+
+  function playerPaths(playerId, options = {}) {
+    const runtime = persistence();
+    if (runtime?.playerPaths) return runtime.playerPaths(playerId, options);
+    const root = String(options.playerRoot || "campaña/jugadores").replace(/\/+$/g, "");
+    const id = String(playerId || "").trim();
+    if (!id) return null;
+    const base = `${root}/${id}`;
+    return {
+      base,
+      active: `${base}/inventario_activo`,
+      stash: `${base}/inventario_stash`,
+      schemaVersion: `${base}/itemInventorySchemaVersion`,
+      equipmentRefs: `${base}/itemEquipmentRefs`,
+      attunement: `${base}/attunedItemInstanceIds`,
+    };
+  }
+
+  function subscribeStashAccess(db, callback, options = {}) {
+    if (!db || typeof db.ref !== "function" || typeof callback !== "function") return () => {};
+    const path = String(options.stashAccessPath || STASH_ACCESS_PATH);
+    const ref = db.ref(path);
+    const handler = (snap) => callback(snap?.val?.() === true, { path, snapshot: snap });
+    ref.on("value", handler);
+    return () => ref.off?.("value", handler);
+  }
+
+  async function setStashAccess(db, unlocked, options = {}) {
+    if (!db || typeof db.ref !== "function") return { saved: false, reason: "firebase_db_unavailable" };
+    const path = String(options.stashAccessPath || STASH_ACCESS_PATH);
+    const ref = db.ref(path);
+    if (typeof ref.set !== "function") return { saved: false, reason: "firebase_write_unavailable", path };
+    await ref.set(unlocked === true);
+    const result = { saved: true, path, unlocked: unlocked === true };
+    emit("luminous:stash-access-written", result);
+    return result;
+  }
+
+  function bindPeer(options = {}) {
+    const runtime = persistence();
+    const db = options.db;
+    const playerId = String(options.playerId || "").trim();
+    const role = normalizeRole(options.role);
+    const unit = options.unit && typeof options.unit === "object" ? options.unit : {};
+    if (!runtime?.subscribePlayerInventory || !runtime?.applyInventoryState || !runtime?.saveInventoryState) {
+      return { bound: false, reason: "item_persistence_runtime_unavailable", role, playerId, unit, dispose() {} };
+    }
+    if (!db || typeof db.ref !== "function") {
+      return { bound: false, reason: "firebase_db_unavailable", role, playerId, unit, dispose() {} };
+    }
+    if (!playerId) return { bound: false, reason: "missing_player_id", role, playerId, unit, dispose() {} };
+
+    let disposed = false;
+    let revision = 0;
+    let stashUnlocked = null;
+    let lastState = null;
+    const disposers = [];
+
+    const unsubscribeInventory = runtime.subscribePlayerInventory(db, playerId, (state) => {
+      if (disposed) return;
+      const applied = runtime.applyInventoryState(unit, state, options);
+      if (!applied?.applied) {
+        options.onError?.({ source: "inventory", reason: applied?.reason || "inventory_apply_failed", state });
+        return;
+      }
+      revision += 1;
+      lastState = clone(state);
+      const detail = { role, playerId, revision, state: clone(state), unit, source: "firebase" };
+      options.onInventory?.(detail);
+      emit("luminous:inventory-realtime", detail);
+    }, options);
+    disposers.push(unsubscribeInventory);
+
+    if (options.watchStashAccess !== false) {
+      const unsubscribeAccess = subscribeStashAccess(db, (unlocked, meta) => {
+        if (disposed) return;
+        stashUnlocked = unlocked;
+        unit.stashUnlocked = unlocked;
+        const detail = { role, playerId, unlocked, path: meta.path, unit, source: "firebase" };
+        options.onStashAccess?.(detail);
+        emit("luminous:stash-access-changed", detail);
+      }, options);
+      disposers.push(unsubscribeAccess);
+    }
+
+    async function save(unitOrState = unit, saveOptions = {}) {
+      if (disposed) return { saved: false, reason: "peer_disposed" };
+      const result = await runtime.saveInventoryState(db, playerId, unitOrState, { ...options, ...saveOptions });
+      if (result?.saved) emit("luminous:inventory-realtime-write", { role, playerId, result });
+      return result;
+    }
+
+    async function move(ref, direction, amount = null, moveOptions = {}) {
+      if (disposed) return { moved: false, saved: false, reason: "peer_disposed" };
+      const itemRuntime = inventory();
+      if (!itemRuntime) return { moved: false, saved: false, reason: "item_inventory_runtime_unavailable" };
+      const normalized = String(direction || "").trim().toLowerCase();
+      const moved = normalized === "to_stash" || normalized === "stash"
+        ? itemRuntime.moveToStash(unit, ref, amount, moveOptions)
+        : normalized === "to_active" || normalized === "active"
+          ? itemRuntime.moveToActive(unit, ref, amount, moveOptions)
+          : { moved: false, reason: "invalid_move_direction" };
+      if (!moved?.moved) return { ...moved, saved: false };
+      const persisted = await save(unit, moveOptions);
+      return { ...moved, saved: persisted?.saved === true, persistence: persisted };
+    }
+
+    async function setStashUnlocked(unlocked, accessOptions = {}) {
+      if (role !== "dm" && accessOptions.allowPlayerWrite !== true) {
+        return { saved: false, reason: "dm_role_required" };
+      }
+      return setStashAccess(db, unlocked, { ...options, ...accessOptions });
+    }
+
+    function dispose() {
+      if (disposed) return;
+      disposed = true;
+      while (disposers.length) {
+        try { disposers.pop()?.(); } catch (_) {}
+      }
+      emit("luminous:inventory-realtime-disposed", { role, playerId });
+    }
+
+    return {
+      bound: true,
+      role,
+      playerId,
+      unit,
+      paths: playerPaths(playerId, options),
+      get revision() { return revision; },
+      get state() { return clone(lastState); },
+      get stashUnlocked() { return stashUnlocked; },
+      save,
+      move,
+      setStashUnlocked,
+      dispose,
+    };
+  }
+
+  function bindPlayerInventory(options = {}) { return bindPeer({ ...options, role: "player" }); }
+  function bindDmInventory(options = {}) { return bindPeer({ ...options, role: "dm" }); }
+
+  const api = Object.freeze({
+    version: 1,
+    STASH_ACCESS_PATH,
+    normalizeRole,
+    playerPaths,
+    subscribeStashAccess,
+    setStashAccess,
+    bindPeer,
+    bindPlayerInventory,
+    bindDmInventory,
+  });
+
+  global.LuminousItemRealtimeSync = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/item-runtime-engine.js
+++ b/js/item-runtime-engine.js
@@ -1,0 +1,820 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousItemRuntime) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousItemRuntime;
+    return;
+  }
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const intOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Math.trunc(Number(value)) : fallback;
+  const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+  const asArray = (value) => value == null ? [] : (Array.isArray(value) ? value : [value]);
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+  function safeRequire(path) {
+    if (typeof require !== "function") return null;
+    try { return require(path); } catch (_) { return null; }
+  }
+
+  const engines = {
+    anatomy: () => global.LuminousAnatomyEquipmentEngine || safeRequire("./anatomy-equipment-engine.js"),
+    actions: () => global.LuminousActionEconomy || safeRequire("./universal-action-economy.js"),
+    statuses: () => global.LuminousStatusEngine || safeRequire("./status-engine.js"),
+    injuries: () => global.LuminousInjuryEngine || safeRequire("./injury-engine.js"),
+    modifiers: () => global.LuminousUniversalModifiers || safeRequire("./universal-modifier-engine.js"),
+  };
+
+  function emit(name, detail) {
+    try {
+      if (typeof global.dispatchEvent === "function" && typeof global.CustomEvent === "function") {
+        global.dispatchEvent(new global.CustomEvent(name, { detail }));
+      }
+    } catch (_) {}
+    return detail;
+  }
+
+  function itemId(item = {}) {
+    return String(item.instanceId || item.instance_id || item.canonicalId || item.definitionId || item.itemId || item.item_id || item.id || item.key || item.nombre || item.name || "item").trim();
+  }
+
+  function definitionId(item = {}) {
+    return String(item.definitionId || item.definition_id || item.canonicalId || item.canonical_id || item.itemId || item.item_id || item.id || item.key || "").trim();
+  }
+
+  function itemName(item = {}) {
+    return String(item.displayName || item.nombre || item.name || definitionId(item) || "Item").trim();
+  }
+
+  function categoryOf(item = {}) {
+    const raw = normalizeId(item.tipo_categoria || item.category || item.itemType || item.item_type || item.kind || item.type || item.tag);
+    const aliases = {
+      arma: "weapon", weapons: "weapon",
+      armadura: "armor", armors: "armor",
+      escudo: "shield", shields: "shield",
+      accesorio: "accessory", accessories: "accessory",
+      consumible: "consumable", consumables: "consumable",
+      aumento: "augmentation", augment: "augmentation", alteracion_corporal: "augmentation",
+      mejora: "upgrade", upgrades: "upgrade", module: "upgrade", modules: "upgrade",
+      municion: "ammo", ammunition: "ammo",
+      herramienta: "tool", tools: "tool",
+    };
+    return aliases[raw] || raw || "item";
+  }
+
+  function tagsOf(item = {}) {
+    const tags = [];
+    asArray(item.tags).forEach((tag) => {
+      if (typeof tag === "string" && tag.includes("|")) tag.split("|").forEach((part) => tags.push(part));
+      else tags.push(tag);
+    });
+    if (typeof item.tag === "string") item.tag.split(/[|,]/).forEach((tag) => tags.push(tag));
+    return [...new Set(tags.map((tag) => String(tag ?? "").trim()).filter(Boolean))];
+  }
+
+  function normalizedTags(item = {}) {
+    return tagsOf(item).map(normalizeId);
+  }
+
+  function tagValue(item, prefix) {
+    const wanted = `${normalizeId(prefix)}:`;
+    for (const raw of tagsOf(item)) {
+      const text = String(raw).trim();
+      const index = text.indexOf(":");
+      if (index < 0) continue;
+      if (`${normalizeId(text.slice(0, index))}:` === wanted) return text.slice(index + 1).trim();
+    }
+    return null;
+  }
+
+  function runtimeOf(item = {}) {
+    return item.runtime && typeof item.runtime === "object" ? item.runtime
+      : item.itemRuntime && typeof item.itemRuntime === "object" ? item.itemRuntime
+        : item.item_runtime && typeof item.item_runtime === "object" ? item.item_runtime
+          : {};
+  }
+
+  function parseFunctionTypes(item = {}) {
+    const out = new Set();
+    const raw = item.function ?? item.functions ?? runtimeOf(item).functions;
+    asArray(raw).forEach((entry) => {
+      if (typeof entry === "string") entry.split(/[|,;]/).forEach((part) => out.add(normalizeId(part)));
+      else if (entry && typeof entry === "object") out.add(normalizeId(entry.functionType || entry.type || entry.id));
+    });
+    if (categoryOf(item) === "consumable") out.add("use");
+    if (["weapon", "armor", "shield", "accessory"].includes(categoryOf(item))) out.add("equip");
+    if (categoryOf(item) === "upgrade") { out.add("install"); out.add("remove"); }
+    if (categoryOf(item) === "ammo") out.add("ammo");
+    return [...out].filter(Boolean);
+  }
+
+  function hasFunction(item, functionType) {
+    return parseFunctionTypes(item).includes(normalizeId(functionType));
+  }
+
+  function inferAccessoryType(item = {}) {
+    const explicit = runtimeOf(item).equipment?.accessoryType || item.equipment?.accessoryType || item.accessorySlot || item.bodySlot || item.slotType || item.equipBodyPart;
+    if (explicit) return normalizeId(explicit);
+    const slot = normalizeId(tagValue(item, "slot"));
+    const map = {
+      face: "head", head: "head", helmet: "head",
+      arm: "arm", arms: "arm", wrist: "arm",
+      hand: "hand", hands: "hand", gloves: "hand",
+      finger: "finger", ring: "finger",
+      foot: "foot", feet: "foot", shoes: "foot", boots: "foot",
+    };
+    return map[slot] || (slot ? "legacy_accessory" : "legacy_accessory");
+  }
+
+  function inferHandCost(item = {}) {
+    const explicit = runtimeOf(item).equipment?.handCost ?? item.equipment?.handCost ?? item.handCost ?? item.handsRequired;
+    if (Number.isFinite(Number(explicit))) return Math.max(0, Math.trunc(Number(explicit)));
+    const tag = tagValue(item, "hands");
+    if (Number.isFinite(Number(tag))) return Math.max(0, Math.trunc(Number(tag)));
+    if (categoryOf(item) === "weapon" || categoryOf(item) === "shield") return 1;
+    return 0;
+  }
+
+  function equipmentSchema(item = {}) {
+    const runtime = runtimeOf(item);
+    const explicit = runtime.equipment || item.equipment || item.equipmentSchema || {};
+    const category = categoryOf(item);
+    const kind = normalizeId(explicit.kind || (["weapon", "armor", "shield", "accessory", "augmentation"].includes(category) ? category : "item"));
+    const blockers = explicit.blocksAccessorySlots || item.blocksAccessorySlots || item.blockedAccessorySlots || [];
+    return {
+      ...clone(explicit),
+      kind,
+      handCost: inferHandCost(item),
+      accessoryType: kind === "accessory" ? inferAccessoryType(item) : null,
+      slotCost: Math.max(1, intOr(explicit.slotCost ?? item.slotCost, 1)),
+      blocksAccessorySlots: clone(blockers),
+    };
+  }
+
+  function hydrateForEquipment(item = {}) {
+    if (!item || typeof item !== "object") return item;
+    item.equipment = equipmentSchema(item);
+    return item;
+  }
+
+  function containersFor(unit = {}) {
+    return [unit.inventory, unit.inventario, unit.activeInventory, unit.items, unit.equipment].filter(Boolean);
+  }
+
+  function objectEntries(container) {
+    if (Array.isArray(container)) return container.map((item, index) => [String(index), item]);
+    if (container && typeof container === "object") return Object.entries(container);
+    return [];
+  }
+
+  function findItem(unit, ref) {
+    if (ref && typeof ref === "object") return ref;
+    const wanted = String(ref ?? "").trim();
+    if (!wanted) return null;
+    for (const container of containersFor(unit)) {
+      for (const [key, item] of objectEntries(container)) {
+        if (!item || typeof item !== "object") continue;
+        const candidates = [key, itemId(item), definitionId(item), item.id, item.key, item.itemId, item.item_id, item.canonicalId]
+          .map((value) => String(value ?? "").trim()).filter(Boolean);
+        if (candidates.includes(wanted)) return item;
+      }
+    }
+    return null;
+  }
+
+  function quantityOf(item = {}) {
+    const candidates = [item.quantity, item.qty, item.cantidad, item.stack, item.count];
+    const found = candidates.find((value) => Number.isFinite(Number(value)));
+    return Math.max(0, intOr(found, 1));
+  }
+
+  function setQuantity(item = {}, next) {
+    const value = Math.max(0, Math.trunc(numberOr(next, 0)));
+    const key = ["quantity", "qty", "cantidad", "stack", "count"].find((name) => Object.prototype.hasOwnProperty.call(item, name)) || "quantity";
+    item[key] = value;
+    return value;
+  }
+
+  function consumeQuantity(item = {}, amount = 1) {
+    const qty = quantityOf(item);
+    const cost = Math.max(0, Math.trunc(numberOr(amount, 1)));
+    if (qty < cost) return { consumed: false, reason: "insufficient_quantity", before: qty, after: qty };
+    const after = setQuantity(item, qty - cost);
+    return { consumed: true, before: qty, after, amount: cost };
+  }
+
+  function makeInstance(definition = {}, options = {}) {
+    const maxCondition = Math.max(0, numberOr(options.conditionMax ?? definition.conditionMax ?? definition.condition_max, 100));
+    const instance = {
+      ...clone(definition),
+      definitionId: definitionId(definition) || normalizeId(itemName(definition)),
+      instanceId: options.instanceId || `item_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+      quantity: Math.max(1, intOr(options.quantity, 1)),
+      conditionMax: maxCondition,
+      condition: clamp(numberOr(options.condition, maxCondition), 0, maxCondition),
+      quality: numberOr(options.quality, 1),
+      stolen: options.stolen === true,
+      originMarketId: options.originMarketId || null,
+      installedModules: clone(options.installedModules || []),
+      charges: options.charges == null ? null : Math.max(0, intOr(options.charges, 0)),
+    };
+    hydrateForEquipment(instance);
+    return instance;
+  }
+
+  function equippedItems(unit = {}) {
+    const anatomy = engines.anatomy();
+    const items = anatomy?.collectEquippedItems?.(unit) || [];
+    return items.map(hydrateForEquipment);
+  }
+
+  function equipItem(unit, itemInput, options = {}) {
+    const item = hydrateForEquipment(findItem(unit, itemInput) || itemInput);
+    if (!unit || !item || typeof item !== "object") return { equipped: false, reason: "missing_unit_or_item" };
+    if (!["weapon", "armor", "shield", "accessory"].includes(equipmentSchema(item).kind)) return { equipped: false, reason: "item_not_equippable", item };
+    const anatomy = engines.anatomy();
+    if (!anatomy?.validateEquipment) return { equipped: false, reason: "anatomy_engine_unavailable", item };
+
+    const wasEquipped = item.equipped === true;
+    const previousParts = clone(item.equippedPartIds || []);
+    item.equipped = true;
+    const all = equippedItems(unit).filter((entry) => entry !== item);
+    all.push(item);
+    const result = anatomy.validateEquipment(unit, all, options);
+    const assignment = result.assignments.find((entry) => entry.item === item || itemId(entry.item) === itemId(item));
+    const invalid = result.invalid.find((entry) => entry.item === item || itemId(entry.item) === itemId(item));
+    if (!assignment || invalid) {
+      item.equipped = wasEquipped;
+      item.equippedPartIds = previousParts;
+      return { equipped: false, reason: invalid?.reason || "equipment_assignment_failed", item, validation: result };
+    }
+    item.equipped = true;
+    item.equippedPartIds = [...assignment.partIds];
+    item.assignedBodyParts = [...assignment.partIds];
+    syncLegacyEquipmentPointers(unit, item, true);
+    emit("luminous:item-equipped", { unit, item, assignment, validation: result });
+    return { equipped: true, unit, item, assignment, validation: result };
+  }
+
+  function syncLegacyEquipmentPointers(unit, item, equip) {
+    if (!unit || !item) return;
+    if (!unit.equipment || typeof unit.equipment !== "object" || Array.isArray(unit.equipment)) unit.equipment = {};
+    const kind = equipmentSchema(item).kind;
+    if (kind === "armor") {
+      if (equip) unit.equipment.armor = item;
+      else if (unit.equipment.armor === item || itemId(unit.equipment.armor || {}) === itemId(item)) delete unit.equipment.armor;
+      return;
+    }
+    if (kind === "shield") {
+      if (equip) unit.equipment.shield = item;
+      else if (unit.equipment.shield === item || itemId(unit.equipment.shield || {}) === itemId(item)) delete unit.equipment.shield;
+      return;
+    }
+    if (kind === "weapon") {
+      if (equip) {
+        if (!unit.equipment.mainHand) unit.equipment.mainHand = item;
+        else if (!unit.equipment.offHand && inferHandCost(item) <= 1) unit.equipment.offHand = item;
+      } else {
+        if (unit.equipment.mainHand === item || itemId(unit.equipment.mainHand || {}) === itemId(item)) delete unit.equipment.mainHand;
+        if (unit.equipment.offHand === item || itemId(unit.equipment.offHand || {}) === itemId(item)) delete unit.equipment.offHand;
+      }
+    }
+  }
+
+  function unequipItem(unit, itemInput) {
+    const item = findItem(unit, itemInput) || itemInput;
+    if (!item || typeof item !== "object") return { unequipped: false, reason: "item_not_found" };
+    item.equipped = false;
+    item.equipped_slot = null;
+    item.equippedSlot = null;
+    item.equippedPartIds = [];
+    item.assignedBodyParts = [];
+    syncLegacyEquipmentPointers(unit, item, false);
+    emit("luminous:item-unequipped", { unit, item });
+    return { unequipped: true, unit, item };
+  }
+
+  function currentAndMax(unit, kind) {
+    const lower = normalizeId(kind);
+    const candidates = lower === "hp" ? [
+      [unit?.combatStats, "hp_actual", ["hp_max", "max_hp", "maxHp"]],
+      [unit, "hp", ["effectiveMaxHp", "maxHp", "max_hp", "hpMax"]],
+      [unit, "currentHp", ["maxHp", "max_hp"]],
+    ] : [
+      [unit?.combatStats, "sp_actual", ["sp_max", "max_sp", "maxSp"]],
+      [unit, "sp", ["maxSp", "max_sp", "spMax"]],
+      [unit, "sanity", ["maxSanity", "sanityMax"]],
+    ];
+    for (const [owner, key, maxKeys] of candidates) {
+      if (!owner || !Number.isFinite(Number(owner[key]))) continue;
+      const maxKey = maxKeys.find((name) => Number.isFinite(Number(owner[name])));
+      const fallbackMax = lower === "sp" ? 45 : Number(owner[key]);
+      return { owner, key, maxKey, current: Number(owner[key]), max: maxKey ? Number(owner[maxKey]) : fallbackMax };
+    }
+    return null;
+  }
+
+  function recoverResource(unit, kind, amount) {
+    const value = Math.max(0, numberOr(amount, 0));
+    if (!value) return { changed: false, amount: 0, kind: normalizeId(kind) };
+    const slot = currentAndMax(unit, kind);
+    if (!slot) return { changed: false, reason: `${normalizeId(kind)}_resource_not_found`, amount: 0 };
+    const before = slot.current;
+    const after = clamp(before + value, 0, Math.max(before, slot.max));
+    slot.owner[slot.key] = after;
+    return { changed: after !== before, before, after, amount: after - before, kind: normalizeId(kind) };
+  }
+
+  function hpPercent(unit) {
+    const slot = currentAndMax(unit, "hp");
+    if (!slot || slot.max <= 0) return 100;
+    return clamp((slot.current / slot.max) * 100, 0, 100);
+  }
+
+  function actionCostFor(item = {}) {
+    const runtime = runtimeOf(item);
+    const details = item.consumable_details || {};
+    return normalizeId(runtime.actionCost || runtime.action_cost || details.action_cost || details.actionCost || "action") || "action";
+  }
+
+  function usageTarget(item, user, options = {}) {
+    const details = item.consumable_details || {};
+    const runtime = runtimeOf(item);
+    if (details.is_throwable === true || normalizeId(runtime.targetMode || runtime.target_mode) === "target") return options.target || null;
+    return options.target || user;
+  }
+
+  function runtimeUseProfile(item = {}) {
+    const runtime = runtimeOf(item);
+    const details = item.consumable_details || {};
+    const effects = runtime.effects && typeof runtime.effects === "object" ? runtime.effects : {};
+    const treatment = runtime.injuryTreatment || runtime.injury_treatment || details.injury_treatment || null;
+    return {
+      hp: numberOr(effects.hpRestore ?? effects.hp_restore ?? runtime.hpRestore ?? runtime.hp_restore ?? details.curacion_hp, 0),
+      sp: numberOr(effects.spRestore ?? effects.sp_restore ?? runtime.spRestore ?? runtime.sp_restore ?? details.curacion_sp, 0),
+      statusId: effects.statusId || effects.status_id || runtime.statusId || runtime.status_id || details.status_id || null,
+      statusPotency: numberOr(effects.statusPotency ?? effects.status_potency ?? runtime.statusPotency ?? runtime.status_potency ?? details.status_potency, 0),
+      statusCount: Math.max(0, intOr(effects.statusCount ?? effects.status_count ?? runtime.statusCount ?? runtime.status_count ?? details.status_count, 0)),
+      statId: normalizeId(effects.statId || effects.stat_id || runtime.statId || runtime.stat_id || details.stat_increase),
+      statValue: numberOr(effects.statValue ?? effects.stat_value ?? runtime.statValue ?? runtime.stat_value ?? details.stat_increase_value, 0),
+      durationHours: Math.max(0, numberOr(effects.durationHours ?? effects.duration_hours ?? runtime.durationHours ?? runtime.duration_hours ?? details.duration_hours, 0)),
+      injuryTreatment: treatment ? clone(treatment) : null,
+      repairAmount: Math.max(0, numberOr(effects.repairAmount ?? effects.repair_amount ?? runtime.repairAmount ?? runtime.repair_amount, 0)),
+      removeStatuses: asArray(effects.removeStatuses || effects.remove_statuses || runtime.removeStatuses || runtime.remove_statuses).map(normalizeId).filter(Boolean),
+    };
+  }
+
+  function ensureRuntimeEffects(unit) {
+    if (!unit || typeof unit !== "object") return [];
+    if (!Array.isArray(unit.itemRuntimeEffects)) unit.itemRuntimeEffects = [];
+    return unit.itemRuntimeEffects;
+  }
+
+  function addTemporaryStatEffect(unit, item, statId, value, hours) {
+    if (!unit || !statId || !value || hours <= 0) return null;
+    const effects = ensureRuntimeEffects(unit);
+    const id = `item_effect_${normalizeId(itemId(item))}_${Date.now()}_${effects.length + 1}`;
+    const effect = { id, sourceItemId: definitionId(item) || itemId(item), kind: "stat", statId, value, remainingHours: hours, active: true };
+    effects.push(effect);
+    emit("luminous:item-temporary-effect-added", { unit, item, effect: clone(effect) });
+    return effect;
+  }
+
+  function advanceTime(unit, hours) {
+    const elapsed = Math.max(0, numberOr(hours, 0));
+    if (!elapsed) return [];
+    const effects = ensureRuntimeEffects(unit);
+    const changed = [];
+    effects.forEach((effect) => {
+      if (!effect || effect.active === false || effect.remainingHours == null) return;
+      const before = Math.max(0, numberOr(effect.remainingHours, 0));
+      effect.remainingHours = Math.max(0, before - elapsed);
+      if (effect.remainingHours <= 0) effect.active = false;
+      changed.push({ id: effect.id, before, after: effect.remainingHours, expired: effect.active === false });
+    });
+    unit.itemRuntimeEffects = effects.filter((effect) => effect && effect.active !== false);
+    if (changed.length) emit("luminous:item-effects-time-advanced", { unit, hours: elapsed, changed });
+    return changed;
+  }
+
+  function conditionOf(item = {}) {
+    const current = numberOr(item.condition ?? item.currentCondition ?? item.durability, 0);
+    const max = Math.max(0, numberOr(item.conditionMax ?? item.maxCondition ?? item.maxDurability, 100));
+    return { current: clamp(current, 0, max), max };
+  }
+
+  function repairItem(targetItem, amount) {
+    if (!targetItem || typeof targetItem !== "object") return { repaired: false, reason: "missing_target_item" };
+    const state = conditionOf(targetItem);
+    const repair = Math.max(0, numberOr(amount, 0));
+    if (!repair) return { repaired: false, reason: "zero_repair", before: state.current, after: state.current, max: state.max };
+    const after = clamp(state.current + repair, 0, state.max);
+    if (Object.prototype.hasOwnProperty.call(targetItem, "condition")) targetItem.condition = after;
+    else if (Object.prototype.hasOwnProperty.call(targetItem, "durability")) targetItem.durability = after;
+    else targetItem.condition = after;
+    return { repaired: after > state.current, before: state.current, after, max: state.max, amount: after - state.current };
+  }
+
+  function applyUseEffects(user, item, options = {}) {
+    const profile = runtimeUseProfile(item);
+    const target = usageTarget(item, user, options);
+    if (!target) return { applied: false, reason: "missing_target", item };
+    const results = { hp: null, sp: null, status: null, removedStatuses: [], injury: null, repair: null, temporaryEffect: null };
+
+    if (profile.hp > 0) results.hp = recoverResource(target, "hp", profile.hp);
+    if (profile.sp > 0) results.sp = recoverResource(target, "sp", profile.sp);
+
+    const statusEngine = engines.statuses();
+    profile.removeStatuses.forEach((statusId) => {
+      if (statusEngine?.removeStatus) results.removedStatuses.push(statusEngine.removeStatus(target, statusId, { from: "item" }));
+    });
+    if (profile.statusId && statusEngine?.applyStatus) {
+      results.status = statusEngine.applyStatus(target, profile.statusId, {
+        count: profile.statusCount || 1,
+        potency: profile.statusPotency,
+        sourceUnitId: String(user?.id || user?.unitId || user?.characterId || ""),
+        data: { sourceItemId: definitionId(item) || itemId(item) },
+      });
+    }
+
+    if (profile.statId && profile.statValue && profile.durationHours > 0) {
+      results.temporaryEffect = addTemporaryStatEffect(target, item, profile.statId, profile.statValue, profile.durationHours);
+    }
+
+    if (profile.injuryTreatment) {
+      const injuryRef = options.injuryRef || options.injury || profile.injuryTreatment.injuryRef || profile.injuryTreatment.injury_ref;
+      const injuryEngine = engines.injuries();
+      if (injuryRef && injuryEngine?.treatInjury) results.injury = injuryEngine.treatInjury(target, injuryRef, profile.injuryTreatment);
+    }
+
+    if (profile.repairAmount > 0) results.repair = repairItem(options.itemTarget || options.repairTarget, profile.repairAmount);
+
+    const effectCount = [results.hp, results.sp, results.status, results.temporaryEffect, results.injury, results.repair]
+      .filter(Boolean).length + results.removedStatuses.length;
+    return { applied: effectCount > 0, user, target, item, profile, results };
+  }
+
+  function applyAndConsume(user, item, options = {}) {
+    const applied = applyUseEffects(user, item, options);
+    if (!applied.applied && options.consumeOnNoEffect !== true) return { ...applied, consumed: false };
+    const consumeQty = Math.max(0, intOr(runtimeOf(item).consumeQty ?? runtimeOf(item).consume_qty ?? options.consumeQty, 1));
+    const consumption = consumeQty > 0 ? consumeQuantity(item, consumeQty) : { consumed: true, before: quantityOf(item), after: quantityOf(item), amount: 0 };
+    if (!consumption.consumed) return { applied: false, reason: consumption.reason, item, consumption };
+    const result = { ...applied, consumed: true, consumption };
+    emit("luminous:item-used", result);
+    return result;
+  }
+
+  function useItem(user, itemInput, options = {}) {
+    const item = findItem(user, itemInput) || itemInput;
+    if (!user || !item || typeof item !== "object") return { used: false, reason: "missing_user_or_item" };
+    if (!hasFunction(item, "use") && categoryOf(item) !== "consumable") return { used: false, reason: "item_not_usable", item };
+    if (quantityOf(item) <= 0) return { used: false, reason: "insufficient_quantity", item };
+
+    const actionEngine = engines.actions();
+    const phase = normalizeId(options.phase || actionEngine?.phaseFor?.(options) || "other");
+    const cost = actionCostFor(item);
+    const inActionEconomy = ["planning", "combat"].includes(phase);
+
+    if (!inActionEconomy || options.ignoreActionCost === true || cost === "none" || cost === "free") {
+      const result = applyAndConsume(user, item, options);
+      return { used: Boolean(result.applied && result.consumed), immediate: true, cost, ...result };
+    }
+
+    if (!actionEngine) return { used: false, reason: "action_economy_unavailable", item, cost };
+
+    if (cost === "action") {
+      if (phase !== "planning") return { used: false, reason: "action_item_requires_planning_phase", item, cost };
+      const scheduled = actionEngine.scheduleAction(user, {
+        kind: "item_use",
+        sourceId: definitionId(item) || itemId(item),
+        targetId: options.target?.id || options.target?.unitId || options.target?.characterId || null,
+        data: {
+          itemInstanceId: item.instanceId || itemId(item),
+          definitionId: definitionId(item),
+          injuryRef: options.injuryRef || null,
+        },
+      }, options);
+      if (!scheduled.scheduled) return { used: false, scheduled: false, reason: scheduled.reason, item, cost };
+      emit("luminous:item-use-scheduled", { user, item, scheduled });
+      return { used: true, scheduled: true, immediate: false, item, cost, ...scheduled };
+    }
+
+    const gate = actionEngine.availability?.(user, cost, options) || { available: true };
+    if (!gate.available) return { used: false, reason: gate.reason || "action_cost_unavailable", item, cost };
+    if (!actionEngine.consume?.(user, cost, options)) return { used: false, reason: "action_cost_not_consumed", item, cost };
+    const result = applyAndConsume(user, item, options);
+    return { used: Boolean(result.applied && result.consumed), immediate: true, cost, ...result };
+  }
+
+  function resolveScheduledUse(user, plannedAction, options = {}) {
+    const entry = plannedAction?.entry || plannedAction;
+    if (normalizeId(entry?.kind) !== "item_use") return { resolved: false, reason: "not_item_use_action" };
+    const instanceRef = entry?.data?.itemInstanceId || entry?.data?.definitionId || entry?.sourceId;
+    const item = options.item || findItem(user, instanceRef);
+    if (!item) return { resolved: false, reason: "scheduled_item_not_found", instanceRef };
+    const target = options.target || null;
+    const result = applyAndConsume(user, item, { ...options, target, injuryRef: options.injuryRef || entry?.data?.injuryRef, ignoreActionCost: true });
+    return { resolved: Boolean(result.applied && result.consumed), item, ...result };
+  }
+
+  function ammoResourceId(item = {}) {
+    const runtime = runtimeOf(item);
+    return normalizeId(runtime.ammoResourceId || runtime.ammo_resource_id || item.ammoResourceId || item.ammo_type || tagValue(item, "ammo") || item.subtype || "ammo");
+  }
+
+  function ensureResourceStore(unit) {
+    if (!unit.resources || typeof unit.resources !== "object" || Array.isArray(unit.resources)) unit.resources = {};
+    return unit.resources;
+  }
+
+  function resourceAmount(store, id) {
+    const raw = store[id];
+    if (raw && typeof raw === "object") return Math.max(0, numberOr(raw.value ?? raw.current ?? raw.amount, 0));
+    return Math.max(0, numberOr(raw, 0));
+  }
+
+  function setResourceAmount(store, id, value) {
+    const next = Math.max(0, Math.trunc(numberOr(value, 0)));
+    if (store[id] && typeof store[id] === "object") {
+      if (Object.prototype.hasOwnProperty.call(store[id], "value")) store[id].value = next;
+      else if (Object.prototype.hasOwnProperty.call(store[id], "current")) store[id].current = next;
+      else store[id].amount = next;
+    } else store[id] = next;
+    return next;
+  }
+
+  function reloadAmmo(unit, ammoInput, options = {}) {
+    const ammoItem = findItem(unit, ammoInput) || ammoInput;
+    if (!unit || !ammoItem || typeof ammoItem !== "object") return { reloaded: false, reason: "missing_unit_or_ammo" };
+    if (!hasFunction(ammoItem, "ammo") && categoryOf(ammoItem) !== "ammo") return { reloaded: false, reason: "item_not_ammunition" };
+    const available = quantityOf(ammoItem);
+    if (available <= 0) return { reloaded: false, reason: "insufficient_quantity" };
+    const wanted = Math.max(1, intOr(options.amount, 1));
+    const moved = Math.min(wanted, available);
+    const id = normalizeId(options.resourceId || ammoResourceId(ammoItem));
+    const store = ensureResourceStore(unit);
+    const before = resourceAmount(store, id);
+    setResourceAmount(store, id, before + moved);
+    consumeQuantity(ammoItem, moved);
+    const result = { reloaded: true, unit, ammoItem, resourceId: id, amount: moved, before, after: before + moved };
+    emit("luminous:item-ammo-reloaded", result);
+    return result;
+  }
+
+  function moduleCapacity(host = {}) {
+    const runtime = runtimeOf(host);
+    return Math.max(0, intOr(runtime.moduleCapacity ?? runtime.module_capacity ?? host.max_upgrade_slots_capacity ?? host.upgrade_details?.max_upgrade_slots_capacity, 3));
+  }
+
+  function installedModules(host = {}) {
+    if (!Array.isArray(host.installedModules)) host.installedModules = [];
+    return host.installedModules;
+  }
+
+  function compatibleModule(host, module) {
+    const runtime = runtimeOf(module);
+    const allowed = asArray(runtime.compatibleKinds || runtime.compatible_kinds).map(normalizeId).filter(Boolean);
+    if (!allowed.length) return true;
+    return allowed.includes(equipmentSchema(host).kind) || allowed.includes(categoryOf(host));
+  }
+
+  function installModule(host, module, options = {}) {
+    if (!host || !module) return { installed: false, reason: "missing_host_or_module" };
+    const list = installedModules(host);
+    const capacity = moduleCapacity(host);
+    if (list.length >= capacity) return { installed: false, reason: "module_capacity_reached", capacity };
+    if (!compatibleModule(host, module)) return { installed: false, reason: "module_incompatible" };
+    const id = definitionId(module) || itemId(module);
+    if (list.some((entry) => String(entry.definitionId || entry.id || entry) === id)) return { installed: false, reason: "module_already_installed" };
+    list.push({ definitionId: id, instanceId: module.instanceId || null, installedAt: options.installedAt || Date.now(), data: clone(runtimeOf(module)) });
+    if (options.consumeModule !== false) consumeQuantity(module, 1);
+    const result = { installed: true, host, module, capacity, installedModules: clone(list) };
+    emit("luminous:item-module-installed", result);
+    return result;
+  }
+
+  function removeModule(host, moduleRef) {
+    const list = installedModules(host);
+    const wanted = String(typeof moduleRef === "object" ? (definitionId(moduleRef) || itemId(moduleRef)) : moduleRef || "");
+    const index = list.findIndex((entry) => String(entry.definitionId || entry.id || entry) === wanted || String(entry.instanceId || "") === wanted);
+    if (index < 0) return { removed: false, reason: "module_not_installed" };
+    const [removed] = list.splice(index, 1);
+    const result = { removed: true, host, module: removed, installedModules: clone(list) };
+    emit("luminous:item-module-removed", result);
+    return result;
+  }
+
+  function inventoryCounts(unit = {}) {
+    const counts = new Map();
+    const container = unit.inventory || unit.inventario || unit.items || [];
+    objectEntries(container).forEach(([key, item]) => {
+      if (!item || typeof item !== "object") return;
+      const id = definitionId(item) || String(key);
+      counts.set(id, (counts.get(id) || 0) + quantityOf(item));
+    });
+    return counts;
+  }
+
+  function recipeIngredients(recipe = {}) {
+    const raw = recipe.ingredientes || recipe.ingredients || {};
+    if (Array.isArray(raw)) return raw.map((entry) => ({ id: entry.definitionId || entry.itemId || entry.id, qty: Math.max(1, intOr(entry.qty ?? entry.quantity, 1)) }));
+    return Object.entries(raw).map(([id, qty]) => ({ id, qty: Math.max(1, intOr(qty, 1)) }));
+  }
+
+  function canCraft(unit, recipe = {}) {
+    const counts = inventoryCounts(unit);
+    const missing = recipeIngredients(recipe).filter((entry) => (counts.get(entry.id) || 0) < entry.qty)
+      .map((entry) => ({ ...entry, available: counts.get(entry.id) || 0 }));
+    return { craftable: missing.length === 0, missing };
+  }
+
+  function consumeDefinition(unit, id, qty) {
+    let remaining = Math.max(0, intOr(qty, 0));
+    const container = unit.inventory || unit.inventario || unit.items || [];
+    for (const [, item] of objectEntries(container)) {
+      if (remaining <= 0) break;
+      if (!item || definitionId(item) !== id) continue;
+      const take = Math.min(remaining, quantityOf(item));
+      consumeQuantity(item, take);
+      remaining -= take;
+    }
+    return remaining === 0;
+  }
+
+  function addToInventory(unit, definition, qty = 1) {
+    if (!unit.inventory) unit.inventory = [];
+    if (Array.isArray(unit.inventory)) {
+      const existing = unit.inventory.find((item) => definitionId(item) === definitionId(definition) && !item.instanceId);
+      if (existing) setQuantity(existing, quantityOf(existing) + qty);
+      else unit.inventory.push({ ...clone(definition), quantity: qty });
+      return true;
+    }
+    const id = definitionId(definition) || normalizeId(itemName(definition));
+    if (!unit.inventory[id]) unit.inventory[id] = { ...clone(definition), quantity: 0 };
+    setQuantity(unit.inventory[id], quantityOf(unit.inventory[id]) + qty);
+    return true;
+  }
+
+  function craft(unit, recipe = {}, options = {}) {
+    const gate = canCraft(unit, recipe);
+    if (!gate.craftable) return { crafted: false, reason: "missing_ingredients", missing: gate.missing };
+    recipeIngredients(recipe).forEach((entry) => consumeDefinition(unit, entry.id, entry.qty));
+    if (normalizeId(recipe.tipo_sintesis || recipe.type) === "upgrade") {
+      const host = options.host || findItem(unit, recipe.base_equipable_id || recipe.baseEquipableId);
+      const module = options.module || findItem(unit, recipe.target_upgrade_id || recipe.targetUpgradeId);
+      const installation = installModule(host, module, { consumeModule: false });
+      if (!installation.installed) return { crafted: false, reason: installation.reason, installation };
+      return { crafted: true, kind: "upgrade", installation };
+    }
+    const resultId = recipe.item_resultado_id || recipe.resultId || recipe.result?.definitionId || recipe.result?.id;
+    const resultDefinition = options.resultDefinition || options.catalog?.[resultId] || { id: resultId, definitionId: resultId, nombre: resultId };
+    const qty = Math.max(1, intOr(recipe.cantidad_resultado ?? recipe.resultQty ?? recipe.result?.qty, 1));
+    addToInventory(unit, resultDefinition, qty);
+    const result = { crafted: true, kind: "craft", resultId, quantity: qty, resultDefinition };
+    emit("luminous:item-crafted", { unit, recipe, ...result });
+    return result;
+  }
+
+  function collectModifierTraits(unit = {}) {
+    unit.hpPercent = hpPercent(unit);
+    const traits = [];
+    const pushModifier = (sourceId, channel, value, mode = "add", conditions = []) => {
+      if (!channel || !Number.isFinite(Number(value)) || Number(value) === 0) return;
+      traits.push({ id: `item_${normalizeId(sourceId)}_${normalizeId(channel)}_${traits.length}`, contexts: ["any"], rules: [{ type: "modifier", trigger: "passive", channel: normalizeId(channel), value: Number(value), mode, conditions }] });
+    };
+    const pushStat = (sourceId, statId, value) => {
+      if (!statId || !Number.isFinite(Number(value)) || Number(value) === 0) return;
+      traits.push({ id: `item_${normalizeId(sourceId)}_stat_${normalizeId(statId)}_${traits.length}`, contexts: ["any"], rules: [{ type: "stat", trigger: "passive", statId: normalizeId(statId), value: Number(value), mode: "add", conditions: [] }] });
+    };
+
+    equippedItems(unit).forEach((item) => {
+      const id = definitionId(item) || itemId(item);
+      const category = categoryOf(item);
+      const details = category === "weapon" ? item.weapon_details || {}
+        : category === "armor" ? item.armor_details || {}
+          : category === "shield" ? item.shield_details || {}
+            : category === "accessory" ? item.accessory_details || {}
+              : {};
+      pushModifier(id, "offensive_level", numberOr(details.off_lvl_mod, 0));
+      pushModifier(id, "defensive_level", numberOr(details.def_lvl_mod, 0));
+      if (category === "shield") pushModifier(id, "defense_power", numberOr(details.defense_power_scale, 0));
+      const ruleList = details.passives || details.rules || [];
+      asArray(ruleList).forEach((rule, index) => {
+        if (normalizeId(rule.trigger || "passive") !== "passive") return;
+        const affectation = normalizeId(rule.affectation);
+        const raw = numberOr(rule.value, 0);
+        const op = normalizeId(rule.operation || "add");
+        const value = op === "sub" ? -Math.abs(raw) : raw;
+        const conditions = Number.isFinite(Number(rule.condition_hp_threshold)) && Number(rule.condition_hp_threshold) < 100
+          ? [{ path: "self.hpPercent", operator: "lte", value: Number(rule.condition_hp_threshold) }]
+          : [];
+        if (["fuerza", "destreza", "constitucion", "inteligencia", "sabiduria", "carisma", "strength", "dexterity", "constitution", "intelligence", "wisdom", "charisma"].includes(affectation)) {
+          const statMap = { fuerza: "strength", destreza: "dexterity", constitucion: "constitution", inteligencia: "intelligence", sabiduria: "wisdom", carisma: "charisma" };
+          pushStat(`${id}_${index}`, statMap[affectation] || affectation, value);
+        } else if (!["hp", "sp"].includes(affectation)) {
+          pushModifier(`${id}_${index}`, affectation, value, op === "mult" ? "multiply" : "add", conditions);
+        }
+      });
+      installedModules(item).forEach((module, index) => {
+        const data = module.data || {};
+        asArray(data.modifiers).forEach((rule) => pushModifier(`${id}_module_${index}`, rule.channel || rule.affectation, numberOr(rule.value, 0), normalizeId(rule.mode || rule.operation || "add")));
+      });
+    });
+
+    ensureRuntimeEffects(unit).filter((effect) => effect?.active !== false).forEach((effect) => {
+      if (effect.kind === "stat") pushStat(effect.id, effect.statId, effect.value);
+      if (effect.kind === "modifier") pushModifier(effect.id, effect.channel, effect.value, effect.mode || "add");
+    });
+    return traits;
+  }
+
+  let modifierBridgeBase = null;
+  function installModifierBridge() {
+    const base = engines.modifiers();
+    if (!base || base.__luminousItemRuntimeBridge) return Boolean(base);
+    if (modifierBridgeBase && global.LuminousUniversalModifiers !== modifierBridgeBase && global.LuminousUniversalModifiers?.__luminousItemRuntimeBridge) return true;
+    const mergeTraits = (options = {}) => {
+      const unit = options.unit || options.character || {};
+      return { ...options, traits: [...asArray(options.traits), ...collectModifierTraits(unit)] };
+    };
+    const wrapped = Object.freeze({
+      ...base,
+      __luminousItemRuntimeBridge: true,
+      __luminousItemRuntimeBase: base,
+      resolveTraitModifiers(options = {}) { return base.resolveTraitModifiers(mergeTraits(options)); },
+      resolveStats(options = {}) { return base.resolveStats(mergeTraits(options)); },
+      resolveCharacterSnapshot(options = {}) { return base.resolveCharacterSnapshot(mergeTraits(options)); },
+    });
+    global.LuminousUniversalModifiers = wrapped;
+    modifierBridgeBase = wrapped;
+    emit("luminous:item-modifier-bridge-installed", { runtime: api });
+    return true;
+  }
+
+  function describeCapabilities(item = {}) {
+    return {
+      definitionId: definitionId(item),
+      category: categoryOf(item),
+      functions: parseFunctionTypes(item),
+      equipment: equipmentSchema(item),
+      use: runtimeUseProfile(item),
+      ammoResourceId: (categoryOf(item) === "ammo" || hasFunction(item, "ammo")) ? ammoResourceId(item) : null,
+      moduleCapacity: hasFunction(item, "module_host") || ["weapon", "armor", "shield", "accessory"].includes(categoryOf(item)) ? moduleCapacity(item) : 0,
+    };
+  }
+
+  function install() {
+    installModifierBridge();
+    return true;
+  }
+
+  const api = Object.freeze({
+    normalizeId,
+    itemId,
+    definitionId,
+    itemName,
+    categoryOf,
+    tagsOf,
+    normalizedTags,
+    tagValue,
+    runtimeOf,
+    parseFunctionTypes,
+    hasFunction,
+    equipmentSchema,
+    hydrateForEquipment,
+    findItem,
+    quantityOf,
+    setQuantity,
+    consumeQuantity,
+    makeInstance,
+    equippedItems,
+    equipItem,
+    unequipItem,
+    recoverResource,
+    hpPercent,
+    actionCostFor,
+    runtimeUseProfile,
+    useItem,
+    resolveScheduledUse,
+    advanceTime,
+    repairItem,
+    ammoResourceId,
+    reloadAmmo,
+    moduleCapacity,
+    installModule,
+    removeModule,
+    recipeIngredients,
+    canCraft,
+    craft,
+    collectModifierTraits,
+    installModifierBridge,
+    describeCapabilities,
+    install,
+  });
+
+  global.LuminousItemRuntime = api;
+  install();
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/item-salvage-runtime.js
+++ b/js/item-salvage-runtime.js
@@ -1,0 +1,159 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousItemSalvageRuntime) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousItemSalvageRuntime;
+    return;
+  }
+
+  function safeRequire(path) {
+    if (typeof require !== "function") return null;
+    try { return require(path); } catch (_) { return null; }
+  }
+
+  const items = () => global.LuminousItemInventoryRuntime || global.LuminousItemRuntime || safeRequire("./item-inventory-runtime.js") || safeRequire("./item-runtime-engine.js");
+  const workshops = () => global.LuminousWorkshopRuntime || safeRequire("./workshop-runtime.js");
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const asArray = (value) => value == null ? [] : (Array.isArray(value) ? value : [value]);
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const intOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Math.trunc(Number(value)) : fallback;
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+
+  const DEFAULT_BANDS = Object.freeze([
+    { id: "condition:76_100", min: 76, max: 100, materialYieldMultiplier: 0.80, moduleRecoveryChance: 0.85, signatureComponentRecoveryChance: 0.65, signatureBlueprintDiscoveryChance: 0.10 },
+    { id: "condition:51_75", min: 51, max: 75, materialYieldMultiplier: 0.60, moduleRecoveryChance: 0.65, signatureComponentRecoveryChance: 0.40, signatureBlueprintDiscoveryChance: 0.08 },
+    { id: "condition:26_50", min: 26, max: 50, materialYieldMultiplier: 0.40, moduleRecoveryChance: 0.40, signatureComponentRecoveryChance: 0.20, signatureBlueprintDiscoveryChance: 0.05 },
+    { id: "condition:1_25", min: 1, max: 25, materialYieldMultiplier: 0.20, moduleRecoveryChance: 0.20, signatureComponentRecoveryChance: 0.05, signatureBlueprintDiscoveryChance: 0.02 },
+    { id: "condition:0", min: 0, max: 0, materialYieldMultiplier: 0.10, moduleRecoveryChance: 0.10, signatureComponentRecoveryChance: 0.00, signatureBlueprintDiscoveryChance: 0.00 },
+  ]);
+
+  function conditionPercent(item = {}) {
+    const state = items()?.getCondition?.(item);
+    if (state && Number.isFinite(Number(state.max)) && Number(state.max) > 0) return Math.max(0, Math.min(100, (Number(state.current) / Number(state.max)) * 100));
+    const max = Math.max(1, numberOr(item.conditionMax ?? item.maxCondition, 100));
+    const current = Math.max(0, Math.min(max, numberOr(item.condition, max)));
+    return (current / max) * 100;
+  }
+
+  function conditionBand(item, options = {}) {
+    const pct = conditionPercent(item);
+    const bands = asArray(options.bands || DEFAULT_BANDS);
+    return clone(bands.find((band) => pct >= numberOr(band.min, 0) && pct <= numberOr(band.max, 100)) || bands[bands.length - 1] || DEFAULT_BANDS[DEFAULT_BANDS.length - 1]);
+  }
+
+  function salvageProfile(item = {}) {
+    const runtime = item.runtime && typeof item.runtime === "object" ? item.runtime : {};
+    const profile = runtime.salvage || item.salvage || item.salvageProfile || {};
+    return profile && typeof profile === "object" ? clone(profile) : {};
+  }
+
+  function normalizeMaterials(raw) {
+    if (!raw) return [];
+    if (Array.isArray(raw)) return raw.map((entry) => typeof entry === "string" ? { id: entry, quantity: 1 } : { ...clone(entry), id: entry?.id || entry?.materialId || entry?.definitionId, quantity: Math.max(0, numberOr(entry?.quantity ?? entry?.qty, 1)) }).filter((entry) => entry.id);
+    if (typeof raw === "object") return Object.entries(raw).map(([id, quantity]) => ({ id, quantity: Math.max(0, numberOr(quantity, 0)) })).filter((entry) => entry.quantity > 0);
+    return [];
+  }
+
+  function seededRandom(item, options = {}) {
+    if (typeof options.random === "function") return options.random;
+    const seed = options.seed || `${item.instanceId || item.definitionId || item.id || "item"}:salvage:${item.condition ?? 100}`;
+    return workshops()?.seededRandom?.(seed) || Math.random;
+  }
+
+  function moduleDefinition(moduleRef, options = {}) {
+    if (moduleRef && typeof moduleRef === "object") return moduleRef;
+    const id = String(moduleRef || "");
+    const catalog = options.moduleCatalog || options.modules || {};
+    if (Array.isArray(catalog)) return catalog.find((entry) => String(entry?.id || entry?.moduleId || entry?.definitionId || "") === id) || { id };
+    return catalog[id] || { id };
+  }
+
+  function isStructural(module = {}) {
+    const cls = normalizeId(module.technologyClass || module.moduleClass || module.class || module.runtime?.technologyClass || "module");
+    return cls === "structural_tech" || cls === "structural_technology";
+  }
+
+  function canSalvage(item, options = {}) {
+    if (!item || typeof item !== "object") return { allowed: false, reason: "missing_item" };
+    if (item.salvageable === false || salvageProfile(item).salvageable === false) return { allowed: false, reason: "item_not_salvageable" };
+    if (item.equipped === true && options.allowEquipped !== true) return { allowed: false, reason: "item_equipped" };
+    return { allowed: true, band: conditionBand(item, options), profile: salvageProfile(item) };
+  }
+
+  function salvageItem(item, options = {}) {
+    const gate = canSalvage(item, options);
+    if (!gate.allowed) return { salvaged: false, ...gate };
+    const random = seededRandom(item, options);
+    const band = gate.band;
+    const profile = gate.profile;
+    const baseMaterials = normalizeMaterials(options.materials || profile.materials || item.salvageMaterials || item.materials);
+    const materials = baseMaterials.map((entry) => ({
+      ...entry,
+      quantity: Math.max(0, Math.floor(numberOr(entry.quantity, 0) * numberOr(band.materialYieldMultiplier, 0))),
+    })).filter((entry) => entry.quantity > 0);
+
+    const moduleRefs = [...new Set([
+      ...asArray(item.installedModuleIds),
+      ...asArray(item.installedModules).map((entry) => typeof entry === "string" ? entry : (entry?.definitionId || entry?.id || entry?.moduleId)).filter(Boolean),
+    ].map(String))];
+    const recoveredModules = [];
+    const destroyedModules = [];
+    moduleRefs.forEach((ref) => {
+      const definition = moduleDefinition(ref, options);
+      if (isStructural(definition) || definition.removable === false) {
+        destroyedModules.push({ id: ref, reason: "structural_or_non_removable" });
+        return;
+      }
+      if (random() <= numberOr(band.moduleRecoveryChance, 0)) recoveredModules.push(ref);
+      else destroyedModules.push({ id: ref, reason: "recovery_roll_failed" });
+    });
+
+    const signatureComponents = asArray(item.signatureComponents || profile.signatureComponents).map((entry) => typeof entry === "string" ? { id: entry } : clone(entry)).filter((entry) => entry?.id || entry?.componentId);
+    const recoveredSignatureComponents = [];
+    signatureComponents.forEach((entry) => {
+      if (entry.salvageable === false) return;
+      if (random() <= numberOr(band.signatureComponentRecoveryChance, 0)) recoveredSignatureComponents.push(entry);
+    });
+
+    const discoveredBlueprints = [];
+    const blueprintIds = asArray(profile.signatureBlueprintIds || item.signatureBlueprintIds).map(String).filter(Boolean);
+    blueprintIds.forEach((id) => {
+      if (random() <= numberOr(band.signatureBlueprintDiscoveryChance, 0)) discoveredBlueprints.push(id);
+    });
+
+    const result = {
+      salvaged: true,
+      sourceInstanceId: item.instanceId || null,
+      sourceDefinitionId: item.definitionId || item.id || null,
+      conditionPercent: conditionPercent(item),
+      band,
+      materials,
+      recoveredModules,
+      destroyedModules,
+      recoveredSignatureComponents,
+      discoveredBlueprints,
+      structuralTechnologyRecoveredAsModule: false,
+    };
+
+    if (options.consumeSource === true) {
+      item.quantity = Math.max(0, intOr(item.quantity ?? item.cantidad, 1) - 1);
+      result.sourceConsumed = true;
+    } else result.sourceConsumed = false;
+    return result;
+  }
+
+  const api = Object.freeze({
+    version: 1,
+    DEFAULT_BANDS: clone(DEFAULT_BANDS),
+    conditionPercent,
+    conditionBand,
+    salvageProfile,
+    normalizeMaterials,
+    isStructural,
+    canSalvage,
+    salvageItem,
+  });
+
+  global.LuminousItemSalvageRuntime = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/workshop-runtime.js
+++ b/js/workshop-runtime.js
@@ -1,0 +1,422 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousWorkshopRuntime) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousWorkshopRuntime;
+    return;
+  }
+
+  function safeRequire(path) {
+    if (typeof require !== "function") return null;
+    try { return require(path); } catch (_) { return null; }
+  }
+
+  const itemRuntime = () => global.LuminousItemInventoryRuntime || safeRequire("./item-inventory-runtime.js");
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  const intOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Math.trunc(Number(value)) : fallback;
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+  const asArray = (value) => value == null ? [] : (Array.isArray(value) ? value : [value]);
+
+  const workshops = new Map();
+  const SCHEMA_VERSION = 1;
+  const REPUTATIONS = ["unknown", "local", "established", "prestigious", "elite", "legendary"];
+
+  const DEFAULT_TIER_PROFILES = {
+    1: { productTierMin: 1, productTierMax: 2, knownModuleCount: 2, signatureTechnologySlots: 0, productLineChance: 0.02, signatureModelChance: 0.00, quality: [45, 45, 10, 0, 0] },
+    2: { productTierMin: 1, productTierMax: 3, knownModuleCount: 3, signatureTechnologySlots: 0, productLineChance: 0.05, signatureModelChance: 0.01, quality: [30, 50, 18, 2, 0] },
+    3: { productTierMin: 1, productTierMax: 4, knownModuleCount: 4, signatureTechnologySlots: 1, productLineChance: 0.10, signatureModelChance: 0.02, quality: [15, 50, 30, 5, 0] },
+    4: { productTierMin: 1, productTierMax: 5, knownModuleCount: 5, signatureTechnologySlots: 1, productLineChance: 0.16, signatureModelChance: 0.04, quality: [8, 35, 45, 12, 0] },
+    5: { productTierMin: 2, productTierMax: 6, knownModuleCount: 6, signatureTechnologySlots: 1, productLineChance: 0.25, signatureModelChance: 0.08, quality: [2, 18, 45, 30, 5] },
+    6: { productTierMin: 2, productTierMax: 7, knownModuleCount: 7, signatureTechnologySlots: 2, productLineChance: 0.35, signatureModelChance: 0.12, quality: [1, 10, 40, 40, 9] },
+    7: { productTierMin: 3, productTierMax: 8, knownModuleCount: 8, signatureTechnologySlots: 2, productLineChance: 0.45, signatureModelChance: 0.18, quality: [0, 5, 30, 45, 20] },
+    8: { productTierMin: 3, productTierMax: 9, knownModuleCount: 9, signatureTechnologySlots: 2, productLineChance: 0.55, signatureModelChance: 0.25, quality: [0, 2, 23, 50, 25] },
+    9: { productTierMin: 4, productTierMax: 10, knownModuleCount: 10, signatureTechnologySlots: 3, productLineChance: 0.65, signatureModelChance: 0.35, quality: [0, 0, 15, 50, 35] },
+    10: { productTierMin: 4, productTierMax: 10, knownModuleCount: 12, signatureTechnologySlots: 3, productLineChance: 0.75, signatureModelChance: 0.45, quality: [0, 0, 5, 45, 50] },
+  };
+
+  const REPUTATION_MULTIPLIERS = {
+    unknown: { price: 0.85, demand: 0.60, productLine: 0.70, signatureModel: 0.75 },
+    local: { price: 0.95, demand: 0.80, productLine: 0.85, signatureModel: 0.90 },
+    established: { price: 1.05, demand: 1.00, productLine: 1.00, signatureModel: 1.00 },
+    prestigious: { price: 1.20, demand: 1.20, productLine: 1.15, signatureModel: 1.15 },
+    elite: { price: 1.40, demand: 1.50, productLine: 1.30, signatureModel: 1.30 },
+    legendary: { price: 1.75, demand: 2.00, productLine: 1.50, signatureModel: 1.50 },
+  };
+
+  function emit(name, detail) {
+    try {
+      if (typeof global.dispatchEvent === "function" && typeof global.CustomEvent === "function") {
+        global.dispatchEvent(new global.CustomEvent(name, { detail }));
+      }
+    } catch (_) {}
+    return detail;
+  }
+
+  function hashSeed(value) {
+    const text = String(value ?? "");
+    let hash = 2166136261;
+    for (let index = 0; index < text.length; index += 1) {
+      hash ^= text.charCodeAt(index);
+      hash = Math.imul(hash, 16777619);
+    }
+    return hash >>> 0;
+  }
+
+  function seededRandom(seed) {
+    let state = hashSeed(seed) || 0x6d2b79f5;
+    return function random() {
+      state += 0x6d2b79f5;
+      let value = state;
+      value = Math.imul(value ^ (value >>> 15), value | 1);
+      value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+      return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+    };
+  }
+
+  function weightedPick(items, random, weightOf = (entry) => entry?.weight ?? 1) {
+    const candidates = asArray(items).filter(Boolean);
+    if (!candidates.length) return null;
+    const weights = candidates.map((entry) => Math.max(0, numberOr(weightOf(entry), 1)));
+    const total = weights.reduce((sum, weight) => sum + weight, 0);
+    if (total <= 0) return candidates[Math.floor(random() * candidates.length)];
+    let roll = random() * total;
+    for (let index = 0; index < candidates.length; index += 1) {
+      roll -= weights[index];
+      if (roll <= 0) return candidates[index];
+    }
+    return candidates[candidates.length - 1];
+  }
+
+  function sampleUnique(items, count, random) {
+    const pool = [...new Set(asArray(items).filter(Boolean))];
+    const output = [];
+    while (pool.length && output.length < count) output.push(pool.splice(Math.floor(random() * pool.length), 1)[0]);
+    return output;
+  }
+
+  function normalizedWorkshopName(value) {
+    return String(value ?? "").trim().replace(/\s+Workshop$/i, "").replace(/\s+/g, " ");
+  }
+
+  function validateWorkshopName(name, options = {}) {
+    const raw = String(name ?? "").trim();
+    if (!raw) return { valid: false, reason: "empty_name" };
+    if (/\bworkshop\b/i.test(raw)) return { valid: false, reason: "raw_name_contains_workshop" };
+    const tokens = raw.toLowerCase().split(/\s+/).filter(Boolean);
+    if (tokens.some((token, index) => index > 0 && token === tokens[index - 1])) return { valid: false, reason: "duplicate_token" };
+    const normalized = normalizeId(raw);
+    const reserved = new Set(asArray(options.reservedNames).map(normalizeId));
+    const existing = new Set([
+      ...asArray(options.existingNames).map(normalizeId),
+      ...[...workshops.values()].map((entry) => normalizeId(entry.workshopName)),
+    ]);
+    if (reserved.has(normalized)) return { valid: false, reason: "reserved_name" };
+    if (existing.has(normalized)) return { valid: false, reason: "duplicate_world_name" };
+    return { valid: true, workshopName: raw };
+  }
+
+  function affinityMatches(entry, specialization) {
+    if (!specialization || !entry?.specializationAffinity) return true;
+    const affinities = String(entry.specializationAffinity).split(/[|,]/).map(normalizeId).filter(Boolean);
+    return !affinities.length || affinities.includes("any") || affinities.includes("general") || affinities.some((affinity) => normalizeId(specialization).includes(affinity) || affinity.includes(normalizeId(specialization)));
+  }
+
+  function generateWorkshopName(options = {}) {
+    const random = options.random || seededRandom(options.seed || "workshop_name");
+    const pools = asArray(options.namePools).filter((entry) => entry && entry.token);
+    if (!pools.length) return { generated: false, reason: "missing_name_pool" };
+    const thematic = random() < numberOr(options.thematicChance, 0.30);
+    const filtered = thematic ? pools.filter((entry) => affinityMatches(entry, options.primarySpecialization)) : pools;
+    const candidates = filtered.length ? filtered : pools;
+    const singles = candidates.filter((entry) => normalizeId(entry.tokenRole) === "single");
+    const adjectives = candidates.filter((entry) => normalizeId(entry.tokenRole) === "adjective");
+    const nouns = candidates.filter((entry) => normalizeId(entry.tokenRole) === "noun");
+
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      let raw = null;
+      if (singles.length && (random() < 0.55 || !adjectives.length || !nouns.length)) raw = weightedPick(singles, random)?.token;
+      else {
+        const adjective = weightedPick(adjectives, random)?.token;
+        const noun = weightedPick(nouns, random)?.token;
+        if (adjective && noun) raw = `${adjective} ${noun}`;
+      }
+      raw = normalizedWorkshopName(raw);
+      const validation = validateWorkshopName(raw, options);
+      if (validation.valid) return { generated: true, workshopName: validation.workshopName, attempts: attempt + 1 };
+    }
+    return { generated: false, reason: "name_generation_exhausted" };
+  }
+
+  function tierProfile(tier, options = {}) {
+    const value = clamp(intOr(tier, 1), 1, 10);
+    const source = options.tierProfiles || DEFAULT_TIER_PROFILES;
+    return clone(source[value] || source[String(value)] || DEFAULT_TIER_PROFILES[value]);
+  }
+
+  function rollQualityTier(profile, random) {
+    const weights = asArray(profile?.quality || profile?.qualityWeights || [0, 0, 100, 0, 0]);
+    return weightedPick([1, 2, 3, 4, 5].map((tier, index) => ({ tier, weight: Math.max(0, numberOr(weights[index], 0)) })), random, (entry) => entry.weight)?.tier || 3;
+  }
+
+  function normalizeSpecialization(entry) {
+    if (typeof entry === "string") return { id: entry, familyIds: [] };
+    return { ...clone(entry), id: entry?.id || entry?.specializationId || entry?.familyId || null, familyIds: clone(entry?.familyIds || entry?.knownItemFamilies || []) };
+  }
+
+  function moduleId(entry) {
+    return String(typeof entry === "string" ? entry : (entry?.moduleId || entry?.definitionId || entry?.canonicalId || entry?.id || "")).trim();
+  }
+
+  function moduleCompatibleWithSpecialization(module, specialization) {
+    const requirements = asArray(module?.specializations || module?.compatibleSpecializations || module?.specializationIds).map(normalizeId).filter(Boolean);
+    return !requirements.length || requirements.includes(normalizeId(specialization));
+  }
+
+  function createWorkshopInstance(options = {}) {
+    const worldSeed = String(options.worldSeed || "world");
+    const regionId = String(options.regionId || "region");
+    const workshopId = String(options.workshopId || `workshop:${normalizeId(regionId)}:${hashSeed(`${worldSeed}:${regionId}:${options.index || 0}`).toString(36)}`);
+    const seed = String(options.seed || `${worldSeed}:${regionId}:${workshopId}`);
+    const random = seededRandom(seed);
+    const tier = clamp(intOr(options.workshopTier, 1), 1, 10);
+    const profile = tierProfile(tier, options);
+    const specializationDefs = asArray(options.specializations).map(normalizeSpecialization).filter((entry) => entry.id);
+    const primary = options.primarySpecialization || weightedPick(specializationDefs, random)?.id || "general";
+    const secondaryCount = Math.max(0, intOr(options.secondarySpecializationCount, tier >= 7 ? 2 : tier >= 4 ? 1 : 0));
+    const secondary = options.secondarySpecializations || sampleUnique(specializationDefs.map((entry) => entry.id).filter((id) => id !== primary), secondaryCount, random);
+    const primaryDef = specializationDefs.find((entry) => entry.id === primary);
+    const secondaryDefs = secondary.map((id) => specializationDefs.find((entry) => entry.id === id)).filter(Boolean);
+    const knownFamilies = [...new Set([...asArray(options.knownItemFamilies), ...asArray(primaryDef?.familyIds), ...secondaryDefs.flatMap((entry) => asArray(entry.familyIds))].filter(Boolean))];
+
+    const modulePool = asArray(options.modules).filter((entry) => moduleId(entry) && moduleCompatibleWithSpecialization(entry, primary));
+    const knownModuleIds = options.knownModuleIds || sampleUnique(modulePool.map(moduleId), Math.max(0, intOr(profile.knownModuleCount, 0)), random);
+    const signatureCount = Math.min(knownModuleIds.length, Math.max(0, intOr(options.signatureModuleCount, tier >= 8 ? 2 : tier >= 4 ? 1 : 0)));
+    const signatureModuleIds = options.signatureModuleIds || sampleUnique(knownModuleIds, signatureCount, random);
+    const technologyPool = asArray(options.technologies).map((entry) => typeof entry === "string" ? entry : (entry?.technologyId || entry?.id)).filter(Boolean);
+    const signatureTechnologyIds = options.signatureTechnologyIds || sampleUnique(technologyPool, Math.max(0, intOr(profile.signatureTechnologySlots, 0)), random);
+
+    let workshopName = normalizedWorkshopName(options.workshopName);
+    if (!workshopName) {
+      const generated = generateWorkshopName({ seed: `${seed}:name`, namePools: options.namePools, primarySpecialization: primary, reservedNames: options.reservedNames, existingNames: options.existingNames });
+      if (!generated.generated) return { created: false, reason: generated.reason };
+      workshopName = generated.workshopName;
+    }
+    const validation = validateWorkshopName(workshopName, { reservedNames: options.reservedNames, existingNames: options.existingNames });
+    if (!validation.valid) return { created: false, reason: validation.reason };
+
+    const workshop = {
+      schemaVersion: SCHEMA_VERSION,
+      workshopId,
+      workshopName,
+      regionId,
+      districtId: options.districtId || null,
+      workshopTier: tier,
+      reputation: REPUTATIONS.includes(normalizeId(options.reputation)) ? normalizeId(options.reputation) : (tier >= 9 ? "elite" : tier >= 7 ? "prestigious" : tier >= 4 ? "established" : "local"),
+      wealthClass: options.wealthClass || null,
+      primarySpecialization: primary,
+      secondarySpecializations: clone(secondary),
+      technologyThemes: clone(options.technologyThemes || []),
+      knownModuleIds: clone(knownModuleIds),
+      signatureModuleIds: clone(signatureModuleIds),
+      signatureTechnologyIds: clone(signatureTechnologyIds),
+      knownItemFamilies: clone(knownFamilies),
+      preferredItemFamilies: clone(options.preferredItemFamilies || (knownFamilies.length ? [knownFamilies[0]] : [])),
+      qualityProfile: clone(options.qualityProfile || profile.quality),
+      pricingProfileId: options.pricingProfileId || `workshop_tier_${tier}`,
+      namingProfileId: options.namingProfileId || "procedural_default",
+      productLines: clone(options.productLines || []),
+      stockGenerationSeed: String(options.stockGenerationSeed || `${seed}:stock`),
+      namingSeed: String(options.namingSeed || `${seed}:name`),
+      createdAt: options.createdAt || null,
+    };
+    workshops.set(workshopId, clone(workshop));
+    emit("luminous:workshop-created", { workshop: clone(workshop) });
+    return { created: true, workshop };
+  }
+
+  function registerWorkshop(workshop) {
+    if (!workshop?.workshopId) return { registered: false, reason: "missing_workshop_id" };
+    const normalized = clone(workshop);
+    normalized.workshopName = normalizedWorkshopName(normalized.workshopName);
+    const validation = validateWorkshopName(normalized.workshopName, { existingNames: [...workshops.values()].filter((entry) => entry.workshopId !== normalized.workshopId).map((entry) => entry.workshopName) });
+    if (!validation.valid) return { registered: false, reason: validation.reason };
+    workshops.set(normalized.workshopId, normalized);
+    return { registered: true, workshop: clone(normalized) };
+  }
+
+  function getWorkshop(workshopId) {
+    const found = workshops.get(String(workshopId));
+    return found ? clone(found) : null;
+  }
+  function listWorkshops() { return [...workshops.values()].map(clone); }
+  function clearWorkshops() { workshops.clear(); }
+
+  function productLineName(options, random) {
+    const pool = asArray(options.productLineNamePool || options.modelNamePool).filter(Boolean);
+    if (!pool.length) return null;
+    const picked = weightedPick(pool.map((entry) => typeof entry === "string" ? { token: entry, weight: 1 } : entry), random);
+    return picked?.token || picked?.name || null;
+  }
+
+  function createProductLine(workshop, options = {}) {
+    if (!workshop?.workshopId) return { created: false, reason: "missing_workshop" };
+    const profile = tierProfile(workshop.workshopTier, options);
+    const rep = REPUTATION_MULTIPLIERS[workshop.reputation] || REPUTATION_MULTIPLIERS.established;
+    const random = options.random || seededRandom(options.seed || `${workshop.namingSeed}:line:${asArray(workshop.productLines).length}`);
+    const chance = clamp(numberOr(profile.productLineChance, 0) * numberOr(rep.productLine, 1), 0, 1);
+    if (options.force !== true && random() > chance) return { created: false, reason: "product_line_roll_failed", chance };
+    const name = options.productLineName || productLineName(options, random);
+    if (!name) return { created: false, reason: "missing_product_line_name_pool" };
+    const line = {
+      productLineId: options.productLineId || `${workshop.workshopId}:line:${normalizeId(name)}`,
+      manufacturerWorkshopId: workshop.workshopId,
+      productLineName: String(name),
+      compatibleItemFamilies: clone(options.compatibleItemFamilies || workshop.preferredItemFamilies || workshop.knownItemFamilies || []),
+      technologyProfile: clone(options.technologyProfile || []),
+      moduleBiasIds: clone(options.moduleBiasIds || workshop.signatureModuleIds || []),
+      qualityBias: clamp(intOr(options.qualityBias, 0), -1, 1),
+    };
+    if (!Array.isArray(workshop.productLines)) workshop.productLines = [];
+    if (!workshop.productLines.some((entry) => entry.productLineId === line.productLineId)) workshop.productLines.push(line);
+    workshops.set(workshop.workshopId, clone(workshop));
+    return { created: true, productLine: clone(line) };
+  }
+
+  function definitionFamilyIds(definition = {}) {
+    return [...new Set(asArray(definition.familyIds || definition.productFamilies || definition.familyId || definition.productFamily).filter(Boolean))];
+  }
+  function definitionTier(definition = {}) { return clamp(intOr(definition.tier ?? definition.tierNumber ?? definition.tierRomanValue, 1), 1, 10); }
+
+  function compatibleDefinitions(workshop, catalog, options = {}) {
+    const profile = tierProfile(workshop.workshopTier, options);
+    const knownFamilies = new Set(asArray(workshop.knownItemFamilies).map(String));
+    const definitions = Array.isArray(catalog) ? catalog : Object.values(catalog || {});
+    return definitions.filter((entry) => {
+      const definition = entry?.definition || entry;
+      const tier = definitionTier(definition);
+      if (tier < profile.productTierMin || tier > profile.productTierMax) return false;
+      const families = definitionFamilyIds(definition);
+      return !knownFamilies.size || !families.length || families.some((family) => knownFamilies.has(String(family)));
+    });
+  }
+
+  function generateProduct(workshopInput, options = {}) {
+    const workshop = typeof workshopInput === "string" ? getWorkshop(workshopInput) : clone(workshopInput);
+    if (!workshop) return { generated: false, reason: "workshop_not_found" };
+    const index = Math.max(0, intOr(options.index, 0));
+    const cycleId = String(options.restockCycleId ?? "initial");
+    const seed = String(options.seed || `${workshop.stockGenerationSeed}:${cycleId}:${index}`);
+    const random = seededRandom(seed);
+    const candidates = compatibleDefinitions(workshop, options.itemCatalog || options.catalog || [], options);
+    if (!candidates.length) return { generated: false, reason: "no_compatible_item_definitions" };
+    const entry = weightedPick(candidates, random, (candidate) => candidate?.weight ?? candidate?.definition?.workshopWeight ?? 1);
+    const definition = clone(entry?.definition || entry);
+    const profile = tierProfile(workshop.workshopTier, options);
+    let qualityTier = rollQualityTier({ quality: workshop.qualityProfile || profile.quality }, random);
+
+    const matchingLines = asArray(workshop.productLines).filter((line) => {
+      const families = definitionFamilyIds(definition);
+      const allowed = new Set(asArray(line.compatibleItemFamilies).map(String));
+      return !allowed.size || !families.length || families.some((family) => allowed.has(String(family)));
+    });
+    const productLine = options.productLine || (matchingLines.length ? matchingLines[Math.floor(random() * matchingLines.length)] : null);
+    if (productLine) qualityTier = clamp(qualityTier + intOr(productLine.qualityBias, 0), 1, 5);
+
+    const capacity = Math.max(0, intOr(definition.moduleCapacity ?? definition.runtime?.moduleCapacity ?? definition.max_upgrade_slots_capacity, 0));
+    const modulePool = asArray(workshop.knownModuleIds);
+    const signatureBias = asArray(productLine?.moduleBiasIds || workshop.signatureModuleIds);
+    const desiredModules = Math.min(capacity, Math.max(0, intOr(options.moduleCount, capacity > 0 ? Math.floor(random() * (Math.min(capacity, 2) + 1)) : 0)));
+    const installedModuleIds = sampleUnique([...signatureBias, ...modulePool], desiredModules, random);
+    const serial = options.productSerial || `${normalizeId(workshop.workshopId)}-${normalizeId(cycleId)}-${String(index + 1).padStart(4, "0")}`;
+    const instanceId = options.instanceId || `item_${hashSeed(`${seed}:${serial}`).toString(36)}_${normalizeId(serial)}`;
+
+    const runtime = itemRuntime();
+    const instance = runtime?.createItemInstance?.(definition, {
+      instanceId,
+      qualityTier,
+      manufacturerId: workshop.workshopId,
+      productLineId: productLine?.productLineId || null,
+      productSerial: serial,
+      installedModuleIds,
+      signatureTechnologyIds: clone(workshop.signatureTechnologyIds || []),
+      currentOwnerId: options.currentOwnerId || null,
+    });
+    if (!instance) return { generated: false, reason: "item_inventory_runtime_unavailable" };
+    if (productLine?.productLineName) instance.productLineName = productLine.productLineName;
+
+    const resolveOptions = {
+      ...options,
+      workshops: api,
+      catalog: options.itemCatalog || options.catalog,
+      productLineName: productLine?.productLineName || options.productLineName || null,
+    };
+    const resolved = runtime?.resolveItem?.(instance, resolveOptions);
+    const result = { generated: true, workshopId: workshop.workshopId, seed, definition, instance, resolved };
+    emit("luminous:workshop-product-generated", result);
+    return result;
+  }
+
+  function restockWorkshop(workshopInput, options = {}) {
+    const workshop = typeof workshopInput === "string" ? getWorkshop(workshopInput) : clone(workshopInput);
+    if (!workshop) return { restocked: false, reason: "workshop_not_found" };
+    const cycleId = String(options.restockCycleId ?? options.cycleId ?? "initial");
+    const count = Math.max(0, intOr(options.count, 5));
+    const products = [];
+    for (let index = 0; index < count; index += 1) {
+      const generated = generateProduct(workshop, { ...options, restockCycleId: cycleId, index });
+      if (generated.generated) products.push(generated);
+    }
+    return { restocked: true, workshopId: workshop.workshopId, restockCycleId: cycleId, products };
+  }
+
+  function priceMultiplier(workshop) {
+    const rep = REPUTATION_MULTIPLIERS[normalizeId(workshop?.reputation)] || REPUTATION_MULTIPLIERS.established;
+    const tier = clamp(intOr(workshop?.workshopTier, 1), 1, 10);
+    return (1 + Math.max(0, tier - 1) * 0.06) * rep.price;
+  }
+
+  function calculateWorkshopPrice(workshop, item, options = {}) {
+    const basePrice = Math.max(0, numberOr(options.basePrice ?? item?.basePrice ?? item?.price ?? item?.precio, 0));
+    const quality = clamp(intOr(item?.qualityTier ?? item?.quality, 1), 1, 5);
+    const qualityMultipliers = options.qualityMultipliers || { 1: 0.80, 2: 1.00, 3: 1.25, 4: 1.60, 5: 2.10 };
+    const moduleValue = Math.max(0, numberOr(options.moduleValue, 0));
+    const signatureValue = Math.max(0, numberOr(options.signatureTechnologyValue, 0));
+    const marketPressure = Math.max(0, numberOr(options.marketPressure, 1));
+    return Math.round(((basePrice * numberOr(qualityMultipliers[quality], 1) * priceMultiplier(workshop)) + moduleValue + signatureValue) * marketPressure);
+  }
+
+  function serializeWorkshop(workshop) { return clone(workshop); }
+
+  const api = Object.freeze({
+    version: 1,
+    schemaVersion: SCHEMA_VERSION,
+    DEFAULT_TIER_PROFILES: clone(DEFAULT_TIER_PROFILES),
+    REPUTATION_MULTIPLIERS: clone(REPUTATION_MULTIPLIERS),
+    hashSeed,
+    seededRandom,
+    weightedPick,
+    sampleUnique,
+    normalizedWorkshopName,
+    validateWorkshopName,
+    generateWorkshopName,
+    tierProfile,
+    rollQualityTier,
+    createWorkshopInstance,
+    registerWorkshop,
+    getWorkshop,
+    listWorkshops,
+    clearWorkshops,
+    createProductLine,
+    compatibleDefinitions,
+    generateProduct,
+    restockWorkshop,
+    priceMultiplier,
+    calculateWorkshopPrice,
+    serializeWorkshop,
+  });
+
+  global.LuminousWorkshopRuntime = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/tests/item_augmentation_runtime.spec.js
+++ b/tests/item_augmentation_runtime.spec.js
@@ -1,0 +1,68 @@
+const { test, expect } = require("@playwright/test");
+
+global.LuminousAnatomyEquipmentEngine = require("../js/anatomy-equipment-engine.js");
+global.LuminousItemRuntime = require("../js/item-runtime-engine.js");
+global.LuminousItemInventoryRuntime = require("../js/item-inventory-runtime.js");
+const augments = require("../js/item-augmentation-runtime.js");
+
+test("installs an augmentation separately from normal equipment", () => {
+  const unit = { id: "player_1", inventario_activo: {}, augmentations: [] };
+  const item = global.LuminousItemInventoryRuntime.createItemInstance({
+    id: "augment:arm",
+    name: "Arm Prosthetic",
+    category: "augmentation",
+    runtime: { augmentation: { replaceBodyPart: "left_arm", removable: true } },
+  }, { instanceId: "augment_arm_1" });
+  // The compact instance normally resolves its definition from the catalog. For
+  // this focused test keep the authoring profile on the instance as legacy data.
+  item.category = "augmentation";
+  item.runtime = { augmentation: { replaceBodyPart: "left_arm", removable: true } };
+
+  const installed = augments.installAugment(unit, item);
+  expect(installed.installed).toBe(true);
+  expect(unit.augmentations).toHaveLength(1);
+  expect(item.equipped).toBe(true);
+  expect(augments.isAugmentation(item)).toBe(true);
+  expect(installed.anatomy.parts.left_arm.state).toBe("replaced");
+  expect(installed.anatomy.parts.left_arm.substrate).toBe("mechanical");
+});
+
+test("augmentation body requirements reject missing target parts", () => {
+  const unit = { augmentations: [] };
+  const item = {
+    instanceId: "augment_wing_1",
+    category: "augmentation",
+    runtime: { augmentation: { targetPartIds: ["third_wing"] } },
+  };
+  const gate = augments.canInstallAugment(unit, item);
+  expect(gate.allowed).toBe(false);
+  expect(gate.reason).toBe("required_body_part_unavailable");
+});
+
+test("non-removable augmentations require an explicit force removal", () => {
+  const item = {
+    instanceId: "tattoo_1",
+    category: "augmentation",
+    runtime: { augmentation: { removable: false } },
+  };
+  const unit = { augmentations: [item] };
+  const blocked = augments.removeAugment(unit, item);
+  expect(blocked.removed).toBe(false);
+  expect(blocked.reason).toBe("augmentation_not_removable");
+  const forced = augments.removeAugment(unit, item, { force: true });
+  expect(forced.removed).toBe(true);
+  expect(unit.augmentations).toHaveLength(0);
+});
+
+test("installed augment modifiers are exposed as synthetic modifier traits", () => {
+  const unit = {
+    augmentations: [{
+      instanceId: "tattoo_2",
+      category: "augmentation",
+      modifiers: [{ channel: "final_power", value: 1 }],
+    }],
+  };
+  const traits = augments.collectAugmentModifierTraits(unit);
+  expect(traits).toHaveLength(1);
+  expect(traits[0].mechanics.modifiers[0].channel).toBe("final_power");
+});

--- a/tests/item_inventory_regression.spec.js
+++ b/tests/item_inventory_regression.spec.js
@@ -1,0 +1,36 @@
+const { test, expect } = require("@playwright/test");
+
+global.LuminousItemRuntime = require("../js/item-runtime-engine.js");
+global.LuminousItemInventoryRuntime = require("../js/item-inventory-runtime.js");
+global.LuminousWorkshopRuntime = require("../js/workshop-runtime.js");
+
+test("missing item lookup returns null instead of delegating recursively", () => {
+  const unit = { inventario_activo: {}, inventario_stash: {}, equipment: {} };
+  expect(global.LuminousItemInventoryRuntime.findItem(unit, "does_not_exist")).toBeNull();
+});
+
+test("product line display resolves from persistent workshop state by id", () => {
+  global.LuminousWorkshopRuntime.clearWorkshops();
+  const workshop = global.LuminousWorkshopRuntime.createWorkshopInstance({
+    workshopId: "workshop:vesper",
+    workshopName: "Vesper",
+    workshopTier: 7,
+    primarySpecialization: "weapon_blades",
+    knownItemFamilies: ["family:weapon_blades"],
+  }).workshop;
+  const line = global.LuminousWorkshopRuntime.createProductLine(workshop, {
+    force: true,
+    productLineName: "Pale Harvest",
+    compatibleItemFamilies: ["family:weapon_blades"],
+  }).productLine;
+  const instance = global.LuminousItemInventoryRuntime.createItemInstance({ id: "item:scythe", name: "Scythe" }, {
+    instanceId: "scythe_1",
+    manufacturerId: workshop.workshopId,
+    productLineId: line.productLineId,
+  });
+  const resolved = global.LuminousItemInventoryRuntime.resolveItem(instance, {
+    catalog: [{ id: "item:scythe", name: "Scythe" }],
+    workshops: global.LuminousWorkshopRuntime,
+  });
+  expect(resolved.displayName).toBe("Vesper Workshop Scythe — Pale Harvest");
+});

--- a/tests/item_inventory_runtime.spec.js
+++ b/tests/item_inventory_runtime.spec.js
@@ -1,0 +1,128 @@
+const { test, expect } = require("@playwright/test");
+
+const itemBase = require("../js/item-runtime-engine.js");
+global.LuminousItemRuntime = itemBase;
+const inventory = require("../js/item-inventory-runtime.js");
+global.LuminousItemInventoryRuntime = inventory;
+const workshops = require("../js/workshop-runtime.js");
+
+test.describe("canonical item inventory runtime", () => {
+  test.beforeEach(() => workshops.clearWorkshops());
+
+  test("creates compact ItemInstances and hydrates definitions without persisting definition copies", () => {
+    const catalog = {
+      "item:scythe": { canonicalId: "item:scythe", name: "Scythe", category: "weapon", tier: 4 },
+    };
+    const workshop = workshops.createWorkshopInstance({
+      workshopId: "workshop:vesper",
+      workshopName: "Vesper",
+      workshopTier: 4,
+      primarySpecialization: "weapon_blades",
+      knownItemFamilies: ["family:weapon_blades"],
+    }).workshop;
+    const instance = inventory.createItemInstance("item:scythe", {
+      catalog,
+      instanceId: "instance:scythe:1",
+      qualityTier: 4,
+      manufacturerId: workshop.workshopId,
+      condition: 87,
+    });
+
+    expect(instance.definitionId).toBe("item:scythe");
+    expect(instance.instanceId).toBe("instance:scythe:1");
+    expect(instance.qualityTier).toBe(4);
+    expect(instance.manufacturerId).toBe("workshop:vesper");
+    expect(instance.condition).toBe(87);
+    expect(instance.name).toBeUndefined();
+
+    const resolved = inventory.resolveItem(instance, { catalog, workshops });
+    expect(resolved.name).toBe("Scythe");
+    expect(resolved.displayName).toBe("Vesper Workshop Scythe");
+  });
+
+  test("moves items between stash and active inventory while enforcing 10 active slots", () => {
+    const unit = { inventario_activo: {}, inventario_stash: {}, activeSlotLimit: 10 };
+    for (let index = 0; index < 10; index += 1) {
+      const item = inventory.createItemInstance({ id: `active_${index}`, name: `Active ${index}` }, { instanceId: `active_${index}` });
+      unit.inventario_activo[item.instanceId] = item;
+    }
+    const stashItem = inventory.createItemInstance({ id: "reserve", name: "Reserve" }, { instanceId: "reserve_1" });
+    unit.inventario_stash[stashItem.instanceId] = stashItem;
+
+    const blocked = inventory.moveToActive(unit, "reserve_1", 1);
+    expect(blocked.moved).toBe(false);
+    expect(blocked.reason).toBe("active_inventory_full");
+
+    delete unit.inventario_activo.active_0;
+    const moved = inventory.moveToActive(unit, "reserve_1", 1);
+    expect(moved.moved).toBe(true);
+    expect(inventory.describeInventory(unit).activeSlots).toBe(10);
+  });
+
+  test("does not stack items with different quality, condition or manufacturer", () => {
+    const base = { definitionId: "item:ammo", quantity: 1, condition: 100, conditionMax: 100, qualityTier: 2 };
+    expect(inventory.canStack(base, { ...base, quantity: 2 })).toBe(true);
+    expect(inventory.canStack(base, { ...base, qualityTier: 3 })).toBe(false);
+    expect(inventory.canStack(base, { ...base, condition: 80 })).toBe(false);
+    expect(inventory.canStack(base, { ...base, manufacturerId: "workshop:vector" })).toBe(false);
+  });
+
+  test("preserves manufacturer identity when ownership changes", () => {
+    const item = inventory.createItemInstance({ id: "scythe", name: "Scythe" }, {
+      instanceId: "scythe_1",
+      manufacturerId: "workshop:vesper",
+      currentOwnerId: "fixer_a",
+    });
+
+    const result = inventory.transferOwnership(item, "player_1", { sellerId: "pawn_shop" });
+    expect(result.transferred).toBe(true);
+    expect(item.manufacturerId).toBe("workshop:vesper");
+    expect(item.currentOwnerId).toBe("player_1");
+    expect(item.previousOwnerIds).toContain("fixer_a");
+    expect(item.sellerId).toBe("pawn_shop");
+  });
+
+  test("tracks quality, condition states and charges canonically", () => {
+    const item = inventory.createItemInstance({ id: "device", name: "Device", chargesMax: 5 }, {
+      instanceId: "device_1",
+      qualityTier: 5,
+      condition: 100,
+      charges: 5,
+    });
+
+    inventory.damageCondition(item, 51);
+    expect(inventory.getConditionState(item).id).toBe("damaged");
+    expect(inventory.getQualityTier(item)).toBe(5);
+
+    expect(inventory.spendCharges(item, 2).spent).toBe(true);
+    expect(inventory.getCharges(item).current).toBe(3);
+    expect(inventory.restoreCharges(item, 1).after).toBe(4);
+  });
+
+  test("prevents structural technologies from being removed as normal modules", () => {
+    const host = { installedModuleIds: ["module:edge"], installedModules: [] };
+    const structural = { id: "module:edge", technologyClass: "STRUCTURAL_TECH", removable: false };
+    const result = inventory.removeInstalledModule(host, structural, { moduleDefinition: structural });
+    expect(result.removed).toBe(false);
+    expect(result.reason).toBe("structural_technology_not_removable");
+    expect(host.installedModuleIds).toContain("module:edge");
+  });
+
+  test("migrates legacy active and stash entries without changing container roles", () => {
+    const unit = {
+      inventario_activo: {
+        legacy_weapon: { id: "weapon_scythe", nombre: "Scythe", cantidad: 1, tier: 4, limite_activo: 2 },
+      },
+      inventario_stash: {
+        legacy_food: { id: "ration", nombre: "Ration", cantidad: 6, limite_alijo: 99 },
+      },
+    };
+
+    const result = inventory.migrateLegacyInventory(unit);
+    expect(result.migrated).toBe(true);
+    expect(result.activeContainer).toBe("inventario_activo");
+    expect(result.stashContainer).toBe("inventario_stash");
+    expect(Object.values(unit.inventario_activo)[0].schemaVersion).toBe(2);
+    expect(Object.values(unit.inventario_stash)[0].quantity).toBe(6);
+  });
+});

--- a/tests/item_magic_runtime.spec.js
+++ b/tests/item_magic_runtime.spec.js
@@ -1,0 +1,87 @@
+const { test, expect } = require("@playwright/test");
+
+global.LuminousItemRuntime = require("../js/item-runtime-engine.js");
+global.LuminousItemInventoryRuntime = require("../js/item-inventory-runtime.js");
+global.LuminousSpellcastingRuntime = require("../js/spellcasting-runtime.js");
+const magic = require("../js/item-magic-runtime.js");
+
+test("attunement respects capacity and stores instance ids", () => {
+  const user = { id: "player_1", attunementCapacity: 1 };
+  const first = { instanceId: "ring_1", requiresAttunement: true };
+  const second = { instanceId: "ring_2", requiresAttunement: true };
+
+  expect(magic.attuneItem(user, first).attuned).toBe(true);
+  expect(magic.isAttuned(user, first)).toBe(true);
+  const blocked = magic.attuneItem(user, second);
+  expect(blocked.attuned).toBe(false);
+  expect(blocked.reason).toBe("attunement_capacity_reached");
+});
+
+test("item spell execution spends charges only after executor succeeds", () => {
+  const user = { id: "caster" };
+  const item = {
+    instanceId: "wand_1",
+    chargesCurrent: 3,
+    chargesMax: 3,
+    runtime: { magic: { spells: [{ spellId: "spell:bolt", chargeCost: 2, spellDC: 15 }] } },
+  };
+
+  const noExecutor = magic.castSpellFromItem(user, item, "spell:bolt");
+  expect(noExecutor.cast).toBe(false);
+  expect(noExecutor.reason).toBe("spell_executor_unavailable");
+  expect(item.chargesCurrent).toBe(3);
+
+  const cast = magic.castSpellFromItem(user, item, "spell:bolt", {
+    executeSpell(payload) { return { executed: true, spellId: payload.spellId }; },
+  });
+  expect(cast.cast).toBe(true);
+  expect(item.chargesCurrent).toBe(1);
+});
+
+test("attuned items reject spell activation until attuned", () => {
+  const user = { id: "caster" };
+  const item = {
+    instanceId: "staff_1",
+    requiresAttunement: true,
+    chargesCurrent: 2,
+    chargesMax: 2,
+    runtime: { magic: { spells: [{ spellId: "spell:ward", chargeCost: 1 }] } },
+  };
+
+  expect(magic.canActivateSpellFromItem(user, item, "spell:ward").reason).toBe("item_not_attuned");
+  expect(magic.attuneItem(user, item).attuned).toBe(true);
+  expect(magic.canActivateSpellFromItem(user, item, "spell:ward").allowed).toBe(true);
+});
+
+test("spell scroll is consumed only after successful spell execution", () => {
+  const user = { id: "caster" };
+  const scroll = {
+    instanceId: "scroll_1",
+    definitionId: "item:spell_scroll",
+    category: "spell_scroll",
+    quantity: 2,
+    runtimeState: { spellId: "spell:test" },
+    runtime: { magic: { spells: [{ spellId: "spell:test", chargeCost: 0 }] } },
+  };
+
+  const failed = magic.useSpellScroll(user, scroll);
+  expect(failed.used).toBe(false);
+  expect(scroll.quantity).toBe(2);
+
+  const used = magic.useSpellScroll(user, scroll, {
+    executeSpell() { return { executed: true }; },
+  });
+  expect(used.used).toBe(true);
+  expect(scroll.quantity).toBe(1);
+});
+
+test("curse state is explicit and removable", () => {
+  const user = { id: "player" };
+  const item = { instanceId: "blade_1", runtime: { curse: { id: "binding" } } };
+  expect(magic.isCursed(item)).toBe(true);
+  expect(magic.revealCurse(item).revealed).toBe(true);
+  expect(magic.applyCurse(user, item).applied).toBe(true);
+  expect(user.itemCurses).toHaveLength(1);
+  expect(magic.removeCurse(user, item).removed).toBe(true);
+  expect(user.itemCurses).toHaveLength(0);
+});

--- a/tests/item_persistence_runtime.spec.js
+++ b/tests/item_persistence_runtime.spec.js
@@ -1,0 +1,135 @@
+const { test, expect } = require("@playwright/test");
+
+global.LuminousItemRuntime = require("../js/item-runtime-engine.js");
+global.LuminousItemInventoryRuntime = require("../js/item-inventory-runtime.js");
+global.LuminousWorkshopRuntime = require("../js/workshop-runtime.js");
+const persistence = require("../js/item-persistence-runtime.js");
+
+function makeDb(initial = {}) {
+  const data = JSON.parse(JSON.stringify(initial));
+  const listeners = new Map();
+  const parts = (path) => String(path).split("/").filter(Boolean);
+  const get = (path) => parts(path).reduce((node, key) => node && node[key], data);
+  const set = (path, value) => {
+    const keys = parts(path);
+    let node = data;
+    keys.slice(0, -1).forEach((key) => { if (!node[key] || typeof node[key] !== "object") node[key] = {}; node = node[key]; });
+    node[keys[keys.length - 1]] = JSON.parse(JSON.stringify(value));
+    const handler = listeners.get(path);
+    if (handler) handler({ val: () => get(path) });
+  };
+  return {
+    data,
+    ref(path) {
+      return {
+        once: async () => ({ val: () => get(path) }),
+        set: async (value) => set(path, value),
+        update: async (updates) => {
+          Object.entries(updates).forEach(([key, value]) => set(`${path}/${key}`, value));
+        },
+        on: (_event, handler) => { listeners.set(path, handler); handler({ val: () => get(path) }); },
+        off: (_event, handler) => { if (listeners.get(path) === handler) listeners.delete(path); },
+      };
+    },
+  };
+}
+
+test("loads legacy Firebase active/stash paths into canonical ItemInstances", async () => {
+  const db = makeDb({
+    campaña: { jugadores: { player_1: {
+      inventario_activo: { legacy_scythe: { id: "item:scythe", nombre: "Scythe", cantidad: 1, tier: 4, limite_activo: 2 } },
+      inventario_stash: { legacy_ration: { id: "item:ration", nombre: "Ration", cantidad: 6, limite_alijo: 99 } },
+    } } },
+  });
+  const loaded = await persistence.loadPlayerInventory(db, "player_1");
+  expect(loaded.loaded).toBe(true);
+  expect(loaded.migrated).toBe(true);
+  const active = Object.values(loaded.state.inventario_activo)[0];
+  const stash = Object.values(loaded.state.inventario_stash)[0];
+  expect(active.schemaVersion).toBe(2);
+  expect(active.definitionId).toBe("item:scythe");
+  expect(active.nombre).toBe("Scythe");
+  expect(stash.quantity).toBe(6);
+});
+
+test("save updates inventory branches without replacing unrelated player data", async () => {
+  const db = makeDb({ campaña: { jugadores: { player_1: { hp: 77, inventario_activo: {}, inventario_stash: {} } } } });
+  const unit = {
+    inventario_activo: {
+      a1: { schemaVersion: 2, instanceId: "a1", definitionId: "item:scythe", quantity: 1, qualityTier: 4, condition: 90, conditionMax: 100, nombre: "Scythe" },
+    },
+    inventario_stash: {},
+    attunedItemInstanceIds: ["a1"],
+  };
+  const result = await persistence.saveInventoryState(db, "player_1", unit);
+  expect(result.saved).toBe(true);
+  expect(db.data.campaña.jugadores.player_1.hp).toBe(77);
+  expect(db.data.campaña.jugadores.player_1.itemInventorySchemaVersion).toBe(2);
+  expect(db.data.campaña.jugadores.player_1.inventario_activo.a1.definitionId).toBe("item:scythe");
+});
+
+test("legacy HUD compatibility fields survive save and reload", async () => {
+  const db = makeDb();
+  const unit = {
+    inventario_activo: {
+      legacy: {
+        schemaVersion: 2,
+        instanceId: "legacy",
+        definitionId: "item:toolkit",
+        quantity: 1,
+        qualityTier: 2,
+        condition: 100,
+        conditionMax: 100,
+        nombre: "Toolkit",
+        tags: ["toolkit"],
+        keywords: ["synth_bonus_2"],
+        limite_activo: 2,
+      },
+    },
+    inventario_stash: {},
+  };
+  await persistence.saveInventoryState(db, "player_1", unit);
+  const loaded = await persistence.loadPlayerInventory(db, "player_1");
+  const item = Object.values(loaded.state.inventario_activo)[0];
+  expect(item.nombre).toBe("Toolkit");
+  expect(item.tags).toContain("toolkit");
+  expect(item.keywords).toContain("synth_bonus_2");
+  expect(item.limite_activo).toBe(2);
+});
+
+test("equipment refs are restored to canonical inventory instances", () => {
+  const unit = {};
+  const snapshot = {
+    schemaVersion: 2,
+    inventario_activo: {
+      weapon_1: { schemaVersion: 2, instanceId: "weapon_1", definitionId: "item:weapon", quantity: 1, qualityTier: 2, condition: 100, conditionMax: 100 },
+    },
+    inventario_stash: {},
+    equipmentRefs: { mainHand: "weapon_1" },
+  };
+  const applied = persistence.applyInventoryState(unit, snapshot);
+  expect(applied.applied).toBe(true);
+  expect(unit.equipment.mainHand).toBe(unit.inventario_activo.weapon_1);
+});
+
+test("Workshop persistence requires explicit world path and hydrates the same identity", async () => {
+  global.LuminousWorkshopRuntime.clearWorkshops();
+  const created = global.LuminousWorkshopRuntime.createWorkshopInstance({
+    workshopId: "workshop:vesper",
+    workshopName: "Vesper",
+    workshopTier: 5,
+    primarySpecialization: "weapon_blades",
+    knownItemFamilies: ["family:weapon_blades"],
+  });
+  expect(created.created).toBe(true);
+  const db = makeDb();
+  expect((await persistence.saveWorkshopState(db, null)).reason).toBe("workshop_path_required");
+  const saved = await persistence.saveWorkshopState(db, "campaña/worldState/workshops");
+  expect(saved.saved).toBe(true);
+
+  global.LuminousWorkshopRuntime.clearWorkshops();
+  expect(global.LuminousWorkshopRuntime.getWorkshop("workshop:vesper")).toBeNull();
+  const loaded = await persistence.loadWorkshopState(db, "campaña/worldState/workshops");
+  expect(loaded.loaded).toBe(true);
+  expect(global.LuminousWorkshopRuntime.getWorkshop("workshop:vesper").workshopName).toBe("Vesper");
+});

--- a/tests/item_realtime_sync.spec.js
+++ b/tests/item_realtime_sync.spec.js
@@ -1,0 +1,298 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("fs");
+const path = require("path");
+
+global.LuminousItemRuntime = require("../js/item-runtime-engine.js");
+global.LuminousItemInventoryRuntime = require("../js/item-inventory-runtime.js");
+global.LuminousItemPersistenceRuntime = require("../js/item-persistence-runtime.js");
+const realtime = require("../js/item-realtime-sync.js");
+const inventory = global.LuminousItemInventoryRuntime;
+
+function clone(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function parts(pathValue) {
+  return String(pathValue || "").split("/").filter(Boolean);
+}
+
+function readAt(root, pathValue) {
+  let current = root;
+  for (const key of parts(pathValue)) {
+    if (current == null || typeof current !== "object") return null;
+    current = current[key];
+  }
+  return current === undefined ? null : clone(current);
+}
+
+function writeAt(root, pathValue, value) {
+  const keys = parts(pathValue);
+  if (!keys.length) throw new Error("root writes are not supported by this fake");
+  let current = root;
+  for (let index = 0; index < keys.length - 1; index += 1) {
+    const key = keys[index];
+    if (!current[key] || typeof current[key] !== "object") current[key] = {};
+    current = current[key];
+  }
+  const finalKey = keys[keys.length - 1];
+  if (value === null || value === undefined) delete current[finalKey];
+  else current[finalKey] = clone(value);
+}
+
+function snapshot(value) {
+  const stored = clone(value);
+  return {
+    val() { return clone(stored); },
+    exists() { return stored !== null && stored !== undefined; },
+    forEach(callback) {
+      if (!stored || typeof stored !== "object") return false;
+      for (const [key, childValue] of Object.entries(stored)) {
+        const child = { key, val: () => clone(childValue) };
+        if (callback(child) === true) return true;
+      }
+      return false;
+    },
+  };
+}
+
+class FakeRealtimeDatabase {
+  constructor(initial = {}) {
+    this.data = clone(initial);
+    this.listeners = new Map();
+    this.pushCounter = 0;
+  }
+
+  ref(pathValue) {
+    const db = this;
+    const refPath = String(pathValue || "").replace(/^\/+|\/+$/g, "");
+    return {
+      key: parts(refPath).at(-1) || null,
+      once(event, callback) {
+        if (event !== "value") throw new Error(`Unsupported once event: ${event}`);
+        const snap = snapshot(readAt(db.data, refPath));
+        if (typeof callback === "function") callback(snap);
+        return Promise.resolve(snap);
+      },
+      on(event, callback) {
+        if (event !== "value") throw new Error(`Unsupported on event: ${event}`);
+        if (!db.listeners.has(refPath)) db.listeners.set(refPath, new Set());
+        db.listeners.get(refPath).add(callback);
+        callback(snapshot(readAt(db.data, refPath)));
+        return callback;
+      },
+      off(event, callback) {
+        if (event !== "value") return;
+        const set = db.listeners.get(refPath);
+        if (!set) return;
+        if (callback) set.delete(callback);
+        else set.clear();
+      },
+      async set(value) {
+        writeAt(db.data, refPath, value);
+        db.notify([refPath]);
+      },
+      async update(updates = {}) {
+        const changed = [];
+        for (const [relative, value] of Object.entries(updates)) {
+          const childPath = relative ? `${refPath}/${relative}` : refPath;
+          writeAt(db.data, childPath, value);
+          changed.push(childPath);
+        }
+        db.notify(changed);
+      },
+      async remove() {
+        writeAt(db.data, refPath, null);
+        db.notify([refPath]);
+      },
+      push(value) {
+        db.pushCounter += 1;
+        const key = `push_${db.pushCounter}`;
+        const childPath = `${refPath}/${key}`;
+        const childRef = db.ref(childPath);
+        if (arguments.length) childRef.set(value);
+        return { ...childRef, key };
+      },
+    };
+  }
+
+  notify(changedPaths) {
+    const callbacks = [];
+    for (const [listenerPath, handlers] of this.listeners.entries()) {
+      const affected = changedPaths.some((changedPath) =>
+        changedPath === listenerPath ||
+        changedPath.startsWith(`${listenerPath}/`) ||
+        listenerPath.startsWith(`${changedPath}/`),
+      );
+      if (!affected) continue;
+      for (const handler of handlers) callbacks.push([listenerPath, handler]);
+    }
+    for (const [listenerPath, handler] of callbacks) {
+      handler(snapshot(readAt(this.data, listenerPath)));
+    }
+  }
+}
+
+async function settle() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function makeItem(id, name = id) {
+  return inventory.createItemInstance({ id, name, category: "tool" }, {
+    instanceId: `${id}:instance`,
+    quantity: 1,
+  });
+}
+
+function createPeers() {
+  const db = new FakeRealtimeDatabase({
+    campaña: {
+      jugadores: { Alice: { inventario_activo: {}, inventario_stash: {} } },
+      ajustes_globales: { alijo_desbloqueado: false },
+    },
+  });
+  const playerUnit = { inventario_activo: {}, inventario_stash: {} };
+  const dmUnit = { inventario_activo: {}, inventario_stash: {} };
+  const playerEvents = [];
+  const dmEvents = [];
+  const playerAccess = [];
+  const dmAccess = [];
+  const player = realtime.bindPlayerInventory({
+    db, playerId: "Alice", unit: playerUnit,
+    onInventory: (event) => playerEvents.push(event),
+    onStashAccess: (event) => playerAccess.push(event.unlocked),
+  });
+  const dm = realtime.bindDmInventory({
+    db, playerId: "Alice", unit: dmUnit,
+    onInventory: (event) => dmEvents.push(event),
+    onStashAccess: (event) => dmAccess.push(event.unlocked),
+  });
+  return { db, player, dm, playerUnit, dmUnit, playerEvents, dmEvents, playerAccess, dmAccess };
+}
+
+test("player and DM bind to the exact same Firebase inventory paths", () => {
+  const { player, dm } = createPeers();
+  expect(player.bound).toBe(true);
+  expect(dm.bound).toBe(true);
+  expect(player.paths.active).toBe("campaña/jugadores/Alice/inventario_activo");
+  expect(player.paths.stash).toBe("campaña/jugadores/Alice/inventario_stash");
+  expect(dm.paths).toEqual(player.paths);
+  player.dispose();
+  dm.dispose();
+});
+
+test("Player -> DM: saving active inventory reaches the DM without reload", async () => {
+  const peers = createPeers();
+  await settle();
+  const item = makeItem("item:player_medkit", "Medkit");
+  peers.playerUnit.inventario_activo[item.instanceId] = item;
+
+  const saved = await peers.player.save();
+  expect(saved.saved).toBe(true);
+  await settle();
+
+  expect(peers.dmUnit.inventario_activo[item.instanceId]).toBeTruthy();
+  expect(peers.dmUnit.inventario_activo[item.instanceId].definitionId).toBe("item:player_medkit");
+  expect(peers.dmEvents.at(-1).source).toBe("firebase");
+  peers.player.dispose();
+  peers.dm.dispose();
+});
+
+test("DM -> Player: saving stash reaches the player without reload", async () => {
+  const peers = createPeers();
+  await settle();
+  const item = makeItem("item:dm_reward", "Reward");
+  peers.dmUnit.inventario_stash[item.instanceId] = item;
+
+  const saved = await peers.dm.save();
+  expect(saved.saved).toBe(true);
+  await settle();
+
+  expect(peers.playerUnit.inventario_stash[item.instanceId]).toBeTruthy();
+  expect(peers.playerUnit.inventario_stash[item.instanceId].definitionId).toBe("item:dm_reward");
+  expect(peers.playerEvents.at(-1).source).toBe("firebase");
+  peers.player.dispose();
+  peers.dm.dispose();
+});
+
+test("Active -> Stash move persists once and converges on both peers", async () => {
+  const peers = createPeers();
+  await settle();
+  const item = makeItem("item:scythe", "Scythe");
+  peers.playerUnit.inventario_activo[item.instanceId] = item;
+  await peers.player.save();
+  await settle();
+
+  const moved = await peers.player.move(item.instanceId, "to_stash");
+  expect(moved.moved).toBe(true);
+  expect(moved.saved).toBe(true);
+  await settle();
+
+  expect(peers.playerUnit.inventario_activo[item.instanceId]).toBeFalsy();
+  expect(peers.dmUnit.inventario_activo[item.instanceId]).toBeFalsy();
+  expect(peers.playerUnit.inventario_stash[item.instanceId]).toBeTruthy();
+  expect(peers.dmUnit.inventario_stash[item.instanceId]).toBeTruthy();
+  peers.player.dispose();
+  peers.dm.dispose();
+});
+
+test("DM stash unlock propagates to the player in realtime", async () => {
+  const peers = createPeers();
+  await settle();
+  expect(peers.player.stashUnlocked).toBe(false);
+  expect(peers.dm.stashUnlocked).toBe(false);
+
+  const result = await peers.dm.setStashUnlocked(true);
+  expect(result.saved).toBe(true);
+  await settle();
+
+  expect(peers.player.stashUnlocked).toBe(true);
+  expect(peers.playerUnit.stashUnlocked).toBe(true);
+  expect(peers.playerAccess.at(-1)).toBe(true);
+  expect(peers.dmAccess.at(-1)).toBe(true);
+  peers.player.dispose();
+  peers.dm.dispose();
+});
+
+test("player role cannot change global stash access by default", async () => {
+  const peers = createPeers();
+  await settle();
+  const result = await peers.player.setStashUnlocked(true);
+  expect(result.saved).toBe(false);
+  expect(result.reason).toBe("dm_role_required");
+  expect(peers.player.stashUnlocked).toBe(false);
+  peers.player.dispose();
+  peers.dm.dispose();
+});
+
+test("disposed peers stop receiving realtime inventory updates", async () => {
+  const peers = createPeers();
+  await settle();
+  const before = peers.dm.revision;
+  peers.dm.dispose();
+
+  const item = makeItem("item:after_dispose", "After Dispose");
+  peers.playerUnit.inventario_activo[item.instanceId] = item;
+  await peers.player.save();
+  await settle();
+
+  expect(peers.dm.revision).toBe(before);
+  expect(peers.dmUnit.inventario_activo[item.instanceId]).toBeFalsy();
+  peers.player.dispose();
+});
+
+test("existing Player and DM UIs already target the same active/stash realtime contract", () => {
+  const root = path.resolve(__dirname, "..");
+  const playerSource = fs.readFileSync(path.join(root, "hoja_personaje.js"), "utf8");
+  const dmSource = fs.readFileSync(path.join(root, "pantalla_dm.html"), "utf8");
+
+  expect(playerSource).toContain("inventario_activo");
+  expect(playerSource).toContain("inventario_stash");
+  expect(playerSource).toMatch(/inventario_activo[\s\S]{0,300}\.on\([\s\n]*["']value["']/);
+  expect(playerSource).toMatch(/inventario_stash[\s\S]{0,300}\.on\([\s\n]*["']value["']/);
+  expect(dmSource).toContain("inventario_activo");
+  expect(dmSource).toContain("inventario_stash");
+  expect(dmSource).toMatch(/inventario_activo[\s\S]{0,300}\.on\([\s\n]*["']value["']/);
+  expect(dmSource).toMatch(/inventario_stash[\s\S]{0,300}\.on\([\s\n]*["']value["']/);
+});

--- a/tests/item_runtime_catalog_profile.spec.js
+++ b/tests/item_runtime_catalog_profile.spec.js
@@ -1,0 +1,69 @@
+const { test, expect } = require("@playwright/test");
+
+const equipment = require("../js/anatomy-equipment-engine.js");
+global.LuminousAnatomyEquipmentEngine = equipment;
+const actions = require("../js/universal-action-economy.js");
+global.LuminousActionEconomy = actions;
+const statuses = require("../js/status-engine.js");
+global.LuminousStatusEngine = statuses;
+const injuries = require("../js/injury-engine.js");
+global.LuminousInjuryEngine = injuries;
+const modifiers = require("../js/universal-modifier-engine.js");
+global.LuminousUniversalModifiers = modifiers;
+const items = require("../js/item-runtime-engine.js");
+
+function applyProfile(item, runtimeJson) {
+  item.runtime = typeof runtimeJson === "string" ? JSON.parse(runtimeJson) : runtimeJson;
+  return item;
+}
+
+test("V3 weapon_chassis profile equips through the canonical anatomy engine", () => {
+  const unit = { inventory: [] };
+  const spear = applyProfile({
+    canonicalId: "item:weapon_chassis_spear",
+    category: "weapon_chassis",
+    function: "equip|module_host|repairable|salvage|trade",
+    tags: ["weapon:melee", "damage:pierce", "reach", "hands:2", "module:host"],
+    quantity: 1,
+  }, '{"equipment":{"kind":"weapon","handCost":2},"moduleCapacity":3}');
+  unit.inventory.push(spear);
+
+  const result = items.equipItem(unit, spear);
+  expect(result.equipped).toBe(true);
+  expect(spear.equippedPartIds).toHaveLength(2);
+});
+
+test("V3 accessory_chassis profile maps catalog face slot onto head anatomy", () => {
+  const unit = { inventory: [] };
+  const visor = applyProfile({
+    canonicalId: "item:accessory_chassis_tactical_visor",
+    category: "accessory_chassis",
+    function: "equip|module_host|repairable|salvage|trade",
+    tags: ["slot:face", "accessory", "module:host"],
+    quantity: 1,
+  }, '{"equipment":{"kind":"accessory","accessoryType":"head"},"moduleCapacity":3}');
+  unit.inventory.push(visor);
+
+  const result = items.equipItem(unit, visor);
+  expect(result.equipped).toBe(true);
+  expect(visor.equippedPartIds).toEqual(["head"]);
+});
+
+test("V3 module compatibility works on workbook chassis without renaming categories", () => {
+  const weapon = applyProfile({
+    canonicalId: "item:weapon_chassis_pistol",
+    category: "weapon_chassis",
+    function: "equip|module_host|repairable|salvage|trade",
+    installedModules: [],
+  }, '{"equipment":{"kind":"weapon","handCost":1},"moduleCapacity":3}');
+  const module = applyProfile({
+    canonicalId: "module:ignition_driver",
+    category: "module",
+    quantity: 1,
+  }, '{"compatibleKinds":["weapon","accessory"]}');
+
+  const result = items.installModule(weapon, module);
+  expect(result.installed).toBe(true);
+  expect(weapon.installedModules).toHaveLength(1);
+  expect(module.quantity).toBe(0);
+});

--- a/tests/item_runtime_engine.spec.js
+++ b/tests/item_runtime_engine.spec.js
@@ -1,0 +1,155 @@
+const { test, expect } = require("@playwright/test");
+
+const equipment = require("../js/anatomy-equipment-engine.js");
+global.LuminousAnatomyEquipmentEngine = equipment;
+const actions = require("../js/universal-action-economy.js");
+global.LuminousActionEconomy = actions;
+const statuses = require("../js/status-engine.js");
+global.LuminousStatusEngine = statuses;
+const injuries = require("../js/injury-engine.js");
+global.LuminousInjuryEngine = injuries;
+const modifiers = require("../js/universal-modifier-engine.js");
+global.LuminousUniversalModifiers = modifiers;
+const items = require("../js/item-runtime-engine.js");
+
+function consumable(id, details = {}, extra = {}) {
+  return {
+    id,
+    definitionId: id,
+    nombre: id,
+    tipo_categoria: "consumable",
+    quantity: 2,
+    consumable_details: details,
+    ...extra,
+  };
+}
+
+test("legacy DM Forge consumables heal HP and consume one item", () => {
+  const unit = { combatStats: { hp_actual: 25, hp_max: 50 }, inventory: [] };
+  const medkit = consumable("basic_medkit", { curacion_hp: 15 });
+  unit.inventory.push(medkit);
+  const result = items.useItem(unit, medkit, { phase: "other" });
+  expect(result.used).toBe(true);
+  expect(unit.combatStats.hp_actual).toBe(40);
+  expect(medkit.quantity).toBe(1);
+});
+
+test("throwable consumables apply status to target instead of user", () => {
+  const user = { inventory: [] };
+  const target = {};
+  const smoke = consumable("smoke_canister", { is_throwable: true, status_id: "blinded", status_count: 1, status_potency: 0 });
+  user.inventory.push(smoke);
+  const result = items.useItem(user, smoke, { phase: "other", target });
+  expect(result.used).toBe(true);
+  expect(statuses.hasStatus(target, "blinded")).toBe(true);
+  expect(statuses.hasStatus(user, "blinded")).toBe(false);
+});
+
+test("action-cost consumable schedules in planning and only consumes on resolution", () => {
+  const unit = { id: "unit_a", activeSlots: 1, combatStats: { hp_actual: 10, hp_max: 30 }, inventory: [] };
+  const medkit = consumable("planned_medkit", { curacion_hp: 10 });
+  unit.inventory.push(medkit);
+  actions.beginPlanning(unit);
+  const scheduled = items.useItem(unit, medkit, { phase: "planning" });
+  expect(scheduled.scheduled).toBe(true);
+  expect(medkit.quantity).toBe(2);
+  expect(unit.combatStats.hp_actual).toBe(10);
+
+  actions.beginCombat(unit);
+  const entry = actions.takePlannedAction(unit, scheduled.slotIndex, { phase: "combat" });
+  const resolved = items.resolveScheduledUse(unit, entry);
+  expect(resolved.resolved).toBe(true);
+  expect(unit.combatStats.hp_actual).toBe(20);
+  expect(medkit.quantity).toBe(1);
+});
+
+test("weapons infer hand requirements from catalog tags and use anatomy validation", () => {
+  const unit = { inventory: [] };
+  const rifle = { id: "rifle", tipo_categoria: "weapon", tags: ["weapon:ranged", "hands:2"], quantity: 1 };
+  const shield = { id: "shield", tipo_categoria: "shield", quantity: 1 };
+  unit.inventory.push(rifle, shield);
+  expect(items.equipItem(unit, rifle).equipped).toBe(true);
+  const blocked = items.equipItem(unit, shield);
+  expect(blocked.equipped).toBe(false);
+  expect(blocked.reason).toBe("not_enough_functional_hands");
+});
+
+test("accessory slot tags map onto actual body parts", () => {
+  const unit = { inventory: [] };
+  const mask = { id: "mask", tipo_categoria: "accessory", tags: ["slot:face"], quantity: 1 };
+  unit.inventory.push(mask);
+  const result = items.equipItem(unit, mask);
+  expect(result.equipped).toBe(true);
+  expect(mask.equippedPartIds).toEqual(["head"]);
+});
+
+test("ammo items feed the same resources checked by ranged skills", () => {
+  const unit = { resources: { pistol: 0 }, inventory: [] };
+  const ammo = { id: "pistol_ammo", category: "ammo", subtype: "pistol", function: "AMMO|TRADE", quantity: 6 };
+  unit.inventory.push(ammo);
+  const result = items.reloadAmmo(unit, ammo, { amount: 4 });
+  expect(result.reloaded).toBe(true);
+  expect(unit.resources.pistol).toBe(4);
+  expect(ammo.quantity).toBe(2);
+
+  const skill = { type: "normal", attackMode: "ranged", ammo: { resourceId: "pistol", cost: 1 } };
+  expect(global.LuminousUniversalModifiers.canUseSkill(unit, skill).usable).toBe(true);
+});
+
+test("repair effects restore item condition without exceeding conditionMax", () => {
+  const target = { id: "armor", condition: 45, conditionMax: 100 };
+  const result = items.repairItem(target, 70);
+  expect(result.repaired).toBe(true);
+  expect(target.condition).toBe(100);
+  expect(result.amount).toBe(55);
+});
+
+test("item injury treatments delegate to the canonical injury engine", () => {
+  const unit = { inventory: [], injuries: [] };
+  const gained = injuries.gainInjury(unit, "deep_wound", { persist: false });
+  expect(gained.gained).toBe(true);
+  const kit = consumable("field_dressing", {}, {
+    runtime: { injuryTreatment: { reduceHours: 8 } },
+  });
+  unit.inventory.push(kit);
+  const before = unit.injuries[0].remainingRecoveryHours;
+  const result = items.useItem(unit, kit, { phase: "other", injuryRef: unit.injuries[0].instanceId });
+  expect(result.used).toBe(true);
+  expect(unit.injuries[0].remainingRecoveryHours).toBe(before - 8);
+});
+
+test("temporary stat consumables become synthetic item traits and expire in world hours", () => {
+  const unit = { inventory: [], stats: { strength: 10 } };
+  const stim = consumable("strength_stim", { stat_increase: "fuerza", stat_increase_value: 2, duration_hours: 3 });
+  unit.inventory.push(stim);
+  expect(items.useItem(unit, stim, { phase: "other" }).used).toBe(true);
+  let traits = items.collectModifierTraits(unit);
+  expect(traits.some((trait) => trait.rules.some((rule) => rule.type === "stat" && rule.statId === "fuerza"))).toBe(true);
+  items.advanceTime(unit, 3);
+  traits = items.collectModifierTraits(unit);
+  expect(traits.some((trait) => trait.id.includes("strength_stim") && trait.rules.some((rule) => rule.type === "stat"))).toBe(false);
+});
+
+test("modules respect host capacity and can be removed", () => {
+  const host = { id: "sword", category: "weapon", function: "EQUIP|MODULE_HOST", installedModules: [], runtime: { moduleCapacity: 1 } };
+  const a = { id: "mod_a", category: "upgrade", quantity: 1 };
+  const b = { id: "mod_b", category: "upgrade", quantity: 1 };
+  expect(items.installModule(host, a).installed).toBe(true);
+  expect(items.installModule(host, b).installed).toBe(false);
+  expect(items.removeModule(host, "mod_a").removed).toBe(true);
+});
+
+test("crafting consumes DM Forge recipe ingredients and creates the result", () => {
+  const unit = {
+    inventory: [
+      { id: "cloth", definitionId: "cloth", quantity: 3 },
+      { id: "chemical", definitionId: "chemical", quantity: 2 },
+    ],
+  };
+  const recipe = { ingredientes: { cloth: 2, chemical: 1 }, item_resultado_id: "bandage", cantidad_resultado: 2 };
+  const result = items.craft(unit, recipe, { resultDefinition: { id: "bandage", definitionId: "bandage", nombre: "Bandage" } });
+  expect(result.crafted).toBe(true);
+  expect(unit.inventory.find((x) => x.definitionId === "cloth").quantity).toBe(1);
+  expect(unit.inventory.find((x) => x.definitionId === "chemical").quantity).toBe(1);
+  expect(unit.inventory.find((x) => x.definitionId === "bandage").quantity).toBe(2);
+});

--- a/tests/item_salvage_runtime.spec.js
+++ b/tests/item_salvage_runtime.spec.js
@@ -1,0 +1,56 @@
+const { test, expect } = require("@playwright/test");
+
+global.LuminousItemRuntime = require("../js/item-runtime-engine.js");
+global.LuminousItemInventoryRuntime = require("../js/item-inventory-runtime.js");
+global.LuminousWorkshopRuntime = require("../js/workshop-runtime.js");
+const salvage = require("../js/item-salvage-runtime.js");
+
+test("healthy items recover materials and removable modules using V11 bands", () => {
+  const item = {
+    instanceId: "scythe_1",
+    definitionId: "item:scythe",
+    quantity: 1,
+    condition: 80,
+    conditionMax: 100,
+    installedModuleIds: ["module:edge", "tech:frame"],
+    signatureComponents: [{ id: "component:vesper" }],
+    salvageMaterials: { steel: 10, parts: 5 },
+  };
+  const result = salvage.salvageItem(item, {
+    random: () => 0,
+    moduleCatalog: {
+      "module:edge": { id: "module:edge", technologyClass: "MODULE", removable: true },
+      "tech:frame": { id: "tech:frame", technologyClass: "STRUCTURAL_TECH", removable: false },
+    },
+  });
+  expect(result.salvaged).toBe(true);
+  expect(result.band.id).toBe("condition:76_100");
+  expect(result.materials.find((entry) => entry.id === "steel").quantity).toBe(8);
+  expect(result.materials.find((entry) => entry.id === "parts").quantity).toBe(4);
+  expect(result.recoveredModules).toContain("module:edge");
+  expect(result.recoveredModules).not.toContain("tech:frame");
+  expect(result.destroyedModules.find((entry) => entry.id === "tech:frame").reason).toBe("structural_or_non_removable");
+  expect(result.recoveredSignatureComponents).toHaveLength(1);
+  expect(result.structuralTechnologyRecoveredAsModule).toBe(false);
+});
+
+test("destroyed items use the 10 percent scrap band", () => {
+  const item = { instanceId: "broken_1", definitionId: "item:armor", condition: 0, conditionMax: 100, salvageMaterials: { steel: 20 } };
+  const result = salvage.salvageItem(item, { random: () => 1 });
+  expect(result.band.id).toBe("condition:0");
+  expect(result.materials[0].quantity).toBe(2);
+});
+
+test("equipped items are not salvageable by default", () => {
+  const result = salvage.salvageItem({ instanceId: "equipped_1", equipped: true, condition: 100, conditionMax: 100 });
+  expect(result.salvaged).toBe(false);
+  expect(result.reason).toBe("item_equipped");
+});
+
+test("optional source consumption removes one quantity only after salvage resolves", () => {
+  const item = { instanceId: "stack_1", definitionId: "item:scrap", quantity: 3, condition: 100, conditionMax: 100, salvageMaterials: { metal: 2 } };
+  const result = salvage.salvageItem(item, { consumeSource: true, random: () => 0 });
+  expect(result.salvaged).toBe(true);
+  expect(result.sourceConsumed).toBe(true);
+  expect(item.quantity).toBe(2);
+});

--- a/tests/workshop_runtime.spec.js
+++ b/tests/workshop_runtime.spec.js
@@ -1,0 +1,125 @@
+const { test, expect } = require("@playwright/test");
+
+global.LuminousItemRuntime = require("../js/item-runtime-engine.js");
+global.LuminousItemInventoryRuntime = require("../js/item-inventory-runtime.js");
+const workshops = require("../js/workshop-runtime.js");
+
+const namePools = [
+  { tokenRole: "single", token: "Vesper", weight: 1, specializationAffinity: "weapon" },
+  { tokenRole: "adjective", token: "Black", weight: 1, specializationAffinity: "weapon" },
+  { tokenRole: "noun", token: "Needle", weight: 1, specializationAffinity: "weapon" },
+];
+const specializations = [{ id: "weapon_blades", familyIds: ["family:weapon_blades"] }];
+const modules = [
+  { id: "module:edge", specializations: ["weapon_blades"] },
+  { id: "module:balance", specializations: ["weapon_blades"] },
+];
+const itemCatalog = [{
+  id: "item:scythe",
+  name: "Scythe",
+  tier: 4,
+  familyIds: ["family:weapon_blades"],
+  moduleCapacity: 2,
+  price: 100,
+}];
+
+test.beforeEach(() => workshops.clearWorkshops());
+
+test("Workshop names store raw manufacturer name and never the Workshop suffix", () => {
+  const created = workshops.createWorkshopInstance({
+    worldSeed: "world-a",
+    regionId: "district-1",
+    workshopId: "workshop:vesper",
+    workshopTier: 5,
+    namePools,
+    specializations,
+    primarySpecialization: "weapon_blades",
+    modules,
+    technologies: ["tech:precision"],
+  });
+  expect(created.created).toBe(true);
+  expect(created.workshop.workshopName).not.toContain("Workshop");
+  expect(workshops.validateWorkshopName("Vesper Workshop").reason).toBe("raw_name_contains_workshop");
+});
+
+test("same workshop seed produces the same persistent identity fields", () => {
+  const options = {
+    worldSeed: "world-a",
+    regionId: "district-1",
+    workshopId: "workshop:one",
+    workshopTier: 5,
+    namePools,
+    specializations,
+    primarySpecialization: "weapon_blades",
+    modules,
+    technologies: ["tech:precision"],
+  };
+  const first = workshops.createWorkshopInstance(options).workshop;
+  workshops.clearWorkshops();
+  const second = workshops.createWorkshopInstance(options).workshop;
+  expect(second.workshopName).toBe(first.workshopName);
+  expect(second.knownModuleIds).toEqual(first.knownModuleIds);
+  expect(second.signatureModuleIds).toEqual(first.signatureModuleIds);
+  expect(second.signatureTechnologyIds).toEqual(first.signatureTechnologyIds);
+});
+
+test("Workshop products keep generic definitions and receive manufacturer provenance", () => {
+  const created = workshops.createWorkshopInstance({
+    worldSeed: "world-a",
+    regionId: "district-1",
+    workshopId: "workshop:blade",
+    workshopName: "Vesper",
+    workshopTier: 5,
+    specializations,
+    primarySpecialization: "weapon_blades",
+    modules,
+    technologies: ["tech:precision"],
+  });
+  const result = workshops.generateProduct(created.workshop, { itemCatalog, restockCycleId: "cycle-1", index: 0 });
+  expect(result.generated).toBe(true);
+  expect(result.instance.definitionId).toBe("item:scythe");
+  expect(result.instance.manufacturerId).toBe("workshop:blade");
+  expect(result.resolved.displayName).toBe("Vesper Workshop Scythe");
+  expect(result.instance.installedModuleIds.every((id) => created.workshop.knownModuleIds.includes(id))).toBe(true);
+});
+
+test("restock is deterministic for the same cycle but produces unique product serials", () => {
+  const created = workshops.createWorkshopInstance({
+    worldSeed: "world-a",
+    regionId: "district-1",
+    workshopId: "workshop:restock",
+    workshopName: "Black Needle",
+    workshopTier: 5,
+    specializations,
+    primarySpecialization: "weapon_blades",
+    modules,
+  });
+  const first = workshops.restockWorkshop(created.workshop, { itemCatalog, restockCycleId: "cycle-2", count: 3 });
+  const second = workshops.restockWorkshop(created.workshop, { itemCatalog, restockCycleId: "cycle-2", count: 3 });
+  expect(first.products.map((entry) => entry.instance.instanceId)).toEqual(second.products.map((entry) => entry.instance.instanceId));
+  expect(new Set(first.products.map((entry) => entry.instance.productSerial)).size).toBe(3);
+});
+
+test("Product Lines append after the mandatory Workshop product name", () => {
+  const created = workshops.createWorkshopInstance({
+    workshopId: "workshop:vesper",
+    workshopName: "Vesper",
+    workshopTier: 7,
+    primarySpecialization: "weapon_blades",
+    knownItemFamilies: ["family:weapon_blades"],
+  });
+  const line = workshops.createProductLine(created.workshop, {
+    force: true,
+    productLineName: "Pale Harvest",
+    compatibleItemFamilies: ["family:weapon_blades"],
+    qualityBias: 1,
+  });
+  expect(line.created).toBe(true);
+  const product = workshops.generateProduct(created.workshop, {
+    itemCatalog,
+    productLine: line.productLine,
+    restockCycleId: "cycle-3",
+    index: 0,
+  });
+  expect(product.resolved.displayName).toBe("Vesper Workshop Scythe — Pale Harvest");
+});


### PR DESCRIPTION
## Summary

Rebuilds the functional Item Runtime on top of the current `main` instead of the stale #634 branch, then adds a shared Firebase Realtime sync adapter for Player and DM inventories.

### Canonical item runtime
- Compact `ItemInstance` state with legacy HUD compatibility.
- Active Inventory / Stash movement and stacking.
- Quality, Condition, Charges, ownership/provenance.
- Workshop manufacturer/product lines and deterministic stock.
- Magic-item bridge, Attunement, Augments and Salvage.

### Realtime integration
- Player and DM bind to the same `campaña/jugadores/<playerId>` source of truth.
- Shared realtime subscription to `inventario_activo` and `inventario_stash`.
- Incoming Firebase state updates local runtime/UI state without automatic write-back, preventing echo loops.
- Explicit save/move operations write once and rely on Firebase fanout to update every connected peer.
- Global Stash access is observed in realtime through `campaña/ajustes_globales/alijo_desbloqueado`.
- Only the DM role can change global Stash access through the adapter by default.
- Listener disposal prevents stale character/player subscriptions.

### Realtime tests
The new test suite simulates Firebase Realtime Database with two simultaneous clients and verifies:
1. Player -> DM active inventory propagation without reload.
2. DM -> Player stash propagation without reload.
3. Active -> Stash movement converges on both peers.
4. DM Stash unlock propagates to Player in realtime.
5. Player cannot change global Stash access through the adapter by default.
6. Disposed peers stop receiving updates.
7. Existing Player and DM UIs still use the same `inventario_activo` / `inventario_stash` realtime contract.

Supersedes the stale implementation PR #634, which had diverged significantly from current `main`.