### PR TITLE
perf(vtt): harden multiclient Realtime convergence

### DIFF
--- a/.github/workflows/vtt-multiclient-realtime-field.yml
+++ b/.github/workflows/vtt-multiclient-realtime-field.yml
@@ -1,0 +1,66 @@
+name: VTT Multiclient Realtime Field
+
+on:
+  pull_request:
+    paths:
+      - 'js/vtt/token-state.js'
+      - 'js/vtt/token-state-dynamic-patch.js'
+      - 'js/vtt/player-discovery-core.js'
+      - 'js/vtt/player-discovery-runtime.js'
+      - 'js/vtt/regional-local-transition-runtime.js'
+      - 'js/vtt/engine.js'
+      - 'tests/vtt_multiclient_realtime_field.spec.js'
+      - 'tests/vtt_canonical_token_state.spec.js'
+      - 'tests/vtt_player_discovery_realtime.spec.js'
+      - 'tests/vtt_player_discovery_fog.spec.js'
+      - 'tests/vtt_map_field_test_sandbox.spec.js'
+      - 'tests/vtt_map_field_test_hardening.spec.js'
+      - 'tests/regional_local_transition_realtime.spec.js'
+      - 'tests/vtt_token_drag.spec.js'
+      - 'tests/vtt_performance_guard.spec.js'
+      - 'tests/vtt_map_theatre_lifecycle.spec.js'
+      - '.github/workflows/vtt-multiclient-realtime-field.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'js/vtt/token-state.js'
+      - 'tests/vtt_multiclient_realtime_field.spec.js'
+      - '.github/workflows/vtt-multiclient-realtime-field.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  multiclient-realtime-field:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Syntax
+        run: |
+          node --check js/vtt/token-state.js
+          node --check tests/vtt_multiclient_realtime_field.spec.js
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Multiclient Realtime ownership Fog transition and performance contracts
+        run: >-
+          npx playwright test --workers=1
+          tests/vtt_multiclient_realtime_field.spec.js
+          tests/vtt_canonical_token_state.spec.js
+          tests/vtt_player_discovery_realtime.spec.js
+          tests/vtt_player_discovery_fog.spec.js
+          tests/vtt_map_field_test_sandbox.spec.js
+          tests/vtt_map_field_test_hardening.spec.js
+          tests/regional_local_transition_realtime.spec.js
+          tests/vtt_token_drag.spec.js
+          tests/vtt_performance_guard.spec.js
+          tests/vtt_map_theatre_lifecycle.spec.js
+      - name: Full repository regression
+        run: npx playwright test --workers=1

--- a/js/vtt/token-state.js
+++ b/js/vtt/token-state.js
@@ -151,6 +151,7 @@
         const mapId = firebaseKey(mapData.id || mapData.mapId || 'default', 'default');
         const current = identity(root);
         const subscriptions = [];
+        const playerStateSubscriptions = new Map();
         const template = clone((mapData.tokens || []).find(isCurrentPlayerTemplate) || null);
         const fixedTokenIds = new Set((mapData.tokens || []).filter((token) => !isCurrentPlayerTemplate(token)).map((token) => clean(token.id)).filter(Boolean));
         let started = false;
@@ -166,9 +167,11 @@
         const worldRef = () => db?.ref(`${WORLD_ROOT}/${mapId}`);
 
         function subscribe(ref, event, handler) {
-            if (!ref?.on) return;
+            if (!ref?.on) return () => {};
             ref.on(event, handler);
-            subscriptions.push(() => ref.off(event, handler));
+            const unsubscribe = () => ref.off(event, handler);
+            subscriptions.push(unsubscribe);
+            return unsubscribe;
         }
 
         function localViewerToken() {
@@ -183,60 +186,80 @@
             return Boolean(uidMatch || playerMatch);
         }
 
-        function syncPlayerRecords(rawRecord = {}) {
-            const records = rawRecord || {};
-            const keepIds = new Set();
+        function emitPlayerChange() {
+            if (typeof onTokensChanged === 'function') onTokensChanged({ scope: 'players', tokens: mapData.tokens });
+        }
+
+        function removePlayerRecord(playerKey, { emit = true } = {}) {
+            const key = clean(playerKey);
+            if (!key) return false;
+            const ownTemplate = !isDm ? (mapData.tokens || []).find(isCurrentPlayerTemplate) : null;
+            const before = (mapData.tokens || []).length;
+            mapData.tokens = (mapData.tokens || []).filter((token) => {
+                if (token === ownTemplate) return true;
+                if (fixedTokenIds.has(clean(token.id))) return true;
+                if (token.canonicalScope !== 'player') return true;
+                return clean(token.canonicalPlayerKey || token.playerId) !== key;
+            });
+            if (emit && before !== mapData.tokens.length) emitPlayerChange();
+            return before !== mapData.tokens.length;
+        }
+
+        function syncSinglePlayerRecord(playerKey, record = null, { emit = true } = {}) {
+            const key = clean(playerKey || record?.playerId);
+            if (!key || !record?.position) return removePlayerRecord(key, { emit });
+            const playerId = clean(record.playerId || key);
+            const ownerUid = clean(record.ownerUid);
             const ownTemplate = !isDm ? (mapData.tokens || []).find(isCurrentPlayerTemplate) : null;
 
-            if (isDm && template) {
-                mapData.tokens = (mapData.tokens || []).filter((token) => !isCurrentPlayerTemplate(token));
+            if (!isDm && isOwnRecord(record, key) && ownTemplate) {
+                ownTemplate.ownerUid = ownerUid || ownTemplate.ownerUid || null;
+                ownTemplate.playerId = playerId || ownTemplate.playerId || current.playerId || null;
+                ownTemplate.actorId = clean(record.actorId) || ownTemplate.actorId || null;
+                ownTemplate.canonicalScope = 'player';
+                ownTemplate.canonicalPlayerKey = key || playerId || current.playerId;
+                ownTemplate.canonicalOwnerUid = ownerUid || current.uid || null;
+                ownTemplate.viewer = true;
+                applyPosition(ownTemplate, record.position);
+                mapData.tokens = (mapData.tokens || []).filter((token) => token === ownTemplate || clean(token.canonicalPlayerKey) !== ownTemplate.canonicalPlayerKey);
+                if (emit) emitPlayerChange();
+                return ownTemplate;
             }
 
-            Object.entries(records).forEach(([playerKey, record]) => {
-                if (!record?.position) return;
-                const playerId = clean(record.playerId || playerKey);
-                const ownerUid = clean(record.ownerUid);
+            const id = `player:${firebaseKey(playerId || ownerUid || key, 'unknown')}`;
+            let token = (mapData.tokens || []).find((entry) => clean(entry.id) === id || (entry.canonicalScope === 'player' && clean(entry.canonicalPlayerKey) === key));
+            if (!token) {
+                token = playerTokenFromRecord(template || ownTemplate || {}, key, record, current);
+                mapData.tokens ||= [];
+                mapData.tokens.push(token);
+            } else {
+                token.id = id;
+                token.ownerUid = ownerUid || null;
+                token.playerId = playerId || null;
+                token.actorId = clean(record.actorId) || token.actorId || null;
+                token.characterLink = { mode: 'player', uid: token.ownerUid, playerId: token.playerId, actorId: token.actorId };
+                token.canonicalScope = 'player';
+                token.canonicalPlayerKey = key || playerId;
+                token.canonicalOwnerUid = ownerUid || null;
+                token.viewer = Boolean(!isDm && isOwnRecord(record, key));
+                applyPosition(token, record.position);
+            }
+            if (emit) emitPlayerChange();
+            return token;
+        }
 
-                if (!isDm && isOwnRecord(record, playerKey) && ownTemplate) {
-                    ownTemplate.ownerUid = ownerUid || ownTemplate.ownerUid || null;
-                    ownTemplate.playerId = playerId || ownTemplate.playerId || current.playerId || null;
-                    ownTemplate.actorId = clean(record.actorId) || ownTemplate.actorId || null;
-                    ownTemplate.canonicalScope = 'player';
-                    ownTemplate.canonicalPlayerKey = clean(playerKey || playerId || current.playerId);
-                    ownTemplate.canonicalOwnerUid = ownerUid || current.uid || null;
-                    ownTemplate.viewer = true;
-                    applyPosition(ownTemplate, record.position);
-                    keepIds.add(clean(ownTemplate.id));
-                    return;
-                }
-
-                const id = `player:${firebaseKey(playerId || ownerUid || playerKey, 'unknown')}`;
-                keepIds.add(id);
-                let token = (mapData.tokens || []).find((entry) => clean(entry.id) === id);
-                if (!token) {
-                    token = playerTokenFromRecord(template || ownTemplate || {}, playerKey, record, current);
-                    mapData.tokens ||= [];
-                    mapData.tokens.push(token);
-                } else {
-                    token.ownerUid = ownerUid || null;
-                    token.playerId = playerId || null;
-                    token.actorId = clean(record.actorId) || token.actorId || null;
-                    token.canonicalScope = 'player';
-                    token.canonicalPlayerKey = clean(playerKey || playerId);
-                    token.canonicalOwnerUid = ownerUid || null;
-                    token.viewer = Boolean(!isDm && isOwnRecord(record, playerKey));
-                    applyPosition(token, record.position);
-                }
-            });
-
+        function syncPlayerRecords(rawRecord = {}) {
+            const records = rawRecord || {};
+            const keepKeys = new Set(Object.keys(records).filter((key) => records[key]?.position).map(clean));
+            if (isDm && template) mapData.tokens = (mapData.tokens || []).filter((token) => !isCurrentPlayerTemplate(token));
+            Object.entries(records).forEach(([playerKey, record]) => syncSinglePlayerRecord(playerKey, record, { emit: false }));
             mapData.tokens = (mapData.tokens || []).filter((token) => {
                 if (fixedTokenIds.has(clean(token.id))) return true;
                 if (!isDm && isCurrentPlayerTemplate(token)) return true;
-                if (token.canonicalScope === 'player') return keepIds.has(clean(token.id));
+                if (token.canonicalScope === 'player') return keepKeys.has(clean(token.canonicalPlayerKey || token.playerId));
                 return true;
             });
-
-            if (typeof onTokensChanged === 'function') onTokensChanged({ scope: 'players', tokens: mapData.tokens });
+            emitPlayerChange();
         }
 
         function syncWorldRecords(rawRecord = {}) {
@@ -250,6 +273,26 @@
                 applyPosition(token, record.position);
             });
             if (typeof onTokensChanged === 'function') onTokensChanged({ scope: 'world', tokens: mapData.tokens });
+        }
+
+        function unwatchPlayerState(playerKey) {
+            const key = clean(playerKey);
+            const unsubscribe = playerStateSubscriptions.get(key);
+            if (!unsubscribe) return false;
+            unsubscribe();
+            playerStateSubscriptions.delete(key);
+            return true;
+        }
+
+        function watchPlayerState(playerKey) {
+            const key = clean(playerKey);
+            if (!db || !key || playerStateSubscriptions.has(key)) return false;
+            const ref = playerStateRef(key);
+            if (!ref?.on) return false;
+            const handler = (snapshot) => syncSinglePlayerRecord(key, snapshot.val() || null);
+            ref.on('value', handler);
+            playerStateSubscriptions.set(key, () => ref.off('value', handler));
+            return true;
         }
 
         async function seedOwnPlayerIfNeeded() {
@@ -327,7 +370,12 @@
             started = true;
             if (!db) return false;
 
-            subscribe(playersRootRef(), 'value', (snapshot) => syncPlayerRecords(extractPlayerRecords(snapshot.val() || {}, mapId)));
+            if (isDm && template) mapData.tokens = (mapData.tokens || []).filter((token) => !isCurrentPlayerTemplate(token));
+            subscribe(playersRootRef(), 'child_added', (snapshot) => watchPlayerState(snapshot.key));
+            subscribe(playersRootRef(), 'child_removed', (snapshot) => {
+                unwatchPlayerState(snapshot.key);
+                removePlayerRecord(snapshot.key);
+            });
             subscribe(worldRef(), 'value', (snapshot) => syncWorldRecords(snapshot.val() || {}));
             seedOwnPlayerIfNeeded().catch((error) => console.error('VTT player token seed failed:', error));
             seedWorldIfNeeded().catch((error) => console.error('VTT world token seed failed:', error));
@@ -335,6 +383,8 @@
         }
 
         function stop() {
+            playerStateSubscriptions.forEach((unsubscribe) => unsubscribe());
+            playerStateSubscriptions.clear();
             subscriptions.splice(0).forEach((unsubscribe) => unsubscribe());
             started = false;
         }
@@ -347,6 +397,9 @@
             stop,
             saveToken,
             syncPlayerRecords,
+            syncSinglePlayerRecord,
+            removePlayerRecord,
+            watchPlayerState,
             syncWorldRecords,
             notify: emitNotice,
         });

--- a/tests/vtt_multiclient_realtime_field.spec.js
+++ b/tests/vtt_multiclient_realtime_field.spec.js
@@ -1,0 +1,357 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const tokenState = require('../js/vtt/token-state.js');
+const Discovery = require('../js/vtt/player-discovery-core.js');
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+function splitPath(value = '') {
+  return String(value || '').split('/').filter(Boolean);
+}
+
+function getAt(root, pathValue) {
+  let cursor = root;
+  for (const key of splitPath(pathValue)) {
+    if (cursor == null || typeof cursor !== 'object') return null;
+    cursor = cursor[key];
+  }
+  return cursor == null ? null : cursor;
+}
+
+function setAt(root, pathValue, value) {
+  const parts = splitPath(pathValue);
+  if (!parts.length) {
+    Object.keys(root).forEach((key) => delete root[key]);
+    if (value && typeof value === 'object') Object.assign(root, clone(value));
+    return;
+  }
+  let cursor = root;
+  for (let i = 0; i < parts.length - 1; i += 1) {
+    cursor[parts[i]] ||= {};
+    cursor = cursor[parts[i]];
+  }
+  const last = parts.at(-1);
+  if (value == null) delete cursor[last];
+  else cursor[last] = clone(value);
+}
+
+class SharedRealtimeDb {
+  constructor(initial = {}) {
+    this.data = clone(initial);
+    this.listeners = new Map();
+    this.registrations = [];
+    this.deliveries = [];
+    this.writes = [];
+  }
+
+  listenerKey(pathValue, event) { return `${pathValue}|${event}`; }
+
+  snapshot(pathValue, keyOverride) {
+    const value = clone(getAt(this.data, pathValue));
+    return {
+      key: keyOverride ?? splitPath(pathValue).at(-1) ?? null,
+      val: () => value,
+      exists: () => value != null,
+      ref: this.ref(pathValue),
+    };
+  }
+
+  deliver(pathValue, event, handler, snapshot) {
+    this.deliveries.push({ path: pathValue, event, key: snapshot?.key ?? null });
+    handler(snapshot);
+  }
+
+  on(pathValue, event, handler) {
+    const key = this.listenerKey(pathValue, event);
+    if (!this.listeners.has(key)) this.listeners.set(key, new Set());
+    this.listeners.get(key).add(handler);
+    this.registrations.push({ type: 'on', path: pathValue, event });
+    if (event === 'value') {
+      this.deliver(pathValue, event, handler, this.snapshot(pathValue));
+    } else if (event === 'child_added') {
+      const current = getAt(this.data, pathValue) || {};
+      Object.keys(current).forEach((childKey) => this.deliver(pathValue, event, handler, this.snapshot(`${pathValue}/${childKey}`, childKey)));
+    }
+  }
+
+  off(pathValue, event, handler) {
+    this.listeners.get(this.listenerKey(pathValue, event))?.delete(handler);
+    this.registrations.push({ type: 'off', path: pathValue, event });
+  }
+
+  emitMutation(changedPath, before) {
+    for (const [listenerKey, handlers] of this.listeners.entries()) {
+      const separator = listenerKey.lastIndexOf('|');
+      const listenerPath = listenerKey.slice(0, separator);
+      const event = listenerKey.slice(separator + 1);
+      const descendantChange = changedPath === listenerPath || changedPath.startsWith(`${listenerPath}/`);
+      const ancestorReplace = listenerPath.startsWith(`${changedPath}/`);
+      if (event === 'value' && (descendantChange || ancestorReplace)) {
+        for (const handler of [...handlers]) this.deliver(listenerPath, event, handler, this.snapshot(listenerPath));
+        continue;
+      }
+      if (!descendantChange || !['child_added', 'child_removed'].includes(event)) continue;
+      const rest = splitPath(changedPath).slice(splitPath(listenerPath).length);
+      const childKey = rest[0];
+      if (!childKey) continue;
+      const childPath = `${listenerPath}/${childKey}`;
+      const previous = getAt(before, childPath);
+      const next = getAt(this.data, childPath);
+      const shouldDeliver = event === 'child_added' ? previous == null && next != null : previous != null && next == null;
+      if (!shouldDeliver) continue;
+      const snapshotData = event === 'child_removed' ? previous : next;
+      const snapshot = {
+        key: childKey,
+        val: () => clone(snapshotData),
+        exists: () => snapshotData != null,
+        ref: this.ref(childPath),
+      };
+      for (const handler of [...handlers]) this.deliver(listenerPath, event, handler, snapshot);
+    }
+  }
+
+  async set(pathValue, value) {
+    const before = clone(this.data);
+    setAt(this.data, pathValue, value);
+    this.writes.push({ type: 'set', path: pathValue, value: clone(value) });
+    this.emitMutation(pathValue, before);
+  }
+
+  async update(pathValue, updates = {}) {
+    for (const [key, value] of Object.entries(updates)) {
+      const target = pathValue ? `${pathValue}/${key}` : key;
+      await this.set(target, value);
+    }
+  }
+
+  listenerCount() {
+    let total = 0;
+    for (const handlers of this.listeners.values()) total += handlers.size;
+    return total;
+  }
+
+  ref(pathValue = '') {
+    const db = this;
+    const normalized = String(pathValue || '').replace(/^\/+|\/+$/g, '');
+    return {
+      path: normalized,
+      child(childKey) { return db.ref(normalized ? `${normalized}/${childKey}` : childKey); },
+      on(event, handler) { db.on(normalized, event, handler); },
+      off(event, handler) { db.off(normalized, event, handler); },
+      once: async () => db.snapshot(normalized),
+      set: async (value) => db.set(normalized, value),
+      update: async (updates) => db.update(normalized, updates),
+      remove: async () => db.set(normalized, null),
+    };
+  }
+}
+
+function templateToken() {
+  return {
+    id: 'player-template',
+    x: 35,
+    y: 35,
+    draggable: true,
+    characterLink: { mode: 'current_player' },
+    zLayer: 0,
+    elevationFt: 0,
+    gridPosition: { col: 0, row: 0, z: 0 },
+    z: [0],
+  };
+}
+
+function baseMap(id = 'alpha') {
+  return {
+    id,
+    grid: { size: 70, cols: 40, rows: 40 },
+    tokens: [
+      templateToken(),
+      { id: 'npc-1', x: 700, y: 700, draggable: true, zLayer: 0, elevationFt: 0, gridPosition: { col: 10, row: 10, z: 0 }, z: [0] },
+    ],
+  };
+}
+
+function rootFor(shared, { uid, playerId, actorId }) {
+  const database = () => shared;
+  database.ServerValue = { TIMESTAMP: 777 };
+  shared.ref = shared.ref.bind(shared);
+  return {
+    document: {},
+    datosJugador: { id: playerId, playerId, actorId },
+    localStorage: { getItem: (key) => key === 'playerId' ? playerId : null },
+    firebase: { auth: () => ({ currentUser: { uid } }), database },
+  };
+}
+
+function client(shared, { uid, playerId, actorId = `actor-${playerId}`, isDm = false, mapId = 'alpha' }) {
+  const mapData = baseMap(mapId);
+  const changes = [];
+  const bridge = tokenState.createBridge({
+    mapData,
+    isDm,
+    root: rootFor(shared, { uid, playerId, actorId }),
+    onTokensChanged: (change) => changes.push({ scope: change.scope, count: change.tokens.length }),
+  });
+  return { uid, playerId, isDm, mapData, bridge, changes };
+}
+
+const playerToken = (session, playerId) => (session.mapData.tokens || []).find((token) => String(token.canonicalPlayerKey || token.playerId || '') === playerId);
+const playerKeys = (session) => (session.mapData.tokens || []).filter((token) => token.canonicalScope === 'player').map((token) => token.canonicalPlayerKey).sort();
+const flush = async () => { for (let i = 0; i < 6; i += 1) await Promise.resolve(); };
+
+function initialDb() {
+  return new SharedRealtimeDb({
+    campaña: {
+      jugadores: {
+        alice: { uid: 'uid-a' },
+        bob: { uid: 'uid-b' },
+        carol: { uid: 'uid-c' },
+      },
+    },
+  });
+}
+
+async function startFour() {
+  const shared = initialDb();
+  const sessions = [
+    client(shared, { uid: tokenState.DM_UID, playerId: 'dm', isDm: true }),
+    client(shared, { uid: 'uid-a', playerId: 'alice' }),
+    client(shared, { uid: 'uid-b', playerId: 'bob' }),
+    client(shared, { uid: 'uid-c', playerId: 'carol' }),
+  ];
+  sessions.forEach((session) => session.bridge.start());
+  await flush();
+  return { shared, sessions, dm: sessions[0], alice: sessions[1], bob: sessions[2], carol: sessions[3] };
+}
+
+test.describe('VTT shared multiclient Realtime field', () => {
+  test('DM + 3 players converge to exactly one canonical token per player', async () => {
+    const { sessions } = await startFour();
+    for (const session of sessions) {
+      expect(playerKeys(session)).toEqual(['alice', 'bob', 'carol']);
+      expect(new Set(playerKeys(session)).size).toBe(3);
+      expect(session.mapData.tokens.filter((token) => token.id === 'npc-1')).toHaveLength(1);
+    }
+    expect(sessions[0].mapData.tokens.some((token) => token.characterLink?.mode === 'current_player')).toBe(false);
+    for (const session of sessions.slice(1)) {
+      expect(session.mapData.tokens.filter((token) => token.viewer === true)).toHaveLength(1);
+      expect(playerToken(session, session.playerId)?.characterLink?.mode).toBe('current_player');
+    }
+    sessions.forEach((session) => session.bridge.stop());
+  });
+
+  test('three simultaneous player moves converge without cross-player overwrite', async () => {
+    const { sessions, dm, alice, bob, carol, shared } = await startFour();
+    const targets = {
+      alice: { x: 140, y: 210, zLayer: 0, elevationFt: 0, gridPosition: { col: 2, row: 3, z: 0 } },
+      bob: { x: 420, y: 350, zLayer: 1, elevationFt: 15, gridPosition: { col: 6, row: 5, z: 1 } },
+      carol: { x: 630, y: 560, zLayer: 2, elevationFt: 30, gridPosition: { col: 9, row: 8, z: 2 } },
+    };
+    for (const session of [alice, bob, carol]) Object.assign(playerToken(session, session.playerId), targets[session.playerId]);
+    const beforeWrites = shared.writes.length;
+    await Promise.all([alice, bob, carol].map((session) => session.bridge.saveToken(playerToken(session, session.playerId))));
+    await flush();
+
+    expect(shared.writes.length - beforeWrites).toBe(3);
+    for (const observer of sessions) {
+      for (const [id, target] of Object.entries(targets)) {
+        expect(playerToken(observer, id)).toMatchObject({ x: target.x, y: target.y, zLayer: target.zLayer, elevationFt: target.elevationFt, gridPosition: target.gridPosition });
+      }
+    }
+    expect(playerToken(dm, 'bob').zLayer).toBe(1);
+    sessions.forEach((session) => session.bridge.stop());
+  });
+
+  test('ownership still rejects moving another player while DM authority remains valid', async () => {
+    const { sessions, dm, alice } = await startFour();
+    await expect(alice.bridge.saveToken(playerToken(alice, 'bob'))).rejects.toThrow('PLAYER_TOKEN_OWNERSHIP_REQUIRED');
+    const bobFromDm = playerToken(dm, 'bob');
+    bobFromDm.x = 777;
+    await expect(dm.bridge.saveToken(bobFromDm)).resolves.toMatchObject({ valid: true, scope: 'player', key: 'bob' });
+    await flush();
+    expect(playerToken(alice, 'bob').x).toBe(777);
+    sessions.forEach((session) => session.bridge.stop());
+  });
+
+  test('disconnect removes listeners; reconnect restores latest X/Y/Z once without duplicate tokens', async () => {
+    const { sessions, shared, alice, bob, carol } = await startFour();
+    expect(shared.listenerCount()).toBe(24);
+    bob.bridge.stop();
+    expect(shared.listenerCount()).toBe(18);
+
+    const aliceToken = playerToken(alice, 'alice');
+    Object.assign(aliceToken, { x: 980, y: 1050, zLayer: 2, elevationFt: 30, gridPosition: { col: 14, row: 15, z: 2 } });
+    await alice.bridge.saveToken(aliceToken);
+    const carolToken = playerToken(carol, 'carol');
+    Object.assign(carolToken, { x: 350, y: 490, zLayer: 1, elevationFt: 15, gridPosition: { col: 5, row: 7, z: 1 } });
+    await carol.bridge.saveToken(carolToken);
+    await flush();
+
+    const reconnectedBob = client(shared, { uid: 'uid-b', playerId: 'bob' });
+    reconnectedBob.bridge.start();
+    await flush();
+    expect(shared.listenerCount()).toBe(24);
+    expect(playerKeys(reconnectedBob)).toEqual(['alice', 'bob', 'carol']);
+    expect(new Set(playerKeys(reconnectedBob)).size).toBe(3);
+    expect(playerToken(reconnectedBob, 'alice')).toMatchObject({ x: 980, y: 1050, zLayer: 2, elevationFt: 30 });
+    expect(playerToken(reconnectedBob, 'carol')).toMatchObject({ x: 350, y: 490, zLayer: 1, elevationFt: 15 });
+    expect(reconnectedBob.mapData.tokens.filter((token) => token.viewer === true)).toHaveLength(1);
+
+    sessions.filter((session) => session !== bob).forEach((session) => session.bridge.stop());
+    reconnectedBob.bridge.stop();
+    expect(shared.listenerCount()).toBe(0);
+  });
+
+  test('map token state is isolated by mapId and alpha movement cannot leak into beta', async () => {
+    const { sessions, shared, alice } = await startFour();
+    const betaAlice = client(shared, { uid: 'uid-a', playerId: 'alice', mapId: 'beta' });
+    betaAlice.bridge.start();
+    await flush();
+    expect(playerKeys(betaAlice)).toEqual(['alice']);
+    const betaBefore = clone(playerToken(betaAlice, 'alice'));
+
+    const alphaAlice = playerToken(alice, 'alice');
+    Object.assign(alphaAlice, { x: 1330, y: 1260, zLayer: 1, elevationFt: 15, gridPosition: { col: 19, row: 18, z: 1 } });
+    await alice.bridge.saveToken(alphaAlice);
+    await flush();
+
+    expect(playerToken(betaAlice, 'alice')).toMatchObject({ x: betaBefore.x, y: betaBefore.y, zLayer: betaBefore.zLayer });
+    expect(getAt(shared.data, 'campaña/jugadores/alice/vttTokenState/alpha/position/x')).toBe(1330);
+    expect(getAt(shared.data, 'campaña/jugadores/alice/vttTokenState/beta/position/x')).toBe(betaBefore.x);
+    sessions.forEach((session) => session.bridge.stop());
+    betaAlice.bridge.stop();
+  });
+
+  test('Fog memory remains player-private through independent capture and reconnect normalization', () => {
+    const aliceIdentity = { worldId: 'limbus', regionId: 'D', zoneId: 'market' };
+    const bobIdentity = { worldId: 'limbus', regionId: 'D', zoneId: 'market' };
+    let aliceFog = Discovery.blank(aliceIdentity, 100);
+    let bobFog = Discovery.blank(bobIdentity, 100);
+    aliceFog = Discovery.capture(aliceFog, { identity: aliceIdentity, zLayer: 0, chunkCol: 0, chunkRow: 0, worldNow: 110, cells: [{ worldCol: 2, worldRow: 3 }] }).record;
+    bobFog = Discovery.capture(bobFog, { identity: bobIdentity, zLayer: 0, chunkCol: 1, chunkRow: 0, worldNow: 120, cells: [{ worldCol: 45, worldRow: 6 }] }).record;
+
+    const restoredAlice = Discovery.normalize(clone(aliceFog), aliceIdentity);
+    const restoredBob = Discovery.normalize(clone(bobFog), bobIdentity);
+    expect(Discovery.slice(restoredAlice, { zLayer: 0, chunkCol: 0, chunkRow: 0 }).cells).toEqual([{ col: 2, row: 3 }]);
+    expect(Discovery.slice(restoredAlice, { zLayer: 0, chunkCol: 1, chunkRow: 0 }).cells).toEqual([]);
+    expect(Discovery.slice(restoredBob, { zLayer: 0, chunkCol: 1, chunkRow: 0 }).cells).toEqual([{ col: 5, row: 6 }]);
+  });
+
+  test('player movement Realtime is incremental and never subscribes to the whole players tree as value', () => {
+    const source = read('js/vtt/token-state.js');
+    expect(source).not.toContain("subscribe(playersRootRef(), 'value'");
+    expect(source).toContain("subscribe(playersRootRef(), 'child_added'");
+    expect(source).toContain("subscribe(playersRootRef(), 'child_removed'");
+    expect(source).toContain("ref.on('value', handler)");
+    expect(source).toContain('playerStateSubscriptions');
+
+    const engine = read('js/vtt/engine.js');
+    const moveStart = engine.indexOf('handleTokenMouseMove(event)');
+    const upStart = engine.indexOf('handleTokenMouseUp(event)');
+    const centerStart = engine.indexOf('    centerCamera() {', upStart);
+    expect(engine.slice(moveStart, upStart)).not.toContain("'vtt:token-moved'");
+    expect((engine.slice(upStart, centerStart).match(/'vtt:token-moved'/g) || [])).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a real shared-state multiclient field contract for the VTT and reduces player-token Realtime fanout.

### Player token Realtime
- Stops subscribing every VTT client to the full `campaña/jugadores` tree with `value`.
- Uses `child_added` / `child_removed` only to discover active campaign player records.
- Subscribes each discovered player directly to `vttTokenState/<mapId>`, so a movement delivers the small canonical token record instead of reprocessing the entire players tree.
- Cleans nested player subscriptions on disconnect/teardown.
- Preserves existing canonical ownership, DM authority, map isolation and current-player template semantics.

### Multiclient field tests
Runs DM + 3 players against one shared Realtime database harness and verifies:
- exactly one canonical token per player on every client;
- simultaneous independent moves converge without cross-player overwrite;
- players cannot persist another player's token while DM authority remains valid;
- disconnect releases listeners and reconnect restores latest X/Y/Z without duplicates;
- map IDs remain isolated;
- Fog memory remains player-private across reconnect normalization;
- movement persistence remains drop/mouseup-bound instead of pointermove-bound.

### CI
Adds a dedicated multiclient gate with canonical token state, discovery/Fog, field sandbox/hardening, regional-local transition, drag, performance and Map/Theatre lifecycle contracts, followed by full repository regression.

Merge only when the focused multiclient gate and repository regression are green.