### PR TITLE
test(vtt): align Zone Creator contracts with async preview

### DIFF
--- a/tests/vtt_procedural_dm_ui.spec.js
+++ b/tests/vtt_procedural_dm_ui.spec.js
@@ -33,6 +33,7 @@ test('DM creator exposes the professional non-destructive Zone Creator workflow'
   const source=read('js/vtt/procedural-generator-authoring-bootstrap.js');
   for(const token of ['CREAR ZONA','TIPO DE ZONA','1×1 CHUNK · 40×40','2×2 CHUNKS · 80×80','3×3 CHUNKS · 120×120','data-proc-random','GENERAR PREVIEW','REROLL','CANCELAR PREVIEW','ENCUADRAR','INTERIORES','MUROS/PUERTAS','procedural-preview-renderer-patch.js'])expect(source).toContain(token);
   expect(source).toContain('chunkCols:size');expect(source).toContain('chunkRows:size');expect(source).toContain('procedural.preview(values())');expect(source).toContain("procedural.apply(lastPlan,{replaceScene:true})");
+  expect(source).toContain('procedural.previewAsync?procedural.previewAsync(values())');
   const previewStart=source.indexOf('function preview('),createStart=source.indexOf('function createZone()');expect(previewStart).toBeGreaterThan(-1);expect(createStart).toBeGreaterThan(previewStart);expect(source.slice(previewStart,createStart)).not.toContain('procedural.apply(');
 });
 
@@ -42,11 +43,12 @@ test('DM creator requires a current valid preview and explicit destructive confi
   expect(source).toContain("window.confirm('CREAR ZONA reemplazará la geometría y semántica actual. Los tokens de jugador se conservarán. ¿Continuar?')");
   expect(source).toContain('function generationChanged');expect(source).toContain('clearPreview();syncUi()');
   expect(source).toContain("addEventListener('change',()=>generationChanged())");expect(source).toContain("addEventListener('input',()=>generationChanged())");
+  expect(source).toContain('requestRevision!==generationRevision');
 });
 
 test('DM creator keeps preview presentation separate from generated scene state',()=>{
   const source=read('js/vtt/procedural-generator-authoring-bootstrap.js'),renderer=read('js/vtt/procedural-preview-renderer-patch.js');
-  expect(source).toContain('mapData.proceduralEditor.previewPlan=lastPlan');expect(source).toContain('mapData.proceduralEditor.previewOptions');
+  expect(source).toMatch(/mapData\.proceduralEditor\.previewPlan=(?:lastPlan|generated)/);expect(source).toContain('mapData.proceduralEditor.previewOptions');
   expect(renderer).toContain('mapData.dmEditMode?.active===true');expect(renderer).toContain('mapData.proceduralEditor?.previewPlan');expect(renderer).toContain('isExporting');
 });
 
@@ -107,4 +109,5 @@ test('DM authoring shell has shared professional states and keyboard focus treat
 test('zone creator and DM shell modules parse as ESM JavaScript',()=>{
   for(const file of ['js/vtt/procedural-generator-authoring-bootstrap.js','js/vtt/dm-authoring-shell-polish.js','js/vtt/semantic-map-bootstrap.js','js/vtt/live-map-creator-hotfix.js'])execFileSync(process.execPath,['--input-type=module','--check'],{input:read(file),stdio:['pipe','pipe','pipe']});
   execFileSync(process.execPath,['--check',path.join(ROOT,'js/vtt/procedural-preview-renderer-patch.js')],{stdio:'pipe'});
+  execFileSync(process.execPath,['--check',path.join(ROOT,'js/vtt/procedural-generator-worker.js')],{stdio:'pipe'});
 });

--- a/tests/vtt_procedural_dm_ui.spec.js
+++ b/tests/vtt_procedural_dm_ui.spec.js
@@ -49,7 +49,7 @@ test('DM creator requires a current valid preview and explicit destructive confi
 test('DM creator keeps preview presentation separate from generated scene state',()=>{
   const source=read('js/vtt/procedural-generator-authoring-bootstrap.js'),renderer=read('js/vtt/procedural-preview-renderer-patch.js');
   expect(source).toMatch(/mapData\.proceduralEditor\.previewPlan=(?:lastPlan|generated)/);expect(source).toContain('mapData.proceduralEditor.previewOptions');
-  expect(renderer).toContain('mapData.dmEditMode?.active===true');expect(renderer).toContain('mapData.proceduralEditor?.previewPlan');expect(renderer).toContain('isExporting');
+  expect(renderer).toMatch(/mapData\??\.dmEditMode\?\.active===true/);expect(renderer).toMatch(/mapData\??\.proceduralEditor\?\.previewPlan/);expect(renderer).toContain('isExporting');
 });
 
 test('live VTT integration always remounts the procedural creator into the DM edit sidebar',()=>{

--- a/tests/vtt_procedural_preview_crash.spec.js
+++ b/tests/vtt_procedural_preview_crash.spec.js
@@ -1,6 +1,7 @@
 const { test, expect } = require('@playwright/test');
 const fs = require('node:fs');
 const path = require('node:path');
+const vm = require('node:vm');
 const { execFileSync } = require('node:child_process');
 
 const ROOT = path.resolve(__dirname, '..');
@@ -63,6 +64,29 @@ function fakeContext() {
     fillStyle: '', strokeStyle: '', lineWidth: 1, globalAlpha: 1, lineCap: '',
     font: '', textAlign: '', textBaseline: '',
   };
+}
+
+function runWorkerGeneration(options) {
+  const workerDir = path.join(ROOT, 'js/vtt');
+  const messages = [];
+  let messageHandler = null;
+  const sandbox = {
+    console: { log(){}, warn(){}, error(){} },
+    importScripts(...scripts) {
+      for (const script of scripts) {
+        const absolute = path.resolve(workerDir, script);
+        vm.runInContext(fs.readFileSync(absolute, 'utf8'), sandbox, { filename: absolute });
+      }
+    },
+    addEventListener(type, handler) { if (type === 'message') messageHandler = handler; },
+    postMessage(message) { messages.push(message); },
+  };
+  sandbox.self = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(read('js/vtt/procedural-generator-worker.js'), sandbox, { filename: 'procedural-generator-worker.js' });
+  expect(typeof messageHandler).toBe('function');
+  messageHandler({ data: { type: 'generate', requestId: 'worker-contract', options } });
+  return messages.at(-1);
 }
 
 test('live default Zone Creator configuration generates a valid 3x3 preview', () => withGenerator((gen, fabric, buildings) => {
@@ -130,6 +154,22 @@ test('ghost presentation failures are isolated from the VTT render loop and keep
   stop();
   delete require.cache[require.resolve(previewPath)];
 }));
+
+test('procedural Worker loads the real core stack and generates a valid plan', () => {
+  const result = runWorkerGeneration({
+    seed: 'worker-contract-zone',
+    profileId: 'mixed_urban',
+    chunkCols: 1,
+    chunkRows: 1,
+    minBuildings: 1,
+    maxAttempts: 8,
+    gridSize: 70,
+  });
+  expect(result?.type).toBe('generated');
+  expect(result?.requestId).toBe('worker-contract');
+  expect(result?.plan?.validation?.valid).toBe(true);
+  expect(result?.plan?.zone).toMatchObject({ cols: 40, rows: 40, chunkCols: 1, chunkRows: 1 });
+});
 
 test('Zone Creator uses a dedicated Web Worker for heavy preview generation', () => {
   const worker = read('js/vtt/procedural-generator-worker.js');

--- a/tests/vtt_zone_creator_completion.spec.js
+++ b/tests/vtt_zone_creator_completion.spec.js
@@ -10,7 +10,7 @@ test('completed Zone Creator exposes ghost preview, editable fabric and Building
   for(const token of ['DENSIDAD','EDIF. PEGADOS','CALLEJONES','SERVICIO','VÍAS SEC.','03 · BUILDING MIX','TIENDAS','APARTAMENTOS','TALLERES','ALMACENES','GENERAR PREVIEW','CANCELAR PREVIEW','ENCUADRAR'])expect(authoring).toContain(token);
   for(const option of ['showChunks','showParcels','showRooms','showTopology','showLabels'])expect(authoring).toContain(option);
   expect(authoring).toContain('buildingMix:customBuildingMix()');expect(authoring).toMatch(/mapData\.proceduralEditor\.previewPlan=(?:lastPlan|generated)/);
-  expect(preview).toContain('mapData.dmEditMode?.active===true');expect(preview).toContain('!isExporting');expect(preview).toContain('drawPreview(renderer,camera,mapData)');
+  expect(preview).toMatch(/mapData\??\.dmEditMode\?\.active===true/);expect(preview).toContain('!isExporting');expect(preview).toContain('drawPreview(renderer,camera,mapData)');
   expect(runtime).toContain("import './procedural-building-mix-patch.js'");expect(mix).toContain('fabric.profile?.buildingMix');expect(mix).toContain('eligibleWeights');
 });
 

--- a/tests/vtt_zone_creator_completion.spec.js
+++ b/tests/vtt_zone_creator_completion.spec.js
@@ -9,7 +9,7 @@ test('completed Zone Creator exposes ghost preview, editable fabric and Building
   const authoring=read('js/vtt/procedural-generator-authoring-bootstrap.js'),runtime=read('js/vtt/procedural-generator-bootstrap.js'),preview=read('js/vtt/procedural-preview-renderer-patch.js'),mix=read('js/vtt/procedural-building-mix-patch.js');
   for(const token of ['DENSIDAD','EDIF. PEGADOS','CALLEJONES','SERVICIO','VÍAS SEC.','03 · BUILDING MIX','TIENDAS','APARTAMENTOS','TALLERES','ALMACENES','GENERAR PREVIEW','CANCELAR PREVIEW','ENCUADRAR'])expect(authoring).toContain(token);
   for(const option of ['showChunks','showParcels','showRooms','showTopology','showLabels'])expect(authoring).toContain(option);
-  expect(authoring).toContain('buildingMix:customBuildingMix()');expect(authoring).toContain('mapData.proceduralEditor.previewPlan=lastPlan');
+  expect(authoring).toContain('buildingMix:customBuildingMix()');expect(authoring).toMatch(/mapData\.proceduralEditor\.previewPlan=(?:lastPlan|generated)/);
   expect(preview).toContain('mapData.dmEditMode?.active===true');expect(preview).toContain('!isExporting');expect(preview).toContain('drawPreview(renderer,camera,mapData)');
   expect(runtime).toContain("import './procedural-building-mix-patch.js'");expect(mix).toContain('fabric.profile?.buildingMix');expect(mix).toContain('eligibleWeights');
 });
@@ -32,6 +32,6 @@ test('preview path cannot apply a plan and apply remains gated by a valid lastPl
 });
 
 test('final Zone Creator modules parse as JavaScript',()=>{
-  for(const file of ['js/vtt/procedural-preview-renderer-patch.js','js/vtt/procedural-building-mix-patch.js'])execFileSync(process.execPath,['--check',path.join(ROOT,file)],{stdio:'pipe'});
+  for(const file of ['js/vtt/procedural-preview-renderer-patch.js','js/vtt/procedural-building-mix-patch.js','js/vtt/procedural-generator-worker.js'])execFileSync(process.execPath,['--check',path.join(ROOT,file)],{stdio:'pipe'});
   for(const file of ['js/vtt/procedural-generator-bootstrap.js','js/vtt/procedural-generator-authoring-bootstrap.js'])execFileSync(process.execPath,['--input-type=module','--check'],{input:read(file),stdio:['pipe','pipe','pipe']});
 });


### PR DESCRIPTION
Follow-up to merged #668. The runtime now stores the accepted async Worker result through local variable `generated`; two legacy static contracts still required the old local spelling `previewPlan=lastPlan`. This PR makes those contracts validate the semantic assignment (`lastPlan` or `generated`) instead of a local variable name, and extends syntax coverage to the new procedural Worker. No runtime/gameplay code changes.