### PR TITLE
feat(vtt): add live map field-test diagnostics

### DIFF
--- a/.github/workflows/vtt-map-field-test-sandbox.yml
+++ b/.github/workflows/vtt-map-field-test-sandbox.yml
@@ -8,6 +8,8 @@ on:
       - 'js/regional-world-graph-*.js'
       - 'js/regional-local-transition-*.js'
       - 'js/vtt/map-field-test-sandbox-core.js'
+      - 'js/vtt/map-field-test-runner-*.js'
+      - 'js/vtt/global-map-*.js'
       - 'js/vtt/world-streaming-*.js'
       - 'js/vtt/map-simulation-*.js'
       - 'js/vtt/player-discovery-*.js'
@@ -17,6 +19,7 @@ on:
       - 'js/vtt/dm-observer.js'
       - 'js/vtt/engine.js'
       - 'js/vtt/renderer.js'
+      - 'tests/vtt_map_field_test_runner.spec.js'
       - 'tests/vtt_map_field_test_sandbox.spec.js'
       - 'tests/vtt_map_field_test_hardening.spec.js'
       - 'tests/regional_world_graph*.spec.js'
@@ -37,11 +40,14 @@ on:
       - 'js/regional-world-graph-*.js'
       - 'js/regional-local-transition-*.js'
       - 'js/vtt/map-field-test-sandbox-core.js'
+      - 'js/vtt/map-field-test-runner-*.js'
+      - 'js/vtt/global-map-*.js'
       - 'js/vtt/world-streaming-*.js'
       - 'js/vtt/map-simulation-*.js'
       - 'js/vtt/player-discovery-*.js'
       - 'js/vtt/procedural-chunk-streaming-*.js'
       - 'js/vtt/regional-local-transition-runtime.js'
+      - 'tests/vtt_map_field_test_runner.spec.js'
       - 'tests/vtt_map_field_test_sandbox.spec.js'
       - '.github/workflows/vtt-map-field-test-sandbox.yml'
 
@@ -64,6 +70,10 @@ jobs:
       - name: Syntax and rules JSON
         run: |
           node --check js/vtt/map-field-test-sandbox-core.js
+          node --check js/vtt/map-field-test-runner-core.js
+          node --input-type=module --check < js/vtt/map-field-test-runner-runtime.js
+          node --input-type=module --check < js/vtt/map-simulation-runtime.js
+          node --check tests/vtt_map_field_test_runner.spec.js
           node --check tests/vtt_map_field_test_sandbox.spec.js
           node --check js/regional-travel-core.js
           node --check js/regional-world-graph-core.js
@@ -74,9 +84,10 @@ jobs:
           node -e "JSON.parse(require('fs').readFileSync('database.rules.json','utf8'))"
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
-      - name: Field sandbox, regional, streaming, fog, camera and performance contracts
+      - name: Field runner, sandbox, regional, streaming, fog, camera and performance contracts
         run: >-
           npx playwright test --workers=1
+          tests/vtt_map_field_test_runner.spec.js
           tests/vtt_map_field_test_sandbox.spec.js
           tests/vtt_map_field_test_hardening.spec.js
           tests/regional_world_graph.spec.js

--- a/js/vtt/map-field-test-runner-core.js
+++ b/js/vtt/map-field-test-runner-core.js
@@ -1,0 +1,87 @@
+(function (root, factory) {
+  'use strict';
+  const api = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttMapFieldTestRunner = api;
+})(typeof window !== 'undefined' ? window : globalThis, function () {
+  'use strict';
+
+  const LIMITS = Object.freeze({ maxPlayers: 8, maxActiveChunks: 8, maxLiveCells: 12800, maxActiveZones: 8, liveChunkCells: 1600, chunkSizeCells: 40, expectedPovDeg: 120 });
+  const COVERAGE_KEYS = Object.freeze(['movementPreview','movementCommit','chunkStreaming','regionalLocal','zLayer','viewAs','fogDiscovery','persistence','reconnect','globalMap','firebaseRules']);
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const clean = (value) => String(value ?? '').trim();
+  const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+  function playerScope(token = {}) {
+    return token.canonicalScope === 'player' || Boolean(clean(token.canonicalPlayerKey || token.playerId || token.characterLink?.playerId)) || ['player','current_player'].includes(clean(token.characterLink?.mode).toLowerCase());
+  }
+  function actorIdentity(token = {}) { return clean(token.actorId || token.characterLink?.actorId || token.actorRef?.id) || null; }
+  function duplicatePlayerActorIds(tokens = []) {
+    const groups = new Map();
+    for (const token of Array.isArray(tokens) ? tokens : []) {
+      const actorId = actorIdentity(token); if (!actorId) continue;
+      const group = groups.get(actorId) || { player: 0, world: 0, tokenIds: [] };
+      if (playerScope(token)) group.player += 1; else group.world += 1;
+      group.tokenIds.push(clean(token.id)); groups.set(actorId, group);
+    }
+    return [...groups.entries()].filter(([,g]) => g.player > 0 && g.world > 0).map(([actorId,g]) => Object.freeze({ actorId, playerTokens:g.player, worldTokens:g.world, tokenIds:Object.freeze(g.tokenIds.filter(Boolean)) }));
+  }
+  function isPermissionDenied(error) {
+    const text = clean(error?.code || error?.message || error).toLowerCase();
+    return text.includes('permission_denied') || text.includes('permission denied') || text.includes('access denied');
+  }
+  const blankCounters = () => ({ previews:0, commits:0, commitsWhilePointerDown:0, completedPreviewDrags:0, zTransitions:0, chunkLoads:0, chunkTransitions:0, regionalLocalTransitions:0, canonicalSyncs:0, observerChanges:0, discoveryUpdates:0, discoveryWrites:0, simulationLifecycles:0, zonePersists:0, deltaRecords:0, permissionDenied:0, errors:0 });
+  const blankCoverage = () => Object.fromEntries(COVERAGE_KEYS.map((key) => [key,false]));
+
+  function createTracker({ now = () => Date.now() } = {}) {
+    let active=false, startedAt=null, stoppedAt=null, pointerDown=false, counters=blankCounters(), coverage=blankCoverage(), lastObserver=null, lastPermissionError=null;
+    const pendingPreviewTokens = new Set();
+    function snapshot(){return Object.freeze({active,startedAt,stoppedAt,pointerDown,counters:Object.freeze({...counters}),coverage:Object.freeze({...coverage}),pendingPreviewTokens:Object.freeze([...pendingPreviewTokens]),lastObserver:clone(lastObserver),lastPermissionError});}
+    function reset(){active=false;startedAt=null;stoppedAt=null;pointerDown=false;counters=blankCounters();coverage=blankCoverage();lastObserver=null;lastPermissionError=null;pendingPreviewTokens.clear();return snapshot();}
+    function start(){reset();active=true;startedAt=now();return snapshot();}
+    function stop(){if(active)stoppedAt=now();active=false;pointerDown=false;return snapshot();}
+    function markCoverage(key,value=true){if(Object.prototype.hasOwnProperty.call(coverage,key))coverage[key]=Boolean(value);return snapshot();}
+    function record(name,detail={}){
+      if(!active)return snapshot(); const tokenId=clean(detail.tokenId);
+      switch(name){
+        case 'field:pointer-down':pointerDown=true;break;
+        case 'field:pointer-up':pointerDown=false;break;
+        case 'vtt:token-preview-moved':counters.previews++;coverage.movementPreview=true;if(tokenId)pendingPreviewTokens.add(tokenId);break;
+        case 'vtt:token-moved':counters.commits++;coverage.movementCommit=true;if(pointerDown)counters.commitsWhilePointerDown++;if(tokenId&&pendingPreviewTokens.has(tokenId)){counters.completedPreviewDrags++;pendingPreviewTokens.delete(tokenId);}break;
+        case 'vtt:token-z-transition':counters.zTransitions++;if(detail.complete!==false)coverage.zLayer=true;break;
+        case 'vtt:procedural-chunk-loaded':counters.chunkLoads++;coverage.chunkStreaming=true;break;
+        case 'vtt:procedural-chunk-transition':counters.chunkTransitions++;coverage.chunkStreaming=true;break;
+        case 'vtt:regional-local-transition-applied':counters.regionalLocalTransitions++;coverage.regionalLocal=true;break;
+        case 'vtt:canonical-tokens-synced':counters.canonicalSyncs++;break;
+        case 'vtt:dm-observer-changed':counters.observerChanges++;lastObserver=clone(detail);if(clean(detail.mode).toLowerCase()==='view_as')coverage.viewAs=true;break;
+        case 'vtt:player-discovery-updated':counters.discoveryUpdates++;coverage.fogDiscovery=true;if(detail.changed===true)counters.discoveryWrites++;break;
+        case 'vtt:map-simulation-lifecycle':counters.simulationLifecycles++;break;
+        case 'vtt:map-simulation-zone-persisted':counters.zonePersists++;coverage.persistence=true;break;
+        case 'vtt:map-simulation-delta-recorded':counters.deltaRecords++;break;
+        case 'field:permission-error':counters.permissionDenied++;counters.errors++;lastPermissionError=clean(detail.message||detail.code||'PERMISSION_DENIED');break;
+        case 'field:error':counters.errors++;break;
+      }
+      return snapshot();
+    }
+    function reportError(error){if(!active)return snapshot();return record(isPermissionDenied(error)?'field:permission-error':'field:error',{code:clean(error?.code),message:clean(error?.message||error)});}
+    return Object.freeze({start,stop,reset,record,reportError,markCoverage,snapshot,isActive:()=>active});
+  }
+
+  function status(id,state,value,limit,message){return Object.freeze({id,state,value,limit,message});}
+  function evaluate(raw={}){
+    const grid=raw.grid||{},world=raw.worldStreaming||{},sim=raw.mapSimulation||{},counters=raw.counters||{},coverage=raw.coverage||{},tokens=Array.isArray(raw.tokens)?raw.tokens:[];
+    const duplicates=duplicatePlayerActorIds(tokens),cols=finite(grid.cols,0),rows=finite(grid.rows,0),activeChunks=finite(world.activeChunks,-1),liveCells=finite(world.liveCells,-1),activeZones=finite(sim.activeZones,-1),players=tokens.filter(playerScope).length,checks=[];
+    checks.push(cols>0&&rows>0?status('live-grid',cols<=40&&rows<=40?'pass':'fail',`${cols}x${rows}`,'40x40','La escena viva debe materializar solo un chunk.'):status('live-grid','warn','unknown','40x40','Grid vivo no disponible.'));
+    checks.push(activeChunks>=0?status('active-chunks',activeChunks<=8?'pass':'fail',activeChunks,8,'WorldStreaming debe permanecer dentro del presupuesto de 8 chunks activos.'):status('active-chunks','warn','unknown',8,'WorldStreaming aún no reporta métricas.'));
+    checks.push(liveCells>=0?status('live-cells',liveCells<=12800?'pass':'fail',liveCells,12800,'8 jugadores separados no deben superar 12,800 celdas vivas.'):status('live-cells','warn','unknown',12800,'No hay métrica de celdas vivas.'));
+    checks.push(activeZones>=0?status('active-zones',activeZones<=8?'pass':'fail',activeZones,8,'Simulation Bubbles debe permanecer acotado.'):status('active-zones','warn','unknown',8,'Map Simulation aún no reporta zonas.'));
+    checks.push(status('duplicate-player-actors',duplicates.length===0?'pass':'fail',duplicates.length,0,'Un Actor asignado a jugador no puede reaparecer como world/NPC token.'));
+    checks.push(status('permission-denied',finite(counters.permissionDenied,0)===0?'pass':'fail',finite(counters.permissionDenied,0),0,'No debe aparecer PERMISSION_DENIED durante el field test.'));
+    checks.push(status('commit-during-drag',finite(counters.commitsWhilePointerDown,0)===0?'pass':'fail',finite(counters.commitsWhilePointerDown,0),0,'La persistencia de movimiento debe ocurrir después del pointer-up.'));
+    if(coverage.viewAs){const cone=finite(raw.viewAsConeDeg,0);checks.push(status('view-as-cone',Math.abs(cone-120)<0.01?'pass':'fail',cone,120,'View As debe usar el POV canónico de 120°.'));}else checks.push(status('view-as-cone','warn','not exercised',120,'Todavía no se probó View As.'));
+    checks.push(players===8?status('eight-player-load','pass',players,8,'Carga de 8 jugadores presente.'):status('eight-player-load',players>8?'fail':'warn',players,8,'La prueba de stress final requiere 8 jugadores.'));
+    const coverageDone=COVERAGE_KEYS.filter((key)=>coverage[key]===true).length,failures=checks.filter((c)=>c.state==='fail'),warnings=checks.filter((c)=>c.state==='warn');
+    return Object.freeze({overall:failures.length?'fail':warnings.length||coverageDone<COVERAGE_KEYS.length?'warn':'pass',checks:Object.freeze(checks),duplicatePlayerActors:Object.freeze(duplicates),coverage:Object.freeze({done:coverageDone,total:COVERAGE_KEYS.length,values:Object.freeze({...coverage})}),counters:Object.freeze({...counters})});
+  }
+  return Object.freeze({LIMITS,COVERAGE_KEYS,playerScope,actorIdentity,duplicatePlayerActorIds,isPermissionDenied,createTracker,evaluate});
+});

--- a/js/vtt/map-field-test-runner-runtime.js
+++ b/js/vtt/map-field-test-runner-runtime.js
@@ -1,0 +1,64 @@
+import './map-field-test-runner-core.js';
+
+const clean=(value)=>String(value??'').trim();
+const clone=(value)=>value==null?value:JSON.parse(JSON.stringify(value));
+function hostWindow(){try{if(window.parent&&window.parent!==window&&window.parent.document)return window.parent;}catch(_){}return window;}
+function playerToken(token={}){return Boolean(globalThis.LuminousVttMapFieldTestRunner?.playerScope?.(token));}
+
+function liveMetrics(runtime,mapData,tracker){
+  const liveRuntime=globalThis.LuminousVttRuntime||runtime;
+  const world=liveRuntime?.worldStreaming?.snapshot?.()||{};
+  const simulationRaw=liveRuntime?.mapSimulation?.snapshot?.()||{};
+  const simulation=simulationRaw.lifecycle||simulationRaw;
+  const perf=globalThis.LuminousVttPerformanceGuard?.snapshot?.()||null;
+  const track=tracker.snapshot(),observer=track.lastObserver||{};
+  const target=(mapData.tokens||[]).find((token)=>clean(token?.id)===clean(observer.targetTokenId));
+  const lighting=hostWindow()?.LuminousVttLightingEngine||globalThis.LuminousVttLightingEngine;
+  const cone=observer.mode==='view_as'?Number(lighting?.visionConeDeg?.(target)??target?.visionConeDeg??target?.vision?.coneDeg??120):null;
+  const grid=mapData.grid||{};
+  return{
+    generatedAt:Date.now(),
+    map:{id:clean(mapData.id||mapData.mapId||'default'),worldId:clean(mapData.worldId||mapData.world?.id||'luminous'),regionId:clean(mapData.regionId||mapData.region?.id||'region'),zoneId:clean(mapData.procedural?.streaming?.zoneId||mapData.zoneId||mapData.id||mapData.mapId||'zone')},
+    grid:{cols:Number(grid.cols)||0,rows:Number(grid.rows)||0,size:Number(grid.size)||70},
+    tokens:(mapData.tokens||[]).map((token)=>({id:clean(token?.id),actorId:clean(token?.actorId||token?.characterLink?.actorId||token?.actorRef?.id)||null,canonicalScope:clean(token?.canonicalScope),canonicalPlayerKey:clean(token?.canonicalPlayerKey),playerId:clean(token?.playerId||token?.characterLink?.playerId),viewer:token?.viewer===true})),
+    playerCount:(mapData.tokens||[]).filter(playerToken).length,
+    worldStreaming:clone(world),mapSimulation:clone(simulation),performance:clone(perf),
+    globalMap:{available:Boolean(globalThis.LuminousGlobalMapRuntime),open:Boolean(globalThis.LuminousGlobalMapRuntime?.isOpen)},
+    observer:clone(observer),viewAsConeDeg:Number.isFinite(cone)?cone:null,counters:clone(track.counters),coverage:clone(track.coverage),startedAt:track.startedAt,stoppedAt:track.stoppedAt,active:track.active,
+  };
+}
+
+export function start({runtime=globalThis.LuminousVttRuntime,mapData=runtime?.engine?.mapData}={}){
+  if(!runtime?.engine||!mapData)return null;
+  if(!Boolean(runtime?.bridge?.isDm||runtime?.tokenState?.isDm))return null;
+  if(globalThis.LuminousVttFieldTestRunnerRuntime?.api)return globalThis.LuminousVttFieldTestRunnerRuntime.api;
+  const Core=globalThis.LuminousVttMapFieldTestRunner;if(!Core)throw new Error('MAP_FIELD_TEST_RUNNER_CORE_REQUIRED');
+  const canvas=runtime.engine.canvas,host=hostWindow(),doc=host?.document||document,tracker=Core.createTracker(),cleanup=[];
+  let stopped=false,panel=null,statusNode=null,metricsNode=null,coverageNode=null;
+  function on(target,name,handler,options){target?.addEventListener?.(name,handler,options);cleanup.push(()=>target?.removeEventListener?.(name,handler,options));}
+  function evaluate(){const input=liveMetrics(runtime,mapData,tracker),evaluation=Core.evaluate(input);return Object.freeze({input,evaluation});}
+  function render(){
+    if(!panel)return evaluate();const{input,evaluation}=evaluate(),world=input.worldStreaming||{},sim=input.mapSimulation||{};
+    statusNode.textContent=`${evaluation.overall.toUpperCase()} · ${evaluation.coverage.done}/${evaluation.coverage.total}`;statusNode.dataset.state=evaluation.overall;
+    metricsNode.textContent=[`Players ${input.playerCount}/8`,`Chunks ${world.activeChunks??'—'}/8`,`Cells ${world.liveCells??'—'}/12800`,`Zones ${sim.activeZones??'—'}/8`,`Preview ${input.counters.previews||0}`,`Commit ${input.counters.commits||0}`,`Denied ${input.counters.permissionDenied||0}`].join(' · ');
+    coverageNode.innerHTML=Core.COVERAGE_KEYS.map((key)=>`<span data-done="${input.coverage[key]===true?'1':'0'}">${input.coverage[key]===true?'✓':'○'} ${key}</span>`).join('');return{input,evaluation};
+  }
+  function recordEvent(event){tracker.record(event.type,event.detail||{});render();}
+  function markPointerDown(){tracker.record('field:pointer-down');render();}
+  function markPointerUp(){tracker.record('field:pointer-up');render();}
+  function onError(event){tracker.reportError(event?.error||event?.reason||event?.message||event);render();}
+  function onDocumentClick(event){if(event.target?.closest?.('#vtt-global-map-toggle,[data-global-map-action="open"]')){tracker.markCoverage('globalMap');render();}}
+  function reportSnapshot(){const{input,evaluation}=evaluate();return Object.freeze({schemaVersion:1,kind:'luminous-vtt-map-field-test-report',generatedAt:input.generatedAt,map:input.map,input,evaluation});}
+  async function copyReport(){const text=JSON.stringify(reportSnapshot(),null,2);if(!host?.navigator?.clipboard?.writeText)throw new Error('CLIPBOARD_UNAVAILABLE');await host.navigator.clipboard.writeText(text);return text;}
+  function action(name){if(name==='start')tracker.start();else if(name==='stop')tracker.stop();else if(name==='reset')tracker.reset();else if(name==='fog')tracker.markCoverage('fogDiscovery');else if(name==='reconnect')tracker.markCoverage('reconnect');else if(name==='rules')tracker.markCoverage('firebaseRules');render();}
+  function onPanelClick(event){const name=event.target?.closest?.('[data-field-action]')?.dataset?.fieldAction;if(!name)return;if(name==='copy'){void copyReport().then(()=>runtime.controller?.notify?.('Field-test report copiado.','info')).catch(()=>runtime.controller?.notify?.('No se pudo copiar el reporte.','error'));return;}action(name);}
+  function ensurePanel(){
+    if(!doc?.body||panel)return panel;const style=doc.createElement('style');style.id='vtt-map-field-test-runner-style';style.textContent='#vtt-map-field-test-runner{position:fixed;right:12px;bottom:230px;z-index:36700;width:310px;background:rgba(7,9,11,.96);border:1px solid #59636c;color:#dce3e8;font:700 9px/1.4 monospace;padding:8px;display:grid;gap:6px;box-shadow:0 8px 30px rgba(0,0,0,.35)}#vtt-map-field-test-runner button{border:1px solid #59636c;background:#11161a;color:#dce3e8;font:700 9px monospace;padding:5px 7px;cursor:pointer}#vtt-field-test-status[data-state="pass"]{color:#9dd6a6}#vtt-field-test-status[data-state="warn"]{color:#e2c17a}#vtt-field-test-status[data-state="fail"]{color:#e38d8d}#vtt-field-test-coverage{display:grid;grid-template-columns:1fr 1fr;gap:2px 8px;font-weight:500}#vtt-field-test-coverage span[data-done="0"]{opacity:.55}#vtt-field-test-metrics{font-weight:500;opacity:.9}';doc.head?.appendChild(style);cleanup.push(()=>style.remove());
+    panel=doc.createElement('section');panel.id='vtt-map-field-test-runner';panel.setAttribute('aria-label','Map field test runner');panel.innerHTML=`<strong>MAP FIELD TEST</strong><div id="vtt-field-test-status">WARN · 0/${Core.COVERAGE_KEYS.length}</div><div id="vtt-field-test-metrics"></div><div id="vtt-field-test-coverage"></div><div><button type="button" data-field-action="start">START</button><button type="button" data-field-action="stop">STOP</button><button type="button" data-field-action="reset">RESET</button><button type="button" data-field-action="copy">COPY REPORT</button></div><div><button type="button" data-field-action="fog">FOG OK</button><button type="button" data-field-action="reconnect">RECONNECT OK</button><button type="button" data-field-action="rules">RULES OK</button></div>`;
+    statusNode=panel.querySelector('#vtt-field-test-status');metricsNode=panel.querySelector('#vtt-field-test-metrics');coverageNode=panel.querySelector('#vtt-field-test-coverage');panel.addEventListener('click',onPanelClick);cleanup.push(()=>panel?.removeEventListener?.('click',onPanelClick));doc.body.appendChild(panel);render();return panel;
+  }
+  const events=['vtt:token-preview-moved','vtt:token-moved','vtt:token-z-transition','vtt:procedural-chunk-loaded','vtt:procedural-chunk-transition','vtt:regional-local-transition-applied','vtt:canonical-tokens-synced','vtt:dm-observer-changed','vtt:player-discovery-updated','vtt:map-simulation-lifecycle','vtt:map-simulation-zone-persisted','vtt:map-simulation-delta-recorded'];
+  for(const name of events)on(canvas,name,recordEvent);on(canvas,'mousedown',markPointerDown,true);on(canvas,'mouseup',markPointerUp,true);if(host!==window)on(host,'mouseup',markPointerUp,true);on(host,'error',onError);on(host,'unhandledrejection',onError);on(doc,'click',onDocumentClick,true);ensurePanel();
+  const api=Object.freeze({tracker,startTest:()=>{tracker.start();return render();},stopTest:()=>{tracker.stop();return render();},reset:()=>{tracker.reset();return render();},markCoverage:(key,value=true)=>{tracker.markCoverage(key,value);return render();},snapshot:reportSnapshot,evaluate:()=>evaluate().evaluation,copyReport,render,stop(){if(stopped)return;stopped=true;tracker.stop();while(cleanup.length)cleanup.pop()?.();panel?.remove?.();panel=statusNode=metricsNode=coverageNode=null;}});
+  globalThis.LuminousVttFieldTestRunnerRuntime={api};globalThis.LuminousVttRuntime=Object.freeze({...globalThis.LuminousVttRuntime,fieldTestRunner:api});return api;
+}

--- a/js/vtt/map-simulation-runtime.js
+++ b/js/vtt/map-simulation-runtime.js
@@ -1,6 +1,7 @@
 import './map-simulation-core.js';
 import { start as startWorldStreaming } from './world-streaming-runtime.js';
 import { start as startPlayerDiscovery } from './player-discovery-runtime.js';
+import { start as startFieldTestRunner } from './map-field-test-runner-runtime.js';
 
 const DM_UID='e9JwFZrtk6g8UMqq2Hf9EHVY7Ay1';
 const PERSIST_ROOT='campaña/estado_mundo/mapSimulationZones';
@@ -170,8 +171,9 @@ export function start({runtime=globalThis.LuminousVttRuntime,mapData=runtime?.en
   globalThis.addEventListener?.('luminous:world-scheduler-updated',onWorldClock);
 
   const initial=reconcile();
-  const api=Object.freeze({Core,PERSIST_ROOT,isDm,manager,store,reconcile,reconcileActors:(actors,now=worldNowMs())=>reconcile(actors,now),restoreZone,flushZone,recordPersistentChange,recordTemporary,markZone,pinZone:(raw,pinned=true)=>markZone(raw,{pinned,persistent:true,reason:'pin-zone'}),snapshot:()=>({lifecycle:manager.snapshot(),persistence:store.metrics(),lastLifecycle}),worldNowMs,stop(){if(stopped)return;stopped=true;globalThis.LuminousVttPlayerDiscoveryRuntime?.api?.stop?.();canvas?.removeEventListener?.('vtt:token-moved',onMovement);canvas?.removeEventListener?.('vtt:regional-local-transition-applied',onMovement);canvas?.removeEventListener?.('vtt:procedural-chunk-loaded',onMovement);globalThis.removeEventListener?.('vtt:map-delta',onDelta);globalThis.removeEventListener?.('luminous:world-scheduler-updated',onWorldClock);for(const key of store.dirtyKeys()){const record=store.get(key,worldNowMs());if(record?.identity)void flushZone(record.identity,{reason:'runtime-stop'});}loadedZones.clear();restoreInFlight.clear();}});
+  const api=Object.freeze({Core,PERSIST_ROOT,isDm,manager,store,reconcile,reconcileActors:(actors,now=worldNowMs())=>reconcile(actors,now),restoreZone,flushZone,recordPersistentChange,recordTemporary,markZone,pinZone:(raw,pinned=true)=>markZone(raw,{pinned,persistent:true,reason:'pin-zone'}),snapshot:()=>({lifecycle:manager.snapshot(),persistence:store.metrics(),lastLifecycle}),worldNowMs,stop(){if(stopped)return;stopped=true;globalThis.LuminousVttFieldTestRunnerRuntime?.api?.stop?.();globalThis.LuminousVttPlayerDiscoveryRuntime?.api?.stop?.();canvas?.removeEventListener?.('vtt:token-moved',onMovement);canvas?.removeEventListener?.('vtt:regional-local-transition-applied',onMovement);canvas?.removeEventListener?.('vtt:procedural-chunk-loaded',onMovement);globalThis.removeEventListener?.('vtt:map-delta',onDelta);globalThis.removeEventListener?.('luminous:world-scheduler-updated',onWorldClock);for(const key of store.dirtyKeys()){const record=store.get(key,worldNowMs());if(record?.identity)void flushZone(record.identity,{reason:'runtime-stop'});}loadedZones.clear();restoreInFlight.clear();}});
   globalThis.LuminousVttMapSimulationRuntime={api};globalThis.LuminousVttRuntime=Object.freeze({...globalThis.LuminousVttRuntime,mapSimulation:api});
   startPlayerDiscovery({runtime:globalThis.LuminousVttRuntime,mapData});
+  startFieldTestRunner({runtime:globalThis.LuminousVttRuntime,mapData});
   return api;
 }

--- a/tests/vtt_map_field_test_runner.spec.js
+++ b/tests/vtt_map_field_test_runner.spec.js
@@ -18,57 +18,39 @@ function healthy(overrides = {}) {
 
 test.describe('Map Field-Test Runner', () => {
   test('healthy 8-player field snapshot passes all hard budgets', () => {
-    const result = Runner.evaluate(healthy());
-    expect(result.overall).toBe('pass');
-    expect(result.checks.every((check) => check.state === 'pass')).toBeTruthy();
-    expect(result.coverage.done).toBe(result.coverage.total);
+    const result = Runner.evaluate(healthy()); expect(result.overall).toBe('pass'); expect(result.checks.every((check) => check.state === 'pass')).toBeTruthy(); expect(result.coverage.done).toBe(result.coverage.total);
   });
   test('120x120 live grid fails the one-live-chunk invariant', () => {
-    const result = Runner.evaluate(healthy({ grid: { cols: 120, rows: 120 } }));
-    expect(result.checks.find((c) => c.id === 'live-grid').state).toBe('fail');
+    const result = Runner.evaluate(healthy({ grid: { cols: 120, rows: 120 } })); expect(result.checks.find((c) => c.id === 'live-grid').state).toBe('fail');
   });
   test('streaming and simulation budgets fail above 8 chunks, 12,800 cells, or 8 Zones', () => {
-    const result = Runner.evaluate(healthy({ worldStreaming: { activeChunks: 9, liveCells: 14400 }, mapSimulation: { activeZones: 9 } }));
-    expect(result.checks.find((c) => c.id === 'active-chunks').state).toBe('fail');
-    expect(result.checks.find((c) => c.id === 'live-cells').state).toBe('fail');
-    expect(result.checks.find((c) => c.id === 'active-zones').state).toBe('fail');
+    const result = Runner.evaluate(healthy({ worldStreaming: { activeChunks: 9, liveCells: 14400 }, mapSimulation: { activeZones: 9 } })); expect(result.checks.find((c) => c.id === 'active-chunks').state).toBe('fail'); expect(result.checks.find((c) => c.id === 'live-cells').state).toBe('fail'); expect(result.checks.find((c) => c.id === 'active-zones').state).toBe('fail');
   });
   test('same Actor as player and world token is detected even with different token ids', () => {
-    const tokens = healthy().tokens.concat({ id: 'npc-agatha-old', actorId: 'actor_1', canonicalScope: 'world' });
-    const result = Runner.evaluate(healthy({ tokens }));
-    expect(result.duplicatePlayerActors).toHaveLength(1);
-    expect(result.checks.find((c) => c.id === 'duplicate-player-actors').state).toBe('fail');
+    const tokens = healthy().tokens.concat({ id: 'npc-agatha-old', actorId: 'actor_1', canonicalScope: 'world' }); const result = Runner.evaluate(healthy({ tokens })); expect(result.duplicatePlayerActors).toHaveLength(1); expect(result.checks.find((c) => c.id === 'duplicate-player-actors').state).toBe('fail');
   });
   test('same visible name does not dedupe unrelated Actor identities', () => {
     expect(Runner.duplicatePlayerActorIds([{ id:'p1',name:'Agatha',actorId:'actor_agatha',canonicalScope:'player',canonicalPlayerKey:'P1' },{ id:'npc1',name:'Agatha',actorId:'actor_other',canonicalScope:'world' }])).toEqual([]);
   });
   test('preview drag can emit many local previews and only one commit after pointer-up', () => {
-    const tracker = Runner.createTracker(); tracker.start(); tracker.record('field:pointer-down');
-    for (let i=0;i<25;i+=1) tracker.record('vtt:token-preview-moved',{tokenId:'P1'});
-    tracker.record('field:pointer-up'); tracker.record('vtt:token-moved',{tokenId:'P1'});
-    const snap=tracker.snapshot(); expect(snap.counters.previews).toBe(25); expect(snap.counters.commits).toBe(1); expect(snap.counters.commitsWhilePointerDown).toBe(0); expect(snap.counters.completedPreviewDrags).toBe(1);
+    const tracker = Runner.createTracker(); tracker.start(); tracker.record('field:pointer-down'); for (let i=0;i<25;i+=1) tracker.record('vtt:token-preview-moved',{tokenId:'P1'}); tracker.record('field:pointer-up'); tracker.record('vtt:token-moved',{tokenId:'P1'}); const snap=tracker.snapshot(); expect(snap.counters.previews).toBe(25); expect(snap.counters.commits).toBe(1); expect(snap.counters.commitsWhilePointerDown).toBe(0); expect(snap.counters.completedPreviewDrags).toBe(1);
   });
   test('commit while pointer remains down is a hard failure', () => {
-    const tracker=Runner.createTracker();tracker.start();tracker.record('field:pointer-down');tracker.record('vtt:token-moved',{tokenId:'P1'});
-    expect(Runner.evaluate(healthy({counters:tracker.snapshot().counters})).checks.find((c)=>c.id==='commit-during-drag').state).toBe('fail');
+    const tracker=Runner.createTracker(); tracker.start(); tracker.record('field:pointer-down'); tracker.record('vtt:token-moved',{tokenId:'P1'}); expect(Runner.evaluate(healthy({counters:tracker.snapshot().counters})).checks.find((c)=>c.id==='commit-during-drag').state).toBe('fail');
   });
   test('View As must exercise the canonical 120 degree cone', () => {
-    const good=Runner.evaluate(healthy({viewAsConeDeg:120}));expect(good.checks.find((c)=>c.id==='view-as-cone').state).toBe('pass');
-    const bad=Runner.evaluate(healthy({viewAsConeDeg:90}));expect(bad.checks.find((c)=>c.id==='view-as-cone').state).toBe('fail');
+    expect(Runner.evaluate(healthy({viewAsConeDeg:120})).checks.find((c)=>c.id==='view-as-cone').state).toBe('pass'); expect(Runner.evaluate(healthy({viewAsConeDeg:90})).checks.find((c)=>c.id==='view-as-cone').state).toBe('fail');
   });
   test('permission denied variants are classified as field failures', () => {
-    expect(Runner.isPermissionDenied({code:'PERMISSION_DENIED'})).toBeTruthy();expect(Runner.isPermissionDenied(new Error('access denied'))).toBeTruthy();expect(Runner.isPermissionDenied(new Error('network disconnected'))).toBeFalsy();
-    const tracker=Runner.createTracker();tracker.start();tracker.reportError({code:'PERMISSION_DENIED',message:'Permission denied'});expect(Runner.evaluate(healthy({counters:tracker.snapshot().counters})).overall).toBe('fail');
+    expect(Runner.isPermissionDenied({code:'PERMISSION_DENIED'})).toBeTruthy(); expect(Runner.isPermissionDenied(new Error('access denied'))).toBeTruthy(); expect(Runner.isPermissionDenied(new Error('network disconnected'))).toBeFalsy(); const tracker=Runner.createTracker(); tracker.start(); tracker.reportError({code:'PERMISSION_DENIED',message:'Permission denied'}); expect(Runner.evaluate(healthy({counters:tracker.snapshot().counters})).overall).toBe('fail');
   });
   test('manual fog, reconnect, global map and Firebase rules evidence complete coverage slots', () => {
-    const tracker=Runner.createTracker();tracker.start();for(const key of ['fogDiscovery','reconnect','globalMap','firebaseRules'])tracker.markCoverage(key);const coverage=tracker.snapshot().coverage;
-    expect(coverage.fogDiscovery&&coverage.reconnect&&coverage.globalMap&&coverage.firebaseRules).toBeTruthy();
+    const tracker=Runner.createTracker(); tracker.start(); for(const key of ['fogDiscovery','reconnect','globalMap','firebaseRules']) tracker.markCoverage(key); const coverage=tracker.snapshot().coverage; expect(coverage.fogDiscovery&&coverage.reconnect&&coverage.globalMap&&coverage.firebaseRules).toBeTruthy();
   });
   test('runner runtime is DM-only, event-driven and never persists telemetry', () => {
-    const runtime=fs.readFileSync(path.join(__dirname,'..','js','vtt','map-field-test-runner-runtime.js'),'utf8');
-    expect(runtime).toContain("runtime?.bridge?.isDm");expect(runtime).not.toMatch(/setInterval\s*\(/);expect(runtime).not.toMatch(/setTimeout\s*\(/);expect(runtime).not.toMatch(/requestAnimationFrame\s*\(/);expect(runtime).not.toMatch(/firebase\s*\.\s*database|\.transaction\s*\(|\.push\s*\(|\.update\s*\(|\.set\s*\(/i);expect(runtime).toContain("worldStreaming?.snapshot?.()");expect(runtime).toContain("mapSimulation?.snapshot?.()");expect(runtime).toContain('LuminousVttPerformanceGuard?.snapshot?.()');expect(runtime).toContain("navigator?.clipboard?.writeText");expect(runtime).toContain("on(canvas,'mouseup',markPointerUp,true)");
+    const runtime=fs.readFileSync(path.join(__dirname,'..','js','vtt','map-field-test-runner-runtime.js'),'utf8'); expect(runtime).toContain("runtime?.bridge?.isDm"); expect(runtime).not.toMatch(/setInterval\s*\(/); expect(runtime).not.toMatch(/setTimeout\s*\(/); expect(runtime).not.toMatch(/requestAnimationFrame\s*\(/); expect(runtime).not.toMatch(/firebase\s*\.\s*database|\.transaction\s*\(|\.push\s*\(|\.update\s*\(|\.set\s*\(/i); expect(runtime).toContain("worldStreaming?.snapshot?.()"); expect(runtime).toContain("mapSimulation?.snapshot?.()"); expect(runtime).toContain('LuminousVttPerformanceGuard?.snapshot?.()'); expect(runtime).toContain("navigator?.clipboard?.writeText"); expect(runtime).toContain("on(canvas,'mouseup',markPointerUp,true)");
   });
-  test('main starts runner after map simulation and lifecycle disposes it', () => {
-    const source=fs.readFileSync(path.join(__dirname,'..','js','vtt','main.js'),'utf8');const simulation=source.indexOf("import('./map-simulation-runtime.js')"),runner=source.indexOf("import('./map-field-test-runner-runtime.js')");expect(simulation).toBeGreaterThanOrEqual(0);expect(runner).toBeGreaterThan(simulation);expect(source).toContain('LuminousVttFieldTestRunnerRuntime?.api?.stop?.()');expect(source).toContain("stopIfDisposed(fieldTestRuntime, 'map-field-test-runner')");
+  test('map simulation owns runner startup and teardown so Map-Theatre dispose cannot leak it', () => {
+    const simulation=fs.readFileSync(path.join(__dirname,'..','js','vtt','map-simulation-runtime.js'),'utf8'); const main=fs.readFileSync(path.join(__dirname,'..','js','vtt','main.js'),'utf8'); expect(simulation).toContain("start as startFieldTestRunner"); expect(simulation).toContain('startFieldTestRunner({runtime:globalThis.LuminousVttRuntime,mapData});'); expect(simulation).toContain('LuminousVttFieldTestRunnerRuntime?.api?.stop?.()'); expect(main).toContain('LuminousVttRuntime?.mapSimulation?.stop?.()');
   });
 });

--- a/tests/vtt_map_field_test_runner.spec.js
+++ b/tests/vtt_map_field_test_runner.spec.js
@@ -1,0 +1,74 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+const Runner = require('../js/vtt/map-field-test-runner-core.js');
+
+function healthy(overrides = {}) {
+  return {
+    grid: { cols: 40, rows: 40 },
+    worldStreaming: { activeChunks: 8, liveCells: 12800 },
+    mapSimulation: { activeZones: 7 },
+    tokens: Array.from({ length: 8 }, (_, i) => ({ id: `P${i + 1}`, actorId: `actor_${i + 1}`, canonicalScope: 'player', canonicalPlayerKey: `P${i + 1}` })),
+    counters: { permissionDenied: 0, commitsWhilePointerDown: 0 },
+    coverage: Object.fromEntries(Runner.COVERAGE_KEYS.map((key) => [key, true])),
+    viewAsConeDeg: 120,
+    ...overrides,
+  };
+}
+
+test.describe('Map Field-Test Runner', () => {
+  test('healthy 8-player field snapshot passes all hard budgets', () => {
+    const result = Runner.evaluate(healthy());
+    expect(result.overall).toBe('pass');
+    expect(result.checks.every((check) => check.state === 'pass')).toBeTruthy();
+    expect(result.coverage.done).toBe(result.coverage.total);
+  });
+  test('120x120 live grid fails the one-live-chunk invariant', () => {
+    const result = Runner.evaluate(healthy({ grid: { cols: 120, rows: 120 } }));
+    expect(result.checks.find((c) => c.id === 'live-grid').state).toBe('fail');
+  });
+  test('streaming and simulation budgets fail above 8 chunks, 12,800 cells, or 8 Zones', () => {
+    const result = Runner.evaluate(healthy({ worldStreaming: { activeChunks: 9, liveCells: 14400 }, mapSimulation: { activeZones: 9 } }));
+    expect(result.checks.find((c) => c.id === 'active-chunks').state).toBe('fail');
+    expect(result.checks.find((c) => c.id === 'live-cells').state).toBe('fail');
+    expect(result.checks.find((c) => c.id === 'active-zones').state).toBe('fail');
+  });
+  test('same Actor as player and world token is detected even with different token ids', () => {
+    const tokens = healthy().tokens.concat({ id: 'npc-agatha-old', actorId: 'actor_1', canonicalScope: 'world' });
+    const result = Runner.evaluate(healthy({ tokens }));
+    expect(result.duplicatePlayerActors).toHaveLength(1);
+    expect(result.checks.find((c) => c.id === 'duplicate-player-actors').state).toBe('fail');
+  });
+  test('same visible name does not dedupe unrelated Actor identities', () => {
+    expect(Runner.duplicatePlayerActorIds([{ id:'p1',name:'Agatha',actorId:'actor_agatha',canonicalScope:'player',canonicalPlayerKey:'P1' },{ id:'npc1',name:'Agatha',actorId:'actor_other',canonicalScope:'world' }])).toEqual([]);
+  });
+  test('preview drag can emit many local previews and only one commit after pointer-up', () => {
+    const tracker = Runner.createTracker(); tracker.start(); tracker.record('field:pointer-down');
+    for (let i=0;i<25;i+=1) tracker.record('vtt:token-preview-moved',{tokenId:'P1'});
+    tracker.record('field:pointer-up'); tracker.record('vtt:token-moved',{tokenId:'P1'});
+    const snap=tracker.snapshot(); expect(snap.counters.previews).toBe(25); expect(snap.counters.commits).toBe(1); expect(snap.counters.commitsWhilePointerDown).toBe(0); expect(snap.counters.completedPreviewDrags).toBe(1);
+  });
+  test('commit while pointer remains down is a hard failure', () => {
+    const tracker=Runner.createTracker();tracker.start();tracker.record('field:pointer-down');tracker.record('vtt:token-moved',{tokenId:'P1'});
+    expect(Runner.evaluate(healthy({counters:tracker.snapshot().counters})).checks.find((c)=>c.id==='commit-during-drag').state).toBe('fail');
+  });
+  test('View As must exercise the canonical 120 degree cone', () => {
+    const good=Runner.evaluate(healthy({viewAsConeDeg:120}));expect(good.checks.find((c)=>c.id==='view-as-cone').state).toBe('pass');
+    const bad=Runner.evaluate(healthy({viewAsConeDeg:90}));expect(bad.checks.find((c)=>c.id==='view-as-cone').state).toBe('fail');
+  });
+  test('permission denied variants are classified as field failures', () => {
+    expect(Runner.isPermissionDenied({code:'PERMISSION_DENIED'})).toBeTruthy();expect(Runner.isPermissionDenied(new Error('access denied'))).toBeTruthy();expect(Runner.isPermissionDenied(new Error('network disconnected'))).toBeFalsy();
+    const tracker=Runner.createTracker();tracker.start();tracker.reportError({code:'PERMISSION_DENIED',message:'Permission denied'});expect(Runner.evaluate(healthy({counters:tracker.snapshot().counters})).overall).toBe('fail');
+  });
+  test('manual fog, reconnect, global map and Firebase rules evidence complete coverage slots', () => {
+    const tracker=Runner.createTracker();tracker.start();for(const key of ['fogDiscovery','reconnect','globalMap','firebaseRules'])tracker.markCoverage(key);const coverage=tracker.snapshot().coverage;
+    expect(coverage.fogDiscovery&&coverage.reconnect&&coverage.globalMap&&coverage.firebaseRules).toBeTruthy();
+  });
+  test('runner runtime is DM-only, event-driven and never persists telemetry', () => {
+    const runtime=fs.readFileSync(path.join(__dirname,'..','js','vtt','map-field-test-runner-runtime.js'),'utf8');
+    expect(runtime).toContain("runtime?.bridge?.isDm");expect(runtime).not.toMatch(/setInterval\s*\(/);expect(runtime).not.toMatch(/setTimeout\s*\(/);expect(runtime).not.toMatch(/requestAnimationFrame\s*\(/);expect(runtime).not.toMatch(/firebase\s*\.\s*database|\.transaction\s*\(|\.push\s*\(|\.update\s*\(|\.set\s*\(/i);expect(runtime).toContain("worldStreaming?.snapshot?.()");expect(runtime).toContain("mapSimulation?.snapshot?.()");expect(runtime).toContain('LuminousVttPerformanceGuard?.snapshot?.()');expect(runtime).toContain("navigator?.clipboard?.writeText");expect(runtime).toContain("on(canvas,'mouseup',markPointerUp,true)");
+  });
+  test('main starts runner after map simulation and lifecycle disposes it', () => {
+    const source=fs.readFileSync(path.join(__dirname,'..','js','vtt','main.js'),'utf8');const simulation=source.indexOf("import('./map-simulation-runtime.js')"),runner=source.indexOf("import('./map-field-test-runner-runtime.js')");expect(simulation).toBeGreaterThanOrEqual(0);expect(runner).toBeGreaterThan(simulation);expect(source).toContain('LuminousVttFieldTestRunnerRuntime?.api?.stop?.()');expect(source).toContain("stopIfDisposed(fieldTestRuntime, 'map-field-test-runner')");
+  });
+});


### PR DESCRIPTION
## Summary
Adds the final live diagnostics layer for the Map Field-Test build on top of the deterministic sandbox and global-map foundation.

### DM field-test runner
- DM-only diagnostic panel; players never load an interactive runner.
- Explicit START/STOP/RESET so setup noise is not mixed into a measured field session.
- Event-driven counters for token preview vs committed movement, chunk streaming, Regional↔Local, Z transitions, DM View As, discovery, simulation lifecycle, persistence and canonical reconnect sync.
- Manual evidence markers for Fog, reconnect and published Firebase Rules where the DM client cannot safely infer remote-player state.
- Copies a local JSON report to clipboard; no telemetry is written to Firebase.

### Hard acceptance checks
- Live grid must remain <= 40×40.
- Active chunks <= 8 and live cells <= 12,800.
- Active Simulation Zones <= 8.
- Player-linked Actors cannot reappear as world/NPC tokens.
- No movement commit while the pointer is still down.
- No captured PERMISSION_DENIED.
- View As must remain the canonical 120° POV.
- Final stress pass expects 8 players.

### Lifecycle / performance
- Runner is owned by Map Simulation, so the existing Map↔Theatre disposal path tears it down automatically.
- No setInterval, setTimeout or requestAnimationFrame added.
- No Firebase set/update/transaction/push in the runner.
- Reuses existing WorldStreaming, MapSimulation and PerformanceGuard snapshots.

### Tests
Extends the existing Map Field Test Sandbox workflow with runner behavioral contracts plus the existing sandbox, hardening, regional, streaming, fog, camera and performance suites, followed by full repository regression.