### PR TITLE
feat(map): add Regional World Graph v1

### DIFF
--- a/.github/workflows/regional-world-graph.yml
+++ b/.github/workflows/regional-world-graph.yml
@@ -1,0 +1,71 @@
+name: Regional World Graph
+
+on:
+  pull_request:
+    paths:
+      - "js/regional-world-graph-*.js"
+      - "js/regional-travel-*.js"
+      - "js/world-time-scheduler-*.js"
+      - "js/scene-time-engine.js"
+      - "js/vtt/world-streaming-*.js"
+      - "tests/regional_world_graph*.spec.js"
+      - "tests/regional_travel*.spec.js"
+      - "tests/world_time_scheduler*.spec.js"
+      - "tests/vtt_world_streaming_lifecycle.spec.js"
+      - "tests/vtt_performance_guard.spec.js"
+      - "tests/vtt_procedural_chunk_streaming_performance.spec.js"
+      - ".github/workflows/regional-world-graph.yml"
+  push:
+    branches: [main]
+    paths:
+      - "js/regional-world-graph-*.js"
+      - "js/regional-travel-*.js"
+      - "js/world-time-scheduler-*.js"
+      - "js/scene-time-engine.js"
+      - "tests/regional_world_graph*.spec.js"
+      - ".github/workflows/regional-world-graph.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  regional-world-graph-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Syntax
+        run: |
+          node --check js/regional-world-graph-core.js
+          node --check js/regional-world-graph-runtime.js
+          node --check js/regional-travel-core.js
+          node --check js/regional-travel-runtime.js
+          node --check js/world-time-scheduler-runtime.js
+          node --check js/scene-time-engine.js
+          node --check tests/regional_world_graph.spec.js
+          node --check tests/regional_world_graph_realtime.spec.js
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Focused graph realtime and performance contracts
+        run: >-
+          npx playwright test --workers=1
+          tests/regional_world_graph.spec.js
+          tests/regional_world_graph_realtime.spec.js
+          tests/regional_travel_engine.spec.js
+          tests/regional_travel_realtime.spec.js
+          tests/world_time_scheduler.spec.js
+          tests/world_time_scheduler_realtime.spec.js
+          tests/scene_time_engine.spec.js
+          tests/theatre_realtime.spec.js
+          tests/vtt_world_streaming_lifecycle.spec.js
+          tests/vtt_performance_guard.spec.js
+          tests/vtt_procedural_chunk_streaming_performance.spec.js
+      - name: Full repository regression
+        run: npx playwright test --workers=1

--- a/js/regional-travel-runtime.js
+++ b/js/regional-travel-runtime.js
@@ -14,6 +14,7 @@
   const currentUid = () => firebase.auth?.().currentUser?.uid || null;
   const isDm = () => currentUid() === DM_UID || document.body?.classList.contains("on-game-dashboard") || document.body?.classList.contains("dm-dashboard");
   const makeId = (prefix = "travel") => `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+  const safeText = (value, max = 120) => String(value ?? "").trim().slice(0, max);
 
   function startTravel(input = {}) {
     const result = Core.createTravelPlan(input);
@@ -34,6 +35,16 @@
     return result.valid && result.plan.durationSeconds === Number(group.durationSeconds) ? result.plan : null;
   }
 
+  function applyGraphArrivalMetadata(worldPosition, group) {
+    const routing = group?.activity?.payload?.routing;
+    if (routing?.mode !== "graph_v1") return worldPosition;
+    worldPosition.regionalEntrySide = safeText(routing.destinationEntrySide, 20) || null;
+    worldPosition.regionalGraphId = safeText(routing.graphId);
+    worldPosition.regionalGraphRevision = Math.max(1, Math.trunc(Number(routing.graphRevision) || 1));
+    worldPosition.regionalGraphFingerprint = safeText(routing.graphFingerprint, 64);
+    return worldPosition;
+  }
+
   async function applyArrival(group) {
     if (!isDm() || group?.status !== "completed") return false;
     const plan = planFromGroup(group);
@@ -49,7 +60,10 @@
       const alreadyApplied = members.every((playerId) => players[playerId]?.worldPosition?.travelArrivalId === arrivalId);
       if (alreadyApplied) return false;
 
-      const worldPosition = Core.destinationWorldPosition(plan, arrivalId, group.completedAtWorldTs || group.processedAtWorldTs || 0);
+      const worldPosition = applyGraphArrivalMetadata(
+        Core.destinationWorldPosition(plan, arrivalId, group.completedAtWorldTs || group.processedAtWorldTs || 0),
+        group
+      );
       const updates = {};
       for (const playerId of members) updates[`${PLAYER_ROOT}/${playerId}/worldPosition`] = worldPosition;
       await db.ref().update(updates);
@@ -80,6 +94,7 @@
     startTravel,
     cancelTravel,
     planFromGroup,
+    applyGraphArrivalMetadata,
     applyArrival,
     reconcileCompleted,
     stop: () => global.removeEventListener?.("luminous:world-scheduler-updated", onSchedulerUpdated),

--- a/js/regional-world-graph-core.js
+++ b/js/regional-world-graph-core.js
@@ -1,0 +1,475 @@
+(function (root, factory) {
+  "use strict";
+  const Travel = typeof module !== "undefined" && module.exports
+    ? require("./regional-travel-core.js")
+    : root?.LuminousRegionalTravelCore;
+  const api = factory(Travel);
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+  if (root) root.LuminousRegionalWorldGraphCore = api;
+})(typeof window !== "undefined" ? window : globalThis, function (Travel) {
+  "use strict";
+
+  if (!Travel) throw new Error("LUMINOUS_REGIONAL_TRAVEL_CORE_REQUIRED");
+
+  const CONFIG = Object.freeze({
+    schemaVersion: 1,
+    maxNodes: 8192,
+    maxEdges: 65536,
+    maxVisitedNodes: 8192,
+    routingMode: "graph_v1",
+    routeMode: "fastest",
+  });
+
+  const JURISDICTIONS = Object.freeze(["nest", "backstreets", "outskirts"]);
+  const ENTRY_SIDES = Object.freeze(["west", "southwest", "southeast", "east", "northeast", "northwest"]);
+  const DIRECTIONS = Object.freeze([
+    Object.freeze([1, 0]), Object.freeze([1, -1]), Object.freeze([0, -1]),
+    Object.freeze([-1, 0]), Object.freeze([-1, 1]), Object.freeze([0, 1]),
+  ]);
+  const ROUTE_SURFACES = Object.freeze({
+    highway: "road",
+    road: "road",
+    dirt: "dirt_road",
+    dirt_road: "dirt_road",
+    trail: "trail",
+    rail: "rail",
+    offroad: "offroad",
+    rough: "rough",
+  });
+
+  const registry = new Map();
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const integer = (value, fallback = 0) => Math.trunc(finite(value, fallback));
+  const safeKey = (value, fallback = "") => String(value ?? fallback).trim().replace(/[.#$\[\]\/]/g, "_").replace(/\s+/g, "_").slice(0, 120) || fallback;
+  const bool = (value, fallback = false) => value == null ? fallback : value === true;
+
+  function stableHash(text) {
+    let hash = 0x811c9dc5;
+    for (let i = 0; i < text.length; i += 1) {
+      hash ^= text.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193);
+    }
+    return (hash >>> 0).toString(16).padStart(8, "0");
+  }
+
+  function normalizeRequirements(value) {
+    const list = Array.isArray(value) ? value : value && typeof value === "object" ? Object.keys(value).filter((key) => value[key]) : value ? [value] : [];
+    const out = [], seen = new Set();
+    for (const raw of list) {
+      const key = safeKey(raw);
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      out.push(key);
+    }
+    return Object.freeze(out.sort());
+  }
+
+  function normalizeAccessState(raw = {}) {
+    const grants = normalizeRequirements(raw.grants ?? raw.passes ?? raw.accessKeys);
+    return Object.freeze({
+      grants,
+      grantSet: new Set(grants),
+      bypassAccess: raw.bypassAccess === true,
+    });
+  }
+
+  function normalizeJurisdiction(value) {
+    const key = safeKey(value, "outskirts").toLowerCase();
+    return JURISDICTIONS.includes(key) ? key : "outskirts";
+  }
+
+  function normalizeNode(raw = {}) {
+    const hex = Travel.normalizeHex(raw.hex || raw);
+    return Object.freeze({
+      key: Travel.hexKey(hex),
+      hex,
+      jurisdiction: normalizeJurisdiction(raw.jurisdiction),
+      terrain: Travel.normalizeTerrain(raw.terrain ?? raw.biome),
+      settlementId: safeKey(raw.settlementId ?? raw.settlement?.id),
+      requiredAccess: normalizeRequirements(raw.requiredAccess ?? raw.access?.required),
+      blocked: raw.blocked === true,
+      metadata: raw.metadata && typeof raw.metadata === "object" ? Object.freeze(clone(raw.metadata)) : null,
+    });
+  }
+
+  function routeSurface(raw = {}) {
+    const routeType = safeKey(raw.routeType ?? raw.type ?? raw.surface, "offroad").toLowerCase();
+    return Travel.normalizeSurface(ROUTE_SURFACES[routeType] || raw.surface || "offroad");
+  }
+
+  function edgeRefKey(value) {
+    if (typeof value === "string") return value;
+    return Travel.hexKey(value || {});
+  }
+
+  function normalizeEdge(raw, nodes, index, reverse = false) {
+    const from = reverse ? edgeRefKey(raw.to) : edgeRefKey(raw.from);
+    const to = reverse ? edgeRefKey(raw.from) : edgeRefKey(raw.to);
+    if (!nodes.has(from) || !nodes.has(to)) throw Object.assign(new Error("GRAPH_EDGE_NODE_MISSING"), { from, to });
+    const fromNode = nodes.get(from), toNode = nodes.get(to);
+    if (!Travel.areAdjacent(fromNode.hex, toNode.hex)) throw Object.assign(new Error("GRAPH_EDGE_NOT_ADJACENT"), { from, to });
+    const surface = routeSurface(raw);
+    const baseId = safeKey(raw.id, `edge_${index}_${from}_${to}_${surface}`);
+    return Object.freeze({
+      id: reverse ? `${baseId}_reverse` : baseId,
+      from,
+      to,
+      surface,
+      terrain: Travel.normalizeTerrain(raw.terrain ?? toNode.terrain),
+      routeQualityMultiplier: Math.max(1, Math.min(3, finite(raw.routeQualityMultiplier ?? raw.qualityMultiplier, 1))),
+      weatherMultiplier: Math.max(1, Math.min(3, finite(raw.weatherMultiplier, 1))),
+      requiredAccess: normalizeRequirements(raw.requiredAccess ?? raw.access?.required),
+      blocked: raw.blocked === true,
+      routeType: safeKey(raw.routeType ?? raw.type ?? surface, surface).toLowerCase(),
+      auto: false,
+    });
+  }
+
+  function autoEdge(fromNode, toNode) {
+    return Object.freeze({
+      id: `auto_${fromNode.key}_to_${toNode.key}`,
+      from: fromNode.key,
+      to: toNode.key,
+      surface: "offroad",
+      terrain: toNode.terrain,
+      routeQualityMultiplier: 1,
+      weatherMultiplier: 1,
+      requiredAccess: Object.freeze([]),
+      blocked: false,
+      routeType: "offroad",
+      auto: true,
+    });
+  }
+
+  function canonicalGraphData(id, revision, nodes, edges) {
+    return {
+      id,
+      revision,
+      nodes: [...nodes.values()].map((node) => ({
+        key: node.key,
+        jurisdiction: node.jurisdiction,
+        terrain: node.terrain,
+        settlementId: node.settlementId,
+        requiredAccess: [...node.requiredAccess],
+        blocked: node.blocked,
+      })).sort((a, b) => a.key.localeCompare(b.key)),
+      edges: edges.map((edge) => ({
+        id: edge.id,
+        from: edge.from,
+        to: edge.to,
+        surface: edge.surface,
+        terrain: edge.terrain,
+        routeQualityMultiplier: edge.routeQualityMultiplier,
+        weatherMultiplier: edge.weatherMultiplier,
+        requiredAccess: [...edge.requiredAccess],
+        blocked: edge.blocked,
+        routeType: edge.routeType,
+        auto: edge.auto,
+      })).sort((a, b) => `${a.from}|${a.to}|${a.surface}|${a.id}`.localeCompare(`${b.from}|${b.to}|${b.surface}|${b.id}`)),
+    };
+  }
+
+  function createGraph(definition = {}) {
+    const id = safeKey(definition.id ?? definition.graphId, "regional_world");
+    const revision = Math.max(1, integer(definition.revision, 1));
+    const rawNodes = Array.isArray(definition.nodes) ? definition.nodes : [];
+    if (!rawNodes.length || rawNodes.length > CONFIG.maxNodes) throw new Error("GRAPH_NODE_COUNT_INVALID");
+
+    const nodes = new Map();
+    for (const raw of rawNodes) {
+      const node = normalizeNode(raw);
+      if (nodes.has(node.key)) throw Object.assign(new Error("GRAPH_DUPLICATE_NODE"), { nodeKey: node.key });
+      nodes.set(node.key, node);
+    }
+
+    const edges = [];
+    const explicit = Array.isArray(definition.edges) ? definition.edges : [];
+    for (let index = 0; index < explicit.length; index += 1) {
+      const raw = explicit[index] || {};
+      edges.push(normalizeEdge(raw, nodes, index, false));
+      if (raw.oneWay !== true) edges.push(normalizeEdge(raw, nodes, index, true));
+    }
+
+    if (definition.autoConnectAdjacent !== false) {
+      for (const node of nodes.values()) {
+        for (const [dq, dr] of DIRECTIONS) {
+          const neighborKey = Travel.hexKey({ district: node.hex.district, q: node.hex.q + dq, r: node.hex.r + dr });
+          const neighbor = nodes.get(neighborKey);
+          if (neighbor) edges.push(autoEdge(node, neighbor));
+        }
+      }
+    }
+
+    if (edges.length > CONFIG.maxEdges) throw new Error("GRAPH_EDGE_COUNT_INVALID");
+    const adjacency = new Map();
+    for (const key of nodes.keys()) adjacency.set(key, []);
+    for (const edge of edges) adjacency.get(edge.from).push(edge);
+    for (const list of adjacency.values()) list.sort((a, b) => `${a.to}|${a.surface}|${a.id}`.localeCompare(`${b.to}|${b.surface}|${b.id}`));
+
+    const canonical = canonicalGraphData(id, revision, nodes, edges);
+    const fingerprint = stableHash(JSON.stringify(canonical));
+    return Object.freeze({
+      schemaVersion: CONFIG.schemaVersion,
+      id,
+      revision,
+      fingerprint,
+      nodes,
+      edges: Object.freeze(edges),
+      adjacency,
+      autoConnectAdjacent: definition.autoConnectAdjacent !== false,
+      stats: Object.freeze({ nodeCount: nodes.size, edgeCount: edges.length }),
+    });
+  }
+
+  function registerGraph(definition) {
+    const graph = definition?.nodes instanceof Map && definition?.adjacency instanceof Map ? definition : createGraph(definition);
+    registry.set(graph.id, graph);
+    return graph;
+  }
+  function unregisterGraph(graphId) { return registry.delete(safeKey(graphId)); }
+  function clearRegistry() { registry.clear(); }
+  function getGraph(graphId) { return registry.get(safeKey(graphId)) || null; }
+  function listGraphs() { return [...registry.values()]; }
+
+  function hasRequirements(requirements, accessState) {
+    if (!requirements?.length || accessState.bypassAccess) return true;
+    return requirements.every((key) => accessState.grantSet.has(key));
+  }
+  function canEnterNode(node, accessState) {
+    return !!node && !node.blocked && hasRequirements(node.requiredAccess, accessState);
+  }
+  function canUseEdge(edge, accessState) {
+    return !!edge && !edge.blocked && hasRequirements(edge.requiredAccess, accessState);
+  }
+
+  function segmentFromEdge(edge) {
+    return Object.freeze({
+      surface: edge.surface,
+      terrain: edge.terrain,
+      routeQualityMultiplier: edge.routeQualityMultiplier,
+      weatherMultiplier: edge.weatherMultiplier,
+    });
+  }
+
+  function movementEntrySide(fromRaw, toRaw) {
+    const from = Travel.normalizeHex(fromRaw), to = Travel.normalizeHex(toRaw);
+    if (from.district !== to.district) return null;
+    const key = `${to.q - from.q},${to.r - from.r}`;
+    return ({
+      "1,0": "west",
+      "1,-1": "southwest",
+      "0,-1": "southeast",
+      "-1,0": "east",
+      "-1,1": "northeast",
+      "0,1": "northwest",
+    })[key] || null;
+  }
+
+  class MinHeap {
+    constructor() { this.items = []; }
+    push(item) {
+      const items = this.items;
+      items.push(item);
+      let i = items.length - 1;
+      while (i > 0) {
+        const p = Math.floor((i - 1) / 2);
+        if (!this.less(items[i], items[p])) break;
+        [items[i], items[p]] = [items[p], items[i]];
+        i = p;
+      }
+    }
+    pop() {
+      const items = this.items;
+      if (!items.length) return null;
+      const first = items[0], last = items.pop();
+      if (items.length) {
+        items[0] = last;
+        let i = 0;
+        while (true) {
+          const l = i * 2 + 1, r = l + 1;
+          let best = i;
+          if (l < items.length && this.less(items[l], items[best])) best = l;
+          if (r < items.length && this.less(items[r], items[best])) best = r;
+          if (best === i) break;
+          [items[i], items[best]] = [items[best], items[i]];
+          i = best;
+        }
+      }
+      return first;
+    }
+    less(a, b) { return a.cost !== b.cost ? a.cost < b.cost : a.key.localeCompare(b.key) < 0; }
+    get size() { return this.items.length; }
+  }
+
+  function findRoute(graphOrId, input = {}) {
+    const graph = typeof graphOrId === "string" ? getGraph(graphOrId) : graphOrId;
+    if (!graph?.nodes || !graph?.adjacency) return { valid: false, reason: "graph_not_registered" };
+    const originKey = edgeRefKey(input.origin ?? input.originHex);
+    const destinationKey = edgeRefKey(input.destination ?? input.destinationHex);
+    const origin = graph.nodes.get(originKey), destination = graph.nodes.get(destinationKey);
+    if (!origin || !destination) return { valid: false, reason: "graph_node_missing" };
+    if (originKey === destinationKey) return { valid: false, reason: "same_origin_destination" };
+
+    const transport = Travel.normalizeTransport(input.transportId ?? input.transport);
+    if (!transport) return { valid: false, reason: "unknown_transport" };
+    const accessState = normalizeAccessState(input.accessState || {});
+    if (!canEnterNode(destination, accessState)) return { valid: false, reason: destination.blocked ? "destination_blocked" : "destination_access_required", requiredAccess: [...destination.requiredAccess] };
+
+    const dist = new Map([[originKey, 0]]);
+    const hops = new Map([[originKey, 0]]);
+    const prev = new Map();
+    const heap = new MinHeap();
+    heap.push({ key: originKey, cost: 0 });
+    let visitedCount = 0;
+
+    while (heap.size) {
+      const current = heap.pop();
+      if (current.cost !== dist.get(current.key)) continue;
+      visitedCount += 1;
+      if (visitedCount > CONFIG.maxVisitedNodes) return { valid: false, reason: "route_search_limit" };
+      if (current.key === destinationKey) break;
+
+      for (const edge of graph.adjacency.get(current.key) || []) {
+        const nextNode = graph.nodes.get(edge.to);
+        if (!canUseEdge(edge, accessState) || !canEnterNode(nextNode, accessState)) continue;
+        const segment = segmentFromEdge(edge);
+        if (!Travel.validateCapabilities(transport, [segment]).valid) continue;
+        const nextHops = (hops.get(current.key) || 0) + 1;
+        if (nextHops >= Travel.CONFIG.maxRouteHexes) continue;
+        const nextCost = current.cost + Travel.segmentDurationSeconds({ ...segment, distanceKm: Travel.CONFIG.hexDistanceKm }, transport);
+        const known = dist.get(edge.to);
+        if (known == null || nextCost < known) {
+          dist.set(edge.to, nextCost);
+          hops.set(edge.to, nextHops);
+          prev.set(edge.to, { from: current.key, edge });
+          heap.push({ key: edge.to, cost: nextCost });
+        }
+      }
+    }
+
+    if (!dist.has(destinationKey)) return { valid: false, reason: "no_route", visitedCount };
+    const nodeKeys = [destinationKey], pathEdges = [];
+    let cursor = destinationKey;
+    while (cursor !== originKey) {
+      const step = prev.get(cursor);
+      if (!step) return { valid: false, reason: "route_reconstruction_failed" };
+      pathEdges.push(step.edge);
+      cursor = step.from;
+      nodeKeys.push(cursor);
+    }
+    nodeKeys.reverse();
+    pathEdges.reverse();
+    const route = nodeKeys.map((key) => clone(graph.nodes.get(key).hex));
+    const segments = pathEdges.map((edge) => clone(segmentFromEdge(edge)));
+    const destinationEntrySide = movementEntrySide(route[route.length - 2], route[route.length - 1]);
+    return {
+      valid: true,
+      graphId: graph.id,
+      graphRevision: graph.revision,
+      graphFingerprint: graph.fingerprint,
+      routeMode: CONFIG.routeMode,
+      route,
+      segments,
+      edgeIds: pathEdges.map((edge) => edge.id),
+      durationSeconds: dist.get(destinationKey),
+      destinationEntrySide,
+      visitedCount,
+    };
+  }
+
+  function routingMetadata(graph, routeResult) {
+    return Object.freeze({
+      mode: CONFIG.routingMode,
+      routeMode: CONFIG.routeMode,
+      graphId: graph.id,
+      graphRevision: graph.revision,
+      graphFingerprint: graph.fingerprint,
+      destinationEntrySide: ENTRY_SIDES.includes(routeResult.destinationEntrySide) ? routeResult.destinationEntrySide : null,
+    });
+  }
+
+  function createTravelPlan(input = {}) {
+    const graph = input.graph || getGraph(input.graphId);
+    if (!graph) return { valid: false, reason: "graph_not_registered" };
+    const routeResult = findRoute(graph, input);
+    if (!routeResult.valid) return routeResult;
+    const travel = Travel.createTravelPlan({
+      groupId: input.groupId ?? input.activityGroupId,
+      memberIds: input.memberIds,
+      worldId: input.worldId,
+      route: routeResult.route,
+      segments: routeResult.segments,
+      transportId: input.transportId ?? input.transport,
+      waitSeconds: input.waitSeconds,
+      stopSeconds: input.stopSeconds,
+    });
+    if (!travel.valid) return travel;
+    return { valid: true, plan: travel.plan, routeResult, routing: routingMetadata(graph, routeResult) };
+  }
+
+  function routeSignature(route) {
+    return (Array.isArray(route) ? route : []).map((hex) => Travel.hexKey(hex)).join(">");
+  }
+  function segmentSignature(segments) {
+    return JSON.stringify((Array.isArray(segments) ? segments : []).map((segment) => ({
+      surface: Travel.normalizeSurface(segment.surface),
+      terrain: Travel.normalizeTerrain(segment.terrain),
+      routeQualityMultiplier: Math.max(1, Math.min(3, finite(segment.routeQualityMultiplier, 1))),
+      weatherMultiplier: Math.max(1, Math.min(3, finite(segment.weatherMultiplier, 1))),
+    })));
+  }
+
+  function validateScheduledCommand(command = {}, options = {}) {
+    const routing = command?.payload?.routing;
+    if (command?.type !== "start_activity" || command?.activityType !== "regional_travel" || routing?.mode !== CONFIG.routingMode) {
+      return { valid: true, specialized: false };
+    }
+    const travelValidation = Travel.validateScheduledCommand(command);
+    if (!travelValidation.valid) return { ...travelValidation, specialized: true };
+    const graph = getGraph(routing.graphId);
+    if (!graph) return { valid: false, specialized: true, reason: "graph_not_registered" };
+    if (integer(routing.graphRevision, -1) !== graph.revision) return { valid: false, specialized: true, reason: "graph_revision_mismatch" };
+    if (String(routing.graphFingerprint || "") !== graph.fingerprint) return { valid: false, specialized: true, reason: "graph_fingerprint_mismatch" };
+    if (routing.routeMode !== CONFIG.routeMode) return { valid: false, specialized: true, reason: "unsupported_route_mode" };
+
+    const route = travelValidation.plan.route;
+    const result = findRoute(graph, {
+      origin: route[0],
+      destination: route[route.length - 1],
+      transportId: travelValidation.plan.transportId,
+      accessState: options.accessState || { bypassAccess: options.allowRestricted === true },
+    });
+    if (!result.valid) return { ...result, specialized: true };
+    if (routeSignature(result.route) !== routeSignature(route)) return { valid: false, specialized: true, reason: "graph_route_mismatch" };
+    if (segmentSignature(result.segments) !== segmentSignature(travelValidation.plan.segments)) return { valid: false, specialized: true, reason: "graph_segment_mismatch" };
+    if ((routing.destinationEntrySide || null) !== (result.destinationEntrySide || null)) return { valid: false, specialized: true, reason: "entry_side_mismatch" };
+    return { valid: true, specialized: true, plan: travelValidation.plan, routeResult: result, graph };
+  }
+
+  return Object.freeze({
+    CONFIG,
+    JURISDICTIONS,
+    ENTRY_SIDES,
+    DIRECTIONS,
+    ROUTE_SURFACES,
+    normalizeRequirements,
+    normalizeAccessState,
+    normalizeJurisdiction,
+    normalizeNode,
+    createGraph,
+    registerGraph,
+    unregisterGraph,
+    clearRegistry,
+    getGraph,
+    listGraphs,
+    canEnterNode,
+    canUseEdge,
+    segmentFromEdge,
+    movementEntrySide,
+    findRoute,
+    routingMetadata,
+    createTravelPlan,
+    validateScheduledCommand,
+  });
+});

--- a/js/regional-world-graph-runtime.js
+++ b/js/regional-world-graph-runtime.js
@@ -30,10 +30,11 @@
     return Graph.createTravelPlan(input);
   }
 
-  function commandFromPlan(result, commandId) {
+  function commandFromPlan(result, commandId, options = {}) {
     if (!result?.valid || !result.plan || !result.routing) throw new Error("VALID_GRAPH_TRAVEL_PLAN_REQUIRED");
     const command = Travel.toSchedulerCommand(result.plan, commandId || makeId());
     command.payload.routing = clone(result.routing);
+    command.payload.routing.accessMode = options.bypassAccess === true ? "bypass" : "normal";
     return command;
   }
 
@@ -42,12 +43,13 @@
     if (!result.valid) {
       return Promise.reject(Object.assign(new Error(result.reason || "INVALID_GRAPH_TRAVEL"), { graphTravelValidation: result }));
     }
-    const command = commandFromPlan(result, input.commandId);
+    const bypassAccess = input?.accessState?.bypassAccess === true;
+    const command = commandFromPlan(result, input.commandId, { bypassAccess });
     return Scheduler.startActivity(command).then((resolvedCommandId) => ({
       commandId: resolvedCommandId,
       plan: result.plan,
       routeResult: result.routeResult,
-      routing: result.routing,
+      routing: command.payload.routing,
     }));
   }
 

--- a/js/regional-world-graph-runtime.js
+++ b/js/regional-world-graph-runtime.js
@@ -1,0 +1,68 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousRegionalWorldGraph) return;
+  const Graph = global.LuminousRegionalWorldGraphCore;
+  const Travel = global.LuminousRegionalTravelCore;
+  const Scheduler = global.LuminousWorldTimeScheduler;
+  if (!Graph || !Travel || !Scheduler) return;
+
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const makeId = (prefix = "graph_travel") => `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+
+  function registerGraph(definition) {
+    return Graph.registerGraph(definition);
+  }
+
+  function registerBootstrapGraphs() {
+    const definitions = Array.isArray(global.LUMINOUS_REGIONAL_WORLD_GRAPHS)
+      ? global.LUMINOUS_REGIONAL_WORLD_GRAPHS
+      : [];
+    const registered = [];
+    for (const definition of definitions) {
+      try { registered.push(Graph.registerGraph(definition)); }
+      catch (error) { console.error("[Luminous] Regional world graph registration failed:", error); }
+    }
+    return registered;
+  }
+
+  function planTravelTo(input = {}) {
+    return Graph.createTravelPlan(input);
+  }
+
+  function commandFromPlan(result, commandId) {
+    if (!result?.valid || !result.plan || !result.routing) throw new Error("VALID_GRAPH_TRAVEL_PLAN_REQUIRED");
+    const command = Travel.toSchedulerCommand(result.plan, commandId || makeId());
+    command.payload.routing = clone(result.routing);
+    return command;
+  }
+
+  function startTravelTo(input = {}) {
+    const result = Graph.createTravelPlan(input);
+    if (!result.valid) {
+      return Promise.reject(Object.assign(new Error(result.reason || "INVALID_GRAPH_TRAVEL"), { graphTravelValidation: result }));
+    }
+    const command = commandFromPlan(result, input.commandId);
+    return Scheduler.startActivity(command).then((resolvedCommandId) => ({
+      commandId: resolvedCommandId,
+      plan: result.plan,
+      routeResult: result.routeResult,
+      routing: result.routing,
+    }));
+  }
+
+  const bootstrapGraphs = registerBootstrapGraphs();
+  const api = Object.freeze({
+    core: Graph,
+    registerGraph,
+    unregisterGraph: Graph.unregisterGraph,
+    getGraph: Graph.getGraph,
+    listGraphs: Graph.listGraphs,
+    planTravelTo,
+    commandFromPlan,
+    startTravelTo,
+    bootstrapGraphs: Object.freeze(bootstrapGraphs),
+  });
+
+  global.LuminousRegionalWorldGraph = api;
+})(window);

--- a/js/scene-time-engine.js
+++ b/js/scene-time-engine.js
@@ -22,9 +22,17 @@
       'regional-travel-core',
       'js/regional-travel-core.js',
       () => load(
-        'world-time-scheduler-runtime',
-        'js/world-time-scheduler-runtime.js',
-        () => load('regional-travel-runtime', 'js/regional-travel-runtime.js')
+        'regional-world-graph-core',
+        'js/regional-world-graph-core.js',
+        () => load(
+          'world-time-scheduler-runtime',
+          'js/world-time-scheduler-runtime.js',
+          () => load(
+            'regional-travel-runtime',
+            'js/regional-travel-runtime.js',
+            () => load('regional-world-graph-runtime', 'js/regional-world-graph-runtime.js')
+          )
+        )
       )
     )
   );

--- a/js/world-time-scheduler-runtime.js
+++ b/js/world-time-scheduler-runtime.js
@@ -23,7 +23,7 @@
     if (request?.type !== "start_activity" || request?.activityType !== "regional_travel") return true;
     const travelCore = global.LuminousRegionalTravelCore;
     if (!travelCore?.validateScheduledCommand) return false;
-    if (travelCore.validateScheduledCommand(request).valid !== true) return false;
+    if (!(travelCore.validateScheduledCommand(request).valid === true)) return false;
 
     if (request?.payload?.routing?.mode === "graph_v1") {
       const graphCore = global.LuminousRegionalWorldGraphCore;

--- a/js/world-time-scheduler-runtime.js
+++ b/js/world-time-scheduler-runtime.js
@@ -29,7 +29,8 @@
       const graphCore = global.LuminousRegionalWorldGraphCore;
       if (!graphCore?.validateScheduledCommand) return false;
       const requesterIsDm = String(request?.requesterUid || "") === DM_UID;
-      return graphCore.validateScheduledCommand(request, { allowRestricted: requesterIsDm }).valid === true;
+      const explicitDmBypass = requesterIsDm && request?.payload?.routing?.accessMode === "bypass";
+      return graphCore.validateScheduledCommand(request, { allowRestricted: explicitDmBypass }).valid === true;
     }
     return true;
   }

--- a/js/world-time-scheduler-runtime.js
+++ b/js/world-time-scheduler-runtime.js
@@ -23,7 +23,15 @@
     if (request?.type !== "start_activity" || request?.activityType !== "regional_travel") return true;
     const travelCore = global.LuminousRegionalTravelCore;
     if (!travelCore?.validateScheduledCommand) return false;
-    return travelCore.validateScheduledCommand(request).valid === true;
+    if (travelCore.validateScheduledCommand(request).valid !== true) return false;
+
+    if (request?.payload?.routing?.mode === "graph_v1") {
+      const graphCore = global.LuminousRegionalWorldGraphCore;
+      if (!graphCore?.validateScheduledCommand) return false;
+      const requesterIsDm = String(request?.requesterUid || "") === DM_UID;
+      return graphCore.validateScheduledCommand(request, { allowRestricted: requesterIsDm }).valid === true;
+    }
+    return true;
   }
 
   function submitCommand(rawCommand) {

--- a/tests/regional_world_graph.spec.js
+++ b/tests/regional_world_graph.spec.js
@@ -122,7 +122,7 @@ test.describe('Regional World Graph v1', () => {
     expect(result.valid).toBe(true);
     expect(result.plan.durationSeconds).toBe(result.routeResult.durationSeconds);
     expect(result.routing.mode).toBe('graph_v1');
-    expect(result.routing.destinationEntrySide).toBe('northwest');
+    expect(result.routing.destinationEntrySide).toBe('southeast');
 
     const command = graphCommand(result);
     expect(Graph.validateScheduledCommand(command).valid).toBe(true);

--- a/tests/regional_world_graph.spec.js
+++ b/tests/regional_world_graph.spec.js
@@ -1,0 +1,217 @@
+const { test, expect } = require('@playwright/test');
+const Graph = require('../js/regional-world-graph-core.js');
+const Travel = require('../js/regional-travel-core.js');
+const Scheduler = require('../js/world-time-scheduler-core.js');
+const Streaming = require('../js/vtt/world-streaming-core.js');
+
+const hex = (q, r = 0, district = 'K') => ({ district, q, r });
+const key = (q, r = 0, district = 'K') => Travel.hexKey(hex(q, r, district));
+const road = (from, to, extra = {}) => ({ from, to, routeType: 'road', ...extra });
+const calendar = () => ({ timestamp: '2026-08-30T12:00:00.000Z', año: 2026, mes: 8, dia: 30, hora: 12, minuto: 0, segundo: 0 });
+
+function corridorDefinition(revision = 1) {
+  const A = hex(0, 0), N = hex(1, 0), B = hex(2, 0);
+  const C = hex(0, 1), D = hex(1, 1), E = hex(2, 1);
+  return {
+    id: 'k_test_graph',
+    revision,
+    nodes: [
+      { ...A, jurisdiction: 'outskirts', terrain: 'plains' },
+      { ...N, jurisdiction: 'nest', terrain: 'plains', requiredAccess: ['pass_k'] },
+      { ...B, jurisdiction: 'outskirts', terrain: 'plains', settlementId: 'villa_b' },
+      { ...C, jurisdiction: 'backstreets', terrain: 'plains' },
+      { ...D, jurisdiction: 'backstreets', terrain: 'plains' },
+      { ...E, jurisdiction: 'outskirts', terrain: 'plains' },
+    ],
+    edges: [
+      road(A, N, { id: 'nest_gate_west' }),
+      road(N, B, { id: 'nest_gate_east' }),
+      road(A, C, { id: 'bypass_1' }),
+      road(C, D, { id: 'bypass_2' }),
+      road(D, E, { id: 'bypass_3' }),
+      road(E, B, { id: 'bypass_4' }),
+    ],
+  };
+}
+
+function makeGraph(revision = 1) {
+  Graph.clearRegistry();
+  return Graph.registerGraph(corridorDefinition(revision));
+}
+
+function graphCommand(result, commandId = 'graph_trip', accessMode = 'normal') {
+  const command = Travel.toSchedulerCommand(result.plan, commandId);
+  command.payload.routing = { ...result.routing, accessMode };
+  return command;
+}
+
+test.describe('Regional World Graph v1', () => {
+  test.beforeEach(() => Graph.clearRegistry());
+
+  test('jurisdiction is independent from terrain and settlement metadata', () => {
+    const graph = makeGraph();
+    expect(graph.nodes.get(key(1, 0)).jurisdiction).toBe('nest');
+    expect(graph.nodes.get(key(1, 0)).terrain).toBe('plains');
+    expect(graph.nodes.get(key(2, 0)).jurisdiction).toBe('outskirts');
+    expect(graph.nodes.get(key(2, 0)).settlementId).toBe('villa_b');
+  });
+
+  test('public travel routes around a Nest when the group lacks its pass', () => {
+    const graph = makeGraph();
+    const result = Graph.findRoute(graph, { origin: hex(0, 0), destination: hex(2, 0), transportId: 'public_bus' });
+    expect(result.valid).toBe(true);
+    expect(result.route.map(Travel.hexKey)).toEqual([key(0, 0), key(0, 1), key(1, 1), key(2, 1), key(2, 0)]);
+    expect(result.durationSeconds).toBe(4 * 2400);
+  });
+
+  test('a valid Nest pass unlocks the shorter infrastructure route', () => {
+    const graph = makeGraph();
+    const result = Graph.findRoute(graph, {
+      origin: hex(0, 0), destination: hex(2, 0), transportId: 'public_bus', accessState: { grants: ['pass_k'] },
+    });
+    expect(result.valid).toBe(true);
+    expect(result.route.map(Travel.hexKey)).toEqual([key(0, 0), key(1, 0), key(2, 0)]);
+    expect(result.durationSeconds).toBe(2 * 2400);
+  });
+
+  test('a Nest destination is blocked without access instead of spawning through it', () => {
+    const graph = makeGraph();
+    const denied = Graph.findRoute(graph, { origin: hex(0, 0), destination: hex(1, 0), transportId: 'walking' });
+    expect(denied.valid).toBe(false);
+    expect(denied.reason).toBe('destination_access_required');
+    expect(denied.requiredAccess).toEqual(['pass_k']);
+
+    const allowed = Graph.findRoute(graph, {
+      origin: hex(0, 0), destination: hex(1, 0), transportId: 'walking', accessState: { grants: ['pass_k'] },
+    });
+    expect(allowed.valid).toBe(true);
+  });
+
+  test('transport capabilities are honored by the graph, not reimplemented', () => {
+    const graph = Graph.registerGraph({
+      id: 'rail_only',
+      nodes: [{ ...hex(0), terrain: 'plains' }, { ...hex(1), terrain: 'mountain' }],
+      edges: [{ from: hex(0), to: hex(1), routeType: 'rail', id: 'rail' }],
+      autoConnectAdjacent: false,
+    });
+    expect(Graph.findRoute(graph, { origin: hex(0), destination: hex(1), transportId: 'train' }).valid).toBe(true);
+    expect(Graph.findRoute(graph, { origin: hex(0), destination: hex(1), transportId: 'public_bus' }).reason).toBe('no_route');
+  });
+
+  test('entry side is derived from the physical last hex transition', () => {
+    expect(Graph.movementEntrySide(hex(0, 0), hex(1, 0))).toBe('west');
+    expect(Graph.movementEntrySide(hex(1, 0), hex(0, 0))).toBe('east');
+    expect(Graph.movementEntrySide(hex(0, 0), hex(1, -1))).toBe('southwest');
+    expect(Graph.movementEntrySide(hex(0, 0), hex(0, 1))).toBe('northwest');
+  });
+
+  test('graph fingerprint is deterministic and revision-sensitive', () => {
+    const first = Graph.createGraph(corridorDefinition(1));
+    const second = Graph.createGraph(corridorDefinition(1));
+    const revised = Graph.createGraph(corridorDefinition(2));
+    expect(first.fingerprint).toBe(second.fingerprint);
+    expect(revised.fingerprint).not.toBe(first.fingerprint);
+  });
+
+  test('graph-produced travel uses the existing Travel ETA and one scheduler event', () => {
+    const graph = makeGraph();
+    const result = Graph.createTravelPlan({
+      graphId: graph.id, groupId: 'party', memberIds: ['p1', 'p2'], worldId: 'luminous',
+      origin: hex(0, 0), destination: hex(2, 0), transportId: 'public_bus',
+    });
+    expect(result.valid).toBe(true);
+    expect(result.plan.durationSeconds).toBe(result.routeResult.durationSeconds);
+    expect(result.routing.mode).toBe('graph_v1');
+    expect(result.routing.destinationEntrySide).toBe('northwest');
+
+    const command = graphCommand(result);
+    expect(Graph.validateScheduledCommand(command).valid).toBe(true);
+    const applied = Scheduler.applyCommandToCalendar(calendar(), command);
+    expect(Object.keys(Scheduler.schedulerStateFrom(applied.calendar).events)).toHaveLength(1);
+  });
+
+  test('a client cannot forge a route through a restricted Nest while keeping a valid ETA', () => {
+    const graph = makeGraph();
+    const forgedTravel = Travel.createTravelPlan({
+      groupId: 'party', memberIds: ['p1'], worldId: 'luminous', transportId: 'public_bus',
+      route: [hex(0, 0), hex(1, 0), hex(2, 0)],
+      segments: [{ surface: 'road', terrain: 'plains' }, { surface: 'road', terrain: 'plains' }],
+    });
+    const command = Travel.toSchedulerCommand(forgedTravel.plan, 'forged_nest');
+    command.payload.routing = {
+      mode: 'graph_v1', routeMode: 'fastest', graphId: graph.id, graphRevision: graph.revision,
+      graphFingerprint: graph.fingerprint, destinationEntrySide: 'west', accessMode: 'normal',
+    };
+    const checked = Graph.validateScheduledCommand(command);
+    expect(checked.valid).toBe(false);
+    expect(checked.reason).toBe('graph_route_mismatch');
+  });
+
+  test('DM bypass must be explicit and cannot validate as ordinary player access', () => {
+    const graph = makeGraph();
+    const result = Graph.createTravelPlan({
+      graphId: graph.id, groupId: 'party', memberIds: ['p1'], worldId: 'luminous',
+      origin: hex(0, 0), destination: hex(2, 0), transportId: 'public_bus', accessState: { bypassAccess: true },
+    });
+    const command = graphCommand(result, 'dm_bypass', 'bypass');
+    expect(Graph.validateScheduledCommand(command, { allowRestricted: false }).valid).toBe(false);
+    expect(Graph.validateScheduledCommand(command, { allowRestricted: true }).valid).toBe(true);
+  });
+
+  test('stale graph revision or fingerprint is rejected before travel', () => {
+    const graph = makeGraph();
+    const result = Graph.createTravelPlan({
+      graphId: graph.id, groupId: 'party', memberIds: ['p1'], origin: hex(0, 0), destination: hex(2, 0), transportId: 'public_bus',
+    });
+    const revisionCommand = graphCommand(result, 'stale_revision');
+    revisionCommand.payload.routing.graphRevision += 1;
+    expect(Graph.validateScheduledCommand(revisionCommand).reason).toBe('graph_revision_mismatch');
+
+    const fingerprintCommand = graphCommand(result, 'stale_fingerprint');
+    fingerprintCommand.payload.routing.graphFingerprint = 'deadbeef';
+    expect(Graph.validateScheduledCommand(fingerprintCommand).reason).toBe('graph_fingerprint_mismatch');
+  });
+
+  test('eight independent parties remain eight scheduler events and do not stream crossed hexes', () => {
+    const nodes = [], edges = [];
+    const width = 32, height = 8;
+    for (let r = 0; r < height; r += 1) {
+      for (let q = 0; q < width; q += 1) {
+        nodes.push({ ...hex(q, r), jurisdiction: 'outskirts', terrain: 'plains' });
+        if (q > 0) edges.push(road(hex(q - 1, r), hex(q, r), { id: `road_${q - 1}_${r}_${q}_${r}` }));
+      }
+    }
+    const graph = Graph.registerGraph({ id: 'stress_graph', nodes, edges, autoConnectAdjacent: false });
+    const manager = Streaming.createLifecycleManager({ warmTtlMs: 0, maxWarmChunks: 0, maxActiveChunks: 8 });
+    manager.reconcile(Array.from({ length: 8 }, (_, i) => ({
+      id: `p${i}`, position: { worldId: 'luminous', regionId: 'K', zoneId: `origin${i}`, chunkCol: 0, chunkRow: 0, x: 1, y: 1 },
+    })), 0);
+
+    let state = calendar();
+    for (let i = 0; i < 8; i += 1) {
+      const result = Graph.createTravelPlan({
+        graphId: graph.id, groupId: `g${i}`, memberIds: [`p${i}`], worldId: 'luminous',
+        origin: hex(0, i), destination: hex(width - 1, i), transportId: 'private_bus',
+      });
+      expect(result.valid).toBe(true);
+      expect(result.routeResult.visitedCount).toBeLessThanOrEqual(nodes.length);
+      const command = graphCommand(result, `graph_stress_${i}`);
+      expect(Graph.validateScheduledCommand(command).valid).toBe(true);
+      state = Scheduler.applyCommandToCalendar(state, command).calendar;
+    }
+
+    const scheduler = Scheduler.schedulerStateFrom(state);
+    expect(Object.keys(scheduler.events)).toHaveLength(8);
+    expect(Object.keys(scheduler.groups)).toHaveLength(8);
+    expect(JSON.stringify(scheduler).length).toBeLessThan(150000);
+    expect(manager.snapshot().activeChunks).toBe(8);
+    expect(manager.snapshot().residentChunks).toBe(8);
+  });
+
+  test('graph size and invalid edges fail closed instead of creating unbounded work', () => {
+    expect(() => Graph.createGraph({ id: 'empty', nodes: [] })).toThrow('GRAPH_NODE_COUNT_INVALID');
+    expect(() => Graph.createGraph({
+      id: 'skip', nodes: [hex(0), hex(2)], edges: [{ from: hex(0), to: hex(2), routeType: 'road' }], autoConnectAdjacent: false,
+    })).toThrow('GRAPH_EDGE_NOT_ADJACENT');
+  });
+});

--- a/tests/regional_world_graph_realtime.spec.js
+++ b/tests/regional_world_graph_realtime.spec.js
@@ -1,0 +1,70 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+test.describe('Regional World Graph Realtime/Performance guards', () => {
+  test('graph core and runtime are pure of Firebase and polling', () => {
+    const core = read('js/regional-world-graph-core.js');
+    const runtime = read('js/regional-world-graph-runtime.js');
+    for (const source of [core, runtime]) {
+      expect(source).not.toContain('firebase.database');
+      expect(source).not.toContain('.ref(');
+      expect(source).not.toContain('setInterval(');
+      expect(source).not.toContain('setTimeout(');
+    }
+    expect(core).toContain('Travel.segmentDurationSeconds');
+    expect(runtime).toContain('Scheduler.startActivity(command)');
+  });
+
+  test('graph planning submits one scheduler activity rather than per-hex writes', () => {
+    const runtime = read('js/regional-world-graph-runtime.js');
+    const calls = runtime.match(/Scheduler\.startActivity\(command\)/g) || [];
+    expect(calls).toHaveLength(1);
+    expect(runtime).not.toMatch(/for\s*\([^)]*route[^)]*\)[\s\S]{0,200}(set|update|push)\(/);
+    expect(runtime).not.toContain('worldPosition');
+  });
+
+  test('scheduler validates graph-v1 requests without adding a graph Firebase listener', () => {
+    const scheduler = read('js/world-time-scheduler-runtime.js');
+    expect(scheduler).toContain('LuminousRegionalWorldGraphCore');
+    expect(scheduler).toContain('graphCore.validateScheduledCommand');
+    expect(scheduler).toContain('requesterIsDm');
+    expect(scheduler).toContain('routing?.accessMode === "bypass"');
+    expect(scheduler).not.toContain('regional_world_graph_requests');
+    expect(scheduler).not.toMatch(/db\.ref\([^\n]*graph[^\n]*\)\.on\(/i);
+  });
+
+  test('loader installs graph core before scheduler runtime and graph runtime after travel runtime', () => {
+    const loader = read('js/scene-time-engine.js');
+    const travelCore = loader.indexOf("'regional-travel-core'");
+    const graphCore = loader.indexOf("'regional-world-graph-core'");
+    const schedulerRuntime = loader.indexOf("'world-time-scheduler-runtime'");
+    const travelRuntime = loader.indexOf("'regional-travel-runtime'");
+    const graphRuntime = loader.indexOf("'regional-world-graph-runtime'");
+    expect(travelCore).toBeGreaterThan(-1);
+    expect(graphCore).toBeGreaterThan(travelCore);
+    expect(schedulerRuntime).toBeGreaterThan(graphCore);
+    expect(travelRuntime).toBeGreaterThan(schedulerRuntime);
+    expect(graphRuntime).toBeGreaterThan(travelRuntime);
+  });
+
+  test('arrival remains one multipath update and carries graph entry metadata', () => {
+    const travelRuntime = read('js/regional-travel-runtime.js');
+    const updateCalls = travelRuntime.match(/db\.ref\(\)\.update\(updates\)/g) || [];
+    expect(updateCalls).toHaveLength(1);
+    expect(travelRuntime).toContain('regionalEntrySide');
+    expect(travelRuntime).toContain('regionalGraphId');
+    expect(travelRuntime).toContain('regionalGraphRevision');
+    expect(travelRuntime).toContain('regionalGraphFingerprint');
+    expect(travelRuntime).not.toMatch(/for\s*\([^)]*route[^)]*\)/);
+  });
+
+  test('legacy direct regional travel remains available for compatibility', () => {
+    const travelRuntime = read('js/regional-travel-runtime.js');
+    expect(travelRuntime).toContain('function startTravel(input = {})');
+    expect(travelRuntime).toContain('Core.createTravelPlan(input)');
+    expect(travelRuntime).toContain('Scheduler.startActivity(command)');
+  });
+});


### PR DESCRIPTION
Adds deterministic Regional World Graph v1 on top of the existing Regional Travel/World Time stack. Includes jurisdiction (Nest/Backstreets/Outskirts), infrastructure edges, transport-aware fastest routing, access/checkpoint gates, deterministic graph fingerprints, physical destination entry side, and graph-routed scheduled travel. The graph is pure in-memory: no Firebase listeners, no polling, no per-hex writes, and no intermediate chunk streaming. Includes 8-party scheduler/streaming stress coverage plus full repository regression. Merge only after all checks are green and main is synchronized.