### PR TITLE
Fix Inventory HUD V2 legacy duplication and approved loadout layout

### DIFF
--- a/.github/workflows/inventory-hud-v2-validation.yml
+++ b/.github/workflows/inventory-hud-v2-validation.yml
@@ -7,12 +7,16 @@ on:
       - "js/player-ux-polish-core.js"
       - "js/item-equipment-bridge.js"
       - "js/inventory-hud-v2.js"
+      - "js/inventory-hud-v2-approved-layout.js"
       - "css/inventory-hud-v2.css"
+      - "css/inventory-hud-v2-approved-layout.css"
       - "tests/inventory_hud_v2.spec.js"
+      - "tests/inventory_hud_v2_approved_layout.spec.js"
       - ".github/workflows/inventory-hud-v2-validation.yml"
   push:
     branches:
       - "codex/inventory-hud-v2-functional"
+      - "codex/inventory-hud-v2-legacy-cleanup-20260829"
 
 jobs:
   inventory-hud-v2-tests:
@@ -27,6 +31,6 @@ jobs:
       - run: npm ci
       - run: npx playwright install --with-deps chromium
       - name: Inventory HUD V2 integration
-        run: npx playwright test tests/inventory_hud_v2.spec.js
+        run: npx playwright test tests/inventory_hud_v2.spec.js tests/inventory_hud_v2_approved_layout.spec.js
       - name: Item Runtime regression suite
         run: npx playwright test tests/item_runtime_engine.spec.js tests/item_runtime_catalog_profile.spec.js tests/item_inventory_runtime.spec.js tests/item_inventory_regression.spec.js tests/workshop_runtime.spec.js tests/item_magic_runtime.spec.js tests/item_persistence_runtime.spec.js tests/item_realtime_sync.spec.js tests/item_augmentation_runtime.spec.js tests/item_salvage_runtime.spec.js

--- a/css/inventory-hud-v2-approved-layout.css
+++ b/css/inventory-hud-v2-approved-layout.css
@@ -1,0 +1,187 @@
+/* Approved Inventory HUD V2 layout correction. */
+#inventory-modal.inventory-v2-ready #equipment-panel,
+#inventory-modal.inventory-v2-ready .inventory-v2-legacy-equipment {
+  display: none !important;
+}
+
+#inventory-modal.inventory-v2-ready #inv-active {
+  overflow: hidden;
+}
+
+#inventory-modal.inventory-v2-ready .inventory-left-panel {
+  overflow: hidden;
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-active-stack {
+  grid-template-rows: minmax(320px, 1fr) minmax(230px, .72fr) !important;
+  gap: 12px !important;
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-equipment {
+  border-color: #4a3824;
+  background:
+    radial-gradient(circle at 50% 47%, rgba(112, 78, 35, .14), transparent 30%),
+    linear-gradient(180deg, #0f0c08, #080706);
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-equipment-header {
+  min-height: 44px;
+  padding: 8px 14px;
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-equipment-header strong {
+  font-size: 23px;
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-equipment-field {
+  min-height: 276px;
+  height: calc(100% - 44px);
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-body-silhouette {
+  width: 150px;
+  height: 300px;
+  top: 51%;
+  transform: translate(-50%, -48%);
+  border-color: #352a1f;
+  background: linear-gradient(180deg, rgba(100, 70, 34, .10), rgba(20, 16, 12, .03));
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-eq-slot {
+  width: 145px;
+  min-height: 76px;
+  padding: 8px 9px;
+  border-color: #4c3a24;
+  background: #0d0b08;
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-eq-name {
+  font-size: 10px;
+}
+
+#inventory-modal.inventory-v2-ready .inv2-eq-main {
+  left: 24px;
+  top: 20px;
+}
+
+#inventory-modal.inventory-v2-ready .inv2-eq-off {
+  right: 24px;
+  top: 20px;
+}
+
+#inventory-modal.inventory-v2-ready .inv2-eq-armor {
+  left: 50%;
+  top: 72px;
+  transform: translateX(-50%);
+}
+
+#inventory-modal.inventory-v2-ready .inv2-eq-acc-a {
+  left: 24px;
+  bottom: 22px;
+}
+
+#inventory-modal.inventory-v2-ready .inv2-eq-acc-b {
+  right: 24px;
+  left: auto;
+  bottom: 22px;
+  transform: none;
+}
+
+#inventory-modal.inventory-v2-ready .inv2-eq-augment-a {
+  left: 50%;
+  bottom: 22px;
+  transform: translateX(-158px);
+}
+
+#inventory-modal.inventory-v2-ready .inv2-eq-augment-b {
+  left: 50%;
+  bottom: 22px;
+  transform: translateX(13px);
+}
+
+#inventory-modal.inventory-v2-ready .inv2-eq-armor:hover {
+  transform: translateX(-50%) translateY(-1px);
+}
+
+#inventory-modal.inventory-v2-ready .inv2-eq-augment-a:hover {
+  transform: translateX(-158px) translateY(-1px);
+}
+
+#inventory-modal.inventory-v2-ready .inv2-eq-augment-b:hover {
+  transform: translateX(13px) translateY(-1px);
+}
+
+/* Off Hand already represents weapon/shield; the duplicate legacy shield target is not shown. */
+#inventory-modal.inventory-v2-ready [data-equipment-slot="shield"],
+#inventory-modal.inventory-v2-ready #inventory-v2-augment-summary {
+  display: none !important;
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-carry {
+  grid-template-rows: 42px minmax(0, 1fr);
+  border-color: #3b3023;
+}
+
+#inventory-modal.inventory-v2-ready .inventory-v2-grid-host {
+  padding: 10px;
+  overflow: hidden;
+}
+
+#inventory-modal.inventory-v2-ready #inv-active-grid.inv-grid {
+  display: grid !important;
+  grid-template-columns: repeat(5, minmax(82px, 1fr)) !important;
+  grid-template-rows: repeat(2, minmax(92px, 1fr)) !important;
+  grid-auto-rows: minmax(92px, 1fr) !important;
+  gap: 10px !important;
+  height: 100%;
+  overflow: hidden;
+}
+
+#inventory-modal.inventory-v2-ready #inv-active-grid .item-slot {
+  min-height: 92px;
+}
+
+@media (max-height: 760px) {
+  #inventory-modal.inventory-v2-ready .inventory-v2-active-stack {
+    grid-template-rows: minmax(270px, 1fr) minmax(190px, .68fr) !important;
+  }
+
+  #inventory-modal.inventory-v2-ready .inventory-v2-equipment-field {
+    min-height: 226px;
+  }
+
+  #inventory-modal.inventory-v2-ready .inventory-v2-body-silhouette {
+    height: 245px;
+  }
+
+  #inventory-modal.inventory-v2-ready .inventory-v2-eq-slot {
+    width: 132px;
+    min-height: 62px;
+  }
+
+  #inventory-modal.inventory-v2-ready .inv2-eq-main,
+  #inventory-modal.inventory-v2-ready .inv2-eq-off {
+    top: 14px;
+  }
+
+  #inventory-modal.inventory-v2-ready .inv2-eq-armor {
+    top: 58px;
+  }
+
+  #inventory-modal.inventory-v2-ready .inv2-eq-augment-a {
+    transform: translateX(-145px);
+  }
+
+  #inventory-modal.inventory-v2-ready .inv2-eq-augment-b {
+    transform: translateX(13px);
+  }
+
+  #inventory-modal.inventory-v2-ready #inv-active-grid.inv-grid {
+    grid-template-rows: repeat(2, minmax(72px, 1fr)) !important;
+    grid-auto-rows: minmax(72px, 1fr) !important;
+  }
+
+  #inventory-modal.inventory-v2-ready #inv-active-grid .item-slot {
+    min-height: 72px;
+  }
+}

--- a/js/inventory-hud-v2-approved-layout.js
+++ b/js/inventory-hud-v2-approved-layout.js
@@ -1,0 +1,92 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousInventoryApprovedLayout) return;
+  const doc = global.document;
+  if (!doc) return;
+
+  const augmentSlots = [
+    { id: "augment0", label: "AUGMENT / BODY", hint: "INSTALLED", className: "inv2-eq-augment-a" },
+    { id: "augment1", label: "AUGMENT / NEURAL", hint: "INSTALLED", className: "inv2-eq-augment-b" },
+  ];
+
+  function suppressLegacyEquipment() {
+    const modal = doc.getElementById("inventory-modal");
+    if (!modal) return 0;
+
+    let hidden = 0;
+    modal.querySelectorAll("#equipment-panel").forEach((panel) => {
+      panel.classList.add("inventory-v2-legacy-equipment");
+      panel.setAttribute("aria-hidden", "true");
+      try { panel.inert = true; } catch (_) {}
+      hidden += 1;
+    });
+
+    modal.querySelectorAll(".cyber-panel").forEach((panel) => {
+      const title = String(panel.querySelector(".cyber-panel-title")?.textContent || "").trim();
+      if (!/EQUIPAMIENTO\s+TÁCTICO/i.test(title)) return;
+      panel.classList.add("inventory-v2-legacy-equipment");
+      panel.setAttribute("aria-hidden", "true");
+      try { panel.inert = true; } catch (_) {}
+      hidden += 1;
+    });
+
+    return hidden;
+  }
+
+  function createEquipmentSlot(spec) {
+    const button = doc.createElement("button");
+    button.type = "button";
+    button.className = `inventory-v2-eq-slot ${spec.className}`;
+    button.dataset.equipmentSlot = spec.id;
+    button.setAttribute("aria-label", spec.label);
+    button.innerHTML = `<span class="inventory-v2-eq-label">${spec.label}</span><span class="inventory-v2-eq-name">EMPTY</span><span class="inventory-v2-eq-hint">${spec.hint}</span>`;
+    return button;
+  }
+
+  function patchApprovedEquipmentField() {
+    const field = doc.querySelector(".inventory-v2-equipment-field");
+    if (!field) return false;
+
+    /* Shield is represented by Off Hand. Showing both duplicated the same equipped shield. */
+    field.querySelector('[data-equipment-slot="shield"]')?.remove();
+    field.querySelector("#inventory-v2-augment-summary")?.remove();
+
+    augmentSlots.forEach((spec) => {
+      if (field.querySelector(`[data-equipment-slot="${spec.id}"]`)) return;
+      field.appendChild(createEquipmentSlot(spec));
+    });
+
+    doc.getElementById("inventory-modal")?.classList.add("inventory-v2-approved-layout");
+    global.LuminousInventoryHudV2?.renderEquipment?.();
+    return true;
+  }
+
+  function patch() {
+    suppressLegacyEquipment();
+    return patchApprovedEquipmentField();
+  }
+
+  function boot() {
+    patch();
+
+    /* The modal is static, but the V2 shell is mounted at DOM ready. Retry briefly if load order shifts. */
+    if (!doc.querySelector(".inventory-v2-equipment-field")) {
+      let attempts = 0;
+      const timer = global.setInterval(() => {
+        attempts += 1;
+        if (patch() || attempts >= 40) global.clearInterval(timer);
+      }, 100);
+    }
+  }
+
+  if (doc.readyState === "loading") doc.addEventListener("DOMContentLoaded", boot, { once: true });
+  else boot();
+
+  global.LuminousInventoryApprovedLayout = Object.freeze({
+    version: 1,
+    patch,
+    suppressLegacyEquipment,
+    patchApprovedEquipmentField,
+  });
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/player-ux-polish.js
+++ b/js/player-ux-polish.js
@@ -50,6 +50,7 @@
       if (!doc.getElementById("inventory-modal")) return;
 
       ensureStyle("inventory-hud-v2-stylesheet", "css/inventory-hud-v2.css");
+      ensureStyle("inventory-hud-v2-approved-layout-stylesheet", "css/inventory-hud-v2-approved-layout.css");
 
       await ensureScript("anatomy-equipment-engine-script", "js/anatomy-equipment-engine.js", "LuminousAnatomyEquipmentEngine");
       await ensureScript("item-runtime-engine-script", "js/item-runtime-engine.js", "LuminousItemRuntime");
@@ -59,6 +60,7 @@
       await ensureScript("item-augmentation-runtime-script", "js/item-augmentation-runtime.js", "LuminousItemAugmentationRuntime");
       await ensureScript("item-equipment-bridge-script", "js/item-equipment-bridge.js", "LuminousItemEquipmentBridge");
       await ensureScript("inventory-hud-v2-script", "js/inventory-hud-v2.js", "LuminousInventoryHudV2");
+      await ensureScript("inventory-hud-v2-approved-layout-script", "js/inventory-hud-v2-approved-layout.js", "LuminousInventoryApprovedLayout");
     } catch (error) {
       console.error("[Luminous] Inventory HUD V2 bootstrap failed:", error);
     }

--- a/tests/inventory_hud_v2_approved_layout.spec.js
+++ b/tests/inventory_hud_v2_approved_layout.spec.js
@@ -1,0 +1,81 @@
+const { test, expect } = require("@playwright/test");
+const path = require("path");
+
+const BASE_CSS = path.resolve(__dirname, "../css/inventory-hud-v2.css");
+const APPROVED_CSS = path.resolve(__dirname, "../css/inventory-hud-v2-approved-layout.css");
+const APPROVED_JS = path.resolve(__dirname, "../js/inventory-hud-v2-approved-layout.js");
+
+async function bootApprovedLayout(page) {
+  await page.setContent(`<!doctype html><html><head></head><body>
+    <div id="inventory-modal" class="inventory-modal inventory-v2-ready">
+      <div class="inventory-modal-content">
+        <div class="inventory-body-wrapper">
+          <div class="inventory-left-panel">
+            <div id="inv-active">
+              <div id="equipment-panel" class="cyber-panel">
+                <h3 class="cyber-panel-title">EQUIPAMIENTO TÁCTICO</h3>
+                <div class="equipamiento-layout"><div class="equip-slot">VACÍO</div></div>
+              </div>
+              <div class="inventory-v2-active-stack">
+                <section class="inventory-v2-equipment">
+                  <header class="inventory-v2-equipment-header"><div><span>ANATOMY / EQUIPMENT MAP</span><strong>EQUIPPED LOADOUT</strong></div></header>
+                  <div class="inventory-v2-equipment-field">
+                    <div class="inventory-v2-body-silhouette"></div>
+                    <button class="inventory-v2-eq-slot inv2-eq-main" data-equipment-slot="mainHand"><span class="inventory-v2-eq-label">MAIN HAND</span><span class="inventory-v2-eq-name">EMPTY</span><span class="inventory-v2-eq-hint">WEAPON</span></button>
+                    <button class="inventory-v2-eq-slot inv2-eq-off" data-equipment-slot="offHand"><span class="inventory-v2-eq-label">OFF HAND</span><span class="inventory-v2-eq-name">EMPTY</span><span class="inventory-v2-eq-hint">WEAPON / SHIELD</span></button>
+                    <button class="inventory-v2-eq-slot inv2-eq-armor" data-equipment-slot="armor"><span class="inventory-v2-eq-label">ARMOR</span><span class="inventory-v2-eq-name">EMPTY</span><span class="inventory-v2-eq-hint">BODY</span></button>
+                    <button class="inventory-v2-eq-slot inv2-eq-shield" data-equipment-slot="shield"><span class="inventory-v2-eq-label">SHIELD</span><span class="inventory-v2-eq-name">EMPTY</span><span class="inventory-v2-eq-hint">DEFENSE</span></button>
+                    <button class="inventory-v2-eq-slot inv2-eq-acc-a" data-equipment-slot="accessory0"><span class="inventory-v2-eq-label">ACCESSORY A</span><span class="inventory-v2-eq-name">EMPTY</span><span class="inventory-v2-eq-hint">ACCESSORY</span></button>
+                    <button class="inventory-v2-eq-slot inv2-eq-acc-b" data-equipment-slot="accessory1"><span class="inventory-v2-eq-label">ACCESSORY B</span><span class="inventory-v2-eq-name">EMPTY</span><span class="inventory-v2-eq-hint">ACCESSORY</span></button>
+                    <div id="inventory-v2-augment-summary"><span>AUGMENTS</span><strong>NO INSTALLED AUGMENTS</strong></div>
+                  </div>
+                </section>
+                <section class="inventory-v2-carry">
+                  <header class="inventory-v2-carry-header"><div><span>FIELD CARRY</span><strong>ACTIVE INVENTORY</strong></div></header>
+                  <div class="inventory-v2-grid-host">
+                    <div id="inv-active-grid" class="inv-grid">
+                      ${Array.from({length:10},(_,i)=>`<div class="item-slot">${i+1}</div>`).join("")}
+                    </div>
+                  </div>
+                </section>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body></html>`);
+  await page.addStyleTag({ path: BASE_CSS });
+  await page.addStyleTag({ path: APPROVED_CSS });
+  await page.addScriptTag({ path: APPROVED_JS });
+  await page.waitForFunction(() => window.LuminousInventoryApprovedLayout);
+}
+
+test("removes the visible legacy tactical equipment block", async ({ page }) => {
+  await bootApprovedLayout(page);
+  await expect(page.locator("#equipment-panel")).toBeHidden();
+  await expect(page.locator("#equipment-panel")).toHaveAttribute("aria-hidden", "true");
+});
+
+test("uses the approved seven visible equipment targets without duplicate shield", async ({ page }) => {
+  await bootApprovedLayout(page);
+  await expect(page.locator('[data-equipment-slot="shield"]')).toHaveCount(0);
+  await expect(page.locator('[data-equipment-slot="augment0"]')).toHaveCount(1);
+  await expect(page.locator('[data-equipment-slot="augment1"]')).toHaveCount(1);
+  await expect(page.locator(".inventory-v2-equipment-field [data-equipment-slot]")).toHaveCount(7);
+});
+
+test("keeps Active Inventory as the approved 5x2 grid below Equipment", async ({ page }) => {
+  await bootApprovedLayout(page);
+  const result = await page.locator("#inv-active-grid").evaluate((el) => {
+    const style = getComputedStyle(el);
+    return {
+      columns: style.gridTemplateColumns.split(" ").filter(Boolean).length,
+      rows: style.gridTemplateRows.split(" ").filter(Boolean).length,
+      belowEquipment: Boolean(el.closest(".inventory-v2-carry")?.previousElementSibling?.classList.contains("inventory-v2-equipment")),
+    };
+  });
+  expect(result.columns).toBe(5);
+  expect(result.rows).toBe(2);
+  expect(result.belowEquipment).toBe(true);
+});


### PR DESCRIPTION
## What this fixes

The merged Inventory HUD V2 was rendering the new `EQUIPPED LOADOUT` while the old `#equipment-panel` (`EQUIPAMIENTO TÁCTICO`) remained visible underneath it. That produced two simultaneous equipment UIs and pushed the 5x2 Active Inventory out of the intended composition.

This corrective PR:
- hides the legacy tactical equipment panel inside the Inventory modal while preserving it only as an internal compatibility surface for old code/data;
- removes the duplicate visible `Shield` target because `Off Hand` already supports shields and the bridge mirrors shields there;
- adds the real `augment0` and `augment1` targets already supported by `LuminousItemEquipmentBridge`;
- restores the approved Equipment-above / Active-Inventory-5x2-below composition;
- keeps the existing runtime, Firebase realtime, Stash and Synthesis behavior unchanged.

## Validation
Adds Playwright coverage that explicitly fails if:
1. `EQUIPAMIENTO TÁCTICO` is visible;
2. the duplicate Shield target survives;
3. Augment Body / Neural targets are missing;
4. Active Inventory stops being a 5x2 grid under Equipment.

The existing Inventory HUD V2 integration tests and full Item Runtime regression suite are also run by CI.