### PR TITLE
feat(vtt): stabilize camera POV and DM observer

### DIFF
--- a/.github/workflows/vtt-camera-pov-observer.yml
+++ b/.github/workflows/vtt-camera-pov-observer.yml
@@ -1,0 +1,86 @@
+name: VTT Camera POV Observer
+
+on:
+  pull_request:
+    paths:
+      - 'js/vtt/camera-follow.js'
+      - 'js/vtt/dm-observer.js'
+      - 'js/vtt/map-hud-bootstrap.js'
+      - 'js/vtt/main.js'
+      - 'js/vtt/lighting-engine.js'
+      - 'js/vtt/pov-*.js'
+      - 'js/vtt/token-state.js'
+      - 'js/vtt/player-discovery-*.js'
+      - 'tests/vtt_camera*.spec.js'
+      - 'tests/vtt_*pov*.spec.js'
+      - 'tests/vtt_*vision*.spec.js'
+      - 'tests/vtt_dynamic_lighting*.spec.js'
+      - 'tests/vtt_canonical_token_state.spec.js'
+      - 'tests/vtt_player_discovery*.spec.js'
+      - 'tests/vtt_*fog*.spec.js'
+      - 'tests/regional_local_transition*.spec.js'
+      - 'tests/vtt_world_streaming_lifecycle.spec.js'
+      - 'tests/vtt_performance_guard.spec.js'
+      - 'tests/vtt_procedural_chunk_streaming_performance.spec.js'
+      - '.github/workflows/vtt-camera-pov-observer.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'js/vtt/camera-follow.js'
+      - 'js/vtt/dm-observer.js'
+      - 'js/vtt/map-hud-bootstrap.js'
+      - 'js/vtt/main.js'
+      - 'tests/vtt_camera*.spec.js'
+      - '.github/workflows/vtt-camera-pov-observer.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  camera-pov-observer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Syntax
+        run: |
+          node --check js/vtt/camera-follow.js
+          node --check js/vtt/dm-observer.js
+          node --input-type=module --check < js/vtt/map-hud-bootstrap.js
+          node --input-type=module --check < js/vtt/main.js
+          node --check tests/vtt_camera_pov_observer_field.spec.js
+          node --check tests/vtt_camera_pov_observer_realtime.spec.js
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Focused camera POV observer field and realtime contracts
+        run: >-
+          npx playwright test --workers=1
+          tests/vtt_camera_pov_observer_field.spec.js
+          tests/vtt_camera_pov_observer_realtime.spec.js
+          tests/vtt_camera_perception.spec.js
+          tests/vtt_token_pov_look_up.spec.js
+          tests/vtt_pov_eye_height_hardening.spec.js
+          tests/vtt_pov_subscription_sync.spec.js
+          tests/vtt_vision_cone_runtime.spec.js
+          tests/vtt_dynamic_lighting.spec.js
+          tests/vtt_dynamic_lighting_runtime.spec.js
+          tests/vtt_canonical_token_state.spec.js
+          tests/vtt_player_discovery_fog.spec.js
+          tests/vtt_player_discovery_realtime.spec.js
+          tests/vtt_fog_memory_integration_hardening.spec.js
+          tests/vtt_persistent_fog_memory.spec.js
+          tests/regional_local_transition.spec.js
+          tests/regional_local_transition_realtime.spec.js
+          tests/vtt_world_streaming_lifecycle.spec.js
+          tests/vtt_map_hud_physical.spec.js
+          tests/vtt_performance_guard.spec.js
+          tests/vtt_procedural_chunk_streaming_performance.spec.js
+      - name: Full repository regression
+        run: npx playwright test --workers=1

--- a/js/vtt/camera-follow.js
+++ b/js/vtt/camera-follow.js
@@ -26,7 +26,7 @@
       if (explicit) return explicit;
     }
 
-    const isDm = Boolean(runtime?.bridge?.isDm);
+    const isDm = Boolean(runtime?.bridge?.isDm || runtime?.tokenState?.isDm);
     if (isDm) {
       const previewId = mapData?.lighting?.dmPreviewTokenId;
       if (!previewId) return null;
@@ -78,15 +78,7 @@
   }
 
   function perceptionModifier(token = {}, host = root) {
-    const carriers = [
-      token,
-      token.actor,
-      token.raw,
-      token.character,
-      token.characterBuild,
-      token.build,
-      host?.datosJugador,
-    ];
+    const carriers = [token, token.actor, token.raw, token.character, token.characterBuild, token.build, host?.datosJugador];
     for (const carrier of carriers) {
       const modifier = modifierFromCarrier(carrier);
       if (modifier != null) return Math.max(-10, Math.min(20, modifier));
@@ -137,16 +129,15 @@
     return Boolean(target?.isContentEditable || ['input', 'textarea', 'select', 'button'].includes(tag));
   }
 
-  function createController({ runtime, mapData = runtime?.engine?.mapData, root: host = root, intervalMs = 120 } = {}) {
+  function createController({ runtime, mapData = runtime?.engine?.mapData, root: host = root } = {}) {
     const engine = runtime?.engine;
     const camera = engine?.camera;
     const canvas = engine?.canvas;
     if (!engine || !camera || !canvas || !mapData) throw new Error('CAMERA_FOLLOW_RUNTIME_REQUIRED');
 
-    const isDm = Boolean(runtime?.bridge?.isDm);
+    const isDm = Boolean(runtime?.bridge?.isDm || runtime?.tokenState?.isDm);
     let enabled = !isDm;
     let targetId = null;
-    let timer = null;
     let stopped = false;
     let lastSignature = '';
     let lastPolicyKey = '';
@@ -184,16 +175,35 @@
       return policy;
     }
 
+    function state() {
+      const policy = policyState();
+      const token = policy.token;
+      const mode = enabled ? 'follow' : policy.active ? 'look' : 'free';
+      return {
+        enabled,
+        targetId: token ? clean(token.id) : targetId,
+        hasTarget: Boolean(token),
+        targetLayer: token ? layerOf(token) : null,
+        mode,
+        isDm,
+        tokenRules: policy.active,
+        perceptionModifier: policy.perceptionModifier,
+        minZoom: policy.minZoom,
+        maxZoom: policy.maxZoom,
+        maxLookFt: policy.maxLookFt,
+      };
+    }
+
     const emit = (reason = 'sync') => {
-      const detail = state();
-      detail.reason = reason;
-      canvas.dispatchEvent(new CustomEvent('vtt:camera-follow-changed', { detail }));
+      const detail = { ...state(), reason };
+      const EventCtor = host?.CustomEvent || root?.CustomEvent || globalThis.CustomEvent;
+      if (typeof EventCtor === 'function') canvas.dispatchEvent(new EventCtor('vtt:camera-follow-changed', { detail }));
       return detail;
     };
 
     function signature(token) {
       if (!token) return '';
-      return [clean(token.id), Number(token.x) || 0, Number(token.y) || 0, layerOf(token), camera.zoom].join('|');
+      return [clean(token.id), Number(token.x) || 0, Number(token.y) || 0, layerOf(token)].join('|');
     }
 
     function center(reason = 'follow') {
@@ -207,6 +217,20 @@
         emit(reason);
       }
       return ok;
+    }
+
+    function sync(reason = 'state-sync', { forceCenter = false } = {}) {
+      if (stopped) return state();
+      const token = target();
+      applyPolicy();
+      if (!token) {
+        lastSignature = '';
+        emit(reason);
+        return state();
+      }
+      if (enabled && (forceCenter || signature(token) !== lastSignature)) center(reason);
+      else if (!enabled && camera.enforceCenterConstraint?.()) emit('look-clamped');
+      return state();
     }
 
     function setEnabled(value, { reason = 'user', centerNow = true } = {}) {
@@ -229,6 +253,7 @@
     function setTarget(id, { follow = true } = {}) {
       targetId = clean(id) || null;
       if (follow && target()) enabled = true;
+      lastSignature = '';
       applyPolicy(true);
       if (enabled) center('target');
       else emit('target');
@@ -237,6 +262,7 @@
 
     function clearTarget() {
       targetId = null;
+      lastSignature = '';
       applyPolicy(true);
       if (enabled) center('target-clear');
       else emit('target-clear');
@@ -246,27 +272,9 @@
     function recenter() {
       if (!target()) return false;
       enabled = true;
+      lastSignature = '';
       applyPolicy(true);
       return center('recenter');
-    }
-
-    function state() {
-      const policy = policyState();
-      const token = policy.token;
-      const mode = enabled ? 'follow' : policy.active ? 'look' : 'free';
-      return {
-        enabled,
-        targetId: token ? clean(token.id) : targetId,
-        hasTarget: Boolean(token),
-        targetLayer: token ? layerOf(token) : null,
-        mode,
-        isDm,
-        tokenRules: policy.active,
-        perceptionModifier: policy.perceptionModifier,
-        minZoom: policy.minZoom,
-        maxZoom: policy.maxZoom,
-        maxLookFt: policy.maxLookFt,
-      };
     }
 
     const onManualPan = () => {
@@ -281,10 +289,11 @@
       const token = target();
       if (!token) return;
       if (event?.detail?.tokenId != null && clean(event.detail.tokenId) !== clean(token.id)) return;
-      applyPolicy();
-      if (enabled) center('token-moved');
-      else if (camera.enforceCenterConstraint?.()) emit('look-clamped');
+      sync('token-moved');
     };
+
+    const onCanonicalSync = () => sync('canonical-token-sync', { forceCenter: true });
+    const onWorldTransition = () => sync('world-transition', { forceCenter: true });
 
     const onKeyDown = (event) => {
       if (isEditableTarget(event.target) || event.ctrlKey || event.metaKey || event.altKey) return;
@@ -297,40 +306,31 @@
       }
     };
 
-    const tick = () => {
-      if (stopped) return;
-      const token = target();
-      applyPolicy();
-      if (!token) return;
-      if (enabled) {
-        const next = signature(token);
-        if (next !== lastSignature) center('state-sync');
-      } else {
-        camera.enforceCenterConstraint?.();
-      }
-    };
-
     camera.setManualPanListener?.(onManualPan);
     canvas.addEventListener('vtt:token-moved', onTokenMoved);
     canvas.addEventListener('vtt:token-z-transition', onTokenMoved);
+    canvas.addEventListener('vtt:canonical-tokens-synced', onCanonicalSync);
+    canvas.addEventListener('vtt:regional-local-transition-applied', onWorldTransition);
+    canvas.addEventListener('vtt:procedural-chunk-loaded', onWorldTransition);
     host?.addEventListener?.('keydown', onKeyDown);
-    timer = host?.setInterval?.(tick, Math.max(60, Number(intervalMs) || 120)) || null;
     applyPolicy(true);
-    if (enabled) host?.setTimeout?.(() => center('initial'), 0);
+    if (enabled) host?.setTimeout?.(() => sync('initial', { forceCenter: true }), 0);
 
     function stop() {
       if (stopped) return;
       stopped = true;
-      if (timer != null) host?.clearInterval?.(timer);
       camera.setManualPanListener?.(null);
       camera.setCenterConstraint?.(null);
       camera.setZoomBounds?.(0.1, 5);
       canvas.removeEventListener('vtt:token-moved', onTokenMoved);
       canvas.removeEventListener('vtt:token-z-transition', onTokenMoved);
+      canvas.removeEventListener('vtt:canonical-tokens-synced', onCanonicalSync);
+      canvas.removeEventListener('vtt:regional-local-transition-applied', onWorldTransition);
+      canvas.removeEventListener('vtt:procedural-chunk-loaded', onWorldTransition);
       host?.removeEventListener?.('keydown', onKeyDown);
     }
 
-    return Object.freeze({ state, target, center, recenter, setEnabled, toggle, setTarget, clearTarget, applyPolicy, stop });
+    return Object.freeze({ state, target, center, sync, recenter, setEnabled, toggle, setTarget, clearTarget, applyPolicy, stop });
   }
 
   return Object.freeze({

--- a/js/vtt/dm-observer.js
+++ b/js/vtt/dm-observer.js
@@ -1,0 +1,295 @@
+(function (root, factory) {
+  const api = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttDmObserver = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (root) {
+  'use strict';
+
+  const MODES = Object.freeze({ FREE: 'free', FOLLOW: 'follow', VIEW_AS: 'view_as' });
+  const clean = (value) => String(value ?? '').trim();
+
+  function layerOf(token = {}) {
+    if (Number.isFinite(Number(token.zLayer))) return Number(token.zLayer);
+    if (Number.isFinite(Number(token.gridPosition?.z))) return Number(token.gridPosition.z);
+    if (Array.isArray(token.z) && token.z.length) return Number(token.z[0]) || 0;
+    return 0;
+  }
+
+  function playerIdForToken(token = {}) {
+    return clean(token.canonicalPlayerKey || token.playerId || token.characterLink?.playerId || token.characterLink?.uid) || null;
+  }
+
+  function isPlayerToken(token = {}) {
+    return token.canonicalScope === 'player'
+      || Boolean(playerIdForToken(token))
+      || token.characterLink?.mode === 'current_player'
+      || token.viewer === true;
+  }
+
+  function createController({ runtime, mapData = runtime?.engine?.mapData, cameraFollow, root: host = root } = {}) {
+    const engine = runtime?.engine;
+    const canvas = engine?.canvas;
+    if (!engine || !canvas || !mapData || !cameraFollow) throw new Error('DM_OBSERVER_RUNTIME_REQUIRED');
+
+    const isDm = Boolean(runtime?.bridge?.isDm || runtime?.tokenState?.isDm);
+    if (!isDm) return null;
+
+    mapData.lighting ||= {};
+    let mode = MODES.FREE;
+    let targetId = null;
+    let selectingMode = null;
+    let stopped = false;
+    let panel = null;
+    let statusNode = null;
+    let restoreRenderer = null;
+
+    const tokens = () => Array.isArray(mapData.tokens) ? mapData.tokens : [];
+    const tokenById = (id = targetId) => tokens().find((token) => clean(token.id) === clean(id)) || null;
+    const target = () => tokenById(targetId);
+
+    function syncLayer(token) {
+      if (!token) return false;
+      const z = layerOf(token);
+      if (typeof runtime?.setLayer === 'function') runtime.setLayer(z);
+      else engine.setZLayer?.(z);
+      return true;
+    }
+
+    function snapshot() {
+      const token = target();
+      return {
+        mode,
+        targetTokenId: token ? clean(token.id) : targetId,
+        targetPlayerId: token ? playerIdForToken(token) : null,
+        targetLayer: token ? layerOf(token) : null,
+        selectingMode,
+        isDm: true,
+      };
+    }
+
+    function emit(reason = 'observer') {
+      const detail = { ...snapshot(), reason };
+      const EventCtor = host?.CustomEvent || root?.CustomEvent || globalThis.CustomEvent;
+      if (typeof EventCtor === 'function') {
+        canvas.dispatchEvent(new EventCtor('vtt:dm-observer-changed', { detail }));
+        if (host && host !== canvas && typeof host.dispatchEvent === 'function') {
+          host.dispatchEvent(new EventCtor('vtt:dm-observer-changed', { detail }));
+        }
+      }
+      renderStatus();
+      return detail;
+    }
+
+    function free(reason = 'free') {
+      mode = MODES.FREE;
+      targetId = null;
+      selectingMode = null;
+      mapData.lighting.dmPreviewTokenId = null;
+      cameraFollow.setEnabled(false, { reason: 'dm-observer-free', centerNow: false });
+      cameraFollow.clearTarget();
+      return emit(reason);
+    }
+
+    function follow(id, reason = 'follow') {
+      const token = tokenById(id);
+      if (!token) return free('target-missing');
+      mode = MODES.FOLLOW;
+      targetId = clean(token.id);
+      selectingMode = null;
+      mapData.lighting.dmPreviewTokenId = null;
+      cameraFollow.setTarget(targetId, { follow: true });
+      cameraFollow.setEnabled(true, { reason: 'dm-observer-follow', centerNow: true });
+      syncLayer(token);
+      return emit(reason);
+    }
+
+    function viewAs(id, reason = 'view-as') {
+      const token = tokenById(id);
+      if (!token) return free('target-missing');
+      mode = MODES.VIEW_AS;
+      targetId = clean(token.id);
+      selectingMode = null;
+      mapData.lighting.dmPreviewTokenId = targetId;
+      cameraFollow.setTarget(targetId, { follow: true });
+      cameraFollow.setEnabled(true, { reason: 'dm-observer-view-as', centerNow: true });
+      syncLayer(token);
+      return emit(reason);
+    }
+
+    function select(nextMode) {
+      if (![MODES.FOLLOW, MODES.VIEW_AS].includes(nextMode)) return free('select-free');
+      selectingMode = nextMode;
+      renderStatus();
+      return snapshot();
+    }
+
+    function applySelected(id) {
+      if (selectingMode === MODES.VIEW_AS) return viewAs(id, 'selected-view-as');
+      if (selectingMode === MODES.FOLLOW) return follow(id, 'selected-follow');
+      return snapshot();
+    }
+
+    function resync(reason = 'canonical-sync') {
+      if (mode === MODES.FREE) return snapshot();
+      const token = target();
+      if (!token) return free('target-missing');
+      if (mode === MODES.VIEW_AS) mapData.lighting.dmPreviewTokenId = clean(token.id);
+      else mapData.lighting.dmPreviewTokenId = null;
+      cameraFollow.setTarget(clean(token.id), { follow: true });
+      syncLayer(token);
+      emit(reason);
+      return snapshot();
+    }
+
+    function onTokenState(event) {
+      if (mode === MODES.FREE) return;
+      const id = clean(event?.detail?.tokenId);
+      if (id && id !== clean(targetId)) return;
+      const token = target();
+      if (!token) return free('target-missing');
+      syncLayer(token);
+      emit('target-state');
+    }
+
+    function onCanonicalSync() { resync('canonical-sync'); }
+    function onWorldTransition() { resync('world-transition'); }
+
+    function tokenAtEvent(event) {
+      if (typeof engine.tokenAtEvent === 'function') return engine.tokenAtEvent(event);
+      return null;
+    }
+
+    function onCanvasSelect(event) {
+      if (!selectingMode || event.button !== 0) return;
+      const token = tokenAtEvent(event);
+      if (!token || !isPlayerToken(token)) return;
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      applySelected(token.id);
+    }
+
+    function ensurePanel() {
+      const doc = host?.document;
+      if (!doc?.body || panel) return panel;
+      const legacy = doc.getElementById('vtt-view-as-token');
+      if (legacy) legacy.hidden = true;
+      panel = doc.createElement('section');
+      panel.id = 'vtt-dm-observer';
+      panel.setAttribute('aria-label', 'DM observer controls');
+      panel.style.cssText = 'position:fixed;right:12px;bottom:84px;z-index:36600;background:rgba(7,9,11,.96);border:1px solid #59636c;padding:7px;font:700 9px monospace;color:#dce3e8;display:grid;gap:5px;min-width:185px';
+      panel.innerHTML = '<strong>DM OBSERVER</strong><small id="vtt-dm-observer-status">FREE</small><div style="display:flex;gap:4px"><button type="button" data-dm-observer="free">FREE</button><button type="button" data-dm-observer="follow">FOLLOW</button><button type="button" data-dm-observer="view_as">VIEW AS</button></div>';
+      for (const button of panel.querySelectorAll('button')) button.style.cssText = 'border:1px solid #59636c;background:#11161a;color:#dce3e8;font:700 9px monospace;padding:5px 7px;cursor:pointer';
+      statusNode = panel.querySelector('#vtt-dm-observer-status');
+      panel.addEventListener('click', onPanelClick);
+      doc.body.appendChild(panel);
+      renderStatus();
+      return panel;
+    }
+
+    function renderStatus() {
+      if (!statusNode) return;
+      const token = target();
+      const name = clean(token?.name || token?.label || token?.id || targetId || '').toUpperCase();
+      if (selectingMode) statusNode.textContent = `SELECT PLAYER · ${selectingMode === MODES.VIEW_AS ? 'VIEW AS' : 'FOLLOW'}`;
+      else if (mode === MODES.FREE) statusNode.textContent = 'FREE CAMERA · DM VISION';
+      else statusNode.textContent = `${mode === MODES.VIEW_AS ? 'VIEW AS' : 'FOLLOW'} · ${name || '—'}`;
+    }
+
+    function onPanelClick(event) {
+      const action = event.target?.closest?.('[data-dm-observer]')?.dataset?.dmObserver;
+      if (action === MODES.FREE) free('panel-free');
+      else if (action === MODES.FOLLOW) select(MODES.FOLLOW);
+      else if (action === MODES.VIEW_AS) select(MODES.VIEW_AS);
+    }
+
+    function playerTokensOnLayer() {
+      const z = Number(engine.activeZ) || 0;
+      return tokens().filter((token) => isPlayerToken(token) && layerOf(token) === z);
+    }
+
+    function drawOutlines() {
+      if (mode === MODES.VIEW_AS || stopped) return;
+      const renderer = engine.renderer;
+      const ctx = renderer?.ctx;
+      const camera = engine.camera;
+      if (!ctx || !camera) return;
+      const lighting = host?.LuminousVttLightingEngine || root?.LuminousVttLightingEngine;
+      const radius = Math.max(140, (Number(mapData.grid?.size) || 70) * 4);
+      ctx.save();
+      camera.applyTransformSimple?.(ctx);
+      for (const token of playerTokensOnLayer()) {
+        const cone = Number(lighting?.visionConeDeg?.(token)) || 120;
+        const facing = Number(token.lookState?.yawDeg ?? lighting?.facingDeg?.(token) ?? token.facingDeg) || 0;
+        const half = Math.min(180, cone / 2) * Math.PI / 180;
+        const center = facing * Math.PI / 180;
+        ctx.beginPath();
+        ctx.moveTo(Number(token.x) || 0, Number(token.y) || 0);
+        ctx.arc(Number(token.x) || 0, Number(token.y) || 0, radius, center - half, center + half);
+        ctx.closePath();
+        ctx.globalAlpha = clean(token.id) === clean(targetId) ? 0.85 : 0.45;
+        ctx.strokeStyle = token.color || '#d7b151';
+        ctx.lineWidth = clean(token.id) === clean(targetId) ? 3 : 2;
+        ctx.stroke();
+      }
+      ctx.restore();
+    }
+
+    function installOutlineRenderer() {
+      const renderer = engine.renderer;
+      if (!renderer || typeof renderer.render !== 'function' || restoreRenderer) return;
+      const original = renderer.render;
+      renderer.render = function (...args) {
+        const result = original.apply(this, args);
+        drawOutlines();
+        return result;
+      };
+      restoreRenderer = () => { renderer.render = original; };
+    }
+
+    canvas.addEventListener('click', onCanvasSelect, true);
+    canvas.addEventListener('vtt:token-moved', onTokenState);
+    canvas.addEventListener('vtt:token-z-transition', onTokenState);
+    canvas.addEventListener('vtt:canonical-tokens-synced', onCanonicalSync);
+    canvas.addEventListener('vtt:regional-local-transition-applied', onWorldTransition);
+    canvas.addEventListener('vtt:procedural-chunk-loaded', onWorldTransition);
+    ensurePanel();
+    installOutlineRenderer();
+    free('initial');
+
+    function stop() {
+      if (stopped) return;
+      stopped = true;
+      mapData.lighting.dmPreviewTokenId = null;
+      canvas.removeEventListener('click', onCanvasSelect, true);
+      canvas.removeEventListener('vtt:token-moved', onTokenState);
+      canvas.removeEventListener('vtt:token-z-transition', onTokenState);
+      canvas.removeEventListener('vtt:canonical-tokens-synced', onCanonicalSync);
+      canvas.removeEventListener('vtt:regional-local-transition-applied', onWorldTransition);
+      canvas.removeEventListener('vtt:procedural-chunk-loaded', onWorldTransition);
+      restoreRenderer?.();
+      restoreRenderer = null;
+      if (panel) panel.removeEventListener('click', onPanelClick);
+      panel?.remove?.();
+      panel = null;
+      statusNode = null;
+      const legacy = host?.document?.getElementById?.('vtt-view-as-token');
+      if (legacy) legacy.hidden = false;
+    }
+
+    return Object.freeze({
+      MODES,
+      state: snapshot,
+      target,
+      free,
+      follow,
+      viewAs,
+      select,
+      applySelected,
+      resync,
+      drawOutlines,
+      stop,
+    });
+  }
+
+  return Object.freeze({ MODES, layerOf, playerIdForToken, isPlayerToken, createController });
+});

--- a/js/vtt/main.js
+++ b/js/vtt/main.js
@@ -110,11 +110,22 @@ document.addEventListener('DOMContentLoaded', async () => {
         mapData: mockMapData,
         isDm: bridge.isDm,
         notify: (message, mode) => controller?.notify(message, mode),
-        onTokensChanged: () => {
+        onTokensChanged: (change = {}) => {
             characterVisionBridge?.syncTokens?.();
-            if (bridge.isDm) return;
             const viewer = (mockMapData.tokens || []).find((token) => token.viewer === true)
-                || (mockMapData.tokens || []).find((token) => token.characterLink?.mode === 'current_player');
+                || (mockMapData.tokens || []).find((token) => token.characterLink?.mode === 'current_player')
+                || null;
+            const EventCtor = window.CustomEvent || globalThis.CustomEvent;
+            if (typeof EventCtor === 'function') {
+                canvas.dispatchEvent(new EventCtor('vtt:canonical-tokens-synced', {
+                    detail: {
+                        scope: String(change.scope || 'unknown'),
+                        tokenIds: (mockMapData.tokens || []).map((token) => String(token?.id || '')).filter(Boolean),
+                        viewerTokenId: viewer?.id ? String(viewer.id) : null,
+                    },
+                }));
+            }
+            if (bridge.isDm) return;
             const zLayer = Number(viewer?.zLayer ?? viewer?.gridPosition?.z ?? viewer?.z?.[0]);
             if (Number.isFinite(zLayer) && zLayer !== engine.activeZ) applyLayer(zLayer);
         },

--- a/js/vtt/map-hud-bootstrap.js
+++ b/js/vtt/map-hud-bootstrap.js
@@ -1,4 +1,5 @@
 import './camera-follow.js';
+import './dm-observer.js';
 import './physical-resolver.js';
 import './interaction-intent.js';
 import './world-object-components.js';
@@ -79,16 +80,17 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   if (window.LuminousVttMapHudRuntime?.api) return window.LuminousVttMapHudRuntime.api;
   ensureStyles();
   const hud = ensureHud(), engine = runtime.engine, canvas = engine.canvas;
-  const physical = window.LuminousVttPhysicalResolver, cameraApi = window.LuminousVttCameraFollow, intentApi = window.LuminousVttInteractionIntent, componentApi = window.LuminousVttWorldObjectComponents;
-  if (!physical || !cameraApi || !intentApi || !componentApi) throw new Error('MAP_HUD_DEPENDENCY_REQUIRED');
+  const physical = window.LuminousVttPhysicalResolver, cameraApi = window.LuminousVttCameraFollow, observerApi = window.LuminousVttDmObserver, intentApi = window.LuminousVttInteractionIntent, componentApi = window.LuminousVttWorldObjectComponents;
+  if (!physical || !cameraApi || !observerApi || !intentApi || !componentApi) throw new Error('MAP_HUD_DEPENDENCY_REQUIRED');
 
-  const cameraFollow = cameraApi.createController({ runtime, mapData });
+  const currentRuntime = () => window.LuminousVttRuntime || runtime;
+  const cameraFollow = cameraApi.createController({ runtime: currentRuntime(), mapData });
+  const dmObserver = observerApi.createController({ runtime: currentRuntime(), mapData, cameraFollow });
   const componentRuntime = componentApi.start({ runtime, mapData });
   const executor = intentApi.createExecutor({ runtime, mapData, worldObjectBridge: runtime.worldObjects?.bridge });
   executor.start();
-  let selectedId = null, cursorPoint = null, stopped = false, timer = null;
+  let selectedId = null, cursorPoint = null, cursorCellKey = '', stopped = false;
   const node = (id) => document.getElementById(id);
-  const currentRuntime = () => window.LuminousVttRuntime || runtime;
   const actor = () => cameraFollow.target()
     || currentRuntime()?.pov?.controlledViewers?.()?.[0]
     || currentRuntime()?.lighting?.controlledViewers?.()?.[0]
@@ -112,18 +114,23 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     hud.querySelector('[data-hud-layer="next"]').disabled = !isDm || index < 0 || index >= floors.length - 1;
   }
   function syncCamera() {
-    const state = cameraFollow.state(), button = hud.querySelector('[data-hud-camera="toggle"]');
+    const state = cameraFollow.state(), observerState = dmObserver?.state?.(), button = hud.querySelector('[data-hud-camera="toggle"]');
     let label;
-    if (state.tokenRules) {
+    if (observerState) {
+      const observed = clean(dmObserver?.target?.()?.name || dmObserver?.target?.()?.label || observerState.targetTokenId || '').toUpperCase();
+      if (observerState.mode === 'view_as') label = `VIEW AS · ${observed || '—'} · PLAYER POV`;
+      else if (observerState.mode === 'follow') label = `DM FOLLOW · ${observed || '—'} · FULL VISION`;
+      else label = 'DM FREE · FULL VISION';
+    } else if (state.tokenRules) {
       const mod = `${state.perceptionModifier >= 0 ? '+' : ''}${state.perceptionModifier}`;
-      const mode = state.mode === 'follow' ? (state.isDm ? 'TOKEN FOLLOW' : 'FOLLOW') : (state.isDm ? 'TOKEN LOOK' : 'LOOK AROUND');
+      const mode = state.mode === 'follow' ? 'FOLLOW' : 'LOOK AROUND';
       label = `${mode} · PER ${mod} · ${state.maxLookFt}FT · MIN ${state.minZoom.toFixed(2)}x`;
     } else {
-      label = 'DM FREE · 0.10x–5x';
+      label = 'FREE · 0.10x–5x';
     }
     node('vtt-hud-camera-state').textContent = label;
     button.textContent = state.enabled ? 'LOOK' : 'FOLLOW';
-    button.classList.toggle('is-following', state.enabled); button.classList.toggle('is-free', !state.enabled); button.disabled = !state.hasTarget;
+    button.classList.toggle('is-following', state.enabled); button.classList.toggle('is-free', !state.enabled); button.disabled = Boolean(observerState) || !state.hasTarget;
     hud.querySelector('[data-hud-camera="recenter"]').disabled = !state.hasTarget;
   }
   function syncMovement(currentActor) {
@@ -163,7 +170,15 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     sync();
   }
 
-  const onCanvasMove = (event) => { const rect = canvas.getBoundingClientRect(); cursorPoint = engine.camera.screenToWorld(event.clientX - rect.left, event.clientY - rect.top); };
+  const onCanvasMove = (event) => {
+    const rect = canvas.getBoundingClientRect();
+    cursorPoint = engine.camera.screenToWorld(event.clientX - rect.left, event.clientY - rect.top);
+    if (actor()) return;
+    const cell = cellForPoint(cursorPoint, mapData), key = `${engine.activeZ}:${cell.col}:${cell.row}`;
+    if (key === cursorCellKey) return;
+    cursorCellKey = key;
+    syncMap(null);
+  };
   const onCanvasClick = (event) => {
     if (mapData.dmEditMode?.active || event.button !== 0) return;
     const rect = canvas.getBoundingClientRect(), point = engine.camera.screenToWorld(event.clientX - rect.left, event.clientY - rect.top), hit = objectAt(point, mapData, engine.activeZ);
@@ -174,24 +189,34 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   };
   const onResolved = () => sync();
   const onKey = (event) => { if (event.key === 'Escape' && selectedId) { selectedId = null; sync(); } };
-  canvas.addEventListener('mousemove', onCanvasMove); canvas.addEventListener('click', onCanvasClick); canvas.addEventListener('vtt:camera-follow-changed', onResolved); canvas.addEventListener('vtt:interaction-resolved', onResolved); canvas.addEventListener('vtt:world-object-changed', onResolved); window.addEventListener('keydown', onKey);
-  hud.addEventListener('click', (event) => {
+  const reactiveEvents = [
+    'vtt:camera-follow-changed', 'vtt:dm-observer-changed', 'vtt:canonical-tokens-synced',
+    'vtt:token-moved', 'vtt:token-z-transition', 'vtt:regional-local-transition-applied',
+    'vtt:procedural-chunk-loaded', 'vtt:interaction-resolved', 'vtt:world-object-changed',
+  ];
+  canvas.addEventListener('mousemove', onCanvasMove);
+  canvas.addEventListener('click', onCanvasClick);
+  reactiveEvents.forEach((name) => canvas.addEventListener(name, onResolved));
+  window.addEventListener('keydown', onKey);
+
+  const onHudClick = (event) => {
     const cameraAction = event.target.closest?.('[data-hud-camera]')?.dataset?.hudCamera;
     if (cameraAction === 'toggle') cameraFollow.toggle(); else if (cameraAction === 'recenter') cameraFollow.recenter();
     const direction = event.target.closest?.('[data-hud-layer]')?.dataset?.hudLayer;
     if (direction && runtime.bridge?.isDm) { const floors = layerList(mapData, engine.activeZ), index = floors.indexOf(Number(engine.activeZ)), next = direction === 'prev' ? floors[index - 1] : floors[index + 1]; if (Number.isFinite(Number(next))) runtime.setLayer?.(Number(next)); }
     const action = event.target.closest?.('[data-hud-action]')?.dataset?.hudAction; if (action) void handleAction(action);
     if (event.target.closest?.('[data-hud-clear-object]')) { selectedId = null; sync(); }
-  });
-  timer = window.setInterval(sync, 250); sync();
+  };
+  hud.addEventListener('click', onHudClick);
+  sync();
 
-  function publish() { const current = currentRuntime(); if (current?.mapHud === api) return; window.LuminousVttRuntime = Object.freeze({ ...current, mapHud: api, cameraFollow, physical, interactionExecutor: executor, worldComponents: componentRuntime }); }
+  function publish() { const current = currentRuntime(); if (current?.mapHud === api) return; window.LuminousVttRuntime = Object.freeze({ ...current, mapHud: api, cameraFollow, dmObserver, physical, interactionExecutor: executor, worldComponents: componentRuntime }); }
   function stop() {
-    if (stopped) return; stopped = true; if (timer != null) window.clearInterval(timer);
-    canvas.removeEventListener('mousemove', onCanvasMove); canvas.removeEventListener('click', onCanvasClick); canvas.removeEventListener('vtt:camera-follow-changed', onResolved); canvas.removeEventListener('vtt:interaction-resolved', onResolved); canvas.removeEventListener('vtt:world-object-changed', onResolved); window.removeEventListener('keydown', onKey);
-    cameraFollow.stop(); executor.stop(); componentRuntime?.stop?.(); hud.remove(); document.getElementById(STYLE_ID)?.remove();
+    if (stopped) return; stopped = true;
+    canvas.removeEventListener('mousemove', onCanvasMove); canvas.removeEventListener('click', onCanvasClick); reactiveEvents.forEach((name) => canvas.removeEventListener(name, onResolved)); window.removeEventListener('keydown', onKey); hud.removeEventListener('click', onHudClick);
+    dmObserver?.stop?.(); cameraFollow.stop(); executor.stop(); componentRuntime?.stop?.(); hud.remove(); document.getElementById(STYLE_ID)?.remove();
   }
-  const api = Object.freeze({ sync, stop, selectObject, selected, actor, cameraFollow, physical, executor, componentRuntime, perceivedByPlayer });
+  const api = Object.freeze({ sync, stop, selectObject, selected, actor, cameraFollow, dmObserver, physical, executor, componentRuntime, perceivedByPlayer });
   window.LuminousVttMapHudRuntime = Object.freeze({ api, stop }); publish(); window.setTimeout(publish, 500); window.addEventListener('beforeunload', stop, { once: true });
   return api;
 }

--- a/tests/vtt_camera_pov_observer_field.spec.js
+++ b/tests/vtt_camera_pov_observer_field.spec.js
@@ -1,0 +1,250 @@
+const { test, expect } = require('@playwright/test');
+
+class MockCustomEvent {
+  constructor(type, init = {}) { this.type = type; this.detail = init.detail || null; this.button = init.button ?? 0; }
+  preventDefault() { this.defaultPrevented = true; }
+  stopPropagation() { this.propagationStopped = true; }
+}
+
+class MockTarget {
+  constructor() { this.listeners = new Map(); this.CustomEvent = MockCustomEvent; }
+  addEventListener(name, fn) { if (!this.listeners.has(name)) this.listeners.set(name, new Set()); this.listeners.get(name).add(fn); }
+  removeEventListener(name, fn) { this.listeners.get(name)?.delete(fn); }
+  dispatchEvent(event) { for (const fn of [...(this.listeners.get(event.type) || [])]) fn(event); return true; }
+}
+
+function loadFollow() {
+  delete require.cache[require.resolve('../js/vtt/camera-follow.js')];
+  return require('../js/vtt/camera-follow.js');
+}
+function loadObserver() {
+  delete require.cache[require.resolve('../js/vtt/dm-observer.js')];
+  return require('../js/vtt/dm-observer.js');
+}
+function loadLighting() {
+  delete require.cache[require.resolve('../js/vtt/lighting-engine.js')];
+  return require('../js/vtt/lighting-engine.js');
+}
+
+function cameraHarness() {
+  const centers = [];
+  let constraint = null;
+  return {
+    centers,
+    camera: {
+      zoom: 1,
+      centerOnWorldPoint(point) { centers.push({ x: Number(point.x), y: Number(point.y) }); return true; },
+      setManualPanListener() {},
+      setCenterConstraint(fn) { constraint = fn; },
+      setZoomBounds() {},
+      enforceCenterConstraint() { return false; },
+      applyTransformSimple() {},
+    },
+    constraint: () => constraint,
+  };
+}
+
+function hostFor(runtime) {
+  const host = new MockTarget();
+  host.LuminousVttRuntime = runtime;
+  host.setTimeout = (fn) => { fn(); return 1; };
+  host.setInterval = () => { throw new Error('POLLING_IS_FORBIDDEN'); };
+  host.clearInterval = () => {};
+  return host;
+}
+
+function event(type, detail = {}) { return new MockCustomEvent(type, { detail }); }
+
+function playerToken(id, x, y, z = 0, extra = {}) {
+  return { id, x, y, zLayer: z, gridPosition: { col: Math.floor(x / 70), row: Math.floor(y / 70), z }, canonicalScope: 'player', canonicalPlayerKey: id, playerId: id, ...extra };
+}
+
+test('field: P1 camera follows only P1 while seven remote tokens move', async () => {
+  const followApi = loadFollow();
+  const canvas = new MockTarget();
+  const mapData = { grid: { size: 70, distancePerCell: 5 }, tokens: Array.from({ length: 8 }, (_, i) => playerToken(`p${i + 1}`, 100 + i * 50, 100, 0, { viewer: i === 0 })) };
+  const harness = cameraHarness();
+  const runtime = { bridge: { isDm: false }, engine: { canvas, camera: harness.camera }, lighting: { controlledViewers: () => [mapData.tokens.find((t) => t.viewer)] } };
+  const host = hostFor(runtime);
+  const controller = followApi.createController({ runtime, mapData, root: host });
+  const initialCenters = harness.centers.length;
+
+  for (let round = 0; round < 25; round += 1) {
+    for (let i = 1; i < 8; i += 1) {
+      mapData.tokens[i].x += 7;
+      canvas.dispatchEvent(event('vtt:token-moved', { tokenId: `p${i + 1}` }));
+    }
+  }
+  expect(harness.centers.length).toBe(initialCenters);
+
+  mapData.tokens[0].x = 420;
+  mapData.tokens[0].y = 315;
+  canvas.dispatchEvent(event('vtt:token-moved', { tokenId: 'p1' }));
+  expect(harness.centers.at(-1)).toEqual({ x: 420, y: 315 });
+  expect(harness.centers.length).toBe(initialCenters + 1);
+  controller.stop();
+});
+
+test('field: reconnect replaces the token object but camera follows canonical identity, not stale object reference', async () => {
+  const followApi = loadFollow();
+  const canvas = new MockTarget();
+  const original = playerToken('p1', 140, 140, 0, { viewer: true });
+  const mapData = { grid: { size: 70, distancePerCell: 5 }, tokens: [original] };
+  const harness = cameraHarness();
+  const runtime = { bridge: { isDm: false }, engine: { canvas, camera: harness.camera }, lighting: { controlledViewers: () => [mapData.tokens[0]] } };
+  const host = hostFor(runtime);
+  const controller = followApi.createController({ runtime, mapData, root: host });
+
+  const replacement = playerToken('p1', 980, 560, 2, { viewer: true });
+  mapData.tokens = [replacement];
+  canvas.dispatchEvent(event('vtt:canonical-tokens-synced', { scope: 'players', tokenIds: ['p1'], viewerTokenId: 'p1' }));
+
+  expect(controller.target()).toBe(replacement);
+  expect(controller.target()).not.toBe(original);
+  expect(controller.state().targetLayer).toBe(2);
+  expect(harness.centers.at(-1)).toEqual({ x: 980, y: 560 });
+  controller.stop();
+});
+
+test('field: regional/local and Z events recenter the same canonical player without a timer', async () => {
+  const followApi = loadFollow();
+  const canvas = new MockTarget();
+  const p1 = playerToken('p1', 70, 70, 0, { viewer: true });
+  const mapData = { grid: { size: 70, distancePerCell: 5 }, tokens: [p1] };
+  const harness = cameraHarness();
+  const runtime = { bridge: { isDm: false }, engine: { canvas, camera: harness.camera }, lighting: { controlledViewers: () => [p1] } };
+  const controller = followApi.createController({ runtime, mapData, root: hostFor(runtime) });
+
+  p1.x = 1260; p1.y = 210; p1.zLayer = 1; p1.gridPosition.z = 1;
+  canvas.dispatchEvent(event('vtt:regional-local-transition-applied', { tokenId: 'p1' }));
+  expect(harness.centers.at(-1)).toEqual({ x: 1260, y: 210 });
+  expect(controller.state().targetLayer).toBe(1);
+
+  p1.x = 1330; p1.y = 350; p1.zLayer = 2; p1.gridPosition.z = 2;
+  canvas.dispatchEvent(event('vtt:token-z-transition', { tokenId: 'p1', complete: true, targetZ: 2 }));
+  expect(harness.centers.at(-1)).toEqual({ x: 1330, y: 350 });
+  expect(controller.state().targetLayer).toBe(2);
+  controller.stop();
+});
+
+test('field: DM Free, Follow and View As are distinct and never mutate the observed player viewer flag', async () => {
+  const followApi = loadFollow();
+  const observerApi = loadObserver();
+  const canvas = new MockTarget();
+  const p4 = playerToken('p4', 700, 420, 1, { name: 'P4', viewer: false, facingDeg: 90 });
+  const p7 = playerToken('p7', 350, 280, 0, { name: 'P7', viewer: false });
+  const mapData = { grid: { size: 70, distancePerCell: 5 }, lighting: { dmPreviewTokenId: null }, tokens: [p4, p7] };
+  const harness = cameraHarness();
+  const layers = [];
+  const runtime = { bridge: { isDm: true }, engine: { canvas, camera: harness.camera, activeZ: 0, setZLayer(z) { this.activeZ = z; } }, setLayer(z) { layers.push(z); this.engine.activeZ = z; } };
+  const host = hostFor(runtime);
+  const cameraFollow = followApi.createController({ runtime, mapData, root: host });
+  const observer = observerApi.createController({ runtime, mapData, cameraFollow, root: host });
+
+  expect(observer.state()).toMatchObject({ mode: 'free', targetTokenId: null });
+  expect(mapData.lighting.dmPreviewTokenId).toBe(null);
+
+  observer.follow('p4');
+  expect(observer.state()).toMatchObject({ mode: 'follow', targetTokenId: 'p4', targetPlayerId: 'p4', targetLayer: 1 });
+  expect(mapData.lighting.dmPreviewTokenId).toBe(null);
+  expect(cameraFollow.state().enabled).toBe(true);
+  expect(layers.at(-1)).toBe(1);
+  expect(p4.viewer).toBe(false);
+
+  observer.viewAs('p4');
+  expect(observer.state().mode).toBe('view_as');
+  expect(mapData.lighting.dmPreviewTokenId).toBe('p4');
+  expect(cameraFollow.state().tokenRules).toBe(true);
+  expect(p4.viewer).toBe(false);
+
+  observer.free();
+  expect(observer.state().mode).toBe('free');
+  expect(mapData.lighting.dmPreviewTokenId).toBe(null);
+  expect(cameraFollow.state().enabled).toBe(false);
+  expect(p4.viewer).toBe(false);
+  observer.stop(); cameraFollow.stop();
+});
+
+test('field: DM View As survives canonical replacement, follows new layer, and ignores unrelated player movement', async () => {
+  const followApi = loadFollow();
+  const observerApi = loadObserver();
+  const canvas = new MockTarget();
+  const p4 = playerToken('p4', 200, 200, 0, { viewer: false });
+  const p7 = playerToken('p7', 300, 300, 0, { viewer: false });
+  const mapData = { grid: { size: 70, distancePerCell: 5 }, lighting: {}, tokens: [p4, p7] };
+  const harness = cameraHarness();
+  const layers = [];
+  const runtime = { bridge: { isDm: true }, engine: { canvas, camera: harness.camera, activeZ: 0 }, setLayer(z) { layers.push(z); this.engine.activeZ = z; } };
+  const host = hostFor(runtime);
+  const cameraFollow = followApi.createController({ runtime, mapData, root: host });
+  const observer = observerApi.createController({ runtime, mapData, cameraFollow, root: host });
+  observer.viewAs('p4');
+  const beforeUnrelated = harness.centers.length;
+
+  p7.x = 999;
+  canvas.dispatchEvent(event('vtt:token-moved', { tokenId: 'p7' }));
+  expect(harness.centers.length).toBe(beforeUnrelated);
+
+  const replacement = playerToken('p4', 1120, 840, 3, { viewer: false });
+  mapData.tokens = [replacement, p7];
+  canvas.dispatchEvent(event('vtt:canonical-tokens-synced', { scope: 'players', tokenIds: ['p4', 'p7'] }));
+  expect(observer.target()).toBe(replacement);
+  expect(observer.state().targetLayer).toBe(3);
+  expect(layers.at(-1)).toBe(3);
+  expect(harness.centers.at(-1)).toEqual({ x: 1120, y: 840 });
+  expect(mapData.lighting.dmPreviewTokenId).toBe('p4');
+  observer.stop(); cameraFollow.stop();
+});
+
+test('field: eight-player observer switching stays single-target and event-driven', async () => {
+  const followApi = loadFollow();
+  const observerApi = loadObserver();
+  const canvas = new MockTarget();
+  const mapData = { grid: { size: 70, distancePerCell: 5 }, lighting: {}, tokens: Array.from({ length: 8 }, (_, i) => playerToken(`p${i + 1}`, i * 140, i * 70, i % 3, { viewer: false })) };
+  const harness = cameraHarness();
+  const runtime = { bridge: { isDm: true }, engine: { canvas, camera: harness.camera, activeZ: 0 }, setLayer(z) { this.engine.activeZ = z; } };
+  const host = hostFor(runtime);
+  const cameraFollow = followApi.createController({ runtime, mapData, root: host });
+  const observer = observerApi.createController({ runtime, mapData, cameraFollow, root: host });
+
+  for (let round = 0; round < 20; round += 1) {
+    const id = `p${(round % 8) + 1}`;
+    if (round % 3 === 0) observer.follow(id);
+    else if (round % 3 === 1) observer.viewAs(id);
+    else observer.free();
+    const state = observer.state();
+    if (state.mode === 'free') expect(state.targetTokenId).toBe(null);
+    else expect(state.targetTokenId).toBe(id);
+  }
+  expect(mapData.tokens.filter((token) => token.viewer === true)).toHaveLength(0);
+  observer.stop(); cameraFollow.stop();
+});
+
+test('field: canonical POV is a real 120 degree cone, not a circular placeholder', async () => {
+  const lighting = loadLighting();
+  expect(lighting.DEFAULT_VISION_CONE_DEG).toBe(120);
+  const origin = { x: 0, y: 0 };
+  const at = (deg) => ({ x: Math.cos(deg * Math.PI / 180) * 100, y: Math.sin(deg * Math.PI / 180) * 100 });
+  expect(lighting.pointInCone(origin, at(50), 0, lighting.DEFAULT_VISION_CONE_DEG)).toBe(true);
+  expect(lighting.pointInCone(origin, at(60), 0, lighting.DEFAULT_VISION_CONE_DEG)).toBe(true);
+  expect(lighting.pointInCone(origin, at(70), 0, lighting.DEFAULT_VISION_CONE_DEG)).toBe(false);
+  expect(lighting.pointInCone(origin, at(-70), 0, lighting.DEFAULT_VISION_CONE_DEG)).toBe(false);
+});
+
+test('field: camera/observer boot successfully when polling APIs throw', async () => {
+  const followApi = loadFollow();
+  const observerApi = loadObserver();
+  const canvas = new MockTarget();
+  const p1 = playerToken('p1', 100, 100, 0, { viewer: false });
+  const mapData = { grid: { size: 70, distancePerCell: 5 }, lighting: {}, tokens: [p1] };
+  const harness = cameraHarness();
+  const runtime = { bridge: { isDm: true }, engine: { canvas, camera: harness.camera, activeZ: 0 }, setLayer() {} };
+  const host = hostFor(runtime);
+  expect(() => {
+    const cameraFollow = followApi.createController({ runtime, mapData, root: host });
+    const observer = observerApi.createController({ runtime, mapData, cameraFollow, root: host });
+    observer.viewAs('p1');
+    canvas.dispatchEvent(event('vtt:token-moved', { tokenId: 'p1' }));
+    observer.stop(); cameraFollow.stop();
+  }).not.toThrow();
+});

--- a/tests/vtt_camera_pov_observer_realtime.spec.js
+++ b/tests/vtt_camera_pov_observer_realtime.spec.js
@@ -1,0 +1,70 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+const read = (name) => fs.readFileSync(path.join(__dirname, '..', 'js', 'vtt', name), 'utf8');
+
+test('camera follow and HUD use event-driven sync with no polling timers', async () => {
+  const follow = read('camera-follow.js');
+  const hud = read('map-hud-bootstrap.js');
+  expect(follow).not.toContain('setInterval');
+  expect(hud).not.toContain('setInterval');
+  expect(follow).toContain("'vtt:canonical-tokens-synced'");
+  expect(follow).toContain("'vtt:regional-local-transition-applied'");
+  expect(follow).toContain("'vtt:procedural-chunk-loaded'");
+  expect(hud).toContain("'vtt:dm-observer-changed'");
+  expect(hud).toContain("'vtt:canonical-tokens-synced'");
+});
+
+test('DM observer is read-only local camera/POV state and never writes Realtime', async () => {
+  const observer = read('dm-observer.js');
+  expect(observer).not.toMatch(/firebase/i);
+  expect(observer).not.toContain('.database(');
+  expect(observer).not.toContain('.ref(');
+  expect(observer).not.toContain('.transaction(');
+  expect(observer).not.toContain('.update(');
+  expect(observer).not.toContain('.set(');
+  expect(observer).not.toMatch(/\.viewer\s*=/);
+  expect(observer).not.toContain('requestAnimationFrame');
+  expect(observer).not.toContain('setInterval');
+  expect(observer).toContain('mapData.lighting.dmPreviewTokenId = targetId');
+  expect(observer).toContain('mapData.lighting.dmPreviewTokenId = null');
+});
+
+test('canonical token reconnect emits a local sync event from the existing token-state callback', async () => {
+  const main = read('main.js');
+  expect(main).toContain('onTokensChanged: (change = {}) =>');
+  expect(main).toContain("new EventCtor('vtt:canonical-tokens-synced'");
+  expect(main).toContain('viewerTokenId');
+  expect(main).not.toContain('vtt_camera_observer_requests');
+});
+
+test('DM observer modes preserve full DM vision for Follow and activate player POV only for View As', async () => {
+  const observer = read('dm-observer.js');
+  expect(observer).toContain("FOLLOW: 'follow'");
+  expect(observer).toContain("VIEW_AS: 'view_as'");
+  expect(observer).toContain("mode = MODES.FOLLOW");
+  expect(observer).toContain("mode = MODES.VIEW_AS");
+  expect(observer).toContain('mapData.lighting.dmPreviewTokenId = targetId');
+  expect(observer).toContain('cameraFollow.setTarget(targetId, { follow: true })');
+  expect(observer).toContain('syncLayer(token)');
+});
+
+test('DM free view draws only lightweight local player-cone outlines while exact View As uses existing lighting POV', async () => {
+  const observer = read('dm-observer.js');
+  const lighting = read('lighting-engine.js');
+  expect(observer).toContain('function drawOutlines()');
+  expect(observer).toContain("if (mode === MODES.VIEW_AS || stopped) return");
+  expect(observer).toContain('lighting?.visionConeDeg?.(token)');
+  expect(observer).toContain('|| 120');
+  expect(lighting).toContain('const DEFAULT_VISION_CONE_DEG = 120');
+  expect(lighting).toContain('pointInCone(viewer, point, facingDeg(viewer), visionConeDeg(viewer))');
+});
+
+test('observer does not create scheduler/calendar/world-state write surfaces', async () => {
+  const combined = `${read('camera-follow.js')}\n${read('dm-observer.js')}\n${read('map-hud-bootstrap.js')}`;
+  expect(combined).not.toContain('campaña/calendario');
+  expect(combined).not.toContain('world_scheduler_requests');
+  expect(combined).not.toContain('mapSimulationZones');
+  expect(combined).not.toContain('playerDiscovery');
+});

--- a/tests/vtt_camera_pov_observer_realtime.spec.js
+++ b/tests/vtt_camera_pov_observer_realtime.spec.js
@@ -24,7 +24,7 @@ test('DM observer is read-only local camera/POV state and never writes Realtime'
   expect(observer).not.toContain('.transaction(');
   expect(observer).not.toContain('.update(');
   expect(observer).not.toContain('.set(');
-  expect(observer).not.toMatch(/\.viewer\s*=/);
+  expect(observer).not.toMatch(/\.viewer\s*=(?!=)/);
   expect(observer).not.toContain('requestAnimationFrame');
   expect(observer).not.toContain('setInterval');
   expect(observer).toContain('mapData.lighting.dmPreviewTokenId = targetId');


### PR DESCRIPTION
Stabilizes player camera authority and DM observation for map field testing. Camera Follow is now event-driven instead of polling, canonical token reconnect emits a local sync event, the map HUD no longer polls, and a read-only DM Observer adds Free / Follow / View As modes. Free/Follow preserve full DM vision, View As reuses the existing dmPreviewTokenId path for the exact player POV, and lightweight 120° player-cone outlines are drawn locally for DM orientation. No Firebase writes/listeners are added by camera/observer code and no per-frame persistence is introduced. Behavioral field tests cover P1 ignoring seven remote movers, canonical object replacement on reconnect, Regional↔Local and Z transitions, DM mode separation, reconnect while observing, 8-player switching stress, and the actual 120° lighting cone. Static guards only supplement those behavioral tests by forbidding polling and Realtime write surfaces. Merge only if focused camera/POV/fog/streaming/performance contracts and full repository regression are green and main remains synchronized.