### PR TITLE
perf(vtt): stop redundant Lighting/Fog redraws on idle maps

### DIFF
--- a/.github/workflows/vtt-performance-guard.yml
+++ b/.github/workflows/vtt-performance-guard.yml
@@ -1,0 +1,36 @@
+name: VTT Performance Guard
+
+on:
+  pull_request:
+    paths:
+      - 'vtt.html'
+      - 'js/vtt/performance-guard.js'
+      - 'tests/vtt_performance_guard.spec.js'
+      - '.github/workflows/vtt-performance-guard.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: vtt-performance-guard-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  performance-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Syntax
+        run: node --input-type=module --check < js/vtt/performance-guard.js
+      - name: Idle render budget
+        run: npx playwright test tests/vtt_performance_guard.spec.js
+      - name: Lighting/Fog focused regression
+        run: >-
+          npx playwright test
+          tests/vtt_dynamic_lighting.spec.js
+          tests/vtt_dynamic_lighting_runtime.spec.js
+          tests/vtt_pov*.spec.js
+          tests/vtt_memory*.spec.js

--- a/js/vtt/performance-guard.js
+++ b/js/vtt/performance-guard.js
@@ -1,0 +1,197 @@
+const DEFAULT_ACTIVE_FRAME_MS = 1000 / 30;
+const STATIC_SIGNATURE_TTL_MS = 100;
+
+const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+const clean = (value) => String(value ?? '');
+
+function tokenSignature(tokens = []) {
+  return (Array.isArray(tokens) ? tokens : []).map((token) => [
+    token?.id,
+    numberOr(token?.x),
+    numberOr(token?.y),
+    numberOr(token?.zLayer ?? token?.gridPosition?.z ?? token?.z?.[0]),
+    numberOr(token?.elevationFt),
+    numberOr(token?.lookDeg ?? token?.facingDeg),
+    numberOr(token?.visionConeDeg),
+    Boolean(token?.verticalMovement),
+  ]);
+}
+
+function topologySignature(mapData = {}) {
+  return (Array.isArray(mapData.topology) ? mapData.topology : []).map((element) => [
+    element?.id,
+    element?.type,
+    element?.state,
+    element?.zLayer ?? element?.z,
+    element?.a?.col ?? element?.x1,
+    element?.a?.row ?? element?.y1,
+    element?.b?.col ?? element?.x2,
+    element?.b?.row ?? element?.y2,
+  ]);
+}
+
+function portalSignature(mapData = {}) {
+  return (Array.isArray(mapData.verticalPortals) ? mapData.verticalPortals : []).map((portal) => [
+    portal?.id,
+    portal?.type,
+    portal?.from?.z ?? portal?.fromZ,
+    portal?.to?.z ?? portal?.toZ,
+    portal?.state,
+  ]);
+}
+
+function hasActiveLightingAnimation(mapData = {}, now = Date.now()) {
+  const sources = mapData.lighting?.scene?.sources || [];
+  const light = globalThis.LuminousVttLightingEngine;
+  return sources.some((source) => {
+    if (source?.motion) {
+      if (light?.interpolateMotion) {
+        try { if (!light.interpolateMotion(source.motion, now)?.complete) return true; } catch (_) { return true; }
+      } else return true;
+    }
+    return Boolean(source?.flicker || source?.visualFlicker || source?.animated);
+  });
+}
+
+export function createStaticSignatureCache(mapData, ttlMs = STATIC_SIGNATURE_TTL_MS) {
+  let at = -Infinity;
+  let value = '';
+  let forceSerial = 0;
+  return Object.freeze({
+    invalidate() { forceSerial += 1; at = -Infinity; },
+    value(now = performance.now()) {
+      if ((now - at) < ttlMs) return value;
+      at = now;
+      const scene = mapData.lighting?.scene || {};
+      value = JSON.stringify({
+        serial: forceSerial,
+        grid: [mapData.grid?.cols, mapData.grid?.rows, mapData.grid?.size, mapData.grid?.distancePerCell],
+        topology: topologySignature(mapData),
+        walls: (mapData.walls || []).map((wall) => [wall.id, wall.x1, wall.y1, wall.x2, wall.y2, wall.z, wall.blocksVision, wall.blocksMovement]),
+        portals: portalSignature(mapData),
+        lights: (scene.sources || []).map((source) => [source.id, source.x, source.y, source.zLayer, source.elevationFt, source.enabled, source.functional, source.brightFt, source.dimAdditionalFt, source.directionDeg, source.coneDeg, source.shape, source.color, source.motion?.startedAt, source.motion?.durationMs]),
+        interiors: (scene.interiors || []).map((zone) => [zone.id, zone.x, zone.y, zone.w, zone.h, zone.zLayer, zone.roof, zone.transparent]),
+        roofs: (scene.roofs || []).map((roof) => [roof.id, roof.x, roof.y, roof.w, roof.h, roof.zLayer, roof.elevationFt, roof.transparent]),
+        switches: (scene.switches || []).map((entry) => [entry.id, entry.enabled, entry.state, entry.circuitId]),
+        transformers: (scene.transformers || []).map((entry) => [entry.id, entry.enabled, entry.functional]),
+        environment: mapData.lighting?.environment?.state || mapData.ambientLight || null,
+        preview: [mapData.lighting?.dmPreviewTokenId || null, mapData.topologyPreview || null, mapData.verticalPortalEditor?.preview || null],
+        chunk: mapData.procedural?.activeChunkSignature || mapData.procedural?.streaming?.activeChunk || null,
+        edit: Boolean(mapData.dmEditMode?.active),
+      });
+      return value;
+    },
+  });
+}
+
+export function frameFingerprint({ engine, mapData, now = Date.now(), staticSignature = '' } = {}) {
+  const camera = engine?.camera || {};
+  const activeZ = numberOr(engine?.activeZ);
+  const animated = hasActiveLightingAnimation(mapData, now);
+  return JSON.stringify({
+    camera: [numberOr(camera.x), numberOr(camera.y), numberOr(camera.zoom, 1)],
+    canvas: [engine?.canvas?.width || 0, engine?.canvas?.height || 0],
+    z: activeZ,
+    tokens: tokenSignature(mapData?.tokens),
+    staticSignature,
+    animationTick: animated ? Math.floor(now / DEFAULT_ACTIVE_FRAME_MS) : 0,
+  });
+}
+
+export function installPerformanceGuard({ runtime = globalThis.LuminousVttRuntime, activeFrameMs = DEFAULT_ACTIVE_FRAME_MS } = {}) {
+  const engine = runtime?.engine;
+  const renderer = engine?.renderer;
+  const mapData = engine?.mapData;
+  if (!engine || !renderer || !mapData || renderer.__performanceGuardInstalled) return null;
+
+  const originalRender = renderer.render.bind(renderer);
+  const signatureCache = createStaticSignatureCache(mapData);
+  const metrics = { calls: 0, rendered: 0, skipped: 0, throttled: 0, lastRenderAt: 0 };
+  let lastFingerprint = '';
+  let lastRenderAt = -Infinity;
+  let stopped = false;
+
+  const invalidate = () => {
+    lastFingerprint = '';
+    signatureCache.invalidate();
+  };
+
+  const interactionInvalidate = () => {
+    if (engine.tokenDrag || mapData.dmEditMode?.active) invalidate();
+  };
+
+  const events = [
+    'vtt:token-moved',
+    'vtt:token-z-transition',
+    'vtt:procedural-chunk-loaded',
+    'vtt:procedural-chunk-transition',
+    'vtt:memory-learn',
+  ];
+  events.forEach((name) => engine.canvas?.addEventListener?.(name, invalidate));
+  globalThis.addEventListener?.('resize', invalidate);
+  globalThis.addEventListener?.('wheel', invalidate, { passive: true });
+  globalThis.addEventListener?.('keydown', invalidate);
+  globalThis.addEventListener?.('keyup', invalidate);
+  globalThis.addEventListener?.('mousemove', interactionInvalidate, { passive: true });
+
+  renderer.render = function guardedRender(...args) {
+    metrics.calls += 1;
+    const perfNow = globalThis.performance?.now?.() ?? Date.now();
+    const wallNow = Date.now();
+    const fingerprint = frameFingerprint({ engine, mapData, now: wallNow, staticSignature: signatureCache.value(perfNow) });
+    const changed = fingerprint !== lastFingerprint;
+    const active = Boolean(engine.tokenDrag) || hasActiveLightingAnimation(mapData, wallNow);
+
+    if (!changed && !active) {
+      metrics.skipped += 1;
+      return;
+    }
+    if (active && (perfNow - lastRenderAt) < activeFrameMs) {
+      metrics.throttled += 1;
+      return;
+    }
+
+    lastFingerprint = fingerprint;
+    lastRenderAt = perfNow;
+    metrics.lastRenderAt = perfNow;
+    metrics.rendered += 1;
+    return originalRender(...args);
+  };
+  renderer.__performanceGuardInstalled = true;
+
+  const api = Object.freeze({
+    invalidate,
+    snapshot: () => ({ ...metrics, savedFrames: metrics.skipped + metrics.throttled }),
+    resetMetrics() { metrics.calls = 0; metrics.rendered = 0; metrics.skipped = 0; metrics.throttled = 0; metrics.lastRenderAt = 0; },
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      renderer.render = originalRender;
+      renderer.__performanceGuardInstalled = false;
+      events.forEach((name) => engine.canvas?.removeEventListener?.(name, invalidate));
+      globalThis.removeEventListener?.('resize', invalidate);
+      globalThis.removeEventListener?.('wheel', invalidate);
+      globalThis.removeEventListener?.('keydown', invalidate);
+      globalThis.removeEventListener?.('keyup', invalidate);
+      globalThis.removeEventListener?.('mousemove', interactionInvalidate);
+    },
+  });
+  globalThis.LuminousVttPerformanceGuard = api;
+  return api;
+}
+
+function startWhenReady() {
+  let attempts = 0;
+  const tryStart = () => {
+    const runtime = globalThis.LuminousVttRuntime;
+    if (runtime?.engine?.renderer) {
+      installPerformanceGuard({ runtime });
+      return;
+    }
+    attempts += 1;
+    if (attempts < 80) globalThis.setTimeout?.(tryStart, 50);
+  };
+  queueMicrotask(tryStart);
+}
+
+if (typeof window !== 'undefined') startWhenReady();

--- a/tests/vtt_performance_guard.spec.js
+++ b/tests/vtt_performance_guard.spec.js
@@ -1,0 +1,85 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+const { execFileSync } = require('node:child_process');
+
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+async function loadGuard() {
+  const tmp = path.join(os.tmpdir(), `luminous-vtt-performance-${process.pid}-${Date.now()}.mjs`);
+  fs.writeFileSync(tmp, read('js/vtt/performance-guard.js'));
+  const mod = await import(`${pathToFileURL(tmp).href}?t=${Date.now()}`);
+  return { mod, tmp };
+}
+
+test('idle VTT frames render once instead of redrawing Lighting/Fog every animation frame', async () => {
+  const { mod, tmp } = await loadGuard();
+  try {
+    let realRenders = 0;
+    const listeners = new Map();
+    const canvas = {
+      width: 1920,
+      height: 1080,
+      addEventListener(name, fn) { listeners.set(name, fn); },
+      removeEventListener(name) { listeners.delete(name); },
+    };
+    const renderer = { render() { realRenders += 1; } };
+    const mapData = {
+      grid: { cols: 40, rows: 40, size: 70, distancePerCell: 5 },
+      tokens: [{ id: 'p1', x: 350, y: 350, zLayer: 0, lookDeg: 0, visionConeDeg: 120 }],
+      topology: [], walls: [], verticalPortals: [],
+      lighting: { scene: { sources: [], interiors: [], roofs: [], switches: [], transformers: [] }, environment: { state: { light: 'bright' } } },
+      dmEditMode: { active: false },
+    };
+    const engine = { renderer, mapData, canvas, camera: { x: 0, y: 0, zoom: 1 }, activeZ: 0, tokenDrag: null };
+    const api = mod.installPerformanceGuard({ runtime: { engine }, activeFrameMs: 0 });
+    expect(api).toBeTruthy();
+
+    for (let i = 0; i < 120; i += 1) renderer.render();
+    expect(realRenders).toBe(1);
+    expect(api.snapshot().rendered).toBe(1);
+    expect(api.snapshot().skipped).toBe(119);
+
+    mapData.tokens[0].x += 70;
+    renderer.render();
+    expect(realRenders).toBe(2);
+
+    mapData.topology.push({ id: 'door-1', type: 'door', state: 'closed', a: { col: 1, row: 1 }, b: { col: 2, row: 1 } });
+    api.invalidate();
+    renderer.render();
+    expect(realRenders).toBe(3);
+    expect(api.snapshot().savedFrames).toBeGreaterThanOrEqual(119);
+
+    api.stop();
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});
+
+test('performance guard loads after Dynamic Lighting and Fog Memory', () => {
+  const html = read('vtt.html');
+  const lighting = html.indexOf('js/vtt/dynamic-lighting-bootstrap.js');
+  const fog = html.indexOf('js/vtt/fog-memory-bootstrap.js');
+  const guard = html.indexOf('js/vtt/performance-guard.js');
+  expect(lighting).toBeGreaterThan(0);
+  expect(fog).toBeGreaterThan(lighting);
+  expect(guard).toBeGreaterThan(fog);
+});
+
+test('performance guard keeps visual rule inputs in its frame fingerprint', () => {
+  const source = read('js/vtt/performance-guard.js');
+  expect(source).toContain('tokenSignature(mapData?.tokens)');
+  expect(source).toContain('topologySignature(mapData)');
+  expect(source).toContain('mapData.lighting?.scene');
+  expect(source).toContain('mapData.procedural?.activeChunkSignature');
+  expect(source).toContain('DEFAULT_ACTIVE_FRAME_MS = 1000 / 30');
+});
+
+test('performance guard parses as an ES module', () => {
+  const tmp = path.join(os.tmpdir(), `luminous-vtt-performance-syntax-${process.pid}.mjs`);
+  fs.writeFileSync(tmp, read('js/vtt/performance-guard.js'));
+  try { execFileSync(process.execPath, ['--check', tmp], { stdio: 'pipe' }); }
+  finally { fs.unlinkSync(tmp); }
+});

--- a/vtt.html
+++ b/vtt.html
@@ -156,6 +156,7 @@
     <script type="module" src="js/vtt/memory-defaults-patch.js"></script>
     <script type="module" src="js/vtt/memory-review-hardening-patch.js"></script>
     <script type="module" src="js/vtt/fog-memory-bootstrap.js"></script>
+    <script type="module" src="js/vtt/performance-guard.js"></script>
     <script src="js/vtt/ui-shell.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Problem
Even with procedural chunk streaming, the VTT render loop still calls the composed Renderer every animation frame. Dynamic Lighting + PoV + Fog Memory therefore keep doing canvas/perception work on a completely static map.

## Patch
- Adds a final `performance-guard.js` layer loaded after Dynamic Lighting and Fog Memory.
- Computes a compact visual frame fingerprint from camera, active Z, token positions/look, grid, topology states, vertical portals, lighting state, environment, editor previews and procedural active-chunk signature.
- Identical idle frames are skipped entirely, so the expensive Lighting/Fog renderer chain is not called again.
- Token drag / active lighting animation is budgeted to ~30 FPS rather than unbounded animation-frame redraws.
- Known VTT state events, resize/wheel/keyboard, and DM editing interactions invalidate the cache immediately.
- Does not alter vision distances, darkness semantics, topology rules, Fog memory contents, Firebase authority or procedural generation.
- Exposes small runtime metrics (`calls`, `rendered`, `skipped`, `throttled`, `savedFrames`) for future performance profiling.

## Performance contract
`tests/vtt_performance_guard.spec.js` simulates 120 identical animation frames on a 40x40 map and requires:
- exactly 1 real renderer call;
- 119 duplicate frames skipped;
- token movement causes an immediate new render;
- topology invalidation causes an immediate new render.

A dedicated `VTT Performance Guard` workflow runs syntax, the performance contract, and the existing Lighting/PoV/Fog focused regressions.

## Relationship to #671
This is independent of the chunk-streaming implementation. #671 reduces live world size to one 40x40 chunk; this PR reduces unnecessary work while that chunk is idle or moving.