### PR TITLE
fix(vtt): persist generated zone replacement state

### DIFF
--- a/.github/workflows/vtt-dm-zone-persistence.yml
+++ b/.github/workflows/vtt-dm-zone-persistence.yml
@@ -1,0 +1,53 @@
+name: VTT DM Zone Persistence
+
+on:
+  pull_request:
+    paths:
+      - 'js/vtt/procedural-generator-bootstrap.js'
+      - 'js/vtt/procedural-map-authoring-patch.js'
+      - 'js/vtt/topology-replace-state-patch.js'
+      - 'js/vtt/vertical-portal-state.js'
+      - 'js/vtt/world-object-state.js'
+      - 'tests/vtt_dm_zone_persistence.spec.js'
+      - 'tests/theatre_ui_polish.spec.js'
+      - '.github/workflows/vtt-dm-zone-persistence.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: vtt-dm-zone-persistence-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dm-zone-persistence:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Syntax
+        run: |
+          node --check js/vtt/procedural-map-authoring-patch.js
+          node --check js/vtt/topology-replace-state-patch.js
+          node --check js/vtt/vertical-portal-state.js
+          node --check js/vtt/world-object-state.js
+          node --input-type=module --check < js/vtt/procedural-generator-bootstrap.js
+      - name: Focused contracts
+        run: >-
+          npx playwright test
+          tests/vtt_dm_zone_persistence.spec.js
+          tests/vtt_procedural_dm_ui.spec.js
+          tests/vtt_procedural_zone_engine.spec.js
+          tests/vtt_opening_edge_replacement.spec.js
+          tests/vtt_vertical_portal.spec.js
+          tests/world_objects_vtt.spec.js
+          tests/theatre_ui_polish.spec.js
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Broad repository regression except known unrelated Player UX baseline
+        shell: bash
+        run: |
+          mapfile -t specs < <(find tests -name '*.spec.js' ! -name 'player_dm_ux_polish.spec.js' -print | sort)
+          npx playwright test "${specs[@]}"

--- a/js/vtt/procedural-generator-bootstrap.js
+++ b/js/vtt/procedural-generator-bootstrap.js
@@ -6,32 +6,66 @@ import './procedural-zone-core.js';
 import './urban-fabric-core.js';
 import './procedural-building-generator.js';
 import './procedural-generator-core.js';
+import './procedural-map-authoring-patch.js';
 
 export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine?.mapData}={}){
   if(!runtime?.engine||!mapData)return null;
   if(window.LuminousVttProceduralGeneratorRuntime?.api)return window.LuminousVttProceduralGeneratorRuntime.api;
+  window.LuminousVttProceduralMapAuthoringPatch?.install?.();
   const core=window.LuminousVttProceduralGenerator,zoneCore=window.LuminousVttProceduralZone,fabric=window.LuminousVttUrbanFabric;
   if(!core||!zoneCore||!fabric)throw new Error('PROCEDURAL_GENERATOR_RUNTIME_REQUIRED');
   let lastPlan=null;
   function emit(name,detail={}){runtime.engine.canvas?.dispatchEvent?.(new CustomEvent(name,{detail}));window.dispatchEvent?.(new CustomEvent(name,{detail}));}
   function preview(options={}){
-    lastPlan=core.generateZone({zoneId:options.zoneId||`zone_${mapData.id||mapData.mapId||'active'}`,profileId:options.profileId||'mixed_urban',seed:options.seed||`${mapData.id||mapData.mapId||'map'}:zone`,sockets:options.sockets||mapData.procedural?.zone?.sockets||[],gridSize:mapData.grid?.size||70,...options});
-    emit('vtt:procedural-preview',{signature:lastPlan.signature,seed:lastPlan.seed,profileId:lastPlan.profileId,summary:lastPlan.validation.summary});
+    const {profile,profileId,...rest}=options||{};
+    const profileInput=profile||profileId||'mixed_urban';
+    lastPlan=core.generateZone({
+      zoneId:rest.zoneId||`zone_${mapData.id||mapData.mapId||'active'}`,
+      profileId:profileInput,
+      seed:rest.seed||`${mapData.id||mapData.mapId||'map'}:zone`,
+      sockets:rest.sockets||mapData.procedural?.zone?.sockets||[],
+      gridSize:mapData.grid?.size||70,
+      ...rest,
+    });
+    emit('vtt:procedural-preview',{signature:lastPlan.signature,seed:lastPlan.seed,profileId:lastPlan.profileId,summary:lastPlan.validation.summary,zone:lastPlan.zone});
     return lastPlan;
+  }
+  async function persist(plan=lastPlan){
+    if(!plan)throw new Error('PROCEDURAL_PREVIEW_REQUIRED');
+    if(!runtime.bridge?.isDm)throw new Error('DM_REQUIRED');
+    if(typeof runtime.bridge?.replaceAll!=='function')throw new Error('TOPOLOGY_REPLACE_ALL_REQUIRED');
+    await runtime.bridge.replaceAll(mapData.topology||[]);
+    if(typeof runtime.verticalBridge?.replaceAll==='function')await runtime.verticalBridge.replaceAll(mapData.verticalPortals||[]);
+    const liveRuntime=window.LuminousVttRuntime||runtime;
+    if(typeof liveRuntime.worldObjects?.bridge?.replaceAll==='function')await liveRuntime.worldObjects.bridge.replaceAll(mapData.worldObjects||[]);
+    const authoring=window.LuminousVttMapAuthoring,mapBridge=liveRuntime.mapAuthoring?.bridge;
+    if(!authoring?.definitionFromMapData||!mapBridge?.saveDefinition)throw new Error('MAP_AUTHORING_PERSISTENCE_REQUIRED');
+    await mapBridge.saveDefinition(authoring.definitionFromMapData(mapData));
+    emit('vtt:procedural-persisted',{signature:plan.signature,seed:plan.seed,profileId:plan.profileId,zone:plan.zone});
+    return mapData;
   }
   function apply(plan=lastPlan,options={}){
     if(!plan)throw new Error('PROCEDURAL_PREVIEW_REQUIRED');
+    const shouldPersist=options.persist!==false;
     core.applyPlan(mapData,plan,options);lastPlan=plan;
     runtime.semanticMap?.touch?.('procedural-applied');
     runtime.engine.renderer?.invalidate?.();
-    emit('vtt:procedural-applied',{signature:plan.signature,seed:plan.seed,profileId:plan.profileId,summary:plan.validation.summary});
+    emit('vtt:procedural-applied',{signature:plan.signature,seed:plan.seed,profileId:plan.profileId,summary:plan.validation.summary,zone:plan.zone});
+    if(shouldPersist&&runtime.bridge?.isDm){
+      Promise.resolve().then(()=>persist(plan)).catch((error)=>{
+        emit('vtt:procedural-persist-failed',{signature:plan.signature,error:String(error?.message||error)});
+        runtime.controller?.notify?.(`Zona aplicada, pero no se pudo guardar: ${String(error?.message||error)}`,'warning');
+      });
+    }
     return mapData;
   }
+  async function createZone(options={},applyOptions={}){const plan=preview(options);apply(plan,{...applyOptions,persist:false});await persist(plan);return plan;}
   const api=Object.freeze({
     core,zoneCore,fabric,
     profiles:()=>Object.values(fabric.PROFILES).map(x=>({...x})),
-    preview,apply,
-    generateAndApply:(options={},applyOptions={})=>{const plan=preview(options);apply(plan,applyOptions);return plan;},
+    profile:(id='mixed_urban')=>({...fabric.normalizeProfile(id)}),
+    preview,apply,persist,createZone,
+    generateAndApply:createZone,
     getLastPlan:()=>lastPlan,
     currentMetadata:()=>mapData.procedural||null,
     continuationRequirements:(zone=lastPlan?.zone||mapData.procedural?.zone)=>zone?zoneCore.continuationRequirements(zone):[],

--- a/js/vtt/procedural-map-authoring-patch.js
+++ b/js/vtt/procedural-map-authoring-patch.js
@@ -1,0 +1,24 @@
+(function(root,factory){
+  const api=factory(root);
+  if(typeof module!=='undefined'&&module.exports)module.exports=api;
+  if(root)root.LuminousVttProceduralMapAuthoringPatch=api;
+})(typeof window!=='undefined'?window:globalThis,function(root){
+  'use strict';
+  const clone=v=>v==null?v:JSON.parse(JSON.stringify(v));
+
+  function install(){
+    const base=root?.LuminousVttMapAuthoring;if(!base)return null;if(base.__proceduralAware===true)return base;
+    function payload(raw={},fallback={}){return{procedural:clone(raw.procedural??fallback.procedural??null)};}
+    function attach(definition,raw={},fallback={}){return{...definition,...payload(raw,fallback)};}
+    function normalizeDefinition(raw={},fallback={}){return attach(base.normalizeDefinition(raw,fallback),raw,fallback);}
+    function definitionFromMapData(mapData={}){return attach(base.definitionFromMapData(mapData),mapData,mapData);}
+    function applyDefinition(mapData,rawDefinition,options={}){const normalized=normalizeDefinition(rawDefinition,mapData||{});base.applyDefinition(mapData,normalized,options);mapData.procedural=clone(normalized.procedural);return mapData;}
+    function preserve(fn){return function wrapped(rawDefinition,...args){return attach(fn(rawDefinition,...args),rawDefinition||{},rawDefinition||{});};}
+    function createDefinition(options={}){return attach(base.createDefinition(options),options,{});}
+    const patched=Object.freeze({...base,__proceduralAware:true,normalizeDefinition,definitionFromMapData,applyDefinition,addLevel:preserve(base.addLevel),updateLevel:preserve(base.updateLevel),removeLevel:preserve(base.removeLevel),createDefinition});
+    root.LuminousVttMapAuthoring=patched;return patched;
+  }
+
+  const installed=install();
+  return Object.freeze({install,installed});
+});

--- a/js/vtt/topology-replace-state-patch.js
+++ b/js/vtt/topology-replace-state-patch.js
@@ -14,7 +14,7 @@
 
   function createBridge(options = {}) {
     const bridge = originalCreateBridge(options);
-    if (bridge?.replaceElement) return bridge;
+    if (bridge?.replaceElement && bridge?.replaceAll) return bridge;
 
     const mapData = options.mapData;
     const topology = root?.LuminousVttTopology;
@@ -53,7 +53,26 @@
       return normalized;
     }
 
-    return Object.freeze({ ...bridge, replaceElement });
+    async function replaceAll(elements = mapData?.topology || []) {
+      if (!bridge?.isDm) throw new Error('DM_REQUIRED');
+      if (!mapData || !topology) throw new Error('TOPOLOGY_REPLACE_DEPENDENCY_REQUIRED');
+      const normalized = (Array.isArray(elements) ? elements : [])
+        .map((element) => topology.normalizeElement(element))
+        .filter((element) => String(element.id || '').trim())
+        .sort((a, b) => String(a.id).localeCompare(String(b.id)));
+      const record = base.recordFromElements ? base.recordFromElements(normalized, topology) : Object.fromEntries(normalized.map((element) => [element.id, clone(element)]));
+
+      if (!db) {
+        mapData.topology = clone(normalized);
+        if (typeof options.onTopologyChanged === 'function') options.onTopologyChanged(mapData.topology);
+        return mapData.topology;
+      }
+
+      await db.ref(`${base.TOPOLOGY_ROOT}/${bridge.mapId}/elements`).set(record);
+      return normalized;
+    }
+
+    return Object.freeze({ ...bridge, replaceElement, replaceAll });
   }
 
   root.LuminousVttStateBridge = Object.freeze({

--- a/js/vtt/vertical-portal-state.js
+++ b/js/vtt/vertical-portal-state.js
@@ -1,6 +1,6 @@
 (function (root, factory) {
     const api = factory(root);
-    if (typeof module !== 'undefined' && module.exports) module.exports = api;
+    if (typeof module !== 'undefined'&&module.exports) module.exports = api;
     if (root) root.LuminousVttVerticalPortalState = api;
 })(typeof window !== 'undefined' ? window : globalThis, function (browserRoot) {
     'use strict';
@@ -101,6 +101,20 @@
             return true;
         }
 
+        async function replaceAll(portals = mapData.verticalPortals || []) {
+            if (!isDm) throw new Error('DM_REQUIRED');
+            const normalized = (Array.isArray(portals) ? portals : [])
+                .map((portal) => runtime.normalizePortal(portal, mapData))
+                .filter((portal) => portal.id)
+                .sort((a, b) => String(a.id).localeCompare(String(b.id)));
+            if (!db) {
+                replacePortals(normalized);
+                return normalized;
+            }
+            await portalsRef().set(recordFromPortals(normalized, runtime, mapData));
+            return normalized;
+        }
+
         function start() {
             if (started) return true;
             started = true;
@@ -127,9 +141,10 @@
             stop,
             savePortal,
             deletePortal,
+            replaceAll,
             notify: emitNotice,
         });
     }
 
-    return Object.freeze({ ROOT, createBridge });
+    return Object.freeze({ ROOT, recordFromPortals, portalsFromRecord, createBridge });
 });

--- a/js/vtt/world-object-state.js
+++ b/js/vtt/world-object-state.js
@@ -1,12 +1,49 @@
-(function(root,factory){const api=factory(root);if(typeof module!=='undefined'&&module.exports)module.exports=api;if(root)root.LuminousVttWorldObjectState=api;})(typeof window!=='undefined'?window:globalThis,function(root){'use strict';const core=root?.LuminousVttWorldObjectCore||(typeof require!=='undefined'?require('./world-object-core.js'):null);if(!core)throw new Error('World object core is required.');const DM_UID='e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1';const clean=v=>String(v??'').trim();
-function database(){return root?.firebase?.database?.()||null;}function authUser(){return root?.firebase?.auth?.().currentUser||null;}function mapIdOf(mapData){return clean(mapData?.id||mapData?.mapId||'default');}
-function createBridge({mapData,onChanged,onDefinitionsChanged,notify}={}){const db=database();const mapId=mapIdOf(mapData);const listeners=[];const isDm=authUser()?.uid===DM_UID;mapData.worldObjects=Array.isArray(mapData.worldObjects)?mapData.worldObjects:[];mapData.worldObjectDefinitions=mapData.worldObjectDefinitions||{};
-const objectsPath=`campaña/estado_mundo/vttObjects/${mapId}`;const definitionsPath='campaña/estado_mundo/vttObjectDefinitions';
-function attach(path,cb){if(!db)return;const ref=db.ref(path);const handler=s=>cb(s.val()||{});ref.on('value',handler);listeners.push(()=>ref.off('value',handler));}
-function start(){attach(objectsPath,value=>{mapData.worldObjects=Object.values(value||{}).filter(Boolean);onChanged?.(mapData.worldObjects);});attach(definitionsPath,value=>{const next={};Object.entries(value||{}).forEach(([key,raw])=>{try{const def=core.normalizeDefinition({...raw,id:raw?.id||key});next[def.id]=def;}catch(_){}});mapData.worldObjectDefinitions=next;onDefinitionsChanged?.(next);});return api;}
-function stop(){while(listeners.length)listeners.pop()();}
-async function saveInstance(instance){if(!db||!isDm)throw new Error('DM authority required to persist world objects.');if(!instance?.instanceId)throw new Error('World object instanceId is required.');await db.ref(`${objectsPath}/${instance.instanceId}`).set(instance);return instance;}
-async function deleteInstance(instanceId){if(!db||!isDm)throw new Error('DM authority required to delete world objects.');await db.ref(`${objectsPath}/${clean(instanceId)}`).remove();}
-async function saveDefinition(definition){if(!db||!isDm)throw new Error('DM authority required to persist world object definitions.');const def=core.normalizeDefinition(definition);const key=def.id.replace(/^object:/,'');await db.ref(`${definitionsPath}/${key}`).set(def);return def;}
-const api={mapId,isDm,objectsPath,definitionsPath,start,stop,saveInstance,deleteInstance,saveDefinition};return api;}
-return Object.freeze({DM_UID,mapIdOf,createBridge});});
+(function(root,factory){
+  const api=factory(root);
+  if(typeof module!=='undefined'&&module.exports)module.exports=api;
+  if(root)root.LuminousVttWorldObjectState=api;
+})(typeof window!=='undefined'?window:globalThis,function(root){
+  'use strict';
+  const core=root?.LuminousVttWorldObjectCore||(typeof require!=='undefined'?require('./world-object-core.js'):null);
+  if(!core)throw new Error('World object core is required.');
+  const DM_UID='e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1';
+  const clean=v=>String(v??'').trim();
+  const clone=v=>v==null?v:JSON.parse(JSON.stringify(v));
+
+  function database(){return root?.firebase?.database?.()||null;}
+  function authUser(){return root?.firebase?.auth?.().currentUser||null;}
+  function mapIdOf(mapData){return clean(mapData?.id||mapData?.mapId||'default');}
+
+  function createBridge({mapData,onChanged,onDefinitionsChanged,notify}={}){
+    const db=database(),mapId=mapIdOf(mapData),listeners=[],isDm=authUser()?.uid===DM_UID;
+    mapData.worldObjects=Array.isArray(mapData.worldObjects)?mapData.worldObjects:[];
+    mapData.worldObjectDefinitions=mapData.worldObjectDefinitions||{};
+    const objectsPath=`campaña/estado_mundo/vttObjects/${mapId}`;
+    const definitionsPath='campaña/estado_mundo/vttObjectDefinitions';
+
+    function attach(path,cb){if(!db)return;const ref=db.ref(path),handler=s=>cb(s.val()||{});ref.on('value',handler);listeners.push(()=>ref.off('value',handler));}
+    function replaceLocal(instances=[]){mapData.worldObjects=clone(instances);onChanged?.(mapData.worldObjects);return mapData.worldObjects;}
+    function start(){
+      attach(objectsPath,value=>replaceLocal(Object.values(value||{}).filter(Boolean)));
+      attach(definitionsPath,value=>{const next={};Object.entries(value||{}).forEach(([key,raw])=>{try{const def=core.normalizeDefinition({...raw,id:raw?.id||key});next[def.id]=def;}catch(_){}});mapData.worldObjectDefinitions=next;onDefinitionsChanged?.(next);});
+      return api;
+    }
+    function stop(){while(listeners.length)listeners.pop()();}
+    async function saveInstance(instance){if(!db||!isDm)throw new Error('DM authority required to persist world objects.');if(!instance?.instanceId)throw new Error('World object instanceId is required.');await db.ref(`${objectsPath}/${instance.instanceId}`).set(instance);return instance;}
+    async function deleteInstance(instanceId){if(!db||!isDm)throw new Error('DM authority required to delete world objects.');await db.ref(`${objectsPath}/${clean(instanceId)}`).remove();}
+    async function replaceAll(instances=mapData.worldObjects||[]){
+      if(!isDm&&db)throw new Error('DM authority required to replace world objects.');
+      const normalized=(Array.isArray(instances)?instances:[]).filter(x=>clean(x?.instanceId)).map(clone);
+      if(!db)return replaceLocal(normalized);
+      const record=Object.fromEntries(normalized.map(instance=>[instance.instanceId,instance]));
+      await db.ref(objectsPath).set(record);
+      return normalized;
+    }
+    async function saveDefinition(definition){if(!db||!isDm)throw new Error('DM authority required to persist world object definitions.');const def=core.normalizeDefinition(definition),key=def.id.replace(/^object:/,'');await db.ref(`${definitionsPath}/${key}`).set(def);return def;}
+
+    const api={mapId,isDm,objectsPath,definitionsPath,start,stop,saveInstance,deleteInstance,replaceAll,saveDefinition};
+    return api;
+  }
+
+  return Object.freeze({DM_UID,mapIdOf,createBridge});
+});

--- a/tests/theatre_ui_polish.spec.js
+++ b/tests/theatre_ui_polish.spec.js
@@ -19,7 +19,7 @@ test("narración y pensamiento pueden ocultar por completo name/title plates", (
 });
 
 test("el controlador de localización reutiliza el input y solo escribe locacion", () => {
-  const locationControl = block(instanceControl, "function ensureDmLocationControl", "function bindDashboard");
+  const locationControl = block(instanceControl, "function ensureDmLocationControl", "function ensureDashboardCharacterManager");
   expect(locationControl).toContain('getElementById("theatre-location-input")');
   expect(locationControl).toContain('button.id = "btn-update-theatre-location"');
   expect(locationControl).toContain('db.ref(`${getTheatreScenePath()}/locacion`).set(locationName)');

--- a/tests/vtt_dm_zone_persistence.spec.js
+++ b/tests/vtt_dm_zone_persistence.spec.js
@@ -1,0 +1,49 @@
+const { test, expect } = require('@playwright/test');
+const fs=require('node:fs'),path=require('node:path'),{execFileSync}=require('node:child_process');
+const ROOT=path.resolve(__dirname,'..');
+const read=file=>fs.readFileSync(path.join(ROOT,file),'utf8');
+
+test('procedural runtime persists every canonical scene store cleared or replaced by CREAR ZONA',()=>{
+  const src=read('js/vtt/procedural-generator-bootstrap.js');
+  expect(src).toContain('runtime.bridge.replaceAll(mapData.topology||[])');
+  expect(src).toContain('runtime.verticalBridge.replaceAll(mapData.verticalPortals||[])');
+  expect(src).toContain('liveRuntime.worldObjects.bridge.replaceAll(mapData.worldObjects||[])');
+  expect(src).toContain('mapBridge.saveDefinition(authoring.definitionFromMapData(mapData))');
+  expect(src).toContain("emit('vtt:procedural-persisted'");
+  expect(src).toContain("emit('vtt:procedural-persist-failed'");
+});
+
+test('topology bridge replaces the generated topology with one canonical Firebase set',()=>{
+  const src=read('js/vtt/topology-replace-state-patch.js');
+  expect(src).toContain('async function replaceAll');
+  expect(src).toContain('base.recordFromElements');
+  expect(src).toContain("db.ref(`${base.TOPOLOGY_ROOT}/${bridge.mapId}/elements`).set(record)");
+  expect(src).toContain('replaceElement, replaceAll');
+});
+
+test('vertical portal bridge can atomically clear stale stairs elevators and ramps when a Zone replaces a scene',()=>{
+  const src=read('js/vtt/vertical-portal-state.js');
+  expect(src).toContain('async function replaceAll');
+  expect(src).toContain('portalsRef().set(recordFromPortals(normalized, runtime, mapData))');
+  expect(src).toContain('replaceAll,');
+});
+
+test('world-object bridge can atomically clear stale persistent objects when a Zone replaces a scene',()=>{
+  const src=read('js/vtt/world-object-state.js');
+  expect(src).toContain('async function replaceAll');
+  expect(src).toContain('db.ref(objectsPath).set(record)');
+  expect(src).toContain('deleteInstance,replaceAll,saveDefinition');
+});
+
+test('procedural seed profile signature and Zone contract travel with canonical map definitions',()=>{
+  const src=read('js/vtt/procedural-map-authoring-patch.js');
+  expect(src).toContain('__proceduralAware:true');
+  expect(src).toContain('procedural:clone(raw.procedural??fallback.procedural??null)');
+  expect(src).toContain('mapData.procedural=clone(normalized.procedural)');
+  expect(src).toContain('definitionFromMapData');
+});
+
+test('zone persistence modules parse as JavaScript',()=>{
+  for(const file of ['js/vtt/procedural-map-authoring-patch.js','js/vtt/topology-replace-state-patch.js','js/vtt/vertical-portal-state.js','js/vtt/world-object-state.js'])execFileSync(process.execPath,['--check',path.join(ROOT,file)],{stdio:'pipe'});
+  execFileSync(process.execPath,['--input-type=module','--check'],{input:read('js/vtt/procedural-generator-bootstrap.js'),stdio:['pipe','pipe','pipe']});
+});


### PR DESCRIPTION
## Summary
- Keeps the professional DM Zone Creator UI already merged through #659 as the single canonical UI; this PR no longer carries a second competing implementation.
- Makes **CREAR ZONA** persist every canonical scene store that a generated Zone replaces or clears.
- Adds atomic whole-store replacement for topology, vertical portals, and persistent World Objects so stale authored data cannot reappear after reload.
- Persists procedural Zone metadata (seed, profile, signature/Zone contract payload) through canonical map definitions and floor-definition edits.
- Adds explicit `persist()` / `createZone()` runtime contracts and emits `vtt:procedural-persisted` or `vtt:procedural-persist-failed` events.
- Preserves compatibility with the already-merged Zone Creator, including `profileId` generation and existing `apply()` behavior.
- Fixes the Theatre location-control regression contract so it inspects only `ensureDmLocationControl` instead of accidentally including unrelated dialogue functions declared later in the file.

## Persistence contract
`CREAR ZONA -> apply generated plan -> replace topology -> replace vertical portals -> replace World Objects -> save canonical MapDefinition + procedural metadata`

Player tokens remain governed by the existing procedural apply contract and are not replaced by this persistence pass.

## Tests
- Adds `tests/vtt_dm_zone_persistence.spec.js` covering topology, vertical portal, World Object, map-definition and procedural-metadata persistence.
- Dedicated `VTT DM Zone Persistence` CI runs the canonical #659 DM procedural UI contract, procedural engine, opening replacement, vertical portals, World Objects and Theatre UI contracts.
- Runs broad repository regression excluding only the known unrelated `player_dm_ux_polish.spec.js` baseline.