### PR TITLE
fix(vtt): mount Zone Creator live and guard NEW MAP crashes

### DIFF
--- a/js/vtt/live-map-creator-hotfix.js
+++ b/js/vtt/live-map-creator-hotfix.js
@@ -1,0 +1,106 @@
+const TOOLBAR_ID='vtt-procedural-generator-toolbar';
+const EDIT_SIDEBAR_ID='vtt-edit-sidebar';
+const MAP_NEW_SELECTOR='[data-map-new]';
+
+function clean(value){return String(value??'').trim();}
+
+function localNotice(root,message,mode='info'){
+  const runtime=root?.LuminousVttRuntime;
+  runtime?.controller?.notify?.(message,mode);
+  const node=root?.document?.getElementById?.('vtt-map-authoring-notice');
+  if(node){node.textContent=message;node.dataset.mode=mode;node.hidden=false;}
+}
+
+export function moveCreatorToolbar(root=window){
+  const doc=root?.document;if(!doc)return false;
+  const toolbar=doc.getElementById(TOOLBAR_ID),sidebar=doc.getElementById(EDIT_SIDEBAR_ID);
+  if(!toolbar||!sidebar)return false;
+  if(toolbar.parentNode!==sidebar)sidebar.appendChild(toolbar);
+  return true;
+}
+
+export async function ensureCreatorRuntime(root=window){
+  let runtime=root?.LuminousVttRuntime;
+  const mapData=runtime?.engine?.mapData;
+  if(!runtime?.engine||!mapData||!runtime?.bridge?.isDm)return false;
+  try{
+    if(!runtime.procedural&&runtime.buildingNavigation){
+      const module=await import('./procedural-generator-bootstrap.js');
+      module.start({runtime,mapData});
+      runtime=root.LuminousVttRuntime||runtime;
+    }
+    if(runtime.procedural&&!root.LuminousVttProceduralGeneratorAuthoringRuntime?.stop){
+      const module=await import('./procedural-generator-authoring-bootstrap.js');
+      module.start({runtime,mapData});
+    }
+    return moveCreatorToolbar(root);
+  }catch(error){
+    console.warn('VTT Zone Creator live mount failed:',error);
+    return false;
+  }
+}
+
+export async function createMapSafely(root=window,button=null){
+  const runtime=root?.LuminousVttRuntime;
+  const authoring=root?.LuminousVttMapAuthoring;
+  const bridge=runtime?.mapAuthoring?.bridge;
+  const doc=root?.document;
+  if(!runtime?.engine||!authoring||!bridge||!doc)throw new Error('MAP_AUTHORING_RUNTIME_REQUIRED');
+  const name=clean(root.prompt?.('Map name','New Map'));
+  if(!name)return null;
+  const selectedId=clean(doc.querySelector?.('[data-map-select]')?.value);
+  const selected=bridge.get?.(selectedId)||authoring.definitionFromMapData(runtime.engine.mapData);
+  const id=authoring.firebaseKey(`${name}_${Date.now().toString(36)}`);
+  const created=authoring.createDefinition({
+    id,name,
+    grid:selected.grid,
+    environmentTags:selected.environmentTags,
+    defaultZStepFt:selected.defaultZStepFt,
+  });
+  if(button)button.disabled=true;
+  try{
+    await bridge.saveDefinition(created);
+    await Promise.resolve();
+    const select=doc.querySelector?.('[data-map-select]');
+    if(select){
+      select.value=created.id;
+      select.dispatchEvent(new Event('change',{bubbles:true}));
+    }
+    localNotice(root,'Map created.','success');
+    return created;
+  }catch(error){
+    const message=clean(error?.message||error)||'MAP_CREATE_FAILED';
+    console.error('VTT NEW MAP FAILED:',error);
+    localNotice(root,message,'error');
+    return null;
+  }finally{
+    if(button?.isConnected)button.disabled=false;
+  }
+}
+
+export function install({root=window}={}){
+  const doc=root?.document;if(!doc||root.__luminousLiveMapCreatorHotfix)return root.__luminousLiveMapCreatorHotfix||null;
+  let stopped=false,busy=false;
+  const sync=()=>{if(!stopped)ensureCreatorRuntime(root);};
+  const clickCapture=(event)=>{
+    const button=event.target?.closest?.(MAP_NEW_SELECTOR);if(!button||busy)return;
+    event.preventDefault();event.stopPropagation();event.stopImmediatePropagation?.();
+    busy=true;
+    createMapSafely(root,button).finally(()=>{busy=false;});
+  };
+  doc.addEventListener('click',clickCapture,true);
+  const interval=root.setInterval?.(sync,300)||null;
+  doc.getElementById('vtt-dm-edit-toggle')?.addEventListener('click',()=>root.setTimeout?.(sync,0));
+  sync();
+  const api=Object.freeze({sync,stop(){if(stopped)return;stopped=true;if(interval!=null)root.clearInterval?.(interval);doc.removeEventListener('click',clickCapture,true);}});
+  root.__luminousLiveMapCreatorHotfix=api;
+  root.addEventListener?.('beforeunload',api.stop,{once:true});
+  return api;
+}
+
+function autoStart(root=window){
+  const run=()=>install({root});
+  if(root?.document?.readyState==='loading')root.document.addEventListener('DOMContentLoaded',run,{once:true});else run();
+}
+
+autoStart();

--- a/js/vtt/live-map-creator-hotfix.js
+++ b/js/vtt/live-map-creator-hotfix.js
@@ -41,30 +41,32 @@ export async function ensureCreatorRuntime(root=window){
 }
 
 export async function createMapSafely(root=window,button=null){
-  const runtime=root?.LuminousVttRuntime;
-  const authoring=root?.LuminousVttMapAuthoring;
-  const bridge=runtime?.mapAuthoring?.bridge;
-  const doc=root?.document;
-  if(!runtime?.engine||!authoring||!bridge||!doc)throw new Error('MAP_AUTHORING_RUNTIME_REQUIRED');
-  const name=clean(root.prompt?.('Map name','New Map'));
-  if(!name)return null;
-  const selectedId=clean(doc.querySelector?.('[data-map-select]')?.value);
-  const selected=bridge.get?.(selectedId)||authoring.definitionFromMapData(runtime.engine.mapData);
-  const id=authoring.firebaseKey(`${name}_${Date.now().toString(36)}`);
-  const created=authoring.createDefinition({
-    id,name,
-    grid:selected.grid,
-    environmentTags:selected.environmentTags,
-    defaultZStepFt:selected.defaultZStepFt,
-  });
   if(button)button.disabled=true;
   try{
+    const runtime=root?.LuminousVttRuntime;
+    const authoring=root?.LuminousVttMapAuthoring;
+    const bridge=runtime?.mapAuthoring?.bridge;
+    const doc=root?.document;
+    if(!runtime?.engine||!authoring||!bridge||!doc)throw new Error('MAP_AUTHORING_RUNTIME_REQUIRED');
+    const name=clean(root.prompt?.('Map name','New Map'));
+    if(!name)return null;
+    const selectedId=clean(doc.querySelector?.('[data-map-select]')?.value);
+    const selected=bridge.get?.(selectedId)||authoring.definitionFromMapData(runtime.engine.mapData);
+    if(!selected)throw new Error('MAP_TEMPLATE_REQUIRED');
+    const id=authoring.firebaseKey(`${name}_${Date.now().toString(36)}`);
+    const created=authoring.createDefinition({
+      id,name,
+      grid:selected.grid,
+      environmentTags:selected.environmentTags,
+      defaultZStepFt:selected.defaultZStepFt,
+    });
     await bridge.saveDefinition(created);
     await Promise.resolve();
     const select=doc.querySelector?.('[data-map-select]');
     if(select){
       select.value=created.id;
-      select.dispatchEvent(new Event('change',{bubbles:true}));
+      const EventCtor=root.Event;
+      if(EventCtor)select.dispatchEvent(new EventCtor('change',{bubbles:true}));
     }
     localNotice(root,'Map created.','success');
     return created;

--- a/js/vtt/map-authoring-state.js
+++ b/js/vtt/map-authoring-state.js
@@ -108,11 +108,19 @@
     async function saveDefinition(rawDefinition) {
       if (!dm) throw new Error('DM_REQUIRED');
       const definition = authoring.normalizeDefinition(rawDefinition, mapData || {});
+      const previous = maps[definition.id];
       maps[definition.id] = definition;
-      if (db) {
-        const payload = { ...definition, updatedByUid: currentUid(root) || DM_UID, updatedAt: firebase.database.ServerValue.TIMESTAMP };
-        if (!payload.createdAt) payload.createdAt = firebase.database.ServerValue.TIMESTAMP;
-        await mapsRef().child(definition.id).set(payload);
+      try {
+        if (db) {
+          const payload = { ...definition, updatedByUid: currentUid(root) || DM_UID, updatedAt: firebase.database.ServerValue.TIMESTAMP };
+          if (!payload.createdAt) payload.createdAt = firebase.database.ServerValue.TIMESTAMP;
+          await mapsRef().child(definition.id).set(payload);
+        }
+      } catch (error) {
+        if (previous === undefined) delete maps[definition.id];
+        else maps[definition.id] = previous;
+        if (typeof onMapsChanged === 'function') onMapsChanged(list());
+        throw error;
       }
       if (typeof onMapsChanged === 'function') onMapsChanged(list());
       return definition;

--- a/js/vtt/semantic-map-bootstrap.js
+++ b/js/vtt/semantic-map-bootstrap.js
@@ -1,6 +1,7 @@
 import './semantic-map-core.js';
 import './semantic-map-authoring-patch.js';
 import './semantic-map-renderer-patch.js';
+import './live-map-creator-hotfix.js';
 import { install as installDmAuthoringShellPolish } from './dm-authoring-shell-polish.js';
 import { start as startBuildingSemantics } from './building-semantic-bootstrap.js';
 import { start as startBuildingSemanticAuthoring } from './building-semantic-authoring-bootstrap.js';

--- a/tests/vtt_map_authoring_floors.spec.js
+++ b/tests/vtt_map_authoring_floors.spec.js
@@ -68,6 +68,31 @@ test('map state uses DM-owned campaign world paths and activates map instance', 
   expect(source).toContain('firebase?.storage?.()');
 });
 
+test('failed Firebase map save rolls local map cache back instead of leaving a phantom map', async () => {
+  const statePath = path.join(__dirname, '..', 'js/vtt/map-authoring-state.js');
+  delete require.cache[require.resolve(statePath)];
+  const state = require(statePath);
+  const db = {
+    ref() {
+      return {
+        child() { return { set: async () => { throw new Error('PERMISSION_DENIED'); } }; },
+        on() {}, off() {},
+      };
+    },
+  };
+  const database = () => db;
+  database.ServerValue = { TIMESTAMP: 123 };
+  const root = {
+    LuminousVttMapAuthoring: authoring,
+    firebase: { auth: () => ({ currentUser: { uid: state.DM_UID } }), database },
+    document: { body: { classList: { contains: () => false } } },
+  };
+  const mapData = authoring.createDefinition({ id: 'active', name: 'Active' });
+  const bridge = state.createBridge({ mapData, root });
+  await expect(bridge.saveDefinition(authoring.createDefinition({ id: 'new-map', name: 'New Map' }))).rejects.toThrow('PERMISSION_DENIED');
+  expect(bridge.list()).toEqual([]);
+});
+
 test('main resolves the active map before constructing the engine and reloads on map switch', () => {
   const source = read('js/vtt/main.js');
   const resolveIndex = source.indexOf('resolveActiveDefinition');

--- a/tests/vtt_procedural_dm_ui.spec.js
+++ b/tests/vtt_procedural_dm_ui.spec.js
@@ -1,10 +1,19 @@
 const { test, expect } = require('@playwright/test');
-const fs=require('node:fs'),path=require('node:path'),{execFileSync}=require('node:child_process');
+const fs=require('node:fs'),path=require('node:path'),vm=require('node:vm'),{execFileSync}=require('node:child_process');
 const ROOT=path.resolve(__dirname,'..');
 const read=file=>fs.readFileSync(path.join(ROOT,file),'utf8');
 const GEN_FILES=['topology.js','surface-core.js','horizontal-plane-core.js','building-physics-core.js','semantic-map-core.js','building-semantic-core.js','building-archetype-core.js','vertical-portal.js','building-navigation-core.js','procedural-zone-core.js','urban-fabric-core.js','procedural-building-generator.js','procedural-generator-core.js'];
 const GEN_KEYS=['LuminousVttTopology','LuminousVttSurfaceCore','LuminousVttHorizontalPlanes','LuminousVttBuildingPhysics','LuminousVttSemanticMap','LuminousVttBuildingSemantics','LuminousVttBuildingArchetypes','LuminousVttVerticalPortal','LuminousVttBuildingNavigation','LuminousVttProceduralZone','LuminousVttUrbanFabric','LuminousVttProceduralBuildings','LuminousVttProceduralGenerator'];
 function withGenerator(run){const original=new Map(GEN_KEYS.map(k=>[k,global[k]]));try{for(let i=0;i<GEN_FILES.length;i++){const resolved=require.resolve(path.join(ROOT,'js/vtt',GEN_FILES[i]));delete require.cache[resolved];global[GEN_KEYS[i]]=require(resolved);}return run(global.LuminousVttProceduralGenerator);}finally{for(const f of GEN_FILES){try{delete require.cache[require.resolve(path.join(ROOT,'js/vtt',f))];}catch(_){}}for(const key of GEN_KEYS){const value=original.get(key);if(value===undefined)delete global[key];else global[key]=value;}}}
+function loadHotfixForRuntimeTest(){
+  const source=read('js/vtt/live-map-creator-hotfix.js')
+    .replace(/\bexport\s+(?=(?:async\s+)?function)/g,'')
+    .replace(/\nautoStart\(\);\s*$/,'');
+  const sandbox={console:{warn(){},error(){}},setTimeout,clearTimeout};
+  vm.createContext(sandbox);
+  vm.runInContext(`${source}\n;globalThis.__hotfix={createMapSafely};`,sandbox,{filename:'live-map-creator-hotfix.runtime-test.js'});
+  return sandbox.__hotfix;
+}
 
 test('zone size presets map cleanly to the 40x40 chunk contract',()=>{
   const file=path.join(ROOT,'js/vtt/procedural-zone-core.js'),resolved=require.resolve(file);delete require.cache[resolved];const zone=require(resolved);
@@ -60,6 +69,34 @@ test('NEW MAP is captured by a safe async path that reports save failures instea
   expect(hotfix).toContain("console.error('VTT NEW MAP FAILED:'");
   expect(hotfix).toContain("localNotice(root,message,'error')");
   expect(hotfix).toContain("select.dispatchEvent(new EventCtor('change',{bubbles:true}))");
+});
+
+test('NEW MAP failure path executes without throwing, restores the button, and reports the Firebase error',async()=>{
+  const {createMapSafely}=loadHotfixForRuntimeTest();
+  const authoring=require('../js/vtt/map-authoring.js');
+  const active=authoring.createDefinition({id:'active',name:'Active'});
+  const notice={textContent:'',dataset:{},hidden:true};
+  const select={value:'active',dispatchEvent(){throw new Error('should not dispatch on failed save');}};
+  const notifications=[];
+  const bridge={
+    get:id=>id==='active'?active:null,
+    async saveDefinition(){throw new Error('PERMISSION_DENIED');},
+  };
+  const root={
+    prompt:()=> 'Crash Test Map',
+    LuminousVttMapAuthoring:authoring,
+    LuminousVttRuntime:{engine:{mapData:active},mapAuthoring:{bridge},controller:{notify:(message,mode)=>notifications.push({message,mode})}},
+    document:{querySelector:selector=>selector==='[data-map-select]'?select:null,getElementById:id=>id==='vtt-map-authoring-notice'?notice:null},
+    Event:class TestEvent{},
+  };
+  const button={disabled:false,isConnected:true};
+  const result=await createMapSafely(root,button);
+  expect(result).toBeNull();
+  expect(button.disabled).toBe(false);
+  expect(notice.hidden).toBe(false);
+  expect(notice.dataset.mode).toBe('error');
+  expect(notice.textContent).toContain('PERMISSION_DENIED');
+  expect(notifications.at(-1)).toEqual({message:'PERMISSION_DENIED',mode:'error'});
 });
 
 test('DM authoring shell has shared professional states and keyboard focus treatment',()=>{

--- a/tests/vtt_procedural_dm_ui.spec.js
+++ b/tests/vtt_procedural_dm_ui.spec.js
@@ -41,12 +41,33 @@ test('DM creator keeps preview presentation separate from generated scene state'
   expect(renderer).toContain('mapData.dmEditMode?.active===true');expect(renderer).toContain('mapData.proceduralEditor?.previewPlan');expect(renderer).toContain('isExporting');
 });
 
+test('live VTT integration always remounts the procedural creator into the DM edit sidebar',()=>{
+  const hotfix=read('js/vtt/live-map-creator-hotfix.js'),semantic=read('js/vtt/semantic-map-bootstrap.js');
+  expect(semantic).toContain("import './live-map-creator-hotfix.js'");
+  expect(hotfix).toContain("TOOLBAR_ID='vtt-procedural-generator-toolbar'");
+  expect(hotfix).toContain("EDIT_SIDEBAR_ID='vtt-edit-sidebar'");
+  expect(hotfix).toContain('sidebar.appendChild(toolbar)');
+  expect(hotfix).toContain('if(!runtime.procedural&&runtime.buildingNavigation)');
+  expect(hotfix).toContain("import('./procedural-generator-authoring-bootstrap.js')");
+});
+
+test('NEW MAP is captured by a safe async path that reports save failures instead of leaking a rejection',()=>{
+  const hotfix=read('js/vtt/live-map-creator-hotfix.js');
+  expect(hotfix).toContain("MAP_NEW_SELECTOR='[data-map-new]'");
+  expect(hotfix).toContain("doc.addEventListener('click',clickCapture,true)");
+  expect(hotfix).toContain('event.stopImmediatePropagation?.()');
+  expect(hotfix).toContain('await bridge.saveDefinition(created)');
+  expect(hotfix).toContain("console.error('VTT NEW MAP FAILED:'");
+  expect(hotfix).toContain("localNotice(root,message,'error')");
+  expect(hotfix).toContain("select.dispatchEvent(new Event('change',{bubbles:true}))");
+});
+
 test('DM authoring shell has shared professional states and keyboard focus treatment',()=>{
   const polish=read('js/vtt/dm-authoring-shell-polish.js'),semantic=read('js/vtt/semantic-map-bootstrap.js');
   expect(polish).toContain('DM MAP TOOLS');expect(polish).toContain('AUTHORING MODE');expect(polish).toContain(':focus-visible');expect(polish).toContain('[aria-pressed="true"]');expect(polish).toContain('width:228px');expect(semantic).toContain('installDmAuthoringShellPolish');
 });
 
 test('zone creator and DM shell modules parse as ESM JavaScript',()=>{
-  for(const file of ['js/vtt/procedural-generator-authoring-bootstrap.js','js/vtt/dm-authoring-shell-polish.js','js/vtt/semantic-map-bootstrap.js'])execFileSync(process.execPath,['--input-type=module','--check'],{input:read(file),stdio:['pipe','pipe','pipe']});
+  for(const file of ['js/vtt/procedural-generator-authoring-bootstrap.js','js/vtt/dm-authoring-shell-polish.js','js/vtt/semantic-map-bootstrap.js','js/vtt/live-map-creator-hotfix.js'])execFileSync(process.execPath,['--input-type=module','--check'],{input:read(file),stdio:['pipe','pipe','pipe']});
   execFileSync(process.execPath,['--check',path.join(ROOT,'js/vtt/procedural-preview-renderer-patch.js')],{stdio:'pipe'});
 });

--- a/tests/vtt_procedural_dm_ui.spec.js
+++ b/tests/vtt_procedural_dm_ui.spec.js
@@ -59,7 +59,7 @@ test('NEW MAP is captured by a safe async path that reports save failures instea
   expect(hotfix).toContain('await bridge.saveDefinition(created)');
   expect(hotfix).toContain("console.error('VTT NEW MAP FAILED:'");
   expect(hotfix).toContain("localNotice(root,message,'error')");
-  expect(hotfix).toContain("select.dispatchEvent(new Event('change',{bubbles:true}))");
+  expect(hotfix).toContain("select.dispatchEvent(new EventCtor('change',{bubbles:true}))");
 });
 
 test('DM authoring shell has shared professional states and keyboard focus treatment',()=>{


### PR DESCRIPTION
## Problem reproduced from the live DM UI
The procedural Zone Creator was merged and covered by isolated contracts, but the real VTT shell could still fail to expose it to the DM. The procedural toolbar may be created outside `#vtt-edit-sidebar` because the shell and authoring runtimes initialize independently, and the shell only reparents topology/vertical/lighting toolbars.

Separately, the `NEW MAP` button in `MAP LIBRARY / FLOORS` runs an async `bridge.saveDefinition()` without a rejection guard. `saveDefinition()` also inserted the new definition into its local cache before Firebase confirmed the write, so a rejected write could leave a phantom map in memory.

## Fix
- Adds a small live integration guard loaded by the actual `semantic-map-bootstrap.js` path used by `vtt.html`.
- Always reparents `#vtt-procedural-generator-toolbar` into `#vtt-edit-sidebar` when available.
- Recovers from partial initialization by starting the procedural runtime when Building Navigation exists, then mounting procedural authoring.
- Intercepts `NEW MAP` in capture phase before the unsafe legacy listener.
- Uses the already-public `runtime.mapAuthoring.bridge` and existing Map Authoring schema; no parallel map format.
- Disables the button while saving, catches/reports failures in the map notice/controller, and selects the successfully-created map through the existing map-select change path.
- Makes `saveDefinition()` transactional with respect to its local map cache: a rejected Firebase write restores/deletes the optimistic cache entry and rethrows for the UI to report.
- Does not change the procedural generator, persistence schema, Theatre, GOAP, combat, Items, or movement rules.

## Expected live behavior
`EDIT MODE` -> right DM authoring sidebar contains `MAP CREATOR / CREAR ZONA`.

`MAPS -> NEW MAP` -> successful save selects the new map; failed save reports the error in the map panel, rolls back local state, and does not leak an unhandled rejection/crash the VTT.

## Tests
- Live toolbar remount/recovery contracts.
- Safe NEW MAP capture/error handling contracts.
- Functional rejected-Firebase-save test proving the local map cache is rolled back.
- Syntax validation of the new live integration module.