### PR TITLE
fix(vtt): keep Map Mode menus usable without logging chatter

### DIFF
--- a/js/instance-control.js
+++ b/js/instance-control.js
@@ -3,6 +3,9 @@
 
   const INSTANCE_PATH = "campaña/estado_mundo/instancia_activa";
   const DEFAULT_THEATRE_SCENE_PATH = "campaña/estado_mundo/escena_actual";
+  const PLAYER_MAP_Z_INDEX = "8000";
+  const MAP_DIALOGUE_RETRY_MS = 250;
+  const MAP_DIALOGUE_STUCK_MS = 120000;
   const COMBAT_RUNTIME_SCRIPTS = Object.freeze([
     ["combat-player-trait-runtime-script", "js/player-trait-runtime.js", "LuminousPlayerTraitRuntime"],
     ["combat-trait-standardization-runtime-script", "js/trait-standardization-runtime.js", "LuminousTraitStandardizationRuntime"],
@@ -116,6 +119,52 @@
     return true;
   }
 
+  function applyPlayerMapUiPolicy(mapActive, doc) {
+    const documentRef = doc || global.document;
+    if (!documentRef) return false;
+
+    const phoneWrapper = documentRef.querySelector?.(".sheet-phone-wrapper") || null;
+    if (phoneWrapper) {
+      if (mapActive) {
+        if (!phoneWrapper.classList?.contains?.("phone-hidden")) {
+          phoneWrapper.dataset ||= {};
+          phoneWrapper.dataset.mapWasVisible = "true";
+          phoneWrapper.classList?.add?.("phone-hidden");
+        }
+        if (phoneWrapper.style) phoneWrapper.style.zIndex = "10000";
+      } else {
+        if (phoneWrapper.style) phoneWrapper.style.zIndex = "";
+        if (phoneWrapper.dataset?.mapWasVisible === "true") {
+          phoneWrapper.classList?.remove?.("phone-hidden");
+          delete phoneWrapper.dataset.mapWasVisible;
+        }
+      }
+    }
+
+    const logButtons = [
+      documentRef.getElementById("btn-toggle-theatre-log-player"),
+      documentRef.getElementById("btn-toggle-theatre-log"),
+    ].filter(Boolean);
+
+    logButtons.forEach((button) => {
+      button.disabled = Boolean(mapActive);
+      button.setAttribute?.("aria-disabled", mapActive ? "true" : "false");
+      if (mapActive) button.setAttribute?.("aria-expanded", "false");
+    });
+
+    if (mapActive) {
+      const logContainer = documentRef.getElementById("theatre-log-container");
+      if (logContainer) {
+        logContainer.classList?.remove?.("active");
+        logContainer.classList?.remove?.("open");
+        if (logContainer.style) logContainer.style.display = "none";
+        logContainer.setAttribute?.("aria-hidden", "true");
+      }
+    }
+
+    return Boolean(mapActive);
+  }
+
   function applyPlayerInstance(instance, doc) {
     const documentRef = doc || global.document;
     const activeInstance = normalizeInstance(instance);
@@ -126,6 +175,8 @@
     const blackout = documentRef.getElementById("player-instance-blackout");
     let combatView = documentRef.getElementById("player-instance-combat");
     let mapView = documentRef.getElementById("player-instance-map");
+
+    applyPlayerMapUiPolicy(mapActive, documentRef);
 
     if (!combatView && documentRef.body) {
       combatView = documentRef.createElement("iframe");
@@ -152,7 +203,7 @@
       mapView.setAttribute("aria-hidden", "true");
       Object.assign(mapView.style, {
         display: "none", position: "fixed", inset: "0", width: "100vw",
-        height: "100vh", border: "0", zIndex: "10000", background: "#000",
+        height: "100vh", border: "0", zIndex: PLAYER_MAP_Z_INDEX, background: "#000",
       });
       mapView.src = "vtt.html";
       documentRef.body.appendChild(mapView);
@@ -343,6 +394,158 @@
     return { link, script };
   }
 
+  function createMapDialogueQueueProcessor({ db, theatre, setTimer } = {}) {
+    const theatreState = theatre || global.LuminousTheatreState;
+    const schedule = setTimer || global.setTimeout?.bind(global);
+    if (!db || !theatreState?.getPaths || !theatreState?.publishIntervention || !schedule) return null;
+
+    let processing = false;
+    let stopped = false;
+    let queueRef = null;
+    let instanceRef = null;
+    let queueListener = null;
+    let instanceListener = null;
+
+    const retry = () => {
+      if (stopped) return;
+      schedule(() => {
+        process().catch((error) => console.error("Error procesando diálogo de Modo Mapa:", error));
+      }, MAP_DIALOGUE_RETRY_MS);
+    };
+
+    const claimQueueItem = (ref) => new Promise((resolve, reject) => {
+      ref.transaction((current) => {
+        if (!current) return current;
+        const now = Date.now();
+        const stuck = current.processing && current.processingStartedAt &&
+          (now - Number(current.processingStartedAt) > MAP_DIALOGUE_STUCK_MS);
+        if (current.processing && !stuck) return;
+        current.processing = true;
+        current.processingStartedAt = now;
+        return current;
+      }, (error, committed, snapshot) => {
+        if (error) reject(error);
+        else resolve(committed ? snapshot.val() : null);
+      });
+    });
+
+    async function releaseQueueItem(ref) {
+      if (typeof ref.update === "function") {
+        await ref.update({ processing: null, processingStartedAt: null });
+      }
+    }
+
+    async function process() {
+      if (stopped || processing) return false;
+
+      const activeSnapshot = await db.ref(INSTANCE_PATH).once("value");
+      if (normalizeInstance(activeSnapshot.val()) !== "mapa") return false;
+
+      const paths = theatreState.getPaths();
+      const nextSnapshot = await db.ref(paths.queue)
+        .orderByChild("createdAt")
+        .limitToFirst(1)
+        .once("value");
+      if (!nextSnapshot.exists()) return false;
+
+      const queued = nextSnapshot.val() || {};
+      const messageId = Object.keys(queued)[0];
+      if (!messageId) return false;
+
+      const messageRef = db.ref(`${paths.queue}/${messageId}`);
+      processing = true;
+
+      let claimed;
+      try {
+        claimed = await claimQueueItem(messageRef);
+      } catch (error) {
+        processing = false;
+        console.error("No se pudo reclamar el diálogo de Modo Mapa:", error);
+        retry();
+        return false;
+      }
+
+      if (!claimed) {
+        processing = false;
+        retry();
+        return false;
+      }
+
+      const verifySnapshot = await db.ref(INSTANCE_PATH).once("value");
+      if (normalizeInstance(verifySnapshot.val()) !== "mapa") {
+        await releaseQueueItem(messageRef).catch(() => {});
+        processing = false;
+        return false;
+      }
+
+      const textLength = String(claimed.mensaje || "").length;
+      claimed.speedMs = Math.max(1, Number(claimed.speedMs) || 30);
+      claimed.durationMs = Math.max(0, Number(claimed.durationMs) || ((textLength * claimed.speedMs) + 3000));
+
+      const result = await theatreState.publishIntervention(messageId, claimed).catch((error) => {
+        console.error("Error publicando diálogo de Modo Mapa:", error);
+        return { published: false, reason: "error" };
+      });
+
+      if (!result?.published) {
+        await messageRef.remove().catch((error) => console.error("No se pudo descartar diálogo inválido de Modo Mapa:", error));
+        processing = false;
+        retry();
+        return false;
+      }
+
+      // Map dialogue is transient world chatter. It deliberately never writes to paths.log.
+      schedule(async () => {
+        try {
+          await messageRef.remove();
+        } catch (error) {
+          console.error("No se pudo finalizar diálogo de Modo Mapa:", error);
+        } finally {
+          processing = false;
+          process().catch((error) => console.error("Error continuando diálogo de Modo Mapa:", error));
+        }
+      }, claimed.durationMs);
+
+      return true;
+    }
+
+    function start() {
+      if (stopped || queueRef || instanceRef) return api;
+      const paths = theatreState.getPaths();
+      queueRef = db.ref(paths.queue);
+      instanceRef = db.ref(INSTANCE_PATH);
+      queueListener = () => {
+        process().catch((error) => console.error("Error iniciando diálogo de Modo Mapa:", error));
+      };
+      instanceListener = (snapshot) => {
+        if (normalizeInstance(snapshot.val()) === "mapa") queueListener();
+      };
+      queueRef.on("child_added", queueListener);
+      instanceRef.on("value", instanceListener);
+      return api;
+    }
+
+    function stop() {
+      stopped = true;
+      if (queueRef && queueListener) queueRef.off?.("child_added", queueListener);
+      if (instanceRef && instanceListener) instanceRef.off?.("value", instanceListener);
+      queueRef = null;
+      instanceRef = null;
+      queueListener = null;
+      instanceListener = null;
+      return true;
+    }
+
+    const api = Object.freeze({ process, start, stop });
+    return api;
+  }
+
+  function bindMapDialogueQueue({ db } = {}) {
+    const processor = createMapDialogueQueueProcessor({ db });
+    processor?.start();
+    return processor;
+  }
+
   function bindDashboard({ db, doc } = {}) {
     const documentRef = doc || global.document;
     if (!db || !documentRef) return;
@@ -354,6 +557,7 @@
     ensureDashboardCharacterManager({ db, doc: documentRef });
     ensureDashboardActorStudioAssets(documentRef);
     ensureDmLocationControl({ db, doc: documentRef });
+    bindMapDialogueQueue({ db });
 
     documentRef.querySelectorAll('input[name="instancia"]').forEach((radio) => {
       radio.addEventListener("change", (evento) => {
@@ -387,6 +591,7 @@
     INSTANCE_PATH,
     applyDmInstance,
     applyPlayerInstance,
+    applyPlayerMapUiPolicy,
     applyDashboardInstance,
     ensureCombatTraitRuntime,
     ensureDmLocationControl,
@@ -395,6 +600,8 @@
     ensureTheatreOpposedAssets,
     ensureDashboardCharacterManager,
     ensureDashboardActorStudioAssets,
+    createMapDialogueQueueProcessor,
+    bindMapDialogueQueue,
     bindDm,
     bindDashboard,
     bindPlayer,

--- a/js/vtt/main.js
+++ b/js/vtt/main.js
@@ -23,6 +23,7 @@ import './movement-engine.js';
 import './movement-state.js';
 import './physical-state-patch.js';
 import './movement-integration-patch.js';
+import './map-dialogue-overlay.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
     const canvas = document.getElementById('vtt-canvas');
@@ -229,6 +230,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     window.addEventListener('beforeunload', () => {
         stopMapWatch();
+        window.LuminousVttMapDialogueOverlay?.stop?.();
         window.LuminousVttWallBuilderRuntime?.stop?.();
         window.LuminousVttStructureRuntime?.stop?.();
         window.LuminousVttSurfaceRuntime?.stop?.();

--- a/js/vtt/map-dialogue-overlay.js
+++ b/js/vtt/map-dialogue-overlay.js
@@ -1,0 +1,133 @@
+const INSTANCE_PATH = 'campaña/estado_mundo/instancia_activa';
+const DEFAULT_DIALOGUE_PATH = 'campaña/estado_mundo/dialogo_activo';
+const MIN_VISIBLE_MS = 1200;
+
+function hostWindow(root = window) {
+    try {
+        if (root.parent && root.parent !== root && root.parent.document) return root.parent;
+    } catch (_) {}
+    return root;
+}
+
+function hideOverlay(element, timerRef) {
+    if (timerRef.value) {
+        clearTimeout(timerRef.value);
+        timerRef.value = null;
+    }
+    element.hidden = true;
+    element.textContent = '';
+}
+
+function createOverlay(documentRef) {
+    const element = documentRef.createElement('div');
+    element.id = 'vtt-map-dialogue-overlay';
+    element.hidden = true;
+    element.setAttribute('role', 'status');
+    element.setAttribute('aria-live', 'polite');
+    Object.assign(element.style, {
+        position: 'fixed',
+        left: '50%',
+        bottom: '7vh',
+        transform: 'translateX(-50%)',
+        width: 'max-content',
+        maxWidth: '72vw',
+        padding: '8px 14px',
+        border: '1px solid rgba(220, 220, 220, 0.35)',
+        background: 'rgba(5, 5, 5, 0.78)',
+        color: '#f1f1f1',
+        fontFamily: 'Share Tech Mono, monospace',
+        fontSize: 'clamp(13px, 1.35vw, 18px)',
+        lineHeight: '1.35',
+        textAlign: 'center',
+        textShadow: '0 1px 3px #000',
+        boxShadow: '0 4px 18px rgba(0, 0, 0, 0.45)',
+        pointerEvents: 'none',
+        zIndex: '7000',
+        whiteSpace: 'pre-wrap',
+    });
+    documentRef.body.appendChild(element);
+    return element;
+}
+
+export function start({ root = window } = {}) {
+    if (root.LuminousVttMapDialogueOverlay?.active) return root.LuminousVttMapDialogueOverlay;
+
+    const host = hostWindow(root);
+    const firebase = host?.firebase || root?.firebase || null;
+    const db = firebase?.database?.() || null;
+    const documentRef = root.document;
+    if (!db || !documentRef?.body) return null;
+
+    const theatre = host?.LuminousTheatreState || null;
+    const dialoguePath = theatre?.getPaths?.().dialogue || DEFAULT_DIALOGUE_PATH;
+    const dialogueRef = db.ref(dialoguePath);
+    const instanceRef = db.ref(INSTANCE_PATH);
+    const element = createOverlay(documentRef);
+    const timerRef = { value: null };
+    let mapActive = false;
+    let currentDialogue = null;
+
+    const render = () => {
+        const payload = currentDialogue || {};
+        if (!mapActive || !payload.mensaje || payload.tipo_dialogo === 'pensamiento') {
+            hideOverlay(element, timerRef);
+            return;
+        }
+
+        const now = Date.now();
+        const durationMs = Math.max(MIN_VISIBLE_MS, Number(payload.durationMs) || 3000);
+        const startedAt = Number(payload.startedAt) || now;
+        const remainingMs = Math.max(0, (startedAt + durationMs) - now);
+        if (!remainingMs) {
+            hideOverlay(element, timerRef);
+            return;
+        }
+
+        const resolved = typeof theatre?.resolveLanguageText === 'function'
+            ? theatre.resolveLanguageText(payload.mensaje, payload)
+            : String(payload.mensaje || '');
+        const text = String(resolved || '').trim();
+        if (!text) {
+            hideOverlay(element, timerRef);
+            return;
+        }
+
+        if (timerRef.value) clearTimeout(timerRef.value);
+        element.textContent = text;
+        element.hidden = false;
+        timerRef.value = setTimeout(() => hideOverlay(element, timerRef), remainingMs);
+    };
+
+    const onDialogue = (snapshot) => {
+        currentDialogue = snapshot.val() || null;
+        render();
+    };
+    const onInstance = (snapshot) => {
+        mapActive = snapshot.val() === 'mapa';
+        render();
+    };
+
+    dialogueRef.on('value', onDialogue);
+    instanceRef.on('value', onInstance);
+
+    const api = Object.freeze({
+        active: true,
+        stop() {
+            dialogueRef.off?.('value', onDialogue);
+            instanceRef.off?.('value', onInstance);
+            hideOverlay(element, timerRef);
+            element.remove?.();
+            if (root.LuminousVttMapDialogueOverlay === api) delete root.LuminousVttMapDialogueOverlay;
+        },
+    });
+    root.LuminousVttMapDialogueOverlay = api;
+    return api;
+}
+
+if (typeof window !== 'undefined') {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => start(), { once: true });
+    } else {
+        start();
+    }
+}

--- a/tests/vtt_map_dialogue_overlay.spec.js
+++ b/tests/vtt_map_dialogue_overlay.spec.js
@@ -1,0 +1,21 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+const mainSource = read('js/vtt/main.js');
+const overlaySource = read('js/vtt/map-dialogue-overlay.js');
+
+test('VTT loads the transient Map Mode dialogue overlay', () => {
+    expect(mainSource).toContain("import './map-dialogue-overlay.js';");
+    expect(mainSource).toContain('window.LuminousVttMapDialogueOverlay?.stop?.()');
+});
+
+test('Map dialogue overlay reads active dialogue without touching Theatre Log', () => {
+    expect(overlaySource).toContain("campaña/estado_mundo/instancia_activa");
+    expect(overlaySource).toContain("campaña/estado_mundo/dialogo_activo");
+    expect(overlaySource).toContain('resolveLanguageText');
+    expect(overlaySource).toContain("payload.tipo_dialogo === 'pensamiento'");
+    expect(overlaySource).not.toContain('campaña/teatro/log');
+    expect(overlaySource).not.toContain('.push(');
+});

--- a/tests/vtt_map_mode_log_boundary.spec.js
+++ b/tests/vtt_map_mode_log_boundary.spec.js
@@ -1,0 +1,240 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const instanceSource = fs.readFileSync(path.join(__dirname, '..', 'js/instance-control.js'), 'utf8');
+
+function createClassList(initial = []) {
+    const values = new Set(initial);
+    return {
+        add(...items) { items.forEach((item) => values.add(item)); },
+        remove(...items) { items.forEach((item) => values.delete(item)); },
+        toggle(item, force) {
+            if (force === true) { values.add(item); return true; }
+            if (force === false) { values.delete(item); return false; }
+            if (values.has(item)) { values.delete(item); return false; }
+            values.add(item); return true;
+        },
+        contains(item) { return values.has(item); },
+    };
+}
+
+function createPlayerDocument() {
+    const nodes = new Map();
+    const theatre = {
+        id: 'theatre-view-player',
+        style: {},
+        classList: createClassList(),
+        setAttribute() {},
+    };
+    const logButton = {
+        id: 'btn-toggle-theatre-log-player',
+        disabled: false,
+        attributes: {},
+        setAttribute(name, value) { this.attributes[name] = String(value); },
+    };
+    const inventoryButton = {
+        id: 'btn-global-inventory',
+        disabled: false,
+        setAttribute() {},
+    };
+    const logContainer = {
+        id: 'theatre-log-container',
+        style: { display: 'flex' },
+        classList: createClassList(['active']),
+        attributes: {},
+        setAttribute(name, value) { this.attributes[name] = String(value); },
+    };
+    const phoneWrapper = {
+        style: {},
+        dataset: {},
+        classList: createClassList(),
+    };
+    [theatre, logButton, inventoryButton, logContainer].forEach((node) => nodes.set(node.id, node));
+
+    const body = {
+        classList: createClassList(),
+        appendChild(node) {
+            node.parentNode = body;
+            nodes.set(node.id, node);
+            return node;
+        },
+        removeChild(node) {
+            nodes.delete(node.id);
+            node.parentNode = null;
+            node.removed = true;
+            return node;
+        },
+    };
+
+    return {
+        body,
+        phoneWrapper,
+        getElementById(id) { return nodes.get(id) || null; },
+        querySelector(selector) { return selector === '.sheet-phone-wrapper' ? phoneWrapper : null; },
+        createElement(tagName) {
+            const attributes = new Map();
+            return {
+                tagName: String(tagName).toUpperCase(),
+                style: {},
+                dataset: {},
+                classList: createClassList(),
+                setAttribute(name, value) { attributes.set(name, String(value)); },
+                removeAttribute(name) { attributes.delete(name); },
+                addEventListener() {},
+                remove() {
+                    if (this.parentNode) this.parentNode.removeChild(this);
+                    else this.removed = true;
+                },
+            };
+        },
+    };
+}
+
+function loadInstanceControl() {
+    const context = { window: { setTimeout }, console, setTimeout };
+    vm.runInNewContext(instanceSource, context, { filename: 'js/instance-control.js' });
+    return context.window.LuminousInstanceControl;
+}
+
+function snapshot(value) {
+    return {
+        val: () => value,
+        exists: () => value !== null && value !== undefined &&
+            (typeof value !== 'object' || Object.keys(value).length > 0),
+    };
+}
+
+function createMapQueueDb(message, instance = 'mapa') {
+    const state = {
+        'campaña/estado_mundo/instancia_activa': instance,
+        'campaña/teatro/cola': message ? { message_1: { ...message } } : {},
+    };
+    const refs = [];
+
+    const resolve = (refPath) => {
+        if (Object.prototype.hasOwnProperty.call(state, refPath)) return state[refPath];
+        if (refPath.startsWith('campaña/teatro/cola/')) {
+            const key = refPath.slice('campaña/teatro/cola/'.length);
+            return state['campaña/teatro/cola'][key];
+        }
+        return undefined;
+    };
+
+    const assign = (refPath, value) => {
+        if (refPath.startsWith('campaña/teatro/cola/')) {
+            const key = refPath.slice('campaña/teatro/cola/'.length);
+            state['campaña/teatro/cola'][key] = value;
+            return;
+        }
+        state[refPath] = value;
+    };
+
+    const db = {
+        ref(refPath) {
+            refs.push(refPath);
+            return {
+                once: async () => snapshot(resolve(refPath)),
+                orderByChild() { return this; },
+                limitToFirst() { return this; },
+                transaction(update, done) {
+                    const current = resolve(refPath);
+                    const candidate = update(current ? { ...current } : current);
+                    if (candidate === undefined) {
+                        done(null, false, snapshot(current));
+                        return;
+                    }
+                    assign(refPath, candidate);
+                    done(null, true, snapshot(candidate));
+                },
+                update: async (changes) => assign(refPath, { ...(resolve(refPath) || {}), ...changes }),
+                remove: async () => {
+                    if (refPath.startsWith('campaña/teatro/cola/')) {
+                        const key = refPath.slice('campaña/teatro/cola/'.length);
+                        delete state['campaña/teatro/cola'][key];
+                    } else {
+                        delete state[refPath];
+                    }
+                },
+                on() {},
+                off() {},
+            };
+        },
+    };
+
+    return { db, refs, state };
+}
+
+test('Map Mode keeps player menus above the VTT and blocks only Theatre Log access', () => {
+    const instanceControl = loadInstanceControl();
+    const documentRef = createPlayerDocument();
+
+    instanceControl.applyPlayerInstance('mapa', documentRef);
+
+    const mapView = documentRef.getElementById('player-instance-map');
+    const logButton = documentRef.getElementById('btn-toggle-theatre-log-player');
+    const inventoryButton = documentRef.getElementById('btn-global-inventory');
+    const logContainer = documentRef.getElementById('theatre-log-container');
+
+    expect(mapView.style.zIndex).toBe('8000');
+    expect(logButton.disabled).toBe(true);
+    expect(logButton.attributes['aria-disabled']).toBe('true');
+    expect(inventoryButton.disabled).toBe(false);
+    expect(logContainer.style.display).toBe('none');
+    expect(logContainer.classList.contains('active')).toBe(false);
+    expect(documentRef.phoneWrapper.classList.contains('phone-hidden')).toBe(true);
+    expect(documentRef.phoneWrapper.style.zIndex).toBe('10000');
+
+    instanceControl.applyPlayerInstance('teatro', documentRef);
+    expect(logButton.disabled).toBe(false);
+    expect(logButton.attributes['aria-disabled']).toBe('false');
+    expect(documentRef.phoneWrapper.style.zIndex).toBe('');
+    expect(documentRef.phoneWrapper.classList.contains('phone-hidden')).toBe(false);
+});
+
+test('Map Mode publishes queued speech but never touches the Theatre Log', async () => {
+    const instanceControl = loadInstanceControl();
+    const { db, refs, state } = createMapQueueDb({ mensaje: 'NPC chatter', createdAt: 1 });
+    const timers = [];
+    const published = [];
+    const theatre = {
+        getPaths: () => ({ queue: 'campaña/teatro/cola', log: 'campaña/teatro/log' }),
+        publishIntervention: async (messageId, payload) => {
+            published.push({ messageId, payload });
+            return { published: true, payload };
+        },
+    };
+
+    const processor = instanceControl.createMapDialogueQueueProcessor({
+        db,
+        theatre,
+        setTimer: (callback, delay) => timers.push({ callback, delay }),
+    });
+
+    expect(await processor.process()).toBe(true);
+    expect(published).toHaveLength(1);
+    expect(published[0].messageId).toBe('message_1');
+    expect(timers).toHaveLength(1);
+    expect(timers[0].delay).toBeGreaterThanOrEqual(3000);
+    expect(refs).not.toContain('campaña/teatro/log');
+
+    await timers[0].callback();
+    expect(state['campaña/teatro/cola'].message_1).toBeUndefined();
+    expect(refs).not.toContain('campaña/teatro/log');
+});
+
+test('Map dialogue processor does not consume or alter Theatre-mode messages', async () => {
+    const instanceControl = loadInstanceControl();
+    const { db, state } = createMapQueueDb({ mensaje: 'Theatre line', createdAt: 1 }, 'teatro');
+    let published = false;
+    const theatre = {
+        getPaths: () => ({ queue: 'campaña/teatro/cola', log: 'campaña/teatro/log' }),
+        publishIntervention: async () => { published = true; return { published: true }; },
+    };
+    const processor = instanceControl.createMapDialogueQueueProcessor({ db, theatre, setTimer: () => {} });
+
+    expect(await processor.process()).toBe(false);
+    expect(published).toBe(false);
+    expect(state['campaña/teatro/cola'].message_1.mensaje).toBe('Theatre line');
+});


### PR DESCRIPTION
## Resumen

Corrige el límite entre **Modo Mapa**, el HUD del jugador y el Theatre Log.

- Baja el iframe del VTT debajo del rail y modales del HUD para que los menús sigan siendo utilizables durante Modo Mapa.
- Al entrar a Mapa se cierra y deshabilita únicamente el acceso al Theatre Log; Inventario, Stats, Terminal y el resto del HUD siguen disponibles.
- La Terminal puede abrirse encima del mapa y se conserva/restaura su estado al salir.
- Añade un procesador específico de la cola de diálogo cuando `instancia_activa === mapa`: publica la intervención como estado activo/transitorio pero **nunca escribe en `campaña/teatro/log`**.
- Esto deja preparada la separación necesaria para futuras conversaciones NPC↔NPC sin llenar el historial del jugador.
- Añade un pequeño overlay de texto dentro del VTT para mostrar esas intervenciones transitorias mientras el mapa está activo; reutiliza la política de idioma del Theatre cuando está disponible y no muestra pensamientos.
- El overlay se desmonta junto con el runtime VTT.

## Regresiones

- Mapa queda debajo del rail HUD (`8000` vs `9000`) y de los modales (`10000`).
- Log queda cerrado/deshabilitado sólo en Modo Mapa y vuelve al salir.
- Inventario permanece habilitado.
- El procesador de Mapa publica mensajes pero no toca ninguna ruta de Log.
- En Teatro, el procesador de Mapa no reclama ni altera mensajes.
- El runtime VTT carga y limpia el overlay transitorio.

## Alcance

El parche no cambia el esquema del mapa, movimiento, pathfinding, iluminación, Fog/Memory ni el formato persistente del Theatre Log.