### PR TITLE
feat(map): close Regional ↔ Local transitions

### DIFF
--- a/.github/workflows/regional-local-transition.yml
+++ b/.github/workflows/regional-local-transition.yml
@@ -54,11 +54,12 @@ jobs:
           node --check js/regional-local-transition-core.js
           node --check js/regional-travel-runtime.js
           node --check js/scene-time-engine.js
-          node --check js/vtt/regional-local-transition-runtime.js
-          node --check js/vtt/world-streaming-runtime.js
-          node --check js/vtt/main.js
+          node --input-type=module --check < js/vtt/regional-local-transition-runtime.js
+          node --input-type=module --check < js/vtt/world-streaming-runtime.js
+          node --input-type=module --check < js/vtt/main.js
           node --check tests/regional_local_transition.spec.js
           node --check tests/regional_local_transition_realtime.spec.js
+          node --check tests/regional_local_transition_bootstrap.spec.js
           node -e "JSON.parse(require('fs').readFileSync('database.rules.json','utf8'))"
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
@@ -67,6 +68,7 @@ jobs:
           npx playwright test --workers=1
           tests/regional_local_transition.spec.js
           tests/regional_local_transition_realtime.spec.js
+          tests/regional_local_transition_bootstrap.spec.js
           tests/regional_world_graph.spec.js
           tests/regional_world_graph_realtime.spec.js
           tests/regional_travel_engine.spec.js

--- a/.github/workflows/regional-local-transition.yml
+++ b/.github/workflows/regional-local-transition.yml
@@ -1,0 +1,82 @@
+name: Regional Local Transition
+
+on:
+  pull_request:
+    paths:
+      - "js/regional-local-transition-*.js"
+      - "js/regional-travel-*.js"
+      - "js/regional-world-graph-*.js"
+      - "js/scene-time-engine.js"
+      - "js/vtt/regional-local-transition-runtime.js"
+      - "js/vtt/world-streaming-*.js"
+      - "js/vtt/procedural-chunk-streaming-*.js"
+      - "js/vtt/procedural-generator-bootstrap.js"
+      - "js/vtt/main.js"
+      - "database.rules.json"
+      - "tests/regional_local_transition*.spec.js"
+      - "tests/regional_world_graph*.spec.js"
+      - "tests/regional_travel*.spec.js"
+      - "tests/world_time_scheduler*.spec.js"
+      - "tests/vtt_world_streaming_lifecycle.spec.js"
+      - "tests/vtt_performance_guard.spec.js"
+      - "tests/vtt_procedural_chunk_streaming_performance.spec.js"
+      - ".github/workflows/regional-local-transition.yml"
+  push:
+    branches: [main]
+    paths:
+      - "js/regional-local-transition-*.js"
+      - "js/regional-travel-*.js"
+      - "js/vtt/regional-local-transition-runtime.js"
+      - "js/vtt/world-streaming-*.js"
+      - "js/vtt/main.js"
+      - "database.rules.json"
+      - "tests/regional_local_transition*.spec.js"
+      - ".github/workflows/regional-local-transition.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  regional-local-transition-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Syntax
+        run: |
+          node --check js/regional-local-transition-core.js
+          node --check js/regional-travel-runtime.js
+          node --check js/scene-time-engine.js
+          node --check js/vtt/regional-local-transition-runtime.js
+          node --check js/vtt/world-streaming-runtime.js
+          node --check js/vtt/main.js
+          node --check tests/regional_local_transition.spec.js
+          node --check tests/regional_local_transition_realtime.spec.js
+          node -e "JSON.parse(require('fs').readFileSync('database.rules.json','utf8'))"
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Focused regional-local realtime and performance contracts
+        run: >-
+          npx playwright test --workers=1
+          tests/regional_local_transition.spec.js
+          tests/regional_local_transition_realtime.spec.js
+          tests/regional_world_graph.spec.js
+          tests/regional_world_graph_realtime.spec.js
+          tests/regional_travel_engine.spec.js
+          tests/regional_travel_realtime.spec.js
+          tests/world_time_scheduler.spec.js
+          tests/world_time_scheduler_realtime.spec.js
+          tests/scene_time_engine.spec.js
+          tests/theatre_realtime.spec.js
+          tests/vtt_world_streaming_lifecycle.spec.js
+          tests/vtt_performance_guard.spec.js
+          tests/vtt_procedural_chunk_streaming_performance.spec.js
+      - name: Full repository regression
+        run: npx playwright test --workers=1

--- a/database.rules.json
+++ b/database.rules.json
@@ -126,6 +126,15 @@
         }
       }
     },
+    "vtt_regional_local_transition_requests": {
+      "$mapId": {
+        ".read": "auth != null && auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1'",
+        "$requestId": {
+          ".read": "auth != null && (auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1' || data.child('requesterUid').val() === auth.uid)",
+          ".write": "auth != null && (auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1' || (!data.exists() && newData.exists() && newData.child('requesterUid').val() === auth.uid && newData.child('requestId').val() === $requestId && newData.child('mapId').val() === $mapId && newData.child('status').val() === 'pending' && newData.child('playerId').isString() && root.child('campaña').child('jugadores').child(newData.child('playerId').val()).child('uid').val() === auth.uid))"
+        }
+      }
+    },
     "theatre_opposed_checks": {
       ".read": "auth != null && auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1'",
       "$sessionId": {

--- a/js/regional-local-transition-core.js
+++ b/js/regional-local-transition-core.js
@@ -1,0 +1,237 @@
+(function (root, factory) {
+  "use strict";
+  const Travel = typeof module !== "undefined" && module.exports
+    ? require("./regional-travel-core.js")
+    : root?.LuminousRegionalTravelCore;
+  const api = factory(Travel);
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+  if (root) root.LuminousRegionalLocalTransitionCore = api;
+})(typeof window !== "undefined" ? window : globalThis, function (Travel) {
+  "use strict";
+
+  if (!Travel) throw new Error("LUMINOUS_REGIONAL_TRAVEL_CORE_REQUIRED");
+
+  const CONFIG = Object.freeze({
+    schemaVersion: 1,
+    chunkCols: 3,
+    chunkRows: 3,
+    chunkSizeCells: 40,
+    cellSize: 70,
+  });
+
+  const SIDES = Object.freeze(["west", "southwest", "southeast", "east", "northeast", "northwest"]);
+  const OPPOSITE = Object.freeze({
+    west: "east",
+    southwest: "northeast",
+    southeast: "northwest",
+    east: "west",
+    northeast: "southwest",
+    northwest: "southeast",
+  });
+  const EXIT_VECTOR = Object.freeze({
+    west: Object.freeze([-1, 0]),
+    southwest: Object.freeze([-1, 1]),
+    southeast: Object.freeze([0, 1]),
+    east: Object.freeze([1, 0]),
+    northeast: Object.freeze([1, -1]),
+    northwest: Object.freeze([0, -1]),
+  });
+  const ENTRY_ANCHOR = Object.freeze({
+    west: Object.freeze({ chunkCol: 0, chunkRow: 1, cellCol: 0, cellRow: 20 }),
+    southwest: Object.freeze({ chunkCol: 0, chunkRow: 2, cellCol: 10, cellRow: 39 }),
+    southeast: Object.freeze({ chunkCol: 2, chunkRow: 2, cellCol: 29, cellRow: 39 }),
+    east: Object.freeze({ chunkCol: 2, chunkRow: 1, cellCol: 39, cellRow: 20 }),
+    northeast: Object.freeze({ chunkCol: 2, chunkRow: 0, cellCol: 29, cellRow: 0 }),
+    northwest: Object.freeze({ chunkCol: 0, chunkRow: 0, cellCol: 10, cellRow: 0 }),
+  });
+
+  const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const integer = (value, fallback = 0) => Math.trunc(finite(value, fallback));
+  const clean = (value, fallback = "") => String(value ?? fallback).trim() || fallback;
+  const safeKey = (value, fallback = "") => clean(value, fallback).replace(/[.#$\[\]\/]/g, "_").replace(/\s+/g, "_").slice(0, 120) || fallback;
+
+  function normalizeSide(value, fallback = null) {
+    const side = clean(value).toLowerCase();
+    return SIDES.includes(side) ? side : fallback;
+  }
+
+  function zoneIdForHex(rawHex = {}) {
+    const hex = Travel.normalizeHex(rawHex);
+    return `regional_${hex.q}_${hex.r}`;
+  }
+
+  function zoneSeedForHex(worldId, rawHex = {}) {
+    const hex = Travel.normalizeHex(rawHex);
+    return `${safeKey(worldId, "luminous")}:regional-zone:${hex.district}:${hex.q},${hex.r}`;
+  }
+
+  function anchorForSide(sideRaw, options = {}) {
+    const side = normalizeSide(sideRaw);
+    if (!side) throw new Error("REGIONAL_ENTRY_SIDE_REQUIRED");
+    const chunkCols = Math.max(1, integer(options.chunkCols, CONFIG.chunkCols));
+    const chunkRows = Math.max(1, integer(options.chunkRows, CONFIG.chunkRows));
+    const chunkSizeCells = Math.max(1, integer(options.chunkSizeCells, CONFIG.chunkSizeCells));
+    const midCol = Math.floor((chunkCols - 1) / 2), midRow = Math.floor((chunkRows - 1) / 2);
+    const maxChunkCol = chunkCols - 1, maxChunkRow = chunkRows - 1, maxCell = chunkSizeCells - 1;
+    const quarter = Math.max(0, Math.min(maxCell, Math.floor(chunkSizeCells * 0.25)));
+    const threeQuarter = Math.max(0, Math.min(maxCell, Math.floor(chunkSizeCells * 0.75) - 1));
+    const midCell = Math.max(0, Math.min(maxCell, Math.floor(chunkSizeCells / 2)));
+    const anchors = {
+      west: { chunkCol: 0, chunkRow: midRow, cellCol: 0, cellRow: midCell },
+      southwest: { chunkCol: 0, chunkRow: maxChunkRow, cellCol: quarter, cellRow: maxCell },
+      southeast: { chunkCol: maxChunkCol, chunkRow: maxChunkRow, cellCol: threeQuarter, cellRow: maxCell },
+      east: { chunkCol: maxChunkCol, chunkRow: midRow, cellCol: maxCell, cellRow: midCell },
+      northeast: { chunkCol: maxChunkCol, chunkRow: 0, cellCol: threeQuarter, cellRow: 0 },
+      northwest: { chunkCol: 0, chunkRow: 0, cellCol: quarter, cellRow: 0 },
+    };
+    return Object.freeze({ side, ...anchors[side] });
+  }
+
+  function entryPosition(input = {}) {
+    const regionalHex = Travel.normalizeHex(input.regionalHex || input.hex || input.destinationHex || {});
+    const entrySide = normalizeSide(input.entrySide);
+    if (!entrySide) throw new Error("REGIONAL_ENTRY_SIDE_REQUIRED");
+    const cellSize = Math.max(1, finite(input.cellSize, CONFIG.cellSize));
+    const chunkSizeCells = Math.max(1, integer(input.chunkSizeCells, CONFIG.chunkSizeCells));
+    const anchor = anchorForSide(entrySide, {
+      chunkCols: input.chunkCols,
+      chunkRows: input.chunkRows,
+      chunkSizeCells,
+    });
+    const x = (anchor.cellCol + 0.5) * cellSize;
+    const y = (anchor.cellRow + 0.5) * cellSize;
+    return Object.freeze({
+      schemaVersion: CONFIG.schemaVersion,
+      worldId: safeKey(input.worldId, "luminous"),
+      regionId: regionalHex.district,
+      zoneId: safeKey(input.zoneId, zoneIdForHex(regionalHex)),
+      chunkCol: anchor.chunkCol,
+      chunkRow: anchor.chunkRow,
+      x,
+      y,
+      zLayer: integer(input.zLayer, 0),
+      elevationFt: finite(input.elevationFt, 0),
+      regionalHex: Object.freeze({ district: regionalHex.district, q: regionalHex.q, r: regionalHex.r }),
+      entrySide,
+      transitionMode: clean(input.transitionMode, "regional_to_local"),
+      regionalGraphId: safeKey(input.regionalGraphId || input.graphId),
+      regionalGraphRevision: Math.max(0, integer(input.regionalGraphRevision ?? input.graphRevision, 0)),
+      regionalGraphFingerprint: safeKey(input.regionalGraphFingerprint || input.graphFingerprint),
+      travelArrivalId: safeKey(input.travelArrivalId || input.arrivalId),
+      arrivedAtWorldTs: Math.max(0, finite(input.arrivedAtWorldTs, 0)),
+      transitionId: safeKey(input.transitionId),
+    });
+  }
+
+  function targetHexForExit(rawHex = {}, sideRaw) {
+    const source = Travel.normalizeHex(rawHex), side = normalizeSide(sideRaw);
+    if (!side) return null;
+    const vector = EXIT_VECTOR[side];
+    return Object.freeze({ district: source.district, q: source.q + vector[0], r: source.r + vector[1] });
+  }
+
+  function oppositeSide(sideRaw) {
+    const side = normalizeSide(sideRaw);
+    return side ? OPPOSITE[side] : null;
+  }
+
+  function boundaryExitSide(input = {}) {
+    const descriptor = input.descriptor || {};
+    const active = descriptor.activeChunk || input.activeChunk || {};
+    const chunkCols = Math.max(1, integer(descriptor.chunkCols, CONFIG.chunkCols));
+    const chunkRows = Math.max(1, integer(descriptor.chunkRows, CONFIG.chunkRows));
+    const col = integer(active.col ?? active.chunkCol, 0), row = integer(active.row ?? active.chunkRow, 0);
+    const exit = input.exit || {};
+    const dx = Math.sign(integer(exit.dx, 0)), dy = Math.sign(integer(exit.dy, 0));
+    if (!dx && !dy) return null;
+    const west = col <= 0 && dx < 0, east = col >= chunkCols - 1 && dx > 0;
+    const north = row <= 0 && dy < 0, south = row >= chunkRows - 1 && dy > 0;
+    if (north && west) return "northwest";
+    if (north && east) return "northeast";
+    if (south && west) return "southwest";
+    if (south && east) return "southeast";
+    if (west) return row <= 0 ? "northwest" : row >= chunkRows - 1 ? "southwest" : "west";
+    if (east) return row <= 0 ? "northeast" : row >= chunkRows - 1 ? "southeast" : "east";
+    if (north) {
+      if (col < Math.floor(chunkCols / 2)) return "northwest";
+      if (col > Math.floor((chunkCols - 1) / 2)) return "northeast";
+      const width = Math.max(1, finite(exit.width, CONFIG.chunkSizeCells * CONFIG.cellSize));
+      const x = finite(input.requestedPoint?.x, width / 2);
+      return x < width / 2 ? "northwest" : "northeast";
+    }
+    if (south) {
+      if (col < Math.floor(chunkCols / 2)) return "southwest";
+      if (col > Math.floor((chunkCols - 1) / 2)) return "southeast";
+      const width = Math.max(1, finite(exit.width, CONFIG.chunkSizeCells * CONFIG.cellSize));
+      const x = finite(input.requestedPoint?.x, width / 2);
+      return x < width / 2 ? "southwest" : "southeast";
+    }
+    return null;
+  }
+
+  function createLocalExitPlan(input = {}) {
+    const sourcePosition = input.worldPosition || input.position || {};
+    const sourceHex = Travel.normalizeHex(sourcePosition.regionalHex || input.regionalHex || {});
+    const exitSide = normalizeSide(input.exitSide) || boundaryExitSide(input);
+    if (!exitSide) return { valid: false, reason: "regional_exit_side_unresolved" };
+    const targetHex = targetHexForExit(sourceHex, exitSide);
+    if (!targetHex) return { valid: false, reason: "regional_target_unresolved" };
+    const targetEntrySide = oppositeSide(exitSide);
+    const transitionId = safeKey(input.transitionId || `regional_local_${sourceHex.district}_${sourceHex.q}_${sourceHex.r}_${targetHex.q}_${targetHex.r}_${exitSide}`);
+    const targetPosition = entryPosition({
+      worldId: sourcePosition.worldId || input.worldId,
+      regionalHex: targetHex,
+      entrySide: targetEntrySide,
+      cellSize: input.cellSize,
+      chunkCols: input.chunkCols,
+      chunkRows: input.chunkRows,
+      chunkSizeCells: input.chunkSizeCells,
+      zLayer: sourcePosition.zLayer,
+      elevationFt: sourcePosition.elevationFt,
+      regionalGraphId: sourcePosition.regionalGraphId || input.regionalGraphId,
+      regionalGraphRevision: sourcePosition.regionalGraphRevision ?? input.regionalGraphRevision,
+      regionalGraphFingerprint: sourcePosition.regionalGraphFingerprint || input.regionalGraphFingerprint,
+      transitionMode: "local_to_regional_to_local",
+      transitionId,
+    });
+    return {
+      valid: true,
+      transitionId,
+      sourceHex,
+      targetHex,
+      exitSide,
+      targetEntrySide,
+      targetPosition,
+      targetZone: Object.freeze({
+        zoneId: targetPosition.zoneId,
+        seed: zoneSeedForHex(targetPosition.worldId, targetHex),
+        chunkCols: Math.max(1, integer(input.chunkCols, CONFIG.chunkCols)),
+        chunkRows: Math.max(1, integer(input.chunkRows, CONFIG.chunkRows)),
+        activeChunk: Object.freeze({ col: targetPosition.chunkCol, row: targetPosition.chunkRow }),
+      }),
+    };
+  }
+
+  function sameRegionalHex(aRaw = {}, bRaw = {}) {
+    const a = Travel.normalizeHex(aRaw), b = Travel.normalizeHex(bRaw);
+    return a.district === b.district && a.q === b.q && a.r === b.r;
+  }
+
+  return Object.freeze({
+    CONFIG,
+    SIDES,
+    OPPOSITE,
+    EXIT_VECTOR,
+    ENTRY_ANCHOR,
+    normalizeSide,
+    zoneIdForHex,
+    zoneSeedForHex,
+    anchorForSide,
+    entryPosition,
+    targetHexForExit,
+    oppositeSide,
+    boundaryExitSide,
+    createLocalExitPlan,
+    sameRegionalHex,
+  });
+});

--- a/js/regional-travel-runtime.js
+++ b/js/regional-travel-runtime.js
@@ -80,12 +80,10 @@
       const alreadyApplied = members.every((playerId) => players[playerId]?.worldPosition?.travelArrivalId === arrivalId);
       if (alreadyApplied) return false;
 
-      const worldPosition = arrivalWorldPosition(
-        plan,
-        group,
-        arrivalId,
-        group.completedAtWorldTs || group.processedAtWorldTs || 0
-      );
+      const worldPosition = {
+        ...arrivalWorldPosition(plan, group, arrivalId, group.completedAtWorldTs || group.processedAtWorldTs || 0),
+        realtimeUpdatedAt: firebase.database.ServerValue.TIMESTAMP,
+      };
       const updates = {};
       for (const playerId of members) updates[`${PLAYER_ROOT}/${playerId}/worldPosition`] = worldPosition;
       await db.ref().update(updates);

--- a/js/regional-travel-runtime.js
+++ b/js/regional-travel-runtime.js
@@ -45,6 +45,26 @@
     return worldPosition;
   }
 
+  function arrivalWorldPosition(plan, group, arrivalId, arrivedAtWorldTs) {
+    const routing = group?.activity?.payload?.routing;
+    const transition = global.LuminousRegionalLocalTransitionCore;
+    if (routing?.mode === "graph_v1" && routing.destinationEntrySide && transition?.entryPosition) {
+      const destination = plan?.route?.[plan.route.length - 1] || {};
+      return transition.entryPosition({
+        worldId: plan.worldId,
+        regionalHex: destination,
+        entrySide: routing.destinationEntrySide,
+        regionalGraphId: routing.graphId,
+        regionalGraphRevision: routing.graphRevision,
+        regionalGraphFingerprint: routing.graphFingerprint,
+        travelArrivalId: arrivalId,
+        arrivedAtWorldTs,
+        transitionMode: "regional_to_local",
+      });
+    }
+    return applyGraphArrivalMetadata(Core.destinationWorldPosition(plan, arrivalId, arrivedAtWorldTs), group);
+  }
+
   async function applyArrival(group) {
     if (!isDm() || group?.status !== "completed") return false;
     const plan = planFromGroup(group);
@@ -60,9 +80,11 @@
       const alreadyApplied = members.every((playerId) => players[playerId]?.worldPosition?.travelArrivalId === arrivalId);
       if (alreadyApplied) return false;
 
-      const worldPosition = applyGraphArrivalMetadata(
-        Core.destinationWorldPosition(plan, arrivalId, group.completedAtWorldTs || group.processedAtWorldTs || 0),
-        group
+      const worldPosition = arrivalWorldPosition(
+        plan,
+        group,
+        arrivalId,
+        group.completedAtWorldTs || group.processedAtWorldTs || 0
       );
       const updates = {};
       for (const playerId of members) updates[`${PLAYER_ROOT}/${playerId}/worldPosition`] = worldPosition;
@@ -95,6 +117,7 @@
     cancelTravel,
     planFromGroup,
     applyGraphArrivalMetadata,
+    arrivalWorldPosition,
     applyArrival,
     reconcileCompleted,
     stop: () => global.removeEventListener?.("luminous:world-scheduler-updated", onSchedulerUpdated),

--- a/js/scene-time-engine.js
+++ b/js/scene-time-engine.js
@@ -25,12 +25,16 @@
         'regional-world-graph-core',
         'js/regional-world-graph-core.js',
         () => load(
-          'world-time-scheduler-runtime',
-          'js/world-time-scheduler-runtime.js',
+          'regional-local-transition-core',
+          'js/regional-local-transition-core.js',
           () => load(
-            'regional-travel-runtime',
-            'js/regional-travel-runtime.js',
-            () => load('regional-world-graph-runtime', 'js/regional-world-graph-runtime.js')
+            'world-time-scheduler-runtime',
+            'js/world-time-scheduler-runtime.js',
+            () => load(
+              'regional-travel-runtime',
+              'js/regional-travel-runtime.js',
+              () => load('regional-world-graph-runtime', 'js/regional-world-graph-runtime.js')
+            )
           )
         )
       )

--- a/js/vtt/main.js
+++ b/js/vtt/main.js
@@ -208,6 +208,15 @@ document.addEventListener('DOMContentLoaded', async () => {
     import('./movement-bootstrap.js')
         .then((module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }))
         .catch((error) => console.error('VTT movement bootstrap failed:', error));
+    import('./procedural-generator-bootstrap.js')
+        .then(async (generatorModule) => {
+            generatorModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
+            const chunkModule = await import('./procedural-chunk-streaming-runtime.js');
+            chunkModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData, procedural: window.LuminousVttRuntime?.procedural });
+            const transitionModule = await import('./regional-local-transition-runtime.js');
+            return transitionModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
+        })
+        .catch((error) => console.error('VTT procedural / regional-local transition bootstrap failed:', error));
     import('./world-object-mainline-integration.js')
         .then(async (module) => {
             await module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
@@ -235,6 +244,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         window.LuminousVttStructureRuntime?.stop?.();
         window.LuminousVttSurfaceRuntime?.stop?.();
         window.LuminousVttMapHudRuntime?.stop?.();
+        window.LuminousVttRuntime?.regionalLocalTransition?.stop?.();
+        window.LuminousVttRuntime?.proceduralChunks?.stop?.();
+        window.LuminousVttRuntime?.procedural?.stop?.();
         window.LuminousVttRuntime?.movement?.stop?.();
         window.LuminousVttRuntime?.worldObjects?.stop?.();
         window.LuminousVttRuntime?.actorLibrary?.stop?.();

--- a/js/vtt/regional-local-transition-runtime.js
+++ b/js/vtt/regional-local-transition-runtime.js
@@ -1,0 +1,164 @@
+import '../regional-travel-core.js';
+import '../regional-local-transition-core.js';
+import './procedural-chunk-streaming-core.js';
+
+const DM_UID='e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1';
+const REQUEST_ROOT='vtt_regional_local_transition_requests';
+const PLAYER_ROOT='campaña/jugadores';
+const clean=value=>String(value??'').trim();
+const clone=value=>value==null?value:JSON.parse(JSON.stringify(value));
+const firebaseKey=(value,fallback='key')=>clean(value).replace(/[.#$\[\]\/]/g,'_')||fallback;
+
+function hostWindow(){try{if(window.parent&&window.parent!==window&&window.parent.document)return window.parent;}catch(_){}return window;}
+function hostFirebase(){const host=hostWindow();return host?.firebase||window.firebase||null;}
+function currentUid(firebase){try{return clean(firebase?.auth?.().currentUser?.uid);}catch(_){return '';}}
+function makeId(prefix='regional_local'){return`${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2,10)}`;}
+
+export function start({runtime=globalThis.LuminousVttRuntime,mapData=runtime?.engine?.mapData}={}){
+  if(!runtime?.engine||!mapData)return null;
+  if(globalThis.LuminousVttRegionalLocalTransitionRuntime?.api)return globalThis.LuminousVttRegionalLocalTransitionRuntime.api;
+
+  const Transition=globalThis.LuminousRegionalLocalTransitionCore;
+  const Procedural=globalThis.LuminousVttProceduralChunkStreaming;
+  const firebase=hostFirebase();
+  const db=firebase?.database?.()||null;
+  if(!Transition||!Procedural)throw new Error('REGIONAL_LOCAL_TRANSITION_DEPENDENCY_REQUIRED');
+
+  const engine=runtime.engine;
+  const identity=runtime.tokenStateBridge?.identity||{};
+  const mapId=firebaseKey(mapData.id||mapData.mapId||'default','default');
+  const isDm=Boolean(runtime.bridge?.isDm)||currentUid(firebase)===DM_UID;
+  const subscriptions=[];
+  const inFlight=new Set();
+  let stopped=false,lastAppliedMarker='';
+
+  const requestMapRoot=()=>db?.ref(`${REQUEST_ROOT}/${mapId}`);
+  const playerWorldRef=playerId=>db?.ref(`${PLAYER_ROOT}/${firebaseKey(playerId,'player')}/worldPosition`);
+  const playerVttRef=playerId=>db?.ref(`${PLAYER_ROOT}/${firebaseKey(playerId,'player')}/vttTokenState/${mapId}`);
+  const notify=(message,mode='info')=>runtime.controller?.notify?.(message,mode);
+
+  function subscribe(ref,event,handler){if(!ref?.on)return;ref.on(event,handler);subscriptions.push(()=>ref.off(event,handler));}
+  function descriptor(){return globalThis.LuminousVttRuntime?.proceduralChunks?.descriptor?.()||Procedural.createDescriptor(mapData.procedural?.streaming||{});}
+  function viewerToken(){return(mapData.tokens||[]).find(token=>token.viewer===true)||(mapData.tokens||[]).find(token=>token.characterLink?.mode==='current_player')||null;}
+  function tokenPlayerId(token){return clean(token?.canonicalPlayerKey||token?.playerId||token?.characterLink?.playerId||identity.playerId);}
+  function sourceWorldPosition(token){return token?.worldPosition&&typeof token.worldPosition==='object'?token.worldPosition:null;}
+
+  function requestedPoint(event,drag){const world=engine.eventWorldPoint(event);return{x:world.x-drag.grabOffsetX,y:world.y-drag.grabOffsetY};}
+  function restoreDrag(drag){
+    drag.token.x=drag.originX;drag.token.y=drag.originY;drag.token.zLayer=drag.originZ;drag.token.z=[drag.originZ];
+    drag.token.elevationFt=drag.originElevationFt;engine.tokenDrag=null;if(engine.canvas?.style)engine.canvas.style.cursor='default';
+  }
+
+  async function submitBoundaryRequest({token,position,transition,requested}){
+    if(!db)throw new Error('REGIONAL_LOCAL_REALTIME_REQUIRED');
+    const playerId=tokenPlayerId(token),uid=currentUid(firebase);
+    if(!playerId||!uid)throw new Error('REGIONAL_LOCAL_PLAYER_IDENTITY_REQUIRED');
+    const exitSide=Transition.boundaryExitSide({descriptor:descriptor(),exit:transition.exit,requestedPoint:requested});
+    if(!exitSide)throw new Error('REGIONAL_EXIT_SIDE_UNRESOLVED');
+    const requestId=makeId('regional_local');
+    const payload={
+      schemaVersion:1,requestId,mapId,playerId,tokenId:clean(token.id),requesterUid:uid,status:'pending',
+      sourceZoneId:clean(position.zoneId),sourceRegionalHex:clone(position.regionalHex),
+      sourceChunk:{col:Number(position.chunkCol)||0,row:Number(position.chunkRow)||0},exitSide,
+      requestedAt:firebase.database.ServerValue.TIMESTAMP,
+    };
+    await db.ref(`${REQUEST_ROOT}/${mapId}/${requestId}`).set(payload);
+    notify('Transición regional solicitada.','pending');
+    return requestId;
+  }
+
+  async function consumeRequest(snapshot){
+    if(!isDm||!snapshot?.ref)return;
+    const request=snapshot.val()||{},requestId=clean(request.requestId||snapshot.key);
+    if(!requestId||inFlight.has(requestId))return;
+    inFlight.add(requestId);
+    try{
+      const playerId=clean(request.playerId),requesterUid=clean(request.requesterUid);
+      const playerSnapshot=await db.ref(`${PLAYER_ROOT}/${firebaseKey(playerId,'player')}`).once('value');
+      const player=playerSnapshot.val()||{},stored=player.worldPosition||null;
+      const ownerUid=clean(player.uid||player.userUid||player.ownerUid||player.firebaseUid||player.authUid);
+      let reason='';
+      if(request.status!=='pending')reason='REQUEST_NOT_PENDING';
+      else if(!playerId||!stored?.regionalHex)reason='WORLD_POSITION_REQUIRED';
+      else if(requesterUid!==DM_UID&&ownerUid!==requesterUid)reason='PLAYER_OWNERSHIP_REQUIRED';
+      else if(clean(request.sourceZoneId)!==clean(stored.zoneId))reason='STALE_ZONE_REQUEST';
+      else if(!Transition.sameRegionalHex(request.sourceRegionalHex||{},stored.regionalHex||{}))reason='STALE_HEX_REQUEST';
+
+      let plan=null;
+      if(!reason){
+        plan=Transition.createLocalExitPlan({worldPosition:stored,exitSide:request.exitSide,transitionId:requestId,cellSize:mapData.grid?.size||70,chunkCols:3,chunkRows:3,chunkSizeCells:40});
+        if(!plan.valid)reason=plan.reason||'REGIONAL_TRANSITION_INVALID';
+      }
+
+      if(!reason&&stored.regionalGraphId){
+        const Graph=globalThis.LuminousRegionalWorldGraphCore,graph=Graph?.getGraph?.(stored.regionalGraphId)||null;
+        const targetNode=graph?.nodes?.get?.(`${plan.targetHex.district}:${plan.targetHex.q},${plan.targetHex.r}`)||null;
+        if(graph&&!targetNode)reason='REGIONAL_GRAPH_TARGET_MISSING';
+        else if(targetNode?.blocked)reason='REGIONAL_GRAPH_TARGET_BLOCKED';
+        else if(requesterUid!==DM_UID&&targetNode?.requiredAccess?.length)reason='REGIONAL_ACCESS_REQUIRED';
+      }
+
+      if(reason){await snapshot.ref.remove();notify(`Transición regional rechazada: ${reason}.`,'error');return;}
+      const targetPosition={...plan.targetPosition,realtimeUpdatedAt:firebase.database.ServerValue.TIMESTAMP};
+      const updates={};
+      updates[`${PLAYER_ROOT}/${firebaseKey(playerId,'player')}/worldPosition`]=targetPosition;
+      updates[`${REQUEST_ROOT}/${mapId}/${requestId}`]=null;
+      await db.ref().update(updates);
+    }catch(error){console.error('VTT REGIONAL LOCAL REQUEST FAILED:',error);try{await snapshot.ref.remove();}catch(_){} }
+    finally{inFlight.delete(requestId);}
+  }
+
+  async function applyAuthoritativePosition(position){
+    if(isDm||!position?.regionalHex||!position?.zoneId)return false;
+    const marker=clean(position.transitionId||position.travelArrivalId)||`${position.zoneId}:${position.chunkCol},${position.chunkRow}:${Number(position.realtimeUpdatedAt)||0}`;
+    if(marker&&marker===lastAppliedMarker)return false;
+    const token=viewerToken();if(!token)return false;
+    const playerId=tokenPlayerId(token);if(!playerId)return false;
+
+    let visualUpdatedAt=0;
+    if(db){try{const snap=await playerVttRef(playerId).once('value');visualUpdatedAt=Number(snap.val()?.updatedAt)||0;}catch(_){} }
+    const authoritativeUpdatedAt=Number(position.realtimeUpdatedAt)||0;
+    const applyEntry=!visualUpdatedAt||!authoritativeUpdatedAt||authoritativeUpdatedAt>=visualUpdatedAt;
+    const current=descriptor();
+    const next=Procedural.createDescriptor({
+      ...current,zoneId:position.zoneId,seed:Transition.zoneSeedForHex(position.worldId,position.regionalHex),
+      chunkCols:3,chunkRows:3,activeChunk:{col:Number(position.chunkCol)||0,row:Number(position.chunkRow)||0},
+    });
+    const chunks=globalThis.LuminousVttRuntime?.proceduralChunks;
+    if(chunks?.activateChunk){
+      await chunks.activateChunk(next,next.activeChunk,{tokenId:token.id,persist:false,publish:false,center:false});
+    }else{
+      mapData.procedural||={};mapData.procedural.streaming=next;
+    }
+    token.worldPosition=clone(position);
+    if(applyEntry){
+      token.x=Number(position.x)||0;token.y=Number(position.y)||0;
+      token.zLayer=Number(position.zLayer)||0;token.z=[token.zLayer];token.elevationFt=Number(position.elevationFt)||0;
+      token.gridPosition={...(token.gridPosition||{}),col:Math.floor(token.x/(mapData.grid?.size||70)),row:Math.floor(token.y/(mapData.grid?.size||70)),z:token.zLayer};
+      await runtime.tokenStateBridge?.saveToken?.(token);
+    }
+    lastAppliedMarker=marker;
+    engine.canvas?.dispatchEvent?.(new CustomEvent('vtt:regional-local-transition-applied',{detail:{playerId,tokenId:token.id,worldPosition:clone(position),applyEntry}}));
+    engine.camera?.centerOnToken?.(token);
+    return true;
+  }
+
+  function captureBoundary(event){
+    const drag=engine.tokenDrag,desc=descriptor();if(!drag||!desc||event.button!==0)return;
+    const requested=requestedPoint(event,drag),transition=Procedural.resolveTransition(desc,requested,mapData.grid);
+    if(transition?.valid||transition?.reason!=='PROCEDURAL_ZONE_BOUNDARY')return;
+    const token=drag.token,position=sourceWorldPosition(token);
+    if(!position?.regionalHex)return;
+    event.preventDefault();event.stopImmediatePropagation();restoreDrag(drag);
+    Promise.resolve(submitBoundaryRequest({token,position,transition,requested})).catch(error=>{console.error('VTT REGIONAL LOCAL REQUEST SUBMIT FAILED:',error);notify(error?.message||'REGIONAL_LOCAL_REQUEST_FAILED','error');});
+  }
+
+  window.addEventListener('mouseup',captureBoundary,true);
+  if(db&&isDm)subscribe(requestMapRoot(),'child_added',snapshot=>{consumeRequest(snapshot).catch(error=>console.error('VTT REGIONAL LOCAL CONSUME FAILED:',error));});
+  if(db&&!isDm&&identity.playerId)subscribe(playerWorldRef(identity.playerId),'value',snapshot=>{applyAuthoritativePosition(snapshot.val()||{}).catch(error=>console.error('VTT REGIONAL LOCAL APPLY FAILED:',error));});
+
+  const api=Object.freeze({Transition,Procedural,REQUEST_ROOT,mapId,isDm,submitBoundaryRequest,consumeRequest,applyAuthoritativePosition,stop(){if(stopped)return;stopped=true;window.removeEventListener('mouseup',captureBoundary,true);subscriptions.splice(0).forEach(unsubscribe=>unsubscribe());inFlight.clear();}});
+  globalThis.LuminousVttRegionalLocalTransitionRuntime={api};
+  globalThis.LuminousVttRuntime=Object.freeze({...globalThis.LuminousVttRuntime,regionalLocalTransition:api});
+  return api;
+}

--- a/js/vtt/world-streaming-runtime.js
+++ b/js/vtt/world-streaming-runtime.js
@@ -1,6 +1,8 @@
 import './world-streaming-core.js';
 
 const clean=value=>String(value??'').trim();
+const clone=value=>value==null?value:JSON.parse(JSON.stringify(value));
+const REGIONAL_KEYS=Object.freeze(['regionalHex','entrySide','regionalEntrySide','transitionMode','transitionId','regionalGraphId','regionalGraphRevision','regionalGraphFingerprint','travelArrivalId','arrivedAtWorldTs']);
 
 export function start({runtime=globalThis.LuminousVttRuntime,mapData=runtime?.engine?.mapData}={}){
   if(!runtime?.engine||!mapData)return null;
@@ -14,12 +16,14 @@ export function start({runtime=globalThis.LuminousVttRuntime,mapData=runtime?.en
     const streaming=mapData.procedural?.streaming||{};
     return{worldId:clean(mapData.worldId||mapData.world?.id)||'luminous',regionId:clean(mapData.regionId||mapData.region?.id)||'region',zoneId:clean(streaming.zoneId||mapData.zoneId||mapData.id||mapData.mapId)||'zone',chunkCol:Number(currentChunk?.col)||0,chunkRow:Number(currentChunk?.row)||0,cellSize:mapData.grid?.size||70,chunkSizeCells:40};
   }
+  function regionalMetadata(prior={}){const meta={};for(const key of REGIONAL_KEYS)if(prior[key]!=null&&prior[key]!=='')meta[key]=clone(prior[key]);return meta;}
   function positionForToken(token,chunkOverride=null){
     const prior=token?.worldPosition||{},base=basePosition(),chunk=chunkOverride||null;
-    return core.normalizeWorldPosition({...base,...prior,chunkCol:chunk?.col??prior.chunkCol??base.chunkCol,chunkRow:chunk?.row??prior.chunkRow??base.chunkRow,x:token?.x??prior.x??0,y:token?.y??prior.y??0,zLayer:token?.zLayer??token?.gridPosition?.z??prior.zLayer??0,elevationFt:token?.elevationFt??prior.elevationFt??0},{cellSize:mapData.grid?.size||70,chunkSizeCells:40});
+    const normalized=core.normalizeWorldPosition({...base,...prior,chunkCol:chunk?.col??prior.chunkCol??base.chunkCol,chunkRow:chunk?.row??prior.chunkRow??base.chunkRow,x:token?.x??prior.x??0,y:token?.y??prior.y??0,zLayer:token?.zLayer??token?.gridPosition?.z??prior.zLayer??0,elevationFt:token?.elevationFt??prior.elevationFt??0},{cellSize:mapData.grid?.size||70,chunkSizeCells:40});
+    return Object.freeze({...normalized,...regionalMetadata(prior)});
   }
   function actorRecords(){return(mapData.tokens||[]).map(token=>({id:token.id,position:positionForToken(token)})).filter(entry=>clean(entry.id));}
-  function persistTokenPosition(token,position){if(!token)return null;token.worldPosition={worldId:position.worldId,regionId:position.regionId,zoneId:position.zoneId,chunkCol:position.chunkCol,chunkRow:position.chunkRow,x:position.x,y:position.y,zLayer:position.zLayer,elevationFt:position.elevationFt};return token.worldPosition;}
+  function persistTokenPosition(token,position){if(!token)return null;token.worldPosition={worldId:position.worldId,regionId:position.regionId,zoneId:position.zoneId,chunkCol:position.chunkCol,chunkRow:position.chunkRow,x:position.x,y:position.y,zLayer:position.zLayer,elevationFt:position.elevationFt,...regionalMetadata(position)};return token.worldPosition;}
   function reconcile(now=Date.now()){for(const token of mapData.tokens||[])persistTokenPosition(token,positionForToken(token));const result=manager.reconcile(actorRecords(),now);mapData.worldStreaming={schemaVersion:core.SCHEMA_VERSION,...result.metrics};return result;}
   function onTokenMoved(event){
     const detail=event?.detail||{},token=(mapData.tokens||[]).find(entry=>String(entry.id)===String(detail.tokenId));if(!token)return;
@@ -29,6 +33,6 @@ export function start({runtime=globalThis.LuminousVttRuntime,mapData=runtime?.en
   function onChunkLoaded(event){const chunk=event?.detail?.chunk;if(chunk)currentChunk={col:Number(chunk.col)||0,row:Number(chunk.row)||0};reconcile();}
   canvas?.addEventListener?.('vtt:token-moved',onTokenMoved);canvas?.addEventListener?.('vtt:procedural-chunk-loaded',onChunkLoaded);
   const initial=reconcile();
-  const api=Object.freeze({core,manager,reconcile,positionForToken,compactChunkRecord:core.createDormantRecord,snapshot:()=>manager.snapshot(),get initial(){return initial;},stop(){if(stopped)return;stopped=true;canvas?.removeEventListener?.('vtt:token-moved',onTokenMoved);canvas?.removeEventListener?.('vtt:procedural-chunk-loaded',onChunkLoaded);}});
+  const api=Object.freeze({core,manager,reconcile,positionForToken,persistTokenPosition,compactChunkRecord:core.createDormantRecord,snapshot:()=>manager.snapshot(),get initial(){return initial;},stop(){if(stopped)return;stopped=true;canvas?.removeEventListener?.('vtt:token-moved',onTokenMoved);canvas?.removeEventListener?.('vtt:procedural-chunk-loaded',onChunkLoaded);}});
   globalThis.LuminousVttWorldStreamingRuntime={api};globalThis.LuminousVttRuntime=Object.freeze({...globalThis.LuminousVttRuntime,worldStreaming:api});return api;
 }

--- a/tests/regional_local_transition.spec.js
+++ b/tests/regional_local_transition.spec.js
@@ -1,0 +1,122 @@
+const { test, expect } = require('@playwright/test');
+const Transition = require('../js/regional-local-transition-core.js');
+const Travel = require('../js/regional-travel-core.js');
+const Streaming = require('../js/vtt/world-streaming-core.js');
+
+const hex = (q, r = 0, district = 'K') => ({ district, q, r });
+const basePosition = (q = 0, r = 0) => ({
+  worldId: 'luminous', regionId: 'K', zoneId: `regional_${q}_${r}`,
+  chunkCol: 1, chunkRow: 1, x: 1400, y: 1400, zLayer: 0, elevationFt: 0,
+  regionalHex: hex(q, r),
+});
+
+test.describe('Regional ↔ Local Transition', () => {
+  test('all six regional entry sides land inside exactly one edge chunk', () => {
+    const expected = {
+      west: [0, 1, 0, 20],
+      southwest: [0, 2, 10, 39],
+      southeast: [2, 2, 29, 39],
+      east: [2, 1, 39, 20],
+      northeast: [2, 0, 29, 0],
+      northwest: [0, 0, 10, 0],
+    };
+    for (const side of Transition.SIDES) {
+      const anchor = Transition.anchorForSide(side);
+      expect([anchor.chunkCol, anchor.chunkRow, anchor.cellCol, anchor.cellRow]).toEqual(expected[side]);
+      const position = Transition.entryPosition({ worldId: 'luminous', regionalHex: hex(4, -2), entrySide: side });
+      expect(position.zoneId).toBe('regional_4_-2');
+      expect(position.regionalHex).toEqual(hex(4, -2));
+      expect(position.entrySide).toBe(side);
+      expect(position.x).toBeGreaterThan(0);
+      expect(position.x).toBeLessThan(40 * 70);
+      expect(position.y).toBeGreaterThan(0);
+      expect(position.y).toBeLessThan(40 * 70);
+    }
+  });
+
+  test('exit vectors and opposite entry sides round-trip every axial direction', () => {
+    const origin = hex(5, -3);
+    for (const side of Transition.SIDES) {
+      const target = Transition.targetHexForExit(origin, side);
+      const back = Transition.targetHexForExit(target, Transition.oppositeSide(side));
+      expect(back).toEqual(origin);
+      expect(Travel.areAdjacent(origin, target)).toBe(true);
+    }
+  });
+
+  test('zone boundary resolver maps the six physical exits deterministically', () => {
+    const descriptor = { chunkCols: 3, chunkRows: 3 };
+    expect(Transition.boundaryExitSide({ descriptor: { ...descriptor, activeChunk: { col: 0, row: 1 } }, exit: { dx: -1, dy: 0 } })).toBe('west');
+    expect(Transition.boundaryExitSide({ descriptor: { ...descriptor, activeChunk: { col: 2, row: 1 } }, exit: { dx: 1, dy: 0 } })).toBe('east');
+    expect(Transition.boundaryExitSide({ descriptor: { ...descriptor, activeChunk: { col: 0, row: 0 } }, exit: { dx: -1, dy: -1 } })).toBe('northwest');
+    expect(Transition.boundaryExitSide({ descriptor: { ...descriptor, activeChunk: { col: 2, row: 0 } }, exit: { dx: 1, dy: -1 } })).toBe('northeast');
+    expect(Transition.boundaryExitSide({ descriptor: { ...descriptor, activeChunk: { col: 0, row: 2 } }, exit: { dx: -1, dy: 1 } })).toBe('southwest');
+    expect(Transition.boundaryExitSide({ descriptor: { ...descriptor, activeChunk: { col: 2, row: 2 } }, exit: { dx: 1, dy: 1 } })).toBe('southeast');
+  });
+
+  test('central north/south boundary uses cursor half to choose the correct hex side', () => {
+    const descriptorNorth = { chunkCols: 3, chunkRows: 3, activeChunk: { col: 1, row: 0 } };
+    const descriptorSouth = { chunkCols: 3, chunkRows: 3, activeChunk: { col: 1, row: 2 } };
+    expect(Transition.boundaryExitSide({ descriptor: descriptorNorth, exit: { dx: 0, dy: -1, width: 2800 }, requestedPoint: { x: 500 } })).toBe('northwest');
+    expect(Transition.boundaryExitSide({ descriptor: descriptorNorth, exit: { dx: 0, dy: -1, width: 2800 }, requestedPoint: { x: 2200 } })).toBe('northeast');
+    expect(Transition.boundaryExitSide({ descriptor: descriptorSouth, exit: { dx: 0, dy: 1, width: 2800 }, requestedPoint: { x: 500 } })).toBe('southwest');
+    expect(Transition.boundaryExitSide({ descriptor: descriptorSouth, exit: { dx: 0, dy: 1, width: 2800 }, requestedPoint: { x: 2200 } })).toBe('southeast');
+  });
+
+  test('local exit creates adjacent target hex and enters from the opposite side', () => {
+    const plan = Transition.createLocalExitPlan({ worldPosition: basePosition(), exitSide: 'east', transitionId: 'move_1' });
+    expect(plan.valid).toBe(true);
+    expect(plan.sourceHex).toEqual(hex(0, 0));
+    expect(plan.targetHex).toEqual(hex(1, 0));
+    expect(plan.targetEntrySide).toBe('west');
+    expect(plan.targetPosition.zoneId).toBe('regional_1_0');
+    expect(plan.targetPosition.chunkCol).toBe(0);
+    expect(plan.targetPosition.chunkRow).toBe(1);
+    expect(plan.targetPosition.transitionId).toBe('move_1');
+    expect(plan.targetZone.activeChunk).toEqual({ col: 0, row: 1 });
+  });
+
+  test('regional zone seed is deterministic and changes with the hex', () => {
+    const a = Transition.zoneSeedForHex('luminous', hex(3, 2));
+    expect(a).toBe(Transition.zoneSeedForHex('luminous', hex(3, 2)));
+    expect(a).not.toBe(Transition.zoneSeedForHex('luminous', hex(4, 2)));
+  });
+
+  test('transition preserves graph identity and vertical metadata', () => {
+    const source = {
+      ...basePosition(), zLayer: 2, elevationFt: 15,
+      regionalGraphId: 'k_graph', regionalGraphRevision: 7, regionalGraphFingerprint: 'abc123',
+    };
+    const plan = Transition.createLocalExitPlan({ worldPosition: source, exitSide: 'northwest', transitionId: 'meta' });
+    expect(plan.targetPosition.zLayer).toBe(2);
+    expect(plan.targetPosition.elevationFt).toBe(15);
+    expect(plan.targetPosition.regionalGraphId).toBe('k_graph');
+    expect(plan.targetPosition.regionalGraphRevision).toBe(7);
+    expect(plan.targetPosition.regionalGraphFingerprint).toBe('abc123');
+  });
+
+  test('eight simultaneous local exits remain eight active chunks, not eight full 3x3 zones', () => {
+    const manager = Streaming.createLifecycleManager({ warmTtlMs: 0, maxWarmChunks: 0, maxActiveChunks: 8 });
+    const actors = [];
+    for (let i = 0; i < 8; i += 1) {
+      const plan = Transition.createLocalExitPlan({ worldPosition: basePosition(i * 2, i), exitSide: 'east', transitionId: `t${i}` });
+      expect(plan.valid).toBe(true);
+      actors.push({ id: `p${i}`, position: plan.targetPosition });
+    }
+    const result = manager.reconcile(actors, 0);
+    expect(result.metrics.activeChunks).toBe(8);
+    expect(result.metrics.residentChunks).toBe(8);
+    expect(result.metrics.liveCells).toBe(8 * 40 * 40);
+  });
+
+  test('ten thousand transition calculations retain no registry or runtime state', () => {
+    let checksum = 0;
+    for (let i = 0; i < 10000; i += 1) {
+      const plan = Transition.createLocalExitPlan({ worldPosition: basePosition(i % 100, Math.floor(i / 100)), exitSide: Transition.SIDES[i % 6], transitionId: `x${i}` });
+      expect(plan.valid).toBe(true);
+      checksum += plan.targetHex.q + plan.targetHex.r;
+    }
+    expect(Number.isFinite(checksum)).toBe(true);
+    expect(Object.keys(Transition).includes('registry')).toBe(false);
+  });
+});

--- a/tests/regional_local_transition_bootstrap.spec.js
+++ b/tests/regional_local_transition_bootstrap.spec.js
@@ -1,0 +1,19 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+test('regional-local bootstrap keeps procedural runtimes singleton-safe', () => {
+  const main = read('js/vtt/main.js');
+  const generator = read('js/vtt/procedural-generator-bootstrap.js');
+  const chunks = read('js/vtt/procedural-chunk-streaming-runtime.js');
+  const transition = read('js/vtt/regional-local-transition-runtime.js');
+
+  expect(generator).toContain('LuminousVttProceduralGeneratorRuntime?.api');
+  expect(chunks).toContain('LuminousVttProceduralChunkStreamingRuntime?.api');
+  expect(transition).toContain('LuminousVttRegionalLocalTransitionRuntime?.api');
+  expect(main).toContain("import('./procedural-generator-bootstrap.js')");
+  expect(main).toContain("import('./procedural-chunk-streaming-runtime.js')");
+  expect(main).toContain("import('./regional-local-transition-runtime.js')");
+});

--- a/tests/regional_local_transition_realtime.spec.js
+++ b/tests/regional_local_transition_realtime.spec.js
@@ -1,0 +1,92 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+const core = read('js/regional-local-transition-core.js');
+const runtime = read('js/vtt/regional-local-transition-runtime.js');
+const travelRuntime = read('js/regional-travel-runtime.js');
+const streamingRuntime = read('js/vtt/world-streaming-runtime.js');
+const main = read('js/vtt/main.js');
+const rules = JSON.parse(read('database.rules.json'));
+
+test.describe('Regional ↔ Local Realtime/performance contract', () => {
+  test('transition core is pure and contains no Realtime or timer loop', () => {
+    expect(core).not.toContain('firebase');
+    expect(core).not.toContain('.database(');
+    expect(core).not.toContain('setInterval(');
+    expect(core).not.toContain('requestAnimationFrame(');
+    expect(core).not.toContain('.on("value"');
+    expect(core).not.toContain(".on('value'");
+  });
+
+  test('runtime only requests a regional exit on mouseup, never mousemove or per-frame', () => {
+    expect(runtime).toContain("window.addEventListener('mouseup',captureBoundary,true)");
+    expect(runtime).not.toContain("addEventListener('mousemove'");
+    expect(runtime).not.toContain('setInterval(');
+    expect(runtime).not.toContain('requestAnimationFrame(');
+    expect(runtime).not.toContain('setTimeout(');
+  });
+
+  test('DM commits target worldPosition and consumes request in one atomic root update', () => {
+    expect(runtime).toContain("updates[`${PLAYER_ROOT}/${firebaseKey(playerId,'player')}/worldPosition`]=targetPosition");
+    expect(runtime).toContain("updates[`${REQUEST_ROOT}/${mapId}/${requestId}`]=null");
+    expect(runtime).toContain('await db.ref().update(updates)');
+    expect(runtime).not.toContain('playerWorldRef(playerId).set(');
+  });
+
+  test('player listens only to its own authoritative worldPosition, not another global players listener', () => {
+    expect(runtime).toContain("subscribe(playerWorldRef(identity.playerId),'value'");
+    expect(runtime).not.toContain("db.ref(PLAYER_ROOT).on('value'");
+    expect(runtime).not.toContain('db.ref(PLAYER_ROOT).on("value"');
+  });
+
+  test('regional travel arrival remains one multipath write for every party member', () => {
+    expect(travelRuntime).toContain('await db.ref().update(updates)');
+    expect(travelRuntime).toContain('LuminousRegionalLocalTransitionCore');
+    expect(travelRuntime).toContain('routing.destinationEntrySide');
+    expect(travelRuntime).not.toContain('setInterval(');
+  });
+
+  test('local world streaming preserves regional identity while tokens move inside a zone', () => {
+    for (const key of ['regionalHex','transitionId','regionalGraphId','regionalGraphRevision','regionalGraphFingerprint','travelArrivalId']) {
+      expect(streamingRuntime).toContain(key);
+    }
+    expect(streamingRuntime).toContain('regionalMetadata(prior)');
+  });
+
+  test('main boot order guarantees generator then chunk streaming then regional-local bridge', () => {
+    const generator = main.indexOf("import('./procedural-generator-bootstrap.js')");
+    const chunks = main.indexOf("import('./procedural-chunk-streaming-runtime.js')");
+    const transition = main.indexOf("import('./regional-local-transition-runtime.js')");
+    expect(generator).toBeGreaterThan(-1);
+    expect(chunks).toBeGreaterThan(generator);
+    expect(transition).toBeGreaterThan(chunks);
+    expect(main).toContain('regionalLocalTransition?.stop?.()');
+    expect(main).toContain('proceduralChunks?.stop?.()');
+  });
+
+  test('Firebase rules make player transition requests create-only and ownership-bound', () => {
+    const requestRule = rules.rules.vtt_regional_local_transition_requests.$mapId.$requestId['.write'];
+    expect(requestRule).toContain('!data.exists()');
+    expect(requestRule).toContain('newData.exists()');
+    expect(requestRule).toContain("newData.child('requesterUid').val() === auth.uid");
+    expect(requestRule).toContain("newData.child('playerId').isString()");
+    expect(requestRule).toContain("root.child('campaña').child('jugadores').child(newData.child('playerId').val()).child('uid').val() === auth.uid");
+    expect(requestRule).toContain("auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1'");
+  });
+
+  test('new transition path never writes or subscribes to the global calendar', () => {
+    expect(runtime).not.toContain('campaña/calendario');
+    expect(runtime).not.toContain('world_scheduler');
+    expect(core).not.toContain('campaña/calendario');
+  });
+
+  test('authoritative apply activates only destination chunk and saves legacy visual state once', () => {
+    expect(runtime).toContain('chunks.activateChunk(next,next.activeChunk,{tokenId:token.id,persist:false,publish:false,center:false})');
+    const saves = (runtime.match(/tokenStateBridge\?\.saveToken\?\./g) || []).length;
+    expect(saves).toBe(1);
+    expect(runtime).not.toContain('for(const chunk');
+    expect(runtime).not.toContain('for (const chunk');
+  });
+});


### PR DESCRIPTION
Closes the Regional ↔ Local map transition contract on top of Regional World Graph, Travel and chunk streaming. Regional arrivals now land on the physical entry edge of the destination 3×3 Zone; exiting the outer Zone boundary resolves the adjacent Regional Hex and opposite entry edge. Player boundary exits are request-only, DM-recomputed, and committed as one atomic worldPosition update with no polling, no mousemove writes, no per-frame persistence and no intermediate chunk generation. Preserves regional metadata through local streaming, bootstraps procedural generator → chunk streaming → transition bridge in singleton-safe order, and adds 8-player/performance plus full regression gates. Merge only after all workflows are green and main is synchronized.