### PR TITLE
test(vtt): verify procedural preview fix on current main

### DIFF
--- a/.github/workflows/vtt-dm-map-creator-ui.yml
+++ b/.github/workflows/vtt-dm-map-creator-ui.yml
@@ -63,3 +63,5 @@ jobs:
         run: |
           mapfile -t specs < <(find tests -name '*.spec.js' ! -name 'player_dm_ux_polish.spec.js' ! -name 'theatre_ui_polish.spec.js' -print | sort)
           npx playwright test "${specs[@]}"
+
+# Verification-only touch: re-run the merged preview crash regression against current main.


### PR DESCRIPTION
Verification-only PR. The critical `Live preview crash regression` passed against merged main, including the default Mixed Urban 3×3 / 120×120 generation and ghost renderer no-throw checks. The later red status came from stale static contracts, not from the crash regression. Those contracts were corrected and merged separately in #669. Closing this verification PR without merge because it contains no runtime change.