### PR TITLE
VTT: realtime movement hardening

### DIFF
--- a/.github/workflows/vtt-multiclient-realtime-field.yml
+++ b/.github/workflows/vtt-multiclient-realtime-field.yml
@@ -9,10 +9,16 @@ on:
       - 'js/vtt/player-discovery-runtime.js'
       - 'js/vtt/regional-local-transition-runtime.js'
       - 'js/vtt/engine.js'
+      - 'js/vtt/movement-bootstrap.js'
+      - 'js/vtt/movement-realtime.js'
       - 'tests/vtt_multiclient_realtime_field.spec.js'
+      - 'tests/vtt_movement_realtime.spec.js'
+      - 'tests/vtt_movement_pathfinding.spec.js'
       - 'tests/vtt_canonical_token_state.spec.js'
       - 'tests/vtt_player_discovery_realtime.spec.js'
       - 'tests/vtt_player_discovery_fog.spec.js'
+      - 'tests/vtt_camera_pov_observer_realtime.spec.js'
+      - 'tests/vtt_world_token_multiclient_stress.spec.js'
       - 'tests/vtt_map_field_test_sandbox.spec.js'
       - 'tests/vtt_map_field_test_hardening.spec.js'
       - 'tests/regional_local_transition_realtime.spec.js'
@@ -24,7 +30,10 @@ on:
     branches: [main]
     paths:
       - 'js/vtt/token-state.js'
+      - 'js/vtt/movement-bootstrap.js'
+      - 'js/vtt/movement-realtime.js'
       - 'tests/vtt_multiclient_realtime_field.spec.js'
+      - 'tests/vtt_movement_realtime.spec.js'
       - '.github/workflows/vtt-multiclient-realtime-field.yml'
 
 permissions:
@@ -46,16 +55,22 @@ jobs:
       - name: Syntax
         run: |
           node --check js/vtt/token-state.js
+          node --check js/vtt/movement-realtime.js
           node --check tests/vtt_multiclient_realtime_field.spec.js
+          node --check tests/vtt_movement_realtime.spec.js
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
-      - name: Multiclient Realtime ownership Fog transition and performance contracts
+      - name: Multiclient movement realtime ownership Fog transition and performance contracts
         run: >-
           npx playwright test --workers=1
+          tests/vtt_movement_realtime.spec.js
+          tests/vtt_movement_pathfinding.spec.js
           tests/vtt_multiclient_realtime_field.spec.js
           tests/vtt_canonical_token_state.spec.js
           tests/vtt_player_discovery_realtime.spec.js
           tests/vtt_player_discovery_fog.spec.js
+          tests/vtt_camera_pov_observer_realtime.spec.js
+          tests/vtt_world_token_multiclient_stress.spec.js
           tests/vtt_map_field_test_sandbox.spec.js
           tests/vtt_map_field_test_hardening.spec.js
           tests/regional_local_transition_realtime.spec.js

--- a/js/vtt/movement-bootstrap.js
+++ b/js/vtt/movement-bootstrap.js
@@ -1,3 +1,5 @@
+import './movement-realtime.js';
+
 export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.engine?.mapData } = {}) {
   if (!runtime?.engine || !mapData) return null;
   const movement = window.LuminousVttMovementEngine;
@@ -10,6 +12,16 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   const camera = engine.camera;
   const canvas = engine.canvas;
   const isDm = Boolean(runtime.bridge?.isDm);
+  const movementRealtimeApi = window.LuminousVttMovementRealtime;
+  const movementRealtimeIdentity = movementRealtimeApi?.identity?.(window) || {};
+  const movementRealtime = movementRealtimeApi?.createController?.({
+    mapData,
+    canvas,
+    engine,
+    isDm,
+    root: window,
+  }) || null;
+  const realtimeCommits = new Map();
   mapData.movement ||= {};
   if (!mapData.movement.diagonalRule) mapData.movement.diagonalRule = '5e';
   if (mapData.movement.blockTokens == null) mapData.movement.blockTokens = true;
@@ -177,6 +189,72 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     ctx.restore();
   }
 
+  function realtimeKey(token) {
+    return movementRealtimeApi?.logicalTokenKey?.(token, movementRealtimeIdentity) || String(token?.id || '');
+  }
+
+  function realtimePosition(token) {
+    return movementRealtimeApi?.snapshotPosition?.(token) || {
+      x: Number(token?.x) || 0,
+      y: Number(token?.y) || 0,
+      zLayer: Number(token?.zLayer ?? token?.gridPosition?.z ?? token?.z?.[0]) || 0,
+    };
+  }
+
+  function sameRealtimePosition(a = {}, b = {}) {
+    return Math.abs((Number(a.x) || 0) - (Number(b.x) || 0)) < 0.01
+      && Math.abs((Number(a.y) || 0) - (Number(b.y) || 0)) < 0.01
+      && Number(a.zLayer ?? a.z?.[0] ?? 0) === Number(b.zLayer ?? b.z?.[0] ?? 0);
+  }
+
+  function settleRealtimeCommit(key, error = null) {
+    const pendingCommit = realtimeCommits.get(key);
+    if (!pendingCommit) return false;
+    realtimeCommits.delete(key);
+    clearTimeout(pendingCommit.timeoutId);
+    if (error) pendingCommit.reject(error);
+    else pendingCommit.resolve({ valid: true, source: 'canonical-sync' });
+    return true;
+  }
+
+  function onRealtimeTokenMoved(event) {
+    const token = (mapData.tokens || []).find((entry) => String(entry.id) === String(event.detail?.tokenId));
+    if (!token || !movementRealtime?.previewRefForToken?.(token)) return;
+    const key = realtimeKey(token);
+    if (!key) return;
+    settleRealtimeCommit(key, new Error('REALTIME_MOVEMENT_SUPERSEDED'));
+    let resolveCanonical;
+    let rejectCanonical;
+    const canonicalPromise = new Promise((resolve, reject) => {
+      resolveCanonical = resolve;
+      rejectCanonical = reject;
+    });
+    const pendingCommit = {
+      token,
+      expected: realtimePosition(token),
+      resolve: resolveCanonical,
+      reject: rejectCanonical,
+      timeoutId: setTimeout(() => {
+        if (realtimeCommits.get(key) !== pendingCommit) return;
+        realtimeCommits.delete(key);
+        rejectCanonical(new Error('REALTIME_CANONICAL_TIMEOUT'));
+      }, 2500),
+    };
+    realtimeCommits.set(key, pendingCommit);
+    void movementRealtime.finalizeToken(token, () => canonicalPromise).catch((error) => {
+      settleRealtimeCommit(key);
+      console.warn('VTT realtime movement finalization failed:', error);
+    });
+  }
+
+  function onRealtimeCanonicalSync() {
+    for (const [key, pendingCommit] of [...realtimeCommits.entries()]) {
+      const token = (mapData.tokens || []).find((entry) => realtimeKey(entry) === key);
+      if (!token || !sameRealtimePosition(realtimePosition(token), pendingCommit.expected)) continue;
+      settleRealtimeCommit(key);
+    }
+  }
+
   const previousRender = renderer.render.bind(renderer);
   renderer.render = function movementRender(...args) {
     previousRender(...args);
@@ -193,16 +271,20 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
 
   window.addEventListener('mousemove', onMouseMove);
   window.addEventListener('mouseup', onMouseUp);
+  canvas.addEventListener('vtt:token-moved', onRealtimeTokenMoved, true);
+  canvas.addEventListener('vtt:canonical-tokens-synced', onRealtimeCanonicalSync);
   canvas.addEventListener('vtt:token-moved', onTokenMoved);
 
   injectUi();
   stateBridge.start();
+  movementRealtime?.start?.();
   applyWorldState(stateBridge.current());
 
   const api = Object.freeze({
     engine: movement,
     pathfinding,
     stateBridge,
+    realtime: movementRealtime,
     worldState,
     nextRound: () => stateBridge.nextRound(),
     setMode: (mode) => stateBridge.setMode(mode),
@@ -213,9 +295,13 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     plan: (options) => movement.planMove({ ...options, mapData, worldState: worldState() }),
     stop() {
       clearTimeout(noticeTimer);
+      for (const key of [...realtimeCommits.keys()]) settleRealtimeCommit(key, new Error('REALTIME_RUNTIME_STOPPED'));
+      movementRealtime?.stop?.();
       stateBridge.stop();
       window.removeEventListener('mousemove', onMouseMove);
       window.removeEventListener('mouseup', onMouseUp);
+      canvas.removeEventListener('vtt:token-moved', onRealtimeTokenMoved, true);
+      canvas.removeEventListener('vtt:canonical-tokens-synced', onRealtimeCanonicalSync);
       canvas.removeEventListener('vtt:token-moved', onTokenMoved);
       renderer.render = previousRender;
       document.getElementById('vtt-world-time-status')?.remove();

--- a/js/vtt/movement-realtime.js
+++ b/js/vtt/movement-realtime.js
@@ -1,0 +1,554 @@
+(function (root, factory) {
+  const api = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttMovementRealtime = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (root) {
+  'use strict';
+
+  const PLAYER_ROOT = 'campaña/jugadores';
+  const WORLD_PREVIEW_ROOT = 'campaña/estado_mundo/vttMovementPreview';
+  const DEFAULT_THROTTLE_MS = 90;
+  const DEFAULT_PREVIEW_TTL_MS = 1800;
+
+  const clean = (value) => String(value ?? '').trim();
+  const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+  function firebaseKey(value, fallback = 'token') {
+    return clean(value).replace(/[.#$\[\]\/]/g, '_') || fallback;
+  }
+
+  function hostWindow(host = root) {
+    if (!host) return null;
+    try {
+      if (host.parent && host.parent !== host && host.parent.document) return host.parent;
+    } catch (_) {}
+    return host;
+  }
+
+  function hostFirebase(host = root) {
+    const resolved = hostWindow(host);
+    return resolved?.firebase || host?.firebase || null;
+  }
+
+  function identity(host = root) {
+    const resolved = hostWindow(host);
+    const data = resolved?.datosJugador || {};
+    let uid = '';
+    try { uid = clean(hostFirebase(host)?.auth?.().currentUser?.uid); } catch (_) {}
+    let playerId = '';
+    try { playerId = clean(resolved?.localStorage?.getItem?.('playerId') || data.playerId || data.id); } catch (_) {
+      playerId = clean(data.playerId || data.id);
+    }
+    return { uid, playerId };
+  }
+
+  function tokenLayer(token = {}) {
+    if (Number.isFinite(Number(token.zLayer))) return Number(token.zLayer);
+    if (Number.isFinite(Number(token.gridPosition?.z))) return Number(token.gridPosition.z);
+    if (Array.isArray(token.z) && token.z.length) return Number(token.z[0]) || 0;
+    return 0;
+  }
+
+  function playerKeyForToken(token = {}, current = {}) {
+    return clean(token.canonicalPlayerKey || token.playerId || (token.characterLink?.mode === 'current_player' ? current.playerId : ''));
+  }
+
+  function isPlayerToken(token = {}, current = {}) {
+    if (token.canonicalScope === 'world') return false;
+    return token.canonicalScope === 'player'
+      || Boolean(playerKeyForToken(token, current))
+      || token.characterLink?.mode === 'current_player'
+      || token.characterLink?.mode === 'player';
+  }
+
+  function logicalTokenKey(token = {}, current = {}) {
+    if (isPlayerToken(token, current)) {
+      const playerKey = playerKeyForToken(token, current);
+      return playerKey ? `player:${firebaseKey(playerKey, 'player')}` : '';
+    }
+    const tokenId = clean(token.id);
+    return tokenId ? `world:${firebaseKey(tokenId)}` : '';
+  }
+
+  function snapshotPosition(token = {}) {
+    return {
+      x: finite(token.x),
+      y: finite(token.y),
+      zLayer: tokenLayer(token),
+      elevationFt: finite(token.elevationFt),
+      gridPosition: clone(token.gridPosition || null),
+      z: Array.isArray(token.z) ? clone(token.z) : [tokenLayer(token)],
+    };
+  }
+
+  function restorePosition(token, position = {}) {
+    if (!token || !position) return token;
+    if (Number.isFinite(Number(position.x))) token.x = Number(position.x);
+    if (Number.isFinite(Number(position.y))) token.y = Number(position.y);
+    const zLayer = Number.isFinite(Number(position.zLayer)) ? Number(position.zLayer) : tokenLayer(token);
+    token.zLayer = zLayer;
+    token.z = Array.isArray(position.z) ? clone(position.z) : [zLayer];
+    if (Number.isFinite(Number(position.elevationFt))) token.elevationFt = Number(position.elevationFt);
+    if (position.gridPosition) token.gridPosition = clone(position.gridPosition);
+    return token;
+  }
+
+  function previewFromToken(token = {}, meta = {}) {
+    const current = meta.current || {};
+    const playerKey = playerKeyForToken(token, current);
+    return {
+      schemaVersion: 1,
+      scope: isPlayerToken(token, current) ? 'player' : 'world',
+      tokenId: clean(token.id) || null,
+      playerKey: playerKey || null,
+      x: finite(token.x),
+      y: finite(token.y),
+      zLayer: tokenLayer(token),
+      elevationFt: finite(token.elevationFt),
+      sequence: Math.max(0, Math.trunc(finite(meta.sequence))),
+      committed: Boolean(meta.committed),
+      sessionId: clean(meta.sessionId) || null,
+      updatedByUid: clean(current.uid) || null,
+      sentAtMs: Math.max(0, Math.trunc(finite(meta.sentAtMs))),
+      expiresAtMs: Math.max(0, Math.trunc(finite(meta.expiresAtMs))),
+      updatedAt: meta.updatedAt ?? null,
+    };
+  }
+
+  function applyPreview(token, preview = {}) {
+    if (!token || !preview || preview.committed === false && preview.cancelled === true) return token;
+    if (Number.isFinite(Number(preview.x))) token.x = Number(preview.x);
+    if (Number.isFinite(Number(preview.y))) token.y = Number(preview.y);
+    if (Number.isFinite(Number(preview.zLayer))) {
+      token.zLayer = Number(preview.zLayer);
+      token.z = [Number(preview.zLayer)];
+    }
+    if (Number.isFinite(Number(preview.elevationFt))) token.elevationFt = Number(preview.elevationFt);
+    return token;
+  }
+
+  function createController(options = {}) {
+    const host = options.root || root;
+    const mapData = options.mapData || options.engine?.mapData || {};
+    const canvas = options.canvas || options.engine?.canvas || null;
+    const engine = options.engine || null;
+    const firebase = options.firebase || hostFirebase(host);
+    const db = options.db || firebase?.database?.() || null;
+    const current = options.identity || identity(host);
+    const isDm = Boolean(options.isDm);
+    const mapId = firebaseKey(mapData.id || mapData.mapId || 'default', 'default');
+    const throttleMs = Math.max(40, finite(options.throttleMs, DEFAULT_THROTTLE_MS));
+    const previewTtlMs = Math.max(throttleMs * 3, finite(options.previewTtlMs, DEFAULT_PREVIEW_TTL_MS));
+    const now = typeof options.now === 'function' ? options.now : () => Date.now();
+    const setTimeoutFn = typeof options.setTimeoutFn === 'function' ? options.setTimeoutFn : (fn, ms) => setTimeout(fn, ms);
+    const clearTimeoutFn = typeof options.clearTimeoutFn === 'function' ? options.clearTimeoutFn : (id) => clearTimeout(id);
+    const sessionId = clean(options.sessionId) || `${clean(current.uid) || 'anon'}:${Math.trunc(now()).toString(36)}:${Math.random().toString(36).slice(2, 8)}`;
+
+    const pending = new Map();
+    const queues = new Map();
+    const playerSubscriptions = new Map();
+    const rootSubscriptions = [];
+    const canonicalPositions = new Map();
+    const activeRemotePreviews = new Map();
+    const expiryTimers = new Map();
+    let sequence = 0;
+    let started = false;
+    let stopped = false;
+    let writes = 0;
+    let received = 0;
+    let droppedStale = 0;
+
+    const worldPreviewRoot = () => db?.ref(`${WORLD_PREVIEW_ROOT}/${mapId}`);
+    const playerPreviewRef = (playerKey) => db?.ref(`${PLAYER_ROOT}/${firebaseKey(playerKey, 'player')}/vttMovementPreview/${mapId}`);
+    const worldPreviewRef = (tokenId) => worldPreviewRoot()?.child?.(firebaseKey(tokenId));
+
+    function tokenForPreview(preview = {}, explicitPlayerKey = '') {
+      const tokens = Array.isArray(mapData.tokens) ? mapData.tokens : [];
+      const playerKey = clean(preview.playerKey || explicitPlayerKey);
+      if (playerKey) {
+        const byPlayer = tokens.find((token) => clean(token.canonicalPlayerKey || token.playerId) === playerKey);
+        if (byPlayer) return byPlayer;
+        if (playerKey === clean(current.playerId)) {
+          const own = tokens.find((token) => token.characterLink?.mode === 'current_player' || token.viewer === true);
+          if (own) return own;
+        }
+      }
+      const tokenId = clean(preview.tokenId);
+      if (tokenId) return tokens.find((token) => clean(token.id) === tokenId) || null;
+      return null;
+    }
+
+    function cacheCanonical(token) {
+      const key = logicalTokenKey(token, current);
+      if (!key) return;
+      canonicalPositions.set(key, snapshotPosition(token));
+    }
+
+    function restoreCanonical(token) {
+      const key = logicalTokenKey(token, current);
+      const position = key ? canonicalPositions.get(key) : null;
+      if (position) restorePosition(token, position);
+    }
+
+    function dispatchPreview(token, preview, detail = {}) {
+      const EventCtor = host?.CustomEvent || root?.CustomEvent || globalThis.CustomEvent;
+      if (!canvas || typeof canvas.dispatchEvent !== 'function' || typeof EventCtor !== 'function' || !token) return;
+      canvas.dispatchEvent(new EventCtor('vtt:token-preview-moved', {
+        detail: {
+          tokenId: token.id,
+          x: token.x,
+          y: token.y,
+          z: tokenLayer(token),
+          remote: true,
+          scope: preview?.scope || null,
+          playerKey: preview?.playerKey || null,
+          sequence: preview?.sequence ?? null,
+          ...detail,
+        },
+      }));
+    }
+
+    function clearExpiry(key) {
+      const timer = expiryTimers.get(key);
+      if (timer != null) clearTimeoutFn(timer);
+      expiryTimers.delete(key);
+    }
+
+    function expirePreview(key) {
+      const active = activeRemotePreviews.get(key);
+      if (!active) return;
+      if (active.preview?.committed) {
+        activeRemotePreviews.delete(key);
+        clearExpiry(key);
+        return;
+      }
+      restoreCanonical(active.token);
+      activeRemotePreviews.delete(key);
+      clearExpiry(key);
+      dispatchPreview(active.token, active.preview, { expired: true, reverted: true });
+    }
+
+    function armExpiry(key, preview, token) {
+      clearExpiry(key);
+      if (preview.committed) return;
+      const expiresAt = Math.max(now() + throttleMs, finite(preview.expiresAtMs, now() + previewTtlMs));
+      const delay = Math.max(throttleMs, expiresAt - now());
+      expiryTimers.set(key, setTimeoutFn(() => expirePreview(key), delay));
+    }
+
+    function clearIncoming(previousPreview = {}, explicitPlayerKey = '') {
+      const playerKey = clean(explicitPlayerKey || previousPreview?.playerKey);
+      const key = playerKey
+        ? `player:${firebaseKey(playerKey, 'player')}`
+        : `world:${firebaseKey(previousPreview?.tokenId || 'token')}`;
+      const active = activeRemotePreviews.get(key);
+      if (!active) return;
+      clearExpiry(key);
+      activeRemotePreviews.delete(key);
+      if (!active.preview?.committed) {
+        restoreCanonical(active.token);
+        dispatchPreview(active.token, active.preview, { reverted: true, cleared: true });
+      }
+    }
+
+    function handleIncoming(preview, explicitPlayerKey = '') {
+      if (!preview || typeof preview !== 'object') {
+        clearIncoming({}, explicitPlayerKey);
+        return;
+      }
+      const playerKey = clean(explicitPlayerKey || preview.playerKey);
+      const scope = playerKey ? 'player' : clean(preview.scope) || 'world';
+      const key = playerKey ? `player:${firebaseKey(playerKey, 'player')}` : `world:${firebaseKey(preview.tokenId || 'token')}`;
+
+      const expiresAt = finite(preview.expiresAtMs, 0);
+      if (!preview.committed && expiresAt > 0 && expiresAt <= now()) {
+        droppedStale += 1;
+        return;
+      }
+      const normalized = { ...preview, scope, playerKey: playerKey || preview.playerKey || null };
+      const token = tokenForPreview(normalized, playerKey);
+      if (!token) {
+        activeRemotePreviews.set(key, { token: null, preview: normalized });
+        return;
+      }
+
+      received += 1;
+      if (normalized.sessionId === sessionId && engine?.tokenDrag?.token === token) return;
+      if (!canonicalPositions.has(key)) cacheCanonical(token);
+      applyPreview(token, normalized);
+      activeRemotePreviews.set(key, { token, preview: normalized });
+      armExpiry(key, normalized, token);
+      dispatchPreview(token, normalized, { committed: Boolean(normalized.committed) });
+    }
+
+    function subscribe(ref, event, handler) {
+      if (!ref?.on) return () => {};
+      ref.on(event, handler);
+      const off = () => ref.off?.(event, handler);
+      rootSubscriptions.push(off);
+      return off;
+    }
+
+    function subscribePlayer(playerKey) {
+      const key = clean(playerKey);
+      if (!db || !key || playerSubscriptions.has(key)) return false;
+      const ref = playerPreviewRef(key);
+      if (!ref?.on) return false;
+      const handler = (snapshot) => handleIncoming(snapshot?.val?.() || null, key);
+      ref.on('value', handler);
+      playerSubscriptions.set(key, () => ref.off?.('value', handler));
+      return true;
+    }
+
+    function reconcilePlayerSubscriptions() {
+      const wanted = new Set();
+      for (const token of (mapData.tokens || [])) {
+        if (!isPlayerToken(token, current)) continue;
+        const key = playerKeyForToken(token, current);
+        if (key) wanted.add(key);
+      }
+      if (current.playerId) wanted.add(clean(current.playerId));
+      for (const key of wanted) subscribePlayer(key);
+      for (const [key, off] of [...playerSubscriptions.entries()]) {
+        if (wanted.has(key)) continue;
+        off();
+        playerSubscriptions.delete(key);
+      }
+    }
+
+    function cacheCanonicalPositions() {
+      for (const token of (mapData.tokens || [])) {
+        const key = logicalTokenKey(token, current);
+        if (!key) continue;
+        canonicalPositions.set(key, snapshotPosition(token));
+      }
+      for (const [key, active] of activeRemotePreviews.entries()) {
+        const token = active.token || tokenForPreview(active.preview, active.preview?.playerKey || '');
+        if (!token) continue;
+        active.token = token;
+        applyPreview(token, active.preview);
+        dispatchPreview(token, active.preview, { canonicalRefresh: true });
+        activeRemotePreviews.set(key, active);
+      }
+    }
+
+    function previewRefForToken(token) {
+      if (!db || !token) return null;
+      if (isPlayerToken(token, current)) {
+        const playerKey = playerKeyForToken(token, current);
+        if (!playerKey) return null;
+        const ownerUid = clean(token.canonicalOwnerUid || token.ownerUid);
+        if (!isDm && playerKey !== clean(current.playerId) && (!ownerUid || ownerUid !== clean(current.uid))) return null;
+        return { ref: playerPreviewRef(playerKey), scope: 'player', playerKey };
+      }
+      if (!isDm) return null;
+      const tokenId = clean(token.id);
+      if (!tokenId) return null;
+      return { ref: worldPreviewRef(tokenId), scope: 'world', playerKey: '' };
+    }
+
+    function enqueue(pathKey, action) {
+      const prior = queues.get(pathKey) || Promise.resolve();
+      const next = prior.catch(() => {}).then(action);
+      let tracked = null;
+      tracked = next.finally(() => {
+        if (queues.get(pathKey) === tracked) queues.delete(pathKey);
+      });
+      queues.set(pathKey, tracked);
+      return tracked;
+    }
+
+    function writePayload(token, { committed = false } = {}) {
+      const target = previewRefForToken(token);
+      if (!target?.ref?.set) return Promise.resolve({ valid: false, reason: 'PREVIEW_WRITE_UNAVAILABLE' });
+      const sentAtMs = Math.max(0, Math.trunc(now()));
+      const serverTimestamp = firebase?.database?.ServerValue?.TIMESTAMP ?? null;
+      const payload = previewFromToken(token, {
+        current,
+        sequence: ++sequence,
+        committed,
+        sessionId,
+        sentAtMs,
+        expiresAtMs: committed ? 0 : sentAtMs + previewTtlMs,
+        updatedAt: serverTimestamp,
+      });
+      const pathKey = `${target.scope}:${target.playerKey || clean(token.id)}`;
+      return enqueue(pathKey, async () => {
+        await target.ref.set(payload);
+        writes += 1;
+        return { valid: true, payload };
+      });
+    }
+
+    function clearPayload(token) {
+      const target = previewRefForToken(token);
+      if (!target?.ref?.set) return Promise.resolve({ valid: false, reason: 'PREVIEW_WRITE_UNAVAILABLE' });
+      const pathKey = `${target.scope}:${target.playerKey || clean(token.id)}`;
+      return enqueue(pathKey, async () => {
+        await target.ref.set(null);
+        writes += 1;
+        return { valid: true };
+      });
+    }
+
+    function cancelPending(token) {
+      const key = logicalTokenKey(token, current);
+      if (!key) return;
+      const state = pending.get(key);
+      if (state?.timer != null) clearTimeoutFn(state.timer);
+      pending.delete(key);
+    }
+
+    function sendNow(token) {
+      const key = logicalTokenKey(token, current);
+      if (!key) return Promise.resolve({ valid: false, reason: 'TOKEN_KEY_REQUIRED' });
+      const state = pending.get(key) || { lastSentAt: -Infinity, timer: null, token };
+      if (state.timer != null) clearTimeoutFn(state.timer);
+      state.timer = null;
+      state.lastSentAt = now();
+      state.token = token;
+      pending.set(key, state);
+      return writePayload(token);
+    }
+
+    function schedulePreview(token) {
+      const key = logicalTokenKey(token, current);
+      if (!key || !previewRefForToken(token)) return;
+      const state = pending.get(key) || { lastSentAt: -Infinity, timer: null, token };
+      state.token = token;
+      const elapsed = now() - finite(state.lastSentAt, -Infinity);
+      if (elapsed >= throttleMs && state.timer == null) {
+        pending.set(key, state);
+        void sendNow(token).catch((error) => console.error('VTT realtime movement preview failed:', error));
+        return;
+      }
+      if (state.timer == null) {
+        const delay = Math.max(0, throttleMs - Math.max(0, elapsed));
+        state.timer = setTimeoutFn(() => {
+          const latest = pending.get(key);
+          if (!latest) return;
+          latest.timer = null;
+          void sendNow(latest.token).catch((error) => console.error('VTT realtime movement preview failed:', error));
+        }, delay);
+      }
+      pending.set(key, state);
+    }
+
+    function handleLocalPreview(event) {
+      if (stopped || event?.detail?.remote) return;
+      const tokenId = clean(event?.detail?.tokenId);
+      const token = (mapData.tokens || []).find((entry) => clean(entry.id) === tokenId);
+      if (!token) return;
+      if (event?.detail?.reverted) {
+        cancelPending(token);
+        void clearPayload(token).catch((error) => console.error('VTT realtime movement rollback failed:', error));
+        return;
+      }
+      schedulePreview(token);
+    }
+
+    function handleCanonicalSync() {
+      if (stopped) return;
+      reconcilePlayerSubscriptions();
+      cacheCanonicalPositions();
+    }
+
+    async function finalizeToken(token, saveCanonical) {
+      if (!token || typeof saveCanonical !== 'function') throw new Error('MOVEMENT_FINALIZER_REQUIRED');
+      cancelPending(token);
+      const previewTarget = previewRefForToken(token);
+      if (!previewTarget) return saveCanonical();
+      await writePayload(token);
+      try {
+        const result = await saveCanonical();
+        cacheCanonical(token);
+        await writePayload(token, { committed: true });
+        await clearPayload(token);
+        return result;
+      } catch (error) {
+        await clearPayload(token).catch(() => {});
+        throw error;
+      }
+    }
+
+    function start() {
+      if (started || stopped) return snapshot();
+      started = true;
+      cacheCanonicalPositions();
+      reconcilePlayerSubscriptions();
+      if (worldPreviewRoot()?.on) {
+        subscribe(worldPreviewRoot(), 'child_added', (snapshot) => handleIncoming(snapshot?.val?.() || null));
+        subscribe(worldPreviewRoot(), 'child_changed', (snapshot) => handleIncoming(snapshot?.val?.() || null));
+        subscribe(worldPreviewRoot(), 'child_removed', (snapshot) => clearIncoming(snapshot?.val?.() || { tokenId: snapshot?.key || null }));
+      }
+      canvas?.addEventListener?.('vtt:token-preview-moved', handleLocalPreview);
+      canvas?.addEventListener?.('vtt:canonical-tokens-synced', handleCanonicalSync);
+      Promise.resolve().then(reconcilePlayerSubscriptions);
+      return snapshot();
+    }
+
+    function stop() {
+      if (stopped) return;
+      stopped = true;
+      for (const state of pending.values()) if (state?.timer != null) clearTimeoutFn(state.timer);
+      pending.clear();
+      for (const timer of expiryTimers.values()) clearTimeoutFn(timer);
+      expiryTimers.clear();
+      for (const off of rootSubscriptions.splice(0)) off();
+      for (const off of playerSubscriptions.values()) off();
+      playerSubscriptions.clear();
+      canvas?.removeEventListener?.('vtt:token-preview-moved', handleLocalPreview);
+      canvas?.removeEventListener?.('vtt:canonical-tokens-synced', handleCanonicalSync);
+    }
+
+    function snapshot() {
+      return Object.freeze({
+        started,
+        stopped,
+        mapId,
+        isDm,
+        throttleMs,
+        previewTtlMs,
+        sessionId,
+        writes,
+        received,
+        droppedStale,
+        pending: pending.size,
+        playerSubscriptions: playerSubscriptions.size,
+        activeRemotePreviews: activeRemotePreviews.size,
+      });
+    }
+
+    return Object.freeze({
+      start,
+      stop,
+      snapshot,
+      finalizeToken,
+      schedulePreview,
+      handleIncoming,
+      clearIncoming,
+      handleCanonicalSync,
+      reconcilePlayerSubscriptions,
+      previewRefForToken,
+    });
+  }
+
+  return Object.freeze({
+    PLAYER_ROOT,
+    WORLD_PREVIEW_ROOT,
+    DEFAULT_THROTTLE_MS,
+    DEFAULT_PREVIEW_TTL_MS,
+    firebaseKey,
+    identity,
+    tokenLayer,
+    playerKeyForToken,
+    isPlayerToken,
+    logicalTokenKey,
+    snapshotPosition,
+    restorePosition,
+    previewFromToken,
+    applyPreview,
+    createController,
+  });
+});

--- a/tests/vtt_movement_realtime.spec.js
+++ b/tests/vtt_movement_realtime.spec.js
@@ -1,0 +1,321 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const movementRealtime = require('../js/vtt/movement-realtime.js');
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+const splitPath = (value = '') => String(value || '').split('/').filter(Boolean);
+
+function getAt(root, pathValue) {
+  let cursor = root;
+  for (const key of splitPath(pathValue)) {
+    if (cursor == null || typeof cursor !== 'object') return null;
+    cursor = cursor[key];
+  }
+  return cursor == null ? null : clone(cursor);
+}
+
+function setAt(root, pathValue, value) {
+  const parts = splitPath(pathValue);
+  let cursor = root;
+  for (let index = 0; index < parts.length - 1; index += 1) {
+    cursor[parts[index]] ||= {};
+    cursor = cursor[parts[index]];
+  }
+  const last = parts.at(-1);
+  if (value == null) delete cursor[last];
+  else cursor[last] = clone(value);
+}
+
+class SharedRealtimeDb {
+  constructor() {
+    this.data = {};
+    this.listeners = new Map();
+    this.writes = [];
+  }
+
+  listenerKey(pathValue, event) { return `${pathValue}|${event}`; }
+
+  snapshot(pathValue, keyOverride, valueOverride) {
+    const value = valueOverride === undefined ? getAt(this.data, pathValue) : clone(valueOverride);
+    return {
+      key: keyOverride ?? splitPath(pathValue).at(-1) ?? null,
+      val: () => clone(value),
+      exists: () => value != null,
+    };
+  }
+
+  on(pathValue, event, handler) {
+    const key = this.listenerKey(pathValue, event);
+    if (!this.listeners.has(key)) this.listeners.set(key, new Set());
+    this.listeners.get(key).add(handler);
+    if (event === 'value') handler(this.snapshot(pathValue));
+    if (event === 'child_added') {
+      const current = getAt(this.data, pathValue) || {};
+      for (const [childKey, value] of Object.entries(current)) {
+        handler(this.snapshot(`${pathValue}/${childKey}`, childKey, value));
+      }
+    }
+  }
+
+  off(pathValue, event, handler) {
+    this.listeners.get(this.listenerKey(pathValue, event))?.delete(handler);
+  }
+
+  emit(pathValue, before) {
+    const parentPath = splitPath(pathValue).slice(0, -1).join('/');
+    const childKey = splitPath(pathValue).at(-1);
+    const after = getAt(this.data, pathValue);
+    for (const [listenerKey, handlers] of this.listeners.entries()) {
+      const separator = listenerKey.lastIndexOf('|');
+      const listenerPath = listenerKey.slice(0, separator);
+      const event = listenerKey.slice(separator + 1);
+      if (event === 'value' && listenerPath === pathValue) {
+        for (const handler of [...handlers]) handler(this.snapshot(pathValue));
+        continue;
+      }
+      if (listenerPath !== parentPath) continue;
+      const added = event === 'child_added' && before == null && after != null;
+      const changed = event === 'child_changed' && before != null && after != null;
+      const removed = event === 'child_removed' && before != null && after == null;
+      if (!added && !changed && !removed) continue;
+      const payload = removed ? before : after;
+      for (const handler of [...handlers]) handler(this.snapshot(pathValue, childKey, payload));
+    }
+  }
+
+  async set(pathValue, value) {
+    const before = getAt(this.data, pathValue);
+    setAt(this.data, pathValue, value);
+    this.writes.push({ path: pathValue, value: clone(value) });
+    this.emit(pathValue, before);
+  }
+
+  ref(pathValue = '') {
+    const db = this;
+    const normalized = String(pathValue || '').replace(/^\/+|\/+$/g, '');
+    return {
+      child(childKey) { return db.ref(normalized ? `${normalized}/${childKey}` : childKey); },
+      on(event, handler) { db.on(normalized, event, handler); },
+      off(event, handler) { db.off(normalized, event, handler); },
+      set(value) { return db.set(normalized, value); },
+    };
+  }
+}
+
+class FakeCanvas {
+  constructor() { this.listeners = new Map(); }
+  addEventListener(name, handler) {
+    if (!this.listeners.has(name)) this.listeners.set(name, new Set());
+    this.listeners.get(name).add(handler);
+  }
+  removeEventListener(name, handler) { this.listeners.get(name)?.delete(handler); }
+  dispatchEvent(event) {
+    for (const handler of [...(this.listeners.get(event.type) || [])]) handler(event);
+    return true;
+  }
+}
+
+class FakeCustomEvent {
+  constructor(type, init = {}) { this.type = type; this.detail = init.detail || {}; }
+}
+
+function hostFor(db, uid, playerId) {
+  const database = () => db;
+  database.ServerValue = { TIMESTAMP: 777 };
+  return {
+    CustomEvent: FakeCustomEvent,
+    datosJugador: { playerId },
+    localStorage: { getItem: () => playerId },
+    firebase: { auth: () => ({ currentUser: { uid } }), database },
+  };
+}
+
+function fakeClock() {
+  let current = 0;
+  let nextId = 0;
+  let timers = [];
+  return {
+    now: () => current,
+    setTimeoutFn(fn, ms) {
+      const timer = { id: ++nextId, at: current + ms, fn };
+      timers.push(timer);
+      return timer.id;
+    },
+    clearTimeoutFn(id) { timers = timers.filter((timer) => timer.id !== id); },
+    async advance(ms) {
+      current += ms;
+      const due = timers.filter((timer) => timer.at <= current);
+      timers = timers.filter((timer) => timer.at > current);
+      for (const timer of due) timer.fn();
+      for (let index = 0; index < 8; index += 1) await Promise.resolve();
+    },
+  };
+}
+
+function playerToken(id, playerId, patch = {}) {
+  return {
+    id,
+    canonicalScope: 'player',
+    canonicalPlayerKey: playerId,
+    playerId,
+    x: 0,
+    y: 0,
+    zLayer: 0,
+    z: [0],
+    elevationFt: 0,
+    gridPosition: { col: 0, row: 0, z: 0 },
+    ...patch,
+  };
+}
+
+function worldToken(id, patch = {}) {
+  return {
+    id,
+    canonicalScope: 'world',
+    x: 0,
+    y: 0,
+    zLayer: 0,
+    z: [0],
+    elevationFt: 0,
+    gridPosition: { col: 0, row: 0, z: 0 },
+    ...patch,
+  };
+}
+
+const flush = async () => { for (let index = 0; index < 8; index += 1) await Promise.resolve(); };
+
+function controller({ db, mapData, canvas, uid, playerId, isDm, clock, sessionId, tokenDrag = null }) {
+  const engine = { mapData, canvas, tokenDrag };
+  return movementRealtime.createController({
+    mapData,
+    canvas,
+    engine,
+    isDm,
+    root: hostFor(db, uid, playerId),
+    sessionId,
+    throttleMs: 90,
+    previewTtlMs: 1800,
+    now: clock.now,
+    setTimeoutFn: clock.setTimeoutFn,
+    clearTimeoutFn: clock.clearTimeoutFn,
+  });
+}
+
+test('player drag streams to DM at <= ~12 Hz and final canonical commit clears preview safely', async () => {
+  const db = new SharedRealtimeDb();
+  const clock = fakeClock();
+  const playerCanvas = new FakeCanvas();
+  const dmCanvas = new FakeCanvas();
+  const own = playerToken('player-template', 'alice', { viewer: true, characterLink: { mode: 'current_player' } });
+  const observed = playerToken('player:alice', 'alice');
+  const playerMap = { id: 'alpha', tokens: [own] };
+  const dmMap = { id: 'alpha', tokens: [observed] };
+  const player = controller({ db, mapData: playerMap, canvas: playerCanvas, uid: 'uid-a', playerId: 'alice', isDm: false, clock, sessionId: 'player-session', tokenDrag: { token: own } });
+  const dm = controller({ db, mapData: dmMap, canvas: dmCanvas, uid: 'dm-uid', playerId: 'dm', isDm: true, clock, sessionId: 'dm-session' });
+  player.start();
+  dm.start();
+
+  for (let x = 1; x <= 120; x += 1) {
+    own.x = x;
+    playerCanvas.dispatchEvent(new FakeCustomEvent('vtt:token-preview-moved', { detail: { tokenId: own.id, x, y: 0 } }));
+  }
+  await flush();
+  expect(db.writes).toHaveLength(1);
+  expect(observed.x).toBe(1);
+
+  await clock.advance(90);
+  expect(db.writes).toHaveLength(2);
+  expect(observed.x).toBe(120);
+  expect(player.snapshot().throttleMs).toBe(90);
+
+  const canonicalSave = async () => {
+    observed.x = own.x;
+    dmCanvas.dispatchEvent(new FakeCustomEvent('vtt:canonical-tokens-synced', { detail: { scope: 'players' } }));
+    return { valid: true, scope: 'player', key: 'alice' };
+  };
+  await expect(player.finalizeToken(own, canonicalSave)).resolves.toMatchObject({ valid: true, scope: 'player' });
+  await flush();
+
+  expect(getAt(db.data, 'campaña/jugadores/alice/vttMovementPreview/alpha')).toBeNull();
+  expect(observed.x).toBe(120);
+  expect(db.writes).toHaveLength(5);
+  player.stop();
+  dm.stop();
+});
+
+test('DM can stream world-token movement while players cannot publish world-token previews', async () => {
+  const db = new SharedRealtimeDb();
+  const clock = fakeClock();
+  const dmCanvas = new FakeCanvas();
+  const playerCanvas = new FakeCanvas();
+  const dmNpc = worldToken('npc-1');
+  const playerNpc = worldToken('npc-1');
+  const dmMap = { id: 'alpha', tokens: [dmNpc] };
+  const playerMap = { id: 'alpha', tokens: [playerNpc] };
+  const dm = controller({ db, mapData: dmMap, canvas: dmCanvas, uid: 'dm-uid', playerId: 'dm', isDm: true, clock, sessionId: 'dm-session', tokenDrag: { token: dmNpc } });
+  const player = controller({ db, mapData: playerMap, canvas: playerCanvas, uid: 'uid-a', playerId: 'alice', isDm: false, clock, sessionId: 'player-session' });
+  dm.start();
+  player.start();
+
+  dmNpc.x = 350;
+  dmCanvas.dispatchEvent(new FakeCustomEvent('vtt:token-preview-moved', { detail: { tokenId: 'npc-1', x: 350, y: 0 } }));
+  await flush();
+  expect(playerNpc.x).toBe(350);
+  expect(db.writes[0].path).toBe('campaña/estado_mundo/vttMovementPreview/alpha/npc-1');
+
+  playerNpc.x = 700;
+  playerCanvas.dispatchEvent(new FakeCustomEvent('vtt:token-preview-moved', { detail: { tokenId: 'npc-1', x: 700, y: 0 } }));
+  await flush();
+  expect(db.writes).toHaveLength(1);
+  expect(player.previewRefForToken(playerNpc)).toBeNull();
+  dm.stop();
+  player.stop();
+});
+
+test('abandoned previews expire back to canonical position without polling', async () => {
+  const db = new SharedRealtimeDb();
+  const clock = fakeClock();
+  const dmCanvas = new FakeCanvas();
+  const observed = playerToken('player:alice', 'alice', { x: 35, y: 35 });
+  const dmMap = { id: 'alpha', tokens: [observed] };
+  const dm = controller({ db, mapData: dmMap, canvas: dmCanvas, uid: 'dm-uid', playerId: 'dm', isDm: true, clock, sessionId: 'dm-session' });
+  dm.start();
+
+  await db.set('campaña/jugadores/alice/vttMovementPreview/alpha', {
+    schemaVersion: 1,
+    scope: 'player',
+    tokenId: 'player-template',
+    playerKey: 'alice',
+    x: 420,
+    y: 350,
+    zLayer: 0,
+    elevationFt: 0,
+    sequence: 1,
+    committed: false,
+    sessionId: 'other-session',
+    sentAtMs: 0,
+    expiresAtMs: 1800,
+  });
+  expect(observed.x).toBe(420);
+  await clock.advance(1800);
+  expect(observed.x).toBe(35);
+  expect(observed.y).toBe(35);
+  dm.stop();
+});
+
+test('realtime movement stays event-driven, isolated from canonical records, and is wired into main lifecycle', () => {
+  const source = read('js/vtt/movement-realtime.js');
+  const main = read('js/vtt/main.js');
+  expect(source).toContain("const DEFAULT_THROTTLE_MS = 90");
+  expect(source).toContain("vttMovementPreview");
+  expect(source).toContain("vtt:token-preview-moved");
+  expect(source).toContain("vtt:canonical-tokens-synced");
+  expect(source).not.toContain('setInterval(');
+  expect(source).not.toContain('requestAnimationFrame(');
+  expect(main).toContain("import './movement-realtime.js'");
+  expect(main).toContain('movementRealtime?.start?.()');
+  expect(main).toContain('movementRealtime?.finalizeToken');
+  expect(main).toContain('movementRealtime?.stop?.()');
+});

--- a/tests/vtt_movement_realtime.spec.js
+++ b/tests/vtt_movement_realtime.spec.js
@@ -305,17 +305,19 @@ test('abandoned previews expire back to canonical position without polling', asy
   dm.stop();
 });
 
-test('realtime movement stays event-driven, isolated from canonical records, and is wired into main lifecycle', () => {
+test('realtime movement stays event-driven, isolated from canonical records, and is wired into movement lifecycle', () => {
   const source = read('js/vtt/movement-realtime.js');
-  const main = read('js/vtt/main.js');
+  const bootstrap = read('js/vtt/movement-bootstrap.js');
   expect(source).toContain("const DEFAULT_THROTTLE_MS = 90");
   expect(source).toContain("vttMovementPreview");
   expect(source).toContain("vtt:token-preview-moved");
   expect(source).toContain("vtt:canonical-tokens-synced");
   expect(source).not.toContain('setInterval(');
   expect(source).not.toContain('requestAnimationFrame(');
-  expect(main).toContain("import './movement-realtime.js'");
-  expect(main).toContain('movementRealtime?.start?.()');
-  expect(main).toContain('movementRealtime?.finalizeToken');
-  expect(main).toContain('movementRealtime?.stop?.()');
+  expect(bootstrap).toContain("import './movement-realtime.js'");
+  expect(bootstrap).toContain('movementRealtime?.start?.()');
+  expect(bootstrap).toContain('movementRealtime.finalizeToken');
+  expect(bootstrap).toContain("canvas.addEventListener('vtt:token-moved', onRealtimeTokenMoved, true)");
+  expect(bootstrap).toContain("canvas.addEventListener('vtt:canonical-tokens-synced', onRealtimeCanonicalSync)");
+  expect(bootstrap).toContain('movementRealtime?.stop?.()');
 });


### PR DESCRIPTION
Cierra el movimiento realtime sin convertir el drag en escrituras por frame.

Cambios principales:
- Preview realtime separado de la posición canónica.
- Jugador → DM y DM → jugadores durante drag, con throttle de 90 ms (~11 Hz).
- La posición canónica sigue confirmándose al soltar.
- Preview final se mantiene hasta observar la sincronización canónica y luego se limpia.
- Preview abandonado expira y revierte a la última posición canónica.
- Jugadores sólo publican su propia ficha; sólo DM publica previews de world tokens/NPCs.
- Reutiliza `vtt:token-preview-moved`, por lo que camera-follow/FOV reaccionan sin polling adicional.
- Tests nuevos de throttle, convergencia Player/DM, autoridad, TTL y lifecycle.

Criterio de merge: realtime, performance y regresiones/dependencias en verde.