### PR TITLE
feat(vtt): add map simulation bubbles and seed-delta persistence

### DIFF
--- a/.github/workflows/vtt-map-simulation-persistence.yml
+++ b/.github/workflows/vtt-map-simulation-persistence.yml
@@ -1,0 +1,70 @@
+name: VTT Map Simulation Persistence
+
+on:
+  pull_request:
+    paths:
+      - 'js/vtt/map-simulation-*.js'
+      - 'js/vtt/world-streaming-*.js'
+      - 'js/vtt/world-object-state.js'
+      - 'js/vtt/main.js'
+      - 'database.rules.json'
+      - 'tests/vtt_map_simulation*.spec.js'
+      - 'tests/vtt_world_streaming_lifecycle.spec.js'
+      - 'tests/vtt_world_objects.spec.js'
+      - 'tests/vtt_performance_guard.spec.js'
+      - 'tests/vtt_procedural_chunk_streaming_performance.spec.js'
+      - 'tests/regional_local_transition*.spec.js'
+      - '.github/workflows/vtt-map-simulation-persistence.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'js/vtt/map-simulation-*.js'
+      - 'js/vtt/world-streaming-*.js'
+      - 'js/vtt/world-object-state.js'
+      - 'js/vtt/main.js'
+      - 'tests/vtt_map_simulation*.spec.js'
+      - '.github/workflows/vtt-map-simulation-persistence.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  map-simulation-persistence:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Syntax
+        run: |
+          node --check js/vtt/map-simulation-core.js
+          node --input-type=module --check < js/vtt/map-simulation-runtime.js
+          node --check js/vtt/world-streaming-core.js
+          node --input-type=module --check < js/vtt/world-streaming-runtime.js
+          node --check js/vtt/world-object-state.js
+          node --input-type=module --check < js/vtt/main.js
+          node --check tests/vtt_map_simulation_bubbles.spec.js
+          node --check tests/vtt_map_simulation_realtime.spec.js
+          node -e "JSON.parse(require('fs').readFileSync('database.rules.json','utf8'))"
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Focused simulation realtime persistence and performance contracts
+        run: >-
+          npx playwright test --workers=1
+          tests/vtt_map_simulation_bubbles.spec.js
+          tests/vtt_map_simulation_realtime.spec.js
+          tests/vtt_world_streaming_lifecycle.spec.js
+          tests/vtt_world_objects.spec.js
+          tests/vtt_performance_guard.spec.js
+          tests/vtt_procedural_chunk_streaming_performance.spec.js
+          tests/regional_local_transition.spec.js
+          tests/regional_local_transition_realtime.spec.js
+          tests/regional_local_transition_bootstrap.spec.js
+      - name: Full repository regression
+        run: npx playwright test --workers=1

--- a/js/vtt/main.js
+++ b/js/vtt/main.js
@@ -171,7 +171,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         currentMapId: initialMapId,
         resolveActiveDefinition: () => mapAuthoringState?.resolveActiveDefinition?.({ fallback: mockMapData }),
         reload: () => window.location.reload(),
-        notify: (message, mode) => controller?.notify?.(message, mode),
+        notify: (message, mode) => controller?.notify(message, mode),
         log: console,
     }) || null;
     const stopMapWatch = mapAuthoringState?.watchActiveMap?.({
@@ -214,9 +214,11 @@ document.addEventListener('DOMContentLoaded', async () => {
             const chunkModule = await import('./procedural-chunk-streaming-runtime.js');
             chunkModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData, procedural: window.LuminousVttRuntime?.procedural });
             const transitionModule = await import('./regional-local-transition-runtime.js');
-            return transitionModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
+            transitionModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
+            const simulationModule = await import('./map-simulation-runtime.js');
+            return simulationModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
         })
-        .catch((error) => console.error('VTT procedural / regional-local transition bootstrap failed:', error));
+        .catch((error) => console.error('VTT procedural / regional-local / map simulation bootstrap failed:', error));
     import('./world-object-mainline-integration.js')
         .then(async (module) => {
             await module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
@@ -244,7 +246,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         window.LuminousVttStructureRuntime?.stop?.();
         window.LuminousVttSurfaceRuntime?.stop?.();
         window.LuminousVttMapHudRuntime?.stop?.();
+        window.LuminousVttRuntime?.mapSimulation?.stop?.();
         window.LuminousVttRuntime?.regionalLocalTransition?.stop?.();
+        window.LuminousVttRuntime?.worldStreaming?.stop?.();
         window.LuminousVttRuntime?.proceduralChunks?.stop?.();
         window.LuminousVttRuntime?.procedural?.stop?.();
         window.LuminousVttRuntime?.movement?.stop?.();

--- a/js/vtt/map-simulation-core.js
+++ b/js/vtt/map-simulation-core.js
@@ -192,12 +192,17 @@
     function hasMeaningfulState(raw){const record=records.get(zoneKey(raw));return Boolean(record&&(record.persistent||record.pinned||entityCount(record)>0||temporaryCount(record)>0));}
     function isDirty(raw){return Boolean(records.get(zoneKey(raw))?.dirty);}
     function clearDirty(raw){const record=records.get(zoneKey(raw));if(record)record.dirty=false;}
+    function forget(raw,{onlyPristine=true}={}){
+      const key=zoneKey(raw),record=records.get(key);if(!record)return false;
+      if(onlyPristine&&(record.persistent||record.pinned||entityCount(record)>0||temporaryCount(record)>0||record.dirty))return false;
+      records.delete(key);return true;
+    }
     function get(raw,worldNow=Date.now()){return compactRecord(raw,worldNow);}
     function keys(){return [...records.keys()];}
     function dirtyKeys(){return [...records.values()].filter(record=>record.dirty).map(record=>record.key);}
     function metrics(){let deltaEntities=0,temporaryEntities=0,dirtyZones=0,pinnedZones=0,persistentZones=0;for(const record of records.values()){deltaEntities+=entityCount(record);temporaryEntities+=temporaryCount(record);if(record.dirty)dirtyZones+=1;if(record.pinned)pinnedZones+=1;if(record.persistent)persistentZones+=1;}return Object.freeze({schemaVersion:SCHEMA_VERSION,records:records.size,deltaEntities,temporaryEntities,dirtyZones,pinnedZones,persistentZones,maxDeltaEntities,maxTemporaryEntities});}
 
-    return Object.freeze({ensure,recordEntityChange,recordTemporary,pruneExpired,markZone,compactRecord,importRecord,touchSimulated,hasMeaningfulState,isDirty,clearDirty,get,keys,dirtyKeys,metrics});
+    return Object.freeze({ensure,recordEntityChange,recordTemporary,pruneExpired,markZone,compactRecord,importRecord,touchSimulated,hasMeaningfulState,isDirty,clearDirty,forget,get,keys,dirtyKeys,metrics});
   }
 
   function stableEntityId(entity,index=0){return safeKey(entity?.entityId||entity?.instanceId||entity?.id||`entity_${index}`);}

--- a/js/vtt/map-simulation-core.js
+++ b/js/vtt/map-simulation-core.js
@@ -1,0 +1,220 @@
+(function(root,factory){
+  'use strict';
+  const Streaming=typeof module!=='undefined'&&module.exports?require('./world-streaming-core.js'):root?.LuminousVttWorldStreaming;
+  const api=factory(Streaming);
+  if(typeof module!=='undefined'&&module.exports)module.exports=api;
+  if(root)root.LuminousVttMapSimulation=api;
+})(typeof window!=='undefined'?window:globalThis,function(Streaming){
+  'use strict';
+
+  if(!Streaming)throw new Error('WORLD_STREAMING_CORE_REQUIRED');
+
+  const SCHEMA_VERSION=1;
+  const STATES=Object.freeze({ACTIVE:'ACTIVE',WARM:'WARM',DORMANT:'DORMANT'});
+  const OPS=Object.freeze({UPSERT:'upsert',ADD:'add',REMOVE:'remove'});
+  const DEFAULTS=Object.freeze({warmTtlMs:60000,maxWarmZones:16,maxActiveZones:8,maxDeltaEntities:4096,maxTemporaryEntities:1024});
+  const clone=value=>value==null?value:JSON.parse(JSON.stringify(value));
+  const clean=(value,fallback='')=>String(value??fallback).trim()||fallback;
+  const finite=(value,fallback=0)=>Number.isFinite(Number(value))?Number(value):fallback;
+  const integer=(value,fallback=0)=>Math.trunc(finite(value,fallback));
+  const safeKey=(value,fallback='key')=>clean(value,fallback).replace(/[.#$\[\]\/]/g,'_').replace(/\s+/g,'_').slice(0,160)||fallback;
+  const nowValue=(value,fallback=Date.now())=>Math.max(0,finite(value,fallback));
+
+  function zoneIdentity(raw={}){
+    const source=raw?.position||raw?.worldPosition||raw||{};
+    const position=Streaming.normalizeWorldPosition(source,{cellSize:source.cellSize||70,chunkSizeCells:source.chunkSizeCells||40});
+    return Object.freeze({worldId:clean(position.worldId,'luminous'),regionId:clean(position.regionId,'region'),zoneId:clean(position.zoneId,'zone')});
+  }
+
+  function zoneKey(raw={}){
+    const id=zoneIdentity(raw);
+    return `${id.worldId}/${id.regionId}/${id.zoneId}`;
+  }
+
+  function storageKey(raw={}){
+    const id=zoneIdentity(raw);
+    return `${safeKey(id.worldId,'luminous')}__${safeKey(id.regionId,'region')}__${safeKey(id.zoneId,'zone')}`;
+  }
+
+  function defaultSeed(raw={}){
+    const id=zoneIdentity(raw);
+    return `${id.worldId}:zone:${id.regionId}:${id.zoneId}`;
+  }
+
+  function createSimulationBubbleManager(options={}){
+    const config=Object.freeze({
+      warmTtlMs:Math.max(0,finite(options.warmTtlMs,DEFAULTS.warmTtlMs)),
+      maxWarmZones:Math.max(0,integer(options.maxWarmZones,DEFAULTS.maxWarmZones)),
+      maxActiveZones:Math.max(1,integer(options.maxActiveZones,DEFAULTS.maxActiveZones)),
+    });
+    const zones=new Map(),actors=new Map(),flags=new Map();
+    let dormantTransitions=0,peakResidentZones=0,peakActiveZones=0,serial=0;
+
+    function flagRecord(key){return flags.get(key)||{persistent:false,pinned:false};}
+    function ensure(raw,now){
+      const identity=zoneIdentity(raw),key=zoneKey(identity);
+      let entry=zones.get(key);
+      if(!entry){
+        const zoneFlags=flagRecord(key);
+        entry={key,identity,state:STATES.WARM,actorIds:new Set(),lastTouched:now,warmUntil:now+config.warmTtlMs,serial:++serial,persistent:Boolean(zoneFlags.persistent),pinned:Boolean(zoneFlags.pinned)};
+        zones.set(key,entry);
+      }
+      return entry;
+    }
+    function toWarm(entry,now,events,reason='released'){
+      if(!entry||entry.actorIds.size>0||entry.state!==STATES.ACTIVE)return;
+      entry.state=STATES.WARM;entry.lastTouched=now;entry.warmUntil=now+config.warmTtlMs;
+      events.warmed.push({key:entry.key,identity:entry.identity,state:STATES.WARM,reason,persistent:entry.persistent,pinned:entry.pinned});
+    }
+    function toDormant(entry,events,reason){
+      if(!entry||entry.state===STATES.DORMANT)return;
+      zones.delete(entry.key);dormantTransitions+=1;
+      events.dormant.push({key:entry.key,identity:entry.identity,state:STATES.DORMANT,lastTouched:entry.lastTouched,reason,persistent:entry.persistent,pinned:entry.pinned});
+    }
+    function expireWarm(now,events){
+      for(const entry of [...zones.values()])if(entry.state===STATES.WARM&&entry.warmUntil<=now)toDormant(entry,events,'warm-ttl');
+      const warm=[...zones.values()].filter(entry=>entry.state===STATES.WARM).sort((a,b)=>a.lastTouched-b.lastTouched||a.serial-b.serial);
+      while(warm.length>config.maxWarmZones)toDormant(warm.shift(),events,'warm-capacity');
+    }
+    function metrics(){
+      let activeZones=0,warmZones=0,actorRefs=0,pinnedZones=0,persistentZones=0;
+      for(const entry of zones.values()){
+        if(entry.state===STATES.ACTIVE)activeZones+=1;else if(entry.state===STATES.WARM)warmZones+=1;
+        actorRefs+=entry.actorIds.size;if(entry.pinned)pinnedZones+=1;if(entry.persistent)persistentZones+=1;
+      }
+      peakResidentZones=Math.max(peakResidentZones,zones.size);peakActiveZones=Math.max(peakActiveZones,activeZones);
+      return Object.freeze({schemaVersion:SCHEMA_VERSION,activeZones,warmZones,residentZones:zones.size,dormantTransitions,actorRefs,uniqueActors:actors.size,pinnedZones,persistentZones,peakActiveZones,peakResidentZones,overActiveBudget:Math.max(0,activeZones-config.maxActiveZones),maxResidentBudget:config.maxActiveZones+config.maxWarmZones});
+    }
+    function reconcile(rawActors=[],rawNow=Date.now()){
+      const now=nowValue(rawNow),events={activated:[],warmed:[],dormant:[],moved:[],released:[]},desired=new Map();
+      for(const raw of Array.isArray(rawActors)?rawActors:[]){
+        const actorId=clean(raw?.id??raw?.actorId);if(!actorId)continue;
+        const identity=zoneIdentity(raw?.position||raw?.worldPosition||raw),key=zoneKey(identity);
+        desired.set(actorId,{actorId,key,identity});
+      }
+      for(const [actorId,current] of [...actors]){
+        if(desired.has(actorId))continue;
+        const entry=zones.get(current.key);if(entry){entry.actorIds.delete(actorId);toWarm(entry,now,events,'actor-released');}
+        actors.delete(actorId);events.released.push({actorId,key:current.key});
+      }
+      for(const next of desired.values()){
+        const previous=actors.get(next.actorId);
+        if(previous&&previous.key!==next.key){
+          const from=zones.get(previous.key);if(from){from.actorIds.delete(next.actorId);toWarm(from,now,events,'actor-moved');}
+          events.moved.push({actorId:next.actorId,from:previous.key,to:next.key});
+        }
+        const entry=ensure(next.identity,now),wasActive=entry.state===STATES.ACTIVE;
+        const zoneFlags=flagRecord(next.key);entry.persistent=Boolean(zoneFlags.persistent);entry.pinned=Boolean(zoneFlags.pinned);
+        entry.state=STATES.ACTIVE;entry.actorIds.add(next.actorId);entry.lastTouched=now;entry.warmUntil=0;
+        actors.set(next.actorId,{key:next.key,identity:next.identity});
+        if(!wasActive)events.activated.push({key:entry.key,identity:entry.identity,state:STATES.ACTIVE,persistent:entry.persistent,pinned:entry.pinned});
+      }
+      expireWarm(now,events);
+      return Object.freeze({...events,metrics:metrics()});
+    }
+    function tick(rawNow=Date.now()){
+      const events={activated:[],warmed:[],dormant:[],moved:[],released:[]};expireWarm(nowValue(rawNow),events);return Object.freeze({...events,metrics:metrics()});
+    }
+    function setFlags(raw,patch={}){
+      const identity=zoneIdentity(raw),key=zoneKey(identity),previous=flagRecord(key),next={persistent:patch.persistent==null?Boolean(previous.persistent):Boolean(patch.persistent),pinned:patch.pinned==null?Boolean(previous.pinned):Boolean(patch.pinned)};
+      flags.set(key,next);const entry=zones.get(key);if(entry){entry.persistent=next.persistent;entry.pinned=next.pinned;}return Object.freeze({key,identity,...next});
+    }
+    function stateOf(raw){return zones.get(zoneKey(raw))?.state||STATES.DORMANT;}
+    function entryOf(raw){const entry=zones.get(zoneKey(raw));return entry?Object.freeze({key:entry.key,identity:entry.identity,state:entry.state,actorIds:[...entry.actorIds],lastTouched:entry.lastTouched,warmUntil:entry.warmUntil,persistent:entry.persistent,pinned:entry.pinned}):null;}
+    function entries(){return [...zones.values()].map(entry=>Object.freeze({key:entry.key,identity:entry.identity,state:entry.state,actorIds:[...entry.actorIds],lastTouched:entry.lastTouched,warmUntil:entry.warmUntil,persistent:entry.persistent,pinned:entry.pinned}));}
+    return Object.freeze({config,reconcile,tick,setFlags,stateOf,entryOf,entries,snapshot:metrics});
+  }
+
+  function normalizeEntityId(raw){return safeKey(raw,'entity');}
+  function normalizeOperation(raw){const op=clean(raw,OPS.UPSERT).toLowerCase();return op===OPS.REMOVE?OPS.REMOVE:op===OPS.ADD?OPS.ADD:OPS.UPSERT;}
+
+  function createDeltaStore(options={}){
+    const maxDeltaEntities=Math.max(1,integer(options.maxDeltaEntities,DEFAULTS.maxDeltaEntities));
+    const maxTemporaryEntities=Math.max(1,integer(options.maxTemporaryEntities,DEFAULTS.maxTemporaryEntities));
+    const records=new Map();
+
+    function ensure(raw,meta={}){
+      const identity=zoneIdentity(raw),key=zoneKey(identity);
+      let record=records.get(key);
+      if(!record){
+        record={schemaVersion:SCHEMA_VERSION,key,identity,seed:clean(meta.seed,defaultSeed(identity)),generatorVersion:clean(meta.generatorVersion,'worldgen_1'),revision:0,updatedAt:0,lastSimulatedAt:0,persistent:Boolean(meta.persistent),pinned:Boolean(meta.pinned),entities:{},temporary:{},dirty:false};records.set(key,record);
+      }else{
+        if(meta.seed)record.seed=clean(meta.seed,record.seed);if(meta.generatorVersion)record.generatorVersion=clean(meta.generatorVersion,record.generatorVersion);
+        if(meta.persistent!=null)record.persistent=Boolean(meta.persistent);if(meta.pinned!=null)record.pinned=Boolean(meta.pinned);
+      }
+      return record;
+    }
+    function bump(record,updatedAt){record.revision+=1;record.updatedAt=Math.max(record.updatedAt,nowValue(updatedAt));record.dirty=true;return record;}
+    function entityCount(record){return Object.keys(record.entities||{}).length;}
+    function temporaryCount(record){return Object.keys(record.temporary||{}).length;}
+    function recordEntityChange(raw,input={}){
+      const record=ensure(raw,input),entityId=normalizeEntityId(input.entityId||input.id),operation=normalizeOperation(input.operation||input.op),updatedAt=nowValue(input.updatedAt);
+      const existing=record.entities[entityId]||null;
+      if(!existing&&entityCount(record)>=maxDeltaEntities)throw new Error('MAP_DELTA_ENTITY_CAP_EXCEEDED');
+      if(operation===OPS.REMOVE){record.entities[entityId]={entityId,kind:clean(input.kind,'entity'),operation:OPS.REMOVE,updatedAt};}
+      else{
+        const patch=clone(input.patch??input.value??{});const mergedPatch=existing&&existing.operation!==OPS.REMOVE&&existing.patch&&typeof existing.patch==='object'&&patch&&typeof patch==='object'?{...clone(existing.patch),...patch}:patch;
+        record.entities[entityId]={entityId,kind:clean(input.kind||existing?.kind,'entity'),operation:existing?.operation===OPS.ADD?OPS.ADD:operation,patch:mergedPatch,updatedAt};
+      }
+      if(input.persistent!==false)record.persistent=true;bump(record,updatedAt);return clone(record.entities[entityId]);
+    }
+    function recordTemporary(raw,input={}){
+      const record=ensure(raw,input),temporaryId=normalizeEntityId(input.temporaryId||input.entityId||input.id),createdAt=nowValue(input.createdAt),expiresAt=Math.max(createdAt,nowValue(input.expiresAt,createdAt));
+      if(!record.temporary[temporaryId]&&temporaryCount(record)>=maxTemporaryEntities)throw new Error('MAP_TEMPORARY_ENTITY_CAP_EXCEEDED');
+      record.temporary[temporaryId]={temporaryId,kind:clean(input.kind,'temporary'),payload:clone(input.payload??input.patch??{}),createdAt,expiresAt};bump(record,createdAt);return clone(record.temporary[temporaryId]);
+    }
+    function pruneExpired(raw,worldNow=Date.now()){
+      const record=records.get(zoneKey(raw));if(!record)return 0;const now=nowValue(worldNow);let removed=0;
+      for(const [id,temp] of Object.entries(record.temporary||{}))if(finite(temp.expiresAt,0)<=now){delete record.temporary[id];removed+=1;}
+      if(removed)bump(record,now);return removed;
+    }
+    function markZone(raw,meta={}){
+      const record=ensure(raw,meta);let changed=false;
+      for(const key of ['seed','generatorVersion'])if(meta[key]&&clean(meta[key])!==record[key]){record[key]=clean(meta[key]);changed=true;}
+      for(const key of ['persistent','pinned'])if(meta[key]!=null&&Boolean(meta[key])!==record[key]){record[key]=Boolean(meta[key]);changed=true;}
+      if(changed)bump(record,meta.updatedAt);return compactRecord(record.identity,meta.worldNow);
+    }
+    function compactRecord(raw,worldNow=Date.now()){
+      const key=zoneKey(raw),record=records.get(key);if(!record)return null;pruneExpired(record.identity,worldNow);
+      return Object.freeze({schemaVersion:SCHEMA_VERSION,state:STATES.DORMANT,key:record.key,identity:clone(record.identity),seed:record.seed,generatorVersion:record.generatorVersion,revision:record.revision,updatedAt:record.updatedAt,lastSimulatedAt:record.lastSimulatedAt,persistent:Boolean(record.persistent),pinned:Boolean(record.pinned),entities:clone(record.entities),temporary:clone(record.temporary)});
+    }
+    function importRecord(raw={}){
+      const identity=zoneIdentity(raw.identity||raw),record=ensure(identity,{seed:raw.seed,generatorVersion:raw.generatorVersion,persistent:raw.persistent,pinned:raw.pinned});
+      record.revision=Math.max(0,integer(raw.revision,0));record.updatedAt=nowValue(raw.updatedAt,0);record.lastSimulatedAt=nowValue(raw.lastSimulatedAt,0);record.entities=clone(raw.entities||{});record.temporary=clone(raw.temporary||{});record.dirty=false;return compactRecord(identity,Number.MAX_SAFE_INTEGER);
+    }
+    function touchSimulated(raw,worldNow=Date.now()){
+      const record=ensure(raw),next=nowValue(worldNow);if(next>record.lastSimulatedAt){record.lastSimulatedAt=next;bump(record,next);}return record.lastSimulatedAt;
+    }
+    function hasMeaningfulState(raw){const record=records.get(zoneKey(raw));return Boolean(record&&(record.persistent||record.pinned||entityCount(record)>0||temporaryCount(record)>0));}
+    function isDirty(raw){return Boolean(records.get(zoneKey(raw))?.dirty);}
+    function clearDirty(raw){const record=records.get(zoneKey(raw));if(record)record.dirty=false;}
+    function get(raw,worldNow=Date.now()){return compactRecord(raw,worldNow);}
+    function keys(){return [...records.keys()];}
+    function dirtyKeys(){return [...records.values()].filter(record=>record.dirty).map(record=>record.key);}
+    function metrics(){let deltaEntities=0,temporaryEntities=0,dirtyZones=0,pinnedZones=0,persistentZones=0;for(const record of records.values()){deltaEntities+=entityCount(record);temporaryEntities+=temporaryCount(record);if(record.dirty)dirtyZones+=1;if(record.pinned)pinnedZones+=1;if(record.persistent)persistentZones+=1;}return Object.freeze({schemaVersion:SCHEMA_VERSION,records:records.size,deltaEntities,temporaryEntities,dirtyZones,pinnedZones,persistentZones,maxDeltaEntities,maxTemporaryEntities});}
+
+    return Object.freeze({ensure,recordEntityChange,recordTemporary,pruneExpired,markZone,compactRecord,importRecord,touchSimulated,hasMeaningfulState,isDirty,clearDirty,get,keys,dirtyKeys,metrics});
+  }
+
+  function stableEntityId(entity,index=0){return safeKey(entity?.entityId||entity?.instanceId||entity?.id||`entity_${index}`);}
+  function applyEntityDeltas(baseEntities=[],record={},options={}){
+    const kind=clean(options.kind);const map=new Map();
+    for(const [index,entity] of (Array.isArray(baseEntities)?baseEntities:[]).entries())map.set(stableEntityId(entity,index),clone(entity));
+    const deltas=record?.entities&&typeof record.entities==='object'?record.entities:{};
+    for(const [rawId,delta] of Object.entries(deltas)){
+      if(!delta||typeof delta!=='object'||(kind&&clean(delta.kind)!==kind))continue;
+      const id=normalizeEntityId(delta.entityId||rawId),operation=normalizeOperation(delta.operation);
+      if(operation===OPS.REMOVE){map.delete(id);continue;}
+      const patch=clone(delta.patch||{}),previous=map.get(id)||{};
+      map.set(id,{...previous,...patch,entityId:patch?.entityId||previous?.entityId||(kind==='world_object'?undefined:id)});
+    }
+    return [...map.values()];
+  }
+
+  function dormantRecordFromStore(store,raw,worldNow=Date.now()){
+    const record=store?.compactRecord?.(raw,worldNow);if(!record)return null;
+    return Object.freeze({...record,state:STATES.DORMANT});
+  }
+
+  return Object.freeze({SCHEMA_VERSION,STATES,OPS,DEFAULTS,zoneIdentity,zoneKey,storageKey,defaultSeed,createSimulationBubbleManager,createDeltaStore,applyEntityDeltas,dormantRecordFromStore});
+});

--- a/js/vtt/map-simulation-core.js
+++ b/js/vtt/map-simulation-core.js
@@ -21,6 +21,10 @@
   const nowValue=(value,fallback=Date.now())=>Math.max(0,finite(value,fallback));
 
   function zoneIdentity(raw={}){
+    if(typeof raw==='string'){
+      const parts=raw.split('/');
+      if(parts.length>=3)return Object.freeze({worldId:clean(parts[0],'luminous'),regionId:clean(parts[1],'region'),zoneId:clean(parts.slice(2).join('/'),'zone')});
+    }
     const source=raw?.position||raw?.worldPosition||raw||{};
     const position=Streaming.normalizeWorldPosition(source,{cellSize:source.cellSize||70,chunkSizeCells:source.chunkSizeCells||40});
     return Object.freeze({worldId:clean(position.worldId,'luminous'),regionId:clean(position.regionId,'region'),zoneId:clean(position.zoneId,'zone')});
@@ -147,6 +151,7 @@
     function bump(record,updatedAt){record.revision+=1;record.updatedAt=Math.max(record.updatedAt,nowValue(updatedAt));record.dirty=true;return record;}
     function entityCount(record){return Object.keys(record.entities||{}).length;}
     function temporaryCount(record){return Object.keys(record.temporary||{}).length;}
+    function snapshotRecord(record){return Object.freeze({schemaVersion:SCHEMA_VERSION,state:STATES.DORMANT,key:record.key,identity:clone(record.identity),seed:record.seed,generatorVersion:record.generatorVersion,revision:record.revision,updatedAt:record.updatedAt,lastSimulatedAt:record.lastSimulatedAt,persistent:Boolean(record.persistent),pinned:Boolean(record.pinned),entities:clone(record.entities),temporary:clone(record.temporary)});}
     function recordEntityChange(raw,input={}){
       const record=ensure(raw,input),entityId=normalizeEntityId(input.entityId||input.id),operation=normalizeOperation(input.operation||input.op),updatedAt=nowValue(input.updatedAt);
       const existing=record.entities[entityId]||null;
@@ -175,12 +180,11 @@
       if(changed)bump(record,meta.updatedAt);return compactRecord(record.identity,meta.worldNow);
     }
     function compactRecord(raw,worldNow=Date.now()){
-      const key=zoneKey(raw),record=records.get(key);if(!record)return null;pruneExpired(record.identity,worldNow);
-      return Object.freeze({schemaVersion:SCHEMA_VERSION,state:STATES.DORMANT,key:record.key,identity:clone(record.identity),seed:record.seed,generatorVersion:record.generatorVersion,revision:record.revision,updatedAt:record.updatedAt,lastSimulatedAt:record.lastSimulatedAt,persistent:Boolean(record.persistent),pinned:Boolean(record.pinned),entities:clone(record.entities),temporary:clone(record.temporary)});
+      const key=zoneKey(raw),record=records.get(key);if(!record)return null;pruneExpired(record.identity,worldNow);return snapshotRecord(record);
     }
     function importRecord(raw={}){
       const identity=zoneIdentity(raw.identity||raw),record=ensure(identity,{seed:raw.seed,generatorVersion:raw.generatorVersion,persistent:raw.persistent,pinned:raw.pinned});
-      record.revision=Math.max(0,integer(raw.revision,0));record.updatedAt=nowValue(raw.updatedAt,0);record.lastSimulatedAt=nowValue(raw.lastSimulatedAt,0);record.entities=clone(raw.entities||{});record.temporary=clone(raw.temporary||{});record.dirty=false;return compactRecord(identity,Number.MAX_SAFE_INTEGER);
+      record.revision=Math.max(0,integer(raw.revision,0));record.updatedAt=nowValue(raw.updatedAt,0);record.lastSimulatedAt=nowValue(raw.lastSimulatedAt,0);record.entities=clone(raw.entities||{});record.temporary=clone(raw.temporary||{});record.dirty=false;return snapshotRecord(record);
     }
     function touchSimulated(raw,worldNow=Date.now()){
       const record=ensure(raw),next=nowValue(worldNow);if(next>record.lastSimulatedAt){record.lastSimulatedAt=next;bump(record,next);}return record.lastSimulatedAt;
@@ -198,7 +202,7 @@
 
   function stableEntityId(entity,index=0){return safeKey(entity?.entityId||entity?.instanceId||entity?.id||`entity_${index}`);}
   function applyEntityDeltas(baseEntities=[],record={},options={}){
-    const kind=clean(options.kind);const map=new Map();
+    const kind=clean(options.kind),map=new Map();
     for(const [index,entity] of (Array.isArray(baseEntities)?baseEntities:[]).entries())map.set(stableEntityId(entity,index),clone(entity));
     const deltas=record?.entities&&typeof record.entities==='object'?record.entities:{};
     for(const [rawId,delta] of Object.entries(deltas)){
@@ -206,7 +210,7 @@
       const id=normalizeEntityId(delta.entityId||rawId),operation=normalizeOperation(delta.operation);
       if(operation===OPS.REMOVE){map.delete(id);continue;}
       const patch=clone(delta.patch||{}),previous=map.get(id)||{};
-      map.set(id,{...previous,...patch,entityId:patch?.entityId||previous?.entityId||(kind==='world_object'?undefined:id)});
+      map.set(id,{...previous,...patch});
     }
     return [...map.values()];
   }

--- a/js/vtt/map-simulation-runtime.js
+++ b/js/vtt/map-simulation-runtime.js
@@ -1,0 +1,166 @@
+import './map-simulation-core.js';
+import { start as startWorldStreaming } from './world-streaming-runtime.js';
+
+const DM_UID='e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1';
+const PERSIST_ROOT='campaña/estado_mundo/mapSimulationZones';
+const clean=value=>String(value??'').trim();
+const clone=value=>value==null?value:JSON.parse(JSON.stringify(value));
+
+function hostWindow(){try{if(window.parent&&window.parent!==window&&window.parent.document)return window.parent;}catch(_){}return window;}
+function hostFirebase(){const host=hostWindow();return host?.firebase||window.firebase||null;}
+function currentUid(firebase){try{return clean(firebase?.auth?.().currentUser?.uid);}catch(_){return '';}}
+function parseWorldTime(value){if(typeof value==='number'&&Number.isFinite(value))return value;const parsed=Date.parse(value||'');return Number.isFinite(parsed)?parsed:null;}
+
+export function start({runtime=globalThis.LuminousVttRuntime,mapData=runtime?.engine?.mapData}={}){
+  if(!runtime?.engine||!mapData)return null;
+  if(globalThis.LuminousVttMapSimulationRuntime?.api)return globalThis.LuminousVttMapSimulationRuntime.api;
+
+  const worldStreaming=startWorldStreaming({runtime,mapData});
+  const liveRuntime=globalThis.LuminousVttRuntime||runtime;
+  const Core=globalThis.LuminousVttMapSimulation;
+  if(!Core||!worldStreaming)throw new Error('MAP_SIMULATION_DEPENDENCY_REQUIRED');
+
+  const firebase=hostFirebase(),db=firebase?.database?.()||null;
+  const isDm=Boolean(liveRuntime.bridge?.isDm)||currentUid(firebase)===DM_UID;
+  const manager=Core.createSimulationBubbleManager({maxActiveZones:8,maxWarmZones:16,warmTtlMs:60000});
+  const store=Core.createDeltaStore({maxDeltaEntities:4096,maxTemporaryEntities:1024});
+  const canvas=liveRuntime.engine.canvas;
+  const loadedZones=new Set(),restoreInFlight=new Map(),flushInFlight=new Map();
+  let stopped=false,lastLifecycle=null;
+
+  function worldNowMs(){
+    const scheduler=hostWindow()?.LuminousWorldTimeScheduler||globalThis.LuminousWorldTimeScheduler;
+    const worldMs=parseWorldTime(scheduler?.getSnapshot?.()?.timestamp);
+    return Number.isFinite(worldMs)?worldMs:Date.now();
+  }
+  function baseIdentity(){
+    const stream=mapData.procedural?.streaming||{};
+    return Core.zoneIdentity({worldId:mapData.worldId||mapData.world?.id||'luminous',regionId:mapData.regionId||mapData.region?.id||'region',zoneId:stream.zoneId||mapData.zoneId||mapData.id||mapData.mapId||'zone'});
+  }
+  function identityForToken(token){
+    const position=token?.worldPosition||worldStreaming.positionForToken?.(token)||baseIdentity();
+    return Core.zoneIdentity(position);
+  }
+  function currentIdentity(){
+    const viewer=(mapData.tokens||[]).find(token=>token.viewer===true)||(mapData.tokens||[]).find(token=>token.characterLink?.mode==='current_player')||(mapData.tokens||[])[0];
+    return viewer?identityForToken(viewer):baseIdentity();
+  }
+  function metadataFor(identity){
+    const stream=mapData.procedural?.streaming||{};
+    const isCurrent=clean(stream.zoneId)===identity.zoneId||(!stream.zoneId&&clean(mapData.zoneId||mapData.id||mapData.mapId)===identity.zoneId);
+    return{
+      seed:isCurrent&&stream.seed?clean(stream.seed):Core.defaultSeed(identity),
+      generatorVersion:clean(mapData.procedural?.generatorVersion||mapData.procedural?.version||'worldgen_1'),
+    };
+  }
+  function actorRecords(){
+    return(mapData.tokens||[]).map(token=>{const id=clean(token?.id);if(!id)return null;const position=token.worldPosition||worldStreaming.positionForToken?.(token);return position?{id,position}:null;}).filter(Boolean);
+  }
+  function zoneRef(identity){return db?.ref(`${PERSIST_ROOT}/${Core.storageKey(identity)}`)||null;}
+  function emit(name,detail){
+    const EventCtor=globalThis.CustomEvent;if(typeof EventCtor!=='function')return;
+    canvas?.dispatchEvent?.(new EventCtor(name,{detail:clone(detail)}));
+    globalThis.dispatchEvent?.(new EventCtor(name,{detail:clone(detail)}));
+  }
+  function ensureRecord(identity,extra={}){
+    const meta={...metadataFor(identity),...extra};store.ensure(identity,meta);manager.setFlags(identity,{persistent:extra.persistent,pinned:extra.pinned});return store.get(identity,worldNowMs());
+  }
+  function applyRestoredWorldObjects(identity,record){
+    if(Core.zoneKey(identity)!==Core.zoneKey(currentIdentity()))return false;
+    if(!record?.entities||!Object.values(record.entities).some(delta=>delta?.kind==='world_object'))return false;
+    mapData.worldObjects=Core.applyEntityDeltas(mapData.worldObjects||[],record,{kind:'world_object'});
+    liveRuntime.engine.renderer?.invalidate?.();
+    emit('vtt:map-simulation-delta-applied',{identity,kind:'world_object',count:mapData.worldObjects.length,revision:record.revision});
+    return true;
+  }
+  async function restoreZone(raw){
+    const identity=Core.zoneIdentity(raw),key=Core.zoneKey(identity);
+    if(loadedZones.has(key))return store.get(identity,worldNowMs());
+    if(restoreInFlight.has(key))return restoreInFlight.get(key);
+    const task=(async()=>{
+      let record=null;
+      if(db){
+        try{const snapshot=await zoneRef(identity).once('value');const value=snapshot.val();if(value)record=store.importRecord(value);}
+        catch(error){console.error('VTT MAP SIMULATION RESTORE FAILED:',error);}
+      }
+      if(!record)record=ensureRecord(identity);
+      store.pruneExpired(identity,worldNowMs());record=store.get(identity,worldNowMs());
+      manager.setFlags(identity,{persistent:record?.persistent,pinned:record?.pinned});
+      loadedZones.add(key);applyRestoredWorldObjects(identity,record);
+      emit('vtt:map-simulation-zone-restored',{identity,record});return record;
+    })().finally(()=>restoreInFlight.delete(key));
+    restoreInFlight.set(key,task);return task;
+  }
+  async function flushZone(raw,{reason='flush',force=false}={}){
+    const identity=Core.zoneIdentity(raw),key=Core.zoneKey(identity);
+    if(!isDm||!db)return store.get(identity,worldNowMs());
+    if(!force&&!store.isDirty(identity))return store.get(identity,worldNowMs());
+    if(!force&&!store.hasMeaningfulState(identity)){store.clearDirty(identity);return null;}
+    if(flushInFlight.has(key))return flushInFlight.get(key);
+    const task=(async()=>{
+      store.touchSimulated(identity,worldNowMs());const record=store.get(identity,worldNowMs());
+      if(!record)return null;
+      await zoneRef(identity).set({...record,lastPersistReason:reason});store.clearDirty(identity);
+      emit('vtt:map-simulation-zone-persisted',{identity,revision:record.revision,reason});return record;
+    })().finally(()=>flushInFlight.delete(key));
+    flushInFlight.set(key,task);return task;
+  }
+  async function persistEntityDelta(identity,entityId,reason='persistent-change'){
+    if(!isDm||!db)return null;
+    const record=store.get(identity,worldNowMs()),entry=record?.entities?.[entityId];if(!record||!entry)return null;
+    const updates={schemaVersion:record.schemaVersion,state:record.state,identity:record.identity,seed:record.seed,generatorVersion:record.generatorVersion,revision:record.revision,updatedAt:record.updatedAt,lastSimulatedAt:worldNowMs(),persistent:record.persistent,pinned:record.pinned,lastPersistReason:reason};
+    updates[`entities/${entityId}`]=entry;
+    await zoneRef(identity).update(updates);return entry;
+  }
+  async function persistTemporary(identity,temporaryId,reason='temporary-change'){
+    if(!isDm||!db)return null;
+    const record=store.get(identity,worldNowMs()),entry=record?.temporary?.[temporaryId];if(!record||!entry)return null;
+    const updates={schemaVersion:record.schemaVersion,state:record.state,identity:record.identity,seed:record.seed,generatorVersion:record.generatorVersion,revision:record.revision,updatedAt:record.updatedAt,lastSimulatedAt:worldNowMs(),persistent:record.persistent,pinned:record.pinned,lastPersistReason:reason};
+    updates[`temporary/${temporaryId}`]=entry;
+    await zoneRef(identity).update(updates);return entry;
+  }
+  function resolveIdentity(detail={}){return Core.zoneIdentity(detail.zoneIdentity||detail.worldPosition||detail.position||currentIdentity());}
+  async function recordPersistentChange(detail={}){
+    const identity=resolveIdentity(detail),meta=metadataFor(identity);
+    const delta=store.recordEntityChange(identity,{...meta,entityId:detail.entityId||detail.id,kind:detail.kind||'entity',operation:detail.operation||detail.op||'upsert',patch:detail.patch??detail.value??{},updatedAt:detail.updatedAt||worldNowMs(),persistent:detail.persistent!==false});
+    manager.setFlags(identity,{persistent:true});
+    emit('vtt:map-simulation-delta-recorded',{identity,delta});
+    try{await persistEntityDelta(identity,delta.entityId,detail.reason||detail.source||'persistent-change');}catch(error){console.error('VTT MAP SIMULATION DELTA PERSIST FAILED:',error);}
+    return delta;
+  }
+  async function recordTemporary(detail={}){
+    const identity=resolveIdentity(detail),meta=metadataFor(identity);
+    const temporary=store.recordTemporary(identity,{...meta,temporaryId:detail.temporaryId||detail.entityId||detail.id,kind:detail.kind||'temporary',payload:detail.payload??detail.patch??{},createdAt:detail.createdAt||worldNowMs(),expiresAt:detail.expiresAt});
+    emit('vtt:map-simulation-temporary-recorded',{identity,temporary});
+    try{await persistTemporary(identity,temporary.temporaryId,detail.reason||detail.source||'temporary-change');}catch(error){console.error('VTT MAP SIMULATION TEMPORARY PERSIST FAILED:',error);}
+    return temporary;
+  }
+  async function markZone(raw,flags={}){
+    const identity=Core.zoneIdentity(raw),record=store.markZone(identity,{...metadataFor(identity),...flags,updatedAt:worldNowMs(),worldNow:worldNowMs()});manager.setFlags(identity,{persistent:record?.persistent,pinned:record?.pinned});
+    await flushZone(identity,{reason:flags.reason||'zone-flags',force:true});return record;
+  }
+  function reconcile(rawActors=actorRecords(),now=worldNowMs()){
+    worldStreaming.reconcile?.(now);
+    const lifecycle=manager.reconcile(rawActors,now);lastLifecycle=lifecycle;
+    for(const active of lifecycle.activated){ensureRecord(active.identity);void restoreZone(active.identity);}
+    for(const dormant of lifecycle.dormant)if(store.hasMeaningfulState(dormant.identity)||store.isDirty(dormant.identity))void flushZone(dormant.identity,{reason:dormant.reason||'dormant'});
+    mapData.mapSimulation={schemaVersion:Core.SCHEMA_VERSION,...lifecycle.metrics,persistence:store.metrics()};
+    emit('vtt:map-simulation-lifecycle',{metrics:mapData.mapSimulation,activated:lifecycle.activated,warmed:lifecycle.warmed,dormant:lifecycle.dormant});return lifecycle;
+  }
+  function pruneTemporary(){
+    const now=worldNowMs();let removed=0;for(const key of store.keys())removed+=store.pruneExpired(key,now);if(removed)emit('vtt:map-simulation-temporary-pruned',{removed,worldNow:now});return removed;
+  }
+  function onMovement(){reconcile();}
+  function onDelta(event){const detail=event?.detail||{};if(detail.temporary===true||detail.expiresAt!=null)void recordTemporary(detail);else void recordPersistentChange(detail);}
+  function onWorldClock(){pruneTemporary();const lifecycle=manager.tick(worldNowMs());lastLifecycle=lifecycle;for(const dormant of lifecycle.dormant)if(store.hasMeaningfulState(dormant.identity)||store.isDirty(dormant.identity))void flushZone(dormant.identity,{reason:dormant.reason||'world-clock'});mapData.mapSimulation={schemaVersion:Core.SCHEMA_VERSION,...lifecycle.metrics,persistence:store.metrics()};}
+
+  canvas?.addEventListener?.('vtt:token-moved',onMovement);
+  canvas?.addEventListener?.('vtt:regional-local-transition-applied',onMovement);
+  canvas?.addEventListener?.('vtt:procedural-chunk-loaded',onMovement);
+  globalThis.addEventListener?.('vtt:map-delta',onDelta);
+  globalThis.addEventListener?.('luminous:world-scheduler-updated',onWorldClock);
+
+  const initial=reconcile();
+  const api=Object.freeze({Core,PERSIST_ROOT,isDm,manager,store,reconcile,reconcileActors:(actors,now=worldNowMs())=>reconcile(actors,now),restoreZone,flushZone,recordPersistentChange,recordTemporary,markZone,pinZone:(raw,pinned=true)=>markZone(raw,{pinned,persistent:true,reason:'pin-zone'}),snapshot:()=>({lifecycle:manager.snapshot(),persistence:store.metrics(),lastLifecycle}),worldNowMs,stop(){if(stopped)return;stopped=true;canvas?.removeEventListener?.('vtt:token-moved',onMovement);canvas?.removeEventListener?.('vtt:regional-local-transition-applied',onMovement);canvas?.removeEventListener?.('vtt:procedural-chunk-loaded',onMovement);globalThis.removeEventListener?.('vtt:map-delta',onDelta);globalThis.removeEventListener?.('luminous:world-scheduler-updated',onWorldClock);for(const key of store.dirtyKeys()){const record=store.get(key,worldNowMs());if(record?.identity)void flushZone(record.identity,{reason:'runtime-stop'});}loadedZones.clear();restoreInFlight.clear();}});
+  globalThis.LuminousVttMapSimulationRuntime={api};globalThis.LuminousVttRuntime=Object.freeze({...globalThis.LuminousVttRuntime,mapSimulation:api});return api;
+}

--- a/js/vtt/map-simulation-runtime.js
+++ b/js/vtt/map-simulation-runtime.js
@@ -105,6 +105,14 @@ export function start({runtime=globalThis.LuminousVttRuntime,mapData=runtime?.en
     })().finally(()=>flushInFlight.delete(key));
     flushInFlight.set(key,task);return task;
   }
+  async function releaseDormant(raw,reason='dormant'){
+    const identity=Core.zoneIdentity(raw),key=Core.zoneKey(identity),meaningful=store.hasMeaningfulState(identity),dirty=store.isDirty(identity);
+    try{if(meaningful||dirty)await flushZone(identity,{reason});}
+    finally{
+      loadedZones.delete(key);
+      const canReload=Boolean(db);if(!meaningful||canReload)store.forget(identity,{onlyPristine:false});
+    }
+  }
   async function persistEntityDelta(identity,entityId,reason='persistent-change'){
     if(!isDm||!db)return null;
     const record=store.get(identity,worldNowMs()),entry=record?.entities?.[entityId];if(!record||!entry)return null;
@@ -143,7 +151,7 @@ export function start({runtime=globalThis.LuminousVttRuntime,mapData=runtime?.en
     worldStreaming.reconcile?.(now);
     const lifecycle=manager.reconcile(rawActors,now);lastLifecycle=lifecycle;
     for(const active of lifecycle.activated){ensureRecord(active.identity);void restoreZone(active.identity);}
-    for(const dormant of lifecycle.dormant)if(store.hasMeaningfulState(dormant.identity)||store.isDirty(dormant.identity))void flushZone(dormant.identity,{reason:dormant.reason||'dormant'});
+    for(const dormant of lifecycle.dormant)void releaseDormant(dormant.identity,dormant.reason||'dormant');
     mapData.mapSimulation={schemaVersion:Core.SCHEMA_VERSION,...lifecycle.metrics,persistence:store.metrics()};
     emit('vtt:map-simulation-lifecycle',{metrics:mapData.mapSimulation,activated:lifecycle.activated,warmed:lifecycle.warmed,dormant:lifecycle.dormant});return lifecycle;
   }
@@ -152,7 +160,7 @@ export function start({runtime=globalThis.LuminousVttRuntime,mapData=runtime?.en
   }
   function onMovement(){reconcile();}
   function onDelta(event){const detail=event?.detail||{};if(detail.temporary===true||detail.expiresAt!=null)void recordTemporary(detail);else void recordPersistentChange(detail);}
-  function onWorldClock(){pruneTemporary();const lifecycle=manager.tick(worldNowMs());lastLifecycle=lifecycle;for(const dormant of lifecycle.dormant)if(store.hasMeaningfulState(dormant.identity)||store.isDirty(dormant.identity))void flushZone(dormant.identity,{reason:dormant.reason||'world-clock'});mapData.mapSimulation={schemaVersion:Core.SCHEMA_VERSION,...lifecycle.metrics,persistence:store.metrics()};}
+  function onWorldClock(){pruneTemporary();const lifecycle=manager.tick(worldNowMs());lastLifecycle=lifecycle;for(const dormant of lifecycle.dormant)void releaseDormant(dormant.identity,dormant.reason||'world-clock');mapData.mapSimulation={schemaVersion:Core.SCHEMA_VERSION,...lifecycle.metrics,persistence:store.metrics()};}
 
   canvas?.addEventListener?.('vtt:token-moved',onMovement);
   canvas?.addEventListener?.('vtt:regional-local-transition-applied',onMovement);

--- a/js/vtt/world-object-state.js
+++ b/js/vtt/world-object-state.js
@@ -23,14 +23,35 @@
 
     function attach(path,cb){if(!db)return;const ref=db.ref(path),handler=s=>cb(s.val()||{});ref.on('value',handler);listeners.push(()=>ref.off('value',handler));}
     function replaceLocal(instances=[]){mapData.worldObjects=clone(instances);onChanged?.(mapData.worldObjects);return mapData.worldObjects;}
+    function zoneIdentity(){
+      const streaming=mapData?.procedural?.streaming||{};
+      return{
+        worldId:clean(mapData?.worldId||mapData?.world?.id||'luminous'),
+        regionId:clean(mapData?.regionId||mapData?.region?.id||'region'),
+        zoneId:clean(streaming.zoneId||mapData?.zoneId||mapData?.id||mapData?.mapId||'zone'),
+      };
+    }
+    function emitMapDelta(detail={}){
+      if(typeof root?.dispatchEvent!=='function'||typeof root?.CustomEvent!=='function')return;
+      root.dispatchEvent(new root.CustomEvent('vtt:map-delta',{detail:{source:'world-object-state',zoneIdentity:zoneIdentity(),kind:'world_object',persistent:true,...clone(detail)}}));
+    }
     function start(){
       attach(objectsPath,value=>replaceLocal(Object.values(value||{}).filter(Boolean)));
       attach(definitionsPath,value=>{const next={};Object.entries(value||{}).forEach(([key,raw])=>{try{const def=core.normalizeDefinition({...raw,id:raw?.id||key});next[def.id]=def;}catch(_){}});mapData.worldObjectDefinitions=next;onDefinitionsChanged?.(next);});
       return api;
     }
     function stop(){while(listeners.length)listeners.pop()();}
-    async function saveInstance(instance){if(!db||!isDm)throw new Error('DM authority required to persist world objects.');if(!instance?.instanceId)throw new Error('World object instanceId is required.');await db.ref(`${objectsPath}/${instance.instanceId}`).set(instance);return instance;}
-    async function deleteInstance(instanceId){if(!db||!isDm)throw new Error('DM authority required to delete world objects.');await db.ref(`${objectsPath}/${clean(instanceId)}`).remove();}
+    async function saveInstance(instance){
+      if(!db||!isDm)throw new Error('DM authority required to persist world objects.');
+      if(!instance?.instanceId)throw new Error('World object instanceId is required.');
+      await db.ref(`${objectsPath}/${instance.instanceId}`).set(instance);
+      emitMapDelta({entityId:instance.instanceId,operation:'upsert',patch:instance});
+      return instance;
+    }
+    async function deleteInstance(instanceId){
+      if(!db||!isDm)throw new Error('DM authority required to delete world objects.');
+      const id=clean(instanceId);await db.ref(`${objectsPath}/${id}`).remove();emitMapDelta({entityId:id,operation:'remove'});
+    }
     async function replaceAll(instances=mapData.worldObjects||[]){
       if(!isDm&&db)throw new Error('DM authority required to replace world objects.');
       const normalized=(Array.isArray(instances)?instances:[]).filter(x=>clean(x?.instanceId)).map(clone);

--- a/tests/vtt_map_simulation_bubbles.spec.js
+++ b/tests/vtt_map_simulation_bubbles.spec.js
@@ -1,0 +1,128 @@
+const {test,expect}=require('@playwright/test');
+const core=require('../js/vtt/map-simulation-core.js');
+
+const position=(zone,chunk=0)=>({worldId:'luminous',regionId:'K',zoneId:zone,chunkCol:chunk,chunkRow:0,x:35,y:35});
+const actor=(id,zone)=>({id,position:position(zone)});
+
+function releaseDormant(store,lifecycle){
+  for(const entry of lifecycle.dormant)store.forget(entry.identity,{onlyPristine:false});
+}
+
+test('actors sharing a Zone share one ACTIVE simulation bubble',()=>{
+  const manager=core.createSimulationBubbleManager({warmTtlMs:100,maxWarmZones:2,maxActiveZones:8});
+  let state=manager.reconcile([actor('p1','villa'),actor('p2','villa')],0);
+  expect(state.metrics.activeZones).toBe(1);
+  expect(state.metrics.actorRefs).toBe(2);
+  expect(state.metrics.uniqueActors).toBe(2);
+  expect(manager.entryOf(position('villa')).actorIds.sort()).toEqual(['p1','p2']);
+
+  state=manager.reconcile([actor('p1','villa')],10);
+  expect(state.metrics.activeZones).toBe(1);
+  expect(state.metrics.actorRefs).toBe(1);
+  state=manager.reconcile([],20);
+  expect(state.metrics.activeZones).toBe(0);
+  expect(state.metrics.warmZones).toBe(1);
+  state=manager.tick(121);
+  expect(state.metrics.residentZones).toBe(0);
+  expect(state.dormant).toHaveLength(1);
+});
+
+test('eight separated players create exactly eight ACTIVE Zone bubbles',()=>{
+  const manager=core.createSimulationBubbleManager({warmTtlMs:0,maxWarmZones:0,maxActiveZones:8});
+  const players=Array.from({length:8},(_,i)=>actor(`p${i+1}`,`zone_${i+1}`));
+  const state=manager.reconcile(players,0);
+  expect(state.metrics.activeZones).toBe(8);
+  expect(state.metrics.residentZones).toBe(8);
+  expect(state.metrics.actorRefs).toBe(8);
+  expect(state.metrics.overActiveBudget).toBe(0);
+  expect(state.metrics.peakActiveZones).toBe(8);
+});
+
+test('two thousand visited Zones keep resident lifecycle and local persistence memory bounded',()=>{
+  const manager=core.createSimulationBubbleManager({warmTtlMs:25,maxWarmZones:3,maxActiveZones:8});
+  const store=core.createDeltaStore();
+  let peakRecords=0;
+  for(let i=0;i<2000;i++){
+    const identity=position(`travel_${i}`);
+    const state=manager.reconcile([actor('traveler',`travel_${i}`)],i*10);
+    for(const active of state.activated)store.ensure(active.identity,{seed:`seed_${i}`});
+    releaseDormant(store,state);
+    const tick=manager.tick(i*10+30);
+    releaseDormant(store,tick);
+    peakRecords=Math.max(peakRecords,store.metrics().records);
+    expect(manager.snapshot().residentZones).toBeLessThanOrEqual(4);
+    expect(store.metrics().records).toBeLessThanOrEqual(4);
+    expect(core.zoneKey(identity)).toContain(`travel_${i}`);
+  }
+  expect(manager.snapshot().activeZones).toBe(1);
+  expect(manager.snapshot().peakResidentZones).toBeLessThanOrEqual(4);
+  expect(manager.snapshot().dormantTransitions).toBeGreaterThan(1900);
+  expect(peakRecords).toBeLessThanOrEqual(4);
+});
+
+test('PERSISTENT and PINNED are durable flags but do not force a Zone to stay resident',()=>{
+  const manager=core.createSimulationBubbleManager({warmTtlMs:10,maxWarmZones:1,maxActiveZones:8});
+  const zone=position('base');
+  manager.setFlags(zone,{persistent:true,pinned:true});
+  let state=manager.reconcile([actor('p1','base')],0);
+  expect(state.metrics.persistentZones).toBe(1);
+  expect(state.metrics.pinnedZones).toBe(1);
+  expect(manager.entryOf(zone).pinned).toBe(true);
+  manager.reconcile([],1);
+  state=manager.tick(12);
+  expect(state.metrics.residentZones).toBe(0);
+  expect(manager.stateOf(zone)).toBe('DORMANT');
+});
+
+test('Seed + Delta compacts repeated entity changes by stable id and reconstructs baseline',()=>{
+  const store=core.createDeltaStore();
+  const zone=position('warehouse');
+  store.ensure(zone,{seed:'warehouse-seed',generatorVersion:'worldgen_1'});
+  store.recordEntityChange(zone,{entityId:'door_1',kind:'world_object',operation:'upsert',patch:{instanceId:'door_1',open:true},updatedAt:10});
+  store.recordEntityChange(zone,{entityId:'door_1',kind:'world_object',operation:'upsert',patch:{hp:4},updatedAt:11});
+  store.recordEntityChange(zone,{entityId:'crate_1',kind:'world_object',operation:'remove',updatedAt:12});
+  store.recordEntityChange(zone,{entityId:'lamp_1',kind:'world_object',operation:'add',patch:{instanceId:'lamp_1',on:true},updatedAt:13});
+
+  const record=store.get(zone,20);
+  expect(record.seed).toBe('warehouse-seed');
+  expect(record.generatorVersion).toBe('worldgen_1');
+  expect(Object.keys(record.entities)).toHaveLength(3);
+  expect(record.entities.door_1.patch).toMatchObject({instanceId:'door_1',open:true,hp:4});
+  expect(record).not.toHaveProperty('mapData');
+  expect(record).not.toHaveProperty('geometry');
+  expect(JSON.stringify(record)).not.toContain('14000');
+
+  const baseline=[{instanceId:'door_1',open:false,hp:10},{instanceId:'crate_1',loot:['item']},{instanceId:'bench_1'}];
+  const restored=core.applyEntityDeltas(baseline,record,{kind:'world_object'});
+  expect(restored.find(x=>x.instanceId==='door_1')).toMatchObject({open:true,hp:4});
+  expect(restored.some(x=>x.instanceId==='crate_1')).toBe(false);
+  expect(restored.find(x=>x.instanceId==='lamp_1')).toMatchObject({on:true});
+  expect(restored.some(x=>x.instanceId==='bench_1')).toBe(true);
+});
+
+test('temporary state expires from WorldClock timestamps without continuous simulation',()=>{
+  const store=core.createDeltaStore();
+  const zone=position('street');
+  store.recordTemporary(zone,{temporaryId:'blood_1',kind:'blood',payload:{size:2},createdAt:100,expiresAt:500});
+  expect(store.get(zone,499).temporary.blood_1).toBeTruthy();
+  expect(store.pruneExpired(zone,500)).toBe(1);
+  expect(store.get(zone,500).temporary.blood_1).toBeUndefined();
+});
+
+test('imported dormant records preserve unexpired temporary state until current WorldClock is applied',()=>{
+  const store=core.createDeltaStore();
+  const imported=store.importRecord({identity:{worldId:'luminous',regionId:'K',zoneId:'alley'},seed:'s',generatorVersion:'worldgen_1',revision:3,updatedAt:100,lastSimulatedAt:100,temporary:{smoke_1:{temporaryId:'smoke_1',kind:'smoke',payload:{density:1},createdAt:100,expiresAt:1000}},entities:{}});
+  expect(imported.temporary.smoke_1).toBeTruthy();
+  expect(store.get(imported.identity,999).temporary.smoke_1).toBeTruthy();
+  expect(store.get(imported.identity,1000).temporary.smoke_1).toBeUndefined();
+});
+
+test('delta caps fail loudly instead of silently growing an unbounded Zone payload',()=>{
+  const store=core.createDeltaStore({maxDeltaEntities:2,maxTemporaryEntities:1});
+  const zone=position('cap');
+  store.recordEntityChange(zone,{entityId:'a',patch:{x:1},updatedAt:1});
+  store.recordEntityChange(zone,{entityId:'b',patch:{x:2},updatedAt:2});
+  expect(()=>store.recordEntityChange(zone,{entityId:'c',patch:{x:3},updatedAt:3})).toThrow('MAP_DELTA_ENTITY_CAP_EXCEEDED');
+  store.recordTemporary(zone,{temporaryId:'t1',createdAt:1,expiresAt:10});
+  expect(()=>store.recordTemporary(zone,{temporaryId:'t2',createdAt:1,expiresAt:10})).toThrow('MAP_TEMPORARY_ENTITY_CAP_EXCEEDED');
+});

--- a/tests/vtt_map_simulation_realtime.spec.js
+++ b/tests/vtt_map_simulation_realtime.spec.js
@@ -1,0 +1,81 @@
+const {test,expect}=require('@playwright/test');
+const fs=require('node:fs'),path=require('node:path'),{execFileSync}=require('node:child_process');
+const ROOT=path.resolve(__dirname,'..');
+const read=file=>fs.readFileSync(path.join(ROOT,file),'utf8');
+
+function checkModule(file){execFileSync(process.execPath,['--input-type=module','--check'],{input:read(file),stdio:['pipe','pipe','pipe']});}
+
+test('map simulation modules parse and bootstrap after regional transition',()=>{
+  execFileSync(process.execPath,['--check',path.join(ROOT,'js/vtt/map-simulation-core.js')]);
+  checkModule('js/vtt/map-simulation-runtime.js');
+  checkModule('js/vtt/main.js');
+  const main=read('js/vtt/main.js');
+  const transition=main.indexOf("import('./regional-local-transition-runtime.js')");
+  const simulation=main.indexOf("import('./map-simulation-runtime.js')");
+  expect(transition).toBeGreaterThan(-1);
+  expect(simulation).toBeGreaterThan(transition);
+  expect(main).toContain('window.LuminousVttRuntime?.mapSimulation?.stop?.()');
+  expect(main).toContain('window.LuminousVttRuntime?.worldStreaming?.stop?.()');
+});
+
+test('map simulation has no polling, frame writes, movement writes, or permanent Firebase value listener',()=>{
+  const runtime=read('js/vtt/map-simulation-runtime.js');
+  expect(runtime).not.toContain('setInterval(');
+  expect(runtime).not.toContain('setTimeout(');
+  expect(runtime).not.toContain('requestAnimationFrame(');
+  expect(runtime).not.toContain("addEventListener('mousemove'");
+  expect(runtime).not.toContain('.on(\'value\'');
+  expect(runtime).not.toContain('.on("value"');
+  expect(runtime).toContain("once('value')");
+  expect(runtime).toContain("globalThis.addEventListener?.('luminous:world-scheduler-updated',onWorldClock)");
+});
+
+test('persistent map state stays under the existing DM-authoritative world-state rules',()=>{
+  const runtime=read('js/vtt/map-simulation-runtime.js');
+  const rules=JSON.parse(read('database.rules.json'));
+  expect(runtime).toContain("PERSIST_ROOT='campaña/estado_mundo/mapSimulationZones'");
+  expect(rules.rules['campaña']['estado_mundo']['.write']).toContain("auth.uid === 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1'");
+  expect(runtime).toContain('if(!isDm||!db)return');
+});
+
+test('meaningful entity changes use one compact path update and dormant flushes use one record write',()=>{
+  const runtime=read('js/vtt/map-simulation-runtime.js');
+  expect(runtime).toContain('updates[`entities/${entityId}`]=entry');
+  expect(runtime).toContain('await zoneRef(identity).update(updates)');
+  expect(runtime).toContain('await zoneRef(identity).set({...record,lastPersistReason:reason})');
+  expect(runtime).not.toContain('mapData:clone(mapData)');
+  expect(runtime).not.toContain('JSON.stringify(mapData)');
+});
+
+test('world object writes emit stable map deltas but procedural replaceAll does not fan out deltas',()=>{
+  const source=read('js/vtt/world-object-state.js');
+  expect(source).toContain("new root.CustomEvent('vtt:map-delta'");
+  const save=source.slice(source.indexOf('async function saveInstance'),source.indexOf('async function deleteInstance'));
+  const remove=source.slice(source.indexOf('async function deleteInstance'),source.indexOf('async function replaceAll'));
+  const replace=source.slice(source.indexOf('async function replaceAll'),source.indexOf('async function saveDefinition'));
+  expect(save).toContain("operation:'upsert'");
+  expect(remove).toContain("operation:'remove'");
+  expect(replace).not.toContain('emitMapDelta');
+});
+
+test('runtime exposes host-fed eight-player reconciliation without adding a player-root realtime listener',()=>{
+  const runtime=read('js/vtt/map-simulation-runtime.js');
+  expect(runtime).toContain('reconcileActors:(actors,now=worldNowMs())=>reconcile(actors,now)');
+  expect(runtime).not.toContain("campaña/jugadores");
+  expect(runtime).toContain('maxActiveZones:8');
+  expect(runtime).toContain('maxWarmZones:16');
+});
+
+test('dormant records are evicted locally after persistence instead of accumulating visited Zones',()=>{
+  const runtime=read('js/vtt/map-simulation-runtime.js');
+  expect(runtime).toContain('async function releaseDormant');
+  expect(runtime).toContain('loadedZones.delete(key)');
+  expect(runtime).toContain('store.forget(identity,{onlyPristine:false})');
+});
+
+test('existing chunk streaming performance budgets remain unchanged',()=>{
+  const runtime=read('js/vtt/world-streaming-runtime.js');
+  expect(runtime).toContain('maxActiveChunks:8');
+  expect(runtime).toContain('maxWarmChunks:16');
+  expect(runtime).toContain('warmTtlMs:30000');
+});


### PR DESCRIPTION
Adds Zone-level Simulation Bubbles on top of the existing chunk lifecycle, with ACTIVE/WARM/DORMANT residency, PERSISTENT/PINNED flags, bounded resident budgets, and event-driven Seed + Delta persistence. Meaningful world-object changes emit compact stable-ID deltas, temporary state expires against WorldClock timestamps, dormant Zones are restored with one-shot reads, and local dormant records are evicted after persistence so thousands of visited Zones do not accumulate in memory. No polling, no per-frame writes, no player-root realtime listener, and no full map payload persistence. Includes 8-player, 2,000-Zone, delta reconstruction, temporary TTL, realtime/static guard, world streaming, world objects, regional transition, procedural performance, and full repository regression gates. Merge only if all workflows pass and main remains synchronized.