### PR TITLE
feat(time): add split-party world scheduler

### DIFF
--- a/.github/workflows/world-time-scheduler.yml
+++ b/.github/workflows/world-time-scheduler.yml
@@ -1,0 +1,63 @@
+name: World Time Scheduler
+
+on:
+  pull_request:
+    paths:
+      - "js/scene-time-*.js"
+      - "js/world-time-scheduler-*.js"
+      - "database.rules.json"
+      - "tests/**"
+      - ".github/workflows/world-time-scheduler.yml"
+  push:
+    branches: [main]
+    paths:
+      - "js/scene-time-*.js"
+      - "js/world-time-scheduler-*.js"
+      - "database.rules.json"
+      - "tests/world_time_scheduler*.spec.js"
+      - ".github/workflows/world-time-scheduler.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  scheduler-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Syntax and rules
+        run: |
+          node --check js/world-time-scheduler-core.js
+          node --check js/world-time-scheduler-runtime.js
+          node --check js/scene-time-engine.js
+          node --check tests/world_time_scheduler.spec.js
+          node --check tests/world_time_scheduler_realtime.spec.js
+          node -e "JSON.parse(require('fs').readFileSync('database.rules.json','utf8'))"
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Focused clock realtime and performance contracts
+        run: >-
+          npx playwright test --workers=1
+          tests/world_time_scheduler.spec.js
+          tests/world_time_scheduler_realtime.spec.js
+          tests/scene_time_engine.spec.js
+          tests/theatre_realtime.spec.js
+          tests/vtt_world_streaming_lifecycle.spec.js
+          tests/vtt_performance_guard.spec.js
+          tests/vtt_procedural_chunk_streaming_performance.spec.js
+
+      - name: Full repository regression
+        run: npx playwright test --workers=1

--- a/database.rules.json
+++ b/database.rules.json
@@ -31,6 +31,16 @@
       "calendario": {
         ".write": "auth != null && auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1'"
       },
+      "tiempo": {
+        "world_scheduler_requests": {
+          "events": {
+            "$requestId": {
+              ".read": "auth != null && (auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1' || data.child('requesterUid').val() === auth.uid)",
+              ".write": "auth != null && (auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1' || (!data.exists() && newData.exists() && newData.child('requesterUid').val() === auth.uid && newData.child('commandId').val() === $requestId && newData.child('type').isString()))"
+            }
+          }
+        }
+      },
       "jugadores": {
         "$nombre_personaje": {
           ".write": "auth != null && (auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1' || !data.child('uid').exists() || data.child('uid').val() === auth.uid)"

--- a/js/scene-time-engine.js
+++ b/js/scene-time-engine.js
@@ -15,7 +15,15 @@
     if (done) script.addEventListener('load', () => { script.dataset.loaded = 'true'; done(); }, { once: true });
     document.head?.appendChild(script);
   }
-  const runtime = () => load('scene-time-v1-runtime', 'js/scene-time-runtime.js');
+  const worldScheduler = () => load(
+    'world-time-scheduler-core',
+    'js/world-time-scheduler-core.js',
+    () => load('world-time-scheduler-runtime', 'js/world-time-scheduler-runtime.js')
+  );
+  const runtime = () => {
+    load('scene-time-v1-runtime', 'js/scene-time-runtime.js');
+    worldScheduler();
+  };
   const spellcasting = () => {
     const basic = () => load('luminous-spellcasting-basic-rules', 'js/spellcasting-basic-rules-runtime.js');
     if (global.LuminousSpellcastingRuntime) basic();

--- a/js/world-time-scheduler-core.js
+++ b/js/world-time-scheduler-core.js
@@ -199,10 +199,6 @@
     return calendar;
   }
 
-  function writeWorldMs(calendar, worldMs) {
-    return SceneTime.writeCalendarWorldMs(calendar, worldMs);
-  }
-
   function commandResult(calendar, state, result, commandId, deltaSeconds = 0, extra = {}) {
     calendar.world_scheduler = prune(state);
     return { calendar, scheduler: clone(calendar.world_scheduler), result, commandId, deltaSeconds, ...extra };
@@ -309,7 +305,7 @@
   }
 
   function applyCommandToCalendar(baseCalendar, rawCommand) {
-    const calendar = clone(baseCalendar || {});
+    let calendar = clone(baseCalendar || {});
     const command = clone(rawCommand || {});
     const commandId = safeKey(command.commandId || command.eventId || `cmd_${Date.now()}_${Math.random().toString(36).slice(2)}`);
     const state = schedulerStateFrom(calendar);
@@ -337,7 +333,7 @@
         const targetMs = Math.max(worldMs, finite(next.dueAtWorldTs));
         deltaSeconds = Math.max(0, (targetMs - worldMs) / 1000);
         advanceSceneRooms(calendar, deltaSeconds);
-        writeWorldMs(calendar, targetMs);
+        calendar = SceneTime.writeCalendarWorldMs(calendar, targetMs);
         const completedGroupIds = reconcileDueState(state, targetMs);
         outcome = { result: "advanced_to_next_event", completedGroupIds, targetWorldTs: targetMs };
       }
@@ -347,7 +343,7 @@
       else {
         deltaSeconds = (targetMs - worldMs) / 1000;
         advanceSceneRooms(calendar, deltaSeconds);
-        writeWorldMs(calendar, targetMs);
+        calendar = SceneTime.writeCalendarWorldMs(calendar, targetMs);
         const completedGroupIds = reconcileDueState(state, targetMs);
         outcome = { result: "advanced_to", completedGroupIds, targetWorldTs: targetMs };
       }

--- a/js/world-time-scheduler-core.js
+++ b/js/world-time-scheduler-core.js
@@ -1,0 +1,380 @@
+(function (root, factory) {
+  "use strict";
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = factory(require("./scene-time-core.js"));
+  } else {
+    root.LuminousWorldTimeSchedulerCore = factory(root.LuminousSceneTimeCore);
+  }
+})(typeof window !== "undefined" ? window : globalThis, function (SceneTime) {
+  "use strict";
+
+  if (!SceneTime) throw new Error("LuminousSceneTimeCore is required");
+
+  const CONFIG = Object.freeze({
+    schemaVersion: 1,
+    processedCommandLimit: 256,
+    historyLimit: 128,
+    terminalGroupLimit: 64,
+    maxMembersPerGroup: 8,
+  });
+
+  const clone = (value) => SceneTime.clone ? SceneTime.clone(value) : JSON.parse(JSON.stringify(value ?? null));
+  const safeKey = (value) => String(value ?? "").trim().replace(/[.#$\[\]/]/g, "_").slice(0, 160);
+  const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const positiveInt = (value, fallback = 0) => Math.max(0, Math.floor(finite(value, fallback)));
+
+  function normalizeMembers(value) {
+    const seen = new Set();
+    const members = [];
+    for (const raw of Array.isArray(value) ? value : []) {
+      const memberId = safeKey(raw);
+      if (!memberId || seen.has(memberId)) continue;
+      seen.add(memberId);
+      members.push(memberId);
+      if (members.length >= CONFIG.maxMembersPerGroup) break;
+    }
+    return members;
+  }
+
+  function blankState() {
+    return {
+      schemaVersion: CONFIG.schemaVersion,
+      sequence: 0,
+      groups: {},
+      events: {},
+      processedCommands: {},
+      history: {},
+      lastEvent: null,
+    };
+  }
+
+  function normalizeState(raw) {
+    const source = raw && typeof raw === "object" ? clone(raw) : {};
+    return {
+      schemaVersion: CONFIG.schemaVersion,
+      sequence: positiveInt(source.sequence),
+      groups: source.groups && typeof source.groups === "object" ? source.groups : {},
+      events: source.events && typeof source.events === "object" ? source.events : {},
+      processedCommands: source.processedCommands && typeof source.processedCommands === "object" ? source.processedCommands : {},
+      history: source.history && typeof source.history === "object" ? source.history : {},
+      lastEvent: source.lastEvent || null,
+    };
+  }
+
+  function schedulerStateFrom(calendar) {
+    return normalizeState(calendar?.world_scheduler);
+  }
+
+  function nextSequence(state) {
+    state.sequence = positiveInt(state.sequence) + 1;
+    return state.sequence;
+  }
+
+  function orderedEvents(state, predicate) {
+    return Object.values(state.events || {})
+      .filter((event) => event && event.status === "queued" && (!predicate || predicate(event)))
+      .sort((a, b) =>
+        finite(a.dueAtWorldTs) - finite(b.dueAtWorldTs) ||
+        positiveInt(a.priority, 50) - positiveInt(b.priority, 50) ||
+        positiveInt(a.sequence) - positiveInt(b.sequence) ||
+        String(a.eventId || "").localeCompare(String(b.eventId || ""))
+      );
+  }
+
+  function nextScheduledEvent(state, worldMs = -Infinity) {
+    return orderedEvents(state, (event) => finite(event.dueAtWorldTs) >= finite(worldMs))[0] || null;
+  }
+
+  function memberBusyGroup(state, memberId, exceptGroupId = null) {
+    return Object.values(state.groups || {}).find((group) =>
+      group && group.status === "active" && group.groupId !== exceptGroupId && Array.isArray(group.memberIds) && group.memberIds.includes(memberId)
+    ) || null;
+  }
+
+  function trimObjectBySequence(object, limit, keepPredicate) {
+    const entries = Object.entries(object || {});
+    if (entries.length <= limit) return object;
+    const removable = entries
+      .filter(([, value]) => !keepPredicate || !keepPredicate(value))
+      .sort((a, b) => positiveInt(a[1]?.sequence) - positiveInt(b[1]?.sequence));
+    let extra = entries.length - limit;
+    for (const [key] of removable) {
+      if (extra <= 0) break;
+      delete object[key];
+      extra -= 1;
+    }
+    return object;
+  }
+
+  function prune(state) {
+    trimObjectBySequence(state.processedCommands, CONFIG.processedCommandLimit);
+    trimObjectBySequence(state.history, CONFIG.historyLimit);
+    const terminals = Object.entries(state.groups)
+      .filter(([, group]) => group && group.status !== "active")
+      .sort((a, b) => positiveInt(a[1]?.updatedSequence) - positiveInt(b[1]?.updatedSequence));
+    while (terminals.length > CONFIG.terminalGroupLimit) {
+      const [key] = terminals.shift();
+      delete state.groups[key];
+    }
+    return state;
+  }
+
+  function recordHistory(state, entry) {
+    const sequence = nextSequence(state);
+    const key = `h_${sequence}`;
+    state.history[key] = { ...clone(entry), sequence };
+    state.lastEvent = clone(state.history[key]);
+    prune(state);
+  }
+
+  function recordCommand(state, commandId, result, worldMs) {
+    if (!commandId) return;
+    const sequence = nextSequence(state);
+    state.processedCommands[safeKey(commandId)] = { sequence, result, worldTs: finite(worldMs) };
+    prune(state);
+  }
+
+  function activityEventId(group) {
+    return safeKey(`activity_${group.groupId}_${positiveInt(group.revision, 1)}`);
+  }
+
+  function queueCompletion(state, group, priority = 50) {
+    const eventId = activityEventId(group);
+    const sequence = nextSequence(state);
+    state.events[eventId] = {
+      eventId,
+      type: "activity_complete",
+      groupId: group.groupId,
+      groupRevision: group.revision,
+      dueAtWorldTs: group.endsAtWorldTs,
+      priority: positiveInt(priority, 50),
+      sequence,
+      status: "queued",
+    };
+    group.eventId = eventId;
+    return state.events[eventId];
+  }
+
+  function deleteGroupEvent(state, group) {
+    if (group?.eventId && state.events[group.eventId]) delete state.events[group.eventId];
+  }
+
+  function reconcileDueState(state, worldMs) {
+    const due = orderedEvents(state, (event) => finite(event.dueAtWorldTs) <= finite(worldMs));
+    const completed = [];
+    for (const event of due) {
+      const group = state.groups[event.groupId];
+      if (event.type === "activity_complete" && group && group.status === "active" && positiveInt(group.revision) === positiveInt(event.groupRevision)) {
+        group.status = "completed";
+        group.completedAtWorldTs = finite(event.dueAtWorldTs);
+        group.processedAtWorldTs = finite(worldMs);
+        group.remainingSeconds = 0;
+        group.updatedSequence = nextSequence(state);
+        completed.push(group.groupId);
+        recordHistory(state, {
+          type: "activity_complete",
+          eventId: event.eventId,
+          groupId: group.groupId,
+          dueAtWorldTs: finite(event.dueAtWorldTs),
+          processedAtWorldTs: finite(worldMs),
+        });
+      }
+      delete state.events[event.eventId];
+    }
+    prune(state);
+    return completed;
+  }
+
+  function advanceSceneRooms(calendar, deltaSeconds) {
+    const seconds = Math.max(0, finite(deltaSeconds));
+    if (!seconds) return calendar;
+    const rooms = calendar?.scene_time?.rooms;
+    if (!rooms || typeof rooms !== "object" || typeof SceneTime.advanceActions !== "function") return calendar;
+    for (const roomKey of Object.keys(rooms)) {
+      const room = rooms[roomKey];
+      if (!room || typeof room !== "object") continue;
+      room.actions = SceneTime.advanceActions(room.actions || {}, seconds);
+      room.lastGlobalAdvance = { seconds, source: "world_scheduler" };
+    }
+    return calendar;
+  }
+
+  function writeWorldMs(calendar, worldMs) {
+    return SceneTime.writeCalendarWorldMs(calendar, worldMs);
+  }
+
+  function commandResult(calendar, state, result, commandId, deltaSeconds = 0, extra = {}) {
+    calendar.world_scheduler = prune(state);
+    return { calendar, scheduler: clone(calendar.world_scheduler), result, commandId, deltaSeconds, ...extra };
+  }
+
+  function startActivity(calendar, state, command, worldMs) {
+    const groupId = safeKey(command.groupId || command.activityGroupId);
+    const memberIds = normalizeMembers(command.memberIds);
+    const durationSeconds = positiveInt(command.durationSeconds);
+    if (!groupId || !memberIds.length) return { result: "invalid_group" };
+    if (!Number.isFinite(Number(command.durationSeconds)) || Number(command.durationSeconds) < 0) return { result: "invalid_duration" };
+    if (state.groups[groupId]?.status === "active") return { result: "group_busy" };
+    for (const memberId of memberIds) {
+      const busy = memberBusyGroup(state, memberId);
+      if (busy) return { result: "member_busy", busyGroupId: busy.groupId, memberId };
+    }
+
+    const previousRevision = positiveInt(state.groups[groupId]?.revision);
+    const group = {
+      groupId,
+      memberIds,
+      status: "active",
+      revision: previousRevision + 1,
+      activity: {
+        type: safeKey(command.activityType || command.activity?.type || "activity") || "activity",
+        payload: clone(command.payload ?? command.activity?.payload ?? null),
+      },
+      startedAtWorldTs: finite(worldMs),
+      endsAtWorldTs: finite(worldMs) + durationSeconds * 1000,
+      durationSeconds,
+      remainingSeconds: durationSeconds,
+      createdSequence: nextSequence(state),
+      updatedSequence: state.sequence,
+    };
+    state.groups[groupId] = group;
+    queueCompletion(state, group, command.priority);
+    recordHistory(state, { type: "activity_started", groupId, worldTs: finite(worldMs), endsAtWorldTs: group.endsAtWorldTs });
+    return { result: "activity_started", groupId };
+  }
+
+  function cancelActivity(state, command, worldMs) {
+    const groupId = safeKey(command.groupId || command.activityGroupId);
+    const group = state.groups[groupId];
+    if (!group || group.status !== "active") return { result: "group_not_active" };
+    deleteGroupEvent(state, group);
+    group.status = "cancelled";
+    group.cancelledAtWorldTs = finite(worldMs);
+    group.remainingSeconds = Math.max(0, Math.ceil((finite(group.endsAtWorldTs) - finite(worldMs)) / 1000));
+    group.updatedSequence = nextSequence(state);
+    recordHistory(state, { type: "activity_cancelled", groupId, worldTs: finite(worldMs) });
+    return { result: "activity_cancelled", groupId };
+  }
+
+  function splitGroup(state, command, worldMs) {
+    const sourceId = safeKey(command.groupId || command.sourceGroupId);
+    const newGroupId = safeKey(command.newGroupId);
+    const source = state.groups[sourceId];
+    const moving = normalizeMembers(command.memberIds);
+    if (!source || source.status !== "active" || !newGroupId || state.groups[newGroupId]?.status === "active") return { result: "invalid_split" };
+    if (!moving.length || moving.length >= source.memberIds.length || moving.some((memberId) => !source.memberIds.includes(memberId))) return { result: "invalid_split_members" };
+
+    source.memberIds = source.memberIds.filter((memberId) => !moving.includes(memberId));
+    source.updatedSequence = nextSequence(state);
+    const group = {
+      ...clone(source),
+      groupId: newGroupId,
+      memberIds: moving,
+      revision: 1,
+      createdSequence: nextSequence(state),
+      updatedSequence: state.sequence,
+      eventId: null,
+      splitFrom: sourceId,
+    };
+    state.groups[newGroupId] = group;
+    queueCompletion(state, group, state.events[source.eventId]?.priority ?? 50);
+    recordHistory(state, { type: "group_split", sourceGroupId: sourceId, newGroupId, memberIds: moving, worldTs: finite(worldMs) });
+    return { result: "group_split", sourceGroupId: sourceId, newGroupId };
+  }
+
+  function compatibleForJoin(a, b) {
+    if (!a || !b || a.status !== "active" || b.status !== "active") return false;
+    if (finite(a.endsAtWorldTs) !== finite(b.endsAtWorldTs)) return false;
+    if (String(a.activity?.type || "") !== String(b.activity?.type || "")) return false;
+    return JSON.stringify(a.activity?.payload ?? null) === JSON.stringify(b.activity?.payload ?? null);
+  }
+
+  function joinGroups(state, command, worldMs) {
+    const targetId = safeKey(command.targetGroupId || command.groupId);
+    const sourceId = safeKey(command.sourceGroupId);
+    const target = state.groups[targetId];
+    const source = state.groups[sourceId];
+    if (!targetId || !sourceId || targetId === sourceId || !compatibleForJoin(target, source)) return { result: "incompatible_groups" };
+    const combined = normalizeMembers([...(target.memberIds || []), ...(source.memberIds || [])]);
+    if (combined.length !== (target.memberIds || []).length + (source.memberIds || []).length) return { result: "duplicate_member" };
+
+    target.memberIds = combined;
+    target.updatedSequence = nextSequence(state);
+    deleteGroupEvent(state, source);
+    source.status = "merged";
+    source.mergedInto = targetId;
+    source.updatedSequence = nextSequence(state);
+    recordHistory(state, { type: "groups_joined", targetGroupId: targetId, sourceGroupId: sourceId, worldTs: finite(worldMs) });
+    return { result: "groups_joined", targetGroupId: targetId, sourceGroupId: sourceId };
+  }
+
+  function applyCommandToCalendar(baseCalendar, rawCommand) {
+    const calendar = clone(baseCalendar || {});
+    const command = clone(rawCommand || {});
+    const commandId = safeKey(command.commandId || command.eventId || `cmd_${Date.now()}_${Math.random().toString(36).slice(2)}`);
+    const state = schedulerStateFrom(calendar);
+    const worldMs = SceneTime.calendarWorldMs(calendar);
+
+    if (state.processedCommands[commandId]) {
+      return commandResult(calendar, state, state.processedCommands[commandId].result, commandId, 0, { duplicate: true });
+    }
+
+    reconcileDueState(state, worldMs);
+    let outcome = { result: "unsupported_command" };
+    let deltaSeconds = 0;
+
+    if (command.type === "start_activity") outcome = startActivity(calendar, state, command, worldMs);
+    else if (command.type === "cancel_activity") outcome = cancelActivity(state, command, worldMs);
+    else if (command.type === "split_group") outcome = splitGroup(state, command, worldMs);
+    else if (command.type === "join_groups") outcome = joinGroups(state, command, worldMs);
+    else if (command.type === "reconcile") {
+      const completedGroupIds = reconcileDueState(state, worldMs);
+      outcome = { result: completedGroupIds.length ? "reconciled" : "nothing_due", completedGroupIds };
+    } else if (command.type === "advance_to_next_event") {
+      const next = nextScheduledEvent(state, worldMs);
+      if (!next) outcome = { result: "no_scheduled_event" };
+      else {
+        const targetMs = Math.max(worldMs, finite(next.dueAtWorldTs));
+        deltaSeconds = Math.max(0, (targetMs - worldMs) / 1000);
+        advanceSceneRooms(calendar, deltaSeconds);
+        writeWorldMs(calendar, targetMs);
+        const completedGroupIds = reconcileDueState(state, targetMs);
+        outcome = { result: "advanced_to_next_event", completedGroupIds, targetWorldTs: targetMs };
+      }
+    } else if (command.type === "advance_to") {
+      const targetMs = finite(command.worldTs, worldMs);
+      if (targetMs < worldMs) outcome = { result: "cannot_rewind" };
+      else {
+        deltaSeconds = (targetMs - worldMs) / 1000;
+        advanceSceneRooms(calendar, deltaSeconds);
+        writeWorldMs(calendar, targetMs);
+        const completedGroupIds = reconcileDueState(state, targetMs);
+        outcome = { result: "advanced_to", completedGroupIds, targetWorldTs: targetMs };
+      }
+    }
+
+    recordCommand(state, commandId, outcome.result, SceneTime.calendarWorldMs(calendar));
+    return commandResult(calendar, state, outcome.result, commandId, deltaSeconds, outcome);
+  }
+
+  function dueEventSummary(calendar) {
+    const state = schedulerStateFrom(calendar);
+    const worldMs = SceneTime.calendarWorldMs(calendar);
+    const due = orderedEvents(state, (event) => finite(event.dueAtWorldTs) <= worldMs);
+    return { worldMs, dueCount: due.length, firstDue: due[0] || null, nextEvent: nextScheduledEvent(state, worldMs) };
+  }
+
+  return Object.freeze({
+    CONFIG,
+    blankState,
+    normalizeState,
+    schedulerStateFrom,
+    orderedEvents,
+    nextScheduledEvent,
+    reconcileDueState,
+    advanceSceneRooms,
+    applyCommandToCalendar,
+    dueEventSummary,
+    normalizeMembers,
+  });
+});

--- a/js/world-time-scheduler-runtime.js
+++ b/js/world-time-scheduler-runtime.js
@@ -44,12 +44,12 @@
   }
 
   async function authorized(request) {
-    if (isDm()) return true;
-    const uid = String(request?.requesterUid || "");
-    if (!uid || uid !== currentUid()) return false;
+    const requesterUid = String(request?.requesterUid || "");
+    if (!requesterUid) return false;
+    if (requesterUid === DM_UID) return true;
 
     const playerSnapshot = await db.ref(PLAYER_ROOT).once("value");
-    const owned = new Set(ownedPlayerIds(playerSnapshot.val(), uid));
+    const owned = new Set(ownedPlayerIds(playerSnapshot.val(), requesterUid));
     if (!owned.size) return false;
 
     if (request.type === "start_activity") {

--- a/js/world-time-scheduler-runtime.js
+++ b/js/world-time-scheduler-runtime.js
@@ -1,0 +1,158 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousWorldTimeScheduler) return;
+  const Core = global.LuminousWorldTimeSchedulerCore;
+  const firebase = global.firebase;
+  if (!Core || !firebase?.database) return;
+
+  const db = firebase.database();
+  const CALENDAR_ROOT = "campaña/calendario";
+  const SCHEDULER_ROOT = `${CALENDAR_ROOT}/world_scheduler`;
+  const REQUEST_ROOT = "campaña/tiempo/world_scheduler_requests/events";
+  const PLAYER_ROOT = "campaña/jugadores";
+  const DM_UID = "e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1";
+  const state = {
+    timestamp: null,
+    scheduler: Core.blankState(),
+    reconciling: false,
+    started: false,
+  };
+
+  const currentUid = () => firebase.auth?.().currentUser?.uid || null;
+  const isDm = () => currentUid() === DM_UID || document.body?.classList.contains("on-game-dashboard") || document.body?.classList.contains("dm-dashboard");
+  const makeId = (prefix = "sched") => `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+  const safeMemberIds = (value) => Core.normalizeMembers(value);
+
+  function submitCommand(rawCommand) {
+    const command = { ...(rawCommand || {}) };
+    command.commandId = command.commandId || command.eventId || makeId(command.type || "sched");
+    command.requesterUid = currentUid();
+    command.requestedAt = firebase.database.ServerValue.TIMESTAMP;
+    return db.ref(`${REQUEST_ROOT}/${command.commandId}`).set(command).then(() => command.commandId);
+  }
+
+  function ownedPlayerIds(players, uid) {
+    if (!uid || !players || typeof players !== "object") return [];
+    const owned = [];
+    for (const [playerId, player] of Object.entries(players)) {
+      if (!player || typeof player !== "object") continue;
+      const ownerUid = player.uid || player.userUid || player.ownerUid || player.firebaseUid || player.authUid;
+      if (ownerUid === uid) owned.push(String(playerId));
+    }
+    return owned;
+  }
+
+  async function authorized(request) {
+    if (isDm()) return true;
+    const uid = String(request?.requesterUid || "");
+    if (!uid || uid !== currentUid()) return false;
+
+    const playerSnapshot = await db.ref(PLAYER_ROOT).once("value");
+    const owned = new Set(ownedPlayerIds(playerSnapshot.val(), uid));
+    if (!owned.size) return false;
+
+    if (request.type === "start_activity") {
+      const members = safeMemberIds(request.memberIds);
+      return members.length > 0 && members.every((memberId) => owned.has(memberId));
+    }
+
+    if (request.type === "cancel_activity") {
+      const group = state.scheduler?.groups?.[String(request.groupId || request.activityGroupId || "")];
+      const members = safeMemberIds(group?.memberIds);
+      return members.length > 0 && members.every((memberId) => owned.has(memberId));
+    }
+
+    return false;
+  }
+
+  async function consumeRequest(snapshot) {
+    if (!isDm()) return;
+    const request = snapshot?.val?.() || null;
+    const requestRef = snapshot?.ref;
+    if (!request || !requestRef) return;
+
+    try {
+      if (!(await authorized(request))) {
+        await requestRef.remove();
+        return;
+      }
+      await db.ref(CALENDAR_ROOT).transaction((calendar) => {
+        if (!calendar) return calendar;
+        return Core.applyCommandToCalendar(calendar, request).calendar;
+      });
+      await requestRef.remove();
+    } catch (error) {
+      console.error("[Luminous] World Time scheduler request failed:", error);
+    }
+  }
+
+  function timestampToMs(value) {
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    const parsed = Date.parse(value || "");
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  function earliestDueEvent() {
+    const events = Core.orderedEvents(state.scheduler || Core.blankState());
+    return events[0] || null;
+  }
+
+  async function maybeReconcile() {
+    if (!isDm() || state.reconciling) return;
+    const worldMs = timestampToMs(state.timestamp);
+    const due = earliestDueEvent();
+    if (!Number.isFinite(worldMs) || !due || Number(due.dueAtWorldTs) > worldMs) return;
+
+    state.reconciling = true;
+    const commandId = `reconcile_${String(due.eventId || "due")}_${Math.floor(worldMs)}`;
+    try {
+      await db.ref(CALENDAR_ROOT).transaction((calendar) => {
+        if (!calendar) return calendar;
+        return Core.applyCommandToCalendar(calendar, { type: "reconcile", commandId }).calendar;
+      });
+    } catch (error) {
+      console.error("[Luminous] World Time scheduler reconcile failed:", error);
+    } finally {
+      state.reconciling = false;
+    }
+  }
+
+  function bindRealtime() {
+    if (state.started) return;
+    state.started = true;
+
+    db.ref(`${CALENDAR_ROOT}/timestamp`).on("value", (snapshot) => {
+      state.timestamp = snapshot.val();
+      void maybeReconcile();
+    });
+
+    db.ref(SCHEDULER_ROOT).on("value", (snapshot) => {
+      state.scheduler = Core.normalizeState(snapshot.val());
+      void maybeReconcile();
+    });
+
+    if (isDm()) db.ref(REQUEST_ROOT).on("child_added", consumeRequest);
+  }
+
+  function getSnapshot() {
+    return {
+      timestamp: state.timestamp,
+      scheduler: JSON.parse(JSON.stringify(state.scheduler || Core.blankState())),
+    };
+  }
+
+  const api = Object.freeze({
+    submitCommand,
+    startActivity: (input) => submitCommand({ type: "start_activity", ...(input || {}) }),
+    cancelActivity: (groupId) => submitCommand({ type: "cancel_activity", groupId }),
+    splitGroup: (input) => submitCommand({ type: "split_group", ...(input || {}) }),
+    joinGroups: (input) => submitCommand({ type: "join_groups", ...(input || {}) }),
+    advanceToNextEvent: () => submitCommand({ type: "advance_to_next_event" }),
+    getSnapshot,
+    roots: Object.freeze({ CALENDAR_ROOT, SCHEDULER_ROOT, REQUEST_ROOT, PLAYER_ROOT }),
+  });
+
+  global.LuminousWorldTimeScheduler = api;
+  bindRealtime();
+})(window);

--- a/tests/world_time_scheduler.spec.js
+++ b/tests/world_time_scheduler.spec.js
@@ -1,0 +1,155 @@
+const { test, expect } = require("@playwright/test");
+const SceneTime = require("../js/scene-time-core.js");
+const Scheduler = require("../js/world-time-scheduler-core.js");
+
+function calendar(timestamp = "2026-08-30T12:00:00.000Z") {
+  return {
+    timestamp,
+    año: 2026,
+    mes: 8,
+    dia: 30,
+    hora: 12,
+    minuto: 0,
+    segundo: 0,
+    scene_time: { schemaVersion: 1, rooms: {} },
+  };
+}
+
+function apply(base, command) {
+  return Scheduler.applyCommandToCalendar(base, command);
+}
+
+function start(base, id, members, durationSeconds, extra = {}) {
+  return apply(base, {
+    commandId: `start_${id}`,
+    type: "start_activity",
+    groupId: id,
+    memberIds: members,
+    durationSeconds,
+    activityType: extra.activityType || "travel",
+    payload: extra.payload ?? { route: "test" },
+    priority: extra.priority,
+  });
+}
+
+test.describe("World Time Scheduler", () => {
+  test("eight separated players create eight activities and only eight queued events", () => {
+    let state = calendar();
+    for (let i = 1; i <= 8; i += 1) state = start(state, `g${i}`, [`p${i}`], 3600 + i).calendar;
+    const scheduler = Scheduler.schedulerStateFrom(state);
+    expect(Object.keys(scheduler.groups)).toHaveLength(8);
+    expect(Object.keys(scheduler.events)).toHaveLength(8);
+    expect(Object.values(scheduler.groups).every((group) => group.status === "active")).toBe(true);
+  });
+
+  test("a 24 hour activity still creates one event instead of per-second realtime ticks", () => {
+    const state = start(calendar(), "sleep", ["p1"], 24 * 60 * 60).calendar;
+    const scheduler = Scheduler.schedulerStateFrom(state);
+    expect(Object.keys(scheduler.events)).toHaveLength(1);
+    expect(scheduler.groups.sleep.durationSeconds).toBe(86400);
+    expect(scheduler.groups.sleep.endsAtWorldTs - scheduler.groups.sleep.startedAtWorldTs).toBe(86400000);
+  });
+
+  test("a player cannot belong to two active activity groups", () => {
+    let state = start(calendar(), "a", ["p1", "p2"], 60).calendar;
+    const duplicate = start(state, "b", ["p2"], 10);
+    expect(duplicate.result).toBe("member_busy");
+    expect(Scheduler.schedulerStateFrom(duplicate.calendar).groups.b).toBeUndefined();
+  });
+
+  test("commands are idempotent and do not duplicate events", () => {
+    const command = { commandId: "same", type: "start_activity", groupId: "bus", memberIds: ["p1"], durationSeconds: 120, activityType: "bus" };
+    const first = apply(calendar(), command);
+    const second = apply(first.calendar, command);
+    expect(second.duplicate).toBe(true);
+    expect(Object.keys(Scheduler.schedulerStateFrom(second.calendar).events)).toHaveLength(1);
+  });
+
+  test("split and join preserve the same absolute activity finish", () => {
+    let state = start(calendar(), "party", ["p1", "p2", "p3"], 600, { activityType: "walk", payload: { route: "K-road" } }).calendar;
+    const originalEnd = Scheduler.schedulerStateFrom(state).groups.party.endsAtWorldTs;
+    state = apply(state, { commandId: "split", type: "split_group", groupId: "party", newGroupId: "scout", memberIds: ["p3"] }).calendar;
+    let scheduler = Scheduler.schedulerStateFrom(state);
+    expect(scheduler.groups.party.memberIds).toEqual(["p1", "p2"]);
+    expect(scheduler.groups.scout.memberIds).toEqual(["p3"]);
+    expect(scheduler.groups.scout.endsAtWorldTs).toBe(originalEnd);
+    expect(Object.keys(scheduler.events)).toHaveLength(2);
+
+    state = apply(state, { commandId: "join", type: "join_groups", targetGroupId: "party", sourceGroupId: "scout" }).calendar;
+    scheduler = Scheduler.schedulerStateFrom(state);
+    expect(scheduler.groups.party.memberIds).toEqual(["p1", "p2", "p3"]);
+    expect(scheduler.groups.scout.status).toBe("merged");
+    expect(Object.keys(scheduler.events)).toHaveLength(1);
+  });
+
+  test("advance to next event moves the canonical calendar and resolves the earliest group", () => {
+    let state = start(calendar(), "slow", ["p1"], 20).calendar;
+    state = start(state, "fast", ["p2"], 5).calendar;
+    const before = SceneTime.calendarWorldMs(state);
+    const result = apply(state, { commandId: "next", type: "advance_to_next_event" });
+    expect(result.deltaSeconds).toBe(5);
+    expect(SceneTime.calendarWorldMs(result.calendar) - before).toBe(5000);
+    const scheduler = Scheduler.schedulerStateFrom(result.calendar);
+    expect(scheduler.groups.fast.status).toBe("completed");
+    expect(scheduler.groups.slow.status).toBe("active");
+  });
+
+  test("scheduler global advance consumes active Scene Time actions in every room", () => {
+    let state = calendar();
+    state = SceneTime.applyEventToCalendar(state, {
+      eventId: "room_a_action",
+      type: "intervention",
+      message: { tipo_dialogo: "actuar", actorId: "a", mensaje: "A", actionDurationSeconds: 12 },
+    }, "room-a").calendar;
+    state = SceneTime.applyEventToCalendar(state, {
+      eventId: "room_b_action",
+      type: "intervention",
+      message: { tipo_dialogo: "actuar", actorId: "b", mensaje: "B", actionDurationSeconds: 18 },
+    }, "room-b").calendar;
+    state = start(state, "trip", ["p1"], 6).calendar;
+    state = apply(state, { commandId: "advance_trip", type: "advance_to_next_event" }).calendar;
+    expect(SceneTime.roomStateFrom(state, "room-a").actions.a.remainingSeconds).toBe(6);
+    expect(SceneTime.roomStateFrom(state, "room-b").actions.b.remainingSeconds).toBe(12);
+  });
+
+  test("normal Scene Time can cross an activity end and lazy reconcile records the real due timestamp without rewinding", () => {
+    let state = start(calendar(), "shop", ["p1"], 5).calendar;
+    const due = Scheduler.schedulerStateFrom(state).groups.shop.endsAtWorldTs;
+    state = SceneTime.applyEventToCalendar(state, { eventId: "speech", type: "advance", seconds: 6 }, "room-a").calendar;
+    const worldAfterSpeech = SceneTime.calendarWorldMs(state);
+    expect(worldAfterSpeech).toBe(due + 1000);
+    const reconciled = apply(state, { commandId: "reconcile_shop", type: "reconcile" });
+    const group = Scheduler.schedulerStateFrom(reconciled.calendar).groups.shop;
+    expect(group.status).toBe("completed");
+    expect(group.completedAtWorldTs).toBe(due);
+    expect(group.processedAtWorldTs).toBe(worldAfterSpeech);
+    expect(SceneTime.calendarWorldMs(reconciled.calendar)).toBe(worldAfterSpeech);
+  });
+
+  test("cancel removes the queued completion and never rewinds time", () => {
+    let state = start(calendar(), "cancel-me", ["p1"], 600).calendar;
+    const before = SceneTime.calendarWorldMs(state);
+    const cancelled = apply(state, { commandId: "cancel", type: "cancel_activity", groupId: "cancel-me" });
+    const scheduler = Scheduler.schedulerStateFrom(cancelled.calendar);
+    expect(scheduler.groups["cancel-me"].status).toBe("cancelled");
+    expect(Object.keys(scheduler.events)).toHaveLength(0);
+    expect(SceneTime.calendarWorldMs(cancelled.calendar)).toBe(before);
+  });
+
+  test("same timestamp events use stable priority then sequence ordering", () => {
+    let state = start(calendar(), "later-priority", ["p1"], 30, { priority: 80 }).calendar;
+    state = start(state, "first-priority", ["p2"], 30, { priority: 10 }).calendar;
+    const ordered = Scheduler.orderedEvents(Scheduler.schedulerStateFrom(state));
+    expect(ordered.map((event) => event.groupId)).toEqual(["first-priority", "later-priority"]);
+  });
+
+  test("processed command and history collections remain bounded", () => {
+    let state = calendar();
+    for (let i = 0; i < 400; i += 1) {
+      state = apply(state, { commandId: `noop_${i}`, type: "reconcile" }).calendar;
+    }
+    const scheduler = Scheduler.schedulerStateFrom(state);
+    expect(Object.keys(scheduler.processedCommands).length).toBeLessThanOrEqual(Scheduler.CONFIG.processedCommandLimit);
+    expect(Object.keys(scheduler.history).length).toBeLessThanOrEqual(Scheduler.CONFIG.historyLimit);
+  });
+});

--- a/tests/world_time_scheduler_realtime.spec.js
+++ b/tests/world_time_scheduler_realtime.spec.js
@@ -1,0 +1,82 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const read = (file) => fs.readFileSync(path.join(__dirname, "..", file), "utf8");
+const runtime = read("js/world-time-scheduler-runtime.js");
+const core = read("js/world-time-scheduler-core.js");
+const engine = read("js/scene-time-engine.js");
+const rules = read("database.rules.json");
+
+test.describe("World Time Scheduler Realtime contract", () => {
+  test("uses the canonical calendar and a request queue instead of a second clock", () => {
+    expect(runtime).toContain('const CALENDAR_ROOT = "campaña/calendario"');
+    expect(runtime).toContain('const SCHEDULER_ROOT = `${CALENDAR_ROOT}/world_scheduler`');
+    expect(runtime).toContain('const REQUEST_ROOT = "campaña/tiempo/world_scheduler_requests/events"');
+    expect(runtime).not.toContain("world_clock");
+    expect(runtime).not.toContain("globalClockRoot");
+  });
+
+  test("only the DM consumer mutates the calendar and does so transactionally", () => {
+    expect(runtime).toContain('if (!isDm()) return;');
+    expect(runtime).toContain('db.ref(CALENDAR_ROOT).transaction((calendar) =>');
+    expect(runtime).toContain('Core.applyCommandToCalendar(calendar, request).calendar');
+    expect(runtime).not.toContain('db.ref(CALENDAR_ROOT).set(');
+    expect(runtime).not.toContain('db.ref(CALENDAR_ROOT).update(');
+  });
+
+  test("authorization validates requesterUid rather than trusting the DM consumer", () => {
+    expect(runtime).toContain('const requesterUid = String(request?.requesterUid || "")');
+    expect(runtime).toContain('if (requesterUid === DM_UID) return true;');
+    expect(runtime).toContain('ownedPlayerIds(playerSnapshot.val(), requesterUid)');
+    expect(runtime).not.toContain('if (isDm()) return true;\n    const uid = String(request?.requesterUid');
+  });
+
+  test("players write requests only and rules bind request id plus requester uid", () => {
+    expect(runtime).toContain('db.ref(`${REQUEST_ROOT}/${command.commandId}`).set(command)');
+    expect(runtime).toContain('command.requesterUid = currentUid()');
+    expect(rules).toContain('"world_scheduler_requests"');
+    expect(rules).toContain("newData.child('requesterUid').val() === auth.uid");
+    expect(rules).toContain("newData.child('commandId').val() === $requestId");
+    expect(rules).toContain('"calendario": {');
+    expect(rules).toContain("auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1'");
+  });
+
+  test("runtime does not tick or write once per second", () => {
+    expect(runtime).not.toContain("setInterval(");
+    expect(runtime).not.toContain("requestAnimationFrame(");
+    expect(runtime).toContain('db.ref(`${CALENDAR_ROOT}/timestamp`).on("value"');
+    expect(runtime).toContain('db.ref(SCHEDULER_ROOT).on("value"');
+    expect(core).toContain('endsAtWorldTs: finite(worldMs) + durationSeconds * 1000');
+    expect(core).toContain('type: "activity_complete"');
+  });
+
+  test("DM reconciliation is demand-driven and guarded against overlapping transactions", () => {
+    expect(runtime).toContain("state.reconciling");
+    expect(runtime).toContain("if (!isDm() || state.reconciling) return;");
+    expect(runtime).toContain('type: "reconcile"');
+    expect(runtime).toContain("state.reconciling = false");
+  });
+
+  test("request is removed only after authorization and calendar transaction", () => {
+    const transactionIndex = runtime.indexOf("db.ref(CALENDAR_ROOT).transaction");
+    const removeIndex = runtime.indexOf("await requestRef.remove();", transactionIndex);
+    expect(transactionIndex).toBeGreaterThanOrEqual(0);
+    expect(removeIndex).toBeGreaterThan(transactionIndex);
+  });
+
+  test("scene-time bootstrap loads scheduler core before scheduler runtime", () => {
+    const coreIndex = engine.indexOf("js/world-time-scheduler-core.js");
+    const runtimeIndex = engine.indexOf("js/world-time-scheduler-runtime.js");
+    expect(coreIndex).toBeGreaterThanOrEqual(0);
+    expect(runtimeIndex).toBeGreaterThan(coreIndex);
+    expect(engine).toContain("js/scene-time-runtime.js");
+  });
+
+  test("scheduler state is bounded instead of keeping unbounded request history", () => {
+    expect(core).toContain("processedCommandLimit: 256");
+    expect(core).toContain("historyLimit: 128");
+    expect(core).toContain("terminalGroupLimit: 64");
+    expect(core).toContain("prune(state)");
+  });
+});


### PR DESCRIPTION
Adds deterministic Activity Groups and a DM-authoritative transactional scheduler on the existing Scene Time calendar. Includes Realtime, 8-player, VTT performance, and full regression gates. Merge only after all checks are green and main is synchronized.