### PR TITLE
Fix Inventory HUD V2: remove legacy equipment and restore approved loadout

### DIFF
--- a/.github/workflows/inventory-hud-v2-validation.yml
+++ b/.github/workflows/inventory-hud-v2-validation.yml
@@ -20,6 +20,10 @@ on:
     branches:
       - "fix/inventory-hud-v2-remove-legacy"
 
+concurrency:
+  group: inventory-hud-v2-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   inventory-hud-v2-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/inventory-hud-v2-validation.yml
+++ b/.github/workflows/inventory-hud-v2-validation.yml
@@ -6,13 +6,17 @@ on:
       - "js/player-ux-polish.js"
       - "js/player-ux-polish-core.js"
       - "js/item-equipment-bridge.js"
+      - "js/item-equipment-v2-persistence.js"
       - "js/inventory-hud-v2.js"
+      - "js/inventory-hud-v2-approved-layout.js"
       - "css/inventory-hud-v2.css"
+      - "css/inventory-hud-v2-approved-layout.css"
       - "tests/inventory_hud_v2.spec.js"
+      - "tests/inventory_hud_v2_approved_layout.spec.js"
       - ".github/workflows/inventory-hud-v2-validation.yml"
   push:
     branches:
-      - "codex/inventory-hud-v2-functional"
+      - "fix/inventory-hud-v2-remove-legacy"
 
 jobs:
   inventory-hud-v2-tests:
@@ -27,6 +31,6 @@ jobs:
       - run: npm ci
       - run: npx playwright install --with-deps chromium
       - name: Inventory HUD V2 integration
-        run: npx playwright test tests/inventory_hud_v2.spec.js
+        run: npx playwright test tests/inventory_hud_v2.spec.js tests/inventory_hud_v2_approved_layout.spec.js
       - name: Item Runtime regression suite
         run: npx playwright test tests/item_runtime_engine.spec.js tests/item_runtime_catalog_profile.spec.js tests/item_inventory_runtime.spec.js tests/item_inventory_regression.spec.js tests/workshop_runtime.spec.js tests/item_magic_runtime.spec.js tests/item_persistence_runtime.spec.js tests/item_realtime_sync.spec.js tests/item_augmentation_runtime.spec.js tests/item_salvage_runtime.spec.js

--- a/.github/workflows/inventory-hud-v2-validation.yml
+++ b/.github/workflows/inventory-hud-v2-validation.yml
@@ -6,6 +6,7 @@ on:
       - "js/player-ux-polish.js"
       - "js/player-ux-polish-core.js"
       - "js/item-equipment-bridge.js"
+      - "js/item-equipment-approved-bridge.js"
       - "js/item-equipment-v2-persistence.js"
       - "js/inventory-hud-v2.js"
       - "js/inventory-hud-v2-approved-layout.js"
@@ -13,6 +14,7 @@ on:
       - "css/inventory-hud-v2-approved-layout.css"
       - "tests/inventory_hud_v2.spec.js"
       - "tests/inventory_hud_v2_approved_layout.spec.js"
+      - "tests/item_equipment_approved_bridge.spec.js"
       - ".github/workflows/inventory-hud-v2-validation.yml"
   push:
     branches:
@@ -31,6 +33,6 @@ jobs:
       - run: npm ci
       - run: npx playwright install --with-deps chromium
       - name: Inventory HUD V2 integration
-        run: npx playwright test tests/inventory_hud_v2.spec.js tests/inventory_hud_v2_approved_layout.spec.js
+        run: npx playwright test tests/inventory_hud_v2.spec.js tests/inventory_hud_v2_approved_layout.spec.js tests/item_equipment_approved_bridge.spec.js
       - name: Item Runtime regression suite
         run: npx playwright test tests/item_runtime_engine.spec.js tests/item_runtime_catalog_profile.spec.js tests/item_inventory_runtime.spec.js tests/item_inventory_regression.spec.js tests/workshop_runtime.spec.js tests/item_magic_runtime.spec.js tests/item_persistence_runtime.spec.js tests/item_realtime_sync.spec.js tests/item_augmentation_runtime.spec.js tests/item_salvage_runtime.spec.js

--- a/css/inventory-hud-v2-approved-layout.css
+++ b/css/inventory-hud-v2-approved-layout.css
@@ -1,0 +1,144 @@
+/* Approved Inventory HUD V2 layout: one Equipment surface above a 5x2 Active grid. */
+#inventory-modal.inventory-v2-ready #equipment-panel,
+#inventory-modal.inventory-v2-ready .inventory-v2-legacy-retired {
+  display: none !important;
+}
+
+#inventory-modal.inventory-v2-ready #inv-active {
+  height: 100% !important;
+  min-height: 0 !important;
+  overflow: hidden !important;
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-active-stack {
+  height: 100%;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: minmax(250px, 1fr) minmax(215px, .78fr);
+  gap: 10px;
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-approved-layout .inventory-v2-equipment-field {
+  min-height: 210px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(126px, 1fr));
+  grid-template-rows: repeat(3, minmax(58px, 1fr));
+  gap: 8px 22px;
+  align-items: center;
+  padding: 12px 18px 14px;
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-approved-layout .inventory-v2-body-silhouette {
+  width: 118px;
+  height: 194px;
+  top: 53%;
+  opacity: .72;
+  z-index: 0;
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-approved-layout .inventory-v2-eq-slot {
+  position: relative !important;
+  inset: auto !important;
+  left: auto !important;
+  right: auto !important;
+  top: auto !important;
+  bottom: auto !important;
+  transform: none !important;
+  width: 100% !important;
+  min-width: 0;
+  min-height: 58px;
+  height: 100%;
+  z-index: 2;
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-approved-layout .inventory-v2-eq-slot:hover {
+  transform: translateY(-1px) !important;
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-approved-layout .inv2-eq-main {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-approved-layout .inv2-eq-off {
+  grid-column: 3;
+  grid-row: 1;
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-approved-layout .inv2-eq-armor {
+  grid-column: 2;
+  grid-row: 2;
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-approved-layout .inv2-eq-acc-a {
+  grid-column: 1;
+  grid-row: 2;
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-approved-layout .inv2-eq-acc-b {
+  grid-column: 3;
+  grid-row: 2;
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-approved-layout .inv2-eq-augment-body {
+  grid-column: 1;
+  grid-row: 3;
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-approved-layout .inv2-eq-augment-neural {
+  grid-column: 3;
+  grid-row: 3;
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-approved-layout [data-equipment-slot="shield"],
+#inventory-modal.inventory-v2-ready .inventory-v2-approved-layout #inventory-v2-augment-summary {
+  display: none !important;
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-carry {
+  min-height: 0;
+  display: grid;
+  grid-template-rows: 40px minmax(0, 1fr);
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-grid-host {
+  min-height: 0;
+  overflow: hidden;
+  padding: 9px;
+}
+
+#inventory-modal.inventory-v2-ready #inv-active-grid.inv-grid {
+  height: 100%;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(82px, 1fr));
+  grid-template-rows: repeat(2, minmax(82px, 1fr));
+  grid-auto-rows: minmax(82px, 1fr);
+  gap: 9px;
+  align-content: stretch;
+}
+
+@media (max-height: 760px) {
+  #inventory-modal.inventory-v2-ready .inventory-v2-active-stack {
+    grid-template-rows: minmax(225px, 1fr) minmax(190px, .75fr);
+  }
+
+  #inventory-modal.inventory-v2-ready .inventory-v2-approved-layout .inventory-v2-equipment-field {
+    min-height: 185px;
+    grid-template-rows: repeat(3, minmax(50px, 1fr));
+    gap: 6px 18px;
+    padding: 8px 14px 10px;
+  }
+
+  #inventory-modal.inventory-v2-ready .inventory-v2-approved-layout .inventory-v2-eq-slot {
+    min-height: 50px;
+  }
+
+  #inventory-modal.inventory-v2-ready .inventory-v2-approved-layout .inventory-v2-body-silhouette {
+    height: 168px;
+  }
+
+  #inventory-modal.inventory-v2-ready #inv-active-grid.inv-grid {
+    grid-template-rows: repeat(2, minmax(70px, 1fr));
+    grid-auto-rows: minmax(70px, 1fr);
+  }
+}

--- a/js/inventory-hud-v2-approved-layout.js
+++ b/js/inventory-hud-v2-approved-layout.js
@@ -1,0 +1,91 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousInventoryApprovedLayout) return;
+  const doc = global.document;
+  if (!doc) return;
+
+  const AUGMENT_SLOTS = [
+    {
+      id: "augment0",
+      label: "AUGMENT / BODY",
+      hint: "BODY INSTALL",
+      className: "inv2-eq-augment-body",
+    },
+    {
+      id: "augment1",
+      label: "AUGMENT / NEURAL",
+      hint: "NEURAL INSTALL",
+      className: "inv2-eq-augment-neural",
+    },
+  ];
+
+  function createSlot(spec) {
+    const button = doc.createElement("button");
+    button.type = "button";
+    button.className = `inventory-v2-eq-slot ${spec.className}`;
+    button.dataset.equipmentSlot = spec.id;
+    button.setAttribute("aria-label", spec.label);
+    button.innerHTML = `
+      <span class="inventory-v2-eq-label">${spec.label}</span>
+      <span class="inventory-v2-eq-name">EMPTY</span>
+      <span class="inventory-v2-eq-hint">${spec.hint}</span>
+    `;
+    return button;
+  }
+
+  function retireLegacyEquipment() {
+    const legacy = doc.getElementById("equipment-panel");
+    if (!legacy) return;
+    legacy.classList.add("inventory-v2-legacy-retired");
+    legacy.setAttribute("aria-hidden", "true");
+  }
+
+  function apply() {
+    retireLegacyEquipment();
+
+    const equipment = doc.querySelector(".inventory-v2-equipment");
+    const field = equipment?.querySelector(".inventory-v2-equipment-field");
+    if (!equipment || !field) return false;
+
+    equipment.classList.add("inventory-v2-approved-layout");
+
+    // Shield is not a separate approved slot. Shields occupy Off Hand.
+    field.querySelector('[data-equipment-slot="shield"]')?.remove();
+
+    // The approved design exposes real augment slots instead of a text summary.
+    field.querySelector("#inventory-v2-augment-summary")?.remove();
+    AUGMENT_SLOTS.forEach((spec) => {
+      if (!field.querySelector(`[data-equipment-slot="${spec.id}"]`)) {
+        field.appendChild(createSlot(spec));
+      }
+    });
+
+    const offHand = field.querySelector('[data-equipment-slot="offHand"]');
+    if (offHand) {
+      const hint = offHand.querySelector(".inventory-v2-eq-hint");
+      if (!offHand.classList.contains("is-filled") && hint) hint.textContent = "WEAPON / SHIELD";
+    }
+
+    global.LuminousInventoryHudV2?.renderEquipment?.();
+    return true;
+  }
+
+  function boot() {
+    if (apply()) return;
+    let attempts = 0;
+    const timer = global.setInterval(() => {
+      attempts += 1;
+      if (apply() || attempts >= 80) global.clearInterval(timer);
+    }, 100);
+  }
+
+  if (doc.readyState === "loading") doc.addEventListener("DOMContentLoaded", boot, { once: true });
+  else boot();
+
+  global.LuminousInventoryApprovedLayout = Object.freeze({
+    version: 1,
+    apply,
+    retireLegacyEquipment,
+  });
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/item-equipment-approved-bridge.js
+++ b/js/item-equipment-approved-bridge.js
@@ -1,0 +1,66 @@
+(function (global) {
+  "use strict";
+
+  const base = global.LuminousItemEquipmentBridge;
+  if (!base || base.__luminousApprovedEquipmentSlots) return;
+
+  function isShield(item = {}) {
+    return String(base.categoryOf?.(item) || item.category || item.tipo_categoria || "")
+      .trim()
+      .toLowerCase() === "shield";
+  }
+
+  function normalizeVisibleSlot(slot) {
+    const normalized = base.normalizeSlot?.(slot) || slot;
+    return normalized === "shield" ? "offHand" : normalized;
+  }
+
+  function compatibleSlots(item = {}) {
+    if (isShield(item)) return ["offHand"];
+    return (base.compatibleSlots?.(item) || []).filter((slot) => slot !== "shield");
+  }
+
+  function getSlotItem(unit, slot) {
+    const visible = normalizeVisibleSlot(slot);
+    if (visible === "offHand") {
+      return base.getSlotItem?.(unit, "offHand") || base.getSlotItem?.(unit, "shield") || null;
+    }
+    return base.getSlotItem?.(unit, visible) || null;
+  }
+
+  function canEquipTo(unit, item, slot) {
+    const visible = normalizeVisibleSlot(slot);
+    if (visible === "offHand" && isShield(item)) return base.canEquipTo(unit, item, "offHand");
+    if (!compatibleSlots(item).includes(visible)) {
+      return { allowed: false, reason: "incompatible_equipment_slot", item, slot: visible };
+    }
+    return base.canEquipTo(unit, item, visible);
+  }
+
+  function equipTo(unit, item, slot, options = {}) {
+    const visible = normalizeVisibleSlot(slot);
+    const gate = canEquipTo(unit, item, visible);
+    if (!gate?.allowed) return { equipped: false, ...gate };
+    return base.equipTo(unit, item, visible, options);
+  }
+
+  function unequipSlot(unit, slot, options = {}) {
+    return base.unequipSlot(unit, normalizeVisibleSlot(slot), options);
+  }
+
+  function itemEquippedSlot(unit, item) {
+    const slot = base.itemEquippedSlot?.(unit, item) || null;
+    return slot === "shield" ? "offHand" : slot;
+  }
+
+  global.LuminousItemEquipmentBridge = Object.freeze({
+    ...base,
+    __luminousApprovedEquipmentSlots: true,
+    compatibleSlots,
+    getSlotItem,
+    canEquipTo,
+    equipTo,
+    unequipSlot,
+    itemEquippedSlot,
+  });
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/item-equipment-v2-persistence.js
+++ b/js/item-equipment-v2-persistence.js
@@ -1,0 +1,84 @@
+(function (global) {
+  "use strict";
+
+  const base = global.LuminousItemPersistenceRuntime;
+  if (!base || base.__luminousEquipmentV2Persistence) return;
+
+  function itemId(item = {}) {
+    return String(item.instanceId || item.instance_id || item.id || item.key || "").trim();
+  }
+
+  function findInstance(state = {}, id) {
+    const wanted = String(id || "").trim();
+    if (!wanted) return null;
+    return state.inventario_activo?.[wanted] || state.inventario_stash?.[wanted] || null;
+  }
+
+  function augmentIds(unit = {}) {
+    const source = unit.augmentations || unit.augments || unit.bodyAugmentations || [];
+    return [...new Set((Array.isArray(source) ? source : []).map(itemId).filter(Boolean))];
+  }
+
+  function restoreAugments(unit, state = {}) {
+    const ids = Array.isArray(state.equipmentRefs?.augmentIds) ? state.equipmentRefs.augmentIds : [];
+    const restored = ids.map((id) => findInstance(state, id)).filter(Boolean);
+    restored.forEach((item) => {
+      item.installed = true;
+      item.equipped = true;
+    });
+    unit.augmentations = restored;
+    return restored;
+  }
+
+  function serializeInventoryState(unit = {}) {
+    const state = base.serializeInventoryState(unit);
+    state.equipmentRefs = {
+      ...(state.equipmentRefs || {}),
+      augmentIds: augmentIds(unit),
+    };
+    return state;
+  }
+
+  function restoreEquipmentRefs(unit, state) {
+    const result = base.restoreEquipmentRefs(unit, state);
+    restoreAugments(unit, state);
+    return result;
+  }
+
+  function applyInventoryState(unit, snapshot, options = {}) {
+    const result = base.applyInventoryState(unit, snapshot, options);
+    if (result?.applied) restoreAugments(unit, result.state || {});
+    return result;
+  }
+
+  async function saveInventoryState(db, playerId, unitOrState, options = {}) {
+    const result = await base.saveInventoryState(db, playerId, unitOrState, options);
+    if (!result?.saved || !db?.ref) return result;
+
+    const paths = base.playerPaths?.(playerId, options);
+    if (!paths?.equipmentRefs) return result;
+
+    const ids = augmentIds(unitOrState || {});
+    const equipmentRef = db.ref(paths.equipmentRefs);
+    if (typeof equipmentRef.update === "function") {
+      await equipmentRef.update({ augmentIds: ids.length ? ids : null });
+    } else if (typeof db.ref(`${paths.equipmentRefs}/augmentIds`).set === "function") {
+      await db.ref(`${paths.equipmentRefs}/augmentIds`).set(ids.length ? ids : null);
+    }
+
+    if (result.state?.itemEquipmentRefs) {
+      result.state.itemEquipmentRefs.augmentIds = ids;
+    }
+    return result;
+  }
+
+  global.LuminousItemPersistenceRuntime = Object.freeze({
+    ...base,
+    __luminousEquipmentV2Persistence: true,
+    serializeInventoryState,
+    restoreEquipmentRefs,
+    applyInventoryState,
+    saveInventoryState,
+    restoreAugments,
+  });
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/player-ux-polish.js
+++ b/js/player-ux-polish.js
@@ -60,6 +60,7 @@
       await ensureScript("item-realtime-sync-script", "js/item-realtime-sync.js", "LuminousItemRealtimeSync");
       await ensureScript("item-augmentation-runtime-script", "js/item-augmentation-runtime.js", "LuminousItemAugmentationRuntime");
       await ensureScript("item-equipment-bridge-script", "js/item-equipment-bridge.js", "LuminousItemEquipmentBridge");
+      await ensureScript("item-equipment-approved-bridge-script", "js/item-equipment-approved-bridge.js");
       await ensureScript("inventory-hud-v2-script", "js/inventory-hud-v2.js", "LuminousInventoryHudV2");
       await ensureScript("inventory-hud-v2-approved-layout-script", "js/inventory-hud-v2-approved-layout.js", "LuminousInventoryApprovedLayout");
     } catch (error) {

--- a/js/player-ux-polish.js
+++ b/js/player-ux-polish.js
@@ -50,15 +50,18 @@
       if (!doc.getElementById("inventory-modal")) return;
 
       ensureStyle("inventory-hud-v2-stylesheet", "css/inventory-hud-v2.css");
+      ensureStyle("inventory-hud-v2-approved-layout-stylesheet", "css/inventory-hud-v2-approved-layout.css");
 
       await ensureScript("anatomy-equipment-engine-script", "js/anatomy-equipment-engine.js", "LuminousAnatomyEquipmentEngine");
       await ensureScript("item-runtime-engine-script", "js/item-runtime-engine.js", "LuminousItemRuntime");
       await ensureScript("item-inventory-runtime-script", "js/item-inventory-runtime.js", "LuminousItemInventoryRuntime");
       await ensureScript("item-persistence-runtime-script", "js/item-persistence-runtime.js", "LuminousItemPersistenceRuntime");
+      await ensureScript("item-equipment-v2-persistence-script", "js/item-equipment-v2-persistence.js");
       await ensureScript("item-realtime-sync-script", "js/item-realtime-sync.js", "LuminousItemRealtimeSync");
       await ensureScript("item-augmentation-runtime-script", "js/item-augmentation-runtime.js", "LuminousItemAugmentationRuntime");
       await ensureScript("item-equipment-bridge-script", "js/item-equipment-bridge.js", "LuminousItemEquipmentBridge");
       await ensureScript("inventory-hud-v2-script", "js/inventory-hud-v2.js", "LuminousInventoryHudV2");
+      await ensureScript("inventory-hud-v2-approved-layout-script", "js/inventory-hud-v2-approved-layout.js", "LuminousInventoryApprovedLayout");
     } catch (error) {
       console.error("[Luminous] Inventory HUD V2 bootstrap failed:", error);
     }

--- a/tests/inventory_hud_v2_approved_layout.spec.js
+++ b/tests/inventory_hud_v2_approved_layout.spec.js
@@ -1,0 +1,178 @@
+const { test, expect } = require("@playwright/test");
+const path = require("path");
+
+const HUD = path.resolve(__dirname, "../js/inventory-hud-v2.js");
+const BRIDGE = path.resolve(__dirname, "../js/item-equipment-bridge.js");
+const LAYOUT = path.resolve(__dirname, "../js/inventory-hud-v2-approved-layout.js");
+const PERSISTENCE_BRIDGE = path.resolve(__dirname, "../js/item-equipment-v2-persistence.js");
+const CSS = path.resolve(__dirname, "../css/inventory-hud-v2.css");
+const APPROVED_CSS = path.resolve(__dirname, "../css/inventory-hud-v2-approved-layout.css");
+
+async function bootHarness(page) {
+  await page.setContent(`<!doctype html><html><head></head><body>
+    <div id="inventory-modal" class="inventory-modal"><div class="inventory-modal-content">
+      <div class="inventory-tabs">
+        <button class="inv-tab-btn active" data-tab="inv-active">Inventario Activo</button>
+        <button class="inv-tab-btn" data-tab="inv-stash">Stash/Alijo</button>
+        <button class="inv-tab-btn" data-tab="inv-sintesis">SÍNTESIS</button>
+      </div>
+      <div class="inventory-body-wrapper"><div class="inventory-left-panel">
+        <div class="inventory-tab-content active" id="inv-active">
+          <div class="inv-grid" id="inv-active-grid">
+            <div class="item-slot" data-key="blade_1">Blade</div>
+            <div class="item-slot" data-key="aug_1">Augment</div>
+          </div>
+          <div id="equipment-panel" class="cyber-panel">
+            <h3 class="cyber-panel-title">EQUIPAMIENTO TÁCTICO</h3>
+            <div class="equipamiento-layout"><div class="equip-slot" data-slot-id="arma_principal">Legacy</div></div>
+          </div>
+        </div>
+        <div class="inventory-tab-content" id="inv-stash"><div class="inv-grid" id="inv-stash-grid"></div></div>
+        <div class="inventory-tab-content" id="inv-sintesis"></div>
+      </div><div class="item-detail-card active" id="item-detail-card"><div id="detail-title">Item</div><div id="detail-equip-btn-container"></div></div></div>
+    </div></div>
+  </body></html>`);
+
+  await page.addStyleTag({ path: CSS });
+  await page.addStyleTag({ path: APPROVED_CSS });
+  await page.evaluate(() => {
+    const active = {
+      blade_1:{instanceId:"blade_1",definitionId:"blade",nombre:"Test Workshop Blade",category:"weapon",tier:3,qualityTier:3,condition:90,conditionMax:100,quantity:1},
+      aug_1:{instanceId:"aug_1",definitionId:"augment",nombre:"Soma Myofiber Reinforcement",category:"augmentation",tier:5,qualityTier:4,condition:100,conditionMax:100,quantity:1}
+    };
+    window.playerId="player_test";
+    window.datosJugador={id:"player_test"};
+    window.__active=active;
+    window.__saves=[];
+    window.__updates=[];
+    window.db={ref(p){return{
+      on(e,h){if(p==="campaña/ajustes_globales/alijo_desbloqueado")queueMicrotask(()=>h({val:()=>true}))},
+      off(){},
+      async update(value){window.__updates.push({path:p,value})},
+      async set(value){window.__updates.push({path:p,value})}
+    }}};
+
+    const categoryOf=i=>String(i?.category||i?.tipo_categoria||"item").toLowerCase();
+    const itemId=i=>String(i?.instanceId||i?.key||"");
+    window.LuminousItemRuntime={
+      itemId,categoryOf,
+      equipmentSchema:i=>({kind:categoryOf(i),handCost:categoryOf(i)==="weapon"?1:0}),
+      resolveItem:i=>({...i,displayName:i.nombre||i.name||i.definitionId}),
+      getConditionState:()=>"good",
+      hasFunction:()=>false,
+      quantityOf:i=>Number(i.quantity??1),
+      findItem(unit,ref){const wanted=typeof ref==="object"?itemId(ref):String(ref);for(const c of [unit.inventario_activo,unit.inventario_stash])for(const [k,i] of Object.entries(c||{}))if(k===wanted||itemId(i)===wanted)return i;return null},
+      equipItem(unit,item){item.equipped=true;return{equipped:true,item,assignment:{partIds:["left_hand"]}}},
+      unequipItem(unit,item){item.equipped=false;return{unequipped:true,item}}
+    };
+    window.LuminousItemInventoryRuntime={
+      ...window.LuminousItemRuntime,
+      activeContainer:u=>({key:"inventario_activo",value:u.inventario_activo}),
+      stashContainer:u=>({key:"inventario_stash",value:u.inventario_stash}),
+      findItem:(u,r)=>window.LuminousItemRuntime.findItem(u,r),
+      moveItem(){return{moved:false,reason:"not_used"}}
+    };
+    window.LuminousItemAugmentationRuntime={
+      installedAugments(unit,create=false){if(!Array.isArray(unit.augmentations)&&create)unit.augmentations=[];return{key:"augmentations",value:Array.isArray(unit.augmentations)?unit.augmentations:[]}},
+      canInstallAugment(unit,item){return categoryOf(item)==="augmentation"?{allowed:true,item,body:{matchedPartIds:["torso"]}}:{allowed:false,reason:"not_augment"}},
+      installAugment(unit,item){if(!Array.isArray(unit.augmentations))unit.augmentations=[];item.installed=true;item.equipped=true;unit.augmentations.push(item);return{installed:true,item}},
+      removeAugment(unit,item){unit.augmentations=(unit.augmentations||[]).filter(entry=>itemId(entry)!==itemId(item));item.installed=false;item.equipped=false;return{removed:true,item}}
+    };
+    window.LuminousItemPersistenceRuntime={
+      serializeInventoryState(unit){return{schemaVersion:2,inventario_activo:unit.inventario_activo||{},inventario_stash:unit.inventario_stash||{},equipmentRefs:{},attunedItemInstanceIds:[]}},
+      restoreEquipmentRefs(unit){unit.equipment={accessories:[]};return unit.equipment},
+      applyInventoryState(unit,s){unit.inventario_activo=s.inventario_activo||{};unit.inventario_stash=s.inventario_stash||{};unit.equipment={accessories:[]};return{applied:true,state:s}},
+      playerPaths(pid){return{equipmentRefs:`campaña/jugadores/${pid}/itemEquipmentRefs`}},
+      subscribePlayerInventory(db,pid,cb){queueMicrotask(()=>cb({schemaVersion:2,inventario_activo:window.__active,inventario_stash:{},equipmentRefs:{},attunedItemInstanceIds:[]}));return()=>{}},
+      async saveInventoryState(db,pid,unit){window.__saves.push({augmentIds:(unit.augmentations||[]).map(itemId)});return{saved:true,state:{itemEquipmentRefs:{}}}}
+    };
+  });
+
+  await page.addScriptTag({ path: PERSISTENCE_BRIDGE });
+  await page.addScriptTag({ path: BRIDGE });
+  await page.addScriptTag({ path: HUD });
+  await page.addScriptTag({ path: LAYOUT });
+  await page.waitForFunction(() => window.LuminousInventoryHudV2?.state?.unit && window.LuminousInventoryApprovedLayout);
+}
+
+test("approved Loadout retires legacy equipment and keeps Active Inventory as a 5x2 grid", async ({page}) => {
+  await bootHarness(page);
+
+  await expect(page.locator("#equipment-panel")).toBeHidden();
+  await expect(page.locator('.inventory-v2-equipment [data-equipment-slot="shield"]')).toHaveCount(0);
+  await expect(page.locator('.inventory-v2-equipment [data-equipment-slot="augment0"]')).toHaveCount(1);
+  await expect(page.locator('.inventory-v2-equipment [data-equipment-slot="augment1"]')).toHaveCount(1);
+
+  const layout = await page.evaluate(() => {
+    const equipment = document.querySelector(".inventory-v2-equipment").getBoundingClientRect();
+    const carry = document.querySelector(".inventory-v2-carry").getBoundingClientRect();
+    const grid = document.getElementById("inv-active-grid");
+    const style = getComputedStyle(grid);
+    return {
+      equipmentAboveCarry: equipment.top < carry.top,
+      columns: style.gridTemplateColumns.split(" ").filter(Boolean).length,
+      rows: style.gridTemplateRows.split(" ").filter(Boolean).length,
+    };
+  });
+
+  expect(layout.equipmentAboveCarry).toBe(true);
+  expect(layout.columns).toBe(5);
+  expect(layout.rows).toBe(2);
+});
+
+test("visible Augment slot installs from Active and persists its reference", async ({page}) => {
+  await bootHarness(page);
+
+  await page.locator('#inv-active-grid .item-slot[data-key="aug_1"]').click();
+  await page.locator('[data-equipment-slot="augment0"]').click();
+  await page.waitForFunction(() => window.__saves.length > 0 && window.__updates.length > 0);
+
+  await expect(page.locator('[data-equipment-slot="augment0"] .inventory-v2-eq-name')).toContainText("Soma Myofiber Reinforcement");
+
+  const state = await page.evaluate(() => ({
+    saves: window.__saves,
+    updates: window.__updates,
+    installed: (window.LuminousInventoryHudV2.state.unit.augmentations||[]).map(item=>item.instanceId),
+  }));
+
+  expect(state.installed).toContain("aug_1");
+  expect(state.saves.at(-1).augmentIds).toContain("aug_1");
+  const augmentUpdate = state.updates.find(entry => entry.path.endsWith("/itemEquipmentRefs"));
+  expect(augmentUpdate.value.augmentIds).toContain("aug_1");
+});
+
+test("augment refs restore from realtime inventory state", async ({page}) => {
+  await page.setContent("<html><body></body></html>");
+  await page.evaluate(() => {
+    window.LuminousItemPersistenceRuntime={
+      serializeInventoryState(unit){return{schemaVersion:2,inventario_activo:unit.inventario_activo||{},inventario_stash:{},equipmentRefs:{},attunedItemInstanceIds:[]}},
+      restoreEquipmentRefs(unit){unit.equipment={accessories:[]};return unit.equipment},
+      applyInventoryState(unit,s){unit.inventario_activo=s.inventario_activo||{};unit.inventario_stash=s.inventario_stash||{};unit.equipment={accessories:[]};return{applied:true,state:s}},
+      playerPaths(pid){return{equipmentRefs:`campaña/jugadores/${pid}/itemEquipmentRefs`}},
+      async saveInventoryState(){return{saved:true,state:{itemEquipmentRefs:{}}}}
+    };
+  });
+  await page.addScriptTag({ path: PERSISTENCE_BRIDGE });
+
+  const restored = await page.evaluate(() => {
+    const item={instanceId:"aug_restore",definitionId:"augment",category:"augmentation"};
+    const unit={};
+    const result=window.LuminousItemPersistenceRuntime.applyInventoryState(unit,{
+      inventario_activo:{aug_restore:item},
+      inventario_stash:{},
+      equipmentRefs:{augmentIds:["aug_restore"]}
+    });
+    const serialized=window.LuminousItemPersistenceRuntime.serializeInventoryState(unit);
+    return{
+      applied:result.applied,
+      augmentIds:serialized.equipmentRefs.augmentIds,
+      installed:unit.augmentations?.[0]?.installed,
+      equipped:unit.augmentations?.[0]?.equipped,
+    };
+  });
+
+  expect(restored.applied).toBe(true);
+  expect(restored.augmentIds).toEqual(["aug_restore"]);
+  expect(restored.installed).toBe(true);
+  expect(restored.equipped).toBe(true);
+});

--- a/tests/item_equipment_approved_bridge.spec.js
+++ b/tests/item_equipment_approved_bridge.spec.js
@@ -1,0 +1,51 @@
+const { test, expect } = require("@playwright/test");
+const path = require("path");
+
+const APPROVED_BRIDGE = path.resolve(__dirname, "../js/item-equipment-approved-bridge.js");
+
+test("approved equipment bridge exposes Shield only through Off Hand", async ({ page }) => {
+  await page.setContent("<html><body></body></html>");
+  await page.evaluate(() => {
+    const shield = { instanceId: "shield_1", category: "shield" };
+    window.__shield = shield;
+    window.__slots = { shield: shield, offHand: null };
+    window.__calls = [];
+    window.LuminousItemEquipmentBridge = Object.freeze({
+      version: 1,
+      normalizeSlot(slot) {
+        const value = String(slot || "");
+        if (value === "off" || value === "off_hand") return "offHand";
+        return value;
+      },
+      categoryOf(item) { return item?.category || "item"; },
+      compatibleSlots(item) { return item?.category === "shield" ? ["offHand", "shield"] : []; },
+      getSlotItem(unit, slot) { return window.__slots[slot] || null; },
+      canEquipTo(unit, item, slot) { window.__calls.push(["can", slot]); return { allowed: true, item, slot }; },
+      equipTo(unit, item, slot) { window.__calls.push(["equip", slot]); return { equipped: true, item, slot }; },
+      unequipSlot(unit, slot) { window.__calls.push(["unequip", slot]); return { unequipped: true, slot }; },
+      itemEquippedSlot(unit, item) { return item === window.__shield ? "shield" : null; },
+    });
+  });
+
+  await page.addScriptTag({ path: APPROVED_BRIDGE });
+
+  const result = await page.evaluate(() => {
+    const bridge = window.LuminousItemEquipmentBridge;
+    return {
+      compatible: bridge.compatibleSlots(window.__shield),
+      offHandItem: bridge.getSlotItem({}, "offHand")?.instanceId || null,
+      gate: bridge.canEquipTo({}, window.__shield, "shield"),
+      equipped: bridge.equipTo({}, window.__shield, "shield"),
+      visibleSlot: bridge.itemEquippedSlot({}, window.__shield),
+      calls: window.__calls,
+    };
+  });
+
+  expect(result.compatible).toEqual(["offHand"]);
+  expect(result.offHandItem).toBe("shield_1");
+  expect(result.gate.slot).toBe("offHand");
+  expect(result.equipped.slot).toBe("offHand");
+  expect(result.visibleSlot).toBe("offHand");
+  expect(result.calls).toContainEqual(["can", "offHand"]);
+  expect(result.calls).toContainEqual(["equip", "offHand"]);
+});


### PR DESCRIPTION
## Fixes the visual/runtime mismatch reported after #655

The previous integration accidentally left the legacy `#equipment-panel` visible under the new HUD and also diverged from the approved mockup by showing a separate Shield slot while collapsing Augments into a text summary.

### Approved layout restored
- Retires/hides legacy `EQUIPAMIENTO TÁCTICO` when Inventory HUD V2 is active.
- Keeps one Equipment surface above Active Inventory.
- Active Inventory remains the real 5x2 `#inv-active-grid`.
- Visible Equipment slots are now:
  - Main Hand
  - Off Hand (also accepts Shield)
  - Armor
  - Accessory A
  - Accessory B
  - Augment / Body
  - Augment / Neural
- Removes the separate Shield presentation and old Augment summary.

### Functional behavior
- New Augment slots use the existing `LuminousItemEquipmentBridge` and augmentation runtime; they are not decorative.
- Click/drop from Active Inventory still equips through runtime validation.
- Augment references are persisted in `itemEquipmentRefs.augmentIds` and restored from realtime inventory state.
- Existing Active/Stash/Synthesis contracts stay intact.

### Regression coverage
Adds tests that assert:
1. Legacy tactical equipment is hidden in V2.
2. Shield is not rendered as a separate slot.
3. Augment Body/Neural slots are visible.
4. Equipment is above the preserved 5x2 Active grid.
5. An Active augmentation can be installed into a visible Augment slot and persisted.
6. Augment refs restore correctly after realtime/load state application.

The Item Runtime regression suite is also run unchanged.