### PR TITLE
fix(vtt): enforce 120 degree token vision

### DIFF
--- a/.github/workflows/vtt-performance-guard.yml
+++ b/.github/workflows/vtt-performance-guard.yml
@@ -5,7 +5,11 @@ on:
     paths:
       - 'vtt.html'
       - 'js/vtt/performance-guard.js'
+      - 'js/vtt/lighting-engine.js'
+      - 'js/vtt/lighting-defaults-patch.js'
+      - 'js/vtt/pov-engine.js'
       - 'tests/vtt_performance_guard.spec.js'
+      - 'tests/vtt_vision_cone_runtime.spec.js'
       - '.github/workflows/vtt-performance-guard.yml'
   workflow_dispatch:
 
@@ -25,6 +29,8 @@ jobs:
       - run: npm ci
       - name: Syntax
         run: node --input-type=module --check < js/vtt/performance-guard.js
+      - name: Vision cone 120 degree regression
+        run: npx playwright test tests/vtt_vision_cone_runtime.spec.js
       - name: Idle render budget
         run: npx playwright test tests/vtt_performance_guard.spec.js
       - name: Lighting/Fog focused regression

--- a/js/vtt/lighting-defaults-patch.js
+++ b/js/vtt/lighting-defaults-patch.js
@@ -3,9 +3,12 @@ import './lighting-engine.js';
 const base = window.LuminousVttLightingEngine;
 if (base) {
   const finite = (value) => Number.isFinite(Number(value));
+  const effectiveViewerCone = (viewer = {}) => finite(viewer.visionConeDeg)
+    ? Math.max(1, Math.min(base.DEFAULT_VISION_CONE_DEG, Number(viewer.visionConeDeg)))
+    : base.DEFAULT_VISION_CONE_DEG;
   const withViewerDefaults = (viewer = {}) => ({
     ...viewer,
-    visionConeDeg: finite(viewer.visionConeDeg) ? Number(viewer.visionConeDeg) : base.DEFAULT_VISION_CONE_DEG,
+    visionConeDeg: effectiveViewerCone(viewer),
   });
   const withSourceDefaults = (source = {}) => ({
     ...source,
@@ -18,9 +21,7 @@ if (base) {
 
   window.LuminousVttLightingEngine = Object.freeze({
     ...base,
-    visionConeDeg: (viewer = {}) => finite(viewer.visionConeDeg)
-      ? Math.max(1, Math.min(360, Number(viewer.visionConeDeg)))
-      : base.DEFAULT_VISION_CONE_DEG,
+    visionConeDeg: effectiveViewerCone,
     normalizeSource: (source, mapData) => base.normalizeSource(withSourceDefaults(source), mapData),
     sourcePosition: (source, mapData, nowMs) => base.sourcePosition(withSourceDefaults(source), mapData, nowMs),
     sourceLevelAtPoint: (source, point, scene, mapData, nowMs) => base.sourceLevelAtPoint(withSourceDefaults(source), point, withSceneDefaults(scene), mapData, nowMs),

--- a/tests/vtt_vision_cone_runtime.spec.js
+++ b/tests/vtt_vision_cone_runtime.spec.js
@@ -1,0 +1,45 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const repo = path.join(__dirname, '..');
+const base = require('../js/vtt/lighting-engine.js');
+
+function patchedLighting() {
+  const source = fs.readFileSync(path.join(repo, 'js/vtt/lighting-defaults-patch.js'), 'utf8')
+    .replace(/^import .*?;\s*/m, '');
+  const context = {
+    window: { LuminousVttLightingEngine: base },
+    console,
+  };
+  vm.runInNewContext(source, context, { filename: 'lighting-defaults-patch.js' });
+  return context.window.LuminousVttLightingEngine;
+}
+
+const mapData = {
+  grid: { size: 70, distancePerCell: 5, cols: 40, rows: 40 },
+  topology: [],
+  walls: [],
+  tokens: [],
+};
+const scene = { sources: [], interiors: [], transformers: [], switches: [], roofs: [] };
+const environment = { state: { light: 'bright' } };
+
+test('normal token vision is capped to 120 degrees even when legacy state says 360', () => {
+  const lighting = patchedLighting();
+  const viewer = { x: 700, y: 700, zLayer: 0, facingDeg: 0, lookDeg: 0, visionConeDeg: 360 };
+
+  expect(lighting.visionConeDeg(viewer)).toBe(120);
+  expect(lighting.perceptionAtPoint(viewer, { x: 900, y: 700, zLayer: 0 }, scene, mapData, environment).visible).toBe(true);
+  expect(lighting.perceptionAtPoint(viewer, { x: 600, y: 700, zLayer: 0 }, scene, mapData, environment)).toMatchObject({
+    visible: false,
+    mode: 'outside_cone',
+  });
+});
+
+test('120 degree cone includes the boundary at plus/minus 60 degrees and rejects points beyond it', () => {
+  expect(base.pointInCone({ x: 0, y: 0 }, { x: 100, y: Math.tan(Math.PI / 3) * 100 }, 0, 120)).toBe(true);
+  expect(base.pointInCone({ x: 0, y: 0 }, { x: 0, y: 100 }, 0, 120)).toBe(false);
+  expect(base.pointInCone({ x: 0, y: 0 }, { x: -100, y: 0 }, 0, 120)).toBe(false);
+});


### PR DESCRIPTION
## Problem
Tokens can carry persisted `visionConeDeg: 360`, and the current defaults patch accepts that as valid. As a result both players and DM `VIEW AS TOKEN` can see omnidirectionally despite the intended 120° vision cone.

## Fix
- Caps normal token vision to `DEFAULT_VISION_CONE_DEG` (120°).
- Preserves narrower configured cones, e.g. 90°.
- Converts legacy 180/270/360 values to 120° at runtime.
- Leaves light-source cone behavior unchanged.

## Regression test
Adds `tests/vtt_vision_cone_runtime.spec.js`:
- injects a legacy token with `visionConeDeg: 360`;
- requires effective cone = 120°;
- verifies a point in front is visible;
- verifies a point behind returns `outside_cone`;
- verifies ±60° boundary behavior.