### PR TITLE
fix(vtt): keep notifications visible above HUD

### DIFF
--- a/.github/workflows/vtt-map-hud.yml
+++ b/.github/workflows/vtt-map-hud.yml
@@ -3,6 +3,7 @@ name: VTT Map HUD and Physical World
 on:
   pull_request:
     paths:
+      - 'css/vtt.css'
       - 'js/vtt/camera.js'
       - 'js/vtt/camera-follow.js'
       - 'js/vtt/physical-resolver.js'
@@ -20,6 +21,7 @@ on:
       - 'tests/vtt_physical_state_persistence.spec.js'
       - 'tests/vtt_interaction_authority.spec.js'
       - 'tests/vtt_camera_perception.spec.js'
+      - 'tests/vtt_notice_layout.spec.js'
       - '.github/workflows/vtt-map-hud.yml'
   workflow_dispatch:
 
@@ -50,6 +52,8 @@ jobs:
           node --input-type=module --check < js/vtt/map-hud-bootstrap.js
           node --input-type=module --check < js/vtt/main.js
           node -e "JSON.parse(require('fs').readFileSync('database.rules.json','utf8'))"
+      - name: Notice visibility regression
+        run: npx playwright test tests/vtt_notice_layout.spec.js --workers=1
       - name: Focused contracts
         run: npx playwright test tests/vtt_world_objects.spec.js tests/vtt_map_hud_physical.spec.js tests/vtt_physical_state_persistence.spec.js tests/vtt_interaction_authority.spec.js tests/vtt_camera_perception.spec.js --workers=1
       - name: Install Chromium

--- a/css/vtt.css
+++ b/css/vtt.css
@@ -271,18 +271,28 @@ button, input, select { font: inherit; }
 }
 
 .vtt-notice {
-    position: absolute;
+    position: fixed;
     left: 50%;
-    bottom: 28px;
+    top: max(12px, env(safe-area-inset-top));
     transform: translateX(-50%);
-    z-index: 1800;
-    max-width: min(560px, calc(100vw - 40px));
+    z-index: 60000;
+    width: max-content;
+    max-width: min(620px, calc(100vw - 200px));
+    box-sizing: border-box;
     padding: 10px 15px;
     background: rgba(4, 7, 9, .96);
     border: 1px solid #68737d;
     box-shadow: 0 8px 22px rgba(0, 0, 0, .7);
     text-align: center;
     font-size: 12px;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
+    white-space: normal;
+    pointer-events: none;
+}
+
+body.vtt-dm-edit-active .vtt-notice {
+    max-width: min(620px, max(240px, calc(100vw - 440px)));
 }
 
 .vtt-notice[data-mode="success"] { border-color: #52b788; }
@@ -296,4 +306,6 @@ button, input, select { font: inherit; }
     .vtt-panel { top: auto; bottom: 10px; left: 10px; }
     .vtt-vertical-panel { left: auto; right: 10px; }
     .brutalist-button { font-size: 10px; padding: 6px 8px; }
+    .vtt-notice { top: max(8px, env(safe-area-inset-top)); max-width: calc(100vw - 180px); }
+    body.vtt-dm-edit-active .vtt-notice { max-width: min(440px, max(220px, calc(100vw - 360px))); }
 }

--- a/tests/vtt_notice_layout.spec.js
+++ b/tests/vtt_notice_layout.spec.js
@@ -1,0 +1,46 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+const read = (relativePath) => fs.readFileSync(path.join(__dirname, '..', relativePath), 'utf8');
+
+function cssBlock(source, selector) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = source.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`, 's'));
+  expect(match, `Missing CSS block for ${selector}`).toBeTruthy();
+  return match[1];
+}
+
+function numericProperty(block, property) {
+  const match = block.match(new RegExp(`${property}\\s*:\\s*(\\d+)`));
+  expect(match, `Missing numeric ${property}`).toBeTruthy();
+  return Number(match[1]);
+}
+
+test('global VTT notice uses a top fixed lane above the tactical HUD', () => {
+  const css = read('css/vtt.css');
+  const hudSource = read('js/vtt/map-hud-bootstrap.js');
+  const notice = cssBlock(css, '.vtt-notice');
+  const hud = hudSource.match(/#\$\{HUD_ID\}\{([^}]*)\}/s)?.[1];
+
+  expect(hud, 'Missing tactical HUD style block').toBeTruthy();
+  expect(notice).toContain('position: fixed');
+  expect(notice).toMatch(/top\s*:/);
+  expect(notice).not.toMatch(/bottom\s*:/);
+  expect(notice).toContain('pointer-events: none');
+  expect(notice).toContain('overflow-wrap: anywhere');
+  expect(numericProperty(notice, 'z-index')).toBeGreaterThan(numericProperty(hud, 'z-index'));
+});
+
+test('DM edit mode reserves horizontal space for the notice lane', () => {
+  const css = read('css/vtt.css');
+  const dmNotice = cssBlock(css, 'body.vtt-dm-edit-active .vtt-notice');
+  expect(dmNotice).toMatch(/max-width\s*:/);
+  expect(dmNotice).toContain('100vw - 440px');
+});
+
+test('VTT exposes exactly one polite global notice live region', () => {
+  const html = read('vtt.html');
+  expect((html.match(/id="vtt-notice"/g) || []).length).toBe(1);
+  expect(html).toMatch(/id="vtt-notice"[^>]*role="status"[^>]*aria-live="polite"/);
+});

--- a/tests/vtt_notice_layout_README.tmp
+++ b/tests/vtt_notice_layout_README.tmp
@@ -1,0 +1,1 @@
+temporary

--- a/tests/vtt_notice_layout_README.tmp
+++ b/tests/vtt_notice_layout_README.tmp
@@ -1,1 +1,0 @@
-temporary


### PR DESCRIPTION
## Problem
The global `#vtt-notice` was rendered at bottom-center with `z-index: 1800`, while the tactical map HUD occupies the same bottom-center region at `z-index: 36500`. Notices could therefore be hidden behind the HUD or other modern VTT chrome.

## Fix
- Moves the global notice to a dedicated fixed top-center notification lane.
- Raises the notice layer to `z-index: 60000`, above VTT HUD/sidebars.
- Prevents notices from intercepting pointer input.
- Adds long-message wrapping and safe-area-aware top spacing.
- Narrows the lane during DM Edit Mode so it does not fight the sidebars.

## Regression
Adds `tests/vtt_notice_layout.spec.js` verifying:
- notice is fixed and top-positioned;
- no bottom positioning remains;
- notice z-index is greater than the tactical HUD z-index;
- DM Edit Mode reserves horizontal room;
- exactly one polite global live region exists.

The Map HUD workflow now runs this regression explicitly when notice CSS or the test changes.