### PR TITLE
feat(travel): add scheduled regional travel engine

### DIFF
--- a/.github/workflows/regional-travel-engine.yml
+++ b/.github/workflows/regional-travel-engine.yml
@@ -1,0 +1,64 @@
+name: Regional Travel Engine
+
+on:
+  pull_request:
+    paths:
+      - "js/regional-travel-*.js"
+      - "js/world-time-scheduler-*.js"
+      - "js/scene-time-engine.js"
+      - "js/vtt/world-streaming-*.js"
+      - "tests/regional_travel*.spec.js"
+      - "tests/world_time_scheduler*.spec.js"
+      - "tests/vtt_world_streaming_lifecycle.spec.js"
+      - "tests/vtt_performance_guard.spec.js"
+      - "tests/vtt_procedural_chunk_streaming_performance.spec.js"
+      - ".github/workflows/regional-travel-engine.yml"
+  push:
+    branches: [main]
+    paths:
+      - "js/regional-travel-*.js"
+      - "js/world-time-scheduler-*.js"
+      - "js/scene-time-engine.js"
+      - "tests/regional_travel*.spec.js"
+      - ".github/workflows/regional-travel-engine.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  regional-travel-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Syntax
+        run: |
+          node --check js/regional-travel-core.js
+          node --check js/regional-travel-runtime.js
+          node --check js/world-time-scheduler-runtime.js
+          node --check js/scene-time-engine.js
+          node --check tests/regional_travel_engine.spec.js
+          node --check tests/regional_travel_realtime.spec.js
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Focused regional realtime and performance contracts
+        run: >-
+          npx playwright test --workers=1
+          tests/regional_travel_engine.spec.js
+          tests/regional_travel_realtime.spec.js
+          tests/world_time_scheduler.spec.js
+          tests/world_time_scheduler_realtime.spec.js
+          tests/scene_time_engine.spec.js
+          tests/theatre_realtime.spec.js
+          tests/vtt_world_streaming_lifecycle.spec.js
+          tests/vtt_performance_guard.spec.js
+          tests/vtt_procedural_chunk_streaming_performance.spec.js
+      - name: Full repository regression
+        run: npx playwright test --workers=1

--- a/js/regional-travel-core.js
+++ b/js/regional-travel-core.js
@@ -95,7 +95,11 @@
     for (const segment of segments || []) if (!transport.surfaces.includes(segment.surface)) return { valid: false, reason: "surface_not_supported", surface: segment.surface };
     return { valid: true };
   }
-  function segmentDurationSeconds(segment, transport) { return Math.ceil((segment.distanceKm / transport.speedKph) * 3600 * segmentMultiplier(segment)); }
+  function segmentDurationSeconds(segment, transport) {
+    const rawSeconds = (segment.distanceKm / transport.speedKph) * 3600 * segmentMultiplier(segment);
+    const tolerance = Number.EPSILON * Math.max(1, Math.abs(rawSeconds)) * 8;
+    return Math.ceil(rawSeconds - tolerance);
+  }
 
   function createTravelPlan(input = {}) {
     const groupId = safeKey(input.groupId ?? input.activityGroupId), memberIds = normalizeMembers(input.memberIds), route = normalizeRoute(input.route), transport = normalizeTransport(input.transportId ?? input.transport);

--- a/js/regional-travel-core.js
+++ b/js/regional-travel-core.js
@@ -1,0 +1,251 @@
+(function (root, factory) {
+  "use strict";
+  const api = factory();
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+  if (root) root.LuminousRegionalTravelCore = api;
+})(typeof window !== "undefined" ? window : globalThis, function () {
+  "use strict";
+
+  const CONFIG = Object.freeze({
+    schemaVersion: 1,
+    hexDistanceKm: 20,
+    maxRouteHexes: 256,
+    maxMembers: 8,
+    maxWaitSeconds: 86400,
+    maxStopSeconds: 86400,
+    maxSegmentKm: 500,
+    maxDurationSeconds: 31 * 24 * 60 * 60,
+  });
+
+  const TRANSPORTS = Object.freeze({
+    walking: Object.freeze({ id: "walking", speedKph: 4.8, surfaces: Object.freeze(["road", "dirt_road", "trail", "offroad", "rough"]) }),
+    public_bus: Object.freeze({ id: "public_bus", speedKph: 30, surfaces: Object.freeze(["road", "dirt_road"]) }),
+    private_bus: Object.freeze({ id: "private_bus", speedKph: 60, surfaces: Object.freeze(["road", "dirt_road", "rough"]) }),
+    train: Object.freeze({ id: "train", speedKph: 80, surfaces: Object.freeze(["rail"]) }),
+  });
+
+  const TERRAIN_TIME = Object.freeze({
+    road: 1,
+    plains: 1,
+    forest: 1.5,
+    hills: 1.5,
+    swamp: 2,
+    desert: 1.5,
+    mountain: 2.5,
+    deep_snow: 2,
+  });
+  const SURFACE_TIME = Object.freeze({ road: 1, dirt_road: 1.25, trail: 1.2, offroad: 1.5, rough: 1.6, rail: 1 });
+  const SURFACE_TERRAIN_SENSITIVITY = Object.freeze({ road: 0.2, dirt_road: 0.55, trail: 0.8, offroad: 1, rough: 1, rail: 0 });
+
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const integer = (value, fallback = 0) => Math.trunc(finite(value, fallback));
+  const safeKey = (value, fallback = "") => String(value ?? fallback).trim().replace(/[.#$\[\]\/]/g, "_").replace(/\s+/g, "_").slice(0, 120) || fallback;
+  const clampInt = (value, min, max) => Math.max(min, Math.min(max, Math.floor(finite(value, min))));
+
+  function normalizeMembers(value) {
+    const out = [], seen = new Set();
+    for (const raw of Array.isArray(value) ? value : []) {
+      const id = safeKey(raw);
+      if (!id || seen.has(id)) continue;
+      seen.add(id); out.push(id);
+      if (out.length >= CONFIG.maxMembers) break;
+    }
+    return out;
+  }
+
+  function normalizeHex(raw = {}) {
+    return Object.freeze({
+      district: safeKey(raw.district ?? raw.regionId ?? raw.region, "region"),
+      q: integer(raw.q ?? raw.col ?? raw.x, 0),
+      r: integer(raw.r ?? raw.row ?? raw.y, 0),
+    });
+  }
+
+  function hexKey(raw = {}) {
+    const h = normalizeHex(raw);
+    return `${h.district}:${h.q},${h.r}`;
+  }
+
+  function axialDistance(aRaw, bRaw) {
+    const a = normalizeHex(aRaw), b = normalizeHex(bRaw);
+    if (a.district !== b.district) return Infinity;
+    const dq = a.q - b.q, dr = a.r - b.r;
+    return (Math.abs(dq) + Math.abs(dr) + Math.abs(dq + dr)) / 2;
+  }
+
+  function areAdjacent(a, b) { return axialDistance(a, b) === 1; }
+
+  function normalizeTransport(id) {
+    const key = safeKey(id, "walking").toLowerCase();
+    return TRANSPORTS[key] || null;
+  }
+
+  function normalizeTerrain(value) {
+    const key = safeKey(value, "plains").toLowerCase();
+    return TERRAIN_TIME[key] ? key : "plains";
+  }
+
+  function normalizeSurface(value) {
+    const key = safeKey(value, "offroad").toLowerCase();
+    return SURFACE_TIME[key] ? key : "offroad";
+  }
+
+  function segmentMultiplier(segment = {}) {
+    const terrain = normalizeTerrain(segment.terrain);
+    const surface = normalizeSurface(segment.surface);
+    const terrainBase = TERRAIN_TIME[terrain];
+    const sensitivity = SURFACE_TERRAIN_SENSITIVITY[surface];
+    const terrainEffective = 1 + (terrainBase - 1) * sensitivity;
+    const quality = Math.max(0.5, Math.min(3, finite(segment.routeQualityMultiplier, 1)));
+    const weather = Math.max(0.5, Math.min(3, finite(segment.weatherMultiplier, 1)));
+    return SURFACE_TIME[surface] * terrainEffective * quality * weather;
+  }
+
+  function normalizeRoute(route) {
+    if (!Array.isArray(route) || route.length < 2 || route.length > CONFIG.maxRouteHexes) return null;
+    return route.map(normalizeHex);
+  }
+
+  function normalizeSegments(route, rawSegments) {
+    const segments = [];
+    const input = Array.isArray(rawSegments) ? rawSegments : [];
+    for (let i = 0; i < route.length - 1; i += 1) {
+      const raw = input[i] || {};
+      const adjacent = areAdjacent(route[i], route[i + 1]);
+      const networkEdge = raw.networkEdge === true;
+      if (!adjacent && !networkEdge) return null;
+      const distanceKm = finite(raw.distanceKm, adjacent ? CONFIG.hexDistanceKm : NaN);
+      if (!(distanceKm > 0) || distanceKm > CONFIG.maxSegmentKm) return null;
+      segments.push(Object.freeze({
+        from: hexKey(route[i]),
+        to: hexKey(route[i + 1]),
+        distanceKm,
+        surface: normalizeSurface(raw.surface),
+        terrain: normalizeTerrain(raw.terrain),
+        networkEdge,
+        routeQualityMultiplier: Math.max(0.5, Math.min(3, finite(raw.routeQualityMultiplier, 1))),
+        weatherMultiplier: Math.max(0.5, Math.min(3, finite(raw.weatherMultiplier, 1))),
+      }));
+    }
+    return segments;
+  }
+
+  function validateCapabilities(transport, segments) {
+    if (!transport) return { valid: false, reason: "unknown_transport" };
+    for (const segment of segments || []) {
+      if (!transport.surfaces.includes(segment.surface)) return { valid: false, reason: "surface_not_supported", surface: segment.surface };
+    }
+    return { valid: true };
+  }
+
+  function segmentDurationSeconds(segment, transport) {
+    const multiplier = segmentMultiplier(segment);
+    return Math.ceil((segment.distanceKm / transport.speedKph) * 3600 * multiplier);
+  }
+
+  function createTravelPlan(input = {}) {
+    const groupId = safeKey(input.groupId ?? input.activityGroupId);
+    const memberIds = normalizeMembers(input.memberIds);
+    const route = normalizeRoute(input.route);
+    const transport = normalizeTransport(input.transportId ?? input.transport);
+    if (!groupId) return { valid: false, reason: "invalid_group" };
+    if (!memberIds.length) return { valid: false, reason: "invalid_members" };
+    if (!route) return { valid: false, reason: "invalid_route" };
+    if (!transport) return { valid: false, reason: "unknown_transport" };
+    const segments = normalizeSegments(route, input.segments);
+    if (!segments) return { valid: false, reason: "invalid_route_hop" };
+    const capability = validateCapabilities(transport, segments);
+    if (!capability.valid) return capability;
+
+    const waitSeconds = clampInt(input.waitSeconds, 0, CONFIG.maxWaitSeconds);
+    const stopSeconds = clampInt(input.stopSeconds, 0, CONFIG.maxStopSeconds);
+    const travelSeconds = segments.reduce((sum, segment) => sum + segmentDurationSeconds(segment, transport), 0);
+    const durationSeconds = travelSeconds + waitSeconds + stopSeconds;
+    if (!(durationSeconds > 0) || durationSeconds > CONFIG.maxDurationSeconds) return { valid: false, reason: "duration_out_of_bounds" };
+    const distanceKm = Math.round(segments.reduce((sum, segment) => sum + segment.distanceKm, 0) * 1000) / 1000;
+    const plan = Object.freeze({
+      schemaVersion: CONFIG.schemaVersion,
+      groupId,
+      memberIds: Object.freeze(memberIds),
+      worldId: safeKey(input.worldId, "luminous"),
+      originHex: hexKey(route[0]),
+      destinationHex: hexKey(route[route.length - 1]),
+      route: Object.freeze(route.map((h) => Object.freeze({ district: h.district, q: h.q, r: h.r }))),
+      segments: Object.freeze(segments),
+      transportId: transport.id,
+      distanceKm,
+      waitSeconds,
+      stopSeconds,
+      travelSeconds,
+      durationSeconds,
+    });
+    return { valid: true, plan };
+  }
+
+  function toSchedulerCommand(planOrResult, commandId) {
+    const plan = planOrResult?.plan || planOrResult;
+    if (!plan || plan.schemaVersion !== CONFIG.schemaVersion) throw new Error("VALID_TRAVEL_PLAN_REQUIRED");
+    return {
+      commandId: safeKey(commandId || `regional_travel_${plan.groupId}_${plan.destinationHex}`),
+      type: "start_activity",
+      groupId: plan.groupId,
+      memberIds: [...plan.memberIds],
+      durationSeconds: plan.durationSeconds,
+      activityType: "regional_travel",
+      payload: {
+        schemaVersion: plan.schemaVersion,
+        worldId: plan.worldId,
+        route: clone(plan.route),
+        segments: clone(plan.segments).map(({ from, to, ...segment }) => segment),
+        transportId: plan.transportId,
+        waitSeconds: plan.waitSeconds,
+        stopSeconds: plan.stopSeconds,
+        originHex: plan.originHex,
+        destinationHex: plan.destinationHex,
+        distanceKm: plan.distanceKm,
+      },
+      priority: 40,
+    };
+  }
+
+  function validateScheduledCommand(command = {}) {
+    if (command.type !== "start_activity" || command.activityType !== "regional_travel") return { valid: true, specialized: false };
+    const payload = command.payload && typeof command.payload === "object" ? command.payload : {};
+    const result = createTravelPlan({ ...payload, groupId: command.groupId, memberIds: command.memberIds });
+    if (!result.valid) return { ...result, specialized: true };
+    if (integer(command.durationSeconds, -1) !== result.plan.durationSeconds) {
+      return { valid: false, specialized: true, reason: "duration_mismatch", expectedDurationSeconds: result.plan.durationSeconds };
+    }
+    if (payload.originHex && payload.originHex !== result.plan.originHex) return { valid: false, specialized: true, reason: "origin_mismatch" };
+    if (payload.destinationHex && payload.destinationHex !== result.plan.destinationHex) return { valid: false, specialized: true, reason: "destination_mismatch" };
+    return { valid: true, specialized: true, plan: result.plan };
+  }
+
+  function destinationWorldPosition(plan, arrivalId, arrivedAtWorldTs) {
+    const destination = normalizeHex(plan?.route?.[plan.route.length - 1] || {});
+    return {
+      schemaVersion: 1,
+      worldId: safeKey(plan?.worldId, "luminous"),
+      regionId: destination.district,
+      zoneId: `regional_${destination.q}_${destination.r}`,
+      chunkCol: 0,
+      chunkRow: 0,
+      x: 0,
+      y: 0,
+      zLayer: 0,
+      elevationFt: 0,
+      regionalHex: { district: destination.district, q: destination.q, r: destination.r },
+      travelArrivalId: safeKey(arrivalId),
+      arrivedAtWorldTs: finite(arrivedAtWorldTs, 0),
+    };
+  }
+
+  return Object.freeze({
+    CONFIG, TRANSPORTS, TERRAIN_TIME, SURFACE_TIME,
+    normalizeMembers, normalizeHex, hexKey, axialDistance, areAdjacent,
+    normalizeTransport, normalizeTerrain, normalizeSurface, segmentMultiplier,
+    normalizeRoute, normalizeSegments, validateCapabilities, segmentDurationSeconds,
+    createTravelPlan, toSchedulerCommand, validateScheduledCommand, destinationWorldPosition,
+  });
+});

--- a/js/regional-travel-core.js
+++ b/js/regional-travel-core.js
@@ -13,7 +13,6 @@
     maxMembers: 8,
     maxWaitSeconds: 86400,
     maxStopSeconds: 86400,
-    maxSegmentKm: 500,
     maxDurationSeconds: 31 * 24 * 60 * 60,
   });
 
@@ -24,16 +23,7 @@
     train: Object.freeze({ id: "train", speedKph: 80, surfaces: Object.freeze(["rail"]) }),
   });
 
-  const TERRAIN_TIME = Object.freeze({
-    road: 1,
-    plains: 1,
-    forest: 1.5,
-    hills: 1.5,
-    swamp: 2,
-    desert: 1.5,
-    mountain: 2.5,
-    deep_snow: 2,
-  });
+  const TERRAIN_TIME = Object.freeze({ road: 1, plains: 1, forest: 1.5, hills: 1.5, swamp: 2, desert: 1.5, mountain: 2.5, deep_snow: 2 });
   const SURFACE_TIME = Object.freeze({ road: 1, dirt_road: 1.25, trail: 1.2, offroad: 1.5, rough: 1.6, rail: 1 });
   const SURFACE_TERRAIN_SENSITIVITY = Object.freeze({ road: 0.2, dirt_road: 0.55, trail: 0.8, offroad: 1, rough: 1, rail: 0 });
 
@@ -55,50 +45,28 @@
   }
 
   function normalizeHex(raw = {}) {
-    return Object.freeze({
-      district: safeKey(raw.district ?? raw.regionId ?? raw.region, "region"),
-      q: integer(raw.q ?? raw.col ?? raw.x, 0),
-      r: integer(raw.r ?? raw.row ?? raw.y, 0),
-    });
+    return Object.freeze({ district: safeKey(raw.district ?? raw.regionId ?? raw.region, "region"), q: integer(raw.q ?? raw.col ?? raw.x, 0), r: integer(raw.r ?? raw.row ?? raw.y, 0) });
   }
 
-  function hexKey(raw = {}) {
-    const h = normalizeHex(raw);
-    return `${h.district}:${h.q},${h.r}`;
-  }
-
+  function hexKey(raw = {}) { const h = normalizeHex(raw); return `${h.district}:${h.q},${h.r}`; }
   function axialDistance(aRaw, bRaw) {
     const a = normalizeHex(aRaw), b = normalizeHex(bRaw);
     if (a.district !== b.district) return Infinity;
     const dq = a.q - b.q, dr = a.r - b.r;
     return (Math.abs(dq) + Math.abs(dr) + Math.abs(dq + dr)) / 2;
   }
-
   function areAdjacent(a, b) { return axialDistance(a, b) === 1; }
 
-  function normalizeTransport(id) {
-    const key = safeKey(id, "walking").toLowerCase();
-    return TRANSPORTS[key] || null;
-  }
-
-  function normalizeTerrain(value) {
-    const key = safeKey(value, "plains").toLowerCase();
-    return TERRAIN_TIME[key] ? key : "plains";
-  }
-
-  function normalizeSurface(value) {
-    const key = safeKey(value, "offroad").toLowerCase();
-    return SURFACE_TIME[key] ? key : "offroad";
-  }
+  function normalizeTransport(id) { const key = safeKey(id, "walking").toLowerCase(); return TRANSPORTS[key] || null; }
+  function normalizeTerrain(value) { const key = safeKey(value, "plains").toLowerCase(); return TERRAIN_TIME[key] ? key : "plains"; }
+  function normalizeSurface(value) { const key = safeKey(value, "offroad").toLowerCase(); return SURFACE_TIME[key] ? key : "offroad"; }
 
   function segmentMultiplier(segment = {}) {
-    const terrain = normalizeTerrain(segment.terrain);
-    const surface = normalizeSurface(segment.surface);
-    const terrainBase = TERRAIN_TIME[terrain];
-    const sensitivity = SURFACE_TERRAIN_SENSITIVITY[surface];
+    const terrain = normalizeTerrain(segment.terrain), surface = normalizeSurface(segment.surface);
+    const terrainBase = TERRAIN_TIME[terrain], sensitivity = SURFACE_TERRAIN_SENSITIVITY[surface];
     const terrainEffective = 1 + (terrainBase - 1) * sensitivity;
-    const quality = Math.max(0.5, Math.min(3, finite(segment.routeQualityMultiplier, 1)));
-    const weather = Math.max(0.5, Math.min(3, finite(segment.weatherMultiplier, 1)));
+    const quality = Math.max(1, Math.min(3, finite(segment.routeQualityMultiplier, 1)));
+    const weather = Math.max(1, Math.min(3, finite(segment.weatherMultiplier, 1)));
     return SURFACE_TIME[surface] * terrainEffective * quality * weather;
   }
 
@@ -108,24 +76,15 @@
   }
 
   function normalizeSegments(route, rawSegments) {
-    const segments = [];
-    const input = Array.isArray(rawSegments) ? rawSegments : [];
+    const segments = [], input = Array.isArray(rawSegments) ? rawSegments : [];
     for (let i = 0; i < route.length - 1; i += 1) {
+      if (!areAdjacent(route[i], route[i + 1])) return null;
       const raw = input[i] || {};
-      const adjacent = areAdjacent(route[i], route[i + 1]);
-      const networkEdge = raw.networkEdge === true;
-      if (!adjacent && !networkEdge) return null;
-      const distanceKm = finite(raw.distanceKm, adjacent ? CONFIG.hexDistanceKm : NaN);
-      if (!(distanceKm > 0) || distanceKm > CONFIG.maxSegmentKm) return null;
       segments.push(Object.freeze({
-        from: hexKey(route[i]),
-        to: hexKey(route[i + 1]),
-        distanceKm,
-        surface: normalizeSurface(raw.surface),
-        terrain: normalizeTerrain(raw.terrain),
-        networkEdge,
-        routeQualityMultiplier: Math.max(0.5, Math.min(3, finite(raw.routeQualityMultiplier, 1))),
-        weatherMultiplier: Math.max(0.5, Math.min(3, finite(raw.weatherMultiplier, 1))),
+        from: hexKey(route[i]), to: hexKey(route[i + 1]), distanceKm: CONFIG.hexDistanceKm,
+        surface: normalizeSurface(raw.surface), terrain: normalizeTerrain(raw.terrain),
+        routeQualityMultiplier: Math.max(1, Math.min(3, finite(raw.routeQualityMultiplier, 1))),
+        weatherMultiplier: Math.max(1, Math.min(3, finite(raw.weatherMultiplier, 1))),
       }));
     }
     return segments;
@@ -133,22 +92,13 @@
 
   function validateCapabilities(transport, segments) {
     if (!transport) return { valid: false, reason: "unknown_transport" };
-    for (const segment of segments || []) {
-      if (!transport.surfaces.includes(segment.surface)) return { valid: false, reason: "surface_not_supported", surface: segment.surface };
-    }
+    for (const segment of segments || []) if (!transport.surfaces.includes(segment.surface)) return { valid: false, reason: "surface_not_supported", surface: segment.surface };
     return { valid: true };
   }
-
-  function segmentDurationSeconds(segment, transport) {
-    const multiplier = segmentMultiplier(segment);
-    return Math.ceil((segment.distanceKm / transport.speedKph) * 3600 * multiplier);
-  }
+  function segmentDurationSeconds(segment, transport) { return Math.ceil((segment.distanceKm / transport.speedKph) * 3600 * segmentMultiplier(segment)); }
 
   function createTravelPlan(input = {}) {
-    const groupId = safeKey(input.groupId ?? input.activityGroupId);
-    const memberIds = normalizeMembers(input.memberIds);
-    const route = normalizeRoute(input.route);
-    const transport = normalizeTransport(input.transportId ?? input.transport);
+    const groupId = safeKey(input.groupId ?? input.activityGroupId), memberIds = normalizeMembers(input.memberIds), route = normalizeRoute(input.route), transport = normalizeTransport(input.transportId ?? input.transport);
     if (!groupId) return { valid: false, reason: "invalid_group" };
     if (!memberIds.length) return { valid: false, reason: "invalid_members" };
     if (!route) return { valid: false, reason: "invalid_route" };
@@ -157,28 +107,15 @@
     if (!segments) return { valid: false, reason: "invalid_route_hop" };
     const capability = validateCapabilities(transport, segments);
     if (!capability.valid) return capability;
-
-    const waitSeconds = clampInt(input.waitSeconds, 0, CONFIG.maxWaitSeconds);
-    const stopSeconds = clampInt(input.stopSeconds, 0, CONFIG.maxStopSeconds);
-    const travelSeconds = segments.reduce((sum, segment) => sum + segmentDurationSeconds(segment, transport), 0);
-    const durationSeconds = travelSeconds + waitSeconds + stopSeconds;
+    const waitSeconds = clampInt(input.waitSeconds, 0, CONFIG.maxWaitSeconds), stopSeconds = clampInt(input.stopSeconds, 0, CONFIG.maxStopSeconds);
+    const travelSeconds = segments.reduce((sum, segment) => sum + segmentDurationSeconds(segment, transport), 0), durationSeconds = travelSeconds + waitSeconds + stopSeconds;
     if (!(durationSeconds > 0) || durationSeconds > CONFIG.maxDurationSeconds) return { valid: false, reason: "duration_out_of_bounds" };
-    const distanceKm = Math.round(segments.reduce((sum, segment) => sum + segment.distanceKm, 0) * 1000) / 1000;
+    const distanceKm = segments.length * CONFIG.hexDistanceKm;
     const plan = Object.freeze({
-      schemaVersion: CONFIG.schemaVersion,
-      groupId,
-      memberIds: Object.freeze(memberIds),
-      worldId: safeKey(input.worldId, "luminous"),
-      originHex: hexKey(route[0]),
-      destinationHex: hexKey(route[route.length - 1]),
-      route: Object.freeze(route.map((h) => Object.freeze({ district: h.district, q: h.q, r: h.r }))),
-      segments: Object.freeze(segments),
-      transportId: transport.id,
-      distanceKm,
-      waitSeconds,
-      stopSeconds,
-      travelSeconds,
-      durationSeconds,
+      schemaVersion: CONFIG.schemaVersion, groupId, memberIds: Object.freeze(memberIds), worldId: safeKey(input.worldId, "luminous"),
+      originHex: hexKey(route[0]), destinationHex: hexKey(route[route.length - 1]),
+      route: Object.freeze(route.map((h) => Object.freeze({ district: h.district, q: h.q, r: h.r }))), segments: Object.freeze(segments),
+      transportId: transport.id, distanceKm, waitSeconds, stopSeconds, travelSeconds, durationSeconds,
     });
     return { valid: true, plan };
   }
@@ -187,25 +124,14 @@
     const plan = planOrResult?.plan || planOrResult;
     if (!plan || plan.schemaVersion !== CONFIG.schemaVersion) throw new Error("VALID_TRAVEL_PLAN_REQUIRED");
     return {
-      commandId: safeKey(commandId || `regional_travel_${plan.groupId}_${plan.destinationHex}`),
-      type: "start_activity",
-      groupId: plan.groupId,
-      memberIds: [...plan.memberIds],
-      durationSeconds: plan.durationSeconds,
-      activityType: "regional_travel",
+      commandId: safeKey(commandId || `regional_travel_${plan.groupId}_${plan.destinationHex}`), type: "start_activity", groupId: plan.groupId,
+      memberIds: [...plan.memberIds], durationSeconds: plan.durationSeconds, activityType: "regional_travel",
       payload: {
-        schemaVersion: plan.schemaVersion,
-        worldId: plan.worldId,
-        route: clone(plan.route),
-        segments: clone(plan.segments).map(({ from, to, ...segment }) => segment),
-        transportId: plan.transportId,
-        waitSeconds: plan.waitSeconds,
-        stopSeconds: plan.stopSeconds,
-        originHex: plan.originHex,
-        destinationHex: plan.destinationHex,
-        distanceKm: plan.distanceKm,
-      },
-      priority: 40,
+        schemaVersion: plan.schemaVersion, worldId: plan.worldId, route: clone(plan.route),
+        segments: clone(plan.segments).map(({ from, to, distanceKm, ...segment }) => segment),
+        transportId: plan.transportId, waitSeconds: plan.waitSeconds, stopSeconds: plan.stopSeconds,
+        originHex: plan.originHex, destinationHex: plan.destinationHex, distanceKm: plan.distanceKm,
+      }, priority: 40,
     };
   }
 
@@ -214,38 +140,25 @@
     const payload = command.payload && typeof command.payload === "object" ? command.payload : {};
     const result = createTravelPlan({ ...payload, groupId: command.groupId, memberIds: command.memberIds });
     if (!result.valid) return { ...result, specialized: true };
-    if (integer(command.durationSeconds, -1) !== result.plan.durationSeconds) {
-      return { valid: false, specialized: true, reason: "duration_mismatch", expectedDurationSeconds: result.plan.durationSeconds };
-    }
+    if (integer(command.durationSeconds, -1) !== result.plan.durationSeconds) return { valid: false, specialized: true, reason: "duration_mismatch", expectedDurationSeconds: result.plan.durationSeconds };
     if (payload.originHex && payload.originHex !== result.plan.originHex) return { valid: false, specialized: true, reason: "origin_mismatch" };
     if (payload.destinationHex && payload.destinationHex !== result.plan.destinationHex) return { valid: false, specialized: true, reason: "destination_mismatch" };
+    if (finite(payload.distanceKm, result.plan.distanceKm) !== result.plan.distanceKm) return { valid: false, specialized: true, reason: "distance_mismatch" };
     return { valid: true, specialized: true, plan: result.plan };
   }
 
   function destinationWorldPosition(plan, arrivalId, arrivedAtWorldTs) {
     const destination = normalizeHex(plan?.route?.[plan.route.length - 1] || {});
     return {
-      schemaVersion: 1,
-      worldId: safeKey(plan?.worldId, "luminous"),
-      regionId: destination.district,
-      zoneId: `regional_${destination.q}_${destination.r}`,
-      chunkCol: 0,
-      chunkRow: 0,
-      x: 0,
-      y: 0,
-      zLayer: 0,
-      elevationFt: 0,
-      regionalHex: { district: destination.district, q: destination.q, r: destination.r },
-      travelArrivalId: safeKey(arrivalId),
-      arrivedAtWorldTs: finite(arrivedAtWorldTs, 0),
+      schemaVersion: 1, worldId: safeKey(plan?.worldId, "luminous"), regionId: destination.district, zoneId: `regional_${destination.q}_${destination.r}`,
+      chunkCol: 0, chunkRow: 0, x: 0, y: 0, zLayer: 0, elevationFt: 0,
+      regionalHex: { district: destination.district, q: destination.q, r: destination.r }, travelArrivalId: safeKey(arrivalId), arrivedAtWorldTs: finite(arrivedAtWorldTs, 0),
     };
   }
 
   return Object.freeze({
-    CONFIG, TRANSPORTS, TERRAIN_TIME, SURFACE_TIME,
-    normalizeMembers, normalizeHex, hexKey, axialDistance, areAdjacent,
-    normalizeTransport, normalizeTerrain, normalizeSurface, segmentMultiplier,
-    normalizeRoute, normalizeSegments, validateCapabilities, segmentDurationSeconds,
-    createTravelPlan, toSchedulerCommand, validateScheduledCommand, destinationWorldPosition,
+    CONFIG, TRANSPORTS, TERRAIN_TIME, SURFACE_TIME, normalizeMembers, normalizeHex, hexKey, axialDistance, areAdjacent,
+    normalizeTransport, normalizeTerrain, normalizeSurface, segmentMultiplier, normalizeRoute, normalizeSegments, validateCapabilities,
+    segmentDurationSeconds, createTravelPlan, toSchedulerCommand, validateScheduledCommand, destinationWorldPosition,
   });
 });

--- a/js/regional-travel-runtime.js
+++ b/js/regional-travel-runtime.js
@@ -1,0 +1,88 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousRegionalTravel) return;
+  const Core = global.LuminousRegionalTravelCore;
+  const Scheduler = global.LuminousWorldTimeScheduler;
+  const firebase = global.firebase;
+  if (!Core || !Scheduler || !firebase?.database) return;
+
+  const db = firebase.database();
+  const PLAYER_ROOT = "campaña/jugadores";
+  const DM_UID = "e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1";
+  const applyingArrivals = new Set();
+  const currentUid = () => firebase.auth?.().currentUser?.uid || null;
+  const isDm = () => currentUid() === DM_UID || document.body?.classList.contains("on-game-dashboard") || document.body?.classList.contains("dm-dashboard");
+  const makeId = (prefix = "travel") => `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+
+  function startTravel(input = {}) {
+    const result = Core.createTravelPlan(input);
+    if (!result.valid) return Promise.reject(Object.assign(new Error(result.reason || "INVALID_REGIONAL_TRAVEL"), { travelValidation: result }));
+    const command = Core.toSchedulerCommand(result.plan, input.commandId || makeId("regional_travel"));
+    return Scheduler.startActivity(command).then((commandId) => ({ commandId, plan: result.plan }));
+  }
+
+  function cancelTravel(groupId) { return Scheduler.cancelActivity(groupId); }
+
+  function planFromGroup(group) {
+    if (!group || group.activity?.type !== "regional_travel") return null;
+    const result = Core.createTravelPlan({
+      ...(group.activity?.payload || {}),
+      groupId: group.groupId,
+      memberIds: group.memberIds,
+    });
+    return result.valid && result.plan.durationSeconds === Number(group.durationSeconds) ? result.plan : null;
+  }
+
+  async function applyArrival(group) {
+    if (!isDm() || group?.status !== "completed") return false;
+    const plan = planFromGroup(group);
+    if (!plan) return false;
+    const arrivalId = `regional_arrival_${group.groupId}_${Number(group.revision) || 1}`;
+    if (applyingArrivals.has(arrivalId)) return false;
+    applyingArrivals.add(arrivalId);
+    try {
+      const snapshot = await db.ref(PLAYER_ROOT).once("value");
+      const players = snapshot.val() || {};
+      const members = Core.normalizeMembers(group.memberIds);
+      if (!members.length) return false;
+      const alreadyApplied = members.every((playerId) => players[playerId]?.worldPosition?.travelArrivalId === arrivalId);
+      if (alreadyApplied) return false;
+
+      const worldPosition = Core.destinationWorldPosition(plan, arrivalId, group.completedAtWorldTs || group.processedAtWorldTs || 0);
+      const updates = {};
+      for (const playerId of members) updates[`${PLAYER_ROOT}/${playerId}/worldPosition`] = worldPosition;
+      await db.ref().update(updates);
+      global.dispatchEvent?.(new CustomEvent("luminous:regional-travel-arrival", { detail: { arrivalId, groupId: group.groupId, memberIds: members, worldPosition } }));
+      return true;
+    } catch (error) {
+      console.error("[Luminous] Regional travel arrival failed:", error);
+      return false;
+    } finally {
+      applyingArrivals.delete(arrivalId);
+    }
+  }
+
+  function reconcileCompleted(snapshot) {
+    if (!isDm()) return;
+    const groups = snapshot?.scheduler?.groups || {};
+    for (const group of Object.values(groups)) {
+      if (group?.status === "completed" && group.activity?.type === "regional_travel") void applyArrival(group);
+    }
+  }
+
+  function onSchedulerUpdated(event) { reconcileCompleted(event?.detail || Scheduler.getSnapshot()); }
+  global.addEventListener?.("luminous:world-scheduler-updated", onSchedulerUpdated);
+  queueMicrotask(() => reconcileCompleted(Scheduler.getSnapshot()));
+
+  const api = Object.freeze({
+    core: Core,
+    startTravel,
+    cancelTravel,
+    planFromGroup,
+    applyArrival,
+    reconcileCompleted,
+    stop: () => global.removeEventListener?.("luminous:world-scheduler-updated", onSchedulerUpdated),
+  });
+  global.LuminousRegionalTravel = api;
+})(window);

--- a/js/scene-time-engine.js
+++ b/js/scene-time-engine.js
@@ -18,7 +18,15 @@
   const worldScheduler = () => load(
     'world-time-scheduler-core',
     'js/world-time-scheduler-core.js',
-    () => load('world-time-scheduler-runtime', 'js/world-time-scheduler-runtime.js')
+    () => load(
+      'regional-travel-core',
+      'js/regional-travel-core.js',
+      () => load(
+        'world-time-scheduler-runtime',
+        'js/world-time-scheduler-runtime.js',
+        () => load('regional-travel-runtime', 'js/regional-travel-runtime.js')
+      )
+    )
   );
   const runtime = () => {
     load('scene-time-v1-runtime', 'js/scene-time-runtime.js');

--- a/js/world-time-scheduler-runtime.js
+++ b/js/world-time-scheduler-runtime.js
@@ -12,12 +12,7 @@
   const REQUEST_ROOT = "campaña/tiempo/world_scheduler_requests/events";
   const PLAYER_ROOT = "campaña/jugadores";
   const DM_UID = "e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1";
-  const state = {
-    timestamp: null,
-    scheduler: Core.blankState(),
-    reconciling: false,
-    started: false,
-  };
+  const state = { timestamp: null, scheduler: Core.blankState(), reconciling: false, started: false };
 
   const currentUid = () => firebase.auth?.().currentUser?.uid || null;
   const isDm = () => currentUid() === DM_UID || document.body?.classList.contains("on-game-dashboard") || document.body?.classList.contains("dm-dashboard");
@@ -55,44 +50,33 @@
     const requesterUid = String(request?.requesterUid || "");
     if (!requesterUid) return false;
     if (requesterUid === DM_UID) return true;
-
     const playerSnapshot = await db.ref(PLAYER_ROOT).once("value");
     const owned = new Set(ownedPlayerIds(playerSnapshot.val(), requesterUid));
     if (!owned.size) return false;
-
     if (request.type === "start_activity") {
       const members = safeMemberIds(request.memberIds);
       return members.length > 0 && members.every((memberId) => owned.has(memberId));
     }
-
     if (request.type === "cancel_activity") {
       const group = state.scheduler?.groups?.[String(request.groupId || request.activityGroupId || "")];
       const members = safeMemberIds(group?.memberIds);
       return members.length > 0 && members.every((memberId) => owned.has(memberId));
     }
-
     return false;
   }
 
   async function consumeRequest(snapshot) {
     if (!isDm()) return;
-    const request = snapshot?.val?.() || null;
-    const requestRef = snapshot?.ref;
+    const request = snapshot?.val?.() || null, requestRef = snapshot?.ref;
     if (!request || !requestRef) return;
-
     try {
-      if (!(await authorized(request))) {
-        await requestRef.remove();
-        return;
-      }
+      if (!(await authorized(request))) { await requestRef.remove(); return; }
       await db.ref(CALENDAR_ROOT).transaction((calendar) => {
         if (!calendar) return calendar;
         return Core.applyCommandToCalendar(calendar, request).calendar;
       });
       await requestRef.remove();
-    } catch (error) {
-      console.error("[Luminous] World Time scheduler request failed:", error);
-    }
+    } catch (error) { console.error("[Luminous] World Time scheduler request failed:", error); }
   }
 
   function timestampToMs(value) {
@@ -100,18 +84,12 @@
     const parsed = Date.parse(value || "");
     return Number.isFinite(parsed) ? parsed : null;
   }
-
-  function earliestDueEvent() {
-    const events = Core.orderedEvents(state.scheduler || Core.blankState());
-    return events[0] || null;
-  }
+  function earliestDueEvent() { return Core.orderedEvents(state.scheduler || Core.blankState())[0] || null; }
 
   async function maybeReconcile() {
     if (!isDm() || state.reconciling) return;
-    const worldMs = timestampToMs(state.timestamp);
-    const due = earliestDueEvent();
+    const worldMs = timestampToMs(state.timestamp), due = earliestDueEvent();
     if (!Number.isFinite(worldMs) || !due || Number(due.dueAtWorldTs) > worldMs) return;
-
     state.reconciling = true;
     const commandId = `reconcile_${String(due.eventId || "due")}_${Math.floor(worldMs)}`;
     try {
@@ -119,20 +97,13 @@
         if (!calendar) return calendar;
         return Core.applyCommandToCalendar(calendar, { type: "reconcile", commandId }).calendar;
       });
-    } catch (error) {
-      console.error("[Luminous] World Time scheduler reconcile failed:", error);
-    } finally {
-      state.reconciling = false;
-    }
+    } catch (error) { console.error("[Luminous] World Time scheduler reconcile failed:", error); }
+    finally { state.reconciling = false; }
   }
 
   function getSnapshot() {
-    return {
-      timestamp: state.timestamp,
-      scheduler: JSON.parse(JSON.stringify(state.scheduler || Core.blankState())),
-    };
+    return { timestamp: state.timestamp, scheduler: JSON.parse(JSON.stringify(state.scheduler || Core.blankState())) };
   }
-
   function publishSchedulerSnapshot() {
     if (typeof global.CustomEvent !== "function") return;
     global.dispatchEvent?.(new global.CustomEvent("luminous:world-scheduler-updated", { detail: getSnapshot() }));
@@ -141,18 +112,12 @@
   function bindRealtime() {
     if (state.started) return;
     state.started = true;
-
-    db.ref(`${CALENDAR_ROOT}/timestamp`).on("value", (snapshot) => {
-      state.timestamp = snapshot.val();
-      void maybeReconcile();
-    });
-
+    db.ref(`${CALENDAR_ROOT}/timestamp`).on("value", (snapshot) => { state.timestamp = snapshot.val(); void maybeReconcile(); });
     db.ref(SCHEDULER_ROOT).on("value", (snapshot) => {
       state.scheduler = Core.normalizeState(snapshot.val());
       publishSchedulerSnapshot();
       void maybeReconcile();
     });
-
     if (isDm()) db.ref(REQUEST_ROOT).on("child_added", consumeRequest);
   }
 
@@ -161,7 +126,7 @@
     startActivity: (input) => submitCommand({ type: "start_activity", ...(input || {}) }),
     cancelActivity: (groupId) => submitCommand({ type: "cancel_activity", groupId }),
     splitGroup: (input) => submitCommand({ type: "split_group", ...(input || {}) }),
-    joinGroups: (input) => submitCommand({ type: "join_group", ...(input || {}) }),
+    joinGroups: (input) => submitCommand({ type: "join_groups", ...(input || {}) }),
     advanceToNextEvent: () => submitCommand({ type: "advance_to_next_event" }),
     getSnapshot,
     roots: Object.freeze({ CALENDAR_ROOT, SCHEDULER_ROOT, REQUEST_ROOT, PLAYER_ROOT }),

--- a/js/world-time-scheduler-runtime.js
+++ b/js/world-time-scheduler-runtime.js
@@ -24,6 +24,13 @@
   const makeId = (prefix = "sched") => `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
   const safeMemberIds = (value) => Core.normalizeMembers(value);
 
+  function specializedRequestValid(request) {
+    if (request?.type !== "start_activity" || request?.activityType !== "regional_travel") return true;
+    const travelCore = global.LuminousRegionalTravelCore;
+    if (!travelCore?.validateScheduledCommand) return false;
+    return travelCore.validateScheduledCommand(request).valid === true;
+  }
+
   function submitCommand(rawCommand) {
     const command = { ...(rawCommand || {}) };
     command.commandId = command.commandId || command.eventId || makeId(command.type || "sched");
@@ -44,6 +51,7 @@
   }
 
   async function authorized(request) {
+    if (!specializedRequestValid(request)) return false;
     const requesterUid = String(request?.requesterUid || "");
     if (!requesterUid) return false;
     if (requesterUid === DM_UID) return true;
@@ -118,6 +126,18 @@
     }
   }
 
+  function getSnapshot() {
+    return {
+      timestamp: state.timestamp,
+      scheduler: JSON.parse(JSON.stringify(state.scheduler || Core.blankState())),
+    };
+  }
+
+  function publishSchedulerSnapshot() {
+    if (typeof global.CustomEvent !== "function") return;
+    global.dispatchEvent?.(new global.CustomEvent("luminous:world-scheduler-updated", { detail: getSnapshot() }));
+  }
+
   function bindRealtime() {
     if (state.started) return;
     state.started = true;
@@ -129,17 +149,11 @@
 
     db.ref(SCHEDULER_ROOT).on("value", (snapshot) => {
       state.scheduler = Core.normalizeState(snapshot.val());
+      publishSchedulerSnapshot();
       void maybeReconcile();
     });
 
     if (isDm()) db.ref(REQUEST_ROOT).on("child_added", consumeRequest);
-  }
-
-  function getSnapshot() {
-    return {
-      timestamp: state.timestamp,
-      scheduler: JSON.parse(JSON.stringify(state.scheduler || Core.blankState())),
-    };
   }
 
   const api = Object.freeze({
@@ -147,7 +161,7 @@
     startActivity: (input) => submitCommand({ type: "start_activity", ...(input || {}) }),
     cancelActivity: (groupId) => submitCommand({ type: "cancel_activity", groupId }),
     splitGroup: (input) => submitCommand({ type: "split_group", ...(input || {}) }),
-    joinGroups: (input) => submitCommand({ type: "join_groups", ...(input || {}) }),
+    joinGroups: (input) => submitCommand({ type: "join_group", ...(input || {}) }),
     advanceToNextEvent: () => submitCommand({ type: "advance_to_next_event" }),
     getSnapshot,
     roots: Object.freeze({ CALENDAR_ROOT, SCHEDULER_ROOT, REQUEST_ROOT, PLAYER_ROOT }),

--- a/tests/regional_travel_engine.spec.js
+++ b/tests/regional_travel_engine.spec.js
@@ -1,0 +1,143 @@
+const { test, expect } = require('@playwright/test');
+const Travel = require('../js/regional-travel-core.js');
+const Scheduler = require('../js/world-time-scheduler-core.js');
+const Streaming = require('../js/vtt/world-streaming-core.js');
+
+const hex = (q, r = 0, district = 'K') => ({ district, q, r });
+const roadSegment = (terrain = 'plains') => ({ surface: 'road', terrain });
+const basic = (transportId = 'walking', extra = {}) => Travel.createTravelPlan({
+  groupId: extra.groupId || 'party', memberIds: extra.memberIds || ['p1'], worldId: 'luminous',
+  route: extra.route || [hex(0), hex(1)], segments: extra.segments || [roadSegment()], transportId,
+  waitSeconds: extra.waitSeconds || 0, stopSeconds: extra.stopSeconds || 0,
+});
+const calendar = () => ({ timestamp: '2026-08-30T12:00:00.000Z', año: 2026, mes: 8, dia: 30, hora: 12, minuto: 0, segundo: 0 });
+
+test.describe('Regional Travel Engine', () => {
+  test('one 20 km road hex is 4h10 walking and 20m by private bus', () => {
+    expect(basic('walking').plan.durationSeconds).toBe(15000);
+    expect(basic('private_bus').plan.durationSeconds).toBe(1200);
+  });
+
+  test('axial hex distance and adjacency are deterministic', () => {
+    expect(Travel.axialDistance(hex(0, 0), hex(3, -2))).toBe(3);
+    expect(Travel.areAdjacent(hex(0, 0), hex(1, 0))).toBe(true);
+    expect(Travel.areAdjacent(hex(0, 0), hex(2, 0))).toBe(false);
+    expect(Travel.axialDistance(hex(0, 0, 'K'), hex(0, 0, 'W'))).toBe(Infinity);
+  });
+
+  test('v1 rejects skipped regional hexes so clients cannot forge short network edges', () => {
+    const result = basic('walking', { route: [hex(0), hex(5)], segments: [{ surface: 'road', terrain: 'plains', distanceKm: 0.01, networkEdge: true }] });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('invalid_route_hop');
+  });
+
+  test('adjacent segment distance is authoritative and ignores client distance injection', () => {
+    const result = basic('walking', { segments: [{ surface: 'road', terrain: 'plains', distanceKm: 0.001 }] });
+    expect(result.valid).toBe(true);
+    expect(result.plan.distanceKm).toBe(20);
+    expect(result.plan.durationSeconds).toBe(15000);
+  });
+
+  test('client modifiers can slow travel but cannot claim faster-than-baseline weather or route quality', () => {
+    const result = basic('private_bus', { segments: [{ surface: 'road', terrain: 'plains', routeQualityMultiplier: 0.01, weatherMultiplier: 0.01 }] });
+    expect(result.plan.durationSeconds).toBe(1200);
+  });
+
+  test('transport capability contract blocks bus offroad and train off rail', () => {
+    expect(basic('public_bus', { segments: [{ surface: 'offroad', terrain: 'plains' }] }).reason).toBe('surface_not_supported');
+    expect(basic('train', { segments: [{ surface: 'road', terrain: 'plains' }] }).reason).toBe('surface_not_supported');
+    expect(basic('train', { segments: [{ surface: 'rail', terrain: 'mountain' }] }).valid).toBe(true);
+  });
+
+  test('rail infrastructure shields train speed from terrain penalties', () => {
+    const rail = basic('train', { segments: [{ surface: 'rail', terrain: 'mountain' }] });
+    expect(rail.plan.durationSeconds).toBe(900);
+  });
+
+  test('terrain meaningfully slows walking outside good infrastructure', () => {
+    const plains = basic('walking', { segments: [{ surface: 'offroad', terrain: 'plains' }] });
+    const swamp = basic('walking', { segments: [{ surface: 'offroad', terrain: 'swamp' }] });
+    expect(swamp.plan.durationSeconds).toBeGreaterThan(plains.plan.durationSeconds);
+  });
+
+  test('travel becomes exactly one scheduler activity and one completion event', () => {
+    const result = basic('private_bus');
+    const command = Travel.toSchedulerCommand(result.plan, 'travel_once');
+    const applied = Scheduler.applyCommandToCalendar(calendar(), command);
+    const state = Scheduler.schedulerStateFrom(applied.calendar);
+    expect(state.groups.party.activity.type).toBe('regional_travel');
+    expect(Object.keys(state.events)).toHaveLength(1);
+    expect(state.groups.party.durationSeconds).toBe(1200);
+  });
+
+  test('eight split players create eight travel events, never per-second events', () => {
+    let state = calendar();
+    for (let i = 0; i < 8; i += 1) {
+      const plan = basic('private_bus', { groupId: `g${i}`, memberIds: [`p${i}`], route: [hex(i * 3), hex(i * 3 + 1)] }).plan;
+      state = Scheduler.applyCommandToCalendar(state, Travel.toSchedulerCommand(plan, `travel_${i}`)).calendar;
+    }
+    const scheduler = Scheduler.schedulerStateFrom(state);
+    expect(Object.keys(scheduler.events)).toHaveLength(8);
+    expect(Object.keys(scheduler.groups)).toHaveLength(8);
+  });
+
+  test('long route duration still produces one event and bounded payload', () => {
+    const route = Array.from({ length: 128 }, (_, i) => hex(i));
+    const segments = Array.from({ length: 127 }, () => roadSegment());
+    const result = basic('private_bus', { route, segments });
+    expect(result.valid).toBe(true);
+    const command = Travel.toSchedulerCommand(result.plan, 'long_trip');
+    let state = Scheduler.applyCommandToCalendar(calendar(), command).calendar;
+    const scheduler = Scheduler.schedulerStateFrom(state);
+    expect(Object.keys(scheduler.events)).toHaveLength(1);
+    expect(JSON.stringify(scheduler).length).toBeLessThan(100000);
+  });
+
+  test('route length is bounded before it can bloat Realtime', () => {
+    const route = Array.from({ length: Travel.CONFIG.maxRouteHexes + 1 }, (_, i) => hex(i));
+    const result = basic('private_bus', { route, segments: route.slice(1).map(() => roadSegment()) });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('invalid_route');
+  });
+
+  test('DM-side validation rejects a forged duration', () => {
+    const command = Travel.toSchedulerCommand(basic('private_bus').plan, 'forged');
+    command.durationSeconds = 1;
+    const checked = Travel.validateScheduledCommand(command);
+    expect(checked.valid).toBe(false);
+    expect(checked.reason).toBe('duration_mismatch');
+    expect(checked.expectedDurationSeconds).toBe(1200);
+  });
+
+  test('scheduled command round-trips through authoritative validation', () => {
+    const command = Travel.toSchedulerCommand(basic('walking').plan, 'valid');
+    const checked = Travel.validateScheduledCommand(command);
+    expect(checked.valid).toBe(true);
+    expect(checked.plan.durationSeconds).toBe(15000);
+  });
+
+  test('regional travel does not stream every crossed local chunk', () => {
+    const manager = Streaming.createLifecycleManager({ warmTtlMs: 0, maxWarmChunks: 0, maxActiveChunks: 8 });
+    const actors = Array.from({ length: 8 }, (_, i) => ({ id: `p${i}`, position: { worldId: 'luminous', regionId: 'K', zoneId: `origin${i}`, chunkCol: 0, chunkRow: 0, x: 1, y: 1 } }));
+    manager.reconcile(actors, 0);
+    let state = calendar();
+    for (let i = 0; i < 8; i += 1) {
+      const route = Array.from({ length: 64 }, (_, q) => hex(q, i));
+      const segments = Array.from({ length: 63 }, () => roadSegment());
+      const plan = basic('private_bus', { groupId: `g${i}`, memberIds: [`p${i}`], route, segments }).plan;
+      state = Scheduler.applyCommandToCalendar(state, Travel.toSchedulerCommand(plan, `r${i}`)).calendar;
+    }
+    expect(Scheduler.schedulerStateFrom(state).events && Object.keys(Scheduler.schedulerStateFrom(state).events)).toHaveLength(8);
+    expect(manager.snapshot().activeChunks).toBe(8);
+    expect(manager.snapshot().residentChunks).toBe(8);
+  });
+
+  test('arrival world position is deterministic and carries idempotency marker', () => {
+    const plan = basic('walking', { route: [hex(0), hex(1, -1)], segments: [roadSegment()] }).plan;
+    const position = Travel.destinationWorldPosition(plan, 'arrival_1', 1234);
+    expect(position.regionId).toBe('K');
+    expect(position.regionalHex).toEqual({ district: 'K', q: 1, r: -1 });
+    expect(position.travelArrivalId).toBe('arrival_1');
+    expect(position.arrivedAtWorldTs).toBe(1234);
+  });
+});

--- a/tests/regional_travel_realtime.spec.js
+++ b/tests/regional_travel_realtime.spec.js
@@ -1,0 +1,85 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const ROOT = path.resolve(__dirname, '..');
+const read = (file) => fs.readFileSync(path.join(ROOT, file), 'utf8');
+
+const core = read('js/regional-travel-core.js');
+const runtime = read('js/regional-travel-runtime.js');
+const schedulerRuntime = read('js/world-time-scheduler-runtime.js');
+const loader = read('js/scene-time-engine.js');
+
+test.describe('Regional Travel Realtime contract', () => {
+  test('modules parse cleanly', () => {
+    execFileSync(process.execPath, ['--check', path.join(ROOT, 'js/regional-travel-core.js')]);
+    execFileSync(process.execPath, ['--check', path.join(ROOT, 'js/regional-travel-runtime.js')]);
+    execFileSync(process.execPath, ['--check', path.join(ROOT, 'js/world-time-scheduler-runtime.js')]);
+  });
+
+  test('loader installs travel core before scheduler runtime and travel runtime after it', () => {
+    const coreAt = loader.indexOf("'regional-travel-core'");
+    const schedulerAt = loader.indexOf("'world-time-scheduler-runtime'");
+    const runtimeAt = loader.indexOf("'regional-travel-runtime'");
+    expect(coreAt).toBeGreaterThan(-1);
+    expect(schedulerAt).toBeGreaterThan(coreAt);
+    expect(runtimeAt).toBeGreaterThan(schedulerAt);
+  });
+
+  test('travel runtime delegates time ownership to the existing scheduler', () => {
+    expect(runtime).toContain('Scheduler.startActivity(command)');
+    expect(runtime).toContain('Scheduler.cancelActivity(groupId)');
+    expect(runtime).not.toContain('campaña/calendario');
+    expect(runtime).not.toContain('.transaction(');
+  });
+
+  test('travel adds no timer polling or per-second loops', () => {
+    expect(runtime).not.toContain('setInterval(');
+    expect(runtime).not.toContain('setTimeout(');
+    expect(runtime).not.toContain('.on("value"');
+    expect(runtime).not.toContain(".on('value'");
+    expect(core).not.toContain('setInterval(');
+  });
+
+  test('scheduler publishes a local snapshot instead of Regional Travel opening another Firebase scheduler listener', () => {
+    expect(schedulerRuntime).toContain('luminous:world-scheduler-updated');
+    expect(runtime).toContain('addEventListener?.("luminous:world-scheduler-updated"');
+    expect(runtime).not.toContain('world_scheduler`).on');
+  });
+
+  test('DM scheduler revalidates regional duration and route before accepting request', () => {
+    expect(schedulerRuntime).toContain('specializedRequestValid(request)');
+    expect(schedulerRuntime).toContain('travelCore.validateScheduledCommand(request).valid === true');
+    expect(schedulerRuntime.indexOf('if (!specializedRequestValid(request)) return false;')).toBeGreaterThan(-1);
+  });
+
+  test('arrival application is DM-only, idempotent, and one multi-path write', () => {
+    expect(runtime).toContain('if (!isDm() || group?.status !== "completed") return false;');
+    expect(runtime).toContain('travelArrivalId === arrivalId');
+    expect(runtime).toContain('await db.ref().update(updates);');
+    expect(runtime).not.toContain('.set(worldPosition)');
+    expect(runtime).not.toContain('.push(');
+  });
+
+  test('arrival only updates player world positions and does not walk local chunks', () => {
+    expect(runtime).toContain('`${PLAYER_ROOT}/${playerId}/worldPosition`');
+    expect(runtime).not.toContain('LuminousVttWorldStreaming');
+    expect(runtime).not.toContain('procedural-chunk-loaded');
+    expect(runtime).not.toContain('vtt:token-moved');
+  });
+
+  test('arrival exposes one local event for map/router integration without extra Realtime writes', () => {
+    expect(runtime).toContain('luminous:regional-travel-arrival');
+    expect(runtime).toContain('new CustomEvent');
+  });
+
+  test('core caps route and members for Realtime payload safety', () => {
+    expect(core).toContain('maxRouteHexes: 256');
+    expect(core).toContain('maxMembers: 8');
+    expect(core).toContain('route.length > CONFIG.maxRouteHexes');
+  });
+
+  test('existing scheduler join command contract remains intact', () => {
+    expect(schedulerRuntime).toContain('type: "join_groups"');
+  });
+});


### PR DESCRIPTION
Adds deterministic 20 km Regional Hex travel on the existing World Time Scheduler. Travel duration is DM-revalidated, players cannot forge distance/duration, Realtime uses no polling or per-second writes, arrivals update player worldPosition idempotently, and local VTT chunks are not streamed per crossed hex. Includes 8-player scheduler/streaming stress gates and full repository regression. Merge only after all checks are green and main is synchronized.