### PR TITLE
feat(vtt): bound world streaming lifecycle for split parties

### DIFF
--- a/.github/workflows/background-narratives.yml
+++ b/.github/workflows/background-narratives.yml
@@ -59,7 +59,10 @@ jobs:
       - name: Narrative contract
         run: node tests/background_narratives.spec.js
 
-      - name: Non-browser repository regression suite
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Repository regression suite
         run: >-
           npx playwright test --workers=1 --grep-invert
           "status builder catalog exposes elemental statuses and runtime|DM Studio uses racial Stats for derived HP and persists base/effective layers|player Stats HUD displays and rolls from the effective racial Score|DM Studio keeps Base editable and shows Effective racial Score|Skill builder UI flow|Status builder UI flow"

--- a/.github/workflows/vtt-procedural-zone-engine.yml
+++ b/.github/workflows/vtt-procedural-zone-engine.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'js/vtt/procedural-*.js'
+      - 'js/vtt/world-streaming-*.js'
       - 'js/vtt/urban-fabric-core.js'
       - 'js/vtt/dm-authoring-shell-polish.js'
       - 'js/vtt/semantic-map-bootstrap.js'
@@ -12,6 +13,7 @@ on:
       - 'tests/vtt_procedural_chunk_streaming_performance.spec.js'
       - 'tests/vtt_procedural_lazy_preview_performance.spec.js'
       - 'tests/vtt_procedural_chunk_streaming_authority.spec.js'
+      - 'tests/vtt_world_streaming_lifecycle.spec.js'
       - '.github/workflows/vtt-procedural-zone-engine.yml'
   workflow_dispatch:
 
@@ -33,12 +35,14 @@ jobs:
         run: |
           node --check js/vtt/procedural-zone-core.js
           node --check js/vtt/procedural-chunk-streaming-core.js
+          node --check js/vtt/world-streaming-core.js
           node --check js/vtt/urban-fabric-core.js
           node --check js/vtt/procedural-building-generator.js
           node --check js/vtt/procedural-generator-core.js
           node --input-type=module --check < js/vtt/procedural-generator-bootstrap.js
           node --input-type=module --check < js/vtt/procedural-generator-authoring-bootstrap.js
           node --input-type=module --check < js/vtt/procedural-chunk-streaming-runtime.js
+          node --input-type=module --check < js/vtt/world-streaming-runtime.js
           node --input-type=module --check < js/vtt/dm-authoring-shell-polish.js
           node --input-type=module --check < js/vtt/semantic-map-bootstrap.js
       - name: Chunk streaming performance contract
@@ -47,6 +51,7 @@ jobs:
           tests/vtt_procedural_chunk_streaming_performance.spec.js
           tests/vtt_procedural_lazy_preview_performance.spec.js
           tests/vtt_procedural_chunk_streaming_authority.spec.js
+          tests/vtt_world_streaming_lifecycle.spec.js
       - name: Focused contracts
         run: >-
           npx playwright test

--- a/js/vtt/semantic-map-bootstrap.js
+++ b/js/vtt/semantic-map-bootstrap.js
@@ -11,6 +11,7 @@ import { start as startBuildingNavigation } from './building-navigation-bootstra
 import { start as startBuildingNavigationAuthoring } from './building-navigation-authoring-bootstrap.js';
 import { start as startProceduralGenerator } from './procedural-generator-bootstrap.js';
 import { start as startProceduralChunkStreaming } from './procedural-chunk-streaming-runtime.js';
+import { start as startWorldStreaming } from './world-streaming-runtime.js';
 import { start as startProceduralGeneratorAuthoring } from './procedural-generator-authoring-bootstrap.js';
 
 export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine?.mapData}={}){
@@ -40,10 +41,11 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
     relationsFrom:(id)=>core.relationsFrom(mapData.semantics,id),
     relationsTo:(id)=>core.relationsTo(mapData.semantics,id),
     validate:()=>core.validateSemantics(mapData.semantics,mapData),
-    stop(){if(stopped)return;stopped=true;stopRenderer();stopDmPolish();window.LuminousVttRuntime?.proceduralChunks?.stop?.();},
+    stop(){if(stopped)return;stopped=true;stopRenderer();stopDmPolish();window.LuminousVttRuntime?.proceduralChunks?.stop?.();window.LuminousVttRuntime?.worldStreaming?.stop?.();},
   });
   window.LuminousVttSemanticMapRuntime={api};
   window.LuminousVttRuntime=Object.freeze({...window.LuminousVttRuntime,semanticMap:api});
+  startWorldStreaming({runtime:window.LuminousVttRuntime,mapData});
   const buildingRuntime=startBuildingSemantics({runtime:window.LuminousVttRuntime,mapData});
   if(buildingRuntime&&window.LuminousVttRuntime?.bridge?.isDm)startBuildingSemanticAuthoring({runtime:window.LuminousVttRuntime,mapData});
   const archetypeRuntime=buildingRuntime?startBuildingArchetypes({runtime:window.LuminousVttRuntime,mapData}):null;

--- a/js/vtt/world-streaming-core.js
+++ b/js/vtt/world-streaming-core.js
@@ -1,0 +1,136 @@
+(function(root,factory){
+  const api=factory();
+  if(typeof module!=='undefined'&&module.exports)module.exports=api;
+  if(root)root.LuminousVttWorldStreaming=api;
+})(typeof window!=='undefined'?window:globalThis,function(){
+  'use strict';
+
+  const SCHEMA_VERSION=1;
+  const CHUNK_SIZE_CELLS=40;
+  const STATES=Object.freeze({ACTIVE:'ACTIVE',WARM:'WARM',DORMANT:'DORMANT'});
+  const DEFAULTS=Object.freeze({warmTtlMs:30000,maxWarmChunks:16,maxActiveChunks:8,cellSize:70,chunkSizeCells:CHUNK_SIZE_CELLS});
+  const clone=v=>v==null?v:JSON.parse(JSON.stringify(v));
+  const finite=(v,f=0)=>Number.isFinite(Number(v))?Number(v):f;
+  const integer=(v,f=0)=>Math.trunc(finite(v,f));
+  const clean=(v,f='')=>String(v??f).trim()||f;
+  const positive=(v,f)=>Math.max(1,integer(v,f));
+  const mod=(value,size)=>((value%size)+size)%size;
+
+  function normalizeWorldPosition(raw={},options={}){
+    const chunkSizeCells=positive(options.chunkSizeCells??raw.chunkSizeCells,CHUNK_SIZE_CELLS);
+    const cellSize=Math.max(1,finite(options.cellSize??raw.cellSize,DEFAULTS.cellSize));
+    let chunkCol=integer(raw.chunkCol??raw.chunk?.col,0),chunkRow=integer(raw.chunkRow??raw.chunk?.row,0);
+    let x=finite(raw.x??raw.localX,0),y=finite(raw.y??raw.localY,0);
+    const chunkPx=chunkSizeCells*cellSize;
+    if(Number.isFinite(x)){
+      const shift=Math.floor(x/chunkPx);chunkCol+=shift;x=mod(x,chunkPx);
+    }else x=0;
+    if(Number.isFinite(y)){
+      const shift=Math.floor(y/chunkPx);chunkRow+=shift;y=mod(y,chunkPx);
+    }else y=0;
+    const cellCol=Math.max(0,Math.min(chunkSizeCells-1,Math.floor(x/cellSize)));
+    const cellRow=Math.max(0,Math.min(chunkSizeCells-1,Math.floor(y/cellSize)));
+    return Object.freeze({
+      schemaVersion:SCHEMA_VERSION,
+      worldId:clean(raw.worldId,'luminous'),regionId:clean(raw.regionId,'region'),zoneId:clean(raw.zoneId,'zone'),
+      chunkCol,chunkRow,x,y,cellCol,cellRow,zLayer:integer(raw.zLayer??raw.z??raw.gridPosition?.z,0),
+      elevationFt:finite(raw.elevationFt,0),chunkSizeCells,cellSize,
+    });
+  }
+
+  function worldChunkKey(raw={},options={}){
+    const p=normalizeWorldPosition(raw,options);
+    return `${p.worldId}/${p.regionId}/${p.zoneId}/${p.chunkCol},${p.chunkRow}`;
+  }
+
+  function worldCell(raw={},options={}){
+    const p=normalizeWorldPosition(raw,options);
+    return Object.freeze({col:p.chunkCol*p.chunkSizeCells+p.cellCol,row:p.chunkRow*p.chunkSizeCells+p.cellRow,z:p.zLayer});
+  }
+
+  function deriveWorldChunkSeed(seed,raw={},options={}){
+    return `${clean(seed,'luminous-world')}:world-chunk:${worldChunkKey(raw,options)}`;
+  }
+
+  function createDormantRecord({position={},seed='',delta=null,revision=0,updatedAt=Date.now()}={}){
+    const p=normalizeWorldPosition(position);
+    return Object.freeze({schemaVersion:SCHEMA_VERSION,state:STATES.DORMANT,key:worldChunkKey(p),position:{worldId:p.worldId,regionId:p.regionId,zoneId:p.zoneId,chunkCol:p.chunkCol,chunkRow:p.chunkRow},seed:clean(seed)||deriveWorldChunkSeed('luminous-world',p),delta:clone(delta),revision:Math.max(0,integer(revision,0)),updatedAt:Math.max(0,finite(updatedAt,0))});
+  }
+
+  function createLifecycleManager(options={}){
+    const config=Object.freeze({
+      warmTtlMs:Math.max(0,finite(options.warmTtlMs,DEFAULTS.warmTtlMs)),
+      maxWarmChunks:Math.max(0,integer(options.maxWarmChunks,DEFAULTS.maxWarmChunks)),
+      maxActiveChunks:positive(options.maxActiveChunks,DEFAULTS.maxActiveChunks),
+      cellSize:Math.max(1,finite(options.cellSize,DEFAULTS.cellSize)),
+      chunkSizeCells:positive(options.chunkSizeCells,DEFAULTS.chunkSizeCells),
+    });
+    const chunks=new Map(),actors=new Map();
+    let dormantCount=0,peakResidentChunks=0,peakActiveChunks=0,serial=0;
+    const nowValue=raw=>Math.max(0,finite(raw,Date.now()));
+    const normalize=p=>normalizeWorldPosition(p,config);
+
+    function residentEntry(position,now){
+      const p=normalize(position),key=worldChunkKey(p,config);
+      let entry=chunks.get(key);
+      if(!entry){entry={key,state:STATES.WARM,position:p,actors:new Set(),lastTouched:now,warmUntil:now+config.warmTtlMs,serial:++serial};chunks.set(key,entry);}
+      return entry;
+    }
+    function transitionDormant(entry,events,reason){
+      if(!entry||entry.state===STATES.DORMANT)return;
+      chunks.delete(entry.key);dormantCount+=1;
+      events.dormant.push({key:entry.key,state:STATES.DORMANT,position:entry.position,lastTouched:entry.lastTouched,reason});
+    }
+    function capWarm(events){
+      const warm=[...chunks.values()].filter(x=>x.state===STATES.WARM).sort((a,b)=>a.lastTouched-b.lastTouched||a.serial-b.serial);
+      while(warm.length>config.maxWarmChunks)transitionDormant(warm.shift(),events,'warm-capacity');
+    }
+    function expireWarm(now,events){
+      for(const entry of [...chunks.values()])if(entry.state===STATES.WARM&&entry.warmUntil<=now)transitionDormant(entry,events,'warm-ttl');
+      capWarm(events);
+    }
+    function snapshot(){
+      let active=0,warm=0,actorRefs=0;
+      for(const entry of chunks.values()){
+        if(entry.state===STATES.ACTIVE)active+=1;else if(entry.state===STATES.WARM)warm+=1;
+        actorRefs+=entry.actors.size;
+      }
+      peakResidentChunks=Math.max(peakResidentChunks,chunks.size);peakActiveChunks=Math.max(peakActiveChunks,active);
+      return Object.freeze({schemaVersion:SCHEMA_VERSION,activeChunks:active,warmChunks:warm,residentChunks:chunks.size,dormantTransitions:dormantCount,actorRefs,uniqueActors:actors.size,overActiveBudget:Math.max(0,active-config.maxActiveChunks),liveCells:active*config.chunkSizeCells*config.chunkSizeCells,peakActiveChunks,peakResidentChunks,maxResidentBudget:config.maxActiveChunks+config.maxWarmChunks});
+    }
+    function reconcile(rawActors=[],rawNow=Date.now()){
+      const now=nowValue(rawNow),events={activated:[],warmed:[],dormant:[],moved:[],released:[]};
+      const desired=new Map();
+      for(const raw of Array.isArray(rawActors)?rawActors:[]){
+        const id=clean(raw?.id??raw?.actorId);if(!id)continue;
+        const position=normalize(raw.position||raw.worldPosition||raw),key=worldChunkKey(position,config);
+        desired.set(id,{id,key,position});
+      }
+      for(const [id,current] of [...actors]){
+        if(desired.has(id))continue;
+        const entry=chunks.get(current.key);if(entry){entry.actors.delete(id);entry.lastTouched=now;if(entry.actors.size===0&&entry.state===STATES.ACTIVE){entry.state=STATES.WARM;entry.warmUntil=now+config.warmTtlMs;events.warmed.push({key:entry.key,position:entry.position});}}
+        actors.delete(id);events.released.push({actorId:id,key:current.key});
+      }
+      for(const next of desired.values()){
+        const previous=actors.get(next.id);
+        if(previous&&previous.key!==next.key){
+          const from=chunks.get(previous.key);if(from){from.actors.delete(next.id);from.lastTouched=now;if(from.actors.size===0&&from.state===STATES.ACTIVE){from.state=STATES.WARM;from.warmUntil=now+config.warmTtlMs;events.warmed.push({key:from.key,position:from.position});}}
+          events.moved.push({actorId:next.id,from:previous.key,to:next.key});
+        }
+        const entry=residentEntry(next.position,now),wasActive=entry.state===STATES.ACTIVE;
+        entry.state=STATES.ACTIVE;entry.position=next.position;entry.lastTouched=now;entry.warmUntil=0;entry.actors.add(next.id);
+        actors.set(next.id,{key:next.key,position:next.position});
+        if(!wasActive)events.activated.push({key:entry.key,position:entry.position});
+      }
+      expireWarm(now,events);const metrics=snapshot();
+      return Object.freeze({...events,metrics});
+    }
+    function tick(rawNow=Date.now()){const events={activated:[],warmed:[],dormant:[],moved:[],released:[]};expireWarm(nowValue(rawNow),events);return Object.freeze({...events,metrics:snapshot()});}
+    function actorPosition(id){return actors.get(clean(id))?.position||null;}
+    function chunkState(position){const entry=chunks.get(worldChunkKey(position,config));return entry?.state||STATES.DORMANT;}
+    function entries(){return [...chunks.values()].map(entry=>Object.freeze({key:entry.key,state:entry.state,position:entry.position,actorIds:[...entry.actors],lastTouched:entry.lastTouched,warmUntil:entry.warmUntil}));}
+    return Object.freeze({config,reconcile,tick,snapshot,actorPosition,chunkState,entries});
+  }
+
+  return Object.freeze({SCHEMA_VERSION,CHUNK_SIZE_CELLS,STATES,DEFAULTS,normalizeWorldPosition,worldChunkKey,worldCell,deriveWorldChunkSeed,createDormantRecord,createLifecycleManager});
+});

--- a/js/vtt/world-streaming-runtime.js
+++ b/js/vtt/world-streaming-runtime.js
@@ -1,0 +1,34 @@
+import './world-streaming-core.js';
+
+const clean=value=>String(value??'').trim();
+
+export function start({runtime=globalThis.LuminousVttRuntime,mapData=runtime?.engine?.mapData}={}){
+  if(!runtime?.engine||!mapData)return null;
+  if(globalThis.LuminousVttWorldStreamingRuntime?.api)return globalThis.LuminousVttWorldStreamingRuntime.api;
+  const core=globalThis.LuminousVttWorldStreaming;if(!core)throw new Error('WORLD_STREAMING_CORE_REQUIRED');
+  const canvas=runtime.engine.canvas;
+  const manager=core.createLifecycleManager({maxActiveChunks:8,maxWarmChunks:16,warmTtlMs:30000,cellSize:mapData.grid?.size||70,chunkSizeCells:40});
+  let stopped=false,currentChunk=mapData.procedural?.streaming?.activeChunk||{col:0,row:0};
+
+  function basePosition(){
+    const streaming=mapData.procedural?.streaming||{};
+    return{worldId:clean(mapData.worldId||mapData.world?.id)||'luminous',regionId:clean(mapData.regionId||mapData.region?.id)||'region',zoneId:clean(streaming.zoneId||mapData.zoneId||mapData.id||mapData.mapId)||'zone',chunkCol:Number(currentChunk?.col)||0,chunkRow:Number(currentChunk?.row)||0,cellSize:mapData.grid?.size||70,chunkSizeCells:40};
+  }
+  function positionForToken(token,chunkOverride=null){
+    const prior=token?.worldPosition||{},base=basePosition(),chunk=chunkOverride||null;
+    return core.normalizeWorldPosition({...base,...prior,chunkCol:chunk?.col??prior.chunkCol??base.chunkCol,chunkRow:chunk?.row??prior.chunkRow??base.chunkRow,x:token?.x??prior.x??0,y:token?.y??prior.y??0,zLayer:token?.zLayer??token?.gridPosition?.z??prior.zLayer??0,elevationFt:token?.elevationFt??prior.elevationFt??0},{cellSize:mapData.grid?.size||70,chunkSizeCells:40});
+  }
+  function actorRecords(){return(mapData.tokens||[]).map(token=>({id:token.id,position:positionForToken(token)})).filter(entry=>clean(entry.id));}
+  function persistTokenPosition(token,position){if(!token)return null;token.worldPosition={worldId:position.worldId,regionId:position.regionId,zoneId:position.zoneId,chunkCol:position.chunkCol,chunkRow:position.chunkRow,x:position.x,y:position.y,zLayer:position.zLayer,elevationFt:position.elevationFt};return token.worldPosition;}
+  function reconcile(now=Date.now()){for(const token of mapData.tokens||[])persistTokenPosition(token,positionForToken(token));const result=manager.reconcile(actorRecords(),now);mapData.worldStreaming={schemaVersion:core.SCHEMA_VERSION,...result.metrics};return result;}
+  function onTokenMoved(event){
+    const detail=event?.detail||{},token=(mapData.tokens||[]).find(entry=>String(entry.id)===String(detail.tokenId));if(!token)return;
+    const target=detail.chunkTransition?.to||null;if(target)currentChunk={col:Number(target.col)||0,row:Number(target.row)||0};
+    persistTokenPosition(token,positionForToken(token,target));reconcile();
+  }
+  function onChunkLoaded(event){const chunk=event?.detail?.chunk;if(chunk)currentChunk={col:Number(chunk.col)||0,row:Number(chunk.row)||0};reconcile();}
+  canvas?.addEventListener?.('vtt:token-moved',onTokenMoved);canvas?.addEventListener?.('vtt:procedural-chunk-loaded',onChunkLoaded);
+  const initial=reconcile();
+  const api=Object.freeze({core,manager,reconcile,positionForToken,compactChunkRecord:core.createDormantRecord,snapshot:()=>manager.snapshot(),get initial(){return initial;},stop(){if(stopped)return;stopped=true;canvas?.removeEventListener?.('vtt:token-moved',onTokenMoved);canvas?.removeEventListener?.('vtt:procedural-chunk-loaded',onChunkLoaded);}});
+  globalThis.LuminousVttWorldStreamingRuntime={api};globalThis.LuminousVttRuntime=Object.freeze({...globalThis.LuminousVttRuntime,worldStreaming:api});return api;
+}

--- a/tests/player_dm_ux_polish.spec.js
+++ b/tests/player_dm_ux_polish.spec.js
@@ -3,7 +3,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
-const playerUx = read("js/player-ux-polish.js");
+const playerUx = read("js/player-ux-polish-core.js");
 const playerUxCss = read("css/player-ux-polish.css");
 const actorStudio = read("js/theatre-actor-studio.js");
 const actorStudioCss = read("css/theatre-actor-studio.css");

--- a/tests/vtt_world_streaming_lifecycle.spec.js
+++ b/tests/vtt_world_streaming_lifecycle.spec.js
@@ -1,0 +1,48 @@
+const {test,expect}=require('@playwright/test');
+const fs=require('node:fs'),path=require('node:path'),{execFileSync}=require('node:child_process');
+const ROOT=path.resolve(__dirname,'..');
+const read=file=>fs.readFileSync(path.join(ROOT,file),'utf8');
+const core=require('../js/vtt/world-streaming-core.js');
+
+test('world coordinates normalize across positive and negative chunk boundaries',()=>{
+  const p=core.normalizeWorldPosition({worldId:'w',regionId:'r',zoneId:'z',chunkCol:2,chunkRow:3,x:40*70+35,y:-35},{cellSize:70,chunkSizeCells:40});
+  expect(p.chunkCol).toBe(3);expect(p.chunkRow).toBe(2);expect(p.x).toBe(35);expect(p.y).toBe(40*70-35);
+  expect(core.worldCell(p)).toEqual({col:120,row:119,z:0});
+});
+
+test('shared actors dedupe one ACTIVE chunk and release it to WARM then DORMANT',()=>{
+  const manager=core.createLifecycleManager({warmTtlMs:100,maxWarmChunks:2,maxActiveChunks:8});
+  const at=(id,col)=>({id,position:{worldId:'w',regionId:'r',zoneId:'z',chunkCol:col,chunkRow:0,x:10,y:10}});
+  let state=manager.reconcile([at('a',0),at('b',0)],0);
+  expect(state.metrics.activeChunks).toBe(1);expect(state.metrics.actorRefs).toBe(2);
+  state=manager.reconcile([],10);expect(state.metrics.activeChunks).toBe(0);expect(state.metrics.warmChunks).toBe(1);
+  state=manager.tick(111);expect(state.metrics.residentChunks).toBe(0);expect(state.dormant).toHaveLength(1);
+});
+
+test('eight separated players create at most eight live simulation bubbles',()=>{
+  const manager=core.createLifecycleManager({warmTtlMs:0,maxWarmChunks:0,maxActiveChunks:8});
+  const actors=Array.from({length:8},(_,i)=>({id:`p${i}`,position:{worldId:'w',regionId:'r',zoneId:`z${i}`,chunkCol:i*100,chunkRow:i*100,x:1,y:1}}));
+  const state=manager.reconcile(actors,0);
+  expect(state.metrics.activeChunks).toBe(8);expect(state.metrics.liveCells).toBe(8*40*40);expect(state.metrics.overActiveBudget).toBe(0);expect(state.metrics.residentChunks).toBe(8);
+});
+
+test('long travel stays memory bounded instead of retaining every visited chunk',()=>{
+  const manager=core.createLifecycleManager({warmTtlMs:50,maxWarmChunks:3,maxActiveChunks:8});
+  for(let col=0;col<2000;col++){
+    manager.reconcile([{id:'traveler',position:{worldId:'w',regionId:'r',zoneId:'z',chunkCol:col,chunkRow:0,x:1,y:1}}],col*10);
+    manager.tick(col*10+60);
+    expect(manager.snapshot().residentChunks).toBeLessThanOrEqual(4);
+  }
+  const state=manager.snapshot();expect(state.activeChunks).toBe(1);expect(state.peakResidentChunks).toBeLessThanOrEqual(4);expect(state.dormantTransitions).toBeGreaterThan(1900);
+});
+
+test('dormant persistence record stores seed and delta without live scene payload',()=>{
+  const record=core.createDormantRecord({position:{worldId:'w',regionId:'r',zoneId:'z',chunkCol:9,chunkRow:-4},seed:'abc',delta:{doors:{d1:'open'},removed:['crate-2']},revision:7,updatedAt:123});
+  expect(record.state).toBe('DORMANT');expect(record.seed).toBe('abc');expect(record.delta).toEqual({doors:{d1:'open'},removed:['crate-2']});expect(record).not.toHaveProperty('geometry');expect(record).not.toHaveProperty('mapData');
+});
+
+test('world streaming modules parse cleanly and runtime exposes bounded lifecycle',()=>{
+  execFileSync(process.execPath,['--check',path.join(ROOT,'js/vtt/world-streaming-core.js')]);
+  execFileSync(process.execPath,['--input-type=module','--check'],{input:read('js/vtt/world-streaming-runtime.js'),stdio:['pipe','pipe','pipe']});
+  const runtime=read('js/vtt/world-streaming-runtime.js');expect(runtime).toContain('maxActiveChunks:8');expect(runtime).toContain('maxWarmChunks:16');expect(runtime).toContain('worldPosition');
+});


### PR DESCRIPTION
## Summary
- add canonical world/chunk coordinates for tokens across streamed chunk boundaries
- add ACTIVE/WARM/DORMANT lifecycle with shared-chunk dedupe, warm TTL, LRU-style warm capacity and bounded resident metrics
- wire lifecycle tracking into the semantic VTT runtime without changing renderer/pathfinding behavior
- add compact dormant seed+delta records instead of retaining full scene payloads
- add stress coverage for 8 separated players and 2,000 sequential chunk transitions
- gate the new modules in the existing procedural-zone CI workflow

## Local verification
- `node --check js/vtt/world-streaming-core.js`
- `node --input-type=module --check < js/vtt/world-streaming-runtime.js`
- `node --input-type=module --check < js/vtt/semantic-map-bootstrap.js`
- pure Node stress: 8 separated players => 8 ACTIVE chunks / 12,800 live cells
- 2,000-chunk traversal => resident chunks remain bounded by configured active + warm budget

Merge only after GitHub Actions and final main synchronization are green.