### PR TITLE
fix(vtt): stream procedural zones one 40x40 chunk at a time

### DIFF
--- a/.github/workflows/vtt-dm-map-creator-ui.yml
+++ b/.github/workflows/vtt-dm-map-creator-ui.yml
@@ -8,10 +8,14 @@ on:
       - 'js/vtt/procedural-generator-worker.js'
       - 'js/vtt/procedural-building-mix-patch.js'
       - 'js/vtt/procedural-preview-renderer-patch.js'
+      - 'js/vtt/procedural-chunk-streaming-core.js'
+      - 'js/vtt/procedural-chunk-streaming-runtime.js'
+      - 'js/vtt/semantic-map-bootstrap.js'
       - 'tests/vtt_procedural_building_mix.spec.js'
       - 'tests/vtt_zone_creator_completion.spec.js'
       - 'tests/vtt_procedural_dm_ui.spec.js'
       - 'tests/vtt_procedural_preview_crash.spec.js'
+      - 'tests/vtt_procedural_chunk_streaming_performance.spec.js'
       - '.github/workflows/vtt-dm-map-creator-ui.yml'
   workflow_dispatch:
 
@@ -34,10 +38,15 @@ jobs:
           node --check js/vtt/procedural-building-mix-patch.js
           node --check js/vtt/procedural-preview-renderer-patch.js
           node --check js/vtt/procedural-generator-worker.js
+          node --check js/vtt/procedural-chunk-streaming-core.js
           node --input-type=module --check < js/vtt/procedural-generator-bootstrap.js
           node --input-type=module --check < js/vtt/procedural-generator-authoring-bootstrap.js
+          node --input-type=module --check < js/vtt/procedural-chunk-streaming-runtime.js
+          node --input-type=module --check < js/vtt/semantic-map-bootstrap.js
       - name: Live preview crash regression
         run: npx playwright test tests/vtt_procedural_preview_crash.spec.js
+      - name: One-live-chunk performance regression
+        run: npx playwright test tests/vtt_procedural_chunk_streaming_performance.spec.js
       - name: Focused contracts
         run: >-
           npx playwright test

--- a/.github/workflows/vtt-dm-map-creator-ui.yml
+++ b/.github/workflows/vtt-dm-map-creator-ui.yml
@@ -17,6 +17,7 @@ on:
       - 'tests/vtt_procedural_preview_crash.spec.js'
       - 'tests/vtt_procedural_chunk_streaming_performance.spec.js'
       - 'tests/vtt_procedural_lazy_preview_performance.spec.js'
+      - 'tests/vtt_procedural_chunk_streaming_authority.spec.js'
       - '.github/workflows/vtt-dm-map-creator-ui.yml'
   workflow_dispatch:
 
@@ -47,7 +48,11 @@ jobs:
       - name: Live preview crash regression
         run: npx playwright test tests/vtt_procedural_preview_crash.spec.js
       - name: One-live-chunk performance regression
-        run: npx playwright test tests/vtt_procedural_chunk_streaming_performance.spec.js tests/vtt_procedural_lazy_preview_performance.spec.js
+        run: >-
+          npx playwright test
+          tests/vtt_procedural_chunk_streaming_performance.spec.js
+          tests/vtt_procedural_lazy_preview_performance.spec.js
+          tests/vtt_procedural_chunk_streaming_authority.spec.js
       - name: Focused contracts
         run: >-
           npx playwright test

--- a/.github/workflows/vtt-dm-map-creator-ui.yml
+++ b/.github/workflows/vtt-dm-map-creator-ui.yml
@@ -16,6 +16,7 @@ on:
       - 'tests/vtt_procedural_dm_ui.spec.js'
       - 'tests/vtt_procedural_preview_crash.spec.js'
       - 'tests/vtt_procedural_chunk_streaming_performance.spec.js'
+      - 'tests/vtt_procedural_lazy_preview_performance.spec.js'
       - '.github/workflows/vtt-dm-map-creator-ui.yml'
   workflow_dispatch:
 
@@ -46,7 +47,7 @@ jobs:
       - name: Live preview crash regression
         run: npx playwright test tests/vtt_procedural_preview_crash.spec.js
       - name: One-live-chunk performance regression
-        run: npx playwright test tests/vtt_procedural_chunk_streaming_performance.spec.js
+        run: npx playwright test tests/vtt_procedural_chunk_streaming_performance.spec.js tests/vtt_procedural_lazy_preview_performance.spec.js
       - name: Focused contracts
         run: >-
           npx playwright test

--- a/.github/workflows/vtt-procedural-zone-engine.yml
+++ b/.github/workflows/vtt-procedural-zone-engine.yml
@@ -10,6 +10,7 @@ on:
       - 'tests/vtt_procedural_zone_engine.spec.js'
       - 'tests/vtt_procedural_dm_ui.spec.js'
       - 'tests/vtt_procedural_chunk_streaming_performance.spec.js'
+      - 'tests/vtt_procedural_lazy_preview_performance.spec.js'
       - '.github/workflows/vtt-procedural-zone-engine.yml'
   workflow_dispatch:
 
@@ -40,7 +41,7 @@ jobs:
           node --input-type=module --check < js/vtt/dm-authoring-shell-polish.js
           node --input-type=module --check < js/vtt/semantic-map-bootstrap.js
       - name: Chunk streaming performance contract
-        run: npx playwright test tests/vtt_procedural_chunk_streaming_performance.spec.js
+        run: npx playwright test tests/vtt_procedural_chunk_streaming_performance.spec.js tests/vtt_procedural_lazy_preview_performance.spec.js
       - name: Focused contracts
         run: >-
           npx playwright test

--- a/.github/workflows/vtt-procedural-zone-engine.yml
+++ b/.github/workflows/vtt-procedural-zone-engine.yml
@@ -9,6 +9,7 @@ on:
       - 'js/vtt/semantic-map-bootstrap.js'
       - 'tests/vtt_procedural_zone_engine.spec.js'
       - 'tests/vtt_procedural_dm_ui.spec.js'
+      - 'tests/vtt_procedural_chunk_streaming_performance.spec.js'
       - '.github/workflows/vtt-procedural-zone-engine.yml'
   workflow_dispatch:
 
@@ -29,13 +30,17 @@ jobs:
       - name: Syntax
         run: |
           node --check js/vtt/procedural-zone-core.js
+          node --check js/vtt/procedural-chunk-streaming-core.js
           node --check js/vtt/urban-fabric-core.js
           node --check js/vtt/procedural-building-generator.js
           node --check js/vtt/procedural-generator-core.js
           node --input-type=module --check < js/vtt/procedural-generator-bootstrap.js
           node --input-type=module --check < js/vtt/procedural-generator-authoring-bootstrap.js
+          node --input-type=module --check < js/vtt/procedural-chunk-streaming-runtime.js
           node --input-type=module --check < js/vtt/dm-authoring-shell-polish.js
           node --input-type=module --check < js/vtt/semantic-map-bootstrap.js
+      - name: Chunk streaming performance contract
+        run: npx playwright test tests/vtt_procedural_chunk_streaming_performance.spec.js
       - name: Focused contracts
         run: >-
           npx playwright test

--- a/.github/workflows/vtt-procedural-zone-engine.yml
+++ b/.github/workflows/vtt-procedural-zone-engine.yml
@@ -11,6 +11,7 @@ on:
       - 'tests/vtt_procedural_dm_ui.spec.js'
       - 'tests/vtt_procedural_chunk_streaming_performance.spec.js'
       - 'tests/vtt_procedural_lazy_preview_performance.spec.js'
+      - 'tests/vtt_procedural_chunk_streaming_authority.spec.js'
       - '.github/workflows/vtt-procedural-zone-engine.yml'
   workflow_dispatch:
 
@@ -41,7 +42,11 @@ jobs:
           node --input-type=module --check < js/vtt/dm-authoring-shell-polish.js
           node --input-type=module --check < js/vtt/semantic-map-bootstrap.js
       - name: Chunk streaming performance contract
-        run: npx playwright test tests/vtt_procedural_chunk_streaming_performance.spec.js tests/vtt_procedural_lazy_preview_performance.spec.js
+        run: >-
+          npx playwright test
+          tests/vtt_procedural_chunk_streaming_performance.spec.js
+          tests/vtt_procedural_lazy_preview_performance.spec.js
+          tests/vtt_procedural_chunk_streaming_authority.spec.js
       - name: Focused contracts
         run: >-
           npx playwright test

--- a/js/vtt/procedural-chunk-streaming-core.js
+++ b/js/vtt/procedural-chunk-streaming-core.js
@@ -1,0 +1,109 @@
+(function(root,factory){
+  const api=factory();
+  if(typeof module!=='undefined'&&module.exports)module.exports=api;
+  if(root)root.LuminousVttProceduralChunkStreaming=api;
+})(typeof window!=='undefined'?window:globalThis,function(){
+  'use strict';
+
+  const SCHEMA_VERSION=1;
+  const CHUNK_SIZE=40;
+  const MODE='chunk_streamed';
+  const clone=v=>v==null?v:JSON.parse(JSON.stringify(v));
+  const finite=(v,f=0)=>Number.isFinite(Number(v))?Number(v):f;
+  const clamp=(v,min,max)=>Math.max(min,Math.min(max,Math.trunc(finite(v,min))));
+  const clean=v=>String(v??'').trim();
+
+  function normalizeCoord(raw={}){return{col:Math.max(0,Math.trunc(finite(raw.col??raw.chunkCol,0))),row:Math.max(0,Math.trunc(finite(raw.row??raw.chunkRow,0)))};}
+  function chunkKey(raw={}){const c=normalizeCoord(raw);return`${c.col},${c.row}`;}
+  function deriveChunkSeed(seed,raw={}){const c=normalizeCoord(raw);return`${clean(seed)||'luminous-zone'}:chunk:${c.col},${c.row}`;}
+
+  function createDescriptor(raw={}){
+    const chunkCols=clamp(raw.chunkCols??raw.logicalChunkCols??raw.zone?.chunkCols,1,3);
+    const chunkRows=clamp(raw.chunkRows??raw.logicalChunkRows??raw.zone?.chunkRows,1,3);
+    const active=normalizeCoord(raw.activeChunk||{});
+    return{
+      schemaVersion:SCHEMA_VERSION,
+      mode:MODE,
+      zoneId:clean(raw.zoneId||raw.zone?.id||'zone_streamed')||'zone_streamed',
+      seed:clean(raw.seed||raw.zone?.seed)||'luminous-zone',
+      profileId:clean(raw.profileId||raw.zone?.profileId||raw.profile?.id)||'mixed_urban',
+      profile:clone(raw.profile||null),
+      chunkSize:CHUNK_SIZE,
+      chunkCols,
+      chunkRows,
+      logicalCols:chunkCols*CHUNK_SIZE,
+      logicalRows:chunkRows*CHUNK_SIZE,
+      activeChunk:{col:Math.min(chunkCols-1,active.col),row:Math.min(chunkRows-1,active.row)},
+    };
+  }
+
+  function containsChunk(descriptor={},raw={}){
+    const d=createDescriptor(descriptor),c=normalizeCoord(raw);
+    return c.col>=0&&c.row>=0&&c.col<d.chunkCols&&c.row<d.chunkRows;
+  }
+
+  function liveGrid(grid={}){
+    return{
+      ...clone(grid),
+      cols:CHUNK_SIZE,
+      rows:CHUNK_SIZE,
+      size:Math.max(8,finite(grid.size,70)),
+      distancePerCell:Math.max(.1,finite(grid.distancePerCell,5)),
+      distanceUnit:clean(grid.distanceUnit)||'ft',
+    };
+  }
+
+  function performanceBudget(descriptor={}){
+    const d=createDescriptor(descriptor),liveCells=CHUNK_SIZE*CHUNK_SIZE,logicalCells=d.logicalCols*d.logicalRows;
+    return{liveCells,logicalCells,loadedChunks:1,logicalChunks:d.chunkCols*d.chunkRows,liveFraction:liveCells/logicalCells};
+  }
+
+  function chunkGenerationOptions(descriptor={},rawCoord={},overrides={}){
+    const d=createDescriptor(descriptor),coord=normalizeCoord(rawCoord);
+    if(!containsChunk(d,coord))throw new Error('PROCEDURAL_CHUNK_OUT_OF_RANGE');
+    return{
+      ...clone(overrides),
+      zoneId:`${d.zoneId}_chunk_${coord.col}_${coord.row}`,
+      seed:deriveChunkSeed(d.seed,coord),
+      profile:d.profile||d.profileId,
+      profileId:d.profile||d.profileId,
+      chunkCols:1,
+      chunkRows:1,
+      minBuildings:Math.max(1,Math.trunc(finite(overrides.minBuildings,1))),
+    };
+  }
+
+  function detectBoundaryExit(point={},grid={}){
+    const g=liveGrid(grid),width=g.cols*g.size,height=g.rows*g.size,x=finite(point.x,NaN),y=finite(point.y,NaN);
+    if(!Number.isFinite(x)||!Number.isFinite(y))return null;
+    const dx=x<0?-1:(x>=width?1:0),dy=y<0?-1:(y>=height?1:0);
+    if(!dx&&!dy)return null;
+    return{dx,dy,edges:[dy<0?'north':dy>0?'south':null,dx<0?'west':dx>0?'east':null].filter(Boolean),width,height};
+  }
+
+  function resolveTransition(descriptor={},point={},grid={}){
+    const d=createDescriptor(descriptor),exit=detectBoundaryExit(point,grid);
+    if(!exit)return null;
+    const target={col:d.activeChunk.col+exit.dx,row:d.activeChunk.row+exit.dy};
+    const valid=target.col>=0&&target.row>=0&&target.col<d.chunkCols&&target.row<d.chunkRows;
+    return{valid,reason:valid?null:'PROCEDURAL_ZONE_BOUNDARY',from:clone(d.activeChunk),target,exit};
+  }
+
+  function entryCell(point={},grid={},exit={}){
+    const g=liveGrid(grid),rawCol=Math.floor(finite(point.x,0)/g.size),rawRow=Math.floor(finite(point.y,0)/g.size);
+    const col=exit.dx>0?0:exit.dx<0?CHUNK_SIZE-1:clamp(rawCol,0,CHUNK_SIZE-1);
+    const row=exit.dy>0?0:exit.dy<0?CHUNK_SIZE-1:clamp(rawRow,0,CHUNK_SIZE-1);
+    return{col,row,x:(col+.5)*g.size,y:(row+.5)*g.size};
+  }
+
+  function withActiveChunk(descriptor={},coord={}){
+    const d=createDescriptor(descriptor),next=normalizeCoord(coord);
+    if(!containsChunk(d,next))throw new Error('PROCEDURAL_CHUNK_OUT_OF_RANGE');
+    return{...d,activeChunk:next};
+  }
+
+  return Object.freeze({
+    SCHEMA_VERSION,CHUNK_SIZE,MODE,createDescriptor,normalizeCoord,chunkKey,deriveChunkSeed,containsChunk,
+    liveGrid,performanceBudget,chunkGenerationOptions,detectBoundaryExit,resolveTransition,entryCell,withActiveChunk,
+  });
+});

--- a/js/vtt/procedural-chunk-streaming-core.js
+++ b/js/vtt/procedural-chunk-streaming-core.js
@@ -13,97 +13,52 @@
   const clamp=(v,min,max)=>Math.max(min,Math.min(max,Math.trunc(finite(v,min))));
   const clean=v=>String(v??'').trim();
 
-  function normalizeCoord(raw={}){return{col:Math.max(0,Math.trunc(finite(raw.col??raw.chunkCol,0))),row:Math.max(0,Math.trunc(finite(raw.row??raw.chunkRow,0)))};}
+  function normalizeCoord(raw={}){return{col:Math.trunc(finite(raw.col??raw.chunkCol,0)),row:Math.trunc(finite(raw.row??raw.chunkRow,0))};}
   function chunkKey(raw={}){const c=normalizeCoord(raw);return`${c.col},${c.row}`;}
   function deriveChunkSeed(seed,raw={}){const c=normalizeCoord(raw);return`${clean(seed)||'luminous-zone'}:chunk:${c.col},${c.row}`;}
 
   function createDescriptor(raw={}){
-    const chunkCols=clamp(raw.chunkCols??raw.logicalChunkCols??raw.zone?.chunkCols,1,3);
-    const chunkRows=clamp(raw.chunkRows??raw.logicalChunkRows??raw.zone?.chunkRows,1,3);
-    const active=normalizeCoord(raw.activeChunk||{});
+    const chunkCols=clamp(raw.chunkCols??raw.logicalChunkCols??raw.zone?.chunkCols,1,3),chunkRows=clamp(raw.chunkRows??raw.logicalChunkRows??raw.zone?.chunkRows,1,3),active=normalizeCoord(raw.activeChunk||{});
+    const chunkSeeds={};for(const[key,value]of Object.entries(raw.chunkSeeds||{})){const seed=clean(value);if(seed)chunkSeeds[key]=seed;}
     return{
-      schemaVersion:SCHEMA_VERSION,
-      mode:MODE,
-      zoneId:clean(raw.zoneId||raw.zone?.id||'zone_streamed')||'zone_streamed',
-      seed:clean(raw.seed||raw.zone?.seed)||'luminous-zone',
-      profileId:clean(raw.profileId||raw.zone?.profileId||raw.profile?.id)||'mixed_urban',
-      profile:clone(raw.profile||null),
-      chunkSize:CHUNK_SIZE,
-      chunkCols,
-      chunkRows,
-      logicalCols:chunkCols*CHUNK_SIZE,
-      logicalRows:chunkRows*CHUNK_SIZE,
-      activeChunk:{col:Math.min(chunkCols-1,active.col),row:Math.min(chunkRows-1,active.row)},
+      schemaVersion:SCHEMA_VERSION,mode:MODE,zoneId:clean(raw.zoneId||raw.zone?.id||'zone_streamed')||'zone_streamed',seed:clean(raw.seed||raw.zone?.seed)||'luminous-zone',
+      profileId:clean(raw.profileId||raw.zone?.profileId||raw.profile?.id)||'mixed_urban',profile:clone(raw.profile||null),chunkSize:CHUNK_SIZE,chunkCols,chunkRows,
+      logicalCols:chunkCols*CHUNK_SIZE,logicalRows:chunkRows*CHUNK_SIZE,chunkSeeds,
+      activeChunk:{col:clamp(active.col,0,chunkCols-1),row:clamp(active.row,0,chunkRows-1)},
     };
   }
 
-  function containsChunk(descriptor={},raw={}){
-    const d=createDescriptor(descriptor),c=normalizeCoord(raw);
-    return c.col>=0&&c.row>=0&&c.col<d.chunkCols&&c.row<d.chunkRows;
-  }
+  function containsChunk(descriptor={},raw={}){const d=createDescriptor(descriptor),c=normalizeCoord(raw);return c.col>=0&&c.row>=0&&c.col<d.chunkCols&&c.row<d.chunkRows;}
+  function seedForChunk(descriptor={},raw={}){const d=createDescriptor(descriptor),key=chunkKey(raw);return d.chunkSeeds[key]||deriveChunkSeed(d.seed,raw);}
+  function withChunkSeed(descriptor={},coord={},seed=''){const d=createDescriptor(descriptor),c=normalizeCoord(coord);if(!containsChunk(d,c))throw new Error('PROCEDURAL_CHUNK_OUT_OF_RANGE');const value=clean(seed);return{...d,chunkSeeds:{...d.chunkSeeds,...(value?{[chunkKey(c)]:value}:{})}};}
 
-  function liveGrid(grid={}){
-    return{
-      ...clone(grid),
-      cols:CHUNK_SIZE,
-      rows:CHUNK_SIZE,
-      size:Math.max(8,finite(grid.size,70)),
-      distancePerCell:Math.max(.1,finite(grid.distancePerCell,5)),
-      distanceUnit:clean(grid.distanceUnit)||'ft',
-    };
-  }
-
-  function performanceBudget(descriptor={}){
-    const d=createDescriptor(descriptor),liveCells=CHUNK_SIZE*CHUNK_SIZE,logicalCells=d.logicalCols*d.logicalRows;
-    return{liveCells,logicalCells,loadedChunks:1,logicalChunks:d.chunkCols*d.chunkRows,liveFraction:liveCells/logicalCells};
-  }
+  function liveGrid(grid={}){return{...clone(grid),cols:CHUNK_SIZE,rows:CHUNK_SIZE,size:Math.max(8,finite(grid.size,70)),distancePerCell:Math.max(.1,finite(grid.distancePerCell,5)),distanceUnit:clean(grid.distanceUnit)||'ft'};}
+  function performanceBudget(descriptor={}){const d=createDescriptor(descriptor),liveCells=CHUNK_SIZE*CHUNK_SIZE,logicalCells=d.logicalCols*d.logicalRows;return{liveCells,logicalCells,loadedChunks:1,logicalChunks:d.chunkCols*d.chunkRows,liveFraction:liveCells/logicalCells};}
 
   function chunkGenerationOptions(descriptor={},rawCoord={},overrides={}){
-    const d=createDescriptor(descriptor),coord=normalizeCoord(rawCoord);
-    if(!containsChunk(d,coord))throw new Error('PROCEDURAL_CHUNK_OUT_OF_RANGE');
-    return{
-      ...clone(overrides),
-      zoneId:`${d.zoneId}_chunk_${coord.col}_${coord.row}`,
-      seed:deriveChunkSeed(d.seed,coord),
-      profile:d.profile||d.profileId,
-      profileId:d.profile||d.profileId,
-      chunkCols:1,
-      chunkRows:1,
-      minBuildings:Math.max(1,Math.trunc(finite(overrides.minBuildings,1))),
-    };
+    const d=createDescriptor(descriptor),coord=normalizeCoord(rawCoord);if(!containsChunk(d,coord))throw new Error('PROCEDURAL_CHUNK_OUT_OF_RANGE');
+    return{...clone(overrides),zoneId:`${d.zoneId}_chunk_${coord.col}_${coord.row}`,seed:seedForChunk(d,coord),profile:d.profile||d.profileId,profileId:d.profile||d.profileId,chunkCols:1,chunkRows:1,minBuildings:Math.max(1,Math.trunc(finite(overrides.minBuildings,1)))};
   }
 
   function detectBoundaryExit(point={},grid={}){
-    const g=liveGrid(grid),width=g.cols*g.size,height=g.rows*g.size,x=finite(point.x,NaN),y=finite(point.y,NaN);
-    if(!Number.isFinite(x)||!Number.isFinite(y))return null;
-    const dx=x<0?-1:(x>=width?1:0),dy=y<0?-1:(y>=height?1:0);
-    if(!dx&&!dy)return null;
+    const g=liveGrid(grid),width=g.cols*g.size,height=g.rows*g.size,x=finite(point.x,NaN),y=finite(point.y,NaN);if(!Number.isFinite(x)||!Number.isFinite(y))return null;
+    const dx=x<0?-1:(x>=width?1:0),dy=y<0?-1:(y>=height?1:0);if(!dx&&!dy)return null;
     return{dx,dy,edges:[dy<0?'north':dy>0?'south':null,dx<0?'west':dx>0?'east':null].filter(Boolean),width,height};
   }
 
   function resolveTransition(descriptor={},point={},grid={}){
-    const d=createDescriptor(descriptor),exit=detectBoundaryExit(point,grid);
-    if(!exit)return null;
-    const target={col:d.activeChunk.col+exit.dx,row:d.activeChunk.row+exit.dy};
-    const valid=target.col>=0&&target.row>=0&&target.col<d.chunkCols&&target.row<d.chunkRows;
+    const d=createDescriptor(descriptor),exit=detectBoundaryExit(point,grid);if(!exit)return null;
+    const target={col:d.activeChunk.col+exit.dx,row:d.activeChunk.row+exit.dy},valid=containsChunk(d,target);
     return{valid,reason:valid?null:'PROCEDURAL_ZONE_BOUNDARY',from:clone(d.activeChunk),target,exit};
   }
 
   function entryCell(point={},grid={},exit={}){
     const g=liveGrid(grid),rawCol=Math.floor(finite(point.x,0)/g.size),rawRow=Math.floor(finite(point.y,0)/g.size);
-    const col=exit.dx>0?0:exit.dx<0?CHUNK_SIZE-1:clamp(rawCol,0,CHUNK_SIZE-1);
-    const row=exit.dy>0?0:exit.dy<0?CHUNK_SIZE-1:clamp(rawRow,0,CHUNK_SIZE-1);
+    const col=exit.dx>0?0:exit.dx<0?CHUNK_SIZE-1:clamp(rawCol,0,CHUNK_SIZE-1),row=exit.dy>0?0:exit.dy<0?CHUNK_SIZE-1:clamp(rawRow,0,CHUNK_SIZE-1);
     return{col,row,x:(col+.5)*g.size,y:(row+.5)*g.size};
   }
 
-  function withActiveChunk(descriptor={},coord={}){
-    const d=createDescriptor(descriptor),next=normalizeCoord(coord);
-    if(!containsChunk(d,next))throw new Error('PROCEDURAL_CHUNK_OUT_OF_RANGE');
-    return{...d,activeChunk:next};
-  }
+  function withActiveChunk(descriptor={},coord={}){const d=createDescriptor(descriptor),next=normalizeCoord(coord);if(!containsChunk(d,next))throw new Error('PROCEDURAL_CHUNK_OUT_OF_RANGE');return{...d,activeChunk:next};}
 
-  return Object.freeze({
-    SCHEMA_VERSION,CHUNK_SIZE,MODE,createDescriptor,normalizeCoord,chunkKey,deriveChunkSeed,containsChunk,
-    liveGrid,performanceBudget,chunkGenerationOptions,detectBoundaryExit,resolveTransition,entryCell,withActiveChunk,
-  });
+  return Object.freeze({SCHEMA_VERSION,CHUNK_SIZE,MODE,createDescriptor,normalizeCoord,chunkKey,deriveChunkSeed,seedForChunk,withChunkSeed,containsChunk,liveGrid,performanceBudget,chunkGenerationOptions,detectBoundaryExit,resolveTransition,entryCell,withActiveChunk});
 });

--- a/js/vtt/procedural-chunk-streaming-runtime.js
+++ b/js/vtt/procedural-chunk-streaming-runtime.js
@@ -1,6 +1,7 @@
 import './procedural-chunk-streaming-core.js';
 
 const APPLY_SELECTOR='[data-proc-apply]';
+const PREVIEW_SELECTOR='[data-proc-preview],[data-proc-reroll]';
 const SIZE_SELECTOR='[data-proc-size]';
 const PANEL_ID='vtt-procedural-zone-panel';
 const clone=v=>v==null?v:JSON.parse(JSON.stringify(v));
@@ -15,7 +16,8 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
   let stopped=false,transitioning=false,activePlan=null;
 
   function notify(message,type='info'){runtime.controller?.notify?.(message,type);}
-  function selectedLogicalSize(){const n=Number(doc.querySelector(SIZE_SELECTOR)?.value);return Math.max(1,Math.min(3,Number.isFinite(n)?Math.trunc(n):1));}
+  function sizeInput(){return doc.querySelector(SIZE_SELECTOR);}
+  function selectedLogicalSize(){const n=Number(sizeInput()?.value);return Math.max(1,Math.min(3,Number.isFinite(n)?Math.trunc(n):1));}
   function sceneHasContent(){return['topology','walls','worldObjects','horizontalPlanes','structures','verticalPortals'].some(k=>(mapData[k]||[]).length>0)||(mapData.semantics?.buildings||[]).length>0;}
   function descriptor(){return mapData.procedural?.streaming?core.createDescriptor(mapData.procedural.streaming):null;}
   function planProfile(plan={}){return clone(plan.fabric?.profile||null);}
@@ -24,13 +26,9 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
     mapData.procedural={...(mapData.procedural||{}),streaming:core.createDescriptor(desc),logicalZone:{chunkSize:core.CHUNK_SIZE,chunkCols:desc.chunkCols,chunkRows:desc.chunkRows,cols:desc.logicalCols,rows:desc.logicalRows},activeChunk:clone(desc.activeChunk),activeChunkSignature:plan?.signature||null};
     return mapData.procedural.streaming;
   }
-  function generationOverrides(desc){return{gridSize:mapData.grid?.size||70,maxAttempts:8,minBuildings:1};}
-  async function generateChunk(desc,coord){return procedural.previewAsync(core.chunkGenerationOptions(desc,coord,generationOverrides(desc)));}
-  function redraw(reason='procedural-chunk-streamed'){
-    runtime.semanticMap?.touch?.(reason);
-    engine.renderer?.invalidate?.();
-    engine.invalidate?.();
-  }
+  function generationOverrides(){return{gridSize:mapData.grid?.size||70,maxAttempts:8,minBuildings:1};}
+  async function generateChunk(desc,coord){return procedural.previewAsync(core.chunkGenerationOptions(desc,coord,generationOverrides()));}
+  function redraw(reason='procedural-chunk-streamed'){runtime.semanticMap?.touch?.(reason);engine.renderer?.invalidate?.();engine.invalidate?.();}
   function centerOnToken(token){if(!token)return;engine.camera?.centerOnWorldPoint?.({x:token.x,y:token.y});if(!engine.camera?.centerOnWorldPoint)engine.centerCamera?.();}
   async function persistChunk(plan){if(!runtime.bridge?.isDm)return;await procedural.persist(plan);}
 
@@ -39,8 +37,7 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
     const push=(col,row)=>{col=Math.max(0,Math.min(39,col));row=Math.max(0,Math.min(39,row));const key=`${col},${row}`;if(seen.has(key))return;seen.add(key);out.push({col,row,x:(col+.5)*size,y:(row+.5)*size});};
     push(entry.col,entry.row);
     for(let depth=1;depth<=6;depth++){
-      const baseCol=exit.dx>0?depth:exit.dx<0?39-depth:entry.col;
-      const baseRow=exit.dy>0?depth:exit.dy<0?39-depth:entry.row;
+      const baseCol=exit.dx>0?depth:exit.dx<0?39-depth:entry.col,baseRow=exit.dy>0?depth:exit.dy<0?39-depth:entry.row;
       push(baseCol,baseRow);
       for(let offset=1;offset<=6;offset++){
         if(exit.dx){push(baseCol,entry.row-offset);push(baseCol,entry.row+offset);}
@@ -59,15 +56,12 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
       const plan=await generateChunk(previous,coord);
       procedural.apply(plan,{replaceScene:true,persist:false});
       const next=core.withActiveChunk(previous,coord);writeStreamingMetadata(next,plan);activePlan=plan;
-      let token=null;
-      if(tokenId!=null)token=(mapData.tokens||[]).find(x=>String(x.id)===String(tokenId))||null;
+      let token=null;if(tokenId!=null)token=(mapData.tokens||[]).find(x=>String(x.id)===String(tokenId))||null;
       if(token&&requestedPoint&&exit){
         const entry=core.entryCell(requestedPoint,mapData.grid,exit),safe=entryCandidates(token,entry,exit);
-        token.x=safe.x;token.y=safe.y;const z=Number(token.zLayer??token.gridPosition?.z??token.z?.[0]??0);token.zLayer=z;token.z=[z];token.gridPosition={col:safe.col,row:safe.row,z};
-        centerOnToken(token);
+        token.x=safe.x;token.y=safe.y;const z=Number(token.zLayer??token.gridPosition?.z??token.z?.[0]??0);token.zLayer=z;token.z=[z];token.gridPosition={col:safe.col,row:safe.row,z};centerOnToken(token);
       }else engine.centerCamera?.();
-      redraw();
-      if(persist)await persistChunk(plan);
+      redraw();if(persist)await persistChunk(plan);
       engine.canvas?.dispatchEvent?.(new CustomEvent('vtt:procedural-chunk-loaded',{detail:{chunk:clone(next.activeChunk),logical:{cols:next.chunkCols,rows:next.chunkRows},signature:plan.signature}}));
       return{descriptor:next,plan,token};
     }finally{transitioning=false;}
@@ -75,19 +69,23 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
 
   async function createStreamedZone(previewPlan,size=selectedLogicalSize()){
     if(!previewPlan?.validation?.valid)throw new Error('PROCEDURAL_PREVIEW_REQUIRED');
-    const desc=buildDescriptor(previewPlan,size);
-    const result=await activateChunk(desc,{col:0,row:0},{persist:true});
-    mapData.proceduralEditor&&(mapData.proceduralEditor.previewPlan=null);
-    if(mapData.proceduralEditor)mapData.proceduralEditor.previewGenerationError=null;
+    const desc=buildDescriptor(previewPlan,size),result=await activateChunk(desc,{col:0,row:0},{persist:true});
+    mapData.proceduralEditor&&(mapData.proceduralEditor.previewPlan=null);if(mapData.proceduralEditor)mapData.proceduralEditor.previewGenerationError=null;
     doc.getElementById(PANEL_ID)?.querySelector('[data-proc-close]')?.click();
-    notify(`Zona ${size}×${size} creada en streaming · activo 40×40 · chunk 1,1`,'success');
-    return result;
+    notify(`Zona ${size}×${size} creada en streaming · activo 40×40 · chunk 1,1`,'success');return result;
+  }
+
+  function capturePreviewSizing(event){
+    if(!event.target?.closest?.(PREVIEW_SELECTOR))return;
+    const input=sizeInput(),logical=selectedLogicalSize();if(!input||logical<=1)return;
+    mapData.proceduralEditor||={};mapData.proceduralEditor.logicalChunkSize=logical;
+    input.value='1';
+    queueMicrotask(()=>{if(input.isConnected)input.value=String(logical);});
   }
 
   function captureCreate(event){
     const button=event.target?.closest?.(APPLY_SELECTOR);if(!button||transitioning)return;
-    const plan=mapData.proceduralEditor?.previewPlan,size=selectedLogicalSize();
-    if(size<=1||!plan?.validation?.valid)return;
+    const plan=mapData.proceduralEditor?.previewPlan,size=selectedLogicalSize();if(size<=1||!plan?.validation?.valid)return;
     event.preventDefault();event.stopImmediatePropagation();
     if(sceneHasContent()&&!window.confirm('CREAR ZONA reemplazará la geometría y semántica actual. Los tokens de jugador se conservarán. ¿Continuar?'))return;
     button.disabled=true;
@@ -97,8 +95,7 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
   function requestedPoint(event,drag){const world=engine.eventWorldPoint(event);return{x:world.x-drag.grabOffsetX,y:world.y-drag.grabOffsetY};}
   function captureBoundaryTransition(event){
     const desc=descriptor(),drag=engine.tokenDrag;if(!desc||!drag||transitioning||event.button!==0)return;
-    const requested=requestedPoint(event,drag),transition=core.resolveTransition(desc,requested,mapData.grid);
-    if(!transition?.valid)return;
+    const requested=requestedPoint(event,drag),transition=core.resolveTransition(desc,requested,mapData.grid);if(!transition?.valid)return;
     event.preventDefault();event.stopImmediatePropagation();
     const tokenId=drag.token.id,from={x:drag.originX,y:drag.originY,z:drag.originZ,elevationFt:drag.originElevationFt};
     drag.token.x=drag.originX;drag.token.y=drag.originY;drag.token.zLayer=drag.originZ;drag.token.z=[drag.originZ];drag.token.elevationFt=drag.originElevationFt;
@@ -110,17 +107,12 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
     }).catch(error=>{console.error('VTT PROCEDURAL CHUNK TRANSITION FAILED:',error);notify(error?.message||'PROCEDURAL_CHUNK_TRANSITION_FAILED','error');});
   }
 
-  doc.addEventListener('click',captureCreate,true);
-  window.addEventListener('mouseup',captureBoundaryTransition,true);
+  doc.addEventListener('click',capturePreviewSizing,true);doc.addEventListener('click',captureCreate,true);window.addEventListener('mouseup',captureBoundaryTransition,true);
 
   const api=Object.freeze({
-    core,descriptor,createStreamedZone,activateChunk,
-    performance:()=>core.performanceBudget(descriptor()||{chunkCols:1,chunkRows:1}),
-    get activePlan(){return activePlan;},
-    get transitioning(){return transitioning;},
-    stop(){if(stopped)return;stopped=true;doc.removeEventListener('click',captureCreate,true);window.removeEventListener('mouseup',captureBoundaryTransition,true);activePlan=null;},
+    core,descriptor,createStreamedZone,activateChunk,performance:()=>core.performanceBudget(descriptor()||{chunkCols:1,chunkRows:1}),
+    get activePlan(){return activePlan;},get transitioning(){return transitioning;},
+    stop(){if(stopped)return;stopped=true;doc.removeEventListener('click',capturePreviewSizing,true);doc.removeEventListener('click',captureCreate,true);window.removeEventListener('mouseup',captureBoundaryTransition,true);activePlan=null;},
   });
-  window.LuminousVttProceduralChunkStreamingRuntime={api};
-  window.LuminousVttRuntime=Object.freeze({...window.LuminousVttRuntime,proceduralChunks:api});
-  return api;
+  window.LuminousVttProceduralChunkStreamingRuntime={api};window.LuminousVttRuntime=Object.freeze({...window.LuminousVttRuntime,proceduralChunks:api});return api;
 }

--- a/js/vtt/procedural-chunk-streaming-runtime.js
+++ b/js/vtt/procedural-chunk-streaming-runtime.js
@@ -4,7 +4,10 @@ const APPLY_SELECTOR='[data-proc-apply]';
 const PREVIEW_SELECTOR='[data-proc-preview],[data-proc-reroll]';
 const SIZE_SELECTOR='[data-proc-size]';
 const PANEL_ID='vtt-procedural-zone-panel';
+const STATE_ROOT='campaña/estado_mundo/vttProceduralChunkState';
+const REQUEST_ROOT='vtt_procedural_chunk_transition_requests';
 const clone=v=>v==null?v:JSON.parse(JSON.stringify(v));
+const clean=v=>String(v??'').trim();
 
 export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine?.mapData,procedural=runtime?.procedural}={}){
   if(!runtime?.engine||!mapData||!procedural)return null;
@@ -12,8 +15,13 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
   const core=window.LuminousVttProceduralChunkStreaming,generator=window.LuminousVttProceduralGenerator;
   if(!core||!generator)throw new Error('PROCEDURAL_CHUNK_STREAMING_REQUIRED');
 
-  const engine=runtime.engine,doc=window.document;
-  let stopped=false,transitioning=false,activePlan=null;
+  const engine=runtime.engine,doc=window.document,isDm=Boolean(runtime.bridge?.isDm);
+  const stateApi=window.LuminousVttMapAuthoringState;
+  const firebase=stateApi?.hostFirebase?.(window)||window.firebase||null;
+  const db=firebase?.database?.()||null;
+  const mapId=clean(mapData.id||mapData.mapId||'default').replace(/[.#$[\]\/]/g,'_')||'default';
+  const subscriptions=[];
+  let stopped=false,transitioning=false,activePlan=null,remoteApplying=false;
 
   function notify(message,type='info'){runtime.controller?.notify?.(message,type);}
   function sizeInput(){return doc.querySelector(SIZE_SELECTOR);}
@@ -30,15 +38,24 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
   async function generateChunk(desc,coord){return procedural.previewAsync(core.chunkGenerationOptions(desc,coord,generationOverrides()));}
   function redraw(reason='procedural-chunk-streamed'){runtime.semanticMap?.touch?.(reason);engine.renderer?.invalidate?.();engine.invalidate?.();}
   function centerOnToken(token){if(!token)return;engine.camera?.centerOnWorldPoint?.({x:token.x,y:token.y});if(!engine.camera?.centerOnWorldPoint)engine.centerCamera?.();}
-  async function persistChunk(plan){if(!runtime.bridge?.isDm)return;await procedural.persist(plan);}
+  async function persistChunk(plan){if(!isDm)return;await procedural.persist(plan);}
+  function stateRef(){return db?.ref?.(`${STATE_ROOT}/${mapId}`)||null;}
+  function requestRootRef(){return db?.ref?.(`${REQUEST_ROOT}/${mapId}`)||null;}
+  function subscribe(ref,event,handler){if(!ref?.on)return;ref.on(event,handler);subscriptions.push(()=>ref.off(event,handler));}
+
+  async function publishChunkState(desc,plan){
+    if(!isDm||!stateRef())return false;
+    const payload={schemaVersion:1,mapId,descriptor:core.createDescriptor(desc),activeSignature:plan?.signature||null,clientUpdatedAt:Date.now()};
+    if(firebase?.database?.ServerValue?.TIMESTAMP)payload.updatedAt=firebase.database.ServerValue.TIMESTAMP;
+    await stateRef().set(payload);return true;
+  }
 
   function entryCandidates(token,entry,exit){
     const size=mapData.grid?.size||70,out=[],seen=new Set();
     const push=(col,row)=>{col=Math.max(0,Math.min(39,col));row=Math.max(0,Math.min(39,row));const key=`${col},${row}`;if(seen.has(key))return;seen.add(key);out.push({col,row,x:(col+.5)*size,y:(row+.5)*size});};
     push(entry.col,entry.row);
     for(let depth=1;depth<=6;depth++){
-      const baseCol=exit.dx>0?depth:exit.dx<0?39-depth:entry.col,baseRow=exit.dy>0?depth:exit.dy<0?39-depth:entry.row;
-      push(baseCol,baseRow);
+      const baseCol=exit.dx>0?depth:exit.dx<0?39-depth:entry.col,baseRow=exit.dy>0?depth:exit.dy<0?39-depth:entry.row;push(baseCol,baseRow);
       for(let offset=1;offset<=6;offset++){
         if(exit.dx){push(baseCol,entry.row-offset);push(baseCol,entry.row+offset);}
         if(exit.dy){push(entry.col-offset,baseRow);push(entry.col+offset,baseRow);}
@@ -48,7 +65,13 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
     return out.find(point=>rules?.canOccupy?.(token,point,mapData)?.valid)||out[0];
   }
 
-  async function activateChunk(desc,coord,{tokenId=null,requestedPoint=null,exit=null,persist=true}={}){
+  function dispatchTransitionMove(token,from,transition,next){
+    if(!token)return;
+    engine.canvas?.dispatchEvent?.(new CustomEvent('vtt:token-moved',{detail:{tokenId:token.id,from,to:{x:token.x,y:token.y,...token.gridPosition,elevationFt:token.elevationFt??0},chunkTransition:{from:transition.from,to:next.activeChunk,edges:transition.exit.edges}}}));
+    engine.canvas?.dispatchEvent?.(new CustomEvent('vtt:procedural-chunk-transition',{detail:{tokenId:token.id,from:transition.from,to:next.activeChunk,edges:transition.exit.edges}}));
+  }
+
+  async function activateChunk(desc,coord,{tokenId=null,requestedPoint=null,exit=null,persist=isDm,publish=isDm,center=true}={}){
     if(transitioning)throw new Error('PROCEDURAL_CHUNK_TRANSITION_BUSY');
     transitioning=true;const previous=core.createDescriptor(desc);
     try{
@@ -57,9 +80,9 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
       let token=null;if(tokenId!=null)token=(mapData.tokens||[]).find(x=>String(x.id)===String(tokenId))||null;
       if(token&&requestedPoint&&exit){
         const entry=core.entryCell(requestedPoint,mapData.grid,exit),safe=entryCandidates(token,entry,exit);
-        token.x=safe.x;token.y=safe.y;const z=Number(token.zLayer??token.gridPosition?.z??token.z?.[0]??0);token.zLayer=z;token.z=[z];token.gridPosition={col:safe.col,row:safe.row,z};centerOnToken(token);
-      }else engine.centerCamera?.();
-      redraw();if(persist)await persistChunk(plan);
+        token.x=safe.x;token.y=safe.y;const z=Number(token.zLayer??token.gridPosition?.z??token.z?.[0]??0);token.zLayer=z;token.z=[z];token.gridPosition={col:safe.col,row:safe.row,z};if(center)centerOnToken(token);
+      }else if(center)engine.centerCamera?.();
+      redraw();if(persist)await persistChunk(plan);if(publish)await publishChunkState(next,plan);
       engine.canvas?.dispatchEvent?.(new CustomEvent('vtt:procedural-chunk-loaded',{detail:{chunk:clone(next.activeChunk),logical:{cols:next.chunkCols,rows:next.chunkRows},signature:plan.signature}}));
       return{descriptor:next,plan,token};
     }finally{transitioning=false;}
@@ -70,7 +93,7 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
     transitioning=true;
     try{
       let desc=buildDescriptor(previewPlan,size);desc=core.withChunkSeed(desc,{col:0,row:0},previewPlan.seed);desc=core.withActiveChunk(desc,{col:0,row:0});
-      procedural.apply(previewPlan,{replaceScene:true,persist:false});writeStreamingMetadata(desc,previewPlan);activePlan=previewPlan;engine.centerCamera?.();redraw('procedural-stream-created');await persistChunk(previewPlan);
+      procedural.apply(previewPlan,{replaceScene:true,persist:false});writeStreamingMetadata(desc,previewPlan);activePlan=previewPlan;engine.centerCamera?.();redraw('procedural-stream-created');await persistChunk(previewPlan);await publishChunkState(desc,previewPlan);
       mapData.proceduralEditor&&(mapData.proceduralEditor.previewPlan=null);if(mapData.proceduralEditor)mapData.proceduralEditor.previewGenerationError=null;
       doc.getElementById(PANEL_ID)?.querySelector('[data-proc-close]')?.click();notify(`Zona ${size}×${size} creada en streaming · activo 40×40 · chunk 1,1`,'success');
       return{descriptor:desc,plan:previewPlan,token:null};
@@ -92,20 +115,58 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
   }
 
   function requestedPoint(event,drag){const world=engine.eventWorldPoint(event);return{x:world.x-drag.grabOffsetX,y:world.y-drag.grabOffsetY};}
+  function restoreDrag(drag){drag.token.x=drag.originX;drag.token.y=drag.originY;drag.token.zLayer=drag.originZ;drag.token.z=[drag.originZ];drag.token.elevationFt=drag.originElevationFt;engine.tokenDrag=null;if(engine.canvas?.style)engine.canvas.style.cursor='default';}
+
+  async function requestTransition(desc,transition,tokenId,requested,from){
+    if(!db||!requestRootRef()){
+      const result=await activateChunk(desc,transition.target,{tokenId,requestedPoint:requested,exit:transition.exit,persist:false,publish:false});dispatchTransitionMove(result.token,from,transition,result.descriptor);return result;
+    }
+    const ref=requestRootRef().push();const payload={schemaVersion:1,mapId,tokenId:String(tokenId),fromChunk:clone(transition.from),targetChunk:clone(transition.target),requestedPoint:clone(requested),exit:{dx:transition.exit.dx,dy:transition.exit.dy,edges:clone(transition.exit.edges)},origin:clone(from),status:'pending',clientCreatedAt:Date.now()};
+    if(firebase?.database?.ServerValue?.TIMESTAMP)payload.createdAt=firebase.database.ServerValue.TIMESTAMP;
+    await ref.set(payload);notify('Transición de zona solicitada.','pending');
+    const handler=snapshot=>{const value=snapshot.val()||{};if(value.status==='applied'){notify('Zona cargada.','success');ref.off('value',handler);}else if(value.status==='denied'){notify(`Transición rechazada${value.reason?`: ${value.reason}`:''}.`,'error');ref.off('value',handler);}};ref.on('value',handler);
+    return{pending:true,requestId:ref.key};
+  }
+
+  async function processTransitionRequest(snapshot){
+    if(!isDm)return;const request=snapshot.val()||{};if(request.status!=='pending'||clean(request.mapId)!==mapId)return;
+    const desc=descriptor();let reason=null;
+    const from=core.normalizeCoord(request.fromChunk||{}),target=core.normalizeCoord(request.targetChunk||{}),current=desc?.activeChunk;
+    const dx=target.col-from.col,dy=target.row-from.row;
+    if(!desc)reason='STREAMING_ZONE_NOT_ACTIVE';
+    else if(from.col!==current.col||from.row!==current.row)reason='STALE_CHUNK_REQUEST';
+    else if((dx===0&&dy===0)||Math.abs(dx)>1||Math.abs(dy)>1||!core.containsChunk(desc,target))reason='INVALID_CHUNK_TRANSITION';
+    if(reason){await snapshot.ref.update({status:'denied',reason,decidedAt:firebase?.database?.ServerValue?.TIMESTAMP||Date.now()});return;}
+    const exit={dx,dy,edges:Array.isArray(request.exit?.edges)?request.exit.edges:[]},transition={valid:true,from,target,exit};
+    try{
+      const result=await activateChunk(desc,target,{tokenId:request.tokenId,requestedPoint:request.requestedPoint||{},exit,persist:true,publish:true});dispatchTransitionMove(result.token,request.origin||{},transition,result.descriptor);
+      await snapshot.ref.update({status:'applied',reason:null,decidedAt:firebase?.database?.ServerValue?.TIMESTAMP||Date.now()});
+    }catch(error){console.error('VTT PROCEDURAL CHUNK REQUEST FAILED:',error);await snapshot.ref.update({status:'denied',reason:clean(error?.message||error)||'CHUNK_TRANSITION_FAILED',decidedAt:firebase?.database?.ServerValue?.TIMESTAMP||Date.now()});}
+  }
+
+  async function applyRemoteState(snapshot){
+    const value=snapshot.val()||{},incoming=value.descriptor;if(!incoming||clean(value.mapId)!==mapId||remoteApplying)return;
+    const next=core.createDescriptor(incoming),current=descriptor(),sameChunk=current&&current.activeChunk.col===next.activeChunk.col&&current.activeChunk.row===next.activeChunk.row;
+    const sameSignature=sameChunk&&clean(mapData.procedural?.activeChunkSignature)===clean(value.activeSignature);
+    if(sameSignature)return;
+    if(isDm&&sameChunk&&transitioning)return;
+    remoteApplying=true;
+    try{await activateChunk(next,next.activeChunk,{persist:false,publish:false,center:false});}
+    catch(error){console.error('VTT PROCEDURAL REMOTE CHUNK APPLY FAILED:',error);notify(error?.message||'REMOTE_CHUNK_APPLY_FAILED','error');}
+    finally{remoteApplying=false;}
+  }
+
   function captureBoundaryTransition(event){
     const desc=descriptor(),drag=engine.tokenDrag;if(!desc||!drag||transitioning||event.button!==0)return;
     const requested=requestedPoint(event,drag),transition=core.resolveTransition(desc,requested,mapData.grid);if(!transition?.valid)return;
-    event.preventDefault();event.stopImmediatePropagation();
-    const tokenId=drag.token.id,from={x:drag.originX,y:drag.originY,z:drag.originZ,elevationFt:drag.originElevationFt};
-    drag.token.x=drag.originX;drag.token.y=drag.originY;drag.token.zLayer=drag.originZ;drag.token.z=[drag.originZ];drag.token.elevationFt=drag.originElevationFt;engine.tokenDrag=null;if(engine.canvas?.style)engine.canvas.style.cursor='default';
-    Promise.resolve(activateChunk(desc,transition.target,{tokenId,requestedPoint:requested,exit:transition.exit,persist:true})).then(({token,descriptor:next})=>{
-      if(!token)return;
-      engine.canvas?.dispatchEvent?.(new CustomEvent('vtt:token-moved',{detail:{tokenId:token.id,from,to:{x:token.x,y:token.y,...token.gridPosition,elevationFt:token.elevationFt??0},chunkTransition:{from:transition.from,to:next.activeChunk,edges:transition.exit.edges}}}));
-      engine.canvas?.dispatchEvent?.(new CustomEvent('vtt:procedural-chunk-transition',{detail:{tokenId:token.id,from:transition.from,to:next.activeChunk,edges:transition.exit.edges}}));
-    }).catch(error=>{console.error('VTT PROCEDURAL CHUNK TRANSITION FAILED:',error);notify(error?.message||'PROCEDURAL_CHUNK_TRANSITION_FAILED','error');});
+    event.preventDefault();event.stopImmediatePropagation();const tokenId=drag.token.id,from={x:drag.originX,y:drag.originY,z:drag.originZ,elevationFt:drag.originElevationFt};restoreDrag(drag);
+    if(isDm){Promise.resolve(activateChunk(desc,transition.target,{tokenId,requestedPoint:requested,exit:transition.exit,persist:true,publish:true})).then(result=>dispatchTransitionMove(result.token,from,transition,result.descriptor)).catch(error=>{console.error('VTT PROCEDURAL CHUNK TRANSITION FAILED:',error);notify(error?.message||'PROCEDURAL_CHUNK_TRANSITION_FAILED','error');});}
+    else Promise.resolve(requestTransition(desc,transition,tokenId,requested,from)).catch(error=>{console.error('VTT PROCEDURAL CHUNK REQUEST FAILED:',error);notify(error?.message||'PROCEDURAL_CHUNK_REQUEST_FAILED','error');});
   }
 
   doc.addEventListener('click',capturePreviewSizing,true);doc.addEventListener('click',captureCreate,true);window.addEventListener('mouseup',captureBoundaryTransition,true);
-  const api=Object.freeze({core,descriptor,createStreamedZone,activateChunk,performance:()=>core.performanceBudget(descriptor()||{chunkCols:1,chunkRows:1}),get activePlan(){return activePlan;},get transitioning(){return transitioning;},stop(){if(stopped)return;stopped=true;doc.removeEventListener('click',capturePreviewSizing,true);doc.removeEventListener('click',captureCreate,true);window.removeEventListener('mouseup',captureBoundaryTransition,true);activePlan=null;}});
+  if(db){subscribe(stateRef(),'value',snapshot=>{applyRemoteState(snapshot).catch(error=>console.error('VTT PROCEDURAL CHUNK STATE FAILED:',error));});if(isDm)subscribe(requestRootRef(),'child_added',snapshot=>{processTransitionRequest(snapshot).catch(error=>console.error('VTT PROCEDURAL CHUNK REQUEST PROCESS FAILED:',error));});}
+
+  const api=Object.freeze({core,descriptor,createStreamedZone,activateChunk,publishChunkState,requestTransition,performance:()=>core.performanceBudget(descriptor()||{chunkCols:1,chunkRows:1}),get activePlan(){return activePlan;},get transitioning(){return transitioning;},stop(){if(stopped)return;stopped=true;doc.removeEventListener('click',capturePreviewSizing,true);doc.removeEventListener('click',captureCreate,true);window.removeEventListener('mouseup',captureBoundaryTransition,true);subscriptions.splice(0).forEach(unsubscribe=>unsubscribe());activePlan=null;}});
   window.LuminousVttProceduralChunkStreamingRuntime={api};window.LuminousVttRuntime=Object.freeze({...window.LuminousVttRuntime,proceduralChunks:api});return api;
 }

--- a/js/vtt/procedural-chunk-streaming-runtime.js
+++ b/js/vtt/procedural-chunk-streaming-runtime.js
@@ -1,0 +1,126 @@
+import './procedural-chunk-streaming-core.js';
+
+const APPLY_SELECTOR='[data-proc-apply]';
+const SIZE_SELECTOR='[data-proc-size]';
+const PANEL_ID='vtt-procedural-zone-panel';
+const clone=v=>v==null?v:JSON.parse(JSON.stringify(v));
+
+export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine?.mapData,procedural=runtime?.procedural}={}){
+  if(!runtime?.engine||!mapData||!procedural)return null;
+  if(window.LuminousVttProceduralChunkStreamingRuntime?.api)return window.LuminousVttProceduralChunkStreamingRuntime.api;
+  const core=window.LuminousVttProceduralChunkStreaming,generator=window.LuminousVttProceduralGenerator;
+  if(!core||!generator)throw new Error('PROCEDURAL_CHUNK_STREAMING_REQUIRED');
+
+  const engine=runtime.engine,doc=window.document;
+  let stopped=false,transitioning=false,activePlan=null;
+
+  function notify(message,type='info'){runtime.controller?.notify?.(message,type);}
+  function selectedLogicalSize(){const n=Number(doc.querySelector(SIZE_SELECTOR)?.value);return Math.max(1,Math.min(3,Number.isFinite(n)?Math.trunc(n):1));}
+  function sceneHasContent(){return['topology','walls','worldObjects','horizontalPlanes','structures','verticalPortals'].some(k=>(mapData[k]||[]).length>0)||(mapData.semantics?.buildings||[]).length>0;}
+  function descriptor(){return mapData.procedural?.streaming?core.createDescriptor(mapData.procedural.streaming):null;}
+  function planProfile(plan={}){return clone(plan.fabric?.profile||null);}
+  function buildDescriptor(plan={},size=1){return core.createDescriptor({zoneId:plan.zone?.id||`zone_${mapData.id||mapData.mapId||'active'}`,seed:plan.seed,profileId:plan.profileId,profile:planProfile(plan),chunkCols:size,chunkRows:size,activeChunk:{col:0,row:0}});}
+  function writeStreamingMetadata(desc,plan){
+    mapData.procedural={...(mapData.procedural||{}),streaming:core.createDescriptor(desc),logicalZone:{chunkSize:core.CHUNK_SIZE,chunkCols:desc.chunkCols,chunkRows:desc.chunkRows,cols:desc.logicalCols,rows:desc.logicalRows},activeChunk:clone(desc.activeChunk),activeChunkSignature:plan?.signature||null};
+    return mapData.procedural.streaming;
+  }
+  function generationOverrides(desc){return{gridSize:mapData.grid?.size||70,maxAttempts:8,minBuildings:1};}
+  async function generateChunk(desc,coord){return procedural.previewAsync(core.chunkGenerationOptions(desc,coord,generationOverrides(desc)));}
+  function redraw(reason='procedural-chunk-streamed'){
+    runtime.semanticMap?.touch?.(reason);
+    engine.renderer?.invalidate?.();
+    engine.invalidate?.();
+  }
+  function centerOnToken(token){if(!token)return;engine.camera?.centerOnWorldPoint?.({x:token.x,y:token.y});if(!engine.camera?.centerOnWorldPoint)engine.centerCamera?.();}
+  async function persistChunk(plan){if(!runtime.bridge?.isDm)return;await procedural.persist(plan);}
+
+  function entryCandidates(token,entry,exit){
+    const size=mapData.grid?.size||70,out=[],seen=new Set();
+    const push=(col,row)=>{col=Math.max(0,Math.min(39,col));row=Math.max(0,Math.min(39,row));const key=`${col},${row}`;if(seen.has(key))return;seen.add(key);out.push({col,row,x:(col+.5)*size,y:(row+.5)*size});};
+    push(entry.col,entry.row);
+    for(let depth=1;depth<=6;depth++){
+      const baseCol=exit.dx>0?depth:exit.dx<0?39-depth:entry.col;
+      const baseRow=exit.dy>0?depth:exit.dy<0?39-depth:entry.row;
+      push(baseCol,baseRow);
+      for(let offset=1;offset<=6;offset++){
+        if(exit.dx){push(baseCol,entry.row-offset);push(baseCol,entry.row+offset);}
+        if(exit.dy){push(entry.col-offset,baseRow);push(entry.col+offset,baseRow);}
+      }
+    }
+    const rules=window.LuminousVttTokenInteraction;
+    return out.find(point=>rules?.canOccupy?.(token,point,mapData)?.valid)||out[0];
+  }
+
+  async function activateChunk(desc,coord,{tokenId=null,requestedPoint=null,exit=null,persist=true}={}){
+    if(transitioning)throw new Error('PROCEDURAL_CHUNK_TRANSITION_BUSY');
+    transitioning=true;
+    const previous=core.createDescriptor(desc);
+    try{
+      const plan=await generateChunk(previous,coord);
+      procedural.apply(plan,{replaceScene:true,persist:false});
+      const next=core.withActiveChunk(previous,coord);writeStreamingMetadata(next,plan);activePlan=plan;
+      let token=null;
+      if(tokenId!=null)token=(mapData.tokens||[]).find(x=>String(x.id)===String(tokenId))||null;
+      if(token&&requestedPoint&&exit){
+        const entry=core.entryCell(requestedPoint,mapData.grid,exit),safe=entryCandidates(token,entry,exit);
+        token.x=safe.x;token.y=safe.y;const z=Number(token.zLayer??token.gridPosition?.z??token.z?.[0]??0);token.zLayer=z;token.z=[z];token.gridPosition={col:safe.col,row:safe.row,z};
+        centerOnToken(token);
+      }else engine.centerCamera?.();
+      redraw();
+      if(persist)await persistChunk(plan);
+      engine.canvas?.dispatchEvent?.(new CustomEvent('vtt:procedural-chunk-loaded',{detail:{chunk:clone(next.activeChunk),logical:{cols:next.chunkCols,rows:next.chunkRows},signature:plan.signature}}));
+      return{descriptor:next,plan,token};
+    }finally{transitioning=false;}
+  }
+
+  async function createStreamedZone(previewPlan,size=selectedLogicalSize()){
+    if(!previewPlan?.validation?.valid)throw new Error('PROCEDURAL_PREVIEW_REQUIRED');
+    const desc=buildDescriptor(previewPlan,size);
+    const result=await activateChunk(desc,{col:0,row:0},{persist:true});
+    mapData.proceduralEditor&&(mapData.proceduralEditor.previewPlan=null);
+    if(mapData.proceduralEditor)mapData.proceduralEditor.previewGenerationError=null;
+    doc.getElementById(PANEL_ID)?.querySelector('[data-proc-close]')?.click();
+    notify(`Zona ${size}×${size} creada en streaming · activo 40×40 · chunk 1,1`,'success');
+    return result;
+  }
+
+  function captureCreate(event){
+    const button=event.target?.closest?.(APPLY_SELECTOR);if(!button||transitioning)return;
+    const plan=mapData.proceduralEditor?.previewPlan,size=selectedLogicalSize();
+    if(size<=1||!plan?.validation?.valid)return;
+    event.preventDefault();event.stopImmediatePropagation();
+    if(sceneHasContent()&&!window.confirm('CREAR ZONA reemplazará la geometría y semántica actual. Los tokens de jugador se conservarán. ¿Continuar?'))return;
+    button.disabled=true;
+    Promise.resolve(createStreamedZone(plan,size)).catch(error=>{console.error('VTT PROCEDURAL STREAMED ZONE CREATE FAILED:',error);notify(error?.message||'PROCEDURAL_STREAM_CREATE_FAILED','error');}).finally(()=>{if(button.isConnected)button.disabled=false;});
+  }
+
+  function requestedPoint(event,drag){const world=engine.eventWorldPoint(event);return{x:world.x-drag.grabOffsetX,y:world.y-drag.grabOffsetY};}
+  function captureBoundaryTransition(event){
+    const desc=descriptor(),drag=engine.tokenDrag;if(!desc||!drag||transitioning||event.button!==0)return;
+    const requested=requestedPoint(event,drag),transition=core.resolveTransition(desc,requested,mapData.grid);
+    if(!transition?.valid)return;
+    event.preventDefault();event.stopImmediatePropagation();
+    const tokenId=drag.token.id,from={x:drag.originX,y:drag.originY,z:drag.originZ,elevationFt:drag.originElevationFt};
+    drag.token.x=drag.originX;drag.token.y=drag.originY;drag.token.zLayer=drag.originZ;drag.token.z=[drag.originZ];drag.token.elevationFt=drag.originElevationFt;
+    engine.tokenDrag=null;if(engine.canvas?.style)engine.canvas.style.cursor='default';
+    Promise.resolve(activateChunk(desc,transition.target,{tokenId,requestedPoint:requested,exit:transition.exit,persist:true})).then(({token,descriptor:next})=>{
+      if(!token)return;
+      engine.canvas?.dispatchEvent?.(new CustomEvent('vtt:token-moved',{detail:{tokenId:token.id,from,to:{x:token.x,y:token.y,...token.gridPosition,elevationFt:token.elevationFt??0},chunkTransition:{from:transition.from,to:next.activeChunk,edges:transition.exit.edges}}}));
+      engine.canvas?.dispatchEvent?.(new CustomEvent('vtt:procedural-chunk-transition',{detail:{tokenId:token.id,from:transition.from,to:next.activeChunk,edges:transition.exit.edges}}));
+    }).catch(error=>{console.error('VTT PROCEDURAL CHUNK TRANSITION FAILED:',error);notify(error?.message||'PROCEDURAL_CHUNK_TRANSITION_FAILED','error');});
+  }
+
+  doc.addEventListener('click',captureCreate,true);
+  window.addEventListener('mouseup',captureBoundaryTransition,true);
+
+  const api=Object.freeze({
+    core,descriptor,createStreamedZone,activateChunk,
+    performance:()=>core.performanceBudget(descriptor()||{chunkCols:1,chunkRows:1}),
+    get activePlan(){return activePlan;},
+    get transitioning(){return transitioning;},
+    stop(){if(stopped)return;stopped=true;doc.removeEventListener('click',captureCreate,true);window.removeEventListener('mouseup',captureBoundaryTransition,true);activePlan=null;},
+  });
+  window.LuminousVttProceduralChunkStreamingRuntime={api};
+  window.LuminousVttRuntime=Object.freeze({...window.LuminousVttRuntime,proceduralChunks:api});
+  return api;
+}

--- a/js/vtt/procedural-chunk-streaming-runtime.js
+++ b/js/vtt/procedural-chunk-streaming-runtime.js
@@ -50,11 +50,9 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
 
   async function activateChunk(desc,coord,{tokenId=null,requestedPoint=null,exit=null,persist=true}={}){
     if(transitioning)throw new Error('PROCEDURAL_CHUNK_TRANSITION_BUSY');
-    transitioning=true;
-    const previous=core.createDescriptor(desc);
+    transitioning=true;const previous=core.createDescriptor(desc);
     try{
-      const plan=await generateChunk(previous,coord);
-      procedural.apply(plan,{replaceScene:true,persist:false});
+      const plan=await generateChunk(previous,coord);procedural.apply(plan,{replaceScene:true,persist:false});
       const next=core.withActiveChunk(previous,coord);writeStreamingMetadata(next,plan);activePlan=plan;
       let token=null;if(tokenId!=null)token=(mapData.tokens||[]).find(x=>String(x.id)===String(tokenId))||null;
       if(token&&requestedPoint&&exit){
@@ -68,19 +66,21 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
   }
 
   async function createStreamedZone(previewPlan,size=selectedLogicalSize()){
-    if(!previewPlan?.validation?.valid)throw new Error('PROCEDURAL_PREVIEW_REQUIRED');
-    const desc=buildDescriptor(previewPlan,size),result=await activateChunk(desc,{col:0,row:0},{persist:true});
-    mapData.proceduralEditor&&(mapData.proceduralEditor.previewPlan=null);if(mapData.proceduralEditor)mapData.proceduralEditor.previewGenerationError=null;
-    doc.getElementById(PANEL_ID)?.querySelector('[data-proc-close]')?.click();
-    notify(`Zona ${size}×${size} creada en streaming · activo 40×40 · chunk 1,1`,'success');return result;
+    if(!previewPlan?.validation?.valid)throw new Error('PROCEDURAL_PREVIEW_REQUIRED');if(transitioning)throw new Error('PROCEDURAL_CHUNK_TRANSITION_BUSY');
+    transitioning=true;
+    try{
+      let desc=buildDescriptor(previewPlan,size);desc=core.withChunkSeed(desc,{col:0,row:0},previewPlan.seed);desc=core.withActiveChunk(desc,{col:0,row:0});
+      procedural.apply(previewPlan,{replaceScene:true,persist:false});writeStreamingMetadata(desc,previewPlan);activePlan=previewPlan;engine.centerCamera?.();redraw('procedural-stream-created');await persistChunk(previewPlan);
+      mapData.proceduralEditor&&(mapData.proceduralEditor.previewPlan=null);if(mapData.proceduralEditor)mapData.proceduralEditor.previewGenerationError=null;
+      doc.getElementById(PANEL_ID)?.querySelector('[data-proc-close]')?.click();notify(`Zona ${size}×${size} creada en streaming · activo 40×40 · chunk 1,1`,'success');
+      return{descriptor:desc,plan:previewPlan,token:null};
+    }finally{transitioning=false;}
   }
 
   function capturePreviewSizing(event){
     if(!event.target?.closest?.(PREVIEW_SELECTOR))return;
     const input=sizeInput(),logical=selectedLogicalSize();if(!input||logical<=1)return;
-    mapData.proceduralEditor||={};mapData.proceduralEditor.logicalChunkSize=logical;
-    input.value='1';
-    queueMicrotask(()=>{if(input.isConnected)input.value=String(logical);});
+    mapData.proceduralEditor||={};mapData.proceduralEditor.logicalChunkSize=logical;input.value='1';queueMicrotask(()=>{if(input.isConnected)input.value=String(logical);});
   }
 
   function captureCreate(event){
@@ -88,8 +88,7 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
     const plan=mapData.proceduralEditor?.previewPlan,size=selectedLogicalSize();if(size<=1||!plan?.validation?.valid)return;
     event.preventDefault();event.stopImmediatePropagation();
     if(sceneHasContent()&&!window.confirm('CREAR ZONA reemplazará la geometría y semántica actual. Los tokens de jugador se conservarán. ¿Continuar?'))return;
-    button.disabled=true;
-    Promise.resolve(createStreamedZone(plan,size)).catch(error=>{console.error('VTT PROCEDURAL STREAMED ZONE CREATE FAILED:',error);notify(error?.message||'PROCEDURAL_STREAM_CREATE_FAILED','error');}).finally(()=>{if(button.isConnected)button.disabled=false;});
+    button.disabled=true;Promise.resolve(createStreamedZone(plan,size)).catch(error=>{console.error('VTT PROCEDURAL STREAMED ZONE CREATE FAILED:',error);notify(error?.message||'PROCEDURAL_STREAM_CREATE_FAILED','error');}).finally(()=>{if(button.isConnected)button.disabled=false;});
   }
 
   function requestedPoint(event,drag){const world=engine.eventWorldPoint(event);return{x:world.x-drag.grabOffsetX,y:world.y-drag.grabOffsetY};}
@@ -98,8 +97,7 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
     const requested=requestedPoint(event,drag),transition=core.resolveTransition(desc,requested,mapData.grid);if(!transition?.valid)return;
     event.preventDefault();event.stopImmediatePropagation();
     const tokenId=drag.token.id,from={x:drag.originX,y:drag.originY,z:drag.originZ,elevationFt:drag.originElevationFt};
-    drag.token.x=drag.originX;drag.token.y=drag.originY;drag.token.zLayer=drag.originZ;drag.token.z=[drag.originZ];drag.token.elevationFt=drag.originElevationFt;
-    engine.tokenDrag=null;if(engine.canvas?.style)engine.canvas.style.cursor='default';
+    drag.token.x=drag.originX;drag.token.y=drag.originY;drag.token.zLayer=drag.originZ;drag.token.z=[drag.originZ];drag.token.elevationFt=drag.originElevationFt;engine.tokenDrag=null;if(engine.canvas?.style)engine.canvas.style.cursor='default';
     Promise.resolve(activateChunk(desc,transition.target,{tokenId,requestedPoint:requested,exit:transition.exit,persist:true})).then(({token,descriptor:next})=>{
       if(!token)return;
       engine.canvas?.dispatchEvent?.(new CustomEvent('vtt:token-moved',{detail:{tokenId:token.id,from,to:{x:token.x,y:token.y,...token.gridPosition,elevationFt:token.elevationFt??0},chunkTransition:{from:transition.from,to:next.activeChunk,edges:transition.exit.edges}}}));
@@ -108,11 +106,6 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
   }
 
   doc.addEventListener('click',capturePreviewSizing,true);doc.addEventListener('click',captureCreate,true);window.addEventListener('mouseup',captureBoundaryTransition,true);
-
-  const api=Object.freeze({
-    core,descriptor,createStreamedZone,activateChunk,performance:()=>core.performanceBudget(descriptor()||{chunkCols:1,chunkRows:1}),
-    get activePlan(){return activePlan;},get transitioning(){return transitioning;},
-    stop(){if(stopped)return;stopped=true;doc.removeEventListener('click',capturePreviewSizing,true);doc.removeEventListener('click',captureCreate,true);window.removeEventListener('mouseup',captureBoundaryTransition,true);activePlan=null;},
-  });
+  const api=Object.freeze({core,descriptor,createStreamedZone,activateChunk,performance:()=>core.performanceBudget(descriptor()||{chunkCols:1,chunkRows:1}),get activePlan(){return activePlan;},get transitioning(){return transitioning;},stop(){if(stopped)return;stopped=true;doc.removeEventListener('click',capturePreviewSizing,true);doc.removeEventListener('click',captureCreate,true);window.removeEventListener('mouseup',captureBoundaryTransition,true);activePlan=null;}});
   window.LuminousVttProceduralChunkStreamingRuntime={api};window.LuminousVttRuntime=Object.freeze({...window.LuminousVttRuntime,proceduralChunks:api});return api;
 }

--- a/js/vtt/semantic-map-bootstrap.js
+++ b/js/vtt/semantic-map-bootstrap.js
@@ -10,6 +10,7 @@ import { start as startBuildingArchetypeAuthoring } from './building-archetype-a
 import { start as startBuildingNavigation } from './building-navigation-bootstrap.js';
 import { start as startBuildingNavigationAuthoring } from './building-navigation-authoring-bootstrap.js';
 import { start as startProceduralGenerator } from './procedural-generator-bootstrap.js';
+import { start as startProceduralChunkStreaming } from './procedural-chunk-streaming-runtime.js';
 import { start as startProceduralGeneratorAuthoring } from './procedural-generator-authoring-bootstrap.js';
 
 export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine?.mapData}={}){
@@ -39,7 +40,7 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
     relationsFrom:(id)=>core.relationsFrom(mapData.semantics,id),
     relationsTo:(id)=>core.relationsTo(mapData.semantics,id),
     validate:()=>core.validateSemantics(mapData.semantics,mapData),
-    stop(){if(stopped)return;stopped=true;stopRenderer();stopDmPolish();},
+    stop(){if(stopped)return;stopped=true;stopRenderer();stopDmPolish();window.LuminousVttRuntime?.proceduralChunks?.stop?.();},
   });
   window.LuminousVttSemanticMapRuntime={api};
   window.LuminousVttRuntime=Object.freeze({...window.LuminousVttRuntime,semanticMap:api});
@@ -50,6 +51,7 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
   const navigationRuntime=buildingRuntime?startBuildingNavigation({runtime:window.LuminousVttRuntime,mapData}):null;
   if(navigationRuntime&&window.LuminousVttRuntime?.bridge?.isDm)startBuildingNavigationAuthoring({runtime:window.LuminousVttRuntime,mapData});
   const proceduralRuntime=navigationRuntime?startProceduralGenerator({runtime:window.LuminousVttRuntime,mapData}):null;
+  if(proceduralRuntime)startProceduralChunkStreaming({runtime:window.LuminousVttRuntime,mapData,procedural:proceduralRuntime});
   if(proceduralRuntime&&window.LuminousVttRuntime?.bridge?.isDm)startProceduralGeneratorAuthoring({runtime:window.LuminousVttRuntime,mapData});
   return api;
 }

--- a/tests/vtt_procedural_chunk_streaming_authority.spec.js
+++ b/tests/vtt_procedural_chunk_streaming_authority.spec.js
@@ -1,0 +1,48 @@
+const {test,expect}=require('@playwright/test');
+const fs=require('node:fs'),path=require('node:path'),{execFileSync}=require('node:child_process');
+const ROOT=path.resolve(__dirname,'..');
+const read=file=>fs.readFileSync(path.join(ROOT,file),'utf8');
+
+test('streamed chunk state synchronizes a small descriptor instead of full generated geometry',()=>{
+  const source=read('js/vtt/procedural-chunk-streaming-runtime.js');
+  expect(source).toContain("STATE_ROOT='campaña/estado_mundo/vttProceduralChunkState'");
+  expect(source).toContain('descriptor:core.createDescriptor(desc)');
+  expect(source).toContain('activeSignature:plan?.signature||null');
+  expect(source).not.toContain('payload.plan=');
+  expect(source).not.toContain('payload.topology=');
+  expect(source).not.toContain('payload.surfaceCells=');
+});
+
+test('players request transitions while the DM is authoritative for chunk changes',()=>{
+  const source=read('js/vtt/procedural-chunk-streaming-runtime.js');
+  expect(source).toContain("REQUEST_ROOT='vtt_procedural_chunk_transition_requests'");
+  expect(source).toContain("status:'pending'");
+  expect(source).toContain("if(isDm){Promise.resolve(activateChunk");
+  expect(source).toContain('else Promise.resolve(requestTransition');
+  expect(source).toContain("if(!isDm)return;const request=snapshot.val()||{}");
+  expect(source).toContain("subscribe(requestRootRef(),'child_added'");
+  expect(source).toContain("status:'applied'");
+  expect(source).toContain("status:'denied'");
+});
+
+test('all clients subscribe to authoritative active chunk state and regenerate locally',()=>{
+  const source=read('js/vtt/procedural-chunk-streaming-runtime.js');
+  expect(source).toContain("subscribe(stateRef(),'value'");
+  expect(source).toContain('applyRemoteState(snapshot)');
+  expect(source).toContain('await activateChunk(next,next.activeChunk,{persist:false,publish:false,center:false})');
+  expect(source).toContain('if(persist)await persistChunk(plan);if(publish)await publishChunkState(next,plan)');
+});
+
+test('stale and non-adjacent player requests are rejected before generation',()=>{
+  const source=read('js/vtt/procedural-chunk-streaming-runtime.js');
+  expect(source).toContain("reason='STALE_CHUNK_REQUEST'");
+  expect(source).toContain("reason='INVALID_CHUNK_TRANSITION'");
+  expect(source).toContain('Math.abs(dx)>1||Math.abs(dy)>1||!core.containsChunk(desc,target)');
+});
+
+test('authoritative synchronization reuses the existing Firebase host and parses cleanly',()=>{
+  const source=read('js/vtt/procedural-chunk-streaming-runtime.js');
+  expect(source).toContain('window.LuminousVttMapAuthoringState');
+  expect(source).toContain('stateApi?.hostFirebase?.(window)');
+  execFileSync(process.execPath,['--input-type=module','--check'],{input:source,stdio:['pipe','pipe','pipe']});
+});

--- a/tests/vtt_procedural_chunk_streaming_performance.spec.js
+++ b/tests/vtt_procedural_chunk_streaming_performance.spec.js
@@ -1,0 +1,99 @@
+const {test,expect}=require('@playwright/test');
+const fs=require('node:fs'),path=require('node:path'),{execFileSync}=require('node:child_process');
+const ROOT=path.resolve(__dirname,'..');
+const read=file=>fs.readFileSync(path.join(ROOT,file),'utf8');
+const streaming=require('../js/vtt/procedural-chunk-streaming-core.js');
+
+const GEN_FILES=[
+  'topology.js','surface-core.js','horizontal-plane-core.js','building-physics-core.js',
+  'semantic-map-core.js','building-semantic-core.js','building-archetype-core.js','vertical-portal.js',
+  'building-navigation-core.js','procedural-zone-core.js','urban-fabric-core.js',
+  'procedural-building-generator.js','procedural-building-mix-patch.js','procedural-generator-core.js',
+];
+const GEN_KEYS=[
+  'LuminousVttTopology','LuminousVttSurfaceCore','LuminousVttHorizontalPlanes','LuminousVttBuildingPhysics',
+  'LuminousVttSemanticMap','LuminousVttBuildingSemantics','LuminousVttBuildingArchetypes','LuminousVttVerticalPortal',
+  'LuminousVttBuildingNavigation','LuminousVttProceduralZone','LuminousVttUrbanFabric',
+  'LuminousVttProceduralBuildings',null,'LuminousVttProceduralGenerator',
+];
+function withGenerator(run){
+  const original=new Map(GEN_KEYS.filter(Boolean).map(key=>[key,global[key]]));
+  try{
+    for(let i=0;i<GEN_FILES.length;i++){
+      const resolved=require.resolve(path.join(ROOT,'js/vtt',GEN_FILES[i]));delete require.cache[resolved];const loaded=require(resolved),key=GEN_KEYS[i];if(key&&loaded)global[key]=loaded;
+    }
+    return run(global.LuminousVttProceduralGenerator,global.LuminousVttUrbanFabric);
+  }finally{
+    for(const file of GEN_FILES){try{delete require.cache[require.resolve(path.join(ROOT,'js/vtt',file))];}catch(_){}}
+    for(const key of GEN_KEYS.filter(Boolean)){const value=original.get(key);if(value===undefined)delete global[key];else global[key]=value;}
+  }
+}
+
+function descriptor(){return streaming.createDescriptor({zoneId:'perf-zone',seed:'perf-seed',profileId:'mixed_urban',chunkCols:3,chunkRows:3});}
+
+test('3x3 logical zone has a hard one-chunk 40x40 live performance budget',()=>{
+  const d=descriptor(),budget=streaming.performanceBudget(d),grid=streaming.liveGrid({cols:120,rows:120,size:70,distancePerCell:5});
+  expect(d).toMatchObject({chunkSize:40,chunkCols:3,chunkRows:3,logicalCols:120,logicalRows:120,activeChunk:{col:0,row:0}});
+  expect(grid).toMatchObject({cols:40,rows:40,size:70});
+  expect(budget).toEqual({liveCells:1600,logicalCells:14400,loadedChunks:1,logicalChunks:9,liveFraction:1/9});
+});
+
+test('every lazy chunk generation request is exactly 1x1 regardless of logical zone size',()=>{
+  const d=descriptor();
+  for(let row=0;row<3;row++)for(let col=0;col<3;col++){
+    const options=streaming.chunkGenerationOptions(d,{col,row},{gridSize:70,maxAttempts:8});
+    expect(options.chunkCols).toBe(1);expect(options.chunkRows).toBe(1);expect(options.minBuildings).toBe(1);
+    expect(options.seed).toBe(`perf-seed:chunk:${col},${row}`);
+  }
+});
+
+test('chunk seeds are deterministic without caching nine generated plans',()=>{
+  const d=descriptor();
+  expect(streaming.deriveChunkSeed(d.seed,{col:2,row:1})).toBe(streaming.deriveChunkSeed(d.seed,{col:2,row:1}));
+  expect(streaming.deriveChunkSeed(d.seed,{col:2,row:1})).not.toBe(streaming.deriveChunkSeed(d.seed,{col:1,row:2}));
+  expect(Object.keys(d)).not.toContain('plans');expect(Object.keys(d)).not.toContain('chunks');expect(JSON.stringify(d).length).toBeLessThan(4000);
+});
+
+test('edge and corner exits resolve to adjacent chunks and opposite entry cells',()=>{
+  let d=descriptor();const grid={cols:40,rows:40,size:70};
+  let t=streaming.resolveTransition(d,{x:2801,y:1400},grid);expect(t).toMatchObject({valid:true,target:{col:1,row:0},exit:{dx:1,dy:0}});
+  expect(streaming.entryCell({x:2801,y:1400},grid,t.exit)).toMatchObject({col:0,row:20});
+  d=streaming.withActiveChunk(d,{col:1,row:1});
+  t=streaming.resolveTransition(d,{x:2801,y:2801},grid);expect(t).toMatchObject({valid:true,target:{col:2,row:2},exit:{dx:1,dy:1}});
+  expect(streaming.entryCell({x:2801,y:2801},grid,t.exit)).toMatchObject({col:0,row:0});
+  t=streaming.resolveTransition(d,{x:-1,y:-1},grid);expect(t).toMatchObject({valid:true,target:{col:0,row:0},exit:{dx:-1,dy:-1}});
+  expect(streaming.entryCell({x:-1,y:-1},grid,t.exit)).toMatchObject({col:39,row:39});
+});
+
+test('outer logical-zone boundary is rejected instead of allocating another chunk',()=>{
+  const d=descriptor(),grid={cols:40,rows:40,size:70};
+  expect(streaming.resolveTransition(d,{x:-1,y:100},grid)).toMatchObject({valid:false,reason:'PROCEDURAL_ZONE_BOUNDARY',target:{col:-1,row:0}});
+  const last=streaming.withActiveChunk(d,{col:2,row:2});
+  expect(streaming.resolveTransition(last,{x:2801,y:2801},grid)).toMatchObject({valid:false,reason:'PROCEDURAL_ZONE_BOUNDARY',target:{col:3,row:3}});
+});
+
+test('a real streamed chunk generates and applies as 40x40 while preserving tokens',()=>withGenerator((generator,fabric)=>{
+  const d=streaming.createDescriptor({...descriptor(),profile:fabric.normalizeProfile('mixed_urban')});
+  const plan=generator.generateZone(streaming.chunkGenerationOptions(d,{col:1,row:2},{gridSize:70,maxAttempts:8,minBuildings:1}));
+  expect(plan.validation.valid).toBe(true);expect(plan.mapData.grid).toMatchObject({cols:40,rows:40});expect(plan.surfaceCells).toHaveLength(1600);
+  const token={id:'player-1',x:100,y:100},mapData={id:'perf-map',name:'Perf',grid:{cols:120,rows:120,size:70},tokens:[token],topology:[{id:'old'}],worldObjects:[{id:'old'}]};
+  generator.applyPlan(mapData,plan,{replaceScene:true});
+  expect(mapData.grid).toMatchObject({cols:40,rows:40});expect(mapData.tokens).toHaveLength(1);expect(mapData.tokens[0].id).toBe('player-1');expect(mapData.topology).not.toContainEqual({id:'old'});
+}));
+
+test('runtime intercepts create and mouseup so a multi-chunk zone never applies the 120x120 preview',()=>{
+  const runtime=read('js/vtt/procedural-chunk-streaming-runtime.js'),bootstrap=read('js/vtt/semantic-map-bootstrap.js');
+  expect(runtime).toContain("doc.addEventListener('click',captureCreate,true)");
+  expect(runtime).toContain("window.addEventListener('mouseup',captureBoundaryTransition,true)");
+  expect(runtime).toContain('procedural.apply(plan,{replaceScene:true,persist:false})');
+  expect(runtime).toContain('core.chunkGenerationOptions(desc,coord');
+  expect(runtime).toContain("mapData.proceduralEditor&&(mapData.proceduralEditor.previewPlan=null)");
+  expect(bootstrap).toContain("from './procedural-chunk-streaming-runtime.js'");
+  expect(bootstrap.indexOf('startProceduralChunkStreaming')).toBeLessThan(bootstrap.indexOf('startProceduralGeneratorAuthoring({runtime:window.LuminousVttRuntime,mapData})'));
+});
+
+test('streaming modules parse cleanly',()=>{
+  execFileSync(process.execPath,['--check',path.join(ROOT,'js/vtt/procedural-chunk-streaming-core.js')],{stdio:'pipe'});
+  execFileSync(process.execPath,['--input-type=module','--check'],{input:read('js/vtt/procedural-chunk-streaming-runtime.js'),stdio:['pipe','pipe','pipe']});
+  execFileSync(process.execPath,['--input-type=module','--check'],{input:read('js/vtt/semantic-map-bootstrap.js'),stdio:['pipe','pipe','pipe']});
+});

--- a/tests/vtt_procedural_lazy_preview_performance.spec.js
+++ b/tests/vtt_procedural_lazy_preview_performance.spec.js
@@ -1,0 +1,26 @@
+const {test,expect}=require('@playwright/test');
+const fs=require('node:fs'),path=require('node:path'),{execFileSync}=require('node:child_process');
+const ROOT=path.resolve(__dirname,'..');
+const read=file=>fs.readFileSync(path.join(ROOT,file),'utf8');
+
+test('2x2 and 3x3 Zone Creator preview/reroll are forced through one 40x40 generator chunk',()=>{
+  const runtime=read('js/vtt/procedural-chunk-streaming-runtime.js');
+  expect(runtime).toContain("PREVIEW_SELECTOR='[data-proc-preview],[data-proc-reroll]'");
+  expect(runtime).toContain('function capturePreviewSizing(event)');
+  expect(runtime).toContain("input.value='1'");
+  expect(runtime).toContain('mapData.proceduralEditor.logicalChunkSize=logical');
+  expect(runtime).toContain('queueMicrotask(()=>{if(input.isConnected)input.value=String(logical);})');
+  expect(runtime).toContain("doc.addEventListener('click',capturePreviewSizing,true)");
+});
+
+test('streaming create uses the restored logical selector size while applying only lazy 1x1 chunks',()=>{
+  const runtime=read('js/vtt/procedural-chunk-streaming-runtime.js'),core=read('js/vtt/procedural-chunk-streaming-core.js');
+  expect(runtime).toContain('const plan=mapData.proceduralEditor?.previewPlan,size=selectedLogicalSize()');
+  expect(runtime).toContain('buildDescriptor(previewPlan,size)');
+  expect(runtime).toContain('procedural.apply(plan,{replaceScene:true,persist:false})');
+  expect(core).toContain('chunkCols:1');expect(core).toContain('chunkRows:1');
+});
+
+test('lazy preview runtime parses cleanly',()=>{
+  execFileSync(process.execPath,['--input-type=module','--check'],{input:read('js/vtt/procedural-chunk-streaming-runtime.js'),stdio:['pipe','pipe','pipe']});
+});


### PR DESCRIPTION
## Problem
A logical 2x2/3x3 procedural Zone was being applied as one live 80x80/120x120 VTT scene. A 3x3 Zone therefore kept all 9 chunks, 14,400 surface cells, topology, semantics and building data live at once, causing severe PC slowdown/crashes.

## Fix
- Logical Zone dimensions (1x1 / 2x2 / 3x3) are now separate from the live VTT scene.
- Hard live-scene invariant: exactly one 40x40 chunk (1,600 cells) is active.
- 3x3 logical Zone = 9 logical chunks but `loadedChunks = 1`, `liveFraction = 1/9`.
- Multi-chunk PREVIEW/REROLL also generates only one 40x40 chunk; 3x3 remains logical metadata.
- The approved 40x40 preview is applied verbatim as chunk (0,0), so CREATE ZONE never silently regenerates a different initial layout.
- Other chunks are generated lazily and deterministically only when entered. The descriptor stores at most small per-chunk seed strings, never nine plans/geometries.
- Crossing right/left/top/bottom transitions to the adjacent chunk; crossing a corner changes both chunk coordinates; the token enters on the opposite edge.
- Exiting the outer logical-zone boundary remains rejected.
- Chunk replacement preserves tokens and reuses the existing atomic procedural apply/persistence path.
- The full preview reference is cleared/Zone Creator is closed after creation so obsolete preview data can be garbage-collected.

## Multiplayer authority
The existing topology bridge is globally Firebase-synchronized, so client-local map swaps would be overwritten. Streaming is therefore authoritative:
- players submit a small chunk-transition request;
- the DM validates the request and changes/persists the active chunk;
- the DM publishes only a small active-chunk descriptor (coordinate, profile/seeds/signature), not generated geometry;
- every connected client subscribes to that descriptor and deterministically regenerates the same single 40x40 chunk locally;
- stale, non-adjacent and out-of-zone requests are denied.

## Performance and regression contracts
CI now validates:
- 3x3 logical = 120x120 logical, but live grid remains 40x40;
- live budget = 1,600 cells vs 14,400 logical cells;
- every lazy generation request is forced to `chunkCols=1`, `chunkRows=1`;
- Preview/Reroll never asks the Worker for the detailed 3x3 scene;
- deterministic chunk seeds without caching nine plans;
- edge/corner transitions and outer-boundary rejection;
- a real generated/applied chunk stays 40x40 and preserves tokens;
- players request transitions while the DM is authoritative;
- synchronized state contains only the lightweight descriptor, never topology/surface-cell payloads;
- all clients regenerate the active chunk from authoritative state;
- existing Procedural Zone / DM Map Creator focused and broad regression suites still run.