### PR TITLE
feat(map): add global world map foundation and HUD

### DIFF
--- a/.github/workflows/global-map-foundation.yml
+++ b/.github/workflows/global-map-foundation.yml
@@ -1,0 +1,66 @@
+name: Global Map Foundation
+
+on:
+  pull_request:
+    paths:
+      - "js/global-map-core.js"
+      - "js/vtt/global-map-runtime.js"
+      - "css/global-map.css"
+      - "vtt.html"
+      - "js/regional-world-graph-*.js"
+      - "js/regional-travel-*.js"
+      - "js/vtt/world-streaming-*.js"
+      - "tests/global_map*.spec.js"
+      - "tests/regional_world_graph*.spec.js"
+      - "tests/regional_travel*.spec.js"
+      - "tests/vtt_world_streaming_lifecycle.spec.js"
+      - "tests/vtt_performance_guard.spec.js"
+      - ".github/workflows/global-map-foundation.yml"
+  push:
+    branches: [main]
+    paths:
+      - "js/global-map-core.js"
+      - "js/vtt/global-map-runtime.js"
+      - "css/global-map.css"
+      - "vtt.html"
+      - "tests/global_map*.spec.js"
+      - ".github/workflows/global-map-foundation.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  global-map-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Syntax
+        run: |
+          node --check js/global-map-core.js
+          node --input-type=module --check < js/vtt/global-map-runtime.js
+          node --check tests/global_map_foundation.spec.js
+          node --check tests/global_map_realtime.spec.js
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Focused global regional streaming and performance contracts
+        run: >-
+          npx playwright test --workers=1
+          tests/global_map_foundation.spec.js
+          tests/global_map_realtime.spec.js
+          tests/regional_world_graph.spec.js
+          tests/regional_world_graph_realtime.spec.js
+          tests/regional_travel_engine.spec.js
+          tests/regional_travel_realtime.spec.js
+          tests/vtt_world_streaming_lifecycle.spec.js
+          tests/vtt_performance_guard.spec.js
+          tests/vtt_procedural_chunk_streaming_performance.spec.js
+      - name: Full repository regression
+        run: npx playwright test --workers=1

--- a/css/global-map.css
+++ b/css/global-map.css
@@ -1,0 +1,209 @@
+.vtt-global-map-toggle {
+  position: fixed;
+  left: 90px;
+  top: 12px;
+  z-index: 37000;
+  min-width: 104px;
+  pointer-events: auto;
+}
+
+.vtt-global-map-root {
+  position: fixed;
+  inset: 0;
+  z-index: 36500;
+  overflow: hidden;
+  background: #080a0c;
+  color: #e8edf0;
+  font: 11px/1.35 "Share Tech Mono", monospace, sans-serif;
+}
+
+.vtt-global-map-root[hidden] { display: none !important; }
+
+#vtt-global-map-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  display: block;
+  cursor: crosshair;
+}
+
+.vtt-global-map-topbar,
+.vtt-global-map-layers,
+.vtt-global-map-inspector,
+.vtt-global-map-editor {
+  position: fixed;
+  z-index: 36600;
+  background: rgba(7, 9, 11, .94);
+  border: 1px solid #59636c;
+  box-shadow: 5px 5px 0 rgba(0, 0, 0, .5);
+  backdrop-filter: blur(3px);
+}
+
+.vtt-global-map-topbar {
+  left: 12px;
+  right: 12px;
+  top: 12px;
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px;
+  box-sizing: border-box;
+}
+
+.vtt-global-map-title {
+  margin-right: 6px;
+  color: #f1f3f4;
+  letter-spacing: .12em;
+  white-space: nowrap;
+}
+
+.vtt-global-map-scale,
+.vtt-global-map-status {
+  padding: 6px 8px;
+  border: 1px solid #3c454d;
+  background: #0b0e11;
+  color: #aeb8c0;
+  white-space: nowrap;
+}
+
+.vtt-global-map-status { margin-left: auto; }
+.vtt-global-map-status[data-mode="dirty"] { color: #e0b35b; border-color: #8c6e35; }
+.vtt-global-map-status[data-mode="ok"] { color: #9bbd91; border-color: #506a49; }
+.vtt-global-map-status[data-mode="error"] { color: #e17474; border-color: #8b4747; }
+
+.vtt-global-map-search {
+  width: min(320px, 28vw);
+  min-width: 160px;
+  padding: 8px 9px;
+  color: #e8edf0;
+  background: #0b0e11;
+  border: 1px solid #46505a;
+  outline: none;
+}
+
+.vtt-global-map-search:focus { border-color: #929da5; }
+
+.vtt-global-map-layers {
+  left: 12px;
+  top: 74px;
+  width: 145px;
+  display: grid;
+  gap: 7px;
+  padding: 10px;
+}
+
+.vtt-global-map-layers strong,
+.vtt-global-map-inspector > strong,
+.vtt-global-map-editor > strong {
+  color: #d2d7db;
+  letter-spacing: .12em;
+  padding-bottom: 6px;
+  border-bottom: 1px solid #3b434a;
+}
+
+.vtt-global-map-layers label {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+  color: #b5bec5;
+  cursor: pointer;
+}
+
+.vtt-global-map-inspector {
+  left: 12px;
+  bottom: 12px;
+  width: 250px;
+  max-height: 38vh;
+  overflow: auto;
+  padding: 10px;
+}
+
+#vtt-global-map-inspector-body {
+  display: grid;
+  gap: 4px;
+  margin-top: 8px;
+  color: #aeb8bf;
+}
+
+#vtt-global-map-inspector-body b { color: #f0f2f4; font-size: 13px; }
+#vtt-global-map-inspector-body span { display: block; }
+
+.vtt-global-map-editor {
+  right: 12px;
+  top: 74px;
+  bottom: 12px;
+  width: 250px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  overflow: auto;
+  padding: 10px;
+  box-sizing: border-box;
+}
+
+.vtt-global-map-editor label {
+  display: grid;
+  gap: 4px;
+  color: #98a3ab;
+  font-size: 9px;
+  letter-spacing: .07em;
+}
+
+.vtt-global-map-editor input,
+.vtt-global-map-editor select {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 7px;
+  color: #e8edf0;
+  background: #0b0e11;
+  border: 1px solid #46505a;
+}
+
+.vtt-global-map-editor .vtt-global-map-check {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 7px;
+}
+
+.vtt-global-map-editor .vtt-global-map-check input { width: auto; }
+
+.vtt-global-map-toolrow {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.vtt-global-map-toolrow:first-of-type { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+
+.vtt-global-map-toolrow .brutalist-button {
+  min-width: 0;
+  padding: 7px 5px;
+  font-size: 9px;
+}
+
+.vtt-global-map-toolrow .brutalist-button.active {
+  color: #f1f3f4;
+  border-color: #f1f3f4;
+  background: #20262b;
+}
+
+.vtt-global-save {
+  margin-top: auto;
+  width: 100%;
+  min-height: 40px;
+}
+
+#vtt-global-help {
+  color: #73808a;
+  line-height: 1.4;
+}
+
+@media (max-width: 900px) {
+  .vtt-global-map-title { display: none; }
+  .vtt-global-map-editor { width: 210px; }
+  .vtt-global-map-search { width: 180px; }
+  .vtt-global-map-inspector { width: 190px; }
+}

--- a/js/global-map-core.js
+++ b/js/global-map-core.js
@@ -1,0 +1,377 @@
+(function (root, factory) {
+  "use strict";
+  const api = factory();
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+  if (root) root.LuminousGlobalMapCore = api;
+})(typeof window !== "undefined" ? window : globalThis, function () {
+  "use strict";
+
+  const CONFIG = Object.freeze({
+    schemaVersion: 1,
+    defaultWorldId: "luminous",
+    defaultWidthKm: 5500,
+    defaultHeightKm: 4000,
+    regionalHexDistanceKm: 20,
+    maxRegions: 512,
+    maxRegionVertices: 512,
+    maxMarkers: 4096,
+    maxRoutes: 4096,
+    maxRoutePoints: 1024,
+  });
+
+  const REGION_LAYERS = Object.freeze(["district", "jurisdiction", "terrain", "water", "special"]);
+  const JURISDICTIONS = Object.freeze(["nest", "backstreets", "outskirts"]);
+  const SOURCE_PRIORITY = Object.freeze({ procedural: 0, campaign: 1, dm: 2, canon: 3 });
+  const MARKER_TYPES = Object.freeze(["nest", "city", "town", "villa", "industrial", "poi", "checkpoint"]);
+  const ROUTE_TYPES = Object.freeze(["road", "dirt_road", "trail", "rail", "waterway"]);
+
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const integer = (value, fallback = 0) => Math.trunc(finite(value, fallback));
+  const clamp = (value, min, max) => Math.max(min, Math.min(max, finite(value, min)));
+  const clean = (value, fallback = "") => String(value ?? fallback).trim() || fallback;
+  const safeKey = (value, fallback = "") => clean(value, fallback).replace(/[.#$\[\]\/]/g, "_").replace(/\s+/g, "_").slice(0, 120) || fallback;
+  const enumValue = (value, allowed, fallback) => allowed.includes(clean(value).toLowerCase()) ? clean(value).toLowerCase() : fallback;
+
+  function normalizeBounds(raw = {}) {
+    const widthKm = clamp(raw.widthKm ?? raw.width, 100, 20000);
+    const heightKm = clamp(raw.heightKm ?? raw.height, 100, 20000);
+    return Object.freeze({
+      minXKm: finite(raw.minXKm, 0),
+      minYKm: finite(raw.minYKm, 0),
+      widthKm: widthKm || CONFIG.defaultWidthKm,
+      heightKm: heightKm || CONFIG.defaultHeightKm,
+    });
+  }
+
+  function defaultBounds() {
+    return normalizeBounds({ widthKm: CONFIG.defaultWidthKm, heightKm: CONFIG.defaultHeightKm });
+  }
+
+  function normalizePoint(raw = {}, bounds = defaultBounds()) {
+    const maxX = bounds.minXKm + bounds.widthKm;
+    const maxY = bounds.minYKm + bounds.heightKm;
+    return Object.freeze({
+      xKm: clamp(raw.xKm ?? raw.x, bounds.minXKm, maxX),
+      yKm: clamp(raw.yKm ?? raw.y, bounds.minYKm, maxY),
+    });
+  }
+
+  function normalizePointList(raw, bounds, maxPoints) {
+    const source = Array.isArray(raw) ? raw : [];
+    if (source.length > maxPoints) throw new Error("GLOBAL_MAP_POINT_LIMIT");
+    return Object.freeze(source.map((point) => normalizePoint(point, bounds)));
+  }
+
+  function polygonArea(points = []) {
+    let sum = 0;
+    for (let index = 0; index < points.length; index += 1) {
+      const a = points[index], b = points[(index + 1) % points.length];
+      sum += a.xKm * b.yKm - b.xKm * a.yKm;
+    }
+    return Math.abs(sum) / 2;
+  }
+
+  function pointInPolygon(point, polygon = []) {
+    if (!point || polygon.length < 3) return false;
+    let inside = false;
+    for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+      const a = polygon[i], b = polygon[j];
+      const intersects = ((a.yKm > point.yKm) !== (b.yKm > point.yKm))
+        && point.xKm < ((b.xKm - a.xKm) * (point.yKm - a.yKm)) / ((b.yKm - a.yKm) || Number.EPSILON) + a.xKm;
+      if (intersects) inside = !inside;
+    }
+    return inside;
+  }
+
+  function boundsForPoints(points = []) {
+    if (!points.length) return null;
+    let minXKm = Infinity, minYKm = Infinity, maxXKm = -Infinity, maxYKm = -Infinity;
+    for (const point of points) {
+      minXKm = Math.min(minXKm, point.xKm);
+      minYKm = Math.min(minYKm, point.yKm);
+      maxXKm = Math.max(maxXKm, point.xKm);
+      maxYKm = Math.max(maxYKm, point.yKm);
+    }
+    return Object.freeze({ minXKm, minYKm, maxXKm, maxYKm });
+  }
+
+  function boxesOverlap(a, b) {
+    return !!a && !!b && a.minXKm <= b.maxXKm && a.maxXKm >= b.minXKm && a.minYKm <= b.maxYKm && a.maxYKm >= b.minYKm;
+  }
+
+  function normalizeRegionalOrigin(raw, bounds) {
+    if (!raw || typeof raw !== "object") return null;
+    const point = normalizePoint(raw, bounds);
+    return Object.freeze({
+      xKm: point.xKm,
+      yKm: point.yKm,
+      q: integer(raw.q, 0),
+      r: integer(raw.r, 0),
+      hexDistanceKm: clamp(raw.hexDistanceKm, 1, 100) || CONFIG.regionalHexDistanceKm,
+      rotationDeg: finite(raw.rotationDeg, 0),
+    });
+  }
+
+  function normalizeRegion(raw = {}, bounds = defaultBounds(), index = 0) {
+    const polygon = normalizePointList(raw.polygon ?? raw.points, bounds, CONFIG.maxRegionVertices);
+    if (polygon.length < 3) throw new Error("GLOBAL_MAP_REGION_POLYGON_REQUIRED");
+    const source = enumValue(raw.source ?? raw.sourceTier, Object.keys(SOURCE_PRIORITY), "campaign");
+    const layer = enumValue(raw.layer, REGION_LAYERS, "terrain");
+    const jurisdiction = raw.jurisdiction == null ? null : enumValue(raw.jurisdiction, JURISDICTIONS, "outskirts");
+    const id = safeKey(raw.id, `region_${index + 1}`);
+    return Object.freeze({
+      id,
+      name: clean(raw.name, id).slice(0, 120),
+      layer,
+      districtId: safeKey(raw.districtId ?? raw.district_id),
+      jurisdiction,
+      terrain: safeKey(raw.terrain ?? raw.biome, "unknown").toLowerCase(),
+      source,
+      locked: raw.locked === true || source === "canon",
+      visibleToPlayers: raw.visibleToPlayers !== false,
+      polygon,
+      bounds: boundsForPoints(polygon),
+      areaKm2: polygonArea(polygon),
+      regionalOrigin: normalizeRegionalOrigin(raw.regionalOrigin, bounds),
+      metadata: raw.metadata && typeof raw.metadata === "object" ? Object.freeze(clone(raw.metadata)) : null,
+    });
+  }
+
+  function normalizeMarker(raw = {}, bounds = defaultBounds(), index = 0) {
+    const point = normalizePoint(raw, bounds);
+    const id = safeKey(raw.id, `marker_${index + 1}`);
+    return Object.freeze({
+      id,
+      type: enumValue(raw.type, MARKER_TYPES, "poi"),
+      name: clean(raw.name, id).slice(0, 120),
+      xKm: point.xKm,
+      yKm: point.yKm,
+      districtId: safeKey(raw.districtId ?? raw.district_id),
+      visibleToPlayers: raw.visibleToPlayers !== false,
+      locked: raw.locked === true,
+      metadata: raw.metadata && typeof raw.metadata === "object" ? Object.freeze(clone(raw.metadata)) : null,
+    });
+  }
+
+  function normalizeRoute(raw = {}, bounds = defaultBounds(), index = 0) {
+    const points = normalizePointList(raw.points, bounds, CONFIG.maxRoutePoints);
+    if (points.length < 2) throw new Error("GLOBAL_MAP_ROUTE_POINTS_REQUIRED");
+    const id = safeKey(raw.id, `route_${index + 1}`);
+    return Object.freeze({
+      id,
+      type: enumValue(raw.type ?? raw.surface, ROUTE_TYPES, "road"),
+      name: clean(raw.name, id).slice(0, 120),
+      districtId: safeKey(raw.districtId ?? raw.district_id),
+      visibleToPlayers: raw.visibleToPlayers !== false,
+      locked: raw.locked === true,
+      points,
+      bounds: boundsForPoints(points),
+      metadata: raw.metadata && typeof raw.metadata === "object" ? Object.freeze(clone(raw.metadata)) : null,
+    });
+  }
+
+  function recordValues(raw) {
+    if (Array.isArray(raw)) return raw;
+    return raw && typeof raw === "object" ? Object.values(raw) : [];
+  }
+
+  function normalizeDocument(raw = {}) {
+    const bounds = normalizeBounds(raw.bounds || {});
+    const regionRaw = recordValues(raw.regions);
+    const markerRaw = recordValues(raw.markers);
+    const routeRaw = recordValues(raw.routes);
+    if (regionRaw.length > CONFIG.maxRegions) throw new Error("GLOBAL_MAP_REGION_LIMIT");
+    if (markerRaw.length > CONFIG.maxMarkers) throw new Error("GLOBAL_MAP_MARKER_LIMIT");
+    if (routeRaw.length > CONFIG.maxRoutes) throw new Error("GLOBAL_MAP_ROUTE_LIMIT");
+
+    const regions = regionRaw.map((item, index) => normalizeRegion(item, bounds, index));
+    const markers = markerRaw.map((item, index) => normalizeMarker(item, bounds, index));
+    const routes = routeRaw.map((item, index) => normalizeRoute(item, bounds, index));
+    return Object.freeze({
+      schemaVersion: CONFIG.schemaVersion,
+      worldId: safeKey(raw.worldId, CONFIG.defaultWorldId),
+      seed: clean(raw.seed, "0").slice(0, 120),
+      generatorVersion: clean(raw.generatorVersion, "manual_v1").slice(0, 80),
+      revision: Math.max(1, integer(raw.revision, 1)),
+      updatedAtWorldTs: Math.max(0, finite(raw.updatedAtWorldTs, 0)),
+      bounds,
+      regions: Object.freeze(regions),
+      markers: Object.freeze(markers),
+      routes: Object.freeze(routes),
+    });
+  }
+
+  function blankDocument(input = {}) {
+    return normalizeDocument({
+      worldId: input.worldId || CONFIG.defaultWorldId,
+      seed: input.seed || "0",
+      generatorVersion: input.generatorVersion || "manual_v1",
+      revision: 1,
+      bounds: input.bounds || { widthKm: CONFIG.defaultWidthKm, heightKm: CONFIG.defaultHeightKm },
+      regions: [], markers: [], routes: [],
+    });
+  }
+
+  function toRecord(list = []) {
+    const out = {};
+    for (const item of list) out[item.id] = clone(item);
+    return out;
+  }
+
+  function serialize(docRaw = {}) {
+    const doc = normalizeDocument(docRaw);
+    const stripDerived = (item) => {
+      const next = clone(item);
+      delete next.bounds;
+      delete next.areaKm2;
+      return next;
+    };
+    return {
+      schemaVersion: CONFIG.schemaVersion,
+      worldId: doc.worldId,
+      seed: doc.seed,
+      generatorVersion: doc.generatorVersion,
+      revision: doc.revision,
+      updatedAtWorldTs: doc.updatedAtWorldTs,
+      bounds: clone(doc.bounds),
+      regions: Object.fromEntries(doc.regions.map((item) => [item.id, stripDerived(item)])),
+      markers: toRecord(doc.markers),
+      routes: Object.fromEntries(doc.routes.map((item) => [item.id, stripDerived(item)])),
+    };
+  }
+
+  function mutate(docRaw, collection, value, options = {}) {
+    const doc = normalizeDocument(docRaw);
+    const key = collection === "regions" ? "regions" : collection === "markers" ? "markers" : collection === "routes" ? "routes" : null;
+    if (!key) throw new Error("GLOBAL_MAP_COLLECTION_INVALID");
+    const current = doc[key];
+    const bounds = doc.bounds;
+    const normalizer = key === "regions" ? normalizeRegion : key === "markers" ? normalizeMarker : normalizeRoute;
+    const item = normalizer(value, bounds, current.length);
+    const existing = current.find((entry) => entry.id === item.id);
+    if (existing?.locked && options.force !== true) throw new Error("GLOBAL_MAP_ITEM_LOCKED");
+    const nextList = current.filter((entry) => entry.id !== item.id).concat(item);
+    return normalizeDocument({ ...serialize(doc), [key]: nextList, revision: doc.revision + 1 });
+  }
+
+  function remove(docRaw, collection, idRaw, options = {}) {
+    const doc = normalizeDocument(docRaw);
+    const key = collection === "regions" ? "regions" : collection === "markers" ? "markers" : collection === "routes" ? "routes" : null;
+    if (!key) throw new Error("GLOBAL_MAP_COLLECTION_INVALID");
+    const id = safeKey(idRaw);
+    const existing = doc[key].find((entry) => entry.id === id);
+    if (!existing) return doc;
+    if (existing.locked && options.force !== true) throw new Error("GLOBAL_MAP_ITEM_LOCKED");
+    return normalizeDocument({ ...serialize(doc), [key]: doc[key].filter((entry) => entry.id !== id), revision: doc.revision + 1 });
+  }
+
+  function visibleDocument(docRaw, isDm = false) {
+    const doc = normalizeDocument(docRaw);
+    if (isDm) return doc;
+    return normalizeDocument({
+      ...serialize(doc),
+      regions: doc.regions.filter((item) => item.visibleToPlayers),
+      markers: doc.markers.filter((item) => item.visibleToPlayers),
+      routes: doc.routes.filter((item) => item.visibleToPlayers),
+    });
+  }
+
+  function sourceRank(region) {
+    return SOURCE_PRIORITY[region?.source] ?? 0;
+  }
+
+  function effectiveRegionAt(docRaw, pointRaw, layer = null, isDm = false) {
+    const doc = visibleDocument(docRaw, isDm);
+    const point = normalizePoint(pointRaw, doc.bounds);
+    const candidates = doc.regions.filter((region) => (!layer || region.layer === layer) && pointInPolygon(point, region.polygon));
+    candidates.sort((a, b) => sourceRank(b) - sourceRank(a) || a.areaKm2 - b.areaKm2 || a.id.localeCompare(b.id));
+    return candidates[0] || null;
+  }
+
+  function viewportWorldBounds(camera = {}, viewport = {}) {
+    const zoom = Math.max(0.0001, finite(camera.zoom, 1));
+    const width = Math.max(1, finite(viewport.width, 1)) / zoom;
+    const height = Math.max(1, finite(viewport.height, 1)) / zoom;
+    return Object.freeze({
+      minXKm: finite(camera.xKm, 0),
+      minYKm: finite(camera.yKm, 0),
+      maxXKm: finite(camera.xKm, 0) + width,
+      maxYKm: finite(camera.yKm, 0) + height,
+    });
+  }
+
+  function cull(docRaw, camera, viewport, isDm = false) {
+    const doc = visibleDocument(docRaw, isDm);
+    const box = viewportWorldBounds(camera, viewport);
+    return Object.freeze({
+      regions: Object.freeze(doc.regions.filter((item) => boxesOverlap(item.bounds, box))),
+      routes: Object.freeze(doc.routes.filter((item) => boxesOverlap(item.bounds, box))),
+      markers: Object.freeze(doc.markers.filter((item) => item.xKm >= box.minXKm && item.xKm <= box.maxXKm && item.yKm >= box.minYKm && item.yKm <= box.maxYKm)),
+      bounds: box,
+    });
+  }
+
+  function axialOffsetKm(qRaw, rRaw, hexDistanceKm = CONFIG.regionalHexDistanceKm) {
+    const q = integer(qRaw, 0), r = integer(rRaw, 0), distance = Math.max(1, finite(hexDistanceKm, CONFIG.regionalHexDistanceKm));
+    return Object.freeze({ xKm: distance * (q + r / 2), yKm: distance * (Math.sqrt(3) / 2) * r });
+  }
+
+  function regionalHexToGlobal(regionRaw, hexRaw = {}) {
+    const origin = regionRaw?.regionalOrigin;
+    if (!origin) return null;
+    const delta = axialOffsetKm(integer(hexRaw.q, 0) - origin.q, integer(hexRaw.r, 0) - origin.r, origin.hexDistanceKm);
+    const radians = finite(origin.rotationDeg, 0) * Math.PI / 180;
+    const cos = Math.cos(radians), sin = Math.sin(radians);
+    return Object.freeze({
+      xKm: origin.xKm + delta.xKm * cos - delta.yKm * sin,
+      yKm: origin.yKm + delta.xKm * sin + delta.yKm * cos,
+    });
+  }
+
+  function playerGlobalPosition(docRaw, worldPosition = {}, isDm = false) {
+    const doc = visibleDocument(docRaw, isDm);
+    const regionalHex = worldPosition.regionalHex || worldPosition.hex || {};
+    const districtId = safeKey(regionalHex.district ?? worldPosition.district_id ?? worldPosition.regionId);
+    if (!districtId) return null;
+    const district = doc.regions.find((region) => region.layer === "district" && region.districtId === districtId && region.regionalOrigin)
+      || doc.regions.find((region) => region.layer === "district" && region.id === districtId && region.regionalOrigin);
+    if (!district) return null;
+    const point = regionalHexToGlobal(district, regionalHex);
+    return point ? Object.freeze({ ...point, districtId, regionId: district.id }) : null;
+  }
+
+  return Object.freeze({
+    CONFIG,
+    REGION_LAYERS,
+    JURISDICTIONS,
+    SOURCE_PRIORITY,
+    MARKER_TYPES,
+    ROUTE_TYPES,
+    normalizeBounds,
+    normalizePoint,
+    polygonArea,
+    pointInPolygon,
+    boundsForPoints,
+    boxesOverlap,
+    normalizeRegion,
+    normalizeMarker,
+    normalizeRoute,
+    normalizeDocument,
+    blankDocument,
+    serialize,
+    upsertRegion: (doc, value, options) => mutate(doc, "regions", value, options),
+    upsertMarker: (doc, value, options) => mutate(doc, "markers", value, options),
+    upsertRoute: (doc, value, options) => mutate(doc, "routes", value, options),
+    removeRegion: (doc, id, options) => remove(doc, "regions", id, options),
+    removeMarker: (doc, id, options) => remove(doc, "markers", id, options),
+    removeRoute: (doc, id, options) => remove(doc, "routes", id, options),
+    visibleDocument,
+    effectiveRegionAt,
+    viewportWorldBounds,
+    cull,
+    axialOffsetKm,
+    regionalHexToGlobal,
+    playerGlobalPosition,
+  });
+});

--- a/js/vtt/global-map-runtime.js
+++ b/js/vtt/global-map-runtime.js
@@ -1,0 +1,585 @@
+import '../global-map-core.js';
+
+const Core = globalThis.LuminousGlobalMapCore;
+const ROOT = 'campaña/estado_mundo/mapa_global';
+const PLAYERS_ROOT = 'campaña/jugadores';
+const LEGACY_DM_UID = 'e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1';
+
+const clean = (value) => String(value ?? '').trim();
+const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+const uid = (prefix = 'global') => `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 9)}`;
+
+function hostWindow() {
+  try {
+    if (window.parent && window.parent !== window && window.parent.document) return window.parent;
+  } catch (_) {}
+  return window;
+}
+
+function hostFirebase() {
+  const host = hostWindow();
+  return host?.firebase || window.firebase || null;
+}
+
+function hostDocument() {
+  return hostWindow()?.document || document;
+}
+
+function currentUid() {
+  try { return hostFirebase()?.auth?.().currentUser?.uid || null; }
+  catch (_) { return null; }
+}
+
+function runtimeIsDm() {
+  if (globalThis.LuminousVttRuntime?.bridge?.isDm === true) return true;
+  const doc = hostDocument();
+  return currentUid() === LEGACY_DM_UID || Boolean(doc?.body?.classList?.contains('on-game-dashboard') || doc?.body?.classList?.contains('dm-dashboard'));
+}
+
+function escapeHtml(value) {
+  return clean(value).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
+function centroid(points = []) {
+  if (!points.length) return { xKm: 0, yKm: 0 };
+  const sum = points.reduce((acc, point) => ({ xKm: acc.xKm + point.xKm, yKm: acc.yKm + point.yKm }), { xKm: 0, yKm: 0 });
+  return { xKm: sum.xKm / points.length, yKm: sum.yKm / points.length };
+}
+
+function injectDom(isDm) {
+  if (document.getElementById('vtt-global-map-root')) return null;
+
+  const toggle = document.createElement('button');
+  toggle.id = 'vtt-global-map-toggle';
+  toggle.type = 'button';
+  toggle.className = 'brutalist-button vtt-global-map-toggle';
+  toggle.textContent = 'WORLD MAP';
+  toggle.setAttribute('aria-controls', 'vtt-global-map-root');
+  toggle.setAttribute('aria-expanded', 'false');
+  document.body.appendChild(toggle);
+
+  const root = document.createElement('section');
+  root.id = 'vtt-global-map-root';
+  root.className = 'vtt-global-map-root';
+  root.hidden = true;
+  root.innerHTML = `
+    <canvas id="vtt-global-map-canvas" aria-label="Mapa global"></canvas>
+    <header class="vtt-global-map-topbar">
+      <button type="button" id="vtt-global-map-close" class="brutalist-button">LOCAL</button>
+      <strong class="vtt-global-map-title">LUMINOUS // WORLD</strong>
+      <span id="vtt-global-map-scale" class="vtt-global-map-scale">WORLD</span>
+      <button type="button" id="vtt-global-map-zoom-out" class="brutalist-button" aria-label="Alejar">−</button>
+      <button type="button" id="vtt-global-map-zoom-in" class="brutalist-button" aria-label="Acercar">+</button>
+      <button type="button" id="vtt-global-map-reset" class="brutalist-button">FIT</button>
+      <input id="vtt-global-map-search" class="vtt-global-map-search" type="search" maxlength="120" placeholder="Buscar región / punto…" aria-label="Buscar en el mapa global">
+      <span id="vtt-global-map-status" class="vtt-global-map-status">READ ONLY</span>
+    </header>
+    <aside class="vtt-global-map-layers" aria-label="Capas del mapa global">
+      <strong>LAYERS</strong>
+      <label><input type="checkbox" data-global-layer="district" checked> DISTRITOS</label>
+      <label><input type="checkbox" data-global-layer="jurisdiction" checked> JURISDICCIÓN</label>
+      <label><input type="checkbox" data-global-layer="terrain" checked> TERRENO</label>
+      <label><input type="checkbox" data-global-layer="water" checked> AGUA</label>
+      <label><input type="checkbox" data-global-layer="routes" checked> RUTAS</label>
+      <label><input type="checkbox" data-global-layer="markers" checked> LUGARES</label>
+      <label><input type="checkbox" data-global-layer="players" checked> GRUPO</label>
+    </aside>
+    <aside id="vtt-global-map-inspector" class="vtt-global-map-inspector">
+      <strong>INSPECT</strong>
+      <div id="vtt-global-map-inspector-body">Selecciona una región o marcador.</div>
+    </aside>
+    ${isDm ? `
+    <aside id="vtt-global-map-editor" class="vtt-global-map-editor">
+      <strong>WORLD AUTHORING</strong>
+      <div class="vtt-global-map-toolrow">
+        <button type="button" class="brutalist-button active" data-global-tool="select">SELECT</button>
+        <button type="button" class="brutalist-button" data-global-tool="region">REGION</button>
+        <button type="button" class="brutalist-button" data-global-tool="marker">MARKER</button>
+        <button type="button" class="brutalist-button" data-global-tool="route">ROUTE</button>
+      </div>
+      <label>NOMBRE<input id="vtt-global-name" maxlength="120" value="Nueva región"></label>
+      <label>CAPA<select id="vtt-global-region-layer">
+        <option value="district">DISTRICT</option><option value="jurisdiction">JURISDICTION</option><option value="terrain">TERRAIN</option><option value="water">WATER</option><option value="special">SPECIAL</option>
+      </select></label>
+      <label>DISTRITO ID<input id="vtt-global-district" maxlength="120" placeholder="district_k"></label>
+      <label>JURISDICCIÓN<select id="vtt-global-jurisdiction"><option value="outskirts">OUTSKIRTS</option><option value="backstreets">BACKSTREETS</option><option value="nest">NEST</option></select></label>
+      <label>TERRENO<input id="vtt-global-terrain" maxlength="80" value="unknown" placeholder="forest / urban / lake"></label>
+      <label>FUENTE<select id="vtt-global-source"><option value="dm">DM OVERRIDE</option><option value="campaign">CAMPAIGN</option><option value="canon">CANON LOCK</option><option value="procedural">PROCEDURAL</option></select></label>
+      <label>MARKER<select id="vtt-global-marker-type"><option value="nest">NEST</option><option value="city">CITY</option><option value="town">TOWN</option><option value="villa">VILLA</option><option value="industrial">INDUSTRIAL</option><option value="checkpoint">CHECKPOINT</option><option value="poi">POI</option></select></label>
+      <label>RUTA<select id="vtt-global-route-type"><option value="road">ROAD</option><option value="dirt_road">DIRT ROAD</option><option value="trail">TRAIL</option><option value="rail">RAIL</option><option value="waterway">WATERWAY</option></select></label>
+      <label class="vtt-global-map-check"><input id="vtt-global-visible" type="checkbox" checked> VISIBLE A JUGADORES</label>
+      <div class="vtt-global-map-toolrow">
+        <button type="button" id="vtt-global-finish" class="brutalist-button" disabled>CERRAR TRAZO</button>
+        <button type="button" id="vtt-global-cancel" class="brutalist-button">CANCEL</button>
+      </div>
+      <div class="vtt-global-map-toolrow">
+        <button type="button" id="vtt-global-apply" class="brutalist-button">APLICAR</button>
+        <button type="button" id="vtt-global-delete" class="brutalist-button">DELETE</button>
+      </div>
+      <button type="button" id="vtt-global-save" class="brutalist-button vtt-global-save">SAVE WORLD</button>
+      <small id="vtt-global-help">SELECT inspecciona. REGION/ROUTE agregan puntos con click; CERRAR TRAZO finaliza. Arrastra con botón derecho/medio para mover el mapa.</small>
+    </aside>` : ''}
+  `;
+  document.body.appendChild(root);
+  return { toggle, root };
+}
+
+function start() {
+  if (!Core || globalThis.LuminousGlobalMapRuntime) return globalThis.LuminousGlobalMapRuntime || null;
+  const isDm = runtimeIsDm();
+  const dom = injectDom(isDm);
+  if (!dom) return null;
+
+  const canvas = document.getElementById('vtt-global-map-canvas');
+  const ctx = canvas.getContext('2d');
+  const scaleEl = document.getElementById('vtt-global-map-scale');
+  const statusEl = document.getElementById('vtt-global-map-status');
+  const inspectorBody = document.getElementById('vtt-global-map-inspector-body');
+  const localCanvas = document.getElementById('vtt-canvas');
+  const layerState = new Set(['district', 'jurisdiction', 'terrain', 'water', 'routes', 'markers', 'players']);
+
+  let doc = Core.blankDocument();
+  let players = {};
+  let open = false;
+  let loaded = false;
+  let dirty = false;
+  let tool = 'select';
+  let draftPoints = [];
+  let selected = null;
+  let mapRef = null;
+  let playersRef = null;
+  let mapListener = null;
+  let playersListener = null;
+  let engineWasRunning = false;
+  let pan = null;
+  const camera = { xKm: 0, yKm: 0, zoom: 0.1 };
+
+  function notify(message, mode = 'info') {
+    statusEl.textContent = clean(message).slice(0, 120) || (isDm ? 'DM' : 'READ ONLY');
+    statusEl.dataset.mode = mode;
+  }
+
+  function resize() {
+    const ratio = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
+    const width = Math.max(1, window.innerWidth), height = Math.max(1, window.innerHeight);
+    canvas.width = Math.floor(width * ratio);
+    canvas.height = Math.floor(height * ratio);
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+    ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+    render();
+  }
+
+  function viewport() {
+    return { width: Math.max(1, window.innerWidth), height: Math.max(1, window.innerHeight) };
+  }
+
+  function fit() {
+    const view = viewport(), bounds = doc.bounds;
+    camera.zoom = Math.max(0.02, Math.min(2.5, Math.min((view.width - 80) / bounds.widthKm, (view.height - 80) / bounds.heightKm)));
+    camera.xKm = bounds.minXKm - Math.max(0, (view.width / camera.zoom - bounds.widthKm) / 2);
+    camera.yKm = bounds.minYKm - Math.max(0, (view.height / camera.zoom - bounds.heightKm) / 2);
+    render();
+  }
+
+  function screenToWorld(clientX, clientY) {
+    const rect = canvas.getBoundingClientRect();
+    return { xKm: camera.xKm + (clientX - rect.left) / camera.zoom, yKm: camera.yKm + (clientY - rect.top) / camera.zoom };
+  }
+
+  function worldToScreen(point) {
+    return { x: (point.xKm - camera.xKm) * camera.zoom, y: (point.yKm - camera.yKm) * camera.zoom };
+  }
+
+  function colorForRegion(region) {
+    if (region.layer === 'water') return { fill: 'rgba(32,74,100,.74)', stroke: '#70a7c3' };
+    if (region.layer === 'district') return { fill: 'rgba(0,0,0,.04)', stroke: '#d2d7db' };
+    if (region.layer === 'jurisdiction') {
+      if (region.jurisdiction === 'nest') return { fill: 'rgba(164,61,61,.36)', stroke: '#d36a6a' };
+      if (region.jurisdiction === 'backstreets') return { fill: 'rgba(172,132,59,.28)', stroke: '#c9a45e' };
+      return { fill: 'rgba(81,105,75,.26)', stroke: '#849c7c' };
+    }
+    if (region.layer === 'terrain') return { fill: 'rgba(78,91,75,.38)', stroke: '#77856f' };
+    return { fill: 'rgba(101,82,115,.28)', stroke: '#9480a3' };
+  }
+
+  function path(points, close = false) {
+    if (!points.length) return false;
+    const first = worldToScreen(points[0]);
+    ctx.beginPath(); ctx.moveTo(first.x, first.y);
+    for (let index = 1; index < points.length; index += 1) {
+      const next = worldToScreen(points[index]); ctx.lineTo(next.x, next.y);
+    }
+    if (close) ctx.closePath();
+    return true;
+  }
+
+  function drawRegion(region) {
+    if (!layerState.has(region.layer) || !path(region.polygon, true)) return;
+    const style = colorForRegion(region);
+    ctx.fillStyle = style.fill; ctx.strokeStyle = selected?.kind === 'region' && selected.id === region.id ? '#ffffff' : style.stroke;
+    ctx.lineWidth = selected?.kind === 'region' && selected.id === region.id ? 3 : region.layer === 'district' ? 2 : 1;
+    ctx.fill(); ctx.stroke();
+    if (region.layer === 'district' && camera.zoom >= 0.12) {
+      const center = worldToScreen(centroid(region.polygon));
+      ctx.fillStyle = '#e8edf0'; ctx.font = '12px monospace'; ctx.textAlign = 'center';
+      ctx.fillText(region.name, center.x, center.y);
+    }
+  }
+
+  function drawRoute(route) {
+    if (!layerState.has('routes') || !path(route.points, false)) return;
+    ctx.strokeStyle = route.type === 'rail' ? '#d8d8d8' : route.type === 'waterway' ? '#77a8c4' : '#b28d5d';
+    ctx.lineWidth = route.type === 'rail' ? 2 : 3;
+    if (route.type === 'dirt_road' || route.type === 'trail') ctx.setLineDash([8, 7]);
+    else ctx.setLineDash([]);
+    ctx.stroke(); ctx.setLineDash([]);
+  }
+
+  function drawMarker(marker) {
+    if (!layerState.has('markers')) return;
+    const p = worldToScreen(marker);
+    ctx.beginPath(); ctx.arc(p.x, p.y, marker.type === 'nest' ? 7 : 5, 0, Math.PI * 2);
+    ctx.fillStyle = marker.type === 'nest' ? '#e25d5d' : '#e0d6b7'; ctx.fill();
+    ctx.strokeStyle = selected?.kind === 'marker' && selected.id === marker.id ? '#fff' : '#111'; ctx.lineWidth = 2; ctx.stroke();
+    if (camera.zoom >= 0.18) {
+      ctx.fillStyle = '#eef1f3'; ctx.font = '11px monospace'; ctx.textAlign = 'left';
+      ctx.fillText(marker.name, p.x + 9, p.y + 4);
+    }
+  }
+
+  function playerName(player, fallback) {
+    return clean(player?.nombre || player?.name || player?.characterName || player?.character_name, fallback);
+  }
+
+  function drawPlayers() {
+    if (!layerState.has('players')) return;
+    for (const [playerId, player] of Object.entries(players || {})) {
+      const position = Core.playerGlobalPosition(doc, player?.worldPosition || {}, isDm);
+      if (!position) continue;
+      const p = worldToScreen(position);
+      ctx.beginPath(); ctx.arc(p.x, p.y, 6, 0, Math.PI * 2);
+      ctx.fillStyle = '#f0f2f4'; ctx.fill(); ctx.strokeStyle = '#111'; ctx.lineWidth = 2; ctx.stroke();
+      ctx.fillStyle = '#f0f2f4'; ctx.font = '10px monospace'; ctx.textAlign = 'left';
+      ctx.fillText(playerName(player, playerId), p.x + 9, p.y + 4);
+    }
+  }
+
+  function drawDraft() {
+    if (!draftPoints.length) return;
+    path(draftPoints, false);
+    ctx.strokeStyle = '#ff5d5d'; ctx.lineWidth = 2; ctx.setLineDash([6, 5]); ctx.stroke(); ctx.setLineDash([]);
+    for (const point of draftPoints) {
+      const p = worldToScreen(point); ctx.beginPath(); ctx.arc(p.x, p.y, 3, 0, Math.PI * 2); ctx.fillStyle = '#ff5d5d'; ctx.fill();
+    }
+  }
+
+  function levelLabel() {
+    if (camera.zoom < 0.14) return 'WORLD';
+    if (camera.zoom < 0.55) return 'DISTRICT';
+    return 'REGIONAL';
+  }
+
+  function render() {
+    if (!open || !ctx) return;
+    const view = viewport();
+    ctx.clearRect(0, 0, view.width, view.height);
+    ctx.fillStyle = '#080a0c'; ctx.fillRect(0, 0, view.width, view.height);
+    const a = worldToScreen({ xKm: doc.bounds.minXKm, yKm: doc.bounds.minYKm });
+    const b = worldToScreen({ xKm: doc.bounds.minXKm + doc.bounds.widthKm, yKm: doc.bounds.minYKm + doc.bounds.heightKm });
+    ctx.fillStyle = '#11161a'; ctx.fillRect(a.x, a.y, b.x - a.x, b.y - a.y);
+    ctx.strokeStyle = '#37414a'; ctx.lineWidth = 1; ctx.strokeRect(a.x, a.y, b.x - a.x, b.y - a.y);
+
+    const visible = Core.cull(doc, camera, view, isDm);
+    const orderedRegions = visible.regions.slice().sort((x, y) => {
+      const rank = { water: 0, terrain: 1, jurisdiction: 2, special: 3, district: 4 };
+      return (rank[x.layer] ?? 2) - (rank[y.layer] ?? 2);
+    });
+    orderedRegions.forEach(drawRegion);
+    visible.routes.forEach(drawRoute);
+    visible.markers.forEach(drawMarker);
+    drawPlayers();
+    drawDraft();
+    scaleEl.textContent = `${levelLabel()} · ${camera.zoom.toFixed(2)} px/km`;
+  }
+
+  function setDirty(value = true) {
+    dirty = Boolean(value);
+    if (isDm) notify(dirty ? 'UNSAVED' : 'SAVED', dirty ? 'dirty' : 'ok');
+  }
+
+  function setTool(nextTool) {
+    tool = ['select', 'region', 'marker', 'route'].includes(nextTool) ? nextTool : 'select';
+    draftPoints = [];
+    document.querySelectorAll('[data-global-tool]').forEach((button) => button.classList.toggle('active', button.dataset.globalTool === tool));
+    const finish = document.getElementById('vtt-global-finish');
+    if (finish) finish.disabled = tool !== 'region' && tool !== 'route';
+    render();
+  }
+
+  function regionForm() {
+    return {
+      name: clean(document.getElementById('vtt-global-name')?.value, 'Nueva región'),
+      layer: document.getElementById('vtt-global-region-layer')?.value || 'terrain',
+      districtId: clean(document.getElementById('vtt-global-district')?.value),
+      jurisdiction: document.getElementById('vtt-global-jurisdiction')?.value || 'outskirts',
+      terrain: clean(document.getElementById('vtt-global-terrain')?.value, 'unknown'),
+      source: document.getElementById('vtt-global-source')?.value || 'dm',
+      visibleToPlayers: document.getElementById('vtt-global-visible')?.checked !== false,
+    };
+  }
+
+  function finishDraft() {
+    if (!isDm) return;
+    const form = regionForm();
+    try {
+      if (tool === 'region') {
+        if (draftPoints.length < 3) return notify('REGION NEEDS 3 POINTS', 'error');
+        const id = uid('region');
+        const center = centroid(draftPoints);
+        doc = Core.upsertRegion(doc, {
+          id, ...form, polygon: draftPoints,
+          regionalOrigin: form.layer === 'district' ? { ...center, q: 0, r: 0, hexDistanceKm: Core.CONFIG.regionalHexDistanceKm } : null,
+        });
+        selected = { kind: 'region', id };
+      } else if (tool === 'route') {
+        if (draftPoints.length < 2) return notify('ROUTE NEEDS 2 POINTS', 'error');
+        const id = uid('route');
+        doc = Core.upsertRoute(doc, { id, name: form.name, districtId: form.districtId, type: document.getElementById('vtt-global-route-type')?.value || 'road', visibleToPlayers: form.visibleToPlayers, points: draftPoints });
+        selected = { kind: 'route', id };
+      } else return;
+      draftPoints = [];
+      setDirty(true); updateInspector(); render();
+    } catch (error) { notify(error.message || 'INVALID DRAWING', 'error'); }
+  }
+
+  function findMarkerAt(point) {
+    let best = null, bestDistance = Infinity;
+    const thresholdKm = Math.max(4, 12 / camera.zoom);
+    for (const marker of Core.visibleDocument(doc, isDm).markers) {
+      const distance = Math.hypot(marker.xKm - point.xKm, marker.yKm - point.yKm);
+      if (distance <= thresholdKm && distance < bestDistance) { best = marker; bestDistance = distance; }
+    }
+    return best;
+  }
+
+  function selectAt(point) {
+    const marker = findMarkerAt(point);
+    if (marker) selected = { kind: 'marker', id: marker.id };
+    else {
+      const region = Core.effectiveRegionAt(doc, point, null, isDm);
+      selected = region ? { kind: 'region', id: region.id } : null;
+    }
+    updateInspector(); render();
+  }
+
+  function selectedItem() {
+    if (!selected) return null;
+    const key = selected.kind === 'region' ? 'regions' : selected.kind === 'marker' ? 'markers' : selected.kind === 'route' ? 'routes' : null;
+    return key ? doc[key].find((item) => item.id === selected.id) || null : null;
+  }
+
+  function updateInspector() {
+    const item = selectedItem();
+    if (!item) { inspectorBody.textContent = 'Selecciona una región o marcador.'; return; }
+    const lines = [item.name || item.id, `ID: ${item.id}`];
+    if (selected.kind === 'region') lines.push(`CAPA: ${item.layer}`, `DISTRITO: ${item.districtId || '—'}`, `LEGAL: ${item.jurisdiction || '—'}`, `TERRENO: ${item.terrain}`, `FUENTE: ${item.source}`, `ÁREA: ${Math.round(item.areaKm2).toLocaleString()} km²`);
+    if (selected.kind === 'marker') lines.push(`TIPO: ${item.type}`, `DISTRITO: ${item.districtId || '—'}`);
+    if (selected.kind === 'route') lines.push(`RUTA: ${item.type}`, `DISTRITO: ${item.districtId || '—'}`);
+    inspectorBody.innerHTML = lines.map((line, index) => index === 0 ? `<b>${escapeHtml(line)}</b>` : `<span>${escapeHtml(line)}</span>`).join('');
+  }
+
+  function applyFormToSelection() {
+    if (!isDm) return;
+    const item = selectedItem();
+    if (!item) return notify('SELECT AN ITEM', 'error');
+    if (item.locked) return notify('CANON ITEM LOCKED', 'error');
+    const form = regionForm();
+    try {
+      if (selected.kind === 'region') doc = Core.upsertRegion(doc, { ...item, ...form, polygon: item.polygon, regionalOrigin: item.regionalOrigin });
+      else if (selected.kind === 'marker') doc = Core.upsertMarker(doc, { ...item, name: form.name, districtId: form.districtId, type: document.getElementById('vtt-global-marker-type')?.value || item.type, visibleToPlayers: form.visibleToPlayers });
+      else if (selected.kind === 'route') doc = Core.upsertRoute(doc, { ...item, name: form.name, districtId: form.districtId, type: document.getElementById('vtt-global-route-type')?.value || item.type, visibleToPlayers: form.visibleToPlayers, points: item.points });
+      setDirty(true); updateInspector(); render();
+    } catch (error) { notify(error.message || 'UPDATE FAILED', 'error'); }
+  }
+
+  function deleteSelection() {
+    if (!isDm) return;
+    const item = selectedItem();
+    if (!item) return;
+    if (item.locked) return notify('CANON ITEM LOCKED', 'error');
+    try {
+      if (selected.kind === 'region') doc = Core.removeRegion(doc, item.id);
+      else if (selected.kind === 'marker') doc = Core.removeMarker(doc, item.id);
+      else if (selected.kind === 'route') doc = Core.removeRoute(doc, item.id);
+      selected = null; setDirty(true); updateInspector(); render();
+    } catch (error) { notify(error.message || 'DELETE FAILED', 'error'); }
+  }
+
+  function onCanvasClick(event) {
+    if (pan?.moved || event.button !== 0) return;
+    const point = screenToWorld(event.clientX, event.clientY);
+    if (!isDm || tool === 'select') return selectAt(point);
+    if (tool === 'marker') {
+      const form = regionForm(), id = uid('marker');
+      try {
+        doc = Core.upsertMarker(doc, { id, ...point, name: form.name, districtId: form.districtId, type: document.getElementById('vtt-global-marker-type')?.value || 'poi', visibleToPlayers: form.visibleToPlayers });
+        selected = { kind: 'marker', id }; setDirty(true); updateInspector(); render();
+      } catch (error) { notify(error.message || 'MARKER FAILED', 'error'); }
+      return;
+    }
+    draftPoints.push(Core.normalizePoint(point, doc.bounds));
+    render();
+  }
+
+  function onPointerDown(event) {
+    const panAllowed = event.button === 1 || event.button === 2 || (!isDm && event.button === 0) || (tool === 'select' && event.button === 0 && event.shiftKey);
+    if (!panAllowed) return;
+    pan = { x: event.clientX, y: event.clientY, cameraX: camera.xKm, cameraY: camera.yKm, moved: false };
+    canvas.setPointerCapture?.(event.pointerId);
+    event.preventDefault();
+  }
+
+  function onPointerMove(event) {
+    if (!pan) return;
+    const dx = event.clientX - pan.x, dy = event.clientY - pan.y;
+    if (Math.abs(dx) + Math.abs(dy) > 3) pan.moved = true;
+    camera.xKm = pan.cameraX - dx / camera.zoom;
+    camera.yKm = pan.cameraY - dy / camera.zoom;
+    render();
+  }
+
+  function onPointerUp() { if (pan) queueMicrotask(() => { pan = null; }); }
+
+  function onWheel(event) {
+    event.preventDefault();
+    const before = screenToWorld(event.clientX, event.clientY);
+    const factor = event.deltaY < 0 ? 1.18 : 1 / 1.18;
+    camera.zoom = Math.max(0.02, Math.min(4, camera.zoom * factor));
+    const after = screenToWorld(event.clientX, event.clientY);
+    camera.xKm += before.xKm - after.xKm; camera.yKm += before.yKm - after.yKm;
+    render();
+  }
+
+  function search() {
+    const query = clean(document.getElementById('vtt-global-map-search')?.value).toLowerCase();
+    if (!query) return;
+    const visible = Core.visibleDocument(doc, isDm);
+    const item = [...visible.markers, ...visible.regions].find((entry) => clean(entry.name).toLowerCase().includes(query) || clean(entry.id).toLowerCase().includes(query));
+    if (!item) return notify('NOT FOUND', 'error');
+    const point = item.polygon ? centroid(item.polygon) : item;
+    const view = viewport();
+    camera.xKm = point.xKm - view.width / camera.zoom / 2; camera.yKm = point.yKm - view.height / camera.zoom / 2;
+    selected = { kind: item.polygon ? 'region' : 'marker', id: item.id };
+    updateInspector(); render();
+  }
+
+  function unwatch() {
+    if (mapRef && mapListener) mapRef.off('value', mapListener);
+    if (playersRef && playersListener) playersRef.off('value', playersListener);
+    mapRef = playersRef = mapListener = playersListener = null;
+  }
+
+  function watch() {
+    const firebase = hostFirebase();
+    const db = firebase?.database?.();
+    if (!db) { notify('LOCAL MAP DATA', 'error'); return; }
+    mapRef = db.ref(ROOT); playersRef = db.ref(PLAYERS_ROOT);
+    mapListener = (snapshot) => {
+      if (dirty && isDm) return;
+      try { doc = snapshot.exists() ? Core.normalizeDocument(snapshot.val()) : Core.blankDocument(); loaded = true; if (!dirty) setDirty(false); render(); }
+      catch (error) { console.error('[Luminous] Global map invalid:', error); notify('GLOBAL MAP INVALID', 'error'); }
+    };
+    playersListener = (snapshot) => { players = snapshot.val() || {}; render(); };
+    mapRef.on('value', mapListener);
+    playersRef.on('value', playersListener);
+  }
+
+  async function ensureLoaded() {
+    if (loaded) return;
+    const firebase = hostFirebase(), db = firebase?.database?.();
+    if (!db) { loaded = true; return; }
+    const snapshot = await db.ref(ROOT).once('value');
+    doc = snapshot.exists() ? Core.normalizeDocument(snapshot.val()) : Core.blankDocument();
+    loaded = true;
+  }
+
+  async function save() {
+    if (!isDm) return false;
+    const firebase = hostFirebase(), db = firebase?.database?.();
+    if (!db) throw new Error('FIREBASE_UNAVAILABLE');
+    const payload = Core.serialize({ ...Core.serialize(doc), updatedAtWorldTs: Date.now(), revision: Math.max(1, doc.revision) });
+    await db.ref(ROOT).set(payload);
+    doc = Core.normalizeDocument(payload);
+    setDirty(false); render();
+    return true;
+  }
+
+  async function openMap() {
+    if (open) return;
+    open = true; dom.root.hidden = false; dom.toggle.setAttribute('aria-expanded', 'true');
+    engineWasRunning = globalThis.LuminousVttRuntime?.engine?.isRunning === true;
+    globalThis.LuminousVttRuntime?.engine?.stop?.();
+    if (localCanvas) localCanvas.hidden = true;
+    resize();
+    try { await ensureLoaded(); fit(); }
+    catch (error) { console.error('[Luminous] Global map load failed:', error); notify('LOAD FAILED', 'error'); }
+    watch(); render();
+  }
+
+  function closeMap() {
+    if (!open) return;
+    open = false; unwatch(); dom.root.hidden = true; dom.toggle.setAttribute('aria-expanded', 'false');
+    if (localCanvas) localCanvas.hidden = false;
+    if (engineWasRunning) globalThis.LuminousVttRuntime?.engine?.start?.();
+  }
+
+  dom.toggle.addEventListener('click', () => open ? closeMap() : void openMap());
+  document.getElementById('vtt-global-map-close')?.addEventListener('click', closeMap);
+  document.getElementById('vtt-global-map-reset')?.addEventListener('click', fit);
+  document.getElementById('vtt-global-map-zoom-in')?.addEventListener('click', () => { camera.zoom = Math.min(4, camera.zoom * 1.25); render(); });
+  document.getElementById('vtt-global-map-zoom-out')?.addEventListener('click', () => { camera.zoom = Math.max(0.02, camera.zoom / 1.25); render(); });
+  document.getElementById('vtt-global-map-search')?.addEventListener('change', search);
+  document.getElementById('vtt-global-map-search')?.addEventListener('keydown', (event) => { if (event.key === 'Enter') search(); });
+  document.querySelectorAll('[data-global-layer]').forEach((input) => input.addEventListener('change', () => { input.checked ? layerState.add(input.dataset.globalLayer) : layerState.delete(input.dataset.globalLayer); render(); }));
+  document.querySelectorAll('[data-global-tool]').forEach((button) => button.addEventListener('click', () => setTool(button.dataset.globalTool)));
+  document.getElementById('vtt-global-finish')?.addEventListener('click', finishDraft);
+  document.getElementById('vtt-global-cancel')?.addEventListener('click', () => { draftPoints = []; setTool('select'); });
+  document.getElementById('vtt-global-apply')?.addEventListener('click', applyFormToSelection);
+  document.getElementById('vtt-global-delete')?.addEventListener('click', deleteSelection);
+  document.getElementById('vtt-global-save')?.addEventListener('click', () => save().catch((error) => { console.error('[Luminous] Global map save failed:', error); notify('SAVE DENIED', 'error'); }));
+
+  canvas.addEventListener('contextmenu', (event) => event.preventDefault());
+  canvas.addEventListener('pointerdown', onPointerDown);
+  canvas.addEventListener('pointermove', onPointerMove);
+  canvas.addEventListener('pointerup', onPointerUp);
+  canvas.addEventListener('pointercancel', onPointerUp);
+  canvas.addEventListener('click', onCanvasClick);
+  canvas.addEventListener('wheel', onWheel, { passive: false });
+  window.addEventListener('resize', resize);
+  window.addEventListener('keydown', (event) => {
+    if (!open) return;
+    if (event.key === 'Escape') { if (draftPoints.length) { draftPoints = []; render(); } else closeMap(); }
+  });
+
+  const api = Object.freeze({
+    ROOT, PLAYERS_ROOT, core: Core,
+    get isOpen() { return open; },
+    get isDm() { return isDm; },
+    get document() { return doc; },
+    get camera() { return { ...camera }; },
+    open: openMap,
+    close: closeMap,
+    fit,
+    render,
+    save,
+    stop() { closeMap(); unwatch(); window.removeEventListener('resize', resize); dom.toggle.remove(); dom.root.remove(); },
+  });
+  globalThis.LuminousGlobalMapRuntime = api;
+  return api;
+}
+
+if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', start, { once: true });
+else start();
+
+export { start };

--- a/tests/global_map_foundation.spec.js
+++ b/tests/global_map_foundation.spec.js
@@ -1,0 +1,114 @@
+const { test, expect } = require('@playwright/test');
+const Core = require('../js/global-map-core.js');
+
+const district = (extra = {}) => ({
+  id: 'district_k',
+  name: 'District K',
+  layer: 'district',
+  districtId: 'K',
+  source: 'campaign',
+  polygon: [
+    { xKm: 1000, yKm: 800 },
+    { xKm: 2200, yKm: 800 },
+    { xKm: 2200, yKm: 1800 },
+    { xKm: 1000, yKm: 1800 },
+  ],
+  regionalOrigin: { xKm: 1600, yKm: 1300, q: 0, r: 0, hexDistanceKm: 20 },
+  ...extra,
+});
+
+function baseDocument() {
+  return Core.normalizeDocument({
+    worldId: 'limbus_world',
+    seed: '1234',
+    generatorVersion: 'worldgen_1.4',
+    bounds: { widthKm: 5500, heightKm: 4000 },
+    regions: [
+      district(),
+      {
+        id: 'k_nest', name: 'K Nest', layer: 'jurisdiction', districtId: 'K', jurisdiction: 'nest', terrain: 'urban', source: 'dm',
+        polygon: [{ xKm: 1450, yKm: 1150 }, { xKm: 1750, yKm: 1150 }, { xKm: 1750, yKm: 1450 }, { xKm: 1450, yKm: 1450 }],
+      },
+    ],
+    markers: [{ id: 'k_capital', name: 'K Corp Nest', type: 'nest', districtId: 'K', xKm: 1600, yKm: 1300 }],
+    routes: [{ id: 'k_rail', name: 'K Rail', type: 'rail', districtId: 'K', points: [{ xKm: 1200, yKm: 1300 }, { xKm: 2000, yKm: 1300 }] }],
+  });
+}
+
+test.describe('Global Map Foundation', () => {
+  test('defaults to the agreed 22M km² world canvas when blank', () => {
+    const doc = Core.blankDocument();
+    expect(doc.bounds.widthKm).toBe(5500);
+    expect(doc.bounds.heightKm).toBe(4000);
+    expect(doc.bounds.widthKm * doc.bounds.heightKm).toBe(22_000_000);
+  });
+
+  test('keeps legal jurisdiction independent from physical terrain', () => {
+    const doc = baseDocument();
+    const nest = doc.regions.find((region) => region.id === 'k_nest');
+    expect(nest.jurisdiction).toBe('nest');
+    expect(nest.terrain).toBe('urban');
+  });
+
+  test('resolves Canon > DM > Campaign > Procedural at overlapping geometry', () => {
+    const polygon = [{ xKm: 100, yKm: 100 }, { xKm: 400, yKm: 100 }, { xKm: 400, yKm: 400 }, { xKm: 100, yKm: 400 }];
+    const doc = Core.normalizeDocument({
+      bounds: { widthKm: 5500, heightKm: 4000 },
+      regions: [
+        { id: 'proc', layer: 'terrain', terrain: 'plains', source: 'procedural', polygon },
+        { id: 'campaign', layer: 'terrain', terrain: 'forest', source: 'campaign', polygon },
+        { id: 'dm', layer: 'terrain', terrain: 'urban', source: 'dm', polygon },
+        { id: 'canon', layer: 'terrain', terrain: 'lake', source: 'canon', polygon },
+      ],
+    });
+    expect(Core.effectiveRegionAt(doc, { xKm: 200, yKm: 200 }, 'terrain', true).id).toBe('canon');
+  });
+
+  test('player view hides DM-only global geometry while DM keeps it', () => {
+    let doc = baseDocument();
+    doc = Core.upsertMarker(doc, { id: 'secret', name: 'Secret Lab', type: 'poi', xKm: 1700, yKm: 1350, visibleToPlayers: false });
+    expect(Core.visibleDocument(doc, false).markers.some((marker) => marker.id === 'secret')).toBe(false);
+    expect(Core.visibleDocument(doc, true).markers.some((marker) => marker.id === 'secret')).toBe(true);
+  });
+
+  test('global map remains compact vector data instead of local tile/chunk payloads', () => {
+    const serialized = JSON.stringify(Core.serialize(baseDocument()));
+    expect(serialized).not.toContain('chunkCol');
+    expect(serialized).not.toContain('chunkRow');
+    expect(serialized).not.toContain('tiles');
+    expect(serialized).not.toContain('topology');
+    expect(serialized.length).toBeLessThan(10_000);
+  });
+
+  test('viewport culling returns only geometry intersecting the camera', () => {
+    let doc = baseDocument();
+    doc = Core.upsertMarker(doc, { id: 'far', name: 'Far', type: 'poi', xKm: 5000, yKm: 3500 });
+    const visible = Core.cull(doc, { xKm: 900, yKm: 700, zoom: 1 }, { width: 1500, height: 1300 }, true);
+    expect(visible.markers.some((marker) => marker.id === 'k_capital')).toBe(true);
+    expect(visible.markers.some((marker) => marker.id === 'far')).toBe(false);
+  });
+
+  test('district regional origin projects axial hex positions into the global map', () => {
+    const doc = baseDocument();
+    const origin = Core.playerGlobalPosition(doc, { regionalHex: { district: 'K', q: 0, r: 0 } }, true);
+    const east = Core.playerGlobalPosition(doc, { regionalHex: { district: 'K', q: 1, r: 0 } }, true);
+    expect(origin).toMatchObject({ xKm: 1600, yKm: 1300, districtId: 'K' });
+    expect(east.xKm - origin.xKm).toBeCloseTo(20, 6);
+    expect(east.yKm).toBeCloseTo(origin.yKm, 6);
+  });
+
+  test('locked canon geometry cannot be silently edited or deleted', () => {
+    const polygon = [{ xKm: 10, yKm: 10 }, { xKm: 100, yKm: 10 }, { xKm: 100, yKm: 100 }];
+    let doc = Core.blankDocument();
+    doc = Core.upsertRegion(doc, { id: 'great_lake', name: 'Great Lake', layer: 'water', terrain: 'water', source: 'canon', polygon });
+    expect(() => Core.upsertRegion(doc, { ...doc.regions[0], name: 'Moved Lake', polygon })).toThrow('GLOBAL_MAP_ITEM_LOCKED');
+    expect(() => Core.removeRegion(doc, 'great_lake')).toThrow('GLOBAL_MAP_ITEM_LOCKED');
+  });
+
+  test('region and route point caps reject unbounded authoring payloads', () => {
+    const tooManyRegionPoints = Array.from({ length: Core.CONFIG.maxRegionVertices + 1 }, (_, index) => ({ xKm: index % 5500, yKm: index % 4000 }));
+    expect(() => Core.normalizeRegion({ id: 'too_big', polygon: tooManyRegionPoints }, Core.blankDocument().bounds)).toThrow('GLOBAL_MAP_POINT_LIMIT');
+    const tooManyRoutePoints = Array.from({ length: Core.CONFIG.maxRoutePoints + 1 }, (_, index) => ({ xKm: index % 5500, yKm: index % 4000 }));
+    expect(() => Core.normalizeRoute({ id: 'too_long', points: tooManyRoutePoints }, Core.blankDocument().bounds)).toThrow('GLOBAL_MAP_POINT_LIMIT');
+  });
+});

--- a/tests/global_map_realtime.spec.js
+++ b/tests/global_map_realtime.spec.js
@@ -1,0 +1,68 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+
+const runtime = fs.readFileSync('js/vtt/global-map-runtime.js', 'utf8');
+const html = fs.readFileSync('vtt.html', 'utf8');
+
+test.describe('Global Map realtime / performance architecture', () => {
+  test('persists under the existing DM-authoritative campaign world state root', () => {
+    expect(runtime).toContain("const ROOT = 'campaña/estado_mundo/mapa_global'");
+    expect(runtime).not.toContain("const ROOT = 'global_map'");
+  });
+
+  test('does not add polling, timers, or a render loop', () => {
+    expect(runtime).not.toContain('setInterval(');
+    expect(runtime).not.toContain('setTimeout(');
+    expect(runtime).not.toContain('requestAnimationFrame(');
+  });
+
+  test('initial load is one-shot and realtime watchers only attach while the HUD is open', () => {
+    expect(runtime).toContain("db.ref(ROOT).once('value')");
+    expect(runtime).toContain("mapRef.on('value', mapListener)");
+    expect(runtime).toContain("playersRef.on('value', playersListener)");
+    expect(runtime).toContain("mapRef.off('value', mapListener)");
+    expect(runtime).toContain("playersRef.off('value', playersListener)");
+    expect(runtime).toMatch(/function closeMap\(\)[\s\S]*?unwatch\(\)/);
+  });
+
+  test('DM authoring writes only through explicit save and not canvas movement', () => {
+    const writeCalls = [...runtime.matchAll(/\.set\(/g)];
+    expect(writeCalls).toHaveLength(1);
+    expect(runtime).toMatch(/async function save\(\)[\s\S]*?db\.ref\(ROOT\)\.set\(payload\)/);
+    const moveBlock = runtime.match(/function onPointerMove\(event\) \{[\s\S]*?\n  \}/)?.[0] || '';
+    expect(moveBlock).not.toContain('.set(');
+    expect(moveBlock).not.toContain('.update(');
+    expect(moveBlock).not.toContain('.transaction(');
+  });
+
+  test('opening the world HUD stops local rendering and closing restores it', () => {
+    expect(runtime).toMatch(/function openMap\(\)[\s\S]*?engine\?\.stop\?\.\(\)/);
+    expect(runtime).toMatch(/function closeMap\(\)[\s\S]*?engine\?\.start\?\.\(\)/);
+    expect(runtime).toContain('localCanvas.hidden = true');
+    expect(runtime).toContain('localCanvas.hidden = false');
+  });
+
+  test('global HUD never imports or requests local procedural chunks', () => {
+    expect(runtime).not.toContain('procedural-chunk-streaming');
+    expect(runtime).not.toContain('loadChunk');
+    expect(runtime).not.toContain('activateChunk');
+    expect(runtime).not.toContain('mapData.topology');
+  });
+
+  test('party positions are read only while the global HUD is open', () => {
+    expect(runtime).toContain("const PLAYERS_ROOT = 'campaña/jugadores'");
+    expect(runtime).toContain('playersRef = db.ref(PLAYERS_ROOT)');
+    expect(runtime).not.toMatch(/db\.ref\(PLAYERS_ROOT\)\.(set|update|transaction)/);
+  });
+
+  test('player mode has no authoring controls in the generated HUD', () => {
+    expect(runtime).toContain("${isDm ? `");
+    expect(runtime).toContain('WORLD AUTHORING');
+    expect(runtime).toContain("if (!isDm) return false;");
+  });
+
+  test('VTT loads the isolated global stylesheet and runtime', () => {
+    expect(html).toContain('css/global-map.css');
+    expect(html).toContain('js/vtt/global-map-runtime.js');
+  });
+});

--- a/vtt.html
+++ b/vtt.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Luminous VTT Map</title>
     <link rel="stylesheet" href="css/vtt.css">
+    <link rel="stylesheet" href="css/global-map.css">
 </head>
 <body>
     <canvas id="vtt-canvas"></canvas>
@@ -158,5 +159,6 @@
     <script type="module" src="js/vtt/fog-memory-bootstrap.js"></script>
     <script type="module" src="js/vtt/performance-guard.js"></script>
     <script src="js/vtt/ui-shell.js"></script>
+    <script type="module" src="js/vtt/global-map-runtime.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Adds the first visual Global Map layer on top of the existing Regional World Graph/Travel architecture so the world can be authored and inspected without loading local 40x40 chunks.

### Global vector model
- 5,500 x 4,000 km default world canvas (~22M km²).
- Compact vector regions, routes and markers; no local tiles/topology/chunks in global persistence.
- Independent region layers for districts, legal jurisdiction, terrain, water and special overlays.
- Source precedence: Canon > DM > Campaign > Procedural.
- District regional origins project existing axial Regional Hex positions into global coordinates.
- Canon-locked geometry cannot be silently edited/deleted.

### Clean HUD
- WORLD MAP overlay available from VTT for both DM and players.
- World/District/Regional zoom readout, pan/zoom, search, layer toggles and inspector.
- Player HUD is read-only and filters DM-hidden regions/markers/routes.
- Party positions are projected from canonical `campaña/jugadores/*/worldPosition` when a district has a regional origin.

### DM authoring
- Draw region polygons, place settlement/POI markers and draw roads/rail/trails.
- Explicit SAVE WORLD is the only persistence write.
- Persists under `campaña/estado_mundo/mapa_global`, reusing existing configured-DM Firebase authority.
- No writes during pointer movement.

### Performance
- Opening the global HUD stops the local map render loop and hides the local canvas.
- Global map is event-driven: no RAF loop, polling or timers.
- Viewport culls vector geometry.
- Does not import or activate procedural local chunks.
- Realtime listeners attach only while WORLD MAP is open and are removed on close.

### Tests
Adds focused global-map geometry, visibility, source-priority, projection, bounded payload, realtime and performance contracts plus Regional Graph/Travel/Streaming regressions and full repository regression.