### PR TITLE
feat(vtt): professional DM zone creator UI

### DIFF
--- a/.github/workflows/vtt-procedural-zone-engine.yml
+++ b/.github/workflows/vtt-procedural-zone-engine.yml
@@ -5,8 +5,10 @@ on:
     paths:
       - 'js/vtt/procedural-*.js'
       - 'js/vtt/urban-fabric-core.js'
+      - 'js/vtt/dm-authoring-shell-polish.js'
       - 'js/vtt/semantic-map-bootstrap.js'
       - 'tests/vtt_procedural_zone_engine.spec.js'
+      - 'tests/vtt_procedural_dm_ui.spec.js'
       - '.github/workflows/vtt-procedural-zone-engine.yml'
   workflow_dispatch:
 
@@ -32,10 +34,13 @@ jobs:
           node --check js/vtt/procedural-generator-core.js
           node --input-type=module --check < js/vtt/procedural-generator-bootstrap.js
           node --input-type=module --check < js/vtt/procedural-generator-authoring-bootstrap.js
+          node --input-type=module --check < js/vtt/dm-authoring-shell-polish.js
+          node --input-type=module --check < js/vtt/semantic-map-bootstrap.js
       - name: Focused contracts
         run: >-
           npx playwright test
           tests/vtt_procedural_zone_engine.spec.js
+          tests/vtt_procedural_dm_ui.spec.js
           tests/vtt_building_navigation_graph.spec.js
           tests/vtt_building_archetypes.spec.js
           tests/vtt_building_semantic_model.spec.js

--- a/js/vtt/dm-authoring-shell-polish.js
+++ b/js/vtt/dm-authoring-shell-polish.js
@@ -1,0 +1,22 @@
+const STYLE_ID='vtt-dm-authoring-polish-style',HEADER_ID='vtt-dm-authoring-header';
+
+function injectStyles(doc){
+  if(!doc||doc.getElementById(STYLE_ID))return;
+  const style=doc.createElement('style');style.id=STYLE_ID;style.textContent=`
+.vtt-edit-sidebar{width:228px!important;gap:8px!important;padding:10px!important;background:rgba(7,9,11,.975)!important;border-color:#76652f!important;scrollbar-width:thin;scrollbar-color:#59636c #0a0d0f}
+#${HEADER_ID}{position:sticky;top:-10px;z-index:5;margin:-2px -2px 2px;padding:9px 8px 10px;background:linear-gradient(180deg,#121619 0%,#0a0d0f 100%);border-bottom:1px solid #76652f;box-shadow:0 5px 10px rgba(0,0,0,.28)}#${HEADER_ID} strong{display:block;color:#e6c861;font:700 11px/1 monospace;letter-spacing:.16em}#${HEADER_ID} small{display:block;margin-top:4px;color:#7f8a92;font:8px/1 monospace;letter-spacing:.14em}
+.vtt-edit-sidebar .vtt-toolbar,.vtt-edit-sidebar .vtt-light-toolbar{border:1px solid #343c42!important;background:#0c1013!important;padding:8px!important;box-shadow:0 2px 0 rgba(0,0,0,.35)}.vtt-edit-sidebar .vtt-toolbar-title{color:#d7b151!important;font-size:9px!important;letter-spacing:.14em!important;padding:2px 1px 7px!important}.vtt-edit-sidebar .brutalist-button{min-height:36px;border-color:#485159!important;background:#11161a!important;color:#e2e7ea!important;transition:border-color .12s ease,background .12s ease,color .12s ease,transform .12s ease}.vtt-edit-sidebar .brutalist-button:hover:not(:disabled){border-color:#8e7a39!important;background:#171c1f!important}.vtt-edit-sidebar .brutalist-button.is-active,.vtt-edit-sidebar .brutalist-button[aria-pressed="true"]{border-color:#d7b151!important;background:#27210f!important;color:#f2dc8d!important}.vtt-edit-sidebar button:focus-visible,.vtt-edit-sidebar input:focus-visible,.vtt-edit-sidebar select:focus-visible{outline:2px solid #e6c861!important;outline-offset:2px}.vtt-edit-sidebar button:disabled{opacity:.38!important;cursor:not-allowed!important}.vtt-edit-sidebar input,.vtt-edit-sidebar select{background:#080b0d!important;border:1px solid #465058!important;color:#edf1f3!important;padding:7px!important;box-sizing:border-box}.vtt-edit-sidebar .vtt-toolbar-field{gap:4px!important}.vtt-edit-sidebar .vtt-toolbar-field>label,.vtt-edit-sidebar label{letter-spacing:.04em}.vtt-panel,.vtt-light-panel{right:254px!important}.vtt-vertical-panel{right:584px!important}
+@media(max-width:900px){.vtt-edit-sidebar{width:176px!important}.vtt-panel,.vtt-light-panel{right:200px!important}.vtt-vertical-panel{right:200px!important}}
+`;doc.head.appendChild(style);
+}
+
+function ensureHeader(doc){
+  const sidebar=doc?.getElementById?.('vtt-edit-sidebar');if(!sidebar)return null;
+  let header=doc.getElementById(HEADER_ID);if(!header){header=doc.createElement('header');header.id=HEADER_ID;header.innerHTML='<strong>DM MAP TOOLS</strong><small>AUTHORING MODE</small>';}
+  if(sidebar.firstElementChild!==header)sidebar.prepend(header);return header;
+}
+
+export function install({root=window}={}){
+  const doc=root?.document;if(!doc)return()=>{};injectStyles(doc);ensureHeader(doc);
+  const timer=root.setInterval?.(()=>ensureHeader(doc),500);return()=>{if(timer!=null)root.clearInterval?.(timer);doc.getElementById(HEADER_ID)?.remove();doc.getElementById(STYLE_ID)?.remove();};
+}

--- a/js/vtt/procedural-generator-authoring-bootstrap.js
+++ b/js/vtt/procedural-generator-authoring-bootstrap.js
@@ -1,49 +1,124 @@
-const TOOLBAR_ID='vtt-procedural-generator-toolbar',STYLE_ID='vtt-procedural-generator-style';
+const LAUNCHER_ID='vtt-procedural-zone-launcher',PANEL_ID='vtt-procedural-zone-creator',STYLE_ID='vtt-procedural-zone-creator-style';
+const esc=value=>String(value??'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+const pct=value=>`${Math.round(Math.max(0,Math.min(1,Number(value)||0))*100)}%`;
+
+function randomSeed(prefix='luminous-zone'){
+  let suffix='';
+  try{const data=new Uint32Array(2);crypto.getRandomValues(data);suffix=[...data].map(x=>x.toString(36)).join('-');}catch(_){suffix=`${Date.now().toString(36)}-${Math.random().toString(36).slice(2,8)}`;}
+  return `${prefix}:${suffix}`;
+}
+
+function buildingFootprints(plan){
+  const byId=new Map();
+  for(const cell of plan?.generated?.surfaceCells||[]){
+    if(!cell.buildingId)continue;
+    const current=byId.get(cell.buildingId)||{id:cell.buildingId,minCol:cell.col,maxCol:cell.col,minRow:cell.row,maxRow:cell.row};
+    current.minCol=Math.min(current.minCol,cell.col);current.maxCol=Math.max(current.maxCol,cell.col);current.minRow=Math.min(current.minRow,cell.row);current.maxRow=Math.max(current.maxRow,cell.row);byId.set(cell.buildingId,current);
+  }
+  return[...byId.values()];
+}
+
+function svgRect(g,cls,title=''){
+  if(!g)return'';const x=Number(g.minCol)||0,y=Number(g.minRow)||0,w=Math.max(1,(Number(g.maxCol)||0)-x+1),h=Math.max(1,(Number(g.maxRow)||0)-y+1);
+  return`<rect class="${cls}" x="${x}" y="${y}" width="${w}" height="${h}">${title?`<title>${esc(title)}</title>`:''}</rect>`;
+}
+
+export function renderPreviewSvg(plan){
+  if(!plan?.zone)return'<div class="proc-empty-preview">GENERA UN PREVIEW PARA INSPECCIONAR LA ZONA</div>';
+  const zone=plan.zone,cols=Math.max(1,Number(zone.cols)||40),rows=Math.max(1,Number(zone.rows)||40),chunk=Math.max(1,Number(zone.chunkSize)||40);
+  const grid=[];for(let x=chunk;x<cols;x+=chunk)grid.push(`<line x1="${x}" y1="0" x2="${x}" y2="${rows}"/>`);for(let y=chunk;y<rows;y+=chunk)grid.push(`<line x1="0" y1="${y}" x2="${cols}" y2="${y}"/>`);
+  const parcels=(plan.fabric?.parcels||[]).map(p=>svgRect(p.geometry,'proc-svg-parcel',p.id)).join('');
+  const streets=(plan.fabric?.streets||[]).filter(s=>s.kind!=='alley').map(s=>svgRect(s.geometry,'proc-svg-street',s.semanticId||s.id)).join('');
+  const alleys=[...(plan.fabric?.streets||[]).filter(s=>s.kind==='alley'),...(plan.fabric?.alleys||[])].map(a=>svgRect(a.geometry,'proc-svg-alley',a.semanticId||a.id)).join('');
+  const buildings=buildingFootprints(plan).map(b=>svgRect(b,'proc-svg-building',b.id)).join('');
+  return`<svg class="proc-preview-svg" viewBox="0 0 ${cols} ${rows}" role="img" aria-label="Procedural zone preview"><rect class="proc-svg-ground" x="0" y="0" width="${cols}" height="${rows}"/>${parcels}${streets}${alleys}${buildings}<g class="proc-svg-chunks">${grid.join('')}</g></svg>`;
+}
+
+function validatorRows(plan){
+  if(!plan?.validation)return'<div class="proc-validation-empty">SIN VALIDACIÓN</div>';
+  const checks=plan.validation.checks||{},specs=[['boundary','BOUNDARY'],['semantic','SEMANTICS'],['buildings','BUILDINGS'],['archetypes','ARCHETYPES'],['navigation','NAVIGATION'],['physics','PHYSICS']];
+  return specs.map(([key,label])=>{const check=checks[key],valid=check?.valid!==false;return`<div class="proc-check ${valid?'is-valid':'is-invalid'}"><span>${label}</span><strong>${valid?'PASS':'FAIL'}</strong></div>`;}).join('');
+}
+
+function summaryMarkup(plan){
+  if(!plan)return'<div class="proc-summary-empty">NO HAY UN PLAN GENERADO</div>';
+  const v=plan.validation||{},s=v.summary||{},f=plan.fabric||{},z=plan.zone||{};
+  return`<div class="proc-summary-grid"><div><small>STATUS</small><strong class="${v.valid?'is-valid':'is-invalid'}">${v.valid?'VALID':'INVALID'}</strong></div><div><small>SIZE</small><strong>${z.cols||0}×${z.rows||0}</strong></div><div><small>BUILDINGS</small><strong>${s.buildings||0}</strong></div><div><small>STREETS</small><strong>${(f.streets||[]).length}</strong></div><div><small>PARCELS</small><strong>${(f.parcels||[]).length}</strong></div><div><small>ALLEYS</small><strong>${(f.alleys||[]).length}</strong></div></div><div class="proc-signature">SIGNATURE · ${esc(plan.signature||'—')}</div>`;
+}
 
 export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine?.mapData}={}){
   if(!runtime?.engine||!mapData||!runtime.bridge?.isDm)return null;
   if(window.LuminousVttProceduralGeneratorAuthoringRuntime?.stop)return window.LuminousVttProceduralGeneratorAuthoringRuntime;
   const procedural=runtime.procedural;if(!procedural)return null;
-  let toolbar=null,lastPlan=null,stopped=false,reroll=0;
+  let launcher=null,panel=null,lastPlan=null,stopped=false,reroll=0,applyArmed=false,selectedChunks=3;
   const enabled=()=>mapData.dmEditMode?.active===true;
+  const notify=(message,type='info')=>runtime.controller?.notify?.(message,type);
+  const baseSeed=()=>panel?.querySelector('[data-proc-seed]')?.value?.trim()||`${mapData.id||mapData.mapId||'map'}:zone`;
+  const currentProfile=()=>procedural.profiles().find(p=>p.id===(panel?.querySelector('[data-proc-profile]')?.value||'mixed_urban'))||procedural.profiles()[0]||{};
 
-  function values(){
-    const seed=toolbar?.querySelector('[data-proc-seed]')?.value?.trim()||`${mapData.id||mapData.mapId||'map'}:zone`;
-    const profileId=toolbar?.querySelector('[data-proc-profile]')?.value||'mixed_urban';
-    return{seed:reroll?`${seed}:reroll:${reroll}`:seed,profileId};
-  }
-  function notify(message,type='info'){runtime.controller?.notify?.(message,type);}
+  function values(){const seed=baseSeed();return{seed:reroll?`${seed}:reroll:${reroll}`:seed,profileId:currentProfile().id||'mixed_urban',chunkCols:selectedChunks,chunkRows:selectedChunks};}
+  function invalidate(){lastPlan=null;applyArmed=false;reroll=0;syncUi();}
+  function open(){if(!enabled())return;panel.hidden=false;panel.setAttribute('aria-hidden','false');syncUi();panel.querySelector('[data-proc-profile]')?.focus?.();}
+  function close(){panel.hidden=true;panel.setAttribute('aria-hidden','true');applyArmed=false;syncUi();}
+
   function preview(){
-    try{lastPlan=procedural.preview(values());notify(`Procedural válido · ${lastPlan.validation.summary.buildings} buildings · ${lastPlan.signature}`,'success');syncUi();return lastPlan;}
-    catch(error){lastPlan=null;const first=error?.failures?.[0]?.errors?.[0]?.code||error?.message||'PROCEDURAL_GENERATION_FAILED';notify(first,'warning');syncUi();return null;}
+    applyArmed=false;
+    try{lastPlan=procedural.preview(values());notify(`Zona procedural válida · ${lastPlan.validation.summary.buildings} buildings · ${lastPlan.signature}`,'success');}
+    catch(error){lastPlan=null;const first=error?.failures?.[0]?.errors?.[0]?.code||error?.message||'PROCEDURAL_GENERATION_FAILED';notify(first,'warning');}
+    syncUi();return lastPlan;
   }
+  function rerollPreview(){reroll+=1;applyArmed=false;return preview();}
+  function randomize(){const input=panel?.querySelector('[data-proc-seed]');if(input)input.value=randomSeed(`${mapData.id||mapData.mapId||'map'}:zone`);invalidate();}
   function apply(){
-    if(!lastPlan)return null;
-    try{procedural.apply(lastPlan,{replaceScene:true});notify(`Zone aplicada · ${lastPlan.signature}`,'success');syncUi();return lastPlan;}
-    catch(error){notify(error?.message||'PROCEDURAL_APPLY_FAILED','warning');return null;}
+    if(!lastPlan?.validation?.valid)return null;
+    if(!applyArmed){applyArmed=true;notify('Confirma APLICAR ZONA para reemplazar la geometría actual. Los tokens se conservarán.','warning');syncUi();return null;}
+    try{procedural.apply(lastPlan,{replaceScene:true});notify(`Zona aplicada · ${lastPlan.signature}`,'success');applyArmed=false;close();return lastPlan;}
+    catch(error){applyArmed=false;notify(error?.message||'PROCEDURAL_APPLY_FAILED','warning');syncUi();return null;}
   }
-  function rerollPreview(){reroll+=1;return preview();}
+
+  function profileMarkup(){const p=currentProfile();return[['DENSITY',p.density],['ATTACHED',p.attachBias],['ALLEYS',p.alleyBias],['SERVICE',p.serviceAccessBias]].map(([label,value])=>`<div class="proc-meter"><div><span>${label}</span><strong>${pct(value)}</strong></div><div class="proc-meter-track"><i style="width:${pct(value)}"></i></div></div>`).join('')+`<div class="proc-profile-meta">ROAD ${p.primaryRoadWidth||'—'} / ${p.secondaryRoadWidth||'—'} TILES · PARCEL ${p.minParcel||'—'}–${p.maxParcel||'—'} · SETBACK ${p.setback||0}</div>`;}
+
   function syncUi(){
-    if(!toolbar)return;toolbar.hidden=!enabled();
-    const applyButton=toolbar.querySelector('[data-proc-apply]'),readout=toolbar.querySelector('[data-proc-readout]');if(applyButton)applyButton.disabled=!lastPlan?.validation?.valid;
-    if(readout){if(!lastPlan)readout.textContent='NO PREVIEW';else{const f=lastPlan.fabric,v=lastPlan.validation;readout.textContent=`${v.valid?'VALID':'INVALID'} · 120×120 · C9 · ST ${f.streets.length} · B ${v.summary.buildings} · P ${f.parcels.length} · A ${f.alleys.length} · ${lastPlan.signature}`;}}
+    if(!launcher||!panel)return;launcher.hidden=!enabled();if(!enabled())panel.hidden=true;
+    launcher.querySelector('[data-proc-launch]')?.classList.toggle('is-active',!panel.hidden);
+    panel.querySelectorAll('[data-proc-size]').forEach(btn=>{const active=Number(btn.dataset.procSize)===selectedChunks;btn.classList.toggle('is-active',active);btn.setAttribute('aria-pressed',active?'true':'false');});
+    const profile=panel.querySelector('[data-proc-profile-summary]');if(profile)profile.innerHTML=profileMarkup();
+    const previewNode=panel.querySelector('[data-proc-visual]');if(previewNode)previewNode.innerHTML=renderPreviewSvg(lastPlan);
+    const summary=panel.querySelector('[data-proc-summary]');if(summary)summary.innerHTML=summaryMarkup(lastPlan);
+    const validation=panel.querySelector('[data-proc-validation]');if(validation)validation.innerHTML=validatorRows(lastPlan);
+    const applyButton=panel.querySelector('[data-proc-apply]');if(applyButton){applyButton.disabled=!lastPlan?.validation?.valid;applyButton.classList.toggle('is-armed',applyArmed);applyButton.textContent=applyArmed?'CONFIRMAR APLICACIÓN':'APLICAR ZONA';}
+    const warning=panel.querySelector('[data-proc-apply-warning]');if(warning)warning.hidden=!applyArmed;
+    const rerollButton=panel.querySelector('[data-proc-reroll]');if(rerollButton)rerollButton.disabled=!lastPlan;
   }
+
+  function installStyles(){
+    if(document.getElementById(STYLE_ID))return;const style=document.createElement('style');style.id=STYLE_ID;style.textContent=`
+#${LAUNCHER_ID}{display:flex;flex-direction:column;gap:5px}#${LAUNCHER_ID} [data-proc-launch]{min-height:44px}
+#${PANEL_ID}{position:fixed;right:252px;top:18px;z-index:36500;width:min(520px,calc(100vw - 290px));max-height:calc(100vh - 36px);overflow:auto;background:#090b0d;border:1px solid #806d2d;box-shadow:-8px 8px 0 rgba(0,0,0,.65);color:#e7ebee;font:11px/1.35 monospace;box-sizing:border-box}#${PANEL_ID}[hidden]{display:none!important}
+.proc-creator-head{position:sticky;top:0;z-index:2;display:flex;justify-content:space-between;align-items:center;padding:12px 14px;background:#0b0e11;border-bottom:1px solid #806d2d}.proc-creator-head h2{margin:0;font:700 14px/1 monospace;letter-spacing:.16em;color:#e6c861}.proc-close{width:32px;height:32px;background:#11161a;border:1px solid #59636c;color:#dce3e8;cursor:pointer}
+.proc-creator-body{display:grid;grid-template-columns:minmax(180px,.85fr) minmax(230px,1.15fr);gap:12px;padding:12px}.proc-card{border:1px solid #394149;background:#0d1013;padding:10px}.proc-card h3{margin:0 0 9px;color:#d7b151;font:700 10px/1 monospace;letter-spacing:.13em}.proc-field{display:grid;gap:5px;margin:0 0 10px}.proc-field>span{color:#8f9aa2;font-size:9px;letter-spacing:.1em}.proc-field input,.proc-field select{width:100%;box-sizing:border-box;background:#080a0c;border:1px solid #4d565e;color:#edf1f3;padding:8px;font:11px monospace}.proc-seed-row{display:grid;grid-template-columns:1fr auto;gap:5px}.proc-size-row{display:grid;grid-template-columns:repeat(3,1fr);gap:5px}.proc-size-row button,.proc-actions button,.proc-seed-row button{background:#11161a;border:1px solid #59636c;color:#dce3e8;padding:8px;cursor:pointer;font:700 10px monospace}.proc-size-row button.is-active{border-color:#d7b151;color:#f4dc8c;background:#25200f}.proc-actions button:disabled{opacity:.35;cursor:not-allowed}.proc-actions{display:grid;grid-template-columns:1fr 1fr;gap:6px;margin-top:10px}.proc-actions [data-proc-generate]{grid-column:1/-1;border-color:#d7b151;color:#f2d774}.proc-actions [data-proc-apply]{grid-column:1/-1;border-color:#587b61;color:#aee1b8}.proc-actions [data-proc-apply].is-armed{border-color:#c36e53;color:#ffd0c2;background:#27120d}.proc-apply-warning{margin-top:7px;padding:7px;border:1px solid #9b5744;color:#ffc3b2;background:#22100c}
+.proc-meter{margin:7px 0}.proc-meter>div:first-child{display:flex;justify-content:space-between;color:#aeb6bc;font-size:9px}.proc-meter-track{height:4px;background:#242a2f;margin-top:3px;overflow:hidden}.proc-meter-track i{display:block;height:100%;background:#b89d4a}.proc-profile-meta{margin-top:9px;color:#7f8a92;font-size:9px}.proc-preview-wrap{aspect-ratio:1/1;min-height:230px;border:1px solid #333b42;background:#07090a;display:grid;place-items:center;overflow:hidden}.proc-preview-svg{width:100%;height:100%;display:block}.proc-svg-ground{fill:#11161a}.proc-svg-parcel{fill:none;stroke:#252d33;stroke-width:.35}.proc-svg-street{fill:#394149}.proc-svg-alley{fill:#252c31}.proc-svg-building{fill:#765f28;stroke:#d7b151;stroke-width:.35}.proc-svg-chunks{stroke:#64717a;stroke-width:.25;stroke-dasharray:1.5 1.5;opacity:.65}.proc-empty-preview{padding:18px;text-align:center;color:#68747c;font-size:9px}.proc-summary-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:5px}.proc-summary-grid>div{border:1px solid #30373d;padding:6px}.proc-summary-grid small{display:block;color:#737e86;font-size:8px}.proc-summary-grid strong{display:block;margin-top:2px}.is-valid{color:#9bd3a7!important}.is-invalid{color:#ef9276!important}.proc-signature{margin-top:6px;color:#7d878e;font-size:9px;overflow-wrap:anywhere}.proc-check{display:flex;justify-content:space-between;padding:5px 0;border-bottom:1px solid #252b30}.proc-check:last-child{border-bottom:0}.proc-validation-empty,.proc-summary-empty{color:#68747c;font-size:9px}.proc-footer{padding:0 12px 12px;color:#7f8a92;font-size:9px}.proc-footer strong{color:#b5bdc3}
+@media(max-width:900px){#${PANEL_ID}{right:176px;width:calc(100vw - 194px)}.proc-creator-body{grid-template-columns:1fr}.proc-preview-wrap{min-height:180px}}
+`;document.head.appendChild(style);
+  }
+
   function ensureUi(){
-    if(!document.getElementById(STYLE_ID)){const style=document.createElement('style');style.id=STYLE_ID;style.textContent=`#${TOOLBAR_ID}{border-color:#f0ca59!important;display:flex;gap:6px;align-items:center;flex-wrap:wrap}#${TOOLBAR_ID} input,#${TOOLBAR_ID} select{background:#111;color:#eee;border:1px solid #806d2d;padding:5px;font:10px monospace}#${TOOLBAR_ID} .proc-readout{font:10px monospace;border:1px solid #806d2d;padding:5px;white-space:nowrap}`;document.head.appendChild(style);}
-    toolbar=document.createElement('div');toolbar.id=TOOLBAR_ID;toolbar.className='vtt-toolbar';toolbar.hidden=true;
-    const options=procedural.profiles().map(p=>`<option value="${p.id}">${p.label||p.id}</option>`).join('');
-    toolbar.innerHTML=`<span class="vtt-toolbar-title">PROCEDURAL ZONE</span><select data-proc-profile>${options}</select><input data-proc-seed type="text" value="${mapData.id||mapData.mapId||'map'}:zone" aria-label="Procedural seed"><button type="button" class="brutalist-button" data-proc-preview>PREVIEW</button><button type="button" class="brutalist-button" data-proc-reroll>REROLL</button><button type="button" class="brutalist-button" data-proc-apply disabled>APPLY</button><span class="proc-readout" data-proc-readout>NO PREVIEW</span>`;
-    (document.getElementById('vtt-edit-sidebar')||document.getElementById('vtt-ui-container')||document.body).appendChild(toolbar);
-    toolbar.querySelector('[data-proc-preview]')?.addEventListener('click',()=>{reroll=0;preview();});toolbar.querySelector('[data-proc-reroll]')?.addEventListener('click',rerollPreview);toolbar.querySelector('[data-proc-apply]')?.addEventListener('click',apply);
+    installStyles();
+    launcher=document.createElement('div');launcher.id=LAUNCHER_ID;launcher.className='vtt-toolbar';launcher.hidden=true;launcher.innerHTML='<span class="vtt-toolbar-title">ZONE CREATOR</span><button type="button" class="brutalist-button" data-proc-launch>CREAR ZONA</button>';
+    (document.getElementById('vtt-edit-sidebar')||document.getElementById('vtt-ui-container')||document.body).prepend(launcher);
+    panel=document.createElement('section');panel.id=PANEL_ID;panel.hidden=true;panel.setAttribute('aria-hidden','true');panel.setAttribute('aria-label','Crear zona procedural');
+    const options=procedural.profiles().map(p=>`<option value="${esc(p.id)}">${esc(p.label||p.id)}</option>`).join('');
+    panel.innerHTML=`<header class="proc-creator-head"><h2>CREAR ZONA</h2><button type="button" class="proc-close" data-proc-close aria-label="Cerrar">×</button></header><div class="proc-creator-body"><div><section class="proc-card"><h3>ZONE CONFIGURATION</h3><label class="proc-field"><span>TIPO DE ZONA</span><select data-proc-profile>${options}</select></label><div class="proc-field"><span>TAMAÑO</span><div class="proc-size-row"><button type="button" data-proc-size="1">1×1</button><button type="button" data-proc-size="2">2×2</button><button type="button" data-proc-size="3">3×3</button></div></div><label class="proc-field"><span>SEED</span><div class="proc-seed-row"><input data-proc-seed type="text" value="${esc(mapData.id||mapData.mapId||'map')}:zone"><button type="button" data-proc-randomize>RANDOM</button></div></label></section><section class="proc-card"><h3>URBAN PROFILE</h3><div data-proc-profile-summary></div></section><section class="proc-card"><h3>VALIDATION GATE</h3><div data-proc-validation></div></section></div><div><section class="proc-card"><h3>GENERATION PREVIEW</h3><div class="proc-preview-wrap" data-proc-visual></div><div data-proc-summary></div><div class="proc-actions"><button type="button" data-proc-generate>GENERAR PREVIEW</button><button type="button" data-proc-reroll disabled>REROLL</button><button type="button" data-proc-cancel>CANCELAR</button><button type="button" data-proc-apply disabled>APLICAR ZONA</button></div><div class="proc-apply-warning" data-proc-apply-warning hidden>REEMPLAZARÁ la geometría, superficies y semántica de la escena. Los tokens existentes se conservarán.</div></section></div></div><footer class="proc-footer"><strong>40×40 cells por Chunk.</strong> 1×1 = 40×40 · 2×2 = 80×80 · 3×3 = 120×120. El preview no modifica el mapa.</footer>`;
+    document.body.appendChild(panel);
+    launcher.querySelector('[data-proc-launch]')?.addEventListener('click',open);panel.querySelector('[data-proc-close]')?.addEventListener('click',close);panel.querySelector('[data-proc-cancel]')?.addEventListener('click',close);
+    panel.querySelector('[data-proc-generate]')?.addEventListener('click',()=>{reroll=0;preview();});panel.querySelector('[data-proc-reroll]')?.addEventListener('click',rerollPreview);panel.querySelector('[data-proc-apply]')?.addEventListener('click',apply);panel.querySelector('[data-proc-randomize]')?.addEventListener('click',randomize);
+    panel.querySelector('[data-proc-profile]')?.addEventListener('change',invalidate);panel.querySelector('[data-proc-seed]')?.addEventListener('input',invalidate);panel.querySelectorAll('[data-proc-size]').forEach(btn=>btn.addEventListener('click',()=>{selectedChunks=Math.max(1,Math.min(3,Number(btn.dataset.procSize)||3));invalidate();}));
   }
+
   ensureUi();const timer=window.setInterval(syncUi,350);syncUi();
-  const api=Object.freeze({preview,apply,reroll:rerollPreview,getLastPlan:()=>lastPlan,syncUi,stop(){if(stopped)return;stopped=true;window.clearInterval(timer);toolbar?.remove();document.getElementById(STYLE_ID)?.remove();}});
+  const api=Object.freeze({open,close,preview,apply,reroll:rerollPreview,randomize,renderPreview:()=>renderPreviewSvg(lastPlan),getLastPlan:()=>lastPlan,getSize:()=>selectedChunks,syncUi,stop(){if(stopped)return;stopped=true;window.clearInterval(timer);launcher?.remove();panel?.remove();document.getElementById(STYLE_ID)?.remove();}});
   window.LuminousVttProceduralGeneratorAuthoringRuntime=api;return api;
 }
 
-function boot(attempt=0){
-  const runtime=window.LuminousVttRuntime;
-  if(runtime?.engine&&runtime?.procedural){start({runtime,mapData:runtime.engine.mapData});return;}
-  if(attempt<100)window.setTimeout(()=>boot(attempt+1),100);
-}
+function boot(attempt=0){const runtime=window.LuminousVttRuntime;if(runtime?.engine&&runtime?.procedural){start({runtime,mapData:runtime.engine.mapData});return;}if(attempt<100)window.setTimeout(()=>boot(attempt+1),100);}
 if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',()=>boot(),{once:true});else boot();

--- a/js/vtt/semantic-map-bootstrap.js
+++ b/js/vtt/semantic-map-bootstrap.js
@@ -1,6 +1,7 @@
 import './semantic-map-core.js';
 import './semantic-map-authoring-patch.js';
 import './semantic-map-renderer-patch.js';
+import { install as installDmAuthoringShellPolish } from './dm-authoring-shell-polish.js';
 import { start as startBuildingSemantics } from './building-semantic-bootstrap.js';
 import { start as startBuildingSemanticAuthoring } from './building-semantic-authoring-bootstrap.js';
 import { start as startBuildingArchetypes } from './building-archetype-bootstrap.js';
@@ -15,6 +16,7 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
   if(window.LuminousVttSemanticMapRuntime?.api)return window.LuminousVttSemanticMapRuntime.api;
   const core=window.LuminousVttSemanticMap;if(!core)throw new Error('SEMANTIC_MAP_RUNTIME_REQUIRED');
   window.LuminousVttSemanticMapAuthoringPatch?.install?.();
+  const stopDmPolish=runtime?.bridge?.isDm?installDmAuthoringShellPolish({root:window}):(()=>{});
   mapData.semantics=core.normalizeSemantics(mapData.semantics||{});
   mapData.semanticEditor||={visible:false,selectedId:null,preview:null};
   let revision=0,index=null,indexRevision=-1,stopped=false;
@@ -36,7 +38,7 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
     relationsFrom:(id)=>core.relationsFrom(mapData.semantics,id),
     relationsTo:(id)=>core.relationsTo(mapData.semantics,id),
     validate:()=>core.validateSemantics(mapData.semantics,mapData),
-    stop(){if(stopped)return;stopped=true;stopRenderer();},
+    stop(){if(stopped)return;stopped=true;stopRenderer();stopDmPolish();},
   });
   window.LuminousVttSemanticMapRuntime={api};
   window.LuminousVttRuntime=Object.freeze({...window.LuminousVttRuntime,semanticMap:api});

--- a/tests/vtt_procedural_dm_ui.spec.js
+++ b/tests/vtt_procedural_dm_ui.spec.js
@@ -2,6 +2,9 @@ const { test, expect } = require('@playwright/test');
 const fs=require('node:fs'),path=require('node:path'),{execFileSync}=require('node:child_process');
 const ROOT=path.resolve(__dirname,'..');
 const read=file=>fs.readFileSync(path.join(ROOT,file),'utf8');
+const GEN_FILES=['topology.js','surface-core.js','horizontal-plane-core.js','building-physics-core.js','semantic-map-core.js','building-semantic-core.js','building-archetype-core.js','vertical-portal.js','building-navigation-core.js','procedural-zone-core.js','urban-fabric-core.js','procedural-building-generator.js','procedural-generator-core.js'];
+const GEN_KEYS=['LuminousVttTopology','LuminousVttSurfaceCore','LuminousVttHorizontalPlanes','LuminousVttBuildingPhysics','LuminousVttSemanticMap','LuminousVttBuildingSemantics','LuminousVttBuildingArchetypes','LuminousVttVerticalPortal','LuminousVttBuildingNavigation','LuminousVttProceduralZone','LuminousVttUrbanFabric','LuminousVttProceduralBuildings','LuminousVttProceduralGenerator'];
+function withGenerator(run){const original=new Map(GEN_KEYS.map(k=>[k,global[k]]));try{for(let i=0;i<GEN_FILES.length;i++){const resolved=require.resolve(path.join(ROOT,'js/vtt',GEN_FILES[i]));delete require.cache[resolved];global[GEN_KEYS[i]]=require(resolved);}return run(global.LuminousVttProceduralGenerator);}finally{for(const f of GEN_FILES){try{delete require.cache[require.resolve(path.join(ROOT,'js/vtt',f))];}catch(_){}}for(const key of GEN_KEYS){const value=original.get(key);if(value===undefined)delete global[key];else global[key]=value;}}}
 
 test('zone size presets map cleanly to the 40x40 chunk contract',()=>{
   const file=path.join(ROOT,'js/vtt/procedural-zone-core.js'),resolved=require.resolve(file);delete require.cache[resolved];const zone=require(resolved);
@@ -9,6 +12,13 @@ test('zone size presets map cleanly to the 40x40 chunk contract',()=>{
   expect(zone.createZone({chunkCols:2,chunkRows:2})).toMatchObject({cols:80,rows:80,chunkCols:2,chunkRows:2});
   expect(zone.createZone({chunkCols:3,chunkRows:3})).toMatchObject({cols:120,rows:120,chunkCols:3,chunkRows:3});delete require.cache[resolved];
 });
+
+test('1x1 and 2x2 creator presets produce fully validated procedural plans',()=>withGenerator(gen=>{
+  const small=gen.generateZone({seed:'dm-ui-small',profileId:'mixed_urban',chunkCols:1,chunkRows:1,maxAttempts:8});
+  const medium=gen.generateZone({seed:'dm-ui-medium',profileId:'residential',chunkCols:2,chunkRows:2,maxAttempts:8});
+  expect(small.zone).toMatchObject({cols:40,rows:40,chunkCols:1,chunkRows:1});expect(small.validation.valid).toBe(true);
+  expect(medium.zone).toMatchObject({cols:80,rows:80,chunkCols:2,chunkRows:2});expect(medium.validation.valid).toBe(true);
+}));
 
 test('DM creator exposes a professional non-destructive generate workflow',()=>{
   const source=read('js/vtt/procedural-generator-authoring-bootstrap.js');

--- a/tests/vtt_procedural_dm_ui.spec.js
+++ b/tests/vtt_procedural_dm_ui.spec.js
@@ -1,0 +1,32 @@
+const { test, expect } = require('@playwright/test');
+const fs=require('node:fs'),path=require('node:path'),{execFileSync}=require('node:child_process');
+const ROOT=path.resolve(__dirname,'..');
+const read=file=>fs.readFileSync(path.join(ROOT,file),'utf8');
+
+test('zone size presets map cleanly to the 40x40 chunk contract',()=>{
+  const file=path.join(ROOT,'js/vtt/procedural-zone-core.js'),resolved=require.resolve(file);delete require.cache[resolved];const zone=require(resolved);
+  expect(zone.createZone({chunkCols:1,chunkRows:1})).toMatchObject({cols:40,rows:40,chunkCols:1,chunkRows:1});
+  expect(zone.createZone({chunkCols:2,chunkRows:2})).toMatchObject({cols:80,rows:80,chunkCols:2,chunkRows:2});
+  expect(zone.createZone({chunkCols:3,chunkRows:3})).toMatchObject({cols:120,rows:120,chunkCols:3,chunkRows:3});delete require.cache[resolved];
+});
+
+test('DM creator exposes a professional non-destructive generate workflow',()=>{
+  const source=read('js/vtt/procedural-generator-authoring-bootstrap.js');
+  for(const token of ['CREAR ZONA','TIPO DE ZONA','data-proc-size="1"','data-proc-size="2"','data-proc-size="3"','data-proc-randomize','GENERAR PREVIEW','REROLL','APLICAR ZONA','CONFIRMAR APLICACIÓN','renderPreviewSvg','VALIDATION GATE'])expect(source).toContain(token);
+  expect(source).toContain('chunkCols:selectedChunks');expect(source).toContain('chunkRows:selectedChunks');expect(source).toContain('procedural.preview(values())');expect(source).toContain("procedural.apply(lastPlan,{replaceScene:true})");
+  const previewStart=source.indexOf('function preview()'),applyStart=source.indexOf('function apply()');expect(previewStart).toBeGreaterThan(-1);expect(applyStart).toBeGreaterThan(previewStart);expect(source.slice(previewStart,applyStart)).not.toContain('procedural.apply(');
+});
+
+test('DM creator requires a valid preview and a second explicit apply action',()=>{
+  const source=read('js/vtt/procedural-generator-authoring-bootstrap.js');
+  expect(source).toContain('applyButton.disabled=!lastPlan?.validation?.valid');expect(source).toContain('if(!applyArmed)');expect(source).toContain('applyArmed=true');expect(source).toContain('Los tokens existentes se conservarán');expect(source).toContain("addEventListener('change',invalidate)");expect(source).toContain("addEventListener('input',invalidate)");
+});
+
+test('DM authoring shell has shared professional states and keyboard focus treatment',()=>{
+  const polish=read('js/vtt/dm-authoring-shell-polish.js'),semantic=read('js/vtt/semantic-map-bootstrap.js');
+  expect(polish).toContain('DM MAP TOOLS');expect(polish).toContain('AUTHORING MODE');expect(polish).toContain(':focus-visible');expect(polish).toContain('[aria-pressed="true"]');expect(polish).toContain('width:228px');expect(semantic).toContain('installDmAuthoringShellPolish');
+});
+
+test('zone creator and DM shell modules parse as ESM JavaScript',()=>{
+  for(const file of ['js/vtt/procedural-generator-authoring-bootstrap.js','js/vtt/dm-authoring-shell-polish.js','js/vtt/semantic-map-bootstrap.js'])execFileSync(process.execPath,['--input-type=module','--check'],{input:read(file),stdio:['pipe','pipe','pipe']});
+});


### PR DESCRIPTION
## Summary
- Replaces the technical procedural toolbar with a professional DM-facing **CREAR ZONA** workflow.
- Adds Zone size presets: `1×1` (40×40), `2×2` (80×80), and `3×3` (120×120) chunks/cells contract.
- Adds profile selection, deterministic Seed editing, Random seed generation, profile metrics, and an SVG mini-map preview.
- Adds validation gate readouts for Boundary, Semantics, Buildings, Archetypes, Navigation, and Physics before Apply is enabled.
- Keeps preview/reroll non-destructive; changing Profile/Seed/Size invalidates the old preview.
- Adds two-step **APLICAR ZONA → CONFIRMAR APLICACIÓN** protection and explicitly preserves existing tokens.
- Keeps DM Edit Mode active after application so the generated zone can be edited manually with existing map tools.
- Adds shared DM authoring shell polish: `DM MAP TOOLS / AUTHORING MODE`, wider sidebar, consistent toolbar cards, active/disabled states, keyboard focus outlines, and adjusted panel offsets.

## UX flow
`DM EDIT MODE -> CREAR ZONA -> Profile / Size / Seed -> GENERAR PREVIEW -> inspect SVG + validators -> REROLL if needed -> APLICAR ZONA -> CONFIRMAR APLICACIÓN -> manual editing`

## Safety
- Opening/closing/canceling the creator never mutates the map.
- Preview never calls Apply.
- Apply is disabled until a valid procedural plan exists.
- Profile, Seed, or Size changes invalidate the current plan.
- Existing player tokens are preserved by the procedural Apply contract.

## Tests
Adds focused contracts for 1×1/2×2/3×3 Zone sizing, non-destructive preview wiring, Apply confirmation, UI controls, shared DM shell treatment, and ESM syntax. Procedural CI continues to run Semantic/Building/Navigation/Physics dependencies plus the full repository regression.