### PR TITLE
fix(vtt): stop procedural preview crashes

### DIFF
--- a/.github/workflows/vtt-dm-map-creator-ui.yml
+++ b/.github/workflows/vtt-dm-map-creator-ui.yml
@@ -34,13 +34,14 @@ jobs:
           node --check js/vtt/procedural-preview-renderer-patch.js
           node --input-type=module --check < js/vtt/procedural-generator-bootstrap.js
           node --input-type=module --check < js/vtt/procedural-generator-authoring-bootstrap.js
+      - name: Live preview crash regression
+        run: npx playwright test tests/vtt_procedural_preview_crash.spec.js
       - name: Focused contracts
         run: >-
           npx playwright test
           tests/vtt_procedural_building_mix.spec.js
           tests/vtt_zone_creator_completion.spec.js
           tests/vtt_procedural_dm_ui.spec.js
-          tests/vtt_procedural_preview_crash.spec.js
           tests/vtt_dm_zone_persistence.spec.js
           tests/vtt_procedural_zone_engine.spec.js
           tests/vtt_building_navigation_graph.spec.js

--- a/.github/workflows/vtt-dm-map-creator-ui.yml
+++ b/.github/workflows/vtt-dm-map-creator-ui.yml
@@ -10,6 +10,7 @@ on:
       - 'tests/vtt_procedural_building_mix.spec.js'
       - 'tests/vtt_zone_creator_completion.spec.js'
       - 'tests/vtt_procedural_dm_ui.spec.js'
+      - 'tests/vtt_procedural_preview_crash.spec.js'
       - '.github/workflows/vtt-dm-map-creator-ui.yml'
   workflow_dispatch:
 
@@ -39,6 +40,7 @@ jobs:
           tests/vtt_procedural_building_mix.spec.js
           tests/vtt_zone_creator_completion.spec.js
           tests/vtt_procedural_dm_ui.spec.js
+          tests/vtt_procedural_preview_crash.spec.js
           tests/vtt_dm_zone_persistence.spec.js
           tests/vtt_procedural_zone_engine.spec.js
           tests/vtt_building_navigation_graph.spec.js

--- a/.github/workflows/vtt-dm-map-creator-ui.yml
+++ b/.github/workflows/vtt-dm-map-creator-ui.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'js/vtt/procedural-generator-bootstrap.js'
       - 'js/vtt/procedural-generator-authoring-bootstrap.js'
+      - 'js/vtt/procedural-generator-worker.js'
       - 'js/vtt/procedural-building-mix-patch.js'
       - 'js/vtt/procedural-preview-renderer-patch.js'
       - 'tests/vtt_procedural_building_mix.spec.js'
@@ -32,6 +33,7 @@ jobs:
         run: |
           node --check js/vtt/procedural-building-mix-patch.js
           node --check js/vtt/procedural-preview-renderer-patch.js
+          node --check js/vtt/procedural-generator-worker.js
           node --input-type=module --check < js/vtt/procedural-generator-bootstrap.js
           node --input-type=module --check < js/vtt/procedural-generator-authoring-bootstrap.js
       - name: Live preview crash regression

--- a/js/vtt/procedural-generator-authoring-bootstrap.js
+++ b/js/vtt/procedural-generator-authoring-bootstrap.js
@@ -13,7 +13,8 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
   const procedural=runtime.procedural;if(!procedural)return null;
 
   mapData.proceduralEditor||={previewPlan:null,previewOptions:{showChunks:true,showParcels:true,showRooms:true,showTopology:true,showLabels:true}};
-  let toolbar=null,panel=null,lastPlan=null,stopped=false,reroll=0,panelOpen=false,busy=false;
+  mapData.proceduralEditor.previewGenerationError??=null;
+  let toolbar=null,panel=null,lastPlan=null,stopped=false,reroll=0,panelOpen=false,busy=false,generationRevision=0;
   const stopPreviewRenderer=window.LuminousVttProceduralPreviewRenderer?.install?.(runtime.engine.renderer,mapData)||(()=>{});
   const enabled=()=>mapData.dmEditMode?.active===true;
 
@@ -46,6 +47,13 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
   function values(){
     const size=selectedSize();
     return{seed:seed(),profile:customProfile(),chunkCols:size,chunkRows:size,minBuildings:size===1?1:size===2?3:4};
+  }
+
+  function clearPreview({invalidateGeneration=true,clearError=true}={}){
+    if(invalidateGeneration)generationRevision+=1;
+    lastPlan=null;mapData.proceduralEditor.previewPlan=null;
+    if(clearError)mapData.proceduralEditor.previewGenerationError=null;
+    invalidate();
   }
 
   function randomSeed(){
@@ -87,20 +95,39 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
     mapData.proceduralEditor.previewOptions=o;invalidate();
   }
 
-  function clearPreview(){lastPlan=null;mapData.proceduralEditor.previewPlan=null;invalidate();}
   function generationChanged({resetReroll=true}={}){if(resetReroll)reroll=0;clearPreview();syncUi();}
   function fitPreview(){
     const plan=lastPlan,camera=runtime.engine.camera;if(!plan||!camera)return false;const size=Number(plan.mapData?.grid?.size)||70,width=(Number(plan.zone?.cols)||120)*size,height=(Number(plan.zone?.rows)||120)*size,canvas=runtime.engine.canvas,pad=64;
+    if(!canvas||!Number.isFinite(Number(canvas.width))||!Number.isFinite(Number(canvas.height)))return false;
     const target=Math.min((canvas.width-pad*2)/Math.max(1,width),(canvas.height-pad*2)/Math.max(1,height));camera.zoom=Math.max(camera.minZoom||.1,Math.min(camera.maxZoom||5,target));camera.centerOnWorldPoint?.({x:width/2,y:height/2});invalidate();return true;
   }
+  function generationErrorMessage(error){
+    const first=error?.failures?.[0]?.errors?.[0];
+    return clean(first?.code||first?.message||error?.message)||'PROCEDURAL_GENERATION_FAILED';
+  }
 
-  function preview({fit=true}={}){
-    if(busy)return null;setBusy(true,'GENERATING');
+  async function preview({fit=true}={}){
+    if(busy)return null;
+    const requestRevision=generationRevision;
+    setBusy(true,'GENERATING');
+    let generated=null;
     try{
-      lastPlan=procedural.preview(values());mapData.proceduralEditor.previewPlan=lastPlan;reroll=Math.max(0,reroll);if(fit)fitPreview();
-      notify(`Preview válido · ${lastPlan.validation.summary.buildings} edificios · ${lastPlan.signature}`,'success');return lastPlan;
-    }catch(error){clearPreview();const first=error?.failures?.[0]?.errors?.[0]?.code||error?.message||'PROCEDURAL_GENERATION_FAILED';notify(first,'warning');return null;}
-    finally{setBusy(false);syncUi();}
+      generated=await(procedural.previewAsync?procedural.previewAsync(values()):Promise.resolve(procedural.preview(values())));
+      if(requestRevision!==generationRevision)return null;
+      lastPlan=generated;mapData.proceduralEditor.previewPlan=generated;mapData.proceduralEditor.previewGenerationError=null;reroll=Math.max(0,reroll);
+    }catch(error){
+      if(requestRevision!==generationRevision)return null;
+      const message=generationErrorMessage(error);clearPreview({invalidateGeneration:false,clearError:false});mapData.proceduralEditor.previewGenerationError=message;
+      console.error('VTT PROCEDURAL PREVIEW GENERATION FAILED:',error);notify(message,'warning');return null;
+    }finally{
+      setBusy(false);syncUi();
+    }
+    if(!generated||requestRevision!==generationRevision)return null;
+    if(fit){
+      try{if(!fitPreview())notify('Preview válido; no se pudo encuadrar automáticamente.','warning');}
+      catch(error){console.warn('VTT procedural preview camera fit failed:',error);notify('Preview válido; ENCUADRAR falló, pero la zona puede crearse.','warning');}
+    }
+    notify(`Preview válido · ${generated.validation.summary.buildings} edificios · ${generated.signature}`,'success');syncUi();return generated;
   }
 
   function rerollPreview(){reroll+=1;return preview();}
@@ -122,9 +149,9 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
     const apply=by('[data-proc-apply]'),rerollButton=by('[data-proc-reroll]'),previewButton=by('[data-proc-preview]');if(apply)apply.disabled=busy||!lastPlan?.validation?.valid;if(rerollButton)rerollButton.disabled=busy;if(previewButton)previewButton.disabled=busy;
     for(const name of ['density','attach','alley','service','secondary']){const input=by(`[data-proc-${name}]`),out=by(`[data-proc-${name}-value]`);if(input&&out)out.textContent=`${input.value}%`;}
     let mixTotal=0;for(const name of Object.keys(MIX_FIELDS)){const input=by(`[data-proc-mix="${name}"]`),out=by(`[data-proc-mix-value="${name}"]`);if(input&&out){out.textContent=`${input.value}%`;mixTotal+=Number(input.value)||0;}}const mixTotalOut=by('[data-proc-mix-total]');if(mixTotalOut)mixTotalOut.textContent=`${mixTotal}%`;
-    const status=by('[data-proc-status]'),metrics=by('[data-proc-metrics]'),signature=by('[data-proc-signature]'),warning=by('[data-proc-replace-warning]');
+    const status=by('[data-proc-status]'),metrics=by('[data-proc-metrics]'),signature=by('[data-proc-signature]'),warning=by('[data-proc-replace-warning]'),generationError=mapData.proceduralEditor?.previewGenerationError;
     if(warning)warning.hidden=!sceneHasContent();
-    if(!lastPlan){if(status){status.textContent='SIN PREVIEW';status.dataset.state='idle';}if(metrics)metrics.innerHTML=metric('ZONE',`${selectedSize()}×${selectedSize()} CHUNKS`)+metric('CELDAS',`${selectedSize()*40}×${selectedSize()*40}`)+metric('ESTADO','—');if(signature)signature.textContent='Genera un preview para validar la zona.';}
+    if(!lastPlan){if(status){status.textContent=generationError?'ERROR':'SIN PREVIEW';status.dataset.state=generationError?'invalid':'idle';}if(metrics)metrics.innerHTML=metric('ZONE',`${selectedSize()}×${selectedSize()} CHUNKS`)+metric('CELDAS',`${selectedSize()*40}×${selectedSize()*40}`)+metric('ESTADO',generationError?'ERROR':'—');if(signature)signature.textContent=generationError?`PREVIEW FALLÓ · ${generationError} · usa REROLL o cambia la configuración.`:'Genera un preview para validar la zona.';}
     else{const v=lastPlan.validation,f=lastPlan.fabric,z=lastPlan.zone;if(status){status.textContent=v.valid?'VALIDADO':'INVÁLIDO';status.dataset.state=v.valid?'valid':'invalid';}if(metrics)metrics.innerHTML=metric('ZONE',`${z.chunkCols}×${z.chunkRows} CHUNKS`)+metric('CELDAS',`${z.cols}×${z.rows}`)+metric('EDIFICIOS',v.summary.buildings)+metric('CALLES',f.streets.length)+metric('PARCELAS',f.parcels.length)+metric('CALLEJONES',f.alleys.length);if(signature)signature.textContent=`SEED ${lastPlan.seed} · SIG ${lastPlan.signature} · ATTEMPT ${lastPlan.attempt}`;}
   }
 
@@ -162,8 +189,8 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
     by('[data-proc-seed]')?.addEventListener('input',()=>generationChanged());
     by('[data-proc-random]')?.addEventListener('click',randomSeed);
     by('[data-proc-reset]')?.addEventListener('click',()=>setProfileControls());
-    by('[data-proc-preview]')?.addEventListener('click',()=>{reroll=0;preview();});
-    by('[data-proc-reroll]')?.addEventListener('click',rerollPreview);
+    by('[data-proc-preview]')?.addEventListener('click',()=>{reroll=0;void preview();});
+    by('[data-proc-reroll]')?.addEventListener('click',()=>{void rerollPreview();});
     by('[data-proc-cancel]')?.addEventListener('click',()=>{clearPreview();syncUi();});
     panel.querySelectorAll('[data-proc-fit]').forEach(b=>b.addEventListener('click',fitPreview));
     by('[data-proc-apply]')?.addEventListener('click',createZone);

--- a/js/vtt/procedural-generator-bootstrap.js
+++ b/js/vtt/procedural-generator-bootstrap.js
@@ -15,22 +15,81 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
   window.LuminousVttProceduralMapAuthoringPatch?.install?.();
   const core=window.LuminousVttProceduralGenerator,zoneCore=window.LuminousVttProceduralZone,fabric=window.LuminousVttUrbanFabric,buildings=window.LuminousVttProceduralBuildings;
   if(!core||!zoneCore||!fabric||!buildings)throw new Error('PROCEDURAL_GENERATOR_RUNTIME_REQUIRED');
-  let lastPlan=null;
+  let lastPlan=null,worker=null,workerSeq=0;
+  const pendingWorkerRequests=new Map();
+
   function emit(name,detail={}){runtime.engine.canvas?.dispatchEvent?.(new CustomEvent(name,{detail}));window.dispatchEvent?.(new CustomEvent(name,{detail}));}
-  function preview(options={}){
+  function generationOptions(options={}){
     const {profile,profileId,...rest}=options||{};
     const profileInput=profile||profileId||'mixed_urban';
-    lastPlan=core.generateZone({
+    return{
       zoneId:rest.zoneId||`zone_${mapData.id||mapData.mapId||'active'}`,
       profileId:profileInput,
       seed:rest.seed||`${mapData.id||mapData.mapId||'map'}:zone`,
       sockets:rest.sockets||mapData.procedural?.zone?.sockets||[],
       gridSize:mapData.grid?.size||70,
       ...rest,
-    });
-    emit('vtt:procedural-preview',{signature:lastPlan.signature,seed:lastPlan.seed,profileId:lastPlan.profileId,summary:lastPlan.validation.summary,zone:lastPlan.zone});
-    return lastPlan;
+    };
   }
+  function publishPreview(plan){
+    lastPlan=plan;
+    emit('vtt:procedural-preview',{signature:plan.signature,seed:plan.seed,profileId:plan.profileId,summary:plan.validation.summary,zone:plan.zone});
+    return plan;
+  }
+  function preview(options={}){
+    return publishPreview(core.generateZone(generationOptions(options)));
+  }
+
+  function workerError(payload={}){
+    const error=new Error(String(payload.message||'PROCEDURAL_GENERATION_FAILED'));
+    error.name=String(payload.name||'Error');
+    if(Array.isArray(payload.failures))error.failures=payload.failures;
+    return error;
+  }
+  function failWorker(error){
+    const failure=error instanceof Error?error:new Error(String(error?.message||error||'PROCEDURAL_WORKER_FAILED'));
+    for(const request of pendingWorkerRequests.values())request.reject(failure);
+    pendingWorkerRequests.clear();
+    try{worker?.terminate?.();}catch(_){}
+    worker=null;
+  }
+  function ensureWorker(){
+    if(worker)return worker;
+    if(typeof Worker!=='function')return null;
+    try{
+      worker=new Worker(new URL('./procedural-generator-worker.js',import.meta.url));
+      worker.addEventListener('message',(event)=>{
+        const data=event?.data||{},request=pendingWorkerRequests.get(String(data.requestId||''));
+        if(!request)return;
+        pendingWorkerRequests.delete(String(data.requestId));
+        if(data.type==='generated'&&data.plan){request.resolve(publishPreview(data.plan));return;}
+        request.reject(workerError(data.error||{}));
+      });
+      worker.addEventListener('error',(event)=>failWorker(new Error(event?.message||'PROCEDURAL_WORKER_FAILED')));
+      worker.addEventListener('messageerror',()=>failWorker(new Error('PROCEDURAL_WORKER_MESSAGE_FAILED')));
+      return worker;
+    }catch(error){
+      console.warn('VTT procedural worker unavailable; using synchronous fallback.',error);
+      worker=null;
+      return null;
+    }
+  }
+  function previewAsync(options={}){
+    const activeWorker=ensureWorker();
+    if(!activeWorker){
+      // Compatibility fallback for environments without Worker. Defer at least one task so
+      // the GENERATING state can paint before the synchronous generator begins.
+      return new Promise((resolve,reject)=>window.setTimeout(()=>{try{resolve(preview(options));}catch(error){reject(error);}},0));
+    }
+    const requestId=`proc_${Date.now().toString(36)}_${(++workerSeq).toString(36)}`;
+    const prepared=generationOptions(options);
+    return new Promise((resolve,reject)=>{
+      pendingWorkerRequests.set(requestId,{resolve,reject});
+      try{activeWorker.postMessage({type:'generate',requestId,options:prepared});}
+      catch(error){pendingWorkerRequests.delete(requestId);reject(error);}
+    });
+  }
+
   async function persist(plan=lastPlan){
     if(!plan)throw new Error('PROCEDURAL_PREVIEW_REQUIRED');
     if(!runtime.bridge?.isDm)throw new Error('DM_REQUIRED');
@@ -60,19 +119,25 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
     }
     return mapData;
   }
-  async function createZone(options={},applyOptions={}){const plan=preview(options);apply(plan,{...applyOptions,persist:false});await persist(plan);return plan;}
+  async function createZone(options={},applyOptions={}){const plan=await previewAsync(options);apply(plan,{...applyOptions,persist:false});await persist(plan);return plan;}
   const api=Object.freeze({
     core,zoneCore,fabric,buildings,
     profiles:()=>Object.values(fabric.PROFILES).map(x=>({...x})),
     profile:(id='mixed_urban')=>({...fabric.normalizeProfile(id)}),
     buildingMix:(id='mixed_urban')=>({...buildings.normalizeBuildingMix?.(buildings.WEIGHTS?.[id]||buildings.WEIGHTS?.mixed_urban,id)}),
-    preview,apply,persist,createZone,
+    preview,previewAsync,apply,persist,createZone,
     generateAndApply:createZone,
     getLastPlan:()=>lastPlan,
     currentMetadata:()=>mapData.procedural||null,
     continuationRequirements:(zone=lastPlan?.zone||mapData.procedural?.zone)=>zone?zoneCore.continuationRequirements(zone):[],
     validatePlan:(plan=lastPlan)=>plan?.validation||null,
-    stop(){lastPlan=null;},
+    stop(){
+      lastPlan=null;
+      for(const request of pendingWorkerRequests.values())request.reject(new Error('PROCEDURAL_GENERATOR_STOPPED'));
+      pendingWorkerRequests.clear();
+      try{worker?.terminate?.();}catch(_){}
+      worker=null;
+    },
   });
   window.LuminousVttProceduralGeneratorRuntime={api};
   window.LuminousVttRuntime=Object.freeze({...window.LuminousVttRuntime,procedural:api});

--- a/js/vtt/procedural-generator-worker.js
+++ b/js/vtt/procedural-generator-worker.js
@@ -1,0 +1,39 @@
+'use strict';
+
+importScripts(
+  './topology.js',
+  './surface-core.js',
+  './horizontal-plane-core.js',
+  './building-physics-core.js',
+  './semantic-map-core.js',
+  './building-semantic-core.js',
+  './building-archetype-core.js',
+  './vertical-portal.js',
+  './building-navigation-core.js',
+  './procedural-zone-core.js',
+  './urban-fabric-core.js',
+  './procedural-building-generator.js',
+  './procedural-building-mix-patch.js',
+  './procedural-generator-core.js',
+);
+
+function errorPayload(error) {
+  return {
+    message: String(error?.message || error || 'PROCEDURAL_GENERATION_FAILED'),
+    name: String(error?.name || 'Error'),
+    failures: Array.isArray(error?.failures) ? error.failures : null,
+  };
+}
+
+self.addEventListener('message', (event) => {
+  const requestId = String(event?.data?.requestId || '');
+  if (!requestId || event?.data?.type !== 'generate') return;
+  try {
+    const core = self.LuminousVttProceduralGenerator;
+    if (!core?.generateZone) throw new Error('PROCEDURAL_GENERATOR_WORKER_REQUIRED');
+    const plan = core.generateZone(event.data.options || {});
+    self.postMessage({ type: 'generated', requestId, plan });
+  } catch (error) {
+    self.postMessage({ type: 'failed', requestId, error: errorPayload(error) });
+  }
+});

--- a/js/vtt/procedural-preview-renderer-patch.js
+++ b/js/vtt/procedural-preview-renderer-patch.js
@@ -7,17 +7,21 @@
 
   const clean=v=>String(v??'').trim();
   const finite=(v,f=0)=>Number.isFinite(Number(v))?Number(v):f;
+  const validRect=g=>Boolean(g&&Number.isFinite(Number(g.minCol))&&Number.isFinite(Number(g.minRow))&&Number.isFinite(Number(g.maxCol))&&Number.isFinite(Number(g.maxRow))&&Number(g.minCol)<=Number(g.maxCol)&&Number(g.minRow)<=Number(g.maxRow));
 
   function rectPath(ctx,g,size){
-    ctx.rect(g.minCol*size,g.minRow*size,(g.maxCol-g.minCol+1)*size,(g.maxRow-g.minRow+1)*size);
+    if(!ctx||!validRect(g))return false;
+    ctx.rect(Number(g.minCol)*size,Number(g.minRow)*size,(Number(g.maxCol)-Number(g.minCol)+1)*size,(Number(g.maxRow)-Number(g.minRow)+1)*size);
+    return true;
   }
 
   function footprintByBuilding(plan={}){
     const out=new Map();
     for(const cell of plan.generated?.surfaceCells||[]){
       const id=clean(cell.buildingId);if(!id)continue;
-      const g=out.get(id)||{minCol:cell.col,minRow:cell.row,maxCol:cell.col,maxRow:cell.row};
-      g.minCol=Math.min(g.minCol,cell.col);g.minRow=Math.min(g.minRow,cell.row);g.maxCol=Math.max(g.maxCol,cell.col);g.maxRow=Math.max(g.maxRow,cell.row);out.set(id,g);
+      const col=Number(cell.col),row=Number(cell.row);if(!Number.isFinite(col)||!Number.isFinite(row))continue;
+      const g=out.get(id)||{minCol:col,minRow:row,maxCol:col,maxRow:row};
+      g.minCol=Math.min(g.minCol,col);g.minRow=Math.min(g.minRow,row);g.maxCol=Math.max(g.maxCol,col);g.maxRow=Math.max(g.maxRow,row);out.set(id,g);
     }
     return out;
   }
@@ -34,64 +38,108 @@
   function drawZone(ctx,plan,options={}){
     const grid=plan.mapData?.grid||{},size=Math.max(1,finite(grid.size,70)),cols=Math.max(1,finite(grid.cols,120)),rows=Math.max(1,finite(grid.rows,120));
     ctx.save();
-    ctx.fillStyle='rgba(8,10,12,.62)';ctx.fillRect(0,0,cols*size,rows*size);
-    ctx.strokeStyle='#f0ca59';ctx.lineWidth=4;ctx.setLineDash([18,10]);ctx.strokeRect(0,0,cols*size,rows*size);ctx.setLineDash([]);
-    if(options.showChunks!==false){
-      const chunkSize=Math.max(1,finite(plan.zone?.chunkSize,40));ctx.strokeStyle='rgba(240,202,89,.28)';ctx.lineWidth=2;ctx.setLineDash([10,12]);
-      for(let c=chunkSize;c<cols;c+=chunkSize){ctx.beginPath();ctx.moveTo(c*size,0);ctx.lineTo(c*size,rows*size);ctx.stroke();}
-      for(let r=chunkSize;r<rows;r+=chunkSize){ctx.beginPath();ctx.moveTo(0,r*size);ctx.lineTo(cols*size,r*size);ctx.stroke();}
-      ctx.setLineDash([]);
-    }
-    ctx.restore();
+    try{
+      ctx.fillStyle='rgba(8,10,12,.62)';ctx.fillRect(0,0,cols*size,rows*size);
+      ctx.strokeStyle='#f0ca59';ctx.lineWidth=4;ctx.setLineDash([18,10]);ctx.strokeRect(0,0,cols*size,rows*size);ctx.setLineDash([]);
+      if(options.showChunks!==false){
+        const chunkSize=Math.max(1,finite(plan.zone?.chunkSize,40));ctx.strokeStyle='rgba(240,202,89,.28)';ctx.lineWidth=2;ctx.setLineDash([10,12]);
+        for(let c=chunkSize;c<cols;c+=chunkSize){ctx.beginPath();ctx.moveTo(c*size,0);ctx.lineTo(c*size,rows*size);ctx.stroke();}
+        for(let r=chunkSize;r<rows;r+=chunkSize){ctx.beginPath();ctx.moveTo(0,r*size);ctx.lineTo(cols*size,r*size);ctx.stroke();}
+        ctx.setLineDash([]);
+      }
+    }finally{ctx.restore();}
   }
 
-  function drawCorridors(ctx,plan,options={}){
+  function drawCorridors(ctx,plan){
     const size=Math.max(1,finite(plan.mapData?.grid?.size,70));
     for(const corridor of plan.fabric?.streets||[]){
-      const alley=corridor.kind==='alley';ctx.save();ctx.beginPath();rectPath(ctx,corridor.geometry,size);ctx.fillStyle=alley?'rgba(88,205,153,.32)':'rgba(255,255,255,.24)';ctx.fill();ctx.strokeStyle=alley?'rgba(112,235,180,.92)':'rgba(255,255,255,.72)';ctx.lineWidth=2;ctx.stroke();ctx.restore();
+      if(!validRect(corridor?.geometry))continue;
+      const alley=corridor.kind==='alley';ctx.save();try{ctx.beginPath();if(!rectPath(ctx,corridor.geometry,size))continue;ctx.fillStyle=alley?'rgba(88,205,153,.32)':'rgba(255,255,255,.24)';ctx.fill();ctx.strokeStyle=alley?'rgba(112,235,180,.92)':'rgba(255,255,255,.72)';ctx.lineWidth=2;ctx.stroke();}finally{ctx.restore();}
     }
-    for(const alley of plan.fabric?.alleys||[]){ctx.save();ctx.beginPath();rectPath(ctx,alley.geometry,size);ctx.fillStyle='rgba(88,205,153,.28)';ctx.fill();ctx.strokeStyle='rgba(112,235,180,.78)';ctx.lineWidth=2;ctx.stroke();ctx.restore();}
+    for(const alley of plan.fabric?.alleys||[]){
+      if(!validRect(alley?.geometry))continue;
+      ctx.save();try{ctx.beginPath();if(!rectPath(ctx,alley.geometry,size))continue;ctx.fillStyle='rgba(88,205,153,.28)';ctx.fill();ctx.strokeStyle='rgba(112,235,180,.78)';ctx.lineWidth=2;ctx.stroke();}finally{ctx.restore();}
+    }
   }
 
   function drawParcels(ctx,plan,options={}){
     if(options.showParcels===false)return;const size=Math.max(1,finite(plan.mapData?.grid?.size,70));
-    ctx.save();ctx.strokeStyle='rgba(255,255,255,.16)';ctx.lineWidth=1;ctx.setLineDash([5,7]);
-    for(const parcel of plan.fabric?.parcels||[]){const g=parcel.buildable||parcel.geometry;if(!g)continue;ctx.beginPath();rectPath(ctx,g,size);ctx.stroke();}
-    ctx.restore();
+    ctx.save();try{ctx.strokeStyle='rgba(255,255,255,.16)';ctx.lineWidth=1;ctx.setLineDash([5,7]);for(const parcel of plan.fabric?.parcels||[]){const g=parcel?.buildable||parcel?.geometry;if(!validRect(g))continue;ctx.beginPath();rectPath(ctx,g,size);ctx.stroke();}}finally{ctx.restore();}
   }
 
   function drawBuildings(ctx,plan,options={}){
     const size=Math.max(1,finite(plan.mapData?.grid?.size,70)),footprints=footprintByBuilding(plan),semantics=plan.mapData?.semantics||{};
     for(const building of semantics.buildings||[]){
-      const g=footprints.get(building.id);if(!g)continue;const color=archetypeColor(building.archetypeId);ctx.save();ctx.beginPath();rectPath(ctx,g,size);ctx.fillStyle=color;ctx.globalAlpha=.28;ctx.fill();ctx.globalAlpha=.95;ctx.strokeStyle=color;ctx.lineWidth=3;ctx.stroke();
-      if(options.showLabels!==false){const x=(g.minCol+g.maxCol+1)*size/2,y=(g.minRow+g.maxRow+1)*size/2,label=`${clean(building.archetypeId||'building').replace(/_/g,' ').toUpperCase()}`;ctx.font='bold 11px monospace';ctx.textAlign='center';ctx.textBaseline='middle';const m=ctx.measureText(label);ctx.fillStyle='rgba(0,0,0,.78)';ctx.fillRect(x-m.width/2-6,y-10,m.width+12,20);ctx.fillStyle=color;ctx.fillText(label,x,y);}
-      ctx.restore();
+      const g=footprints.get(building.id);if(!validRect(g))continue;const color=archetypeColor(building.archetypeId);ctx.save();try{ctx.beginPath();rectPath(ctx,g,size);ctx.fillStyle=color;ctx.globalAlpha=.28;ctx.fill();ctx.globalAlpha=.95;ctx.strokeStyle=color;ctx.lineWidth=3;ctx.stroke();
+      if(options.showLabels!==false){const x=(g.minCol+g.maxCol+1)*size/2,y=(g.minRow+g.maxRow+1)*size/2,label=`${clean(building.archetypeId||'building').replace(/_/g,' ').toUpperCase()}`;ctx.font='bold 11px monospace';ctx.textAlign='center';ctx.textBaseline='middle';const m=ctx.measureText(label);ctx.fillStyle='rgba(0,0,0,.78)';ctx.fillRect(x-m.width/2-6,y-10,m.width+12,20);ctx.fillStyle=color;ctx.fillText(label,x,y);}}finally{ctx.restore();}
     }
     if(options.showRooms!==false){
-      for(const area of semantics.areas||[]){if(!area.buildingId||area.geometry?.type!=='rect')continue;ctx.save();ctx.beginPath();rectPath(ctx,area.geometry,size);ctx.strokeStyle='rgba(255,255,255,.32)';ctx.lineWidth=1.5;ctx.stroke();ctx.restore();}
+      for(const area of semantics.areas||[]){if(!area?.buildingId||area.geometry?.type!=='rect'||!validRect(area.geometry))continue;ctx.save();try{ctx.beginPath();rectPath(ctx,area.geometry,size);ctx.strokeStyle='rgba(255,255,255,.32)';ctx.lineWidth=1.5;ctx.stroke();}finally{ctx.restore();}}
     }
   }
 
   function drawTopology(ctx,plan,options={}){
     if(options.showTopology===false)return;const topology=root?.LuminousVttTopology,grid=plan.mapData?.grid;if(!topology||!grid)return;
-    for(const raw of plan.mapData?.topology||[]){const e=topology.normalizeElement?topology.normalizeElement(raw):raw,line=topology.segment?topology.segment(e,grid):null;if(!line)continue;ctx.save();ctx.lineCap='round';ctx.strokeStyle=e.type==='door'?'#ffcf5a':'rgba(255,255,255,.52)';ctx.lineWidth=e.type==='door'?4:2;ctx.beginPath();ctx.moveTo(line.x1,line.y1);ctx.lineTo(line.x2,line.y2);ctx.stroke();ctx.restore();}
+    for(const raw of plan.mapData?.topology||[]){
+      try{
+        const e=topology.normalizeElement?topology.normalizeElement(raw):raw,line=topology.segment?topology.segment(e,grid):null;if(!line||![line.x1,line.y1,line.x2,line.y2].every(v=>Number.isFinite(Number(v))))continue;
+        ctx.save();try{ctx.lineCap='round';ctx.strokeStyle=e.type==='door'?'#ffcf5a':'rgba(255,255,255,.52)';ctx.lineWidth=e.type==='door'?4:2;ctx.beginPath();ctx.moveTo(line.x1,line.y1);ctx.lineTo(line.x2,line.y2);ctx.stroke();}finally{ctx.restore();}
+      }catch(error){console.warn('Procedural preview skipped malformed topology element:',error);}
+    }
   }
 
   function drawLegend(ctx,renderer,plan){
     const summary=plan.validation?.summary||{},label=`PREVIEW · ${plan.profileId||'zone'} · ${plan.zone?.cols||0}×${plan.zone?.rows||0} · B ${summary.buildings||0} · ${plan.signature||''}`;
-    ctx.save();ctx.setTransform(1,0,0,1,0,0);ctx.font='bold 12px monospace';const m=ctx.measureText(label);ctx.fillStyle='rgba(0,0,0,.86)';ctx.fillRect(18,18,m.width+20,30);ctx.strokeStyle='#f0ca59';ctx.lineWidth=1;ctx.strokeRect(18,18,m.width+20,30);ctx.fillStyle='#f0ca59';ctx.textAlign='left';ctx.textBaseline='middle';ctx.fillText(label,28,33);ctx.restore();
+    ctx.save();try{ctx.setTransform(1,0,0,1,0,0);ctx.font='bold 12px monospace';const m=ctx.measureText(label);ctx.fillStyle='rgba(0,0,0,.86)';ctx.fillRect(18,18,m.width+20,30);ctx.strokeStyle='#f0ca59';ctx.lineWidth=1;ctx.strokeRect(18,18,m.width+20,30);ctx.fillStyle='#f0ca59';ctx.textAlign='left';ctx.textBaseline='middle';ctx.fillText(label,28,33);}finally{ctx.restore();}
   }
 
   function drawPreview(renderer,camera,mapData){
-    const editor=mapData.proceduralEditor,plan=editor?.previewPlan;if(!plan)return;const ctx=renderer.ctx;ctx.save();camera.applyTransformSimple(ctx);drawZone(ctx,plan,editor.previewOptions||{});drawCorridors(ctx,plan,editor.previewOptions||{});drawParcels(ctx,plan,editor.previewOptions||{});drawBuildings(ctx,plan,editor.previewOptions||{});drawTopology(ctx,plan,editor.previewOptions||{});ctx.restore();drawLegend(ctx,renderer,plan);
+    const editor=mapData?.proceduralEditor,plan=editor?.previewPlan,ctx=renderer?.ctx;if(!plan||!ctx||typeof camera?.applyTransformSimple!=='function')return false;
+    ctx.save();
+    try{
+      camera.applyTransformSimple(ctx);
+      drawZone(ctx,plan,editor.previewOptions||{});
+      drawCorridors(ctx,plan,editor.previewOptions||{});
+      drawParcels(ctx,plan,editor.previewOptions||{});
+      drawBuildings(ctx,plan,editor.previewOptions||{});
+      drawTopology(ctx,plan,editor.previewOptions||{});
+    }finally{ctx.restore();}
+    drawLegend(ctx,renderer,plan);
+    return true;
+  }
+
+  function reportRenderFailure(mapData,plan,error){
+    mapData.proceduralEditor||={};
+    const message=clean(error?.message||error)||'PROCEDURAL_PREVIEW_RENDER_FAILED';
+    const key=`${plan?.signature||'preview'}:${message}`;
+    if(mapData.proceduralEditor.previewRenderErrorKey===key)return;
+    mapData.proceduralEditor.previewRenderErrorKey=key;
+    mapData.proceduralEditor.previewRenderError=message;
+    console.error('VTT PROCEDURAL PREVIEW RENDER FAILED:',error);
+    root?.LuminousVttRuntime?.controller?.notify?.(`Preview generado, pero el ghost visual falló: ${message}`,'warning');
+    try{root?.dispatchEvent?.(new CustomEvent('vtt:procedural-preview-render-failed',{detail:{signature:plan?.signature||null,error:message}}));}catch(_){}
+  }
+
+  function clearRenderFailure(mapData){
+    if(!mapData?.proceduralEditor)return;
+    mapData.proceduralEditor.previewRenderError=null;
+    mapData.proceduralEditor.previewRenderErrorKey=null;
   }
 
   function install(renderer,mapData){
     if(!renderer||renderer.__proceduralPreviewRendererPatch)return()=>{};const original=renderer.render?.bind(renderer);if(!original)return()=>{};
-    renderer.render=function(camera,activeZ,renderData,isExporting=false){const result=original(camera,activeZ,renderData,isExporting);if(!isExporting&&mapData.dmEditMode?.active===true&&mapData.proceduralEditor?.previewPlan)drawPreview(renderer,camera,mapData);return result;};
+    renderer.render=function(camera,activeZ,renderData,isExporting=false){
+      const result=original(camera,activeZ,renderData,isExporting);
+      const plan=mapData?.proceduralEditor?.previewPlan;
+      if(!isExporting&&mapData?.dmEditMode?.active===true&&plan){
+        try{if(drawPreview(renderer,camera,mapData))clearRenderFailure(mapData);}
+        catch(error){reportRenderFailure(mapData,plan,error);}
+      }
+      return result;
+    };
     renderer.__proceduralPreviewRendererPatch=true;
     return()=>{renderer.render=original;delete renderer.__proceduralPreviewRendererPatch;};
   }
 
-  return Object.freeze({install,drawPreview,footprintByBuilding,archetypeColor});
+  return Object.freeze({install,drawPreview,footprintByBuilding,archetypeColor,validRect});
 });

--- a/tests/vtt_procedural_preview_crash.spec.js
+++ b/tests/vtt_procedural_preview_crash.spec.js
@@ -1,0 +1,106 @@
+const { test, expect } = require('@playwright/test');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+const GEN_FILES = [
+  'topology.js','surface-core.js','horizontal-plane-core.js','building-physics-core.js',
+  'semantic-map-core.js','building-semantic-core.js','building-archetype-core.js','vertical-portal.js',
+  'building-navigation-core.js','procedural-zone-core.js','urban-fabric-core.js',
+  'procedural-building-generator.js','procedural-building-mix-patch.js','procedural-generator-core.js',
+];
+const GEN_KEYS = [
+  'LuminousVttTopology','LuminousVttSurfaceCore','LuminousVttHorizontalPlanes','LuminousVttBuildingPhysics',
+  'LuminousVttSemanticMap','LuminousVttBuildingSemantics','LuminousVttBuildingArchetypes','LuminousVttVerticalPortal',
+  'LuminousVttBuildingNavigation','LuminousVttProceduralZone','LuminousVttUrbanFabric',
+  'LuminousVttProceduralBuildings',null,'LuminousVttProceduralGenerator',
+];
+
+function withGenerator(run) {
+  const original = new Map(GEN_KEYS.filter(Boolean).map((key) => [key, global[key]]));
+  try {
+    for (let i = 0; i < GEN_FILES.length; i += 1) {
+      const resolved = require.resolve(path.join(ROOT, 'js/vtt', GEN_FILES[i]));
+      delete require.cache[resolved];
+      const loaded = require(resolved);
+      const key = GEN_KEYS[i];
+      if (key && loaded) global[key] = loaded;
+    }
+    return run(global.LuminousVttProceduralGenerator, global.LuminousVttUrbanFabric, global.LuminousVttProceduralBuildings);
+  } finally {
+    for (const file of GEN_FILES) {
+      try { delete require.cache[require.resolve(path.join(ROOT, 'js/vtt', file))]; } catch (_) {}
+    }
+    for (const key of GEN_KEYS.filter(Boolean)) {
+      const value = original.get(key);
+      if (value === undefined) delete global[key]; else global[key] = value;
+    }
+  }
+}
+
+function defaultCreatorProfile(fabric, buildings) {
+  const base = fabric.normalizeProfile('mixed_urban');
+  return {
+    ...base,
+    density: base.density,
+    attachBias: base.attachBias,
+    alleyBias: base.alleyBias,
+    serviceAccessBias: base.serviceAccessBias,
+    secondaryRoadChance: base.secondaryRoadChance,
+    buildingMix: buildings.normalizeBuildingMix?.(buildings.WEIGHTS?.mixed_urban || null, 'mixed_urban')
+      || { shop: .3, apartment_building: .35, workshop: .2, warehouse: .15 },
+  };
+}
+
+function fakeContext() {
+  const fn = () => {};
+  return {
+    save: fn, restore: fn, fillRect: fn, strokeRect: fn, setLineDash: fn, beginPath: fn,
+    moveTo: fn, lineTo: fn, stroke: fn, fill: fn, rect: fn, setTransform: fn, fillText: fn,
+    measureText: (text) => ({ width: String(text).length * 7 }),
+    fillStyle: '', strokeStyle: '', lineWidth: 1, globalAlpha: 1, lineCap: '',
+    font: '', textAlign: '', textBaseline: '',
+  };
+}
+
+test('live default Zone Creator configuration generates a valid 3x3 preview', () => withGenerator((gen, fabric, buildings) => {
+  const plan = gen.generateZone({
+    seed: 'default:zone',
+    profile: defaultCreatorProfile(fabric, buildings),
+    chunkCols: 3,
+    chunkRows: 3,
+    minBuildings: 4,
+    maxAttempts: 8,
+    gridSize: 70,
+  });
+  expect(plan.validation.valid).toBe(true);
+  expect(plan.zone).toMatchObject({ cols: 120, rows: 120, chunkCols: 3, chunkRows: 3 });
+}));
+
+test('a valid generated plan can be painted by the ghost preview renderer without throwing', () => withGenerator((gen, fabric, buildings) => {
+  const plan = gen.generateZone({
+    seed: 'default:zone',
+    profile: defaultCreatorProfile(fabric, buildings),
+    chunkCols: 3,
+    chunkRows: 3,
+    minBuildings: 4,
+    maxAttempts: 8,
+    gridSize: 70,
+  });
+  const previewPath = path.join(ROOT, 'js/vtt/procedural-preview-renderer-patch.js');
+  delete require.cache[require.resolve(previewPath)];
+  const preview = require(previewPath);
+  const ctx = fakeContext();
+  const renderer = { ctx, canvas: { width: 1280, height: 720 }, render() {} };
+  const camera = { applyTransformSimple() {} };
+  const mapData = {
+    dmEditMode: { active: true },
+    proceduralEditor: {
+      previewPlan: plan,
+      previewOptions: { showChunks: true, showParcels: true, showRooms: true, showTopology: true, showLabels: true },
+    },
+  };
+  const stop = preview.install(renderer, mapData);
+  expect(() => renderer.render(camera, 0, null, false)).not.toThrow();
+  stop();
+  delete require.cache[require.resolve(previewPath)];
+}));

--- a/tests/vtt_procedural_preview_crash.spec.js
+++ b/tests/vtt_procedural_preview_crash.spec.js
@@ -1,7 +1,10 @@
 const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
 const path = require('node:path');
+const { execFileSync } = require('node:child_process');
 
 const ROOT = path.resolve(__dirname, '..');
+const read = (file) => fs.readFileSync(path.join(ROOT, file), 'utf8');
 const GEN_FILES = [
   'topology.js','surface-core.js','horizontal-plane-core.js','building-physics-core.js',
   'semantic-map-core.js','building-semantic-core.js','building-archetype-core.js','vertical-portal.js',
@@ -104,3 +107,55 @@ test('a valid generated plan can be painted by the ghost preview renderer withou
   stop();
   delete require.cache[require.resolve(previewPath)];
 }));
+
+test('ghost presentation failures are isolated from the VTT render loop and keep the valid plan', () => withGenerator((gen, fabric, buildings) => {
+  const plan = gen.generateZone({
+    seed: 'default:zone',
+    profile: defaultCreatorProfile(fabric, buildings),
+    chunkCols: 1,
+    chunkRows: 1,
+    minBuildings: 1,
+    maxAttempts: 8,
+    gridSize: 70,
+  });
+  const previewPath = path.join(ROOT, 'js/vtt/procedural-preview-renderer-patch.js');
+  delete require.cache[require.resolve(previewPath)];
+  const preview = require(previewPath);
+  const renderer = { ctx: fakeContext(), canvas: { width: 1280, height: 720 }, render() { return 'base-render'; } };
+  const mapData = { dmEditMode: { active: true }, proceduralEditor: { previewPlan: plan, previewOptions: {} } };
+  const stop = preview.install(renderer, mapData);
+  expect(() => renderer.render({ applyTransformSimple() { throw new Error('CAMERA_TEST_FAILURE'); } }, 0, null, false)).not.toThrow();
+  expect(mapData.proceduralEditor.previewPlan).toBe(plan);
+  expect(mapData.proceduralEditor.previewRenderError).toContain('CAMERA_TEST_FAILURE');
+  stop();
+  delete require.cache[require.resolve(previewPath)];
+}));
+
+test('Zone Creator uses a dedicated Web Worker for heavy preview generation', () => {
+  const worker = read('js/vtt/procedural-generator-worker.js');
+  const runtime = read('js/vtt/procedural-generator-bootstrap.js');
+  const authoring = read('js/vtt/procedural-generator-authoring-bootstrap.js');
+
+  for (const dependency of [
+    'topology.js','surface-core.js','horizontal-plane-core.js','building-physics-core.js',
+    'semantic-map-core.js','building-semantic-core.js','building-archetype-core.js','vertical-portal.js',
+    'building-navigation-core.js','procedural-zone-core.js','urban-fabric-core.js',
+    'procedural-building-generator.js','procedural-building-mix-patch.js','procedural-generator-core.js',
+  ]) expect(worker).toContain(`'./${dependency}'`);
+  expect(worker).toContain("event?.data?.type !== 'generate'");
+  expect(worker).toContain('core.generateZone(event.data.options || {})');
+  expect(runtime).toContain("new Worker(new URL('./procedural-generator-worker.js',import.meta.url))");
+  expect(runtime).toContain('function previewAsync(options={})');
+  expect(runtime).toContain('preview,previewAsync,apply,persist,createZone');
+  expect(authoring).toContain('procedural.previewAsync?procedural.previewAsync(values())');
+  expect(authoring).toContain('requestRevision!==generationRevision');
+  expect(authoring).toContain('ENCUADRAR falló, pero la zona puede crearse.');
+});
+
+test('worker and preview crash-fix modules parse cleanly', () => {
+  execFileSync(process.execPath, ['--check', path.join(ROOT, 'js/vtt/procedural-generator-worker.js')], { stdio: 'pipe' });
+  execFileSync(process.execPath, ['--check', path.join(ROOT, 'js/vtt/procedural-preview-renderer-patch.js')], { stdio: 'pipe' });
+  for (const file of ['js/vtt/procedural-generator-bootstrap.js','js/vtt/procedural-generator-authoring-bootstrap.js']) {
+    execFileSync(process.execPath, ['--input-type=module','--check'], { input: read(file), stdio: ['pipe','pipe','pipe'] });
+  }
+});


### PR DESCRIPTION
## Reproduced live failure
The DM Zone Creator could appear to crash/freeze on **GENERAR PREVIEW**, leaving **CREAR ZONA** disabled.

The exact live default configuration is now covered: `default:zone` + Mixed Urban + 3×3 (120×120) + default Urban Fabric / Building Mix. That configuration generates a valid plan, so this is not a bad default seed or an intrinsically invalid 3×3 Zone.

The expensive procedural pipeline (`Fabric -> Buildings -> Semantics -> Navigation -> Physics`, with deterministic retries) was being executed synchronously on the VTT/UI thread. On a full 3×3 preview this can stall rendering/input long enough to look like a crash. The ghost renderer also had no exception boundary, so a presentation-only error could escape the engine render loop.

## Fix
- Adds `procedural-generator-worker.js`, a dedicated Web Worker containing only the existing procedural/core dependency stack.
- Adds `runtime.procedural.previewAsync()` while preserving the existing synchronous `preview()` API for compatibility/tests.
- Zone Creator uses `previewAsync()` so heavy generation/validation no longer owns the VTT render/input thread.
- Worker results are revision-gated: changing Seed/Profile/Size/Fabric/Building Mix or cancelling while generation is in flight makes the old result stale and it cannot enable **CREAR ZONA**.
- Keeps `GENERATING` visible while the worker is active.
- Separates valid-plan generation from camera **ENCUADRAR**: a camera-fit failure cannot discard a valid plan or disable **CREAR ZONA**.
- Persists the actual generation error in the panel instead of silently returning to generic `SIN PREVIEW`.
- Hardens the ghost preview renderer: malformed preview-only geometry is skipped; Canvas save/restore is balanced with `finally`; remaining overlay failures are caught outside the main VTT render loop and do not clear the valid plan.
- No map geometry is applied until the existing explicit **CREAR ZONA** action.

## Regression coverage
- exact live `default:zone` Mixed Urban 3×3 generation
- valid-plan ghost rendering
- deliberate ghost/camera render failure does not escape the VTT renderer or clear the plan
- Worker dependency contract and async API wiring
- stale-result revision guard
- syntax checks for Worker, renderer and ESM bootstraps
- existing procedural/semantic/navigation/physics/persistence contracts and broad VTT regression via the dedicated workflow
