### PR TITLE
test(vtt): preserve local Zone across Theatre view switches

### DIFF
--- a/.github/workflows/vtt-zone-theatre-location-invariant.yml
+++ b/.github/workflows/vtt-zone-theatre-location-invariant.yml
@@ -1,0 +1,56 @@
+name: VTT Zone Theatre Location Invariant
+
+on:
+  pull_request:
+    paths:
+      - 'js/instance-control.js'
+      - 'js/vtt/dm-map-lazy-loader.js'
+      - 'js/vtt/regional-local-transition-runtime.js'
+      - 'js/regional-local-transition-core.js'
+      - 'tests/vtt_zone_theatre_location_invariant.spec.js'
+      - 'tests/vtt_map_theatre_lifecycle.spec.js'
+      - 'tests/regional_local_transition.spec.js'
+      - 'tests/regional_local_transition_realtime.spec.js'
+      - '.github/workflows/vtt-zone-theatre-location-invariant.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'js/instance-control.js'
+      - 'js/vtt/dm-map-lazy-loader.js'
+      - 'js/vtt/regional-local-transition-runtime.js'
+      - 'js/regional-local-transition-core.js'
+      - 'tests/vtt_zone_theatre_location_invariant.spec.js'
+      - '.github/workflows/vtt-zone-theatre-location-invariant.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  zone-theatre-location-invariant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Syntax
+        run: node --check tests/vtt_zone_theatre_location_invariant.spec.js
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Zone Theatre location contracts
+        run: >-
+          npx playwright test --workers=1
+          tests/vtt_zone_theatre_location_invariant.spec.js
+          tests/vtt_map_theatre_lifecycle.spec.js
+          tests/regional_local_transition.spec.js
+          tests/regional_local_transition_realtime.spec.js
+          tests/vtt_dm_zone_persistence.spec.js
+          tests/vtt_physical_state_persistence.spec.js
+          tests/vtt_persistent_fog_memory.spec.js
+      - name: Full repository regression
+        run: npx playwright test --workers=1

--- a/tests/vtt_zone_theatre_location_invariant.spec.js
+++ b/tests/vtt_zone_theatre_location_invariant.spec.js
@@ -1,0 +1,180 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const Transition = require('../js/regional-local-transition-core.js');
+const lazyLoader = require('../js/vtt/dm-map-lazy-loader.js');
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+function loadInstanceControl() {
+  const context = { window: {}, console, setTimeout, clearTimeout };
+  vm.runInNewContext(read('js/instance-control.js'), context, { filename: 'js/instance-control.js' });
+  return context.window.LuminousInstanceControl;
+}
+
+const instanceControl = loadInstanceControl();
+
+function fakeClassList(initial = []) {
+  const values = new Set(initial);
+  return {
+    add(...names) { names.forEach((name) => values.add(name)); },
+    remove(...names) { names.forEach((name) => values.delete(name)); },
+    contains(name) { return values.has(name); },
+  };
+}
+
+function fakeModule(id, active = false) {
+  return {
+    id,
+    style: {},
+    classList: fakeClassList(active ? ['game-module', 'active-module'] : ['game-module', 'hidden']),
+  };
+}
+
+function createDmDocument() {
+  const standby = fakeModule('modulo-standby');
+  const theatre = fakeModule('modulo-teatro');
+  const map = fakeModule('modulo-mapa');
+  const combat = fakeModule('modulo-combate');
+  const attrs = new Map();
+  const frame = {
+    dataset: { vttSrc: 'vtt.html' },
+    contentWindow: {},
+    getAttribute(name) { return attrs.get(name) || null; },
+    setAttribute(name, value) { attrs.set(name, String(value)); },
+    removeAttribute(name) { attrs.delete(name); },
+  };
+  map.querySelector = (selector) => selector === 'iframe[data-vtt-src]' ? frame : null;
+  const nodes = new Map([
+    [standby.id, standby], [theatre.id, theatre], [map.id, map], [combat.id, combat],
+  ]);
+  return {
+    frame,
+    map,
+    theatre,
+    querySelector() { return null; },
+    querySelectorAll(selector) { return selector === '.game-module' ? [standby, theatre, map, combat] : []; },
+    getElementById(id) { return nodes.get(id) || null; },
+  };
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function seededZoneState() {
+  return {
+    worldPosition: {
+      worldId: 'luminous',
+      regionId: 'K',
+      zoneId: 'k_villa_interior',
+      chunkCol: 1,
+      chunkRow: 2,
+      x: 1771,
+      y: 931,
+      zLayer: 2,
+      elevationFt: 15,
+      regionalHex: { district: 'K', q: 4, r: -2 },
+      regionalGraphId: 'k_graph',
+      regionalGraphRevision: 7,
+      regionalGraphFingerprint: 'abc123',
+      transitionId: 'entered_villa',
+    },
+    vttTokenState: {
+      villa_map: { x: 1771, y: 931, zLayer: 2, elevationFt: 15, updatedAt: 101 },
+    },
+    fog: {
+      villa_map: { explored: ['1:2:10:13', '1:2:11:13'], updatedAt: 102 },
+    },
+    zoneDelta: {
+      openDoors: ['villa_front_door'],
+      removedNpcIds: ['guard_2'],
+    },
+  };
+}
+
+test.describe('Zone ↔ Theatre physical-location invariant', () => {
+  test('DM switching MAPA -> TEATRO -> MAPA preserves the same canonical Zone state and creates no regional transition', () => {
+    const doc = createDmDocument();
+    const canonical = seededZoneState();
+    const before = clone(canonical);
+    const regionalTransitionRequests = [];
+    let disposeCalls = 0;
+
+    instanceControl.applyDashboardInstance('mapa', doc);
+    expect(lazyLoader.sync(doc)).toBe(true);
+    expect(doc.frame.getAttribute('src')).toBe('vtt.html');
+
+    doc.frame.contentWindow = {
+      LuminousVttRuntime: {
+        dispose(reason) {
+          expect(reason).toBe('dm-map-deactivated');
+          disposeCalls += 1;
+          return true;
+        },
+      },
+    };
+
+    instanceControl.applyDashboardInstance('teatro', doc);
+    expect(lazyLoader.sync(doc)).toBe(true);
+    expect(doc.frame.getAttribute('src')).toBeNull();
+    expect(doc.theatre.classList.contains('active-module')).toBe(true);
+
+    // Theatre is a presentation mode. It must not move the party, collapse the
+    // local Zone into its parent regional hex, or enqueue a physical exit.
+    expect(canonical).toEqual(before);
+    expect(canonical.worldPosition.zoneId).toBe('k_villa_interior');
+    expect(canonical.worldPosition.regionalHex).toEqual({ district: 'K', q: 4, r: -2 });
+    expect(canonical.worldPosition.zLayer).toBe(2);
+    expect(canonical.worldPosition.elevationFt).toBe(15);
+    expect(canonical.fog.villa_map.explored).toEqual(before.fog.villa_map.explored);
+    expect(canonical.zoneDelta).toEqual(before.zoneDelta);
+    expect(regionalTransitionRequests).toHaveLength(0);
+
+    instanceControl.applyDashboardInstance('mapa', doc);
+    expect(lazyLoader.sync(doc)).toBe(true);
+    expect(doc.frame.getAttribute('src')).toBe('vtt.html');
+    expect(canonical).toEqual(before);
+    expect(disposeCalls).toBe(1);
+  });
+
+  test('view-mode code has no authority to write worldPosition or submit a regional exit', () => {
+    const instanceSource = read('js/instance-control.js');
+    const lazySource = read('js/vtt/dm-map-lazy-loader.js');
+    const transitionRuntime = read('js/vtt/regional-local-transition-runtime.js');
+
+    expect(instanceSource).not.toContain('vtt_regional_local_transition_requests');
+    expect(instanceSource).not.toContain('/worldPosition');
+    expect(lazySource).not.toContain('vtt_regional_local_transition_requests');
+    expect(lazySource).not.toContain('/worldPosition');
+
+    expect(transitionRuntime).toContain("window.addEventListener('mouseup',captureBoundary,true)");
+    expect(transitionRuntime).toContain('submitBoundaryRequest({token,position,transition,requested})');
+    expect(transitionRuntime).not.toContain('modulo-teatro');
+    expect(transitionRuntime).not.toContain("'teatro'");
+    expect(transitionRuntime).not.toContain('instancia_activa');
+  });
+
+  test('only an explicit physical Zone exit changes the regional destination', () => {
+    const source = seededZoneState().worldPosition;
+    const plan = Transition.createLocalExitPlan({
+      worldPosition: source,
+      exitSide: 'east',
+      transitionId: 'explicit_zone_exit',
+    });
+
+    expect(plan.valid).toBe(true);
+    expect(plan.sourceHex).toEqual({ district: 'K', q: 4, r: -2 });
+    expect(plan.targetHex).toEqual({ district: 'K', q: 5, r: -2 });
+    expect(plan.targetPosition.zoneId).toBe('regional_5_-2');
+    expect(plan.targetPosition.transitionId).toBe('explicit_zone_exit');
+    expect(plan.targetPosition.zLayer).toBe(2);
+    expect(plan.targetPosition.elevationFt).toBe(15);
+
+    // Planning an exit is pure: until the authoritative transition is committed,
+    // the current Zone remains the canonical physical truth.
+    expect(source.zoneId).toBe('k_villa_interior');
+    expect(source.regionalHex).toEqual({ district: 'K', q: 4, r: -2 });
+  });
+});


### PR DESCRIPTION
## Summary
Locks the physical-location contract for Map ↔ Theatre.

### Contract
- Theatre is a presentation/view mode, not physical travel.
- Switching MAPA → TEATRO must preserve the current local Zone, parent regional hex, chunk, X/Y/Z/elevation, Fog, and Zone deltas.
- Switching TEATRO → MAPA must return to the same Zone rather than implicitly returning to the Regional Map.
- Only an explicit physical Zone boundary exit may create a Regional ↔ Local transition.

### Tests
Adds a dedicated invariant test that verifies:
- DM MAPA → TEATRO → MAPA preserves seeded Zone state unchanged;
- no regional transition request is created by a view switch;
- instance/lazy-loader code has no worldPosition/transition authority;
- the regional transition runtime remains mouseup-boundary-driven;
- an explicit Zone exit still produces the adjacent regional destination while leaving the source state pure until authoritative commit.

### CI
Runs the new invariant with existing Map/Theatre lifecycle, Regional↔Local, Zone persistence, physical persistence, Fog memory, and the full Playwright regression.

Merge only if the focused gate and full repository regression are green.