### PR TITLE
fix(vtt): harden repeated Map Theatre lifecycle

### DIFF
--- a/.github/workflows/vtt-map-theatre-lifecycle.yml
+++ b/.github/workflows/vtt-map-theatre-lifecycle.yml
@@ -1,0 +1,65 @@
+name: VTT Map Theatre Lifecycle
+
+on:
+  pull_request:
+    paths:
+      - 'js/instance-control.js'
+      - 'js/vtt/main.js'
+      - 'js/vtt/runtime-lifecycle.js'
+      - 'js/vtt/dm-map-lazy-loader.js'
+      - 'tests/vtt_map_theatre_lifecycle.spec.js'
+      - 'tests/vtt_instance_activation.spec.js'
+      - 'tests/vtt_*realtime.spec.js'
+      - 'tests/vtt_performance_guard.spec.js'
+      - 'tests/theatre_realtime.spec.js'
+      - '.github/workflows/vtt-map-theatre-lifecycle.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'js/instance-control.js'
+      - 'js/vtt/main.js'
+      - 'js/vtt/runtime-lifecycle.js'
+      - 'js/vtt/dm-map-lazy-loader.js'
+      - 'tests/vtt_map_theatre_lifecycle.spec.js'
+      - '.github/workflows/vtt-map-theatre-lifecycle.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  map-theatre-lifecycle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Syntax
+        run: |
+          node --check js/instance-control.js
+          node --check js/vtt/runtime-lifecycle.js
+          node --check js/vtt/dm-map-lazy-loader.js
+          node --input-type=module --check < js/vtt/main.js
+          node --check tests/vtt_map_theatre_lifecycle.spec.js
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Lifecycle realtime and performance contracts
+        run: >-
+          npx playwright test --workers=1
+          tests/vtt_map_theatre_lifecycle.spec.js
+          tests/vtt_instance_activation.spec.js
+          tests/vtt_token_drag.spec.js
+          tests/vtt_canonical_token_state.spec.js
+          tests/vtt_camera_pov_observer_realtime.spec.js
+          tests/vtt_player_discovery_realtime.spec.js
+          tests/vtt_world_streaming_lifecycle.spec.js
+          tests/vtt_map_simulation_realtime.spec.js
+          tests/vtt_performance_guard.spec.js
+          tests/theatre_realtime.spec.js
+      - name: Full repository regression
+        run: npx playwright test --workers=1

--- a/js/vtt/dm-map-lazy-loader.js
+++ b/js/vtt/dm-map-lazy-loader.js
@@ -11,6 +11,21 @@
     return { section, frame };
   }
 
+  function requestFrameDispose(frame, reason = 'dm-map-deactivated') {
+    if (!frame) return false;
+    try {
+      const dispose = frame.contentWindow?.LuminousVttRuntime?.dispose;
+      if (typeof dispose !== 'function') return false;
+      dispose(reason);
+      return true;
+    } catch (error) {
+      // The iframe is same-origin in production. If it is already navigating or
+      // inaccessible, removing src below still guarantees browser teardown.
+      browserRoot?.console?.warn?.('VTT DM map graceful dispose unavailable; falling back to iframe teardown.', error);
+      return false;
+    }
+  }
+
   function ensureLoaded(documentRef = browserRoot?.document) {
     const { section, frame } = resolveMapFrame(documentRef);
     if (!section || !frame || !section.classList?.contains?.('active-module')) return false;
@@ -27,9 +42,9 @@
     if (!section || !frame || section.classList?.contains?.('active-module')) return false;
     if (!frame.getAttribute?.('src')) return false;
 
-    // Navigating an iframe with its src removed tears down the VTT document.
-    // That gives vtt/main.js a real unload lifecycle so its animation loop,
-    // Firebase subscriptions and bridges cannot keep running behind Theatre.
+    // Ask the VTT to stop RAF/Firebase/bridges synchronously before navigation.
+    // Removing src remains the hard teardown fallback and releases the document.
+    requestFrameDispose(frame, 'dm-map-deactivated');
     frame.removeAttribute?.('src');
     return !frame.getAttribute?.('src');
   }
@@ -67,5 +82,5 @@
   }
 
   autoStart();
-  return Object.freeze({ ensureLoaded, ensureUnloaded, sync, start });
+  return Object.freeze({ ensureLoaded, ensureUnloaded, requestFrameDispose, sync, start });
 });

--- a/js/vtt/main.js
+++ b/js/vtt/main.js
@@ -36,7 +36,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     const lifecycle = globalThis.LuminousVttRuntimeLifecycle?.createLifecycle?.({ log: console }) || {
         dispose: () => true,
         isDisposed: () => false,
-        run: async (_label, load, start) => ({ status: 'started', runtime: await start(await load()) }),
     };
 
     const mapAuthoring = globalThis.LuminousVttMapAuthoring;
@@ -264,52 +263,106 @@ document.addEventListener('DOMContentLoaded', async () => {
         isDisposed: lifecycle.isDisposed,
     });
 
+    const stopIfDisposed = (runtime, label = 'runtime') => {
+        if (!lifecycle.isDisposed()) return false;
+        try {
+            runtime?.stop?.();
+        } catch (error) {
+            console.warn(`VTT lifecycle late-stop failed for ${label}.`, error);
+        }
+        return true;
+    };
+
     const reportBootstrapError = (label, error) => {
         if (lifecycle.isDisposed()) return;
         console.error(`VTT ${label} bootstrap failed:`, error);
     };
 
-    void (async () => {
-        try {
-            await lifecycle.run('map-authoring', () => import('./map-authoring-bootstrap.js'), (module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }));
-            await lifecycle.run('surfaces', () => import('./surface-bootstrap.js'), (module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }));
-            await lifecycle.run('structures', () => import('./structure-bootstrap.js'), (module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }));
-        } catch (error) {
-            reportBootstrapError('map authoring / surfaces / structures', error);
-        }
-    })();
+    import('./map-authoring-bootstrap.js')
+        .then(async (module) => {
+            if (lifecycle.isDisposed()) return null;
+            const mapAuthoringRuntime = await module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
+            if (stopIfDisposed(mapAuthoringRuntime, 'map-authoring')) return null;
 
-    void lifecycle.run('wall-builder', () => import('./wall-builder-bootstrap.js'), (module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }))
+            const surfaceModule = await import('./surface-bootstrap.js');
+            if (lifecycle.isDisposed()) return null;
+            const surfaceRuntime = await surfaceModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
+            if (stopIfDisposed(surfaceRuntime, 'surfaces')) return null;
+
+            const structureModule = await import('./structure-bootstrap.js');
+            if (lifecycle.isDisposed()) return null;
+            const structureRuntime = await structureModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
+            if (stopIfDisposed(structureRuntime, 'structures')) return null;
+            return structureRuntime;
+        })
+        .catch((error) => reportBootstrapError('map authoring / surfaces / structures', error));
+
+    import('./wall-builder-bootstrap.js')
+        .then(async (module) => {
+            if (lifecycle.isDisposed()) return null;
+            const runtime = await module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
+            if (stopIfDisposed(runtime, 'wall-builder')) return null;
+            return runtime;
+        })
         .catch((error) => reportBootstrapError('wall builder', error));
 
-    void lifecycle.run('actor-library', () => import('./actor-library-bootstrap.js'), (module) => {
-        const actorLibrary = module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
-        if (!lifecycle.isDisposed()) tokenAppearanceApi?.installRenderer?.(engine.renderer);
-        return actorLibrary;
-    }).catch((error) => reportBootstrapError('actor library', error));
+    import('./actor-library-bootstrap.js')
+        .then(async (module) => {
+            if (lifecycle.isDisposed()) return null;
+            const actorLibrary = module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
+            const resolvedActorLibrary = await actorLibrary;
+            if (stopIfDisposed(resolvedActorLibrary, 'actor-library')) return null;
+            tokenAppearanceApi?.installRenderer?.(engine.renderer);
+            return resolvedActorLibrary;
+        })
+        .catch((error) => reportBootstrapError('actor library', error));
 
-    void lifecycle.run('movement', () => import('./movement-bootstrap.js'), (module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }))
+    import('./movement-bootstrap.js')
+        .then(async (module) => {
+            if (lifecycle.isDisposed()) return null;
+            const runtime = await module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
+            if (stopIfDisposed(runtime, 'movement')) return null;
+            return runtime;
+        })
         .catch((error) => reportBootstrapError('movement', error));
 
-    void (async () => {
-        try {
-            await lifecycle.run('procedural-generator', () => import('./procedural-generator-bootstrap.js'), (module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }));
-            await lifecycle.run('procedural-chunks', () => import('./procedural-chunk-streaming-runtime.js'), (module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData, procedural: window.LuminousVttRuntime?.procedural }));
-            await lifecycle.run('regional-local-transition', () => import('./regional-local-transition-runtime.js'), (module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }));
-            await lifecycle.run('map-simulation', () => import('./map-simulation-runtime.js'), (module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }));
-        } catch (error) {
-            reportBootstrapError('procedural / regional-local / map simulation', error);
-        }
-    })();
+    import('./procedural-generator-bootstrap.js')
+        .then(async (generatorModule) => {
+            if (lifecycle.isDisposed()) return null;
+            const proceduralRuntime = await generatorModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
+            if (stopIfDisposed(proceduralRuntime, 'procedural-generator')) return null;
 
-    void (async () => {
-        try {
-            await lifecycle.run('world-objects', () => import('./world-object-mainline-integration.js'), (module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }));
-            await lifecycle.run('map-hud', () => import('./map-hud-bootstrap.js'), (module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }));
-        } catch (error) {
-            reportBootstrapError('world object / map HUD', error);
-        }
-    })();
+            const chunkModule = await import('./procedural-chunk-streaming-runtime.js');
+            if (lifecycle.isDisposed()) return null;
+            const chunkRuntime = await chunkModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData, procedural: window.LuminousVttRuntime?.procedural });
+            if (stopIfDisposed(chunkRuntime, 'procedural-chunks')) return null;
+
+            const transitionModule = await import('./regional-local-transition-runtime.js');
+            if (lifecycle.isDisposed()) return null;
+            const transitionRuntime = await transitionModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
+            if (stopIfDisposed(transitionRuntime, 'regional-local-transition')) return null;
+
+            const simulationModule = await import('./map-simulation-runtime.js');
+            if (lifecycle.isDisposed()) return null;
+            const simulationRuntime = await simulationModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
+            if (stopIfDisposed(simulationRuntime, 'map-simulation')) return null;
+            return simulationRuntime;
+        })
+        .catch((error) => reportBootstrapError('procedural / regional-local / map simulation', error));
+
+    import('./world-object-mainline-integration.js')
+        .then(async (module) => {
+            if (lifecycle.isDisposed()) return null;
+            const worldObjectsRuntime = await module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
+            if (stopIfDisposed(worldObjectsRuntime, 'world-objects')) return null;
+
+            const hudModule = await import('./map-hud-bootstrap.js');
+            if (lifecycle.isDisposed()) return null;
+            const hudRuntime = await hudModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
+            if (stopIfDisposed(hudRuntime, 'map-hud')) return null;
+            return hudRuntime;
+        })
+        .catch((error) => reportBootstrapError('world object / map HUD', error));
 
     // E belongs exclusively to token PoV Look Lock/Unlock. Camera uses F/Home/Space and never consumes E.
     const handlePageHide = () => disposeRuntime('pagehide');

--- a/js/vtt/main.js
+++ b/js/vtt/main.js
@@ -13,6 +13,7 @@ import './structure-topology-patch.js';
 import './structure-physical-patch.js';
 import './map-authoring-state.js';
 import './map-switch-guard.js';
+import './runtime-lifecycle.js';
 import './topology-replace-state-patch.js';
 import './actor-library.js';
 import './actor-library-state.js';
@@ -31,6 +32,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         console.error('VTT Canvas not found!');
         return;
     }
+
+    const lifecycle = globalThis.LuminousVttRuntimeLifecycle?.createLifecycle?.({ log: console }) || {
+        dispose: () => true,
+        isDisposed: () => false,
+        run: async (_label, load, start) => ({ status: 'started', runtime: await start(await load()) }),
+    };
 
     const mapAuthoring = globalThis.LuminousVttMapAuthoring;
     const mapAuthoringState = globalThis.LuminousVttMapAuthoringState;
@@ -145,37 +152,31 @@ document.addEventListener('DOMContentLoaded', async () => {
     const checkPortal = globalThis.LuminousVttCheckPortal?.start?.() || null;
 
     const exportBtn = document.getElementById('btn-export-uv');
-    exportBtn?.addEventListener('click', () => engine.exportUVTemplate());
+    const handleExport = () => engine.exportUVTemplate();
+    exportBtn?.addEventListener('click', handleExport);
 
-    canvas.addEventListener('vtt:token-moved', (event) => {
+    const handleTokenMoved = (event) => {
+        if (lifecycle.isDisposed()) return;
         const detail = event.detail || {};
         const token = (mockMapData.tokens || []).find((entry) => String(entry.id) === String(detail.tokenId));
         if (!token) return;
         tokenStateBridge.saveToken(token).catch((error) => {
+            if (lifecycle.isDisposed()) return;
             console.error('VTT token persistence failed:', error);
             controller?.notify?.('No se pudo sincronizar la posición de la ficha.', 'error');
         });
-    });
+    };
+    canvas.addEventListener('vtt:token-moved', handleTokenMoved);
 
-    canvas.addEventListener('vtt:token-z-transition', (event) => {
+    const handleTokenZTransition = (event) => {
+        if (lifecycle.isDisposed()) return;
         const detail = event.detail || {};
         const token = (mockMapData.tokens || []).find((entry) => String(entry.id) === String(detail.tokenId));
         if (detail.complete && token?.viewer === true && Number.isFinite(Number(detail.targetZ))) applyLayer(Number(detail.targetZ));
-    });
+    };
+    canvas.addEventListener('vtt:token-z-transition', handleTokenZTransition);
 
     engine.start();
-
-    window.LuminousVttRuntime = Object.freeze({
-        engine,
-        controller,
-        bridge,
-        verticalController,
-        verticalBridge,
-        tokenStateBridge,
-        editMode,
-        characterVisionBridge,
-        setLayer: applyLayer,
-    });
 
     const initialMapId = String(mockMapData.id || mockMapData.mapId || 'default');
     const mapSwitchGuard = globalThis.LuminousVttMapSwitchGuard?.createGuard?.({
@@ -187,7 +188,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }) || null;
     const stopMapWatch = mapAuthoringState?.watchActiveMap?.({
         onChanged: (mapId) => {
-            if (!mapId || String(mapId) === initialMapId) return;
+            if (!mapId || String(mapId) === initialMapId || lifecycle.isDisposed()) return;
             if (!mapSwitchGuard) {
                 console.error('VTT map switch guard unavailable; refusing blind reload.', { initialMapId, mapId });
                 controller?.notify?.('No se pudo validar el cambio de mapa. Se mantiene el mapa actual.', 'error');
@@ -197,49 +198,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         },
     }) || (() => {});
 
-    import('./map-authoring-bootstrap.js')
-        .then(async (module) => {
-            module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
-            const surfaceModule = await import('./surface-bootstrap.js');
-            await surfaceModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
-            const structureModule = await import('./structure-bootstrap.js');
-            return structureModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
-        })
-        .catch((error) => console.error('VTT map authoring / surfaces / structures bootstrap failed:', error));
-    import('./wall-builder-bootstrap.js')
-        .then((module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }))
-        .catch((error) => console.error('VTT wall builder bootstrap failed:', error));
-    import('./actor-library-bootstrap.js')
-        .then((module) => {
-            const actorLibrary = module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
-            tokenAppearanceApi?.installRenderer?.(engine.renderer);
-            return actorLibrary;
-        })
-        .catch((error) => console.error('VTT actor library bootstrap failed:', error));
-    import('./movement-bootstrap.js')
-        .then((module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }))
-        .catch((error) => console.error('VTT movement bootstrap failed:', error));
-    import('./procedural-generator-bootstrap.js')
-        .then(async (generatorModule) => {
-            generatorModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
-            const chunkModule = await import('./procedural-chunk-streaming-runtime.js');
-            chunkModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData, procedural: window.LuminousVttRuntime?.procedural });
-            const transitionModule = await import('./regional-local-transition-runtime.js');
-            transitionModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
-            const simulationModule = await import('./map-simulation-runtime.js');
-            return simulationModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
-        })
-        .catch((error) => console.error('VTT procedural / regional-local / map simulation bootstrap failed:', error));
-    import('./world-object-mainline-integration.js')
-        .then(async (module) => {
-            await module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
-            const hudModule = await import('./map-hud-bootstrap.js');
-            return hudModule.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
-        })
-        .catch((error) => console.error('VTT world object / map HUD bootstrap failed:', error));
-
-    // E belongs exclusively to token PoV Look Lock/Unlock. Camera uses F/Home/Space and never consumes E.
-    window.addEventListener('keydown', (event) => {
+    const handleKeydown = (event) => {
+        if (lifecycle.isDisposed()) return;
         if (event.key === '0') applyLayer(0);
         else if (event.key === '1') applyLayer(1);
         else if (event.key === '2') applyLayer(2);
@@ -248,10 +208,18 @@ document.addEventListener('DOMContentLoaded', async () => {
             controller.setTool('select');
             verticalController.setTool('select', false);
         }
-    });
+    };
+    window.addEventListener('keydown', handleKeydown);
 
-    window.addEventListener('beforeunload', () => {
+    function disposeRuntime(reason = 'vtt-document-teardown') {
+        if (!lifecycle.dispose(reason)) return false;
+
         stopMapWatch();
+        exportBtn?.removeEventListener?.('click', handleExport);
+        canvas.removeEventListener('vtt:token-moved', handleTokenMoved);
+        canvas.removeEventListener('vtt:token-z-transition', handleTokenZTransition);
+        window.removeEventListener('keydown', handleKeydown);
+
         window.LuminousVttMapDialogueOverlay?.stop?.();
         window.LuminousVttWallBuilderRuntime?.stop?.();
         window.LuminousVttStructureRuntime?.stop?.();
@@ -275,5 +243,77 @@ document.addEventListener('DOMContentLoaded', async () => {
         checkPortal?.stop?.();
         engine.stop();
         engine.camera?.destroy?.();
-    }, { once: true });
+        window.removeEventListener('resize', engine.handleResize);
+        canvas.removeEventListener('mousedown', engine.handleTokenMouseDown);
+        window.removeEventListener('mousemove', engine.handleTokenMouseMove);
+        window.removeEventListener('mouseup', engine.handleTokenMouseUp);
+        return true;
+    }
+
+    window.LuminousVttRuntime = Object.freeze({
+        engine,
+        controller,
+        bridge,
+        verticalController,
+        verticalBridge,
+        tokenStateBridge,
+        editMode,
+        characterVisionBridge,
+        setLayer: applyLayer,
+        dispose: disposeRuntime,
+        isDisposed: lifecycle.isDisposed,
+    });
+
+    const reportBootstrapError = (label, error) => {
+        if (lifecycle.isDisposed()) return;
+        console.error(`VTT ${label} bootstrap failed:`, error);
+    };
+
+    void (async () => {
+        try {
+            await lifecycle.run('map-authoring', () => import('./map-authoring-bootstrap.js'), (module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }));
+            await lifecycle.run('surfaces', () => import('./surface-bootstrap.js'), (module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }));
+            await lifecycle.run('structures', () => import('./structure-bootstrap.js'), (module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }));
+        } catch (error) {
+            reportBootstrapError('map authoring / surfaces / structures', error);
+        }
+    })();
+
+    void lifecycle.run('wall-builder', () => import('./wall-builder-bootstrap.js'), (module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }))
+        .catch((error) => reportBootstrapError('wall builder', error));
+
+    void lifecycle.run('actor-library', () => import('./actor-library-bootstrap.js'), (module) => {
+        const actorLibrary = module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData });
+        if (!lifecycle.isDisposed()) tokenAppearanceApi?.installRenderer?.(engine.renderer);
+        return actorLibrary;
+    }).catch((error) => reportBootstrapError('actor library', error));
+
+    void lifecycle.run('movement', () => import('./movement-bootstrap.js'), (module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }))
+        .catch((error) => reportBootstrapError('movement', error));
+
+    void (async () => {
+        try {
+            await lifecycle.run('procedural-generator', () => import('./procedural-generator-bootstrap.js'), (module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }));
+            await lifecycle.run('procedural-chunks', () => import('./procedural-chunk-streaming-runtime.js'), (module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData, procedural: window.LuminousVttRuntime?.procedural }));
+            await lifecycle.run('regional-local-transition', () => import('./regional-local-transition-runtime.js'), (module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }));
+            await lifecycle.run('map-simulation', () => import('./map-simulation-runtime.js'), (module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }));
+        } catch (error) {
+            reportBootstrapError('procedural / regional-local / map simulation', error);
+        }
+    })();
+
+    void (async () => {
+        try {
+            await lifecycle.run('world-objects', () => import('./world-object-mainline-integration.js'), (module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }));
+            await lifecycle.run('map-hud', () => import('./map-hud-bootstrap.js'), (module) => module.start?.({ runtime: window.LuminousVttRuntime, mapData: mockMapData }));
+        } catch (error) {
+            reportBootstrapError('world object / map HUD', error);
+        }
+    })();
+
+    // E belongs exclusively to token PoV Look Lock/Unlock. Camera uses F/Home/Space and never consumes E.
+    const handlePageHide = () => disposeRuntime('pagehide');
+    const handleBeforeUnload = () => disposeRuntime('beforeunload');
+    window.addEventListener('pagehide', handlePageHide, { once: true });
+    window.addEventListener('beforeunload', handleBeforeUnload, { once: true });
 });

--- a/js/vtt/runtime-lifecycle.js
+++ b/js/vtt/runtime-lifecycle.js
@@ -1,0 +1,61 @@
+(function (root, factory) {
+  'use strict';
+  const api = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttRuntimeLifecycle = api;
+})(typeof window !== 'undefined' ? window : globalThis, function () {
+  'use strict';
+
+  function createLifecycle({ log = console } = {}) {
+    let disposed = false;
+    let reason = '';
+
+    const isDisposed = () => disposed;
+    const getReason = () => reason;
+
+    function dispose(nextReason = 'runtime-disposed') {
+      if (disposed) return false;
+      disposed = true;
+      reason = String(nextReason || 'runtime-disposed');
+      return true;
+    }
+
+    async function run(label, load, start) {
+      const taskLabel = String(label || 'runtime');
+      if (disposed) return { status: 'skipped', label: taskLabel, reason };
+
+      let module;
+      try {
+        module = await (typeof load === 'function' ? load() : load);
+      } catch (error) {
+        if (!disposed) throw error;
+        return { status: 'skipped', label: taskLabel, reason, error };
+      }
+
+      if (disposed) return { status: 'skipped', label: taskLabel, reason };
+
+      let runtime;
+      try {
+        runtime = await start(module);
+      } catch (error) {
+        if (!disposed) throw error;
+        return { status: 'disposed', label: taskLabel, reason, error };
+      }
+
+      if (disposed) {
+        try {
+          runtime?.stop?.();
+        } catch (error) {
+          log?.warn?.(`VTT lifecycle late-stop failed for ${taskLabel}.`, error);
+        }
+        return { status: 'disposed', label: taskLabel, reason };
+      }
+
+      return { status: 'started', label: taskLabel, runtime };
+    }
+
+    return Object.freeze({ dispose, getReason, isDisposed, run });
+  }
+
+  return Object.freeze({ createLifecycle });
+});

--- a/tests/vtt_map_theatre_lifecycle.spec.js
+++ b/tests/vtt_map_theatre_lifecycle.spec.js
@@ -1,11 +1,19 @@
 const { test, expect } = require('@playwright/test');
 const fs = require('node:fs');
 const path = require('node:path');
+const vm = require('node:vm');
 
 const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
 const lifecycleApi = require('../js/vtt/runtime-lifecycle.js');
 const lazyLoader = require('../js/vtt/dm-map-lazy-loader.js');
-const instanceControl = require('../js/instance-control.js');
+
+function loadInstanceControl() {
+  const context = { window: {}, console, setTimeout, clearTimeout };
+  vm.runInNewContext(read('js/instance-control.js'), context, { filename: 'js/instance-control.js' });
+  return context.window.LuminousInstanceControl;
+}
+
+const instanceControl = loadInstanceControl();
 
 function fakeClassList(initial = []) {
   const values = new Set(initial);
@@ -186,7 +194,7 @@ test('player can repeat MAPA -> TEATRO -> MAPA three times without reusing a des
 test('VTT main owns an explicit parent-callable teardown and page lifecycle fallback', () => {
   const source = read('js/vtt/main.js');
   expect(source).toContain("import './runtime-lifecycle.js';");
-  expect(source).toContain("dispose: disposeRuntime");
+  expect(source).toContain('dispose: disposeRuntime');
   expect(source).toContain("window.addEventListener('pagehide', handlePageHide");
   expect(source).toContain("window.addEventListener('beforeunload', handleBeforeUnload");
   expect(source).toContain("await lifecycle.run('map-authoring'");

--- a/tests/vtt_map_theatre_lifecycle.spec.js
+++ b/tests/vtt_map_theatre_lifecycle.spec.js
@@ -197,9 +197,8 @@ test('VTT main owns an explicit parent-callable teardown and page lifecycle fall
   expect(source).toContain('dispose: disposeRuntime');
   expect(source).toContain("window.addEventListener('pagehide', handlePageHide");
   expect(source).toContain("window.addEventListener('beforeunload', handleBeforeUnload");
-  expect(source).toContain("await lifecycle.run('map-authoring'");
-  expect(source).toContain("await lifecycle.run('procedural-generator'");
-  expect(source).toContain("await lifecycle.run('world-objects'");
+  expect(source).toContain('const stopIfDisposed = (runtime');
+  expect(source).toContain('if (lifecycle.isDisposed()) return null');
   expect(source).toContain("window.removeEventListener('mousemove', engine.handleTokenMouseMove)");
 });
 

--- a/tests/vtt_map_theatre_lifecycle.spec.js
+++ b/tests/vtt_map_theatre_lifecycle.spec.js
@@ -1,0 +1,204 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+const lifecycleApi = require('../js/vtt/runtime-lifecycle.js');
+const lazyLoader = require('../js/vtt/dm-map-lazy-loader.js');
+const instanceControl = require('../js/instance-control.js');
+
+function fakeClassList(initial = []) {
+  const values = new Set(initial);
+  return {
+    add(...names) { names.forEach((name) => values.add(name)); },
+    remove(...names) { names.forEach((name) => values.delete(name)); },
+    contains(name) { return values.has(name); },
+    toggle(name, force) {
+      const next = force == null ? !values.has(name) : Boolean(force);
+      if (next) values.add(name); else values.delete(name);
+      return next;
+    },
+  };
+}
+
+function fakeModule(id, active = false) {
+  return {
+    id,
+    style: {},
+    classList: fakeClassList(active ? ['game-module', 'active-module'] : ['game-module', 'hidden']),
+  };
+}
+
+function createDmDocument() {
+  const standby = fakeModule('modulo-standby');
+  const theatre = fakeModule('modulo-teatro');
+  const map = fakeModule('modulo-mapa');
+  const combat = fakeModule('modulo-combate');
+  const attrs = new Map();
+  const frame = {
+    dataset: { vttSrc: 'vtt.html' },
+    contentWindow: {},
+    getAttribute(name) { return attrs.get(name) || null; },
+    setAttribute(name, value) { attrs.set(name, String(value)); },
+    removeAttribute(name) { attrs.delete(name); },
+  };
+  map.querySelector = (selector) => selector === 'iframe[data-vtt-src]' ? frame : null;
+  const nodes = new Map([
+    [standby.id, standby], [theatre.id, theatre], [map.id, map], [combat.id, combat],
+  ]);
+  return {
+    frame,
+    map,
+    theatre,
+    querySelector() { return null; },
+    querySelectorAll(selector) { return selector === '.game-module' ? [standby, theatre, map, combat] : []; },
+    getElementById(id) { return nodes.get(id) || null; },
+  };
+}
+
+function createPlayerDocument() {
+  const nodes = new Map();
+  const theatre = {
+    id: 'theatre-view-player', style: {}, classList: fakeClassList(),
+    setAttribute() {},
+  };
+  nodes.set(theatre.id, theatre);
+  const body = {
+    classList: fakeClassList(),
+    appendChild(node) { node.parentNode = body; nodes.set(node.id, node); return node; },
+    removeChild(node) { nodes.delete(node.id); node.parentNode = null; node.removed = true; return node; },
+  };
+  return {
+    body,
+    querySelector() { return null; },
+    getElementById(id) { return nodes.get(id) || null; },
+    createElement(tagName) {
+      const attributes = new Map();
+      return {
+        tagName: String(tagName).toUpperCase(), style: {}, dataset: {}, classList: fakeClassList(),
+        setAttribute(name, value) { attributes.set(name, String(value)); },
+        getAttribute(name) { return attributes.get(name) || null; },
+        removeAttribute(name) { attributes.delete(name); },
+        addEventListener() {},
+        remove() {
+          if (this.parentNode) this.parentNode.removeChild(this);
+          else this.removed = true;
+        },
+      };
+    },
+  };
+}
+
+test('runtime lifecycle dispose is idempotent and blocks a late bootstrap before start', async () => {
+  const lifecycle = lifecycleApi.createLifecycle();
+  let releaseLoad;
+  let starts = 0;
+  const load = new Promise((resolve) => { releaseLoad = resolve; });
+  const pending = lifecycle.run('firebase-bridge', () => load, () => { starts += 1; return {}; });
+
+  expect(lifecycle.dispose('map-to-theatre')).toBe(true);
+  expect(lifecycle.dispose('duplicate-teardown')).toBe(false);
+  releaseLoad({});
+
+  const result = await pending;
+  expect(result.status).toBe('skipped');
+  expect(starts).toBe(0);
+  expect(lifecycle.isDisposed()).toBe(true);
+  expect(lifecycle.getReason()).toBe('map-to-theatre');
+});
+
+test('runtime lifecycle late-start result is stopped exactly once if disposal wins the race', async () => {
+  const lifecycle = lifecycleApi.createLifecycle();
+  let releaseStart;
+  let stops = 0;
+  const pending = lifecycle.run('streaming', async () => ({}), async () => new Promise((resolve) => {
+    releaseStart = () => resolve({ stop() { stops += 1; } });
+  }));
+
+  await Promise.resolve();
+  expect(lifecycle.dispose('pagehide')).toBe(true);
+  releaseStart();
+  const result = await pending;
+
+  expect(result.status).toBe('disposed');
+  expect(stops).toBe(1);
+});
+
+test('DM can repeat MAPA -> TEATRO -> MAPA three times with graceful VTT disposal and fresh src reload', () => {
+  const doc = createDmDocument();
+  let disposeCalls = 0;
+
+  for (let cycle = 0; cycle < 3; cycle += 1) {
+    instanceControl.applyDashboardInstance('mapa', doc);
+    expect(lazyLoader.sync(doc)).toBe(true);
+    expect(doc.frame.getAttribute('src')).toBe('vtt.html');
+    expect(doc.map.classList.contains('active-module')).toBe(true);
+
+    let disposedThisDocument = false;
+    doc.frame.contentWindow = {
+      LuminousVttRuntime: {
+        dispose(reason) {
+          expect(reason).toBe('dm-map-deactivated');
+          expect(disposedThisDocument).toBe(false);
+          disposedThisDocument = true;
+          disposeCalls += 1;
+          return true;
+        },
+      },
+    };
+
+    instanceControl.applyDashboardInstance('teatro', doc);
+    expect(lazyLoader.sync(doc)).toBe(true);
+    expect(doc.frame.getAttribute('src')).toBeNull();
+    expect(doc.theatre.classList.contains('active-module')).toBe(true);
+    expect(disposedThisDocument).toBe(true);
+  }
+
+  expect(disposeCalls).toBe(3);
+
+  instanceControl.applyDashboardInstance('mapa', doc);
+  expect(lazyLoader.sync(doc)).toBe(true);
+  expect(doc.frame.getAttribute('src')).toBe('vtt.html');
+});
+
+test('player can repeat MAPA -> TEATRO -> MAPA three times without reusing a destroyed iframe', () => {
+  const doc = createPlayerDocument();
+  const mapFrames = [];
+
+  for (let cycle = 0; cycle < 3; cycle += 1) {
+    instanceControl.applyPlayerInstance('mapa', doc);
+    const frame = doc.getElementById('player-instance-map');
+    expect(frame).not.toBeNull();
+    expect(frame.src).toBe('vtt.html');
+    mapFrames.push(frame);
+
+    instanceControl.applyPlayerInstance('teatro', doc);
+    expect(frame.removed).toBe(true);
+    expect(doc.getElementById('player-instance-map')).toBeNull();
+    expect(doc.getElementById('theatre-view-player').style.display).toBe('flex');
+  }
+
+  expect(new Set(mapFrames).size).toBe(3);
+  instanceControl.applyPlayerInstance('mapa', doc);
+  expect(doc.getElementById('player-instance-map')).not.toBeNull();
+});
+
+test('VTT main owns an explicit parent-callable teardown and page lifecycle fallback', () => {
+  const source = read('js/vtt/main.js');
+  expect(source).toContain("import './runtime-lifecycle.js';");
+  expect(source).toContain("dispose: disposeRuntime");
+  expect(source).toContain("window.addEventListener('pagehide', handlePageHide");
+  expect(source).toContain("window.addEventListener('beforeunload', handleBeforeUnload");
+  expect(source).toContain("await lifecycle.run('map-authoring'");
+  expect(source).toContain("await lifecycle.run('procedural-generator'");
+  expect(source).toContain("await lifecycle.run('world-objects'");
+  expect(source).toContain("window.removeEventListener('mousemove', engine.handleTokenMouseMove)");
+});
+
+test('DM lazy unload requests graceful dispose before removing iframe src', () => {
+  const source = read('js/vtt/dm-map-lazy-loader.js');
+  const disposeIndex = source.indexOf("requestFrameDispose(frame, 'dm-map-deactivated')");
+  const removeIndex = source.indexOf("frame.removeAttribute?.('src')");
+  expect(disposeIndex).toBeGreaterThan(-1);
+  expect(removeIndex).toBeGreaterThan(disposeIndex);
+});


### PR DESCRIPTION
## Summary
Hardens the VTT surface lifecycle for repeated `MAPA -> TEATRO -> MAPA` transitions without leaving render loops, Firebase listeners, streaming runtimes or late dynamic bootstraps alive behind Theatre.

### Runtime teardown
- Adds an idempotent VTT lifecycle gate.
- `LuminousVttRuntime.dispose()` is now parent-callable before iframe destruction.
- VTT also disposes on `pagehide` and `beforeunload` as browser lifecycle fallbacks.
- Main-owned DOM/window listeners are explicitly removed during teardown.
- Late `import()` bootstraps are skipped after disposal; a runtime that finishes starting after disposal is immediately stopped.

### DM map iframe
- DM lazy loader requests graceful runtime disposal before removing the iframe `src`.
- Removing `src` remains the hard browser teardown fallback.

### Tests
- Repeats DM `MAPA -> TEATRO -> MAPA` three times and requires a fresh load plus exactly one graceful disposal per old VTT document.
- Repeats Player `MAPA -> TEATRO -> MAPA` three times and verifies destroyed map iframes are never reused.
- Deterministically tests async bootstrap/dispose races and idempotent teardown.
- Adds a dedicated CI gate combining lifecycle tests with existing Realtime, token-state, camera/POV, Fog, streaming, simulation, Theatre Realtime and performance guards, followed by full repository regression.

Merge only when the lifecycle gate and repository regression are green.