### PR TITLE
test(vtt): add deterministic map field-test sandbox

### DIFF
--- a/.github/workflows/vtt-map-field-test-sandbox.yml
+++ b/.github/workflows/vtt-map-field-test-sandbox.yml
@@ -1,0 +1,99 @@
+name: VTT Map Field Test Sandbox
+
+on:
+  pull_request:
+    paths:
+      - 'database.rules.json'
+      - 'js/regional-travel-*.js'
+      - 'js/regional-world-graph-*.js'
+      - 'js/regional-local-transition-*.js'
+      - 'js/vtt/map-field-test-sandbox-core.js'
+      - 'js/vtt/world-streaming-*.js'
+      - 'js/vtt/map-simulation-*.js'
+      - 'js/vtt/player-discovery-*.js'
+      - 'js/vtt/procedural-chunk-streaming-*.js'
+      - 'js/vtt/regional-local-transition-runtime.js'
+      - 'js/vtt/camera-follow.js'
+      - 'js/vtt/dm-observer.js'
+      - 'js/vtt/engine.js'
+      - 'js/vtt/renderer.js'
+      - 'tests/vtt_map_field_test_sandbox.spec.js'
+      - 'tests/vtt_map_field_test_hardening.spec.js'
+      - 'tests/regional_world_graph*.spec.js'
+      - 'tests/regional_travel*.spec.js'
+      - 'tests/regional_local_transition*.spec.js'
+      - 'tests/vtt_world_streaming_lifecycle.spec.js'
+      - 'tests/vtt_map_simulation*.spec.js'
+      - 'tests/vtt_player_discovery*.spec.js'
+      - 'tests/vtt_procedural_chunk_streaming_performance.spec.js'
+      - 'tests/vtt_camera*.spec.js'
+      - 'tests/vtt_performance_guard.spec.js'
+      - '.github/workflows/vtt-map-field-test-sandbox.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'database.rules.json'
+      - 'js/regional-travel-*.js'
+      - 'js/regional-world-graph-*.js'
+      - 'js/regional-local-transition-*.js'
+      - 'js/vtt/map-field-test-sandbox-core.js'
+      - 'js/vtt/world-streaming-*.js'
+      - 'js/vtt/map-simulation-*.js'
+      - 'js/vtt/player-discovery-*.js'
+      - 'js/vtt/procedural-chunk-streaming-*.js'
+      - 'js/vtt/regional-local-transition-runtime.js'
+      - 'tests/vtt_map_field_test_sandbox.spec.js'
+      - '.github/workflows/vtt-map-field-test-sandbox.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  map-field-test-sandbox:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Syntax and rules JSON
+        run: |
+          node --check js/vtt/map-field-test-sandbox-core.js
+          node --check tests/vtt_map_field_test_sandbox.spec.js
+          node --check js/regional-travel-core.js
+          node --check js/regional-world-graph-core.js
+          node --check js/vtt/world-streaming-core.js
+          node --check js/vtt/map-simulation-core.js
+          node --check js/vtt/player-discovery-core.js
+          node --check js/vtt/procedural-chunk-streaming-core.js
+          node -e "JSON.parse(require('fs').readFileSync('database.rules.json','utf8'))"
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Field sandbox, regional, streaming, fog, camera and performance contracts
+        run: >-
+          npx playwright test --workers=1
+          tests/vtt_map_field_test_sandbox.spec.js
+          tests/vtt_map_field_test_hardening.spec.js
+          tests/regional_world_graph.spec.js
+          tests/regional_world_graph_realtime.spec.js
+          tests/regional_travel_engine.spec.js
+          tests/regional_travel_realtime.spec.js
+          tests/regional_local_transition.spec.js
+          tests/regional_local_transition_realtime.spec.js
+          tests/regional_local_transition_bootstrap.spec.js
+          tests/vtt_world_streaming_lifecycle.spec.js
+          tests/vtt_map_simulation_persistence.spec.js
+          tests/vtt_map_simulation_realtime.spec.js
+          tests/vtt_player_discovery_fog.spec.js
+          tests/vtt_player_discovery_realtime.spec.js
+          tests/vtt_procedural_chunk_streaming_performance.spec.js
+          tests/vtt_camera_pov_observer_field.spec.js
+          tests/vtt_camera_pov_observer_realtime.spec.js
+          tests/vtt_performance_guard.spec.js
+      - name: Full repository regression
+        run: npx playwright test --workers=1

--- a/js/vtt/map-field-test-sandbox-core.js
+++ b/js/vtt/map-field-test-sandbox-core.js
@@ -1,0 +1,150 @@
+(function(root,factory){
+  'use strict';
+  const api=factory();
+  if(typeof module!=='undefined'&&module.exports)module.exports=api;
+  if(root)root.LuminousVttMapFieldTestSandbox=api;
+})(typeof window!=='undefined'?window:globalThis,function(){
+  'use strict';
+
+  const CONFIG=Object.freeze({
+    schemaVersion:1,
+    seed:'map-field-test-2026',
+    generatorVersion:'field_test_1',
+    worldId:'luminous-field-test',
+    regionId:'field-region-k',
+    hexRadius:3,
+    regionalHexCount:37,
+    chunkSize:40,
+    logicalChunkCols:3,
+    logicalChunkRows:3,
+    playerCount:8,
+  });
+  const LEGAL_CLASSES=Object.freeze(['nest','backstreets','outskirts']);
+  const clone=v=>v==null?v:JSON.parse(JSON.stringify(v));
+  const hexKey=h=>`${CONFIG.regionId}:${Number(h?.q)||0},${Number(h?.r)||0}`;
+  const axialDistance=(q,r)=>(Math.abs(q)+Math.abs(r)+Math.abs(q+r))/2;
+
+  function landcoverFor(q,r,jurisdiction){
+    if(jurisdiction==='nest')return'urban_core';
+    if(jurisdiction==='backstreets')return(q+r)%2===0?'dense_urban':'industrial';
+    if(q===2&&r===-1)return'rural_villa';
+    const pick=Math.abs((q*17)+(r*31))%4;
+    return ['wilderness_forest','rural_plains','wilderness_hills','wilderness_swamp'][pick];
+  }
+  function travelTerrainFor(landcover){
+    if(landcover.includes('forest'))return'forest';
+    if(landcover.includes('hills'))return'hills';
+    if(landcover.includes('swamp'))return'swamp';
+    if(landcover==='urban_core'||landcover==='dense_urban'||landcover==='industrial')return'road';
+    return'plains';
+  }
+  function jurisdictionFor(q,r){const d=axialDistance(q,r);return d===0?'nest':d===1?'backstreets':'outskirts';}
+  function featureFlags(q,r){
+    return Object.freeze({
+      road:r===0,
+      dirtRoad:q===1,
+      rail:r===-1&&q>=-2,
+      checkpoint:q===0&&r===0,
+      villa:q===2&&r===-1,
+    });
+  }
+  function createRegionalHexes(){
+    const out=[];
+    for(let q=-CONFIG.hexRadius;q<=CONFIG.hexRadius;q+=1){
+      const minR=Math.max(-CONFIG.hexRadius,-q-CONFIG.hexRadius);
+      const maxR=Math.min(CONFIG.hexRadius,-q+CONFIG.hexRadius);
+      for(let r=minR;r<=maxR;r+=1){
+        const jurisdiction=jurisdictionFor(q,r),landcover=landcoverFor(q,r,jurisdiction),features=featureFlags(q,r);
+        out.push(Object.freeze({
+          q,r,key:hexKey({q,r}),distance:axialDistance(q,r),jurisdiction,landcover,
+          terrain:travelTerrainFor(landcover),
+          settlementId:features.villa?'field_villa':jurisdiction==='nest'?'field_nest':'',
+          requiredAccess:jurisdiction==='nest'?Object.freeze(['nest_pass']):Object.freeze([]),
+          features,
+        }));
+      }
+    }
+    return Object.freeze(out.sort((a,b)=>a.q-b.q||a.r-b.r));
+  }
+  function routeEdges(){
+    const edges=[];
+    const addLine=(idPrefix,points,routeType,extra={})=>{
+      for(let i=0;i<points.length-1;i+=1){
+        const from=points[i],to=points[i+1];
+        edges.push({id:`${idPrefix}_${i}`,from:{district:CONFIG.regionId,...from},to:{district:CONFIG.regionId,...to},routeType,...extra});
+      }
+    };
+    addLine('road_spine',[-3,-2,-1,0,1,2,3].map(q=>({q,r:0})),'road');
+    addLine('dirt_connector',[-3,-2,-1,0,1,2].map(r=>({q:1,r})),'dirt_road',{routeQualityMultiplier:1.15});
+    addLine('rail_line',[-2,-1,0,1,2,3].map(q=>({q,r:-1})),'rail');
+    return Object.freeze(edges);
+  }
+  function createGraphDefinition(){
+    const hexes=createRegionalHexes();
+    return Object.freeze({
+      id:'field_test_graph',revision:1,autoConnectAdjacent:true,
+      nodes:hexes.map(h=>({
+        hex:{district:CONFIG.regionId,q:h.q,r:h.r},jurisdiction:h.jurisdiction,terrain:h.terrain,
+        settlementId:h.settlementId,requiredAccess:h.requiredAccess,
+        metadata:{landcover:h.landcover,features:clone(h.features)},
+      })),
+      edges:routeEdges(),
+    });
+  }
+
+  const ZONE_DEFINITIONS=Object.freeze([
+    Object.freeze({id:'nest_checkpoint',name:'Nest Gate',kind:'nest_entry',legalClass:'nest',landcover:'urban_core',regionalHex:{q:0,r:0},zLayers:[0],features:['checkpoint','controlled_access','exterior']}),
+    Object.freeze({id:'backstreets_market',name:'Backstreets Market',kind:'street',legalClass:'backstreets',landcover:'dense_urban',regionalHex:{q:1,r:0},zLayers:[0],features:['street','shops','exterior']}),
+    Object.freeze({id:'field_villa',name:'Outskirts Villa',kind:'villa',legalClass:'outskirts',landcover:'rural_villa',regionalHex:{q:2,r:-1},zLayers:[0,1],features:['villa','interior','exterior']}),
+    Object.freeze({id:'multilevel_factory',name:'Backstreets Factory',kind:'building',legalClass:'backstreets',landcover:'industrial',regionalHex:{q:1,r:-1},zLayers:[0,1,2],features:['industrial','interior','stairs','roof']}),
+    Object.freeze({id:'wilderness_forest',name:'Outskirts Forest',kind:'wilderness',legalClass:'outskirts',landcover:'wilderness_forest',regionalHex:{q:-2,r:1},zLayers:[0],features:['wilderness','forest','low_visibility']}),
+    Object.freeze({id:'road_corridor',name:'Regional Road Corridor',kind:'road',legalClass:'backstreets',landcover:'dense_urban',regionalHex:{q:-1,r:0},zLayers:[0],features:['road','exterior']}),
+    Object.freeze({id:'rail_station',name:'Outskirts Rail Station',kind:'rail',legalClass:'outskirts',landcover:'industrial',regionalHex:{q:-2,r:-1},zLayers:[0,1],features:['rail','station','interior','exterior']}),
+    Object.freeze({id:'outskirts_ruins',name:'Outskirts Ruins',kind:'ruins',legalClass:'outskirts',landcover:'wilderness_hills',regionalHex:{q:0,r:2},zLayers:[0,1],features:['ruins','interior','exterior']}),
+  ]);
+
+  function createLocalZones(seed=CONFIG.seed){
+    return Object.freeze(ZONE_DEFINITIONS.map((raw,index)=>Object.freeze({
+      ...clone(raw),worldId:CONFIG.worldId,regionId:CONFIG.regionId,
+      seed:`${seed}:zone:${raw.id}`,
+      generatorVersion:CONFIG.generatorVersion,
+      chunkSize:CONFIG.chunkSize,
+      chunkCols:CONFIG.logicalChunkCols,
+      chunkRows:CONFIG.logicalChunkRows,
+      logicalCells:CONFIG.chunkSize*CONFIG.chunkSize*CONFIG.logicalChunkCols*CONFIG.logicalChunkRows,
+      activeChunk:Object.freeze({col:index%2,row:1}),
+    })));
+  }
+  function position(zone,chunkCol,chunkRow,zLayer=0){
+    return Object.freeze({
+      worldId:CONFIG.worldId,regionId:CONFIG.regionId,zoneId:zone.id,
+      chunkCol,chunkRow,x:17.5*70,y:17.5*70,zLayer,elevationFt:zLayer*10,
+      regionalHex:Object.freeze({district:CONFIG.regionId,...zone.regionalHex}),
+    });
+  }
+  function createPlayers(zones=createLocalZones()){
+    const byId=Object.fromEntries(zones.map(z=>[z.id,z]));
+    return Object.freeze([
+      Object.freeze({id:'P1',playerId:'P1',role:'player',position:position(byId.backstreets_market,0,1,0),scenario:'shared-zone-a'}),
+      Object.freeze({id:'P2',playerId:'P2',role:'player',position:position(byId.backstreets_market,1,1,0),scenario:'shared-zone-b'}),
+      Object.freeze({id:'P3',playerId:'P3',role:'player',position:position(byId.field_villa,0,1,0),scenario:'villa'}),
+      Object.freeze({id:'P4',playerId:'P4',role:'player',position:position(byId.multilevel_factory,1,1,2),scenario:'multilevel'}),
+      Object.freeze({id:'P5',playerId:'P5',role:'player',position:position(byId.wilderness_forest,0,1,0),scenario:'wilderness'}),
+      Object.freeze({id:'P6',playerId:'P6',role:'player',position:position(byId.road_corridor,1,1,0),scenario:'road'}),
+      Object.freeze({id:'P7',playerId:'P7',role:'player',position:position(byId.rail_station,0,1,0),scenario:'regional-travel',regionalTravel:true}),
+      Object.freeze({id:'P8',playerId:'P8',role:'player',position:position(byId.outskirts_ruins,1,1,1),scenario:'reconnect',reconnect:true}),
+    ]);
+  }
+  function createScenario(seed=CONFIG.seed){
+    const zones=createLocalZones(seed),players=createPlayers(zones),regionalHexes=createRegionalHexes();
+    return Object.freeze({
+      schemaVersion:CONFIG.schemaVersion,seed,generatorVersion:CONFIG.generatorVersion,
+      worldId:CONFIG.worldId,regionId:CONFIG.regionId,
+      regionalHexes,graphDefinition:createGraphDefinition(),zones,players,
+      dmSequence:Object.freeze(['FREE','FOLLOW:P1','VIEW_AS:P1','FOLLOW:P4','FREE','VIEW_AS:P8']),
+      acceptance:Object.freeze({maxPlayers:8,maxActiveChunks:8,maxLiveCells:12800,maxActiveZones:8,liveChunkCells:1600,logicalZoneCells:14400}),
+    });
+  }
+
+  return Object.freeze({CONFIG,LEGAL_CLASSES,axialDistance,hexKey,jurisdictionFor,createRegionalHexes,routeEdges,createGraphDefinition,createLocalZones,createPlayers,createScenario});
+});

--- a/tests/vtt_map_field_test_sandbox.spec.js
+++ b/tests/vtt_map_field_test_sandbox.spec.js
@@ -1,0 +1,229 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+const Sandbox = require('../js/vtt/map-field-test-sandbox-core.js');
+const Streaming = require('../js/vtt/world-streaming-core.js');
+const Simulation = require('../js/vtt/map-simulation-core.js');
+const Discovery = require('../js/vtt/player-discovery-core.js');
+const Chunk = require('../js/vtt/procedural-chunk-streaming-core.js');
+const Graph = require('../js/regional-world-graph-core.js');
+
+const scenario = () => Sandbox.createScenario();
+const hex = (q, r) => ({ district: Sandbox.CONFIG.regionId, q, r });
+
+test.describe('Map Field-Test Sandbox', () => {
+  test('fixture is deterministic and contains exactly the 37 radius-3 regional hexes', () => {
+    const a = scenario(), b = scenario();
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+    expect(a.regionalHexes).toHaveLength(37);
+    expect(new Set(a.regionalHexes.map(h => h.key)).size).toBe(37);
+    for (const h of a.regionalHexes) expect(Sandbox.axialDistance(h.q, h.r)).toBeLessThanOrEqual(3);
+  });
+
+  test('legal geography uses only Nest, Backstreets and Outskirts while wilderness remains terrain', () => {
+    const s = scenario();
+    expect(new Set(s.regionalHexes.map(h => h.jurisdiction))).toEqual(new Set(['nest', 'backstreets', 'outskirts']));
+    const wilderness = s.regionalHexes.filter(h => h.landcover.startsWith('wilderness_'));
+    expect(wilderness.length).toBeGreaterThan(0);
+    expect(wilderness.every(h => h.jurisdiction === 'outskirts')).toBeTruthy();
+    expect(s.regionalHexes.some(h => h.features.villa)).toBeTruthy();
+    expect(s.regionalHexes.some(h => h.features.checkpoint)).toBeTruthy();
+    expect(s.regionalHexes.some(h => h.features.road)).toBeTruthy();
+    expect(s.regionalHexes.some(h => h.features.dirtRoad)).toBeTruthy();
+    expect(s.regionalHexes.some(h => h.features.rail)).toBeTruthy();
+  });
+
+  test('real Regional World Graph routes road and rail and enforces the Nest pass', () => {
+    const graph = Graph.createGraph(scenario().graphDefinition);
+    expect(graph.stats.nodeCount).toBe(37);
+
+    const denied = Graph.findRoute(graph, {
+      origin: hex(-1, 0), destination: hex(0, 0), transportId: 'walking', accessState: { grants: [] },
+    });
+    expect(denied.valid).toBeFalsy();
+    expect(denied.reason).toBe('destination_access_required');
+
+    const road = Graph.findRoute(graph, {
+      origin: hex(-3, 0), destination: hex(3, 0), transportId: 'public_bus', accessState: { grants: ['nest_pass'] },
+    });
+    expect(road.valid).toBeTruthy();
+    expect(road.route).toHaveLength(7);
+    expect(road.segments.every(segment => ['road', 'dirt_road'].includes(segment.surface))).toBeTruthy();
+
+    const rail = Graph.findRoute(graph, {
+      origin: hex(-2, -1), destination: hex(3, -1), transportId: 'train', accessState: { grants: [] },
+    });
+    expect(rail.valid).toBeTruthy();
+    expect(rail.segments).toHaveLength(5);
+    expect(rail.segments.every(segment => segment.surface === 'rail')).toBeTruthy();
+  });
+
+  test('local sandbox has 8 logical Zones with interiors, wilderness, rail and a multi-level building', () => {
+    const zones = scenario().zones;
+    expect(zones).toHaveLength(8);
+    expect(new Set(zones.map(z => z.id)).size).toBe(8);
+    expect(zones.every(z => z.chunkCols === 3 && z.chunkRows === 3 && z.logicalCells === 14400)).toBeTruthy();
+    expect(zones.some(z => z.kind === 'nest_entry')).toBeTruthy();
+    expect(zones.some(z => z.kind === 'villa')).toBeTruthy();
+    expect(zones.some(z => z.kind === 'wilderness')).toBeTruthy();
+    expect(zones.some(z => z.kind === 'rail')).toBeTruthy();
+    expect(zones.some(z => z.features.includes('interior'))).toBeTruthy();
+    expect(zones.some(z => z.zLayers.length >= 3)).toBeTruthy();
+  });
+
+  test('8-player scenario assigns the intended split-party stress roles', () => {
+    const players = scenario().players;
+    expect(players).toHaveLength(8);
+    expect(new Set(players.map(p => p.id)).size).toBe(8);
+    expect(players[0].position.zoneId).toBe(players[1].position.zoneId);
+    expect(players[0].position.chunkCol).not.toBe(players[1].position.chunkCol);
+    expect(players.find(p => p.id === 'P4').position.zLayer).toBe(2);
+    expect(players.find(p => p.id === 'P5').scenario).toBe('wilderness');
+    expect(players.find(p => p.id === 'P6').scenario).toBe('road');
+    expect(players.find(p => p.id === 'P7').regionalTravel).toBeTruthy();
+    expect(players.find(p => p.id === 'P8').reconnect).toBeTruthy();
+  });
+
+  test('World Streaming keeps the 8 separated player chunks bounded to 12,800 live cells', () => {
+    const manager = Streaming.createLifecycleManager({ maxActiveChunks: 8, maxWarmChunks: 16, warmTtlMs: 1000 });
+    const result = manager.reconcile(scenario().players, 0);
+    expect(result.metrics.uniqueActors).toBe(8);
+    expect(result.metrics.activeChunks).toBe(8);
+    expect(result.metrics.liveCells).toBe(12800);
+    expect(result.metrics.overActiveBudget).toBe(0);
+    expect(result.metrics.peakActiveChunks).toBeLessThanOrEqual(8);
+  });
+
+  test('Simulation Bubbles deduplicate players sharing a Zone and remain within the 8-Zone budget', () => {
+    const manager = Simulation.createSimulationBubbleManager({ maxActiveZones: 8, maxWarmZones: 16, warmTtlMs: 1000 });
+    const result = manager.reconcile(scenario().players, 0);
+    expect(result.metrics.uniqueActors).toBe(8);
+    expect(result.metrics.activeZones).toBe(7);
+    expect(result.metrics.actorRefs).toBe(8);
+    expect(result.metrics.overActiveBudget).toBe(0);
+  });
+
+  test('a logical 120x120 Zone materializes only one 40x40 chunk and transitions one chunk at a time', () => {
+    const zone = scenario().zones.find(z => z.id === 'backstreets_market');
+    let descriptor = Chunk.createDescriptor(zone);
+    const budget = Chunk.performanceBudget(descriptor);
+    expect(budget.logicalCells).toBe(14400);
+    expect(budget.liveCells).toBe(1600);
+    expect(budget.loadedChunks).toBe(1);
+    expect(budget.logicalChunks).toBe(9);
+
+    descriptor = Chunk.withActiveChunk(descriptor, { col: 0, row: 1 });
+    const transition = Chunk.resolveTransition(descriptor, { x: 40 * 70 + 1, y: 20 * 70 }, Chunk.liveGrid());
+    expect(transition.valid).toBeTruthy();
+    expect(transition.target).toEqual({ col: 1, row: 1 });
+    const next = Chunk.withActiveChunk(descriptor, transition.target);
+    expect(next.activeChunk).toEqual({ col: 1, row: 1 });
+    const generation = Chunk.chunkGenerationOptions(next, next.activeChunk);
+    expect(generation.chunkCols).toBe(1);
+    expect(generation.chunkRows).toBe(1);
+  });
+
+  test('all 8 local views together still generate only eight 40x40 live chunks, never eight 120x120 Zones', () => {
+    let liveCells = 0, logicalCells = 0;
+    for (const zone of scenario().zones) {
+      const budget = Chunk.performanceBudget(Chunk.createDescriptor(zone));
+      liveCells += budget.liveCells;
+      logicalCells += budget.logicalCells;
+      expect(budget.loadedChunks).toBe(1);
+    }
+    expect(liveCells).toBe(12800);
+    expect(logicalCells).toBe(115200);
+    expect(liveCells).toBeLessThan(logicalCells);
+  });
+
+  test('P1 and P2 maintain different Fog knowledge even inside the same Zone', () => {
+    const [p1, p2] = scenario().players;
+    const identity = p1.position;
+    let r1 = Discovery.blank(identity, 100), r2 = Discovery.blank(identity, 100);
+    r1 = Discovery.capture(r1, { identity, zLayer: 0, chunkCol: 0, chunkRow: 1, worldNow: 100, cells: [{ worldCol: 5, worldRow: 45 }] }).record;
+    r2 = Discovery.capture(r2, { identity, zLayer: 0, chunkCol: 1, chunkRow: 1, worldNow: 100, cells: [{ worldCol: 48, worldRow: 48 }] }).record;
+    expect(Discovery.slice(r1, { zLayer: 0, chunkCol: 0, chunkRow: 1 }).cells).toEqual([{ col: 5, row: 5 }]);
+    expect(Discovery.slice(r1, { zLayer: 0, chunkCol: 1, chunkRow: 1 }).cells).toEqual([]);
+    expect(Discovery.slice(r2, { zLayer: 0, chunkCol: 1, chunkRow: 1 }).cells).toEqual([{ col: 8, row: 8 }]);
+  });
+
+  test('P8 reconnect reconstructs the same Fog record without leaking another Zone', () => {
+    const p8 = scenario().players.find(p => p.id === 'P8');
+    let record = Discovery.blank(p8.position, 500);
+    record = Discovery.capture(record, {
+      identity: p8.position, zLayer: p8.position.zLayer, chunkCol: 1, chunkRow: 1, worldNow: 500,
+      cells: [{ worldCol: 44, worldRow: 47 }, { worldCol: 45, worldRow: 47 }],
+      topology: [{ id: 'door_ruins', type: 'door', state: 'closed' }],
+    }).record;
+    const restored = Discovery.normalize(JSON.parse(JSON.stringify(record)), p8.position);
+    expect(Discovery.metrics(restored)).toEqual(Discovery.metrics(record));
+    expect(Discovery.slice(restored, { zLayer: 1, chunkCol: 1, chunkRow: 1 })).toEqual(Discovery.slice(record, { zLayer: 1, chunkCol: 1, chunkRow: 1 }));
+    expect(Discovery.zoneKey(restored)).toBe(`${Sandbox.CONFIG.worldId}/${Sandbox.CONFIG.regionId}/outskirts_ruins`);
+  });
+
+  test('disconnect makes P8 chunk dormant after TTL and reconnect reactivates exactly its canonical chunk', () => {
+    const players = scenario().players;
+    const p8 = players.find(p => p.id === 'P8');
+    const manager = Streaming.createLifecycleManager({ maxActiveChunks: 8, maxWarmChunks: 16, warmTtlMs: 1000 });
+    manager.reconcile(players, 0);
+    manager.reconcile(players.filter(p => p.id !== 'P8'), 100);
+    expect(manager.chunkState(p8.position)).toBe(Streaming.STATES.WARM);
+    manager.tick(1101);
+    expect(manager.chunkState(p8.position)).toBe(Streaming.STATES.DORMANT);
+    manager.reconcile(players, 1200);
+    expect(manager.chunkState(p8.position)).toBe(Streaming.STATES.ACTIVE);
+    expect(manager.actorPosition('P8').zoneId).toBe('outskirts_ruins');
+  });
+
+  test('Seed+Delta survives a Zone becoming DORMANT and can be imported on return', () => {
+    const players = scenario().players;
+    const p4 = players.find(p => p.id === 'P4');
+    const bubbles = Simulation.createSimulationBubbleManager({ maxActiveZones: 8, maxWarmZones: 16, warmTtlMs: 1000 });
+    const store = Simulation.createDeltaStore();
+    bubbles.reconcile(players, 0);
+    store.recordEntityChange(p4.position, {
+      entityId: 'factory_door_01', kind: 'topology', operation: 'upsert', patch: { state: 'open', zLayer: 2 },
+      seed: 'field-factory-seed', generatorVersion: Sandbox.CONFIG.generatorVersion, updatedAt: 300,
+    });
+    bubbles.reconcile(players.filter(p => p.id !== 'P4'), 400);
+    bubbles.tick(1401);
+    expect(bubbles.stateOf(p4.position)).toBe(Simulation.STATES.DORMANT);
+    const dormant = store.get(p4.position, 1401);
+    expect(dormant.entities.factory_door_01.patch).toEqual({ state: 'open', zLayer: 2 });
+
+    const restoredStore = Simulation.createDeltaStore();
+    restoredStore.importRecord(JSON.parse(JSON.stringify(dormant)));
+    expect(restoredStore.get(p4.position, 1500).entities.factory_door_01.patch.state).toBe('open');
+  });
+
+  test('published source Rules keep configured DM authority and player/request ownership guards', () => {
+    const rulesPath = path.join(__dirname, '..', 'database.rules.json');
+    const source = fs.readFileSync(rulesPath, 'utf8');
+    const rules = JSON.parse(source).rules;
+    const writes = [
+      rules.campaña.estado_mundo['.write'],
+      rules.campaña.jugadores['$nombre_personaje']['.write'],
+      rules.vtt_topology['$mapId']['.write'],
+      rules.vtt_topology_action_requests['$mapId']['$requestId']['.write'],
+      rules.vtt_world_object_action_requests['$mapId']['$requestId']['.write'],
+      rules.vtt_regional_local_transition_requests['$mapId']['$requestId']['.write'],
+    ];
+    for (const rule of writes) {
+      expect(rule).toContain("child('config').child('dm_uid')");
+      expect(rule).toContain("!root.child('campaña').child('config').child('dm_uid').exists()");
+      expect(rule.trim()).not.toBe('auth != null');
+    }
+    expect(rules.campaña.jugadores['$nombre_personaje']['.write']).toContain("data.child('uid').val() === auth.uid");
+    expect(rules.vtt_topology_action_requests['$mapId']['$requestId']['.write']).toContain("newData.child('requesterUid').val() === auth.uid");
+    expect(rules.vtt_world_object_action_requests['$mapId']['$requestId']['.write']).toContain("newData.child('requesterUid').val() === auth.uid");
+    expect(rules.vtt_regional_local_transition_requests['$mapId']['$requestId']['.write']).toContain("child('uid').val() === auth.uid");
+  });
+
+  test('sandbox core has no polling, timers or Firebase dependency', () => {
+    const source = fs.readFileSync(path.join(__dirname, '..', 'js', 'vtt', 'map-field-test-sandbox-core.js'), 'utf8');
+    expect(source).not.toMatch(/setInterval\s*\(/);
+    expect(source).not.toMatch(/setTimeout\s*\(/);
+    expect(source).not.toMatch(/requestAnimationFrame\s*\(/);
+    expect(source).not.toMatch(/firebase|\.database\s*\(/i);
+  });
+});


### PR DESCRIPTION
## Summary
Adds the final deterministic Map Field-Test Sandbox used to validate the VTT as an integrated map product rather than isolated modules.

### Sandbox
- 37 Regional Hexes (axial radius 3) with Nest / Backstreets / Outskirts legal geography.
- Terrain/landcover remains separate from jurisdiction, including wilderness only inside Outskirts.
- Deterministic road spine, dirt-road connector, rail line, Nest checkpoint/access and an Outskirts Villa.
- 8 local logical Zones, including streets, Villa, wilderness, road, rail, interiors and a 3-level industrial building.

### 8-player field scenario
- P1/P2 share one Zone but occupy separate chunks.
- P3 Villa, P4 multi-level building, P5 wilderness, P6 road, P7 regional travel, P8 disconnect/reconnect.
- Streaming must stay at <=8 active 40x40 chunks / <=12,800 live cells.
- Simulation Bubbles deduplicate P1/P2 to 7 active Zones.
- Fog knowledge stays player-specific, reconnect restores discovery, and Seed+Delta survives DORMANT/return.

### Regional and permissions
- Uses the real Regional World Graph for road/rail routing and Nest Pass denial/allowance.
- Locks the source Firebase Rules contract to configured `campaña/config/dm_uid`, legacy fallback only when config is absent, and existing player/request ownership guards.

### CI
Adds `VTT Map Field Test Sandbox`, which runs the new integrated scenario alongside Regional Travel/Graph/Transition, World Streaming, Simulation, Discovery/Fog, Camera/POV, procedural chunk performance and existing field hardening, followed by full repository regression.