### PR TITLE
VTT: close movement route and occupancy rules

### DIFF
--- a/.github/workflows/vtt-multiclient-realtime-field.yml
+++ b/.github/workflows/vtt-multiclient-realtime-field.yml
@@ -11,9 +11,12 @@ on:
       - 'js/vtt/engine.js'
       - 'js/vtt/movement-bootstrap.js'
       - 'js/vtt/movement-realtime.js'
+      - 'js/vtt/movement-rules.js'
+      - 'js/vtt/movement-rules-runtime.js'
       - 'tests/vtt_multiclient_realtime_field.spec.js'
       - 'tests/vtt_movement_realtime.spec.js'
       - 'tests/vtt_movement_pathfinding.spec.js'
+      - 'tests/vtt_movement_rules_closure.spec.js'
       - 'tests/vtt_canonical_token_state.spec.js'
       - 'tests/vtt_player_discovery_realtime.spec.js'
       - 'tests/vtt_player_discovery_fog.spec.js'
@@ -30,10 +33,14 @@ on:
     branches: [main]
     paths:
       - 'js/vtt/token-state.js'
+      - 'js/vtt/engine.js'
       - 'js/vtt/movement-bootstrap.js'
       - 'js/vtt/movement-realtime.js'
+      - 'js/vtt/movement-rules.js'
+      - 'js/vtt/movement-rules-runtime.js'
       - 'tests/vtt_multiclient_realtime_field.spec.js'
       - 'tests/vtt_movement_realtime.spec.js'
+      - 'tests/vtt_movement_rules_closure.spec.js'
       - '.github/workflows/vtt-multiclient-realtime-field.yml'
 
 permissions:
@@ -56,8 +63,11 @@ jobs:
         run: |
           node --check js/vtt/token-state.js
           node --check js/vtt/movement-realtime.js
+          node --check js/vtt/movement-rules.js
+          node --check js/vtt/movement-rules-runtime.js
           node --check tests/vtt_multiclient_realtime_field.spec.js
           node --check tests/vtt_movement_realtime.spec.js
+          node --check tests/vtt_movement_rules_closure.spec.js
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
       - name: Multiclient movement realtime ownership Fog transition and performance contracts
@@ -65,6 +75,7 @@ jobs:
           npx playwright test --workers=1
           tests/vtt_movement_realtime.spec.js
           tests/vtt_movement_pathfinding.spec.js
+          tests/vtt_movement_rules_closure.spec.js
           tests/vtt_multiclient_realtime_field.spec.js
           tests/vtt_canonical_token_state.spec.js
           tests/vtt_player_discovery_realtime.spec.js

--- a/.github/workflows/vtt-multiclient-realtime-field.yml
+++ b/.github/workflows/vtt-multiclient-realtime-field.yml
@@ -3,6 +3,7 @@ name: VTT Multiclient Realtime Field
 on:
   pull_request:
     paths:
+      - 'js/vtt/main.js'
       - 'js/vtt/token-state.js'
       - 'js/vtt/token-state-dynamic-patch.js'
       - 'js/vtt/player-discovery-core.js'
@@ -12,11 +13,14 @@ on:
       - 'js/vtt/movement-bootstrap.js'
       - 'js/vtt/movement-realtime.js'
       - 'js/vtt/movement-connectivity.js'
+      - 'js/vtt/movement-destination-claims.js'
+      - 'js/vtt/movement-door-runtime.js'
       - 'js/vtt/movement-rules.js'
       - 'js/vtt/movement-rules-runtime.js'
       - 'tests/vtt_multiclient_realtime_field.spec.js'
       - 'tests/vtt_movement_realtime.spec.js'
       - 'tests/vtt_movement_connectivity.spec.js'
+      - 'tests/vtt_movement_destination_claims.spec.js'
       - 'tests/vtt_movement_pathfinding.spec.js'
       - 'tests/vtt_movement_rules_closure.spec.js'
       - 'tests/vtt_canonical_token_state.spec.js'
@@ -34,16 +38,20 @@ on:
   push:
     branches: [main]
     paths:
+      - 'js/vtt/main.js'
       - 'js/vtt/token-state.js'
       - 'js/vtt/engine.js'
       - 'js/vtt/movement-bootstrap.js'
       - 'js/vtt/movement-realtime.js'
       - 'js/vtt/movement-connectivity.js'
+      - 'js/vtt/movement-destination-claims.js'
+      - 'js/vtt/movement-door-runtime.js'
       - 'js/vtt/movement-rules.js'
       - 'js/vtt/movement-rules-runtime.js'
       - 'tests/vtt_multiclient_realtime_field.spec.js'
       - 'tests/vtt_movement_realtime.spec.js'
       - 'tests/vtt_movement_connectivity.spec.js'
+      - 'tests/vtt_movement_destination_claims.spec.js'
       - 'tests/vtt_movement_rules_closure.spec.js'
       - '.github/workflows/vtt-multiclient-realtime-field.yml'
 
@@ -65,14 +73,18 @@ jobs:
         run: npm ci
       - name: Syntax
         run: |
+          node --check js/vtt/main.js
           node --check js/vtt/token-state.js
           node --check js/vtt/movement-realtime.js
           node --check js/vtt/movement-connectivity.js
+          node --check js/vtt/movement-destination-claims.js
+          node --check js/vtt/movement-door-runtime.js
           node --check js/vtt/movement-rules.js
           node --check js/vtt/movement-rules-runtime.js
           node --check tests/vtt_multiclient_realtime_field.spec.js
           node --check tests/vtt_movement_realtime.spec.js
           node --check tests/vtt_movement_connectivity.spec.js
+          node --check tests/vtt_movement_destination_claims.spec.js
           node --check tests/vtt_movement_rules_closure.spec.js
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
@@ -81,6 +93,7 @@ jobs:
           npx playwright test --workers=1
           tests/vtt_movement_realtime.spec.js
           tests/vtt_movement_connectivity.spec.js
+          tests/vtt_movement_destination_claims.spec.js
           tests/vtt_movement_pathfinding.spec.js
           tests/vtt_movement_rules_closure.spec.js
           tests/vtt_multiclient_realtime_field.spec.js

--- a/.github/workflows/vtt-multiclient-realtime-field.yml
+++ b/.github/workflows/vtt-multiclient-realtime-field.yml
@@ -11,10 +11,12 @@ on:
       - 'js/vtt/engine.js'
       - 'js/vtt/movement-bootstrap.js'
       - 'js/vtt/movement-realtime.js'
+      - 'js/vtt/movement-connectivity.js'
       - 'js/vtt/movement-rules.js'
       - 'js/vtt/movement-rules-runtime.js'
       - 'tests/vtt_multiclient_realtime_field.spec.js'
       - 'tests/vtt_movement_realtime.spec.js'
+      - 'tests/vtt_movement_connectivity.spec.js'
       - 'tests/vtt_movement_pathfinding.spec.js'
       - 'tests/vtt_movement_rules_closure.spec.js'
       - 'tests/vtt_canonical_token_state.spec.js'
@@ -36,10 +38,12 @@ on:
       - 'js/vtt/engine.js'
       - 'js/vtt/movement-bootstrap.js'
       - 'js/vtt/movement-realtime.js'
+      - 'js/vtt/movement-connectivity.js'
       - 'js/vtt/movement-rules.js'
       - 'js/vtt/movement-rules-runtime.js'
       - 'tests/vtt_multiclient_realtime_field.spec.js'
       - 'tests/vtt_movement_realtime.spec.js'
+      - 'tests/vtt_movement_connectivity.spec.js'
       - 'tests/vtt_movement_rules_closure.spec.js'
       - '.github/workflows/vtt-multiclient-realtime-field.yml'
 
@@ -63,10 +67,12 @@ jobs:
         run: |
           node --check js/vtt/token-state.js
           node --check js/vtt/movement-realtime.js
+          node --check js/vtt/movement-connectivity.js
           node --check js/vtt/movement-rules.js
           node --check js/vtt/movement-rules-runtime.js
           node --check tests/vtt_multiclient_realtime_field.spec.js
           node --check tests/vtt_movement_realtime.spec.js
+          node --check tests/vtt_movement_connectivity.spec.js
           node --check tests/vtt_movement_rules_closure.spec.js
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
@@ -74,6 +80,7 @@ jobs:
         run: >-
           npx playwright test --workers=1
           tests/vtt_movement_realtime.spec.js
+          tests/vtt_movement_connectivity.spec.js
           tests/vtt_movement_pathfinding.spec.js
           tests/vtt_movement_rules_closure.spec.js
           tests/vtt_multiclient_realtime_field.spec.js

--- a/js/vtt/engine.js
+++ b/js/vtt/engine.js
@@ -84,23 +84,14 @@ export class Engine {
         }
         const worldPoint = this.eventWorldPoint(event);
         const token = this.tokenDrag.token;
-        const target = {
-            x: worldPoint.x - this.tokenDrag.grabOffsetX,
-            y: worldPoint.y - this.tokenDrag.grabOffsetY,
-        };
+        const target = { x: worldPoint.x - this.tokenDrag.grabOffsetX, y: worldPoint.y - this.tokenDrag.grabOffsetY };
         this.canvas.style.cursor = 'grabbing';
-
         if (this.tokenMoveResolver) {
             this.canvas.dispatchEvent(new CustomEvent('vtt:movement-destination-preview', {
-                detail: {
-                    tokenId: token.id,
-                    from: { x: this.tokenDrag.originX, y: this.tokenDrag.originY, z: this.tokenDrag.originZ },
-                    target,
-                },
+                detail: { tokenId: token.id, from: { x: this.tokenDrag.originX, y: this.tokenDrag.originY, z: this.tokenDrag.originZ }, target },
             }));
             return;
         }
-
         token.x = target.x;
         token.y = target.y;
         this.canvas.dispatchEvent(new CustomEvent('vtt:token-preview-moved', {
@@ -119,7 +110,6 @@ export class Engine {
         const caf = globalThis.cancelAnimationFrame || clearTimeout;
         const motion = { cancelled: false, frameId: null, tokenId: token.id };
         this.tokenMotion = motion;
-
         const moveSegment = (from, to) => new Promise((resolve) => {
             const startAt = globalThis.performance?.now?.() ?? Date.now();
             const step = (nowValue) => {
@@ -129,21 +119,13 @@ export class Engine {
                 token.x = Number(from.x) + ((Number(to.x) - Number(from.x)) * t);
                 token.y = Number(from.y) + ((Number(to.y) - Number(from.y)) * t);
                 this.canvas.dispatchEvent(new CustomEvent('vtt:token-preview-moved', {
-                    detail: {
-                        tokenId: token.id,
-                        x: token.x,
-                        y: token.y,
-                        z: Number(token.zLayer ?? token.gridPosition?.z ?? token.z?.[0] ?? 0),
-                        traversing: true,
-                        actionMode: mode,
-                    },
+                    detail: { tokenId: token.id, x: token.x, y: token.y, z: Number(token.zLayer ?? token.gridPosition?.z ?? token.z?.[0] ?? 0), traversing: true, actionMode: mode },
                 }));
                 if (t >= 1) return resolve(true);
                 motion.frameId = raf(step);
             };
             motion.frameId = raf(step);
         });
-
         try {
             token.x = Number(points[0].x);
             token.y = Number(points[0].y);
@@ -162,6 +144,51 @@ export class Engine {
         if (!this.tokenMotion) return false;
         this.tokenMotion.cancelled = true;
         return true;
+    }
+
+    async handleTokenMouseUp(event) {
+        if (!this.tokenDrag || event.button !== 0) return;
+        const drag = this.tokenDrag;
+        const token = drag.token;
+        const worldPoint = this.eventWorldPoint(event);
+        const requestedPoint = { x: worldPoint.x - drag.grabOffsetX, y: worldPoint.y - drag.grabOffsetY };
+        this.tokenDrag = null;
+        if (this.tokenMoveResolver) {
+            let result = null;
+            try {
+                result = await this.tokenMoveResolver({ token, from: { x: drag.originX, y: drag.originY }, requestedPoint, drag, event });
+            } catch (error) {
+                result = { valid: false, reason: error?.message || 'MOVEMENT_RESOLVER_FAILED' };
+            }
+            if (result?.valid) {
+                const traversed = await this.animateTokenPath(token, result.path || [], { actionMode: result.actionMode });
+                if (traversed.valid) this.finalizeTokenMove(token, drag, result);
+            } else {
+                token.x = drag.originX;
+                token.y = drag.originY;
+                token.zLayer = drag.originZ;
+                token.z = [drag.originZ];
+                token.elevationFt = drag.originElevationFt;
+                this.canvas.dispatchEvent(new CustomEvent('vtt:movement-order-rejected', { detail: { tokenId: token.id, reason: result?.reason || 'NO_PATH', requestedPoint } }));
+            }
+            this.canvas.style.cursor = this.tokenAtEvent(event) ? 'grab' : 'default';
+            return;
+        }
+        const rules = this.tokenRules;
+        const result = rules?.resolveDrop?.(token, { x: drag.originX, y: drag.originY }, requestedPoint, this.mapData) || { valid: false, reason: 'TOKEN_RULES_UNAVAILABLE' };
+        if (result.valid) {
+            token.x = result.x;
+            token.y = result.y;
+            this.finalizeTokenMove(token, drag, result);
+        } else {
+            token.x = drag.originX;
+            token.y = drag.originY;
+            token.zLayer = drag.originZ;
+            token.z = [drag.originZ];
+            token.elevationFt = drag.originElevationFt;
+            this.canvas.dispatchEvent(new CustomEvent('vtt:token-preview-moved', { detail: { tokenId: token.id, x: token.x, y: token.y, z: drag.originZ, reverted: true } }));
+        }
+        this.canvas.style.cursor = this.tokenAtEvent(event) ? 'grab' : 'default';
     }
 
     finalizeTokenMove(token, drag, result = {}) {
@@ -192,53 +219,6 @@ export class Engine {
             },
         }));
         if (transition.valid) this.canvas.dispatchEvent(new CustomEvent('vtt:token-z-transition', { detail: { tokenId: token.id, ...transition } }));
-    }
-
-    async handleTokenMouseUp(event) {
-        if (!this.tokenDrag || event.button !== 0) return;
-        const drag = this.tokenDrag;
-        const token = drag.token;
-        const worldPoint = this.eventWorldPoint(event);
-        const requestedPoint = { x: worldPoint.x - drag.grabOffsetX, y: worldPoint.y - drag.grabOffsetY };
-        this.tokenDrag = null;
-
-        if (this.tokenMoveResolver) {
-            let result = null;
-            try {
-                result = await this.tokenMoveResolver({ token, from: { x: drag.originX, y: drag.originY }, requestedPoint, drag, event });
-            } catch (error) {
-                result = { valid: false, reason: error?.message || 'MOVEMENT_RESOLVER_FAILED' };
-            }
-            if (result?.valid) {
-                const traversed = await this.animateTokenPath(token, result.path || [], { actionMode: result.actionMode });
-                if (traversed.valid) this.finalizeTokenMove(token, drag, result);
-            } else {
-                token.x = drag.originX;
-                token.y = drag.originY;
-                token.zLayer = drag.originZ;
-                token.z = [drag.originZ];
-                token.elevationFt = drag.originElevationFt;
-                this.canvas.dispatchEvent(new CustomEvent('vtt:movement-order-rejected', { detail: { tokenId: token.id, reason: result?.reason || 'NO_PATH', requestedPoint } }));
-            }
-            this.canvas.style.cursor = this.tokenAtEvent(event) ? 'grab' : 'default';
-            return;
-        }
-
-        const rules = this.tokenRules;
-        const result = rules?.resolveDrop?.(token, { x: drag.originX, y: drag.originY }, requestedPoint, this.mapData) || { valid: false, reason: 'TOKEN_RULES_UNAVAILABLE' };
-        if (result.valid) {
-            token.x = result.x;
-            token.y = result.y;
-            this.finalizeTokenMove(token, drag, result);
-        } else {
-            token.x = drag.originX;
-            token.y = drag.originY;
-            token.zLayer = drag.originZ;
-            token.z = [drag.originZ];
-            token.elevationFt = drag.originElevationFt;
-            this.canvas.dispatchEvent(new CustomEvent('vtt:token-preview-moved', { detail: { tokenId: token.id, x: token.x, y: token.y, z: drag.originZ, reverted: true } }));
-        }
-        this.canvas.style.cursor = this.tokenAtEvent(event) ? 'grab' : 'default';
     }
 
     centerCamera() {

--- a/js/vtt/engine.js
+++ b/js/vtt/engine.js
@@ -14,6 +14,8 @@ export class Engine {
         this.isExporting = false;
         this.tokenDrag = null;
         this.tokenControlResolver = null;
+        this.tokenMoveResolver = null;
+        this.tokenMotion = null;
         this.handleResize = this.handleResize.bind(this);
         this.handleTokenMouseDown = this.handleTokenMouseDown.bind(this);
         this.handleTokenMouseMove = this.handleTokenMouseMove.bind(this);
@@ -29,6 +31,7 @@ export class Engine {
     get spatialVisionRules() { return globalThis.LuminousVttSpatialVision || null; }
     get verticalMovementRules() { return globalThis.LuminousVttVerticalMovement || null; }
     setTokenControlResolver(resolver) { this.tokenControlResolver = typeof resolver === 'function' ? resolver : null; }
+    setTokenMoveResolver(resolver) { this.tokenMoveResolver = typeof resolver === 'function' ? resolver : null; }
 
     init() {
         window.addEventListener('resize', this.handleResize);
@@ -57,7 +60,7 @@ export class Engine {
     }
 
     handleTokenMouseDown(event) {
-        if (event.button !== 0) return;
+        if (event.button !== 0 || this.tokenMotion) return;
         const token = this.tokenAtEvent(event);
         if (!token) return;
         const worldPoint = this.eventWorldPoint(event);
@@ -81,43 +84,152 @@ export class Engine {
         }
         const worldPoint = this.eventWorldPoint(event);
         const token = this.tokenDrag.token;
-        token.x = worldPoint.x - this.tokenDrag.grabOffsetX;
-        token.y = worldPoint.y - this.tokenDrag.grabOffsetY;
+        const target = {
+            x: worldPoint.x - this.tokenDrag.grabOffsetX,
+            y: worldPoint.y - this.tokenDrag.grabOffsetY,
+        };
         this.canvas.style.cursor = 'grabbing';
-        // LOCAL-ONLY preview. Persistence intentionally listens only to
-        // `vtt:token-moved`, which is emitted once after a valid mouseup.
+
+        if (this.tokenMoveResolver) {
+            this.canvas.dispatchEvent(new CustomEvent('vtt:movement-destination-preview', {
+                detail: {
+                    tokenId: token.id,
+                    from: { x: this.tokenDrag.originX, y: this.tokenDrag.originY, z: this.tokenDrag.originZ },
+                    target,
+                },
+            }));
+            return;
+        }
+
+        token.x = target.x;
+        token.y = target.y;
         this.canvas.dispatchEvent(new CustomEvent('vtt:token-preview-moved', {
             detail: { tokenId: token.id, x: token.x, y: token.y, z: Number(token.zLayer ?? token.gridPosition?.z ?? token.z?.[0] ?? 0) },
         }));
     }
 
-    handleTokenMouseUp(event) {
+    async animateTokenPath(token, path = [], options = {}) {
+        const points = Array.isArray(path) ? path.filter((point) => Number.isFinite(Number(point?.x)) && Number.isFinite(Number(point?.y))) : [];
+        if (!token || points.length < 2) return { valid: true, complete: true };
+        const movement = this.mapData.movement || {};
+        const mode = String(options.actionMode || token.activeActionMovementMode || 'walk').toLowerCase();
+        const defaultMs = mode === 'dash' || mode === 'run' ? 55 : 90;
+        const msPerCell = Math.max(20, Number(movement.animationMsPerCell) || defaultMs);
+        const raf = globalThis.requestAnimationFrame || ((fn) => setTimeout(() => fn(Date.now()), 16));
+        const caf = globalThis.cancelAnimationFrame || clearTimeout;
+        const motion = { cancelled: false, frameId: null, tokenId: token.id };
+        this.tokenMotion = motion;
+
+        const moveSegment = (from, to) => new Promise((resolve) => {
+            const startAt = globalThis.performance?.now?.() ?? Date.now();
+            const step = (nowValue) => {
+                if (motion.cancelled) return resolve(false);
+                const elapsed = Math.max(0, Number(nowValue) - startAt);
+                const t = Math.min(1, elapsed / msPerCell);
+                token.x = Number(from.x) + ((Number(to.x) - Number(from.x)) * t);
+                token.y = Number(from.y) + ((Number(to.y) - Number(from.y)) * t);
+                this.canvas.dispatchEvent(new CustomEvent('vtt:token-preview-moved', {
+                    detail: {
+                        tokenId: token.id,
+                        x: token.x,
+                        y: token.y,
+                        z: Number(token.zLayer ?? token.gridPosition?.z ?? token.z?.[0] ?? 0),
+                        traversing: true,
+                        actionMode: mode,
+                    },
+                }));
+                if (t >= 1) return resolve(true);
+                motion.frameId = raf(step);
+            };
+            motion.frameId = raf(step);
+        });
+
+        try {
+            token.x = Number(points[0].x);
+            token.y = Number(points[0].y);
+            for (let index = 1; index < points.length; index += 1) {
+                const complete = await moveSegment(points[index - 1], points[index]);
+                if (!complete) return { valid: false, reason: 'MOVEMENT_CANCELLED', complete: false };
+            }
+            return { valid: true, complete: true };
+        } finally {
+            if (motion.frameId != null && motion.cancelled) caf(motion.frameId);
+            if (this.tokenMotion === motion) this.tokenMotion = null;
+        }
+    }
+
+    cancelTokenMotion() {
+        if (!this.tokenMotion) return false;
+        this.tokenMotion.cancelled = true;
+        return true;
+    }
+
+    finalizeTokenMove(token, drag, result = {}) {
+        const endpoint = (Array.isArray(result.path) && result.path.length ? result.path[result.path.length - 1] : result);
+        token.x = Number(endpoint.x);
+        token.y = Number(endpoint.y);
+        const zLayer = this.spatialVisionRules?.layerOf?.(token) ?? token.z?.[0] ?? drag.originZ ?? 0;
+        token.zLayer = Number(zLayer) || 0;
+        token.z = [token.zLayer];
+        token.gridPosition = {
+            col: Number.isFinite(Number(endpoint.col)) ? Number(endpoint.col) : this.tokenRules?.snapPointToGrid?.(token, this.mapData.grid)?.col ?? token.gridPosition?.col ?? 0,
+            row: Number.isFinite(Number(endpoint.row)) ? Number(endpoint.row) : this.tokenRules?.snapPointToGrid?.(token, this.mapData.grid)?.row ?? token.gridPosition?.row ?? 0,
+            z: token.zLayer,
+        };
+        const transition = this.verticalMovementRules?.transitionOnDrop?.(token, { x: token.x, y: token.y }, this.mapData) || { valid: false, reason: 'NO_VERTICAL_TRANSITION' };
+        if (transition.valid && transition.complete && token.viewer === true) this.setZLayer(transition.targetZ);
+        this.canvas.dispatchEvent(new CustomEvent('vtt:token-moved', {
+            detail: {
+                tokenId: token.id,
+                from: { x: drag.originX, y: drag.originY, z: drag.originZ, elevationFt: drag.originElevationFt },
+                to: { x: token.x, y: token.y, ...token.gridPosition, elevationFt: token.elevationFt ?? 0, verticalMovement: token.verticalMovement || null },
+                path: Array.isArray(result.path) ? result.path : [],
+                routeCostFt: result.routeCostFt ?? result.costFt ?? null,
+                movementCostFt: result.movementCostFt ?? result.costFt ?? null,
+                movementMode: result.movementMode || result.mode || null,
+                actionMode: result.actionMode || null,
+                transition: transition.valid ? { routeId: transition.route?.id || null, complete: Boolean(transition.complete), targetZ: transition.targetZ, costSpentFt: transition.costSpentFt ?? null } : null,
+            },
+        }));
+        if (transition.valid) this.canvas.dispatchEvent(new CustomEvent('vtt:token-z-transition', { detail: { tokenId: token.id, ...transition } }));
+    }
+
+    async handleTokenMouseUp(event) {
         if (!this.tokenDrag || event.button !== 0) return;
         const drag = this.tokenDrag;
         const token = drag.token;
         const worldPoint = this.eventWorldPoint(event);
         const requestedPoint = { x: worldPoint.x - drag.grabOffsetX, y: worldPoint.y - drag.grabOffsetY };
+        this.tokenDrag = null;
+
+        if (this.tokenMoveResolver) {
+            let result = null;
+            try {
+                result = await this.tokenMoveResolver({ token, from: { x: drag.originX, y: drag.originY }, requestedPoint, drag, event });
+            } catch (error) {
+                result = { valid: false, reason: error?.message || 'MOVEMENT_RESOLVER_FAILED' };
+            }
+            if (result?.valid) {
+                const traversed = await this.animateTokenPath(token, result.path || [], { actionMode: result.actionMode });
+                if (traversed.valid) this.finalizeTokenMove(token, drag, result);
+            } else {
+                token.x = drag.originX;
+                token.y = drag.originY;
+                token.zLayer = drag.originZ;
+                token.z = [drag.originZ];
+                token.elevationFt = drag.originElevationFt;
+                this.canvas.dispatchEvent(new CustomEvent('vtt:movement-order-rejected', { detail: { tokenId: token.id, reason: result?.reason || 'NO_PATH', requestedPoint } }));
+            }
+            this.canvas.style.cursor = this.tokenAtEvent(event) ? 'grab' : 'default';
+            return;
+        }
+
         const rules = this.tokenRules;
         const result = rules?.resolveDrop?.(token, { x: drag.originX, y: drag.originY }, requestedPoint, this.mapData) || { valid: false, reason: 'TOKEN_RULES_UNAVAILABLE' };
-
         if (result.valid) {
             token.x = result.x;
             token.y = result.y;
-            const zLayer = this.spatialVisionRules?.layerOf?.(token) ?? token.z?.[0] ?? 0;
-            token.zLayer = zLayer;
-            token.z = [Number(zLayer)];
-            token.gridPosition = { col: result.col, row: result.row, z: zLayer };
-            const transition = this.verticalMovementRules?.transitionOnDrop?.(token, { x: token.x, y: token.y }, this.mapData) || { valid: false, reason: 'NO_VERTICAL_TRANSITION' };
-            if (transition.valid && transition.complete && token.viewer === true) this.setZLayer(transition.targetZ);
-            this.canvas.dispatchEvent(new CustomEvent('vtt:token-moved', {
-                detail: {
-                    tokenId: token.id,
-                    from: { x: drag.originX, y: drag.originY, z: drag.originZ, elevationFt: drag.originElevationFt },
-                    to: { x: token.x, y: token.y, ...token.gridPosition, elevationFt: token.elevationFt ?? 0, verticalMovement: token.verticalMovement || null },
-                    transition: transition.valid ? { routeId: transition.route?.id || null, complete: Boolean(transition.complete), targetZ: transition.targetZ, costSpentFt: transition.costSpentFt ?? null } : null,
-                },
-            }));
-            if (transition.valid) this.canvas.dispatchEvent(new CustomEvent('vtt:token-z-transition', { detail: { tokenId: token.id, ...transition } }));
+            this.finalizeTokenMove(token, drag, result);
         } else {
             token.x = drag.originX;
             token.y = drag.originY;
@@ -126,7 +238,6 @@ export class Engine {
             token.elevationFt = drag.originElevationFt;
             this.canvas.dispatchEvent(new CustomEvent('vtt:token-preview-moved', { detail: { tokenId: token.id, x: token.x, y: token.y, z: drag.originZ, reverted: true } }));
         }
-        this.tokenDrag = null;
         this.canvas.style.cursor = this.tokenAtEvent(event) ? 'grab' : 'default';
     }
 
@@ -138,7 +249,7 @@ export class Engine {
     }
     handleResize() { this.canvas.width = window.innerWidth; this.canvas.height = window.innerHeight; }
     start() { if (!this.isRunning) { this.isRunning = true; requestAnimationFrame(this.loop); } }
-    stop() { this.isRunning = false; }
+    stop() { this.cancelTokenMotion(); this.isRunning = false; }
     loop() {
         if (!this.isRunning) return;
         const renderData = this.calculateVision();

--- a/js/vtt/engine.js
+++ b/js/vtt/engine.js
@@ -15,6 +15,7 @@ export class Engine {
         this.tokenDrag = null;
         this.tokenControlResolver = null;
         this.tokenMoveResolver = null;
+        this.movementInteractionResolver = null;
         this.tokenMotion = null;
         this.handleResize = this.handleResize.bind(this);
         this.handleTokenMouseDown = this.handleTokenMouseDown.bind(this);
@@ -32,6 +33,7 @@ export class Engine {
     get verticalMovementRules() { return globalThis.LuminousVttVerticalMovement || null; }
     setTokenControlResolver(resolver) { this.tokenControlResolver = typeof resolver === 'function' ? resolver : null; }
     setTokenMoveResolver(resolver) { this.tokenMoveResolver = typeof resolver === 'function' ? resolver : null; }
+    setMovementInteractionResolver(resolver) { this.movementInteractionResolver = typeof resolver === 'function' ? resolver : null; }
 
     init() {
         window.addEventListener('resize', this.handleResize);
@@ -106,6 +108,7 @@ export class Engine {
         const mode = String(options.actionMode || token.activeActionMovementMode || 'walk').toLowerCase();
         const defaultMs = mode === 'dash' || mode === 'run' ? 55 : 90;
         const msPerCell = Math.max(20, Number(movement.animationMsPerCell) || defaultMs);
+        const gridSize = Math.max(1, Number(this.mapData.grid?.size) || 70);
         const doorInteractions = Array.isArray(options.doorInteractions) ? options.doorInteractions : [];
         const raf = globalThis.requestAnimationFrame || ((fn) => setTimeout(() => fn(Date.now()), 16));
         const caf = globalThis.cancelAnimationFrame || clearTimeout;
@@ -113,11 +116,13 @@ export class Engine {
         const motion = { cancelled: false, frameId: null, tokenId: token.id };
         this.tokenMotion = motion;
         const moveSegment = (from, to) => new Promise((resolve) => {
+            const distancePx = Math.hypot(Number(to.x) - Number(from.x), Number(to.y) - Number(from.y));
+            const durationMs = Math.max(8, msPerCell * (distancePx / gridSize));
             const startAt = globalThis.performance?.now?.() ?? Date.now();
             const step = (nowValue) => {
                 if (motion.cancelled) return resolve(false);
                 const elapsed = Math.max(0, Number(nowValue) - startAt);
-                const t = Math.min(1, elapsed / msPerCell);
+                const t = Math.min(1, elapsed / durationMs);
                 token.x = Number(from.x) + ((Number(to.x) - Number(from.x)) * t);
                 token.y = Number(from.y) + ((Number(to.y) - Number(from.y)) * t);
                 this.canvas.dispatchEvent(new CustomEvent('vtt:token-preview-moved', {
@@ -132,8 +137,35 @@ export class Engine {
             token.x = Number(points[0].x);
             token.y = Number(points[0].y);
             for (let index = 1; index < points.length; index += 1) {
-                const interactions = doorInteractions.filter((entry) => Number(entry.pathIndex) === index - 1);
+                const segmentEnd = points[index];
+                let segmentStart = points[index - 1];
+                const interactions = doorInteractions
+                    .filter((entry) => Number(entry.pathIndex) === index - 1)
+                    .sort((left, right) => {
+                        const leftDistance = Math.hypot(Number(left.at?.x ?? segmentStart.x) - Number(segmentStart.x), Number(left.at?.y ?? segmentStart.y) - Number(segmentStart.y));
+                        const rightDistance = Math.hypot(Number(right.at?.x ?? segmentStart.x) - Number(segmentStart.x), Number(right.at?.y ?? segmentStart.y) - Number(segmentStart.y));
+                        return leftDistance - rightDistance;
+                    });
                 for (const interaction of interactions) {
+                    const threshold = Number.isFinite(Number(interaction.at?.x)) && Number.isFinite(Number(interaction.at?.y))
+                        ? { x: Number(interaction.at.x), y: Number(interaction.at.y) }
+                        : { x: Number(segmentStart.x), y: Number(segmentStart.y) };
+                    if (Math.hypot(threshold.x - Number(segmentStart.x), threshold.y - Number(segmentStart.y)) > 0.01) {
+                        const reachedThreshold = await moveSegment(segmentStart, threshold);
+                        if (!reachedThreshold) return { valid: false, reason: 'MOVEMENT_CANCELLED', complete: false };
+                    }
+                    if (motion.cancelled) return { valid: false, reason: 'MOVEMENT_CANCELLED', complete: false };
+                    if (this.movementInteractionResolver) {
+                        let resolution = null;
+                        try {
+                            resolution = await this.movementInteractionResolver({ token, interaction, at: threshold, from: segmentStart, to: segmentEnd, actionMode: mode });
+                        } catch (error) {
+                            resolution = { valid: false, reason: error?.message || 'MOVEMENT_INTERACTION_FAILED' };
+                        }
+                        if (resolution === false || resolution?.valid === false) {
+                            return { valid: false, reason: resolution?.reason || 'MOVEMENT_INTERACTION_FAILED', complete: false, interaction };
+                        }
+                    }
                     this.canvas.dispatchEvent(new CustomEvent('vtt:movement-interaction', {
                         detail: { tokenId: token.id, x: token.x, y: token.y, actionMode: mode, ...interaction },
                     }));
@@ -153,8 +185,9 @@ export class Engine {
                     }
                     if (interaction.pauseMs) await pause(interaction.pauseMs);
                     if (motion.cancelled) return { valid: false, reason: 'MOVEMENT_CANCELLED', complete: false };
+                    segmentStart = threshold;
                 }
-                const complete = await moveSegment(points[index - 1], points[index]);
+                const complete = await moveSegment(segmentStart, segmentEnd);
                 if (!complete) return { valid: false, reason: 'MOVEMENT_CANCELLED', complete: false };
             }
             return { valid: true, complete: true };

--- a/js/vtt/engine.js
+++ b/js/vtt/engine.js
@@ -113,7 +113,7 @@ export class Engine {
         const raf = globalThis.requestAnimationFrame || ((fn) => setTimeout(() => fn(Date.now()), 16));
         const caf = globalThis.cancelAnimationFrame || clearTimeout;
         const pause = (ms) => new Promise((resolve) => setTimeout(resolve, Math.max(0, Number(ms) || 0)));
-        const motion = { cancelled: false, frameId: null, tokenId: token.id };
+        const motion = { cancelled: false, irreversible: false, frameId: null, tokenId: token.id };
         this.tokenMotion = motion;
         const moveSegment = (from, to) => new Promise((resolve) => {
             const distancePx = Math.hypot(Number(to.x) - Number(from.x), Number(to.y) - Number(from.y));
@@ -155,6 +155,7 @@ export class Engine {
                         if (!reachedThreshold) return { valid: false, reason: 'MOVEMENT_CANCELLED', complete: false };
                     }
                     if (motion.cancelled) return { valid: false, reason: 'MOVEMENT_CANCELLED', complete: false };
+                    let resolvedInteraction = interaction;
                     if (this.movementInteractionResolver) {
                         let resolution = null;
                         try {
@@ -165,32 +166,36 @@ export class Engine {
                         if (resolution === false || resolution?.valid === false) {
                             return { valid: false, reason: resolution?.reason || 'MOVEMENT_INTERACTION_FAILED', complete: false, interaction };
                         }
+                        if (resolution?.interaction && typeof resolution.interaction === 'object') {
+                            resolvedInteraction = { ...interaction, ...resolution.interaction };
+                        }
+                        if (resolution?.irreversible === true) motion.irreversible = true;
                     }
                     this.canvas.dispatchEvent(new CustomEvent('vtt:movement-interaction', {
-                        detail: { tokenId: token.id, x: token.x, y: token.y, actionMode: mode, ...interaction },
+                        detail: { tokenId: token.id, x: token.x, y: token.y, actionMode: mode, ...resolvedInteraction },
                     }));
-                    if (interaction.soundEvent) {
+                    if (resolvedInteraction.soundEvent) {
                         this.canvas.dispatchEvent(new CustomEvent('vtt:sound-event', {
                             detail: {
                                 kind: 'movement',
-                                event: interaction.soundEvent,
+                                event: resolvedInteraction.soundEvent,
                                 sourceTokenId: token.id,
-                                doorId: interaction.doorId || null,
-                                intensity: interaction.noise || 'high',
+                                doorId: resolvedInteraction.doorId || null,
+                                intensity: resolvedInteraction.noise || 'high',
                                 x: token.x,
                                 y: token.y,
                                 z: Number(token.zLayer ?? token.gridPosition?.z ?? token.z?.[0] ?? 0),
                             },
                         }));
                     }
-                    if (interaction.pauseMs) await pause(interaction.pauseMs);
+                    if (resolvedInteraction.pauseMs) await pause(resolvedInteraction.pauseMs);
                     if (motion.cancelled) return { valid: false, reason: 'MOVEMENT_CANCELLED', complete: false };
                     segmentStart = threshold;
                 }
                 const complete = await moveSegment(segmentStart, segmentEnd);
                 if (!complete) return { valid: false, reason: 'MOVEMENT_CANCELLED', complete: false };
             }
-            return { valid: true, complete: true };
+            return { valid: true, complete: true, irreversible: motion.irreversible };
         } finally {
             if (motion.frameId != null && motion.cancelled) caf(motion.frameId);
             if (this.tokenMotion === motion) this.tokenMotion = null;

--- a/js/vtt/engine.js
+++ b/js/vtt/engine.js
@@ -106,8 +106,10 @@ export class Engine {
         const mode = String(options.actionMode || token.activeActionMovementMode || 'walk').toLowerCase();
         const defaultMs = mode === 'dash' || mode === 'run' ? 55 : 90;
         const msPerCell = Math.max(20, Number(movement.animationMsPerCell) || defaultMs);
+        const doorInteractions = Array.isArray(options.doorInteractions) ? options.doorInteractions : [];
         const raf = globalThis.requestAnimationFrame || ((fn) => setTimeout(() => fn(Date.now()), 16));
         const caf = globalThis.cancelAnimationFrame || clearTimeout;
+        const pause = (ms) => new Promise((resolve) => setTimeout(resolve, Math.max(0, Number(ms) || 0)));
         const motion = { cancelled: false, frameId: null, tokenId: token.id };
         this.tokenMotion = motion;
         const moveSegment = (from, to) => new Promise((resolve) => {
@@ -130,6 +132,28 @@ export class Engine {
             token.x = Number(points[0].x);
             token.y = Number(points[0].y);
             for (let index = 1; index < points.length; index += 1) {
+                const interactions = doorInteractions.filter((entry) => Number(entry.pathIndex) === index - 1);
+                for (const interaction of interactions) {
+                    this.canvas.dispatchEvent(new CustomEvent('vtt:movement-interaction', {
+                        detail: { tokenId: token.id, x: token.x, y: token.y, actionMode: mode, ...interaction },
+                    }));
+                    if (interaction.soundEvent) {
+                        this.canvas.dispatchEvent(new CustomEvent('vtt:sound-event', {
+                            detail: {
+                                kind: 'movement',
+                                event: interaction.soundEvent,
+                                sourceTokenId: token.id,
+                                doorId: interaction.doorId || null,
+                                intensity: interaction.noise || 'high',
+                                x: token.x,
+                                y: token.y,
+                                z: Number(token.zLayer ?? token.gridPosition?.z ?? token.z?.[0] ?? 0),
+                            },
+                        }));
+                    }
+                    if (interaction.pauseMs) await pause(interaction.pauseMs);
+                    if (motion.cancelled) return { valid: false, reason: 'MOVEMENT_CANCELLED', complete: false };
+                }
                 const complete = await moveSegment(points[index - 1], points[index]);
                 if (!complete) return { valid: false, reason: 'MOVEMENT_CANCELLED', complete: false };
             }
@@ -161,7 +185,7 @@ export class Engine {
                 result = { valid: false, reason: error?.message || 'MOVEMENT_RESOLVER_FAILED' };
             }
             if (result?.valid) {
-                const traversed = await this.animateTokenPath(token, result.path || [], { actionMode: result.actionMode });
+                const traversed = await this.animateTokenPath(token, result.path || [], { actionMode: result.actionMode, doorInteractions: result.doorInteractions });
                 if (traversed.valid) this.finalizeTokenMove(token, drag, result);
             } else {
                 token.x = drag.originX;
@@ -218,6 +242,11 @@ export class Engine {
                 transition: transition.valid ? { routeId: transition.route?.id || null, complete: Boolean(transition.complete), targetZ: transition.targetZ, costSpentFt: transition.costSpentFt ?? null } : null,
             },
         }));
+        if (result.stopAtDoor) {
+            this.canvas.dispatchEvent(new CustomEvent('vtt:movement-stopped-at-door', {
+                detail: { tokenId: token.id, x: token.x, y: token.y, z: token.zLayer, ...result.stopAtDoor },
+            }));
+        }
         if (transition.valid) this.canvas.dispatchEvent(new CustomEvent('vtt:token-z-transition', { detail: { tokenId: token.id, ...transition } }));
     }
 

--- a/js/vtt/main.js
+++ b/js/vtt/main.js
@@ -24,6 +24,8 @@ import './movement-engine.js';
 import './movement-state.js';
 import './physical-state-patch.js';
 import './movement-integration-patch.js';
+import './movement-connectivity.js';
+import './movement-destination-claims.js';
 import './map-dialogue-overlay.js';
 
 document.addEventListener('DOMContentLoaded', async () => {

--- a/js/vtt/movement-bootstrap.js
+++ b/js/vtt/movement-bootstrap.js
@@ -313,6 +313,29 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     };
   }
 
+  async function cancelActiveMotion(reason = 'MOVEMENT_CANCELLED') {
+    const motion = engine.tokenMotion;
+    if (!motion) return { valid: false, reason: 'NO_ACTIVE_MOVEMENT' };
+    const token = (mapData.tokens || []).find((entry) => String(entry.id) === String(motion.tokenId));
+    if (!engine.cancelTokenMotion?.()) return { valid: false, reason: 'NO_ACTIVE_MOVEMENT' };
+    if (token) {
+      await cancelDestination(token, reason, true);
+      canvas.dispatchEvent(new CustomEvent('vtt:token-preview-moved', {
+        detail: {
+          tokenId: token.id,
+          x: token.x,
+          y: token.y,
+          z: token.zLayer ?? token.z?.[0] ?? 0,
+          reverted: true,
+          cancelled: true,
+        },
+      }));
+    }
+    clearPreview();
+    updateUi();
+    return { valid: true, reason };
+  }
+
   function resetControlledMovement() {
     try { assertMovementOnline(); } catch (error) { showError(error); return; }
     const token = controlledToken();
@@ -442,6 +465,10 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
 
   function onMouseMove(event) { updatePreview(event); }
   function onMouseUp() { clearPreview(); setTimeout(updateUi, 0); }
+  function onKeyDown(event) {
+    if (event.key !== 'Escape' || !engine.tokenMotion) return;
+    void cancelActiveMotion('MOVEMENT_CANCELLED').catch(showError);
+  }
   function onTokenMoved(event) {
     const token = (mapData.tokens || []).find((entry) => String(entry.id) === String(event.detail?.tokenId));
     if (token) movement.reconcileVertical(token, worldState());
@@ -460,6 +487,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   engine.setTokenMoveResolver?.(resolveMovementOrder);
   window.addEventListener('mousemove', onMouseMove);
   window.addEventListener('mouseup', onMouseUp);
+  window.addEventListener('keydown', onKeyDown);
   canvas.addEventListener('vtt:token-moved', onRealtimeTokenMoved, true);
   canvas.addEventListener('vtt:canonical-tokens-synced', onRealtimeCanonicalSync);
   canvas.addEventListener('vtt:token-moved', onTokenMoved);
@@ -488,6 +516,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
       return result;
     },
     resetMovement: resetControlledMovement,
+    cancelMovement: cancelActiveMotion,
     prone: (token) => { if (!movementOnline()) return { valid: false, reason: 'VTT_OFFLINE_NO_UPDATE' }; const result = movement.setProne(token, true); updateUi(); return result; },
     stand: (token) => { if (!movementOnline()) return { valid: false, reason: 'VTT_OFFLINE_NO_UPDATE' }; const result = movement.standUp(token, worldState()); updateUi(); return result; },
     setMovementMode: (token, mode) => { if (!movementOnline()) throw new Error('VTT_OFFLINE_NO_UPDATE'); return movement.setMovementMode(token, mode, worldState()); },
@@ -502,6 +531,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
       stateBridge.stop();
       window.removeEventListener('mousemove', onMouseMove);
       window.removeEventListener('mouseup', onMouseUp);
+      window.removeEventListener('keydown', onKeyDown);
       canvas.removeEventListener('vtt:token-moved', onRealtimeTokenMoved, true);
       canvas.removeEventListener('vtt:canonical-tokens-synced', onRealtimeCanonicalSync);
       canvas.removeEventListener('vtt:token-moved', onTokenMoved);

--- a/js/vtt/movement-bootstrap.js
+++ b/js/vtt/movement-bootstrap.js
@@ -1,6 +1,9 @@
 import './movement-realtime.js';
+import './movement-connectivity.js';
 import './movement-rules.js';
 import './movement-rules-runtime.js';
+
+window.LuminousVttMovementConnectivity?.installRealtime?.(window);
 
 export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.engine?.mapData } = {}) {
   if (!runtime?.engine || !mapData) return null;
@@ -14,9 +17,16 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   const camera = engine.camera;
   const canvas = engine.canvas;
   const isDm = Boolean(runtime.bridge?.isDm);
+  const movementConnectivity = window.LuminousVttMovementConnectivity;
   const movementRealtimeApi = window.LuminousVttMovementRealtime;
   const movementRealtimeIdentity = movementRealtimeApi?.identity?.(window) || {};
   const movementRealtime = movementRealtimeApi?.createController?.({ mapData, canvas, engine, isDm, root: window }) || null;
+  const tokenStateApi = window.LuminousVttTokenState;
+  const firebase = tokenStateApi?.hostFirebase?.(window) || window.firebase || null;
+  const db = firebase?.database?.() || null;
+  const mapId = tokenStateApi?.firebaseKey?.(mapData.id || mapData.mapId || 'default', 'default') || String(mapData.id || mapData.mapId || 'default');
+  const playerRoot = tokenStateApi?.PLAYER_ROOT || 'campaña/jugadores';
+  const worldTokenRoot = `${tokenStateApi?.WORLD_ROOT || 'campaña/estado_mundo/vttTokens'}/${mapId}`;
   const realtimeCommits = new Map();
   mapData.movement ||= {};
   if (!mapData.movement.diagonalRule) mapData.movement.diagonalRule = '5e';
@@ -27,6 +37,20 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   let lastRoundId = null;
   let lastMode = null;
   let noticeTimer = null;
+  let turnPlayerHandler = null;
+  let turnWorldHandler = null;
+
+  function movementOnline() {
+    return movementRealtime ? movementRealtime.isConnected?.() === true : false;
+  }
+
+  function offlineResult() {
+    return { valid: false, reason: 'VTT_OFFLINE_NO_UPDATE', path: [], costFt: Infinity, movementCostFt: Infinity };
+  }
+
+  function assertMovementOnline() {
+    if (!movementOnline()) throw new Error('VTT_OFFLINE_NO_UPDATE');
+  }
 
   function worldState() { return stateBridge.current(); }
 
@@ -68,6 +92,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   }
 
   function statusText() {
+    if (!movementOnline()) return 'WORLD · OFFLINE · MOVEMENT LOCKED';
     const state = worldState();
     if (state.mode !== 'round') return 'WORLD · FREE EXPLORATION';
     const token = controlledToken();
@@ -80,7 +105,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     const style = document.createElement('style');
     style.id = 'vtt-movement-style';
     style.textContent = `
-      .vtt-world-time{position:fixed;left:50%;top:18px;transform:translateX(-50%);z-index:33020;display:flex;align-items:center;gap:6px;background:#0b0b0b;border:1px solid #aaa;padding:5px 7px;color:#fff;font:700 11px monospace;box-shadow:3px 3px 0 #000}.vtt-world-time[data-mode="round"]{border-color:#fff}.vtt-world-time button{font-size:10px}.vtt-move-toast{position:fixed;left:50%;top:58px;transform:translateX(-50%);z-index:33021;background:#111;color:#fff;border:1px solid #ff6b6b;padding:5px 8px;font:11px monospace}.vtt-move-toast[hidden]{display:none}
+      .vtt-world-time{position:fixed;left:50%;top:18px;transform:translateX(-50%);z-index:33020;display:flex;align-items:center;gap:6px;background:#0b0b0b;border:1px solid #aaa;padding:5px 7px;color:#fff;font:700 11px monospace;box-shadow:3px 3px 0 #000}.vtt-world-time[data-mode="round"]{border-color:#fff}.vtt-world-time[data-online="false"]{border-color:#ff6b6b}.vtt-world-time button{font-size:10px}.vtt-move-toast{position:fixed;left:50%;top:58px;transform:translateX(-50%);z-index:33021;background:#111;color:#fff;border:1px solid #ff6b6b;padding:5px 8px;font:11px monospace}.vtt-move-toast[hidden]{display:none}
     `;
     document.head.appendChild(style);
     const bar = document.createElement('div');
@@ -95,9 +120,9 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     document.body.appendChild(toast);
     bar.querySelector('[data-move-reset]')?.addEventListener('click', resetControlledMovement);
     if (isDm) {
-      bar.querySelector('[data-world-free]')?.addEventListener('click', () => stateBridge.setMode('free').catch(showError));
-      bar.querySelector('[data-world-round]')?.addEventListener('click', () => stateBridge.setMode('round').catch(showError));
-      bar.querySelector('[data-world-next]')?.addEventListener('click', () => stateBridge.nextRound().catch(showError));
+      bar.querySelector('[data-world-free]')?.addEventListener('click', () => setWorldMode('free'));
+      bar.querySelector('[data-world-round]')?.addEventListener('click', () => setWorldMode('round'));
+      bar.querySelector('[data-world-next]')?.addEventListener('click', nextWorldRound);
     }
   }
 
@@ -105,14 +130,20 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     const bar = document.getElementById('vtt-world-time-status');
     const label = bar?.querySelector('[data-world-time-label]');
     const state = stateBridge.current();
-    if (bar) bar.dataset.mode = state.mode;
+    const online = movementOnline();
+    if (bar) {
+      bar.dataset.mode = state.mode;
+      bar.dataset.online = String(online);
+    }
     if (label) label.textContent = statusText();
     const next = bar?.querySelector('[data-world-next]');
-    if (next) next.disabled = state.mode !== 'round';
+    if (next) next.disabled = !online || state.mode !== 'round';
     const reset = bar?.querySelector('[data-move-reset]');
-    if (reset) reset.disabled = state.mode !== 'round' || !controlledToken()?.movementTurnStart;
+    if (reset) reset.disabled = !online || state.mode !== 'round' || !controlledToken()?.movementTurnStart;
     const free = bar?.querySelector('[data-world-free]');
     const round = bar?.querySelector('[data-world-round]');
+    if (free) free.disabled = !online;
+    if (round) round.disabled = !online;
     free?.classList.toggle('is-active', state.mode === 'free');
     round?.classList.toggle('is-active', state.mode === 'round');
   }
@@ -134,6 +165,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   }
 
   function planFor(token, start, target) {
+    if (!movementOnline()) return offlineResult();
     return movement.planMove({
       token,
       start,
@@ -161,7 +193,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   function drawPreview(ctx) {
     if (!preview?.path?.length || !engine.tokenDrag) return;
     const token = engine.tokenDrag.token;
-    const showRuler = worldState().mode === 'round' && isActiveCombatTurn(token);
+    const showRuler = movementOnline() && worldState().mode === 'round' && isActiveCombatTurn(token);
     ctx.save();
     camera.applyTransformSimple(ctx);
     ctx.lineWidth = 3 / Math.max(0.01, camera.zoom || 1);
@@ -198,6 +230,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   }
 
   async function resolveMovementOrder({ token, from, requestedPoint }) {
+    if (!movementOnline()) return offlineResult();
     const plan = planFor(token, from, requestedPoint);
     if (!plan.valid) return plan;
     const committed = movement.commitMove(token, plan, worldState());
@@ -216,6 +249,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   }
 
   function resetControlledMovement() {
+    try { assertMovementOnline(); } catch (error) { showError(error); return; }
     const token = controlledToken();
     if (!token) return;
     const from = { x: token.x, y: token.y, z: token.zLayer ?? token.z?.[0] ?? 0, elevationFt: token.elevationFt ?? 0 };
@@ -225,6 +259,71 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     canvas.dispatchEvent(new CustomEvent('vtt:token-moved', { detail: { tokenId: token.id, from, to: { x: token.x, y: token.y, z: token.zLayer, ...token.gridPosition, elevationFt: token.elevationFt ?? 0 }, reset: true } }));
     canvas.dispatchEvent(new CustomEvent('vtt:movement-reset', { detail: { tokenId: token.id, refundActionType: result.refundActionType || null } }));
     updateUi();
+  }
+
+  function turnExtraRef(token) {
+    if (!db || !token) return null;
+    const playerKey = movementRealtimeApi?.playerKeyForToken?.(token, movementRealtimeIdentity) || '';
+    if (playerKey) {
+      const key = tokenStateApi?.firebaseKey?.(playerKey, 'player') || playerKey;
+      return db.ref(`${playerRoot}/${key}/vttTokenState/${mapId}`);
+    }
+    if (!isDm) return null;
+    const tokenId = String(token.id || '');
+    if (!tokenId) return null;
+    const key = tokenStateApi?.firebaseKey?.(tokenId, 'token') || tokenId;
+    return db.ref(worldTokenRoot).child(key);
+  }
+
+  async function persistTurnExtras(token) {
+    if (!movementOnline()) throw new Error('VTT_OFFLINE_NO_UPDATE');
+    const ref = turnExtraRef(token);
+    if (!ref?.update) return { valid: false, reason: 'TURN_PERSISTENCE_UNAVAILABLE' };
+    const extras = movementConnectivity?.turnExtras?.(token) || { movementTurnStart: token.movementTurnStart || null, dashActionType: token.dashActionType || null };
+    await ref.update({
+      'position/movementTurnStart': extras.movementTurnStart,
+      'position/dashActionType': extras.dashActionType,
+    });
+    return { valid: true, extras };
+  }
+
+  function applyPlayerTurnExtras(rawPlayers = {}) {
+    if (!movementOnline()) return;
+    Object.entries(rawPlayers || {}).forEach(([playerKey, playerData]) => {
+      const record = playerData?.vttTokenState?.[mapId];
+      if (!record?.position) return;
+      const recordPlayerId = String(record.playerId || playerKey);
+      const token = (mapData.tokens || []).find((entry) => String(entry.canonicalPlayerKey || entry.playerId || '') === String(playerKey)
+        || (recordPlayerId === String(movementRealtimeIdentity.playerId || '') && (entry.viewer === true || entry.characterLink?.mode === 'current_player')));
+      if (token) movementConnectivity?.applyTurnExtras?.(token, record.position);
+    });
+    updateUi();
+  }
+
+  function applyWorldTurnExtras(rawWorld = {}) {
+    if (!movementOnline()) return;
+    Object.entries(rawWorld || {}).forEach(([key, record]) => {
+      if (!record?.position) return;
+      const tokenId = String(record.tokenId || key);
+      const token = (mapData.tokens || []).find((entry) => String(entry.id || '') === tokenId);
+      if (token) movementConnectivity?.applyTurnExtras?.(token, record.position);
+    });
+    updateUi();
+  }
+
+  function startTurnPersistence() {
+    if (!db) return;
+    turnPlayerHandler = (snapshot) => applyPlayerTurnExtras(snapshot?.val?.() || {});
+    turnWorldHandler = (snapshot) => applyWorldTurnExtras(snapshot?.val?.() || {});
+    db.ref(playerRoot).on('value', turnPlayerHandler);
+    db.ref(worldTokenRoot).on('value', turnWorldHandler);
+  }
+
+  function stopTurnPersistence() {
+    if (db && turnPlayerHandler) db.ref(playerRoot).off('value', turnPlayerHandler);
+    if (db && turnWorldHandler) db.ref(worldTokenRoot).off('value', turnWorldHandler);
+    turnPlayerHandler = null;
+    turnWorldHandler = null;
   }
 
   function realtimeKey(token) { return movementRealtimeApi?.logicalTokenKey?.(token, movementRealtimeIdentity) || String(token?.id || ''); }
@@ -242,7 +341,8 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
 
   function onRealtimeTokenMoved(event) {
     const token = (mapData.tokens || []).find((entry) => String(entry.id) === String(event.detail?.tokenId));
-    if (!token || !movementRealtime?.previewRefForToken?.(token)) return;
+    if (!token || !movementOnline() || !movementRealtime?.previewRefForToken?.(token)) return;
+    void persistTurnExtras(token).catch((error) => console.warn('VTT movement turn persistence failed:', error));
     const key = realtimeKey(token);
     if (!key) return;
     settleRealtimeCommit(key, new Error('REALTIME_MOVEMENT_SUPERSEDED'));
@@ -284,6 +384,14 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   }
   function onRejected(event) { showError(event.detail?.reason || 'MOVEMENT_REJECTED'); clearPreview(); }
 
+  async function setWorldMode(mode) {
+    try { assertMovementOnline(); await stateBridge.setMode(mode); } catch (error) { showError(error); }
+  }
+
+  async function nextWorldRound() {
+    try { assertMovementOnline(); await stateBridge.nextRound(); } catch (error) { showError(error); }
+  }
+
   engine.setTokenMoveResolver?.(resolveMovementOrder);
   window.addEventListener('mousemove', onMouseMove);
   window.addEventListener('mouseup', onMouseUp);
@@ -295,6 +403,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   injectUi();
   stateBridge.start();
   movementRealtime?.start?.();
+  startTurnPersistence();
   applyWorldState(stateBridge.current());
 
   const api = Object.freeze({
@@ -303,19 +412,27 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     stateBridge,
     realtime: movementRealtime,
     worldState,
-    nextRound: () => stateBridge.nextRound(),
-    setMode: (mode) => stateBridge.setMode(mode),
-    dash: (token, options) => { const result = movement.dash(token, worldState(), options); updateUi(); return result; },
+    isConnected: movementOnline,
+    nextRound: nextWorldRound,
+    setMode: setWorldMode,
+    dash: (token, options) => {
+      try { assertMovementOnline(); } catch (error) { return { valid: false, reason: error.message }; }
+      const result = movement.dash(token, worldState(), options);
+      if (result.valid) void persistTurnExtras(token).catch((error) => console.warn('VTT Dash turn persistence failed:', error));
+      updateUi();
+      return result;
+    },
     resetMovement: resetControlledMovement,
-    prone: (token) => { const result = movement.setProne(token, true); updateUi(); return result; },
-    stand: (token) => { const result = movement.standUp(token, worldState()); updateUi(); return result; },
-    setMovementMode: (token, mode) => movement.setMovementMode(token, mode, worldState()),
-    plan: (options) => movement.planMove({ ...options, mapData, worldState: worldState() }),
+    prone: (token) => { if (!movementOnline()) return { valid: false, reason: 'VTT_OFFLINE_NO_UPDATE' }; const result = movement.setProne(token, true); updateUi(); return result; },
+    stand: (token) => { if (!movementOnline()) return { valid: false, reason: 'VTT_OFFLINE_NO_UPDATE' }; const result = movement.standUp(token, worldState()); updateUi(); return result; },
+    setMovementMode: (token, mode) => { if (!movementOnline()) throw new Error('VTT_OFFLINE_NO_UPDATE'); return movement.setMovementMode(token, mode, worldState()); },
+    plan: (options) => movementOnline() ? movement.planMove({ ...options, mapData, worldState: worldState() }) : offlineResult(),
     stop() {
       clearTimeout(noticeTimer);
       engine.cancelTokenMotion?.();
       engine.setTokenMoveResolver?.(null);
       for (const key of [...realtimeCommits.keys()]) settleRealtimeCommit(key, new Error('REALTIME_RUNTIME_STOPPED'));
+      stopTurnPersistence();
       movementRealtime?.stop?.();
       stateBridge.stop();
       window.removeEventListener('mousemove', onMouseMove);

--- a/js/vtt/movement-bootstrap.js
+++ b/js/vtt/movement-bootstrap.js
@@ -232,7 +232,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     ctx.restore();
   }
 
-  async function prepareDoorInteractions(token, plan = {}) {
+  function validateDoorInteractions(plan = {}) {
     const interactions = Array.isArray(plan.doorInteractions) ? plan.doorInteractions : [];
     if (!interactions.length) return { valid: true, interactions: [] };
     if (typeof runtime.bridge?.requestDirectAction !== 'function') return { valid: false, reason: 'DOOR_ACTION_BRIDGE_UNAVAILABLE' };
@@ -242,11 +242,6 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
       if (!door) return { valid: false, reason: 'DOOR_NOT_FOUND', doorId: interaction.doorId || null };
       const traversal = movementRules.doorTraversal({ mode: 'dash', dashActive: true, door, remainingFt: plan.remainingFt });
       if (!traversal.valid) return { valid: false, reason: traversal.reason || 'DOOR_BLOCKED', doorId: door.id };
-      const state = String(door.state || 'closed').toLowerCase();
-      if (state !== 'open' && state !== 'broken') {
-        const result = await runtime.bridge.requestDirectAction(door.id, 'open');
-        if (result === false || result?.valid === false) return { valid: false, reason: result?.reason || 'DOOR_OPEN_FAILED', doorId: door.id };
-      }
       prepared.push({ ...interaction, doorId: door.id, soundEvent: traversal.soundEvent || interaction.soundEvent, noise: traversal.noise || interaction.noise });
     }
     return { valid: true, interactions: prepared };
@@ -277,10 +272,55 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     }
   }
 
+  async function executeMovementInteraction({ token, interaction = {} } = {}) {
+    if (String(interaction.type || '').toLowerCase() !== 'door') return { valid: true, irreversible: false };
+    if (typeof runtime.bridge?.requestDirectAction !== 'function') {
+      await cancelDestination(token, 'DOOR_ACTION_BRIDGE_UNAVAILABLE', true);
+      return { valid: false, reason: 'DOOR_ACTION_BRIDGE_UNAVAILABLE' };
+    }
+    const door = (mapData.topology || []).find((element) => String(element.id || '') === String(interaction.doorId || ''));
+    if (!door) {
+      await cancelDestination(token, 'DOOR_NOT_FOUND', true);
+      return { valid: false, reason: 'DOOR_NOT_FOUND' };
+    }
+    const traversal = movementRules.doorTraversal({ mode: 'dash', dashActive: true, door, remainingFt: Infinity });
+    if (!traversal.valid) {
+      await cancelDestination(token, traversal.reason || 'DOOR_BLOCKED', true);
+      return { valid: false, reason: traversal.reason || 'DOOR_BLOCKED' };
+    }
+    const state = String(door.state || 'closed').toLowerCase();
+    if (state === 'open' || state === 'broken') {
+      return {
+        valid: true,
+        irreversible: false,
+        interaction: { ...interaction, burstOpen: false, soundEvent: null, noise: 'normal' },
+      };
+    }
+    const result = await runtime.bridge.requestDirectAction(door.id, 'open');
+    if (result === false || result?.valid === false) {
+      const reason = result?.reason || 'DOOR_OPEN_FAILED';
+      await cancelDestination(token, reason, true);
+      return { valid: false, reason };
+    }
+    return {
+      valid: true,
+      irreversible: true,
+      interaction: {
+        ...interaction,
+        burstOpen: true,
+        soundEvent: traversal.soundEvent || interaction.soundEvent || 'DASH_DOOR_BURST',
+        noise: traversal.noise || interaction.noise || 'high',
+      },
+    };
+  }
+
   async function resolveMovementOrder({ token, from, requestedPoint }) {
     if (!movementOnline()) return offlineResult();
     const plan = planFor(token, from, requestedPoint);
     if (!plan.valid) return plan;
+
+    const doors = validateDoorInteractions(plan);
+    if (!doors.valid) return { ...plan, valid: false, reason: doors.reason || 'DOOR_INTERACTION_FAILED' };
 
     const committed = movement.commitMove(token, plan, worldState());
     if (!committed.valid) return committed;
@@ -289,12 +329,6 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     if (!reserved.valid) {
       await cancelDestination(token, reserved.reason || 'MOVEMENT_DESTINATION_CLAIM_LOST', true);
       return { ...plan, valid: false, reason: reserved.reason || 'MOVEMENT_DESTINATION_CLAIM_LOST' };
-    }
-
-    const doors = await prepareDoorInteractions(token, plan);
-    if (!doors.valid) {
-      await cancelDestination(token, doors.reason || 'DOOR_INTERACTION_FAILED', true);
-      return { ...plan, valid: false, reason: doors.reason || 'DOOR_INTERACTION_FAILED' };
     }
 
     const endpoint = plan.path?.[plan.path.length - 1] || pathfinding.pointForCell(pathfinding.cellFromPoint(requestedPoint, mapData), mapData, pathfinding.tokenLayer(token));
@@ -316,6 +350,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   async function cancelActiveMotion(reason = 'MOVEMENT_CANCELLED') {
     const motion = engine.tokenMotion;
     if (!motion) return { valid: false, reason: 'NO_ACTIVE_MOVEMENT' };
+    if (motion.irreversible) return { valid: false, reason: 'MOVEMENT_INTERACTION_COMMITTED' };
     const token = (mapData.tokens || []).find((entry) => String(entry.id) === String(motion.tokenId));
     if (!engine.cancelTokenMotion?.()) return { valid: false, reason: 'NO_ACTIVE_MOVEMENT' };
     if (token) {
@@ -338,6 +373,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
 
   function resetControlledMovement() {
     try { assertMovementOnline(); } catch (error) { showError(error); return; }
+    if (engine.tokenMotion) return showError('MOVEMENT_IN_PROGRESS');
     const token = controlledToken();
     if (!token) return;
     const from = { x: token.x, y: token.y, z: token.zLayer ?? token.z?.[0] ?? 0, elevationFt: token.elevationFt ?? 0 };
@@ -467,7 +503,9 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   function onMouseUp() { clearPreview(); setTimeout(updateUi, 0); }
   function onKeyDown(event) {
     if (event.key !== 'Escape' || !engine.tokenMotion) return;
-    void cancelActiveMotion('MOVEMENT_CANCELLED').catch(showError);
+    void cancelActiveMotion('MOVEMENT_CANCELLED')
+      .then((result) => { if (!result.valid && result.reason === 'MOVEMENT_INTERACTION_COMMITTED') showError(result.reason); })
+      .catch(showError);
   }
   function onTokenMoved(event) {
     const token = (mapData.tokens || []).find((entry) => String(entry.id) === String(event.detail?.tokenId));
@@ -485,6 +523,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   }
 
   engine.setTokenMoveResolver?.(resolveMovementOrder);
+  engine.setMovementInteractionResolver?.(executeMovementInteraction);
   window.addEventListener('mousemove', onMouseMove);
   window.addEventListener('mouseup', onMouseUp);
   window.addEventListener('keydown', onKeyDown);
@@ -525,6 +564,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
       clearTimeout(noticeTimer);
       engine.cancelTokenMotion?.();
       engine.setTokenMoveResolver?.(null);
+      engine.setMovementInteractionResolver?.(null);
       for (const key of [...realtimeCommits.keys()]) settleRealtimeCommit(key, new Error('REALTIME_RUNTIME_STOPPED'));
       stopTurnPersistence();
       movementRealtime?.stop?.();

--- a/js/vtt/movement-bootstrap.js
+++ b/js/vtt/movement-bootstrap.js
@@ -1,4 +1,6 @@
 import './movement-realtime.js';
+import './movement-rules.js';
+import './movement-rules-runtime.js';
 
 export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.engine?.mapData } = {}) {
   if (!runtime?.engine || !mapData) return null;
@@ -14,13 +16,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   const isDm = Boolean(runtime.bridge?.isDm);
   const movementRealtimeApi = window.LuminousVttMovementRealtime;
   const movementRealtimeIdentity = movementRealtimeApi?.identity?.(window) || {};
-  const movementRealtime = movementRealtimeApi?.createController?.({
-    mapData,
-    canvas,
-    engine,
-    isDm,
-    root: window,
-  }) || null;
+  const movementRealtime = movementRealtimeApi?.createController?.({ mapData, canvas, engine, isDm, root: window }) || null;
   const realtimeCommits = new Map();
   mapData.movement ||= {};
   if (!mapData.movement.diagonalRule) mapData.movement.diagonalRule = '5e';
@@ -44,23 +40,12 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     lastMode = current.mode;
     lastRoundId = current.roundId;
     if (newRound) {
-      window.dispatchEvent(new CustomEvent('vtt:world-round', {
-        detail: {
-          mapId: String(mapData.id || mapData.mapId || 'default'),
-          roundId: current.roundId,
-          roundSeconds: current.roundSeconds,
-          worldSeconds: current.worldSeconds,
-        },
-      }));
+      window.dispatchEvent(new CustomEvent('vtt:world-round', { detail: { mapId: String(mapData.id || mapData.mapId || 'default'), roundId: current.roundId, roundSeconds: current.roundSeconds, worldSeconds: current.worldSeconds } }));
     }
     updateUi();
   }
 
-  const stateBridge = stateApi.createBridge({
-    mapData,
-    isDm,
-    onChanged: applyWorldState,
-  });
+  const stateBridge = stateApi.createBridge({ mapData, isDm, onChanged: applyWorldState });
 
   function controlledToken() {
     if (engine.tokenDrag?.token) return engine.tokenDrag.token;
@@ -71,6 +56,15 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     }
     const previewId = mapData.lighting?.dmPreviewTokenId;
     return (mapData.tokens || []).find((token) => String(token.id) === String(previewId)) || null;
+  }
+
+  function combatActiveTokenId() {
+    return String(mapData.combat?.activeTokenId || mapData.combat?.currentTokenId || mapData.initiative?.activeTokenId || mapData.initiative?.currentTokenId || '');
+  }
+
+  function isActiveCombatTurn(token) {
+    const activeId = combatActiveTokenId();
+    return Boolean(activeId && token && String(token.id) === activeId);
   }
 
   function statusText() {
@@ -92,13 +86,14 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     const bar = document.createElement('div');
     bar.id = 'vtt-world-time-status';
     bar.className = 'vtt-world-time';
-    bar.innerHTML = `<span data-world-time-label></span>${isDm ? '<button type="button" class="brutalist-button" data-world-free>FREE</button><button type="button" class="brutalist-button" data-world-round>ROUND TIME</button><button type="button" class="brutalist-button" data-world-next>NEXT ROUND</button>' : ''}`;
+    bar.innerHTML = `<span data-world-time-label></span><button type="button" class="brutalist-button" data-move-reset>RESET MOVE</button>${isDm ? '<button type="button" class="brutalist-button" data-world-free>FREE</button><button type="button" class="brutalist-button" data-world-round>ROUND TIME</button><button type="button" class="brutalist-button" data-world-next>NEXT ROUND</button>' : ''}`;
     document.body.appendChild(bar);
     const toast = document.createElement('div');
     toast.id = 'vtt-move-toast';
     toast.className = 'vtt-move-toast';
     toast.hidden = true;
     document.body.appendChild(toast);
+    bar.querySelector('[data-move-reset]')?.addEventListener('click', resetControlledMovement);
     if (isDm) {
       bar.querySelector('[data-world-free]')?.addEventListener('click', () => stateBridge.setMode('free').catch(showError));
       bar.querySelector('[data-world-round]')?.addEventListener('click', () => stateBridge.setMode('round').catch(showError));
@@ -114,6 +109,8 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     if (label) label.textContent = statusText();
     const next = bar?.querySelector('[data-world-next]');
     if (next) next.disabled = state.mode !== 'round';
+    const reset = bar?.querySelector('[data-move-reset]');
+    if (reset) reset.disabled = state.mode !== 'round' || !controlledToken()?.movementTurnStart;
     const free = bar?.querySelector('[data-world-free]');
     const round = bar?.querySelector('[data-world-round]');
     free?.classList.toggle('is-active', state.mode === 'free');
@@ -136,84 +133,110 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     return { x: world.x - drag.grabOffsetX, y: world.y - drag.grabOffsetY };
   }
 
+  function planFor(token, start, target) {
+    return movement.planMove({
+      token,
+      start,
+      target,
+      mapData,
+      worldState: worldState(),
+      movementMode: token.movementState?.mode || 'walk',
+      movementType: token.pendingMovementType || 'normal',
+      blockTokens: mapData.movement.blockTokens,
+      diagonalRule: mapData.movement.diagonalRule,
+    });
+  }
+
   function updatePreview(event) {
     const drag = engine.tokenDrag;
     if (!drag || !event || Date.now() - previewAt < 45) return;
     previewAt = Date.now();
     const target = requestedPoint(event, drag);
-    const plan = movement.planMove({
-      token: drag.token,
-      start: { x: drag.originX, y: drag.originY },
-      target,
-      mapData,
-      worldState: worldState(),
-      movementMode: drag.token.movementState?.mode || 'walk',
-      blockTokens: mapData.movement.blockTokens,
-      diagonalRule: mapData.movement.diagonalRule,
-    });
-    preview = {
-      tokenId: drag.token.id,
-      valid: Boolean(plan.valid),
-      reason: plan.reason || null,
-      path: plan.path || [],
-      costFt: plan.movementCostFt ?? plan.costFt ?? 0,
-    };
+    const plan = planFor(drag.token, { x: drag.originX, y: drag.originY }, target);
+    preview = { tokenId: drag.token.id, valid: Boolean(plan.valid), reason: plan.reason || null, path: plan.path || [], costFt: plan.movementCostFt ?? plan.costFt ?? 0 };
   }
 
   function clearPreview() { preview = null; }
 
   function drawPreview(ctx) {
     if (!preview?.path?.length || !engine.tokenDrag) return;
+    const token = engine.tokenDrag.token;
+    const showRuler = worldState().mode === 'round' && isActiveCombatTurn(token);
     ctx.save();
     camera.applyTransformSimple(ctx);
     ctx.lineWidth = 3 / Math.max(0.01, camera.zoom || 1);
     ctx.setLineDash([10 / Math.max(0.01, camera.zoom || 1), 6 / Math.max(0.01, camera.zoom || 1)]);
-    ctx.strokeStyle = preview.valid ? '#ffffff' : '#ff6b6b';
+    ctx.strokeStyle = showRuler ? (preview.valid ? '#55ff80' : '#ff5f5f') : '#ffffff';
     ctx.beginPath();
     preview.path.forEach((point, index) => { if (index === 0) ctx.moveTo(point.x, point.y); else ctx.lineTo(point.x, point.y); });
     ctx.stroke();
-    const last = preview.path[preview.path.length - 1];
-    ctx.setLineDash([]);
-    ctx.fillStyle = '#000000';
-    ctx.strokeStyle = preview.valid ? '#ffffff' : '#ff6b6b';
-    const text = preview.valid ? `${Math.round(preview.costFt)} ft` : String(preview.reason || 'NO PATH');
-    ctx.font = `${12 / Math.max(0.01, camera.zoom || 1)}px monospace`;
-    const width = ctx.measureText(text).width + 10 / Math.max(0.01, camera.zoom || 1);
-    const height = 18 / Math.max(0.01, camera.zoom || 1);
-    ctx.fillRect(last.x - width / 2, last.y - height - 12 / Math.max(0.01, camera.zoom || 1), width, height);
-    ctx.strokeRect(last.x - width / 2, last.y - height - 12 / Math.max(0.01, camera.zoom || 1), width, height);
-    ctx.fillStyle = '#ffffff';
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillText(text, last.x, last.y - height / 2 - 12 / Math.max(0.01, camera.zoom || 1));
+    if (showRuler) {
+      const last = preview.path[preview.path.length - 1];
+      ctx.setLineDash([]);
+      ctx.fillStyle = '#000000';
+      ctx.strokeStyle = preview.valid ? '#55ff80' : '#ff5f5f';
+      const text = preview.valid ? `${Math.round(preview.costFt)} ft` : String(preview.reason || 'NO PATH');
+      ctx.font = `${12 / Math.max(0.01, camera.zoom || 1)}px monospace`;
+      const width = ctx.measureText(text).width + 10 / Math.max(0.01, camera.zoom || 1);
+      const height = 18 / Math.max(0.01, camera.zoom || 1);
+      ctx.fillRect(last.x - width / 2, last.y - height - 12 / Math.max(0.01, camera.zoom || 1), width, height);
+      ctx.strokeRect(last.x - width / 2, last.y - height - 12 / Math.max(0.01, camera.zoom || 1), width, height);
+      ctx.fillStyle = '#ffffff';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(text, last.x, last.y - height / 2 - 12 / Math.max(0.01, camera.zoom || 1));
+    }
+    const start = movement.movementStart?.(token);
+    if (showRuler && start) {
+      ctx.setLineDash([]);
+      ctx.beginPath();
+      ctx.arc(start.x, start.y, 7 / Math.max(0.01, camera.zoom || 1), 0, Math.PI * 2);
+      ctx.strokeStyle = '#ffffff';
+      ctx.stroke();
+    }
     ctx.restore();
   }
 
-  function realtimeKey(token) {
-    return movementRealtimeApi?.logicalTokenKey?.(token, movementRealtimeIdentity) || String(token?.id || '');
-  }
-
-  function realtimePosition(token) {
-    return movementRealtimeApi?.snapshotPosition?.(token) || {
-      x: Number(token?.x) || 0,
-      y: Number(token?.y) || 0,
-      zLayer: Number(token?.zLayer ?? token?.gridPosition?.z ?? token?.z?.[0]) || 0,
+  async function resolveMovementOrder({ token, from, requestedPoint }) {
+    const plan = planFor(token, from, requestedPoint);
+    if (!plan.valid) return plan;
+    const committed = movement.commitMove(token, plan, worldState());
+    if (!committed.valid) return committed;
+    const endpoint = plan.path?.[plan.path.length - 1] || pathfinding.pointForCell(pathfinding.cellFromPoint(requestedPoint, mapData), mapData, pathfinding.tokenLayer(token));
+    return {
+      ...plan,
+      ...endpoint,
+      valid: true,
+      path: plan.path || [],
+      routeCostFt: plan.routeCostFt ?? plan.costFt ?? 0,
+      movementCostFt: plan.movementCostFt ?? 0,
+      remainingFt: committed.remainingFt,
+      actionMode: token.activeActionMovementMode || 'walk',
     };
   }
 
-  function sameRealtimePosition(a = {}, b = {}) {
-    return Math.abs((Number(a.x) || 0) - (Number(b.x) || 0)) < 0.01
-      && Math.abs((Number(a.y) || 0) - (Number(b.y) || 0)) < 0.01
-      && Number(a.zLayer ?? a.z?.[0] ?? 0) === Number(b.zLayer ?? b.z?.[0] ?? 0);
+  function resetControlledMovement() {
+    const token = controlledToken();
+    if (!token) return;
+    const from = { x: token.x, y: token.y, z: token.zLayer ?? token.z?.[0] ?? 0, elevationFt: token.elevationFt ?? 0 };
+    const result = movement.resetMovement?.(token, worldState());
+    if (!result?.valid) return showError(result?.reason || 'RESET_MOVEMENT_UNAVAILABLE');
+    canvas.dispatchEvent(new CustomEvent('vtt:token-preview-moved', { detail: { tokenId: token.id, x: token.x, y: token.y, z: token.zLayer, reset: true } }));
+    canvas.dispatchEvent(new CustomEvent('vtt:token-moved', { detail: { tokenId: token.id, from, to: { x: token.x, y: token.y, z: token.zLayer, ...token.gridPosition, elevationFt: token.elevationFt ?? 0 }, reset: true } }));
+    canvas.dispatchEvent(new CustomEvent('vtt:movement-reset', { detail: { tokenId: token.id, refundActionType: result.refundActionType || null } }));
+    updateUi();
   }
+
+  function realtimeKey(token) { return movementRealtimeApi?.logicalTokenKey?.(token, movementRealtimeIdentity) || String(token?.id || ''); }
+  function realtimePosition(token) { return movementRealtimeApi?.snapshotPosition?.(token) || { x: Number(token?.x) || 0, y: Number(token?.y) || 0, zLayer: Number(token?.zLayer ?? token?.gridPosition?.z ?? token?.z?.[0]) || 0 }; }
+  function sameRealtimePosition(a = {}, b = {}) { return Math.abs((Number(a.x) || 0) - (Number(b.x) || 0)) < 0.01 && Math.abs((Number(a.y) || 0) - (Number(b.y) || 0)) < 0.01 && Number(a.zLayer ?? a.z?.[0] ?? 0) === Number(b.zLayer ?? b.z?.[0] ?? 0); }
 
   function settleRealtimeCommit(key, error = null) {
     const pendingCommit = realtimeCommits.get(key);
     if (!pendingCommit) return false;
     realtimeCommits.delete(key);
     clearTimeout(pendingCommit.timeoutId);
-    if (error) pendingCommit.reject(error);
-    else pendingCommit.resolve({ valid: true, source: 'canonical-sync' });
+    if (error) pendingCommit.reject(error); else pendingCommit.resolve({ valid: true, source: 'canonical-sync' });
     return true;
   }
 
@@ -225,10 +248,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     settleRealtimeCommit(key, new Error('REALTIME_MOVEMENT_SUPERSEDED'));
     let resolveCanonical;
     let rejectCanonical;
-    const canonicalPromise = new Promise((resolve, reject) => {
-      resolveCanonical = resolve;
-      rejectCanonical = reject;
-    });
+    const canonicalPromise = new Promise((resolve, reject) => { resolveCanonical = resolve; rejectCanonical = reject; });
     const pendingCommit = {
       token,
       expected: realtimePosition(token),
@@ -241,10 +261,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
       }, 2500),
     };
     realtimeCommits.set(key, pendingCommit);
-    void movementRealtime.finalizeToken(token, () => canonicalPromise).catch((error) => {
-      settleRealtimeCommit(key);
-      console.warn('VTT realtime movement finalization failed:', error);
-    });
+    void movementRealtime.finalizeToken(token, () => canonicalPromise).catch((error) => { settleRealtimeCommit(key); console.warn('VTT realtime movement finalization failed:', error); });
   }
 
   function onRealtimeCanonicalSync() {
@@ -256,10 +273,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   }
 
   const previousRender = renderer.render.bind(renderer);
-  renderer.render = function movementRender(...args) {
-    previousRender(...args);
-    drawPreview(renderer.ctx);
-  };
+  renderer.render = function movementRender(...args) { previousRender(...args); drawPreview(renderer.ctx); };
 
   function onMouseMove(event) { updatePreview(event); }
   function onMouseUp() { clearPreview(); setTimeout(updateUi, 0); }
@@ -268,12 +282,15 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     if (token) movement.reconcileVertical(token, worldState());
     updateUi();
   }
+  function onRejected(event) { showError(event.detail?.reason || 'MOVEMENT_REJECTED'); clearPreview(); }
 
+  engine.setTokenMoveResolver?.(resolveMovementOrder);
   window.addEventListener('mousemove', onMouseMove);
   window.addEventListener('mouseup', onMouseUp);
   canvas.addEventListener('vtt:token-moved', onRealtimeTokenMoved, true);
   canvas.addEventListener('vtt:canonical-tokens-synced', onRealtimeCanonicalSync);
   canvas.addEventListener('vtt:token-moved', onTokenMoved);
+  canvas.addEventListener('vtt:movement-order-rejected', onRejected);
 
   injectUi();
   stateBridge.start();
@@ -289,12 +306,15 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     nextRound: () => stateBridge.nextRound(),
     setMode: (mode) => stateBridge.setMode(mode),
     dash: (token, options) => { const result = movement.dash(token, worldState(), options); updateUi(); return result; },
+    resetMovement: resetControlledMovement,
     prone: (token) => { const result = movement.setProne(token, true); updateUi(); return result; },
     stand: (token) => { const result = movement.standUp(token, worldState()); updateUi(); return result; },
     setMovementMode: (token, mode) => movement.setMovementMode(token, mode, worldState()),
     plan: (options) => movement.planMove({ ...options, mapData, worldState: worldState() }),
     stop() {
       clearTimeout(noticeTimer);
+      engine.cancelTokenMotion?.();
+      engine.setTokenMoveResolver?.(null);
       for (const key of [...realtimeCommits.keys()]) settleRealtimeCommit(key, new Error('REALTIME_RUNTIME_STOPPED'));
       movementRealtime?.stop?.();
       stateBridge.stop();
@@ -303,6 +323,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
       canvas.removeEventListener('vtt:token-moved', onRealtimeTokenMoved, true);
       canvas.removeEventListener('vtt:canonical-tokens-synced', onRealtimeCanonicalSync);
       canvas.removeEventListener('vtt:token-moved', onTokenMoved);
+      canvas.removeEventListener('vtt:movement-order-rejected', onRejected);
       renderer.render = previousRender;
       document.getElementById('vtt-world-time-status')?.remove();
       document.getElementById('vtt-move-toast')?.remove();

--- a/js/vtt/movement-bootstrap.js
+++ b/js/vtt/movement-bootstrap.js
@@ -2,15 +2,17 @@ import './movement-realtime.js';
 import './movement-connectivity.js';
 import './movement-rules.js';
 import './movement-rules-runtime.js';
+import './movement-door-runtime.js';
 
 window.LuminousVttMovementConnectivity?.installRealtime?.(window);
 
 export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.engine?.mapData } = {}) {
   if (!runtime?.engine || !mapData) return null;
   const movement = window.LuminousVttMovementEngine;
+  const movementRules = window.LuminousVttMovementRules;
   const pathfinding = window.LuminousVttPathfinding;
   const stateApi = window.LuminousVttMovementState;
-  if (!movement || !pathfinding || !stateApi) return null;
+  if (!movement || !movementRules || !pathfinding || !stateApi) return null;
 
   const engine = runtime.engine;
   const renderer = engine.renderer;
@@ -185,7 +187,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     previewAt = Date.now();
     const target = requestedPoint(event, drag);
     const plan = planFor(drag.token, { x: drag.originX, y: drag.originY }, target);
-    preview = { tokenId: drag.token.id, valid: Boolean(plan.valid), reason: plan.reason || null, path: plan.path || [], costFt: plan.movementCostFt ?? plan.costFt ?? 0 };
+    preview = { tokenId: drag.token.id, valid: Boolean(plan.valid), reason: plan.reason || plan.stopAtDoor?.reason || null, path: plan.path || [], costFt: plan.movementCostFt ?? plan.costFt ?? 0 };
   }
 
   function clearPreview() { preview = null; }
@@ -229,10 +231,32 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     ctx.restore();
   }
 
+  async function prepareDoorInteractions(token, plan = {}) {
+    const interactions = Array.isArray(plan.doorInteractions) ? plan.doorInteractions : [];
+    if (!interactions.length) return { valid: true, interactions: [] };
+    if (typeof runtime.bridge?.requestDirectAction !== 'function') return { valid: false, reason: 'DOOR_ACTION_BRIDGE_UNAVAILABLE' };
+    const prepared = [];
+    for (const interaction of interactions) {
+      const door = (mapData.topology || []).find((element) => String(element.id || '') === String(interaction.doorId || ''));
+      if (!door) return { valid: false, reason: 'DOOR_NOT_FOUND', doorId: interaction.doorId || null };
+      const traversal = movementRules.doorTraversal({ mode: 'dash', dashActive: true, door, remainingFt: plan.remainingFt });
+      if (!traversal.valid) return { valid: false, reason: traversal.reason || 'DOOR_BLOCKED', doorId: door.id };
+      const state = String(door.state || 'closed').toLowerCase();
+      if (state !== 'open' && state !== 'broken') {
+        const result = await runtime.bridge.requestDirectAction(door.id, 'open');
+        if (result === false || result?.valid === false) return { valid: false, reason: result?.reason || 'DOOR_OPEN_FAILED', doorId: door.id };
+      }
+      prepared.push({ ...interaction, doorId: door.id, soundEvent: traversal.soundEvent || interaction.soundEvent, noise: traversal.noise || interaction.noise });
+    }
+    return { valid: true, interactions: prepared };
+  }
+
   async function resolveMovementOrder({ token, from, requestedPoint }) {
     if (!movementOnline()) return offlineResult();
     const plan = planFor(token, from, requestedPoint);
     if (!plan.valid) return plan;
+    const doors = await prepareDoorInteractions(token, plan);
+    if (!doors.valid) return { ...plan, valid: false, reason: doors.reason || 'DOOR_INTERACTION_FAILED' };
     const committed = movement.commitMove(token, plan, worldState());
     if (!committed.valid) return committed;
     const endpoint = plan.path?.[plan.path.length - 1] || pathfinding.pointForCell(pathfinding.cellFromPoint(requestedPoint, mapData), mapData, pathfinding.tokenLayer(token));
@@ -245,6 +269,8 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
       movementCostFt: plan.movementCostFt ?? 0,
       remainingFt: committed.remainingFt,
       actionMode: token.activeActionMovementMode || 'walk',
+      doorInteractions: doors.interactions,
+      stopAtDoor: plan.stopAtDoor || null,
     };
   }
 

--- a/js/vtt/movement-bootstrap.js
+++ b/js/vtt/movement-bootstrap.js
@@ -1,5 +1,6 @@
 import './movement-realtime.js';
 import './movement-connectivity.js';
+import './movement-destination-claims.js';
 import './movement-rules.js';
 import './movement-rules-runtime.js';
 import './movement-door-runtime.js';
@@ -251,14 +252,51 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     return { valid: true, interactions: prepared };
   }
 
+  async function reserveDestination(token) {
+    if (!token?.pendingMovementClaim) return { valid: true, skipped: true };
+    const bridge = runtime.tokenStateBridge;
+    if (typeof bridge?.reserveMovementDestinationClaim !== 'function') return { valid: false, reason: 'MOVEMENT_CLAIM_BRIDGE_UNAVAILABLE' };
+    try {
+      return await bridge.reserveMovementDestinationClaim(token, token.pendingMovementClaim);
+    } catch (error) {
+      return { valid: false, reason: error?.message || 'MOVEMENT_DESTINATION_CLAIM_FAILED' };
+    }
+  }
+
+  async function cancelDestination(token, reason, rollback = true) {
+    const bridge = runtime.tokenStateBridge;
+    if (typeof bridge?.cancelMovementDestinationClaim !== 'function') {
+      if (rollback && token?.pendingMovementClaim) window.LuminousVttMovementDestinationClaims?.restoreFromClaim?.(token, token.pendingMovementClaim);
+      else if (token) delete token.pendingMovementClaim;
+      return { valid: false, reason: 'MOVEMENT_CLAIM_BRIDGE_UNAVAILABLE' };
+    }
+    try {
+      return await bridge.cancelMovementDestinationClaim(token, { rollback, reason });
+    } catch (_) {
+      return { valid: false, reason: reason || 'MOVEMENT_DESTINATION_CLAIM_CANCEL_FAILED' };
+    }
+  }
+
   async function resolveMovementOrder({ token, from, requestedPoint }) {
     if (!movementOnline()) return offlineResult();
     const plan = planFor(token, from, requestedPoint);
     if (!plan.valid) return plan;
-    const doors = await prepareDoorInteractions(token, plan);
-    if (!doors.valid) return { ...plan, valid: false, reason: doors.reason || 'DOOR_INTERACTION_FAILED' };
+
     const committed = movement.commitMove(token, plan, worldState());
     if (!committed.valid) return committed;
+
+    const reserved = await reserveDestination(token);
+    if (!reserved.valid) {
+      await cancelDestination(token, reserved.reason || 'MOVEMENT_DESTINATION_CLAIM_LOST', true);
+      return { ...plan, valid: false, reason: reserved.reason || 'MOVEMENT_DESTINATION_CLAIM_LOST' };
+    }
+
+    const doors = await prepareDoorInteractions(token, plan);
+    if (!doors.valid) {
+      await cancelDestination(token, doors.reason || 'DOOR_INTERACTION_FAILED', true);
+      return { ...plan, valid: false, reason: doors.reason || 'DOOR_INTERACTION_FAILED' };
+    }
+
     const endpoint = plan.path?.[plan.path.length - 1] || pathfinding.pointForCell(pathfinding.cellFromPoint(requestedPoint, mapData), mapData, pathfinding.tokenLayer(token));
     return {
       ...plan,
@@ -271,6 +309,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
       actionMode: token.activeActionMovementMode || 'walk',
       doorInteractions: doors.interactions,
       stopAtDoor: plan.stopAtDoor || null,
+      destinationReserved: Boolean(reserved.reservation),
     };
   }
 

--- a/js/vtt/movement-connectivity.js
+++ b/js/vtt/movement-connectivity.js
@@ -1,0 +1,283 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) {
+    root.LuminousVttMovementConnectivity = api;
+    api.installTokenState(root);
+  }
+})(typeof window !== 'undefined' ? window : globalThis, function () {
+  'use strict';
+
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const clean = (value) => String(value ?? '').trim();
+
+  function connectionRefFor(base, host, options = {}) {
+    if (options.connectionRef) return options.connectionRef;
+    const firebase = options.firebase || base?.hostFirebase?.(host) || host?.firebase;
+    const db = options.db || firebase?.database?.() || null;
+    return { ref: db?.ref?.('.info/connected') || null, db, firebase };
+  }
+
+  function turnExtras(token = {}) {
+    return {
+      movementTurnStart: token.movementTurnStart ? clone(token.movementTurnStart) : null,
+      dashActionType: clean(token.dashActionType) || null,
+    };
+  }
+
+  function applyTurnExtras(token, position = {}) {
+    if (!token || !position || typeof position !== 'object') return token;
+    if (position.movementTurnStart && typeof position.movementTurnStart === 'object') token.movementTurnStart = clone(position.movementTurnStart);
+    else delete token.movementTurnStart;
+    const actionType = clean(position.dashActionType);
+    if (actionType) token.dashActionType = actionType;
+    else delete token.dashActionType;
+    return token;
+  }
+
+  function installTokenState(host) {
+    const base = host?.LuminousVttTokenState;
+    if (!base || base.__onlineOnlyMovementPatch) return base || null;
+    const createBridgeBase = base.createBridge;
+
+    function createBridge(options = {}) {
+      const bridge = createBridgeBase(options);
+      const mapData = options.mapData || {};
+      const { ref: connectedRef, db, firebase } = connectionRefFor(base, host, options);
+      const mapId = String(bridge.mapId || mapData.id || mapData.mapId || 'default');
+      const playerRoot = base.PLAYER_ROOT || 'campaña/jugadores';
+      const worldRoot = `${base.WORLD_ROOT || 'campaña/estado_mundo/vttTokens'}/${mapId}`;
+      let requestedStart = false;
+      let connected = false;
+      let innerStarted = false;
+      let connectionHandler = null;
+      let playerExtrasHandler = null;
+      let worldExtrasHandler = null;
+
+      function playerTokenFor(playerKey, record = {}) {
+        const normalizedKey = clean(playerKey);
+        const recordPlayerId = clean(record.playerId || playerKey);
+        return (mapData.tokens || []).find((entry) => {
+          if (entry.canonicalScope === 'player') return clean(entry.canonicalPlayerKey || entry.playerId) === normalizedKey || clean(entry.playerId) === recordPlayerId;
+          return recordPlayerId && recordPlayerId === clean(bridge.identity?.playerId) && (entry.viewer === true || entry.characterLink?.mode === 'current_player');
+        }) || null;
+      }
+
+      function applyPlayerExtras(rawPlayers = {}) {
+        Object.entries(rawPlayers || {}).forEach(([playerKey, playerData]) => {
+          const record = playerData?.vttTokenState?.[mapId];
+          if (!record?.position) return;
+          const token = playerTokenFor(playerKey, record);
+          if (token) applyTurnExtras(token, record.position);
+        });
+      }
+
+      function applyWorldExtras(rawWorld = {}) {
+        Object.entries(rawWorld || {}).forEach(([key, record]) => {
+          if (!record?.position) return;
+          const tokenId = clean(record.tokenId || key);
+          const token = (mapData.tokens || []).find((entry) => clean(entry.id) === tokenId);
+          if (token) applyTurnExtras(token, record.position);
+        });
+      }
+
+      function attachExtraListeners() {
+        if (!db || playerExtrasHandler || worldExtrasHandler) return;
+        playerExtrasHandler = (snapshot) => applyPlayerExtras(snapshot?.val?.() || {});
+        worldExtrasHandler = (snapshot) => applyWorldExtras(snapshot?.val?.() || {});
+        db.ref(playerRoot).on('value', playerExtrasHandler);
+        db.ref(worldRoot).on('value', worldExtrasHandler);
+      }
+
+      function detachExtraListeners() {
+        if (db && playerExtrasHandler) db.ref(playerRoot).off('value', playerExtrasHandler);
+        if (db && worldExtrasHandler) db.ref(worldRoot).off('value', worldExtrasHandler);
+        playerExtrasHandler = null;
+        worldExtrasHandler = null;
+      }
+
+      function startInner() {
+        if (innerStarted || !connected) return false;
+        innerStarted = Boolean(bridge.start?.() !== false);
+        attachExtraListeners();
+        return innerStarted;
+      }
+
+      function stopInner() {
+        detachExtraListeners();
+        if (innerStarted) bridge.stop?.();
+        innerStarted = false;
+      }
+
+      function setConnected(value) {
+        const next = Boolean(value);
+        if (connected === next) return connected;
+        connected = next;
+        if (!connected) stopInner();
+        else if (requestedStart) startInner();
+        return connected;
+      }
+
+      function start() {
+        if (requestedStart) return connected;
+        requestedStart = true;
+        if (!connectedRef?.on) return false;
+        connectionHandler = (snapshot) => setConnected(snapshot?.val?.() === true);
+        connectedRef.on('value', connectionHandler);
+        return connected;
+      }
+
+      function stop() {
+        requestedStart = false;
+        stopInner();
+        if (connectedRef && connectionHandler) connectedRef.off?.('value', connectionHandler);
+        connectionHandler = null;
+        connected = false;
+      }
+
+      function assertConnected() {
+        if (!connected || !db) throw new Error('VTT_OFFLINE_NO_UPDATE');
+      }
+
+      async function persistExtras(token, result = {}) {
+        if (!token || !result?.scope || !result?.key) return turnExtras(token);
+        assertConnected();
+        const extras = turnExtras(token);
+        const updates = {
+          'position/movementTurnStart': extras.movementTurnStart,
+          'position/dashActionType': extras.dashActionType,
+        };
+        if (result.scope === 'player') {
+          const key = base.firebaseKey?.(result.key, 'player') || clean(result.key);
+          await db.ref(`${playerRoot}/${key}/vttTokenState/${mapId}`).update(updates);
+        } else if (result.scope === 'world') {
+          const key = base.firebaseKey?.(result.key, 'token') || clean(result.key);
+          await db.ref(worldRoot).child(key).update(updates);
+        }
+        return extras;
+      }
+
+      async function saveToken(token) {
+        assertConnected();
+        const result = await bridge.saveToken(token);
+        await persistExtras(token, result);
+        return { ...result, turn: turnExtras(token), connected: true };
+      }
+
+      async function createWorldToken(token) {
+        assertConnected();
+        const result = typeof bridge.createWorldToken === 'function' ? await bridge.createWorldToken(token) : await bridge.saveToken(token);
+        await persistExtras(token, result);
+        return { ...result, turn: turnExtras(token), connected: true };
+      }
+
+      return Object.freeze({
+        ...bridge,
+        start,
+        stop,
+        saveToken,
+        createWorldToken,
+        isConnected: () => connected,
+        applyPlayerTurnExtras: applyPlayerExtras,
+        applyWorldTurnExtras: applyWorldExtras,
+      });
+    }
+
+    const patched = Object.freeze({
+      ...base,
+      __onlineOnlyMovementPatch: true,
+      turnExtras,
+      applyTurnExtras,
+      createBridge,
+    });
+    host.LuminousVttTokenState = patched;
+    return patched;
+  }
+
+  function installRealtime(host) {
+    const base = host?.LuminousVttMovementRealtime;
+    if (!base || base.__onlineOnlyMovementPatch) return base || null;
+    const createControllerBase = base.createController;
+
+    function createController(options = {}) {
+      const firebase = options.firebase || base.hostFirebase?.(options.root || host) || host?.firebase;
+      const db = options.db || firebase?.database?.() || null;
+      const connectedRef = options.connectionRef || db?.ref?.('.info/connected') || null;
+      let requestedStart = false;
+      let stopped = false;
+      let connected = false;
+      let connectionHandler = null;
+      let inner = null;
+
+      function createInner() {
+        if (!connected || stopped || inner) return inner;
+        inner = createControllerBase(options);
+        if (requestedStart) inner.start?.();
+        return inner;
+      }
+
+      function dropInner() {
+        inner?.stop?.();
+        inner = null;
+      }
+
+      function setConnected(value) {
+        const next = Boolean(value);
+        if (connected === next) return connected;
+        connected = next;
+        if (!connected) dropInner();
+        else if (requestedStart) createInner();
+        return connected;
+      }
+
+      function start() {
+        if (requestedStart || stopped) return snapshot();
+        requestedStart = true;
+        if (!connectedRef?.on) return snapshot();
+        connectionHandler = (snapshotValue) => setConnected(snapshotValue?.val?.() === true);
+        connectedRef.on('value', connectionHandler);
+        return snapshot();
+      }
+
+      function stop() {
+        if (stopped) return;
+        stopped = true;
+        requestedStart = false;
+        dropInner();
+        if (connectedRef && connectionHandler) connectedRef.off?.('value', connectionHandler);
+        connectionHandler = null;
+        connected = false;
+      }
+
+      function requireOnline() {
+        if (!connected || !inner) throw new Error('VTT_OFFLINE_NO_UPDATE');
+        return inner;
+      }
+
+      function snapshot() {
+        const value = inner?.snapshot?.() || {};
+        return Object.freeze({ ...value, started: requestedStart, stopped, connected, onlineOnly: true });
+      }
+
+      return Object.freeze({
+        start,
+        stop,
+        snapshot,
+        finalizeToken: (token, saveCanonical) => requireOnline().finalizeToken(token, saveCanonical),
+        schedulePreview: (token) => connected && inner ? inner.schedulePreview(token) : false,
+        handleIncoming: (...args) => connected && inner ? inner.handleIncoming(...args) : false,
+        clearIncoming: (...args) => connected && inner ? inner.clearIncoming(...args) : false,
+        handleCanonicalSync: (...args) => connected && inner ? inner.handleCanonicalSync(...args) : false,
+        reconcilePlayerSubscriptions: (...args) => connected && inner ? inner.reconcilePlayerSubscriptions(...args) : false,
+        previewRefForToken: (token) => connected && inner ? inner.previewRefForToken(token) : null,
+        isConnected: () => connected,
+      });
+    }
+
+    const patched = Object.freeze({ ...base, __onlineOnlyMovementPatch: true, createController });
+    host.LuminousVttMovementRealtime = patched;
+    return patched;
+  }
+
+  return Object.freeze({ turnExtras, applyTurnExtras, installTokenState, installRealtime });
+});

--- a/js/vtt/movement-destination-claims.js
+++ b/js/vtt/movement-destination-claims.js
@@ -107,8 +107,10 @@
       const schedule = typeof options.movementClaimSchedule === 'function'
         ? options.movementClaimSchedule
         : (fn, ms) => setTimeout(fn, ms);
+      const reservations = new Map();
 
       function rulesRuntime() { return host?.LuminousVttMovementRules || null; }
+      function tokenKey(token = {}) { return clean(token.id || token.canonicalPlayerKey || token.playerId || bridge.identity?.playerId); }
 
       function candidateFor(token, pending, cell) {
         const timestamp = Math.max(0, Math.trunc(now()));
@@ -125,6 +127,7 @@
           locked: false,
           committed: false,
           cell,
+          localId: clean(pending.localId) || null,
           from: clone(pending.from || null),
           to: clone(pending.to || null),
           movementCostFt: Math.max(0, finite(pending.movementCostFt, 0)),
@@ -193,24 +196,60 @@
         options.onTokensChanged?.({ scope: 'movement-claim', tokenId: token?.id || null, reason, reverted: true });
       }
 
+      async function reserveMovementDestinationClaim(token, pending = token?.pendingMovementClaim) {
+        if (!pending) return { valid: true, skipped: true };
+        const key = tokenKey(token);
+        if (!key) return { valid: false, reason: 'MOVEMENT_CLAIM_TOKEN_KEY_REQUIRED' };
+        const existing = reservations.get(key);
+        if (existing && clean(existing.localId) === clean(pending.localId)) return { valid: true, reused: true, reservation: existing };
+        if (existing) {
+          await releaseClaim(existing).catch(() => false);
+          reservations.delete(key);
+        }
+        const reservation = await acquireClaim(token, pending);
+        if (!reservation.valid) return reservation;
+        reservation.localId = clean(pending.localId) || null;
+        reservations.set(key, reservation);
+        return { valid: true, reservation };
+      }
+
+      async function cancelMovementDestinationClaim(token, optionsValue = {}) {
+        const key = tokenKey(token);
+        const reservation = key ? reservations.get(key) : null;
+        if (reservation) {
+          reservations.delete(key);
+          await releaseClaim(reservation);
+        }
+        if (optionsValue.rollback === true && token?.pendingMovementClaim) rollback(token, token.pendingMovementClaim, optionsValue.reason || 'MOVEMENT_DESTINATION_CLAIM_CANCELLED');
+        else if (token) delete token.pendingMovementClaim;
+        return { valid: true, released: Boolean(reservation) };
+      }
+
       async function saveWithClaim(token, saveCanonical) {
         const pending = token?.pendingMovementClaim;
         if (!pending) return saveCanonical();
-        const reservation = await acquireClaim(token, pending);
-        if (!reservation.valid) {
-          rollback(token, pending, reservation.reason);
-          const error = new Error(reservation.reason || 'MOVEMENT_DESTINATION_CLAIM_LOST');
-          error.claim = reservation.occupant || null;
-          throw error;
+        const key = tokenKey(token);
+        let reservation = key ? reservations.get(key) : null;
+        if (!reservation || clean(reservation.localId) !== clean(pending.localId)) {
+          const reserved = await reserveMovementDestinationClaim(token, pending);
+          if (!reserved.valid) {
+            rollback(token, pending, reserved.reason);
+            const error = new Error(reserved.reason || 'MOVEMENT_DESTINATION_CLAIM_LOST');
+            error.claim = reserved.occupant || null;
+            throw error;
+          }
+          reservation = reserved.reservation;
         }
         try {
           const result = await saveCanonical();
           const committed = await markCommitted(reservation);
           if (!committed) throw new Error('MOVEMENT_DESTINATION_CLAIM_COMMIT_LOST');
+          if (key) reservations.delete(key);
           delete token.pendingMovementClaim;
           schedule(() => { void releaseClaim(reservation); }, postCommitHoldMs);
           return { ...result, destinationClaim: { valid: true, cell: reservation.candidate.cell, authority: reservation.candidate.authority } };
         } catch (error) {
+          if (key) reservations.delete(key);
           await releaseClaim(reservation);
           rollback(token, pending, error?.message || 'MOVEMENT_CANONICAL_SAVE_FAILED');
           throw error;
@@ -226,12 +265,22 @@
         return saveWithClaim(token, saver);
       }
 
+      function stop() {
+        for (const reservation of reservations.values()) void releaseClaim(reservation);
+        reservations.clear();
+        return bridge.stop?.();
+      }
+
       return Object.freeze({
         ...bridge,
+        stop,
         saveToken,
         createWorldToken,
         acquireMovementDestinationClaim: acquireClaim,
+        reserveMovementDestinationClaim,
+        cancelMovementDestinationClaim,
         releaseMovementDestinationClaim: releaseClaim,
+        movementDestinationReservationCount: () => reservations.size,
       });
     }
 

--- a/js/vtt/movement-destination-claims.js
+++ b/js/vtt/movement-destination-claims.js
@@ -1,0 +1,267 @@
+(function (root, factory) {
+  const api = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) {
+    root.LuminousVttMovementDestinationClaims = api;
+    api.install(root);
+  }
+})(typeof window !== 'undefined' ? window : globalThis, function (root) {
+  'use strict';
+
+  const CLAIM_ROOT = 'campaña/estado_mundo/vttMovementClaims';
+  const DEFAULT_ARBITRATION_MS = 120;
+  const DEFAULT_LEASE_MS = 3000;
+  const DEFAULT_POST_COMMIT_HOLD_MS = 650;
+  const clean = (value) => String(value ?? '').trim();
+  const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+  function firebaseKey(value, fallback = 'key') {
+    return clean(value).replace(/[.#$\[\]\/]/g, '_') || fallback;
+  }
+
+  function authorityFor(token = {}, isDm = false) {
+    const explicit = clean(token.pendingMovementAuthority || token.controlSource || token.controllerType).toLowerCase();
+    if (explicit === 'goap' || explicit === 'ai') return 'goap';
+    if (explicit === 'dm' || explicit === 'gm') return 'dm';
+    if (explicit === 'player' || explicit === 'human') return 'player';
+    return isDm ? 'dm' : 'player';
+  }
+
+  function cellForClaim(claim = {}, mapData = {}) {
+    const to = claim.to || {};
+    const size = Math.max(1, finite(mapData.grid?.size, 70));
+    const cols = Math.max(1, Math.trunc(finite(mapData.grid?.cols, 1)));
+    const rows = Math.max(1, Math.trunc(finite(mapData.grid?.rows, 1)));
+    const col = Number.isFinite(Number(to.col)) ? Math.trunc(Number(to.col)) : Math.floor(finite(to.x) / size);
+    const row = Number.isFinite(Number(to.row)) ? Math.trunc(Number(to.row)) : Math.floor(finite(to.y) / size);
+    if (col < 0 || row < 0 || col >= cols || row >= rows) return null;
+    return { col, row, zLayer: Math.trunc(finite(to.zLayer ?? to.z, 0)) };
+  }
+
+  function claimPath(mapId, cell) {
+    return `${CLAIM_ROOT}/${firebaseKey(mapId, 'default')}/${firebaseKey(cell.zLayer, '0')}/${cell.col}_${cell.row}`;
+  }
+
+  function sameClaim(a, b) {
+    return Boolean(a?.claimId && b?.claimId && String(a.claimId) === String(b.claimId));
+  }
+
+  function claimExpired(claim, nowMs) {
+    return !claim || finite(claim.expiresAtMs, 0) <= nowMs;
+  }
+
+  function winnerBetween(current, candidate, nowMs, rules) {
+    if (!current || claimExpired(current, nowMs)) return candidate;
+    if (sameClaim(current, candidate) || String(current.tokenId || '') === String(candidate.tokenId || '')) return candidate;
+    if (current.locked === true || current.committed === true) return current;
+    const resolver = rules?.resolveSpaceClaim;
+    if (typeof resolver !== 'function') return current;
+    return resolver([current, candidate]) || current;
+  }
+
+  function restoreFromClaim(token, claim = {}) {
+    const from = claim.from || {};
+    if (Number.isFinite(Number(from.x))) token.x = Number(from.x);
+    if (Number.isFinite(Number(from.y))) token.y = Number(from.y);
+    const zLayer = Number.isFinite(Number(from.zLayer)) ? Number(from.zLayer) : Number(token.zLayer || 0);
+    token.zLayer = zLayer;
+    token.z = [zLayer];
+    if (Number.isFinite(Number(from.elevationFt))) token.elevationFt = Number(from.elevationFt);
+    if (from.gridPosition) token.gridPosition = clone(from.gridPosition);
+
+    const refund = Math.max(0, finite(claim.movementCostFt, 0));
+    if (refund > 0 && Number.isFinite(Number(token.movementRemainingFt))) {
+      const state = token.movementState || {};
+      const speed = Math.max(0, finite(state.speedFt, 0));
+      const capacity = speed * (state.dashed ? 2 : 1);
+      const next = capacity > 0 ? Math.min(capacity, Number(token.movementRemainingFt) + refund) : Number(token.movementRemainingFt) + refund;
+      token.movementRemainingFt = next;
+      state.remainingFt = next;
+      token.movementState = state;
+    }
+    if (Array.isArray(token.movementTurnHistory) && token.movementTurnHistory.length) token.movementTurnHistory.pop();
+    delete token.pendingMovementClaim;
+    return token;
+  }
+
+  function install(host = root) {
+    const base = host?.LuminousVttTokenState;
+    if (!base || base.__destinationClaimPatch) return base || null;
+    const createBridgeBase = base.createBridge;
+
+    function createBridge(options = {}) {
+      const bridge = createBridgeBase(options);
+      const mapData = options.mapData || {};
+      const firebase = options.firebase || base.hostFirebase?.(host) || host?.firebase;
+      const db = options.db || firebase?.database?.() || null;
+      const mapId = String(bridge.mapId || mapData.id || mapData.mapId || 'default');
+      const isDm = Boolean(options.isDm ?? bridge.isDm);
+      const arbitrationMs = Math.max(0, finite(options.movementClaimArbitrationMs, DEFAULT_ARBITRATION_MS));
+      const leaseMs = Math.max(arbitrationMs + 250, finite(options.movementClaimLeaseMs, DEFAULT_LEASE_MS));
+      const postCommitHoldMs = Math.max(0, finite(options.movementClaimPostCommitHoldMs, DEFAULT_POST_COMMIT_HOLD_MS));
+      const now = typeof options.movementClaimNow === 'function' ? options.movementClaimNow : () => Date.now();
+      const sleep = typeof options.movementClaimSleep === 'function'
+        ? options.movementClaimSleep
+        : (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+      const schedule = typeof options.movementClaimSchedule === 'function'
+        ? options.movementClaimSchedule
+        : (fn, ms) => setTimeout(fn, ms);
+
+      function rulesRuntime() { return host?.LuminousVttMovementRules || null; }
+
+      function candidateFor(token, pending, cell) {
+        const timestamp = Math.max(0, Math.trunc(now()));
+        const rtt = Number.isFinite(Number(pending.rttMs ?? token.networkRttMs ?? token.rttMs)) ? Number(pending.rttMs ?? token.networkRttMs ?? token.rttMs) : null;
+        return {
+          schemaVersion: 1,
+          claimId: `${firebaseKey(token.id || bridge.identity?.playerId || 'token')}:${timestamp.toString(36)}:${Math.random().toString(36).slice(2, 8)}`,
+          tokenId: clean(token.id) || null,
+          playerId: clean(token.playerId || token.canonicalPlayerKey || bridge.identity?.playerId) || null,
+          authority: authorityFor(token, isDm),
+          rttMs: rtt,
+          receivedAtMs: timestamp,
+          expiresAtMs: timestamp + leaseMs,
+          locked: false,
+          committed: false,
+          cell,
+          from: clone(pending.from || null),
+          to: clone(pending.to || null),
+          movementCostFt: Math.max(0, finite(pending.movementCostFt, 0)),
+          movementType: clean(pending.movementType || 'normal') || 'normal',
+        };
+      }
+
+      async function transact(ref, updater) {
+        if (!ref?.transaction) throw new Error('MOVEMENT_CLAIM_TRANSACTION_UNAVAILABLE');
+        return ref.transaction(updater, undefined, false);
+      }
+
+      async function readClaim(ref) {
+        if (!ref?.once) throw new Error('MOVEMENT_CLAIM_READ_UNAVAILABLE');
+        const snapshot = await ref.once('value');
+        return snapshot?.val?.() || null;
+      }
+
+      async function acquireClaim(token, pending) {
+        if (!db) throw new Error('MOVEMENT_CLAIM_DB_UNAVAILABLE');
+        const cell = cellForClaim(pending, mapData);
+        if (!cell) throw new Error('OUT_OF_BOUNDS');
+        const ref = db.ref(claimPath(mapId, cell));
+        const candidate = candidateFor(token, pending, cell);
+        const first = await transact(ref, (current) => {
+          const winner = winnerBetween(current, candidate, now(), rulesRuntime());
+          return sameClaim(winner, candidate) ? candidate : undefined;
+        });
+        if (!first?.committed) return { valid: false, reason: 'MOVEMENT_DESTINATION_CLAIM_LOST', ref, candidate, occupant: first?.snapshot?.val?.() || null };
+
+        if (arbitrationMs > 0) await sleep(arbitrationMs);
+        const observed = await readClaim(ref);
+        if (!sameClaim(observed, candidate)) return { valid: false, reason: 'MOVEMENT_DESTINATION_CLAIM_LOST', ref, candidate, occupant: observed };
+
+        const locked = await transact(ref, (current) => {
+          if (!sameClaim(current, candidate) || current?.committed === true) return undefined;
+          return { ...current, locked: true, lockedAtMs: Math.max(0, Math.trunc(now())), expiresAtMs: Math.max(finite(current.expiresAtMs, 0), now() + leaseMs) };
+        });
+        if (!locked?.committed) return { valid: false, reason: 'MOVEMENT_DESTINATION_CLAIM_LOST', ref, candidate, occupant: locked?.snapshot?.val?.() || null };
+        return { valid: true, ref, candidate: { ...candidate, locked: true } };
+      }
+
+      async function markCommitted(reservation) {
+        if (!reservation?.ref || !reservation?.candidate) return false;
+        const result = await transact(reservation.ref, (current) => {
+          if (!sameClaim(current, reservation.candidate)) return undefined;
+          return { ...current, locked: true, committed: true, committedAtMs: Math.max(0, Math.trunc(now())), expiresAtMs: Math.max(finite(current.expiresAtMs, 0), now() + postCommitHoldMs + 500) };
+        });
+        return Boolean(result?.committed);
+      }
+
+      async function releaseClaim(reservation) {
+        if (!reservation?.ref || !reservation?.candidate) return false;
+        try {
+          const result = await transact(reservation.ref, (current) => sameClaim(current, reservation.candidate) ? null : undefined);
+          return Boolean(result?.committed);
+        } catch (_) {
+          return false;
+        }
+      }
+
+      function rollback(token, pending, reason = 'MOVEMENT_DESTINATION_CLAIM_LOST') {
+        restoreFromClaim(token, pending);
+        mapData.movement ||= {};
+        mapData.movement.lastClaimLoss = { tokenId: token?.id || null, reason, atMs: Math.max(0, Math.trunc(now())) };
+        options.onTokensChanged?.({ scope: 'movement-claim', tokenId: token?.id || null, reason, reverted: true });
+      }
+
+      async function saveWithClaim(token, saveCanonical) {
+        const pending = token?.pendingMovementClaim;
+        if (!pending) return saveCanonical();
+        const reservation = await acquireClaim(token, pending);
+        if (!reservation.valid) {
+          rollback(token, pending, reservation.reason);
+          const error = new Error(reservation.reason || 'MOVEMENT_DESTINATION_CLAIM_LOST');
+          error.claim = reservation.occupant || null;
+          throw error;
+        }
+        try {
+          const result = await saveCanonical();
+          const committed = await markCommitted(reservation);
+          if (!committed) throw new Error('MOVEMENT_DESTINATION_CLAIM_COMMIT_LOST');
+          delete token.pendingMovementClaim;
+          schedule(() => { void releaseClaim(reservation); }, postCommitHoldMs);
+          return { ...result, destinationClaim: { valid: true, cell: reservation.candidate.cell, authority: reservation.candidate.authority } };
+        } catch (error) {
+          await releaseClaim(reservation);
+          rollback(token, pending, error?.message || 'MOVEMENT_CANONICAL_SAVE_FAILED');
+          throw error;
+        }
+      }
+
+      async function saveToken(token) {
+        return saveWithClaim(token, () => bridge.saveToken(token));
+      }
+
+      async function createWorldToken(token) {
+        const saver = typeof bridge.createWorldToken === 'function' ? () => bridge.createWorldToken(token) : () => bridge.saveToken(token);
+        return saveWithClaim(token, saver);
+      }
+
+      return Object.freeze({
+        ...bridge,
+        saveToken,
+        createWorldToken,
+        acquireMovementDestinationClaim: acquireClaim,
+        releaseMovementDestinationClaim: releaseClaim,
+      });
+    }
+
+    const patched = Object.freeze({
+      ...base,
+      __destinationClaimPatch: true,
+      CLAIM_ROOT,
+      DEFAULT_ARBITRATION_MS,
+      DEFAULT_LEASE_MS,
+      DEFAULT_POST_COMMIT_HOLD_MS,
+      authorityFor,
+      cellForClaim,
+      winnerBetween,
+      restoreFromClaim,
+      createBridge,
+    });
+    host.LuminousVttTokenState = patched;
+    return patched;
+  }
+
+  return Object.freeze({
+    CLAIM_ROOT,
+    DEFAULT_ARBITRATION_MS,
+    DEFAULT_LEASE_MS,
+    DEFAULT_POST_COMMIT_HOLD_MS,
+    firebaseKey,
+    authorityFor,
+    cellForClaim,
+    winnerBetween,
+    restoreFromClaim,
+    install,
+  });
+});

--- a/js/vtt/movement-door-runtime.js
+++ b/js/vtt/movement-door-runtime.js
@@ -22,6 +22,57 @@
     return closedDoor(door) && doorState(door) === 'closed' && !door.locked;
   }
 
+  function requestedInBounds(target = {}, mapData = {}) {
+    const grid = mapData.grid || {};
+    const size = Math.max(1, finite(grid.size, 70));
+    const cols = Math.max(1, Math.trunc(finite(grid.cols, 1)));
+    const rows = Math.max(1, Math.trunc(finite(grid.rows, 1)));
+    if (target.col != null || target.row != null) {
+      const col = Number(target.col);
+      const row = Number(target.row);
+      return Number.isFinite(col) && Number.isFinite(row) && col >= 0 && row >= 0 && col < cols && row < rows;
+    }
+    const x = Number(target.x);
+    const y = Number(target.y);
+    return Number.isFinite(x) && Number.isFinite(y) && x >= 0 && y >= 0 && x < cols * size && y < rows * size;
+  }
+
+  function rejected(reason) {
+    return { valid: false, reason, path: [], cells: [], costFt: Infinity, routeCostFt: Infinity, movementCostFt: Infinity };
+  }
+
+  function verticalResumePlan(options = {}) {
+    const token = options.token || {};
+    if (!token.verticalMovement) return null;
+    const mapData = options.mapData || {};
+    const start = options.start || { x: token.x, y: token.y };
+    const zLayer = pathfinding.tokenLayer(token);
+    const cell = token.gridPosition
+      ? { col: Number(token.gridPosition.col) || 0, row: Number(token.gridPosition.row) || 0 }
+      : pathfinding.cellFromPoint(start, mapData);
+    const point = {
+      x: finite(start.x, token.x),
+      y: finite(start.y, token.y),
+      col: cell.col,
+      row: cell.row,
+      z: zLayer,
+      elevationFt: finite(token.elevationFt),
+    };
+    return {
+      valid: true,
+      reason: null,
+      verticalResume: true,
+      path: [point],
+      cells: [cell],
+      costFt: 0,
+      routeCostFt: 0,
+      movementCostFt: 0,
+      movementType: clean(options.movementType || 'normal') || 'normal',
+      mode: clean(options.movementMode || token.movementState?.mode || 'walk') || 'walk',
+      remainingFt: Number.isFinite(Number(token.movementRemainingFt)) ? Number(token.movementRemainingFt) : Infinity,
+    };
+  }
+
   function movementArgs(options = {}, mapData = options.mapData || {}) {
     const token = options.token || {};
     const state = base.currentMovementState(token);
@@ -48,7 +99,7 @@
     const candidate = rawRoute(options, planningMap);
     if (!candidate.valid) return originalPlan;
     const crossings = rules.doorCrossings(candidate.path, mapData, pathfinding.tokenLayer(options.token));
-      const first = crossings.find((entry) => closedDoor(entry.door));
+    const first = crossings.find((entry) => closedDoor(entry.door));
     if (!first) return originalPlan;
     const partialPath = rules.truncateBeforeDoor(candidate.path, first);
     const endpoint = partialPath[partialPath.length - 1];
@@ -95,6 +146,10 @@
   }
 
   function planMove(options = {}) {
+    if (!requestedInBounds(options.target, options.mapData || {})) return rejected('OUT_OF_BOUNDS');
+    const resumed = verticalResumePlan(options);
+    if (resumed) return resumed;
+
     const normalPlan = base.planMove(options);
     const token = options.token || {};
     const actionMode = clean(token.activeActionMovementMode || (token.movementState?.dashed ? 'dash' : '') || 'walk');
@@ -119,5 +174,7 @@
     __doorAwareMovementPatch: true,
     planMove,
     describeDoorPlan,
+    requestedInBounds,
+    verticalResumePlan,
   });
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/js/vtt/movement-door-runtime.js
+++ b/js/vtt/movement-door-runtime.js
@@ -134,6 +134,7 @@
           action: 'open',
           doorId: entry.door?.id || null,
           pathIndex: entry.pathIndex,
+          at: entry.point ? { x: entry.point.x, y: entry.point.y } : null,
           burstOpen: true,
           noise: 'high',
           soundEvent: 'DASH_DOOR_BURST',

--- a/js/vtt/movement-door-runtime.js
+++ b/js/vtt/movement-door-runtime.js
@@ -146,7 +146,8 @@
   }
 
   function planMove(options = {}) {
-    if (!requestedInBounds(options.target, options.mapData || {})) return rejected('OUT_OF_BOUNDS');
+    if (!options.token || !options.start || !options.target || !options.mapData?.grid) return base.planMove(options);
+    if (!requestedInBounds(options.target, options.mapData)) return rejected('OUT_OF_BOUNDS');
     const resumed = verticalResumePlan(options);
     if (resumed) return resumed;
 

--- a/js/vtt/movement-door-runtime.js
+++ b/js/vtt/movement-door-runtime.js
@@ -1,0 +1,123 @@
+(function (root) {
+  'use strict';
+
+  const base = root?.LuminousVttMovementEngine;
+  const pathfinding = root?.LuminousVttPathfinding;
+  const rules = root?.LuminousVttMovementRules;
+  if (!base || !pathfinding || !rules || base.__doorAwareMovementPatch) return;
+
+  const clean = (value) => String(value ?? '').trim().toLowerCase();
+  const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+  function doorState(door = {}) {
+    return clean(door.state || 'closed') || 'closed';
+  }
+
+  function closedDoor(door = {}) {
+    const state = doorState(door);
+    return clean(door.type) === 'door' && state !== 'open' && state !== 'broken';
+  }
+
+  function unlockedClosedDoor(door = {}) {
+    return closedDoor(door) && doorState(door) === 'closed' && !door.locked;
+  }
+
+  function movementArgs(options = {}, mapData = options.mapData || {}) {
+    const token = options.token || {};
+    const state = base.currentMovementState(token);
+    return {
+      token,
+      start: options.start,
+      target: options.target,
+      mapData,
+      zLayer: pathfinding.tokenLayer(token),
+      movementMode: options.movementMode || state.mode || 'walk',
+      blockTokens: options.blockTokens,
+      diagonalRule: options.diagonalRule,
+    };
+  }
+
+  function rawRoute(options = {}, mapData = options.mapData || {}) {
+    const args = movementArgs(options, mapData);
+    return pathfinding.findPath(args);
+  }
+
+  function stopAtFirstDoor(options = {}, originalPlan = null) {
+    const mapData = options.mapData || {};
+    const planningMap = rules.mapWithPassableDoors(mapData, closedDoor);
+    const candidate = rawRoute(options, planningMap);
+    if (!candidate.valid) return originalPlan;
+    const crossings = rules.doorCrossings(candidate.path, mapData, pathfinding.tokenLayer(options.token));
+      const first = crossings.find((entry) => closedDoor(entry.door));
+    if (!first) return originalPlan;
+    const partialPath = rules.truncateBeforeDoor(candidate.path, first);
+    const endpoint = partialPath[partialPath.length - 1];
+    if (!endpoint) return originalPlan;
+    const partial = base.planMove({ ...options, target: endpoint, mapData });
+    if (!partial.valid) return originalPlan;
+    const traversal = rules.doorTraversal({ mode: options.token?.activeActionMovementMode || 'walk', door: first.door, remainingFt: partial.remainingFt });
+    return {
+      ...partial,
+      valid: true,
+      complete: false,
+      requestedTarget: options.target,
+      stopAtDoor: {
+        doorId: first.door?.id || null,
+        state: doorState(first.door),
+        reason: traversal.reason || (doorState(first.door) === 'locked' ? 'DOOR_LOCKED' : 'DOOR_ACTION_REQUIRED'),
+        actionRequired: true,
+      },
+    };
+  }
+
+  function dashPlan(options = {}, normalPlan = null) {
+    const mapData = options.mapData || {};
+    const planningMap = rules.mapWithPassableDoors(mapData, unlockedClosedDoor);
+    const throughDoors = base.planMove({ ...options, mapData: planningMap });
+    if (throughDoors.valid) {
+      const crossings = rules.doorCrossings(throughDoors.path, mapData, pathfinding.tokenLayer(options.token));
+      const interactions = crossings
+        .filter((entry) => unlockedClosedDoor(entry.door))
+        .map((entry) => ({
+          type: 'door',
+          action: 'open',
+          doorId: entry.door?.id || null,
+          pathIndex: entry.pathIndex,
+          burstOpen: true,
+          noise: 'high',
+          soundEvent: 'DASH_DOOR_BURST',
+          pauseMs: 110,
+        }));
+      return { ...throughDoors, doorInteractions: interactions, dashThroughDoors: interactions.length > 0 };
+    }
+    if (throughDoors.reason === 'INSUFFICIENT_MOVEMENT') return throughDoors;
+    return stopAtFirstDoor(options, normalPlan || throughDoors);
+  }
+
+  function planMove(options = {}) {
+    const normalPlan = base.planMove(options);
+    const token = options.token || {};
+    const actionMode = clean(token.activeActionMovementMode || (token.movementState?.dashed ? 'dash' : '') || 'walk');
+    const movementType = clean(options.movementType || 'normal');
+    if (movementType === 'forced' || movementType === 'teleport') return normalPlan;
+    if (actionMode === 'dash' || actionMode === 'run') return dashPlan(options, normalPlan);
+    if (normalPlan.valid || normalPlan.reason === 'INSUFFICIENT_MOVEMENT') return normalPlan;
+    return stopAtFirstDoor(options, normalPlan);
+  }
+
+  function describeDoorPlan(plan = {}) {
+    return {
+      stopAtDoor: plan.stopAtDoor || null,
+      doorInteractions: Array.isArray(plan.doorInteractions) ? plan.doorInteractions.map((entry) => ({ ...entry })) : [],
+      dashThroughDoors: Boolean(plan.dashThroughDoors),
+      movementCostFt: Math.max(0, finite(plan.movementCostFt, 0)),
+    };
+  }
+
+  root.LuminousVttMovementEngine = Object.freeze({
+    ...base,
+    __doorAwareMovementPatch: true,
+    planMove,
+    describeDoorPlan,
+  });
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/vtt/movement-rules-runtime.js
+++ b/js/vtt/movement-rules-runtime.js
@@ -1,0 +1,216 @@
+(function (root) {
+  'use strict';
+
+  const rules = root?.LuminousVttMovementRules;
+  const basePathfinding = root?.LuminousVttPathfinding;
+  const baseMovement = root?.LuminousVttMovementEngine;
+  if (!rules || !basePathfinding || !baseMovement) return;
+
+  const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const EPS = 1e-9;
+
+  function occupantAt(token, point, mapData = {}, zLayer = basePathfinding.tokenLayer(token)) {
+    return (mapData.tokens || []).filter((other) => {
+      if (!other || String(other.id || '') === String(token?.id || '')) return false;
+      if (basePathfinding.tokenLayer(other) !== Number(zLayer)) return false;
+      if (other.blocksMovement === false || other.intangible === true) return false;
+      const distance = Math.hypot(finite(other.x) - finite(point.x), finite(other.y) - finite(point.y));
+      const tokenRadius = root?.LuminousVttTokenInteraction?.tokenRadius?.(token, mapData.grid || {}) || Math.max(4, finite(token?.radius, basePathfinding.gridBounds(mapData).size * 0.4));
+      const otherRadius = root?.LuminousVttTokenInteraction?.tokenRadius?.(other, mapData.grid || {}) || Math.max(4, finite(other?.radius, basePathfinding.gridBounds(mapData).size * 0.4));
+      return distance + EPS < tokenRadius + otherRadius;
+    });
+  }
+
+  function pointPassable(token, point, mapData = {}, zLayer = basePathfinding.tokenLayer(token), options = {}) {
+    const baseGate = basePathfinding.pointPassable(token, point, mapData, zLayer, { ...options, blockTokens: false });
+    if (!baseGate.valid) return baseGate;
+    if ((options.blockTokens ?? mapData.movement?.blockTokens ?? true) === false) return baseGate;
+    const occupants = occupantAt(token, point, mapData, zLayer);
+    if (!occupants.length) return baseGate;
+    if (options.allowOccupiedTransit === true) {
+      for (const occupant of occupants) {
+        const traversal = rules.canTraverseOccupiedSpace(token, occupant, { relationResolver: options.relationResolver || mapData.movement?.relationResolver });
+        if (!traversal.valid) return { valid: false, reason: traversal.reason, token: occupant, relation: traversal.relation };
+      }
+      return { ...baseGate, transitOccupants: occupants };
+    }
+    return { valid: false, reason: 'OCCUPIED_DESTINATION', token: occupants[0] };
+  }
+
+  function edgePassable(token, fromCell, toCell, mapData = {}, zLayer = basePathfinding.tokenLayer(token), options = {}) {
+    const from = basePathfinding.pointForCell(fromCell, mapData, zLayer);
+    const to = basePathfinding.pointForCell(toCell, mapData, zLayer);
+    const destination = pointPassable(token, to, mapData, zLayer, { ...options, allowOccupiedTransit: true });
+    if (!destination.valid) return destination;
+    const dx = toCell.col - fromCell.col;
+    const dy = toCell.row - fromCell.row;
+    if (Math.abs(dx) === 1 && Math.abs(dy) === 1) {
+      const a = { col: fromCell.col + dx, row: fromCell.row };
+      const b = { col: fromCell.col, row: fromCell.row + dy };
+      const ap = pointPassable(token, basePathfinding.pointForCell(a, mapData, zLayer), mapData, zLayer, { ...options, allowOccupiedTransit: true });
+      const bp = pointPassable(token, basePathfinding.pointForCell(b, mapData, zLayer), mapData, zLayer, { ...options, allowOccupiedTransit: true });
+      if (!ap.valid || !bp.valid) return { valid: false, reason: 'CORNER_CUT_BLOCKED' };
+    }
+    const interaction = root?.LuminousVttTokenInteraction;
+    const path = interaction?.isPathClear?.(token, from, to, mapData) || { valid: true };
+    return path.valid ? { valid: true, terrain: destination.terrain } : path;
+  }
+
+  function reconstruct(cameFrom, nodes, endKey, mapData, zLayer) {
+    const cells = [];
+    let key = endKey;
+    while (key) {
+      const cell = nodes.get(key);
+      if (!cell) break;
+      cells.push(cell);
+      key = cameFrom.get(key) || null;
+    }
+    cells.reverse();
+    return cells.map((cell) => basePathfinding.pointForCell(cell, mapData, zLayer));
+  }
+
+  function findPath({ token, start, target, mapData = {}, zLayer = basePathfinding.tokenLayer(token), movementMode = 'walk', blockTokens, diagonalRule: rule, maxVisited = 20000 } = {}) {
+    if (!token || !mapData.grid || !start || !target) return { valid: false, reason: 'INVALID_INPUT', path: [], costFt: Infinity };
+    const startCell = start.col != null && start.row != null ? { col: Math.trunc(Number(start.col)), row: Math.trunc(Number(start.row)) } : basePathfinding.cellFromPoint(start, mapData);
+    const targetCell = target.col != null && target.row != null ? { col: Math.trunc(Number(target.col)), row: Math.trunc(Number(target.row)) } : basePathfinding.cellFromPoint(target, mapData);
+    const options = { movementMode, blockTokens, diagonalRule: rule };
+    const targetPoint = basePathfinding.pointForCell(targetCell, mapData, zLayer);
+    const targetGate = pointPassable(token, targetPoint, mapData, zLayer, { ...options, allowOccupiedTransit: false });
+    if (!targetGate.valid) return { valid: false, reason: targetGate.reason || 'TARGET_BLOCKED', path: [], costFt: Infinity, blocker: targetGate };
+    const startKey = basePathfinding.cellKey(startCell.col, startCell.row);
+    const goalKey = basePathfinding.cellKey(targetCell.col, targetCell.row);
+    if (startKey === goalKey) return { valid: true, reason: null, path: [basePathfinding.pointForCell(startCell, mapData, zLayer)], cells: [startCell], costFt: 0, visited: 0 };
+
+    const open = new Set([startKey]);
+    const nodes = new Map([[startKey, startCell]]);
+    const cameFrom = new Map();
+    const g = new Map([[startKey, 0]]);
+    const minTerrainMultiplier = Math.max(0.001, finite(basePathfinding.MIN_TERRAIN_MULTIPLIER, 0.05));
+    const heuristic = (cell) => basePathfinding.heuristicFt(cell, targetCell, mapData, options) * (basePathfinding.__cheapTerrainHeuristicPatch ? 1 : minTerrainMultiplier);
+    const f = new Map([[startKey, heuristic(startCell)]]);
+    let visited = 0;
+    const limit = Math.max(1, Math.trunc(finite(maxVisited, 20000)));
+
+    while (open.size && visited < limit) {
+      let currentKey = null;
+      let currentScore = Infinity;
+      for (const key of open) {
+        const score = f.get(key) ?? Infinity;
+        if (score < currentScore) { currentScore = score; currentKey = key; }
+      }
+      if (!currentKey) break;
+      const current = nodes.get(currentKey);
+      if (currentKey === goalKey) {
+        const path = reconstruct(cameFrom, nodes, currentKey, mapData, zLayer);
+        return { valid: true, reason: null, path, cells: path.map((point) => ({ col: point.col, row: point.row })), costFt: g.get(currentKey) || 0, visited };
+      }
+      open.delete(currentKey);
+      visited += 1;
+      for (const next of basePathfinding.neighbors(current, mapData)) {
+        const edge = edgePassable(token, current, next, mapData, zLayer, options);
+        if (!edge.valid) continue;
+        const nextKey = basePathfinding.cellKey(next.col, next.row);
+        const tentative = (g.get(currentKey) ?? Infinity) + basePathfinding.stepCostFt(current, next, mapData, zLayer, options);
+        if (tentative + EPS >= (g.get(nextKey) ?? Infinity)) continue;
+        cameFrom.set(nextKey, currentKey);
+        nodes.set(nextKey, next);
+        g.set(nextKey, tentative);
+        f.set(nextKey, tentative + heuristic(next));
+        open.add(nextKey);
+      }
+    }
+    return { valid: false, reason: visited >= limit ? 'SEARCH_LIMIT' : 'NO_PATH', path: [], cells: [], costFt: Infinity, visited };
+  }
+
+  root.LuminousVttPathfinding = Object.freeze({
+    ...basePathfinding,
+    __occupancyRulesPatch: true,
+    occupantAt,
+    pointPassable,
+    edgePassable,
+    findPath,
+  });
+
+  function captureTurnStart(token = {}) {
+    token.movementTurnStart = rules.snapshotTurnStart(token);
+    token.movementTurnHistory = [];
+    return clone(token.movementTurnStart);
+  }
+
+  function beginRound(token = {}, roundId = 0, mode = null) {
+    const state = baseMovement.beginRound(token, roundId, mode);
+    captureTurnStart(token);
+    return state;
+  }
+
+  function ensureRound(token = {}, worldState = {}, mode = null) {
+    const world = baseMovement.normalizeWorldState(worldState);
+    if (world.mode !== 'round') return baseMovement.setFreeMode(token);
+    const current = baseMovement.currentMovementState(token);
+    if (current.roundId !== world.roundId || !Number.isFinite(Number(token.movementRemainingFt))) return beginRound(token, world.roundId, mode || current.mode);
+    if (!token.movementTurnStart) captureTurnStart(token);
+    return current;
+  }
+
+  function commitMove(token = {}, plan = {}, worldState = {}) {
+    const result = baseMovement.commitMove(token, plan, worldState);
+    if (!result.valid) return result;
+    const world = baseMovement.normalizeWorldState(worldState);
+    if (world.mode === 'round') {
+      if (!token.movementTurnStart) captureTurnStart(token);
+      token.movementTurnHistory ||= [];
+      token.movementTurnHistory.push({
+        path: clone(result.path || []),
+        costFt: Math.max(0, finite(result.costFt)),
+        movementType: plan.movementType || 'normal',
+      });
+    }
+    return result;
+  }
+
+  function dash(token = {}, worldState = {}, options = {}) {
+    const result = baseMovement.dash(token, worldState, options);
+    if (!result.valid) return result;
+    token.activeActionMovementMode = 'dash';
+    token.dashActionType = String(options.actionType || options.cost || 'action');
+    return { ...result, actionType: token.dashActionType, noise: 'high' };
+  }
+
+  function resetMovement(token = {}, worldState = {}) {
+    const world = baseMovement.normalizeWorldState(worldState);
+    if (world.mode !== 'round') return { valid: false, reason: 'ROUND_MODE_REQUIRED' };
+    const state = ensureRound(token, world);
+    const start = token.movementTurnStart;
+    if (!start) return { valid: false, reason: 'TURN_START_UNAVAILABLE' };
+    token.x = finite(start.x);
+    token.y = finite(start.y);
+    token.zLayer = finite(start.zLayer);
+    token.z = [token.zLayer];
+    token.elevationFt = finite(start.elevationFt);
+    if (start.gridPosition) token.gridPosition = clone(start.gridPosition);
+    state.remainingFt = Math.max(0, finite(state.speedFt));
+    state.dashed = false;
+    token.movementState = state;
+    token.movementRemainingFt = state.remainingFt;
+    token.movementTurnHistory = [];
+    delete token.activeActionMovementMode;
+    const actionType = token.dashActionType || null;
+    delete token.dashActionType;
+    return { valid: true, position: clone(start), remainingFt: state.remainingFt, refundActionType: actionType };
+  }
+
+  function movementStart(token = {}) { return clone(token.movementTurnStart || null); }
+
+  root.LuminousVttMovementEngine = Object.freeze({
+    ...baseMovement,
+    __movementRulesClosurePatch: true,
+    beginRound,
+    ensureRound,
+    commitMove,
+    dash,
+    resetMovement,
+    movementStart,
+    captureTurnStart,
+  });
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/vtt/movement-rules-runtime.js
+++ b/js/vtt/movement-rules-runtime.js
@@ -141,16 +141,81 @@
   function beginRound(token = {}, roundId = 0, mode = null) {
     const state = baseMovement.beginRound(token, roundId, mode);
     captureTurnStart(token);
+    delete token.dashActionType;
+    delete token.activeActionMovementMode;
+    delete token.movementRoundResume;
+    delete token.pendingMovementClaim;
     return state;
+  }
+
+  function setFreeMode(token = {}) {
+    const current = baseMovement.currentMovementState(token);
+    if (token.movementTurnStart && Number.isFinite(Number(token.movementRemainingFt))) {
+      token.movementRoundResume = {
+        roundId: current.roundId,
+        movementState: clone(token.movementState),
+        movementRemainingFt: Number(token.movementRemainingFt),
+        movementTurnStart: clone(token.movementTurnStart),
+        movementTurnHistory: clone(token.movementTurnHistory || []),
+        dashActionType: token.dashActionType || null,
+        activeActionMovementMode: token.activeActionMovementMode || null,
+      };
+    }
+    return baseMovement.setFreeMode(token);
+  }
+
+  function restorePausedRound(token = {}, world = {}) {
+    const paused = token.movementRoundResume;
+    if (!paused || Number(paused.roundId) !== Number(world.roundId)) return null;
+    token.movementState = clone(paused.movementState || {});
+    token.movementRemainingFt = Math.max(0, finite(paused.movementRemainingFt));
+    if (paused.movementTurnStart) token.movementTurnStart = clone(paused.movementTurnStart);
+    token.movementTurnHistory = clone(paused.movementTurnHistory || []);
+    if (paused.dashActionType) token.dashActionType = paused.dashActionType; else delete token.dashActionType;
+    if (paused.activeActionMovementMode) token.activeActionMovementMode = paused.activeActionMovementMode; else delete token.activeActionMovementMode;
+    delete token.movementRoundResume;
+    return baseMovement.currentMovementState(token);
   }
 
   function ensureRound(token = {}, worldState = {}, mode = null) {
     const world = baseMovement.normalizeWorldState(worldState);
-    if (world.mode !== 'round') return baseMovement.setFreeMode(token);
+    if (world.mode !== 'round') return setFreeMode(token);
+    const resumed = restorePausedRound(token, world);
+    if (resumed) return resumed;
     const current = baseMovement.currentMovementState(token);
     if (current.roundId !== world.roundId || !Number.isFinite(Number(token.movementRemainingFt))) return beginRound(token, world.roundId, mode || current.mode);
     if (!token.movementTurnStart) captureTurnStart(token);
     return current;
+  }
+
+  function movementClaimFromPlan(token = {}, plan = {}, result = {}) {
+    if (plan.verticalResume || plan.movementType === 'teleport') return null;
+    const path = Array.isArray(plan.path) ? plan.path : [];
+    if (path.length < 2) return null;
+    const endpoint = path[path.length - 1] || {};
+    const start = path[0] || {};
+    if (!Number.isFinite(Number(endpoint.x)) || !Number.isFinite(Number(endpoint.y))) return null;
+    return {
+      localId: `${String(token.id || 'token')}:${Date.now().toString(36)}:${Math.random().toString(36).slice(2, 7)}`,
+      from: {
+        x: finite(start.x, token.x),
+        y: finite(start.y, token.y),
+        zLayer: finite(start.z ?? token.zLayer ?? token.gridPosition?.z ?? token.z?.[0]),
+        elevationFt: finite(token.elevationFt),
+        gridPosition: token.gridPosition ? clone(token.gridPosition) : null,
+      },
+      to: {
+        x: finite(endpoint.x),
+        y: finite(endpoint.y),
+        col: Number.isFinite(Number(endpoint.col)) ? Number(endpoint.col) : null,
+        row: Number.isFinite(Number(endpoint.row)) ? Number(endpoint.row) : null,
+        zLayer: finite(endpoint.z ?? token.zLayer ?? token.gridPosition?.z ?? token.z?.[0]),
+      },
+      movementCostFt: Math.max(0, finite(result.costFt ?? plan.movementCostFt)),
+      movementType: plan.movementType || 'normal',
+      authority: token.pendingMovementAuthority || token.controlSource || null,
+      rttMs: Number.isFinite(Number(token.networkRttMs ?? token.rttMs)) ? Number(token.networkRttMs ?? token.rttMs) : null,
+    };
   }
 
   function commitMove(token = {}, plan = {}, worldState = {}) {
@@ -166,6 +231,9 @@
         movementType: plan.movementType || 'normal',
       });
     }
+    const claim = movementClaimFromPlan(token, plan, result);
+    if (claim) token.pendingMovementClaim = claim;
+    else delete token.pendingMovementClaim;
     return result;
   }
 
@@ -195,6 +263,8 @@
     token.movementRemainingFt = state.remainingFt;
     token.movementTurnHistory = [];
     delete token.activeActionMovementMode;
+    delete token.pendingMovementClaim;
+    delete token.movementRoundResume;
     const actionType = token.dashActionType || null;
     delete token.dashActionType;
     return { valid: true, position: clone(start), remainingFt: state.remainingFt, refundActionType: actionType };
@@ -206,11 +276,13 @@
     ...baseMovement,
     __movementRulesClosurePatch: true,
     beginRound,
+    setFreeMode,
     ensureRound,
     commitMove,
     dash,
     resetMovement,
     movementStart,
     captureTurnStart,
+    movementClaimFromPlan,
   });
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/js/vtt/movement-rules.js
+++ b/js/vtt/movement-rules.js
@@ -98,6 +98,79 @@
     return { valid: false, continueMovement: false, actionRequired: true, opensDoor: false, reason: 'DOOR_ACTION_REQUIRED', noise: 'none' };
   }
 
+  function orientation(a, b, c) {
+    const value = ((finite(b.y) - finite(a.y)) * (finite(c.x) - finite(b.x))) - ((finite(b.x) - finite(a.x)) * (finite(c.y) - finite(b.y)));
+    if (Math.abs(value) < 1e-9) return 0;
+    return value > 0 ? 1 : 2;
+  }
+
+  function onSegment(a, b, c) {
+    return finite(b.x) <= Math.max(finite(a.x), finite(c.x)) + 1e-9
+      && finite(b.x) + 1e-9 >= Math.min(finite(a.x), finite(c.x))
+      && finite(b.y) <= Math.max(finite(a.y), finite(c.y)) + 1e-9
+      && finite(b.y) + 1e-9 >= Math.min(finite(a.y), finite(c.y));
+  }
+
+  function segmentsIntersect(a, b, c, d) {
+    const o1 = orientation(a, b, c);
+    const o2 = orientation(a, b, d);
+    const o3 = orientation(c, d, a);
+    const o4 = orientation(c, d, b);
+    if (o1 !== o2 && o3 !== o4) return true;
+    if (o1 === 0 && onSegment(a, c, b)) return true;
+    if (o2 === 0 && onSegment(a, d, b)) return true;
+    if (o3 === 0 && onSegment(c, a, d)) return true;
+    if (o4 === 0 && onSegment(c, b, d)) return true;
+    return false;
+  }
+
+  function topologyElementLayer(element = {}, zLayer = 0) {
+    const layers = Array.isArray(element.z) ? element.z.map(Number) : [Number(element.z ?? 0)];
+    return layers.includes(Number(zLayer));
+  }
+
+  function doorSegment(door = {}, grid = {}) {
+    const size = Math.max(1, finite(grid.size, 70));
+    return {
+      a: { x: finite(door.from?.col) * size, y: finite(door.from?.row) * size },
+      b: { x: finite(door.to?.col) * size, y: finite(door.to?.row) * size },
+    };
+  }
+
+  function doorCrossings(path = [], mapData = {}, zLayer = 0) {
+    const points = Array.isArray(path) ? path : [];
+    if (points.length < 2) return [];
+    const doors = (Array.isArray(mapData.topology) ? mapData.topology : []).filter((element) => clean(element?.type) === 'door' && topologyElementLayer(element, zLayer));
+    const results = [];
+    for (let pathIndex = 0; pathIndex < points.length - 1; pathIndex += 1) {
+      const from = points[pathIndex];
+      const to = points[pathIndex + 1];
+      for (const door of doors) {
+        const segment = doorSegment(door, mapData.grid || {});
+        if (!segmentsIntersect(from, to, segment.a, segment.b)) continue;
+        if (results.some((entry) => String(entry.door?.id || '') === String(door.id || '') && entry.pathIndex === pathIndex)) continue;
+        results.push({ door, pathIndex, from, to, state: clean(door.state || 'closed') || 'closed' });
+      }
+    }
+    return results;
+  }
+
+  function mapWithPassableDoors(mapData = {}, predicate = () => true) {
+    return {
+      ...mapData,
+      topology: (Array.isArray(mapData.topology) ? mapData.topology : []).map((element) => {
+        if (clean(element?.type) !== 'door' || !predicate(element)) return element;
+        return { ...element, state: 'open' };
+      }),
+    };
+  }
+
+  function truncateBeforeDoor(path = [], crossing = null) {
+    if (!crossing || !Array.isArray(path) || !path.length) return Array.isArray(path) ? [...path] : [];
+    const stopIndex = Math.max(0, Math.min(path.length - 1, Math.trunc(finite(crossing.pathIndex, 0))));
+    return path.slice(0, stopIndex + 1);
+  }
+
   function snapshotTurnStart(token = {}) {
     return {
       x: finite(token.x),
@@ -129,6 +202,11 @@
     compareSpaceClaims,
     resolveSpaceClaim,
     doorTraversal,
+    segmentsIntersect,
+    doorSegment,
+    doorCrossings,
+    mapWithPassableDoors,
+    truncateBeforeDoor,
     snapshotTurnStart,
     rememberVisibility,
     zoneShouldPersist,

--- a/js/vtt/movement-rules.js
+++ b/js/vtt/movement-rules.js
@@ -124,6 +124,19 @@
     return false;
   }
 
+  function segmentIntersectionPoint(a = {}, b = {}, c = {}, d = {}) {
+    const x1 = finite(a.x); const y1 = finite(a.y);
+    const x2 = finite(b.x); const y2 = finite(b.y);
+    const x3 = finite(c.x); const y3 = finite(c.y);
+    const x4 = finite(d.x); const y4 = finite(d.y);
+    const denominator = ((x1 - x2) * (y3 - y4)) - ((y1 - y2) * (x3 - x4));
+    if (Math.abs(denominator) < 1e-9) return null;
+    const t = (((x1 - x3) * (y3 - y4)) - ((y1 - y3) * (x3 - x4))) / denominator;
+    const u = -((((x1 - x2) * (y1 - y3)) - ((y1 - y2) * (x1 - x3))) / denominator);
+    if (t < -1e-9 || t > 1 + 1e-9 || u < -1e-9 || u > 1 + 1e-9) return null;
+    return { x: x1 + (t * (x2 - x1)), y: y1 + (t * (y2 - y1)) };
+  }
+
   function topologyElementLayer(element = {}, zLayer = 0) {
     const layers = Array.isArray(element.z) ? element.z.map(Number) : [Number(element.z ?? 0)];
     return layers.includes(Number(zLayer));
@@ -149,7 +162,9 @@
         const segment = doorSegment(door, mapData.grid || {});
         if (!segmentsIntersect(from, to, segment.a, segment.b)) continue;
         if (results.some((entry) => String(entry.door?.id || '') === String(door.id || '') && entry.pathIndex === pathIndex)) continue;
-        results.push({ door, pathIndex, from, to, state: clean(door.state || 'closed') || 'closed' });
+        const point = segmentIntersectionPoint(from, to, segment.a, segment.b)
+          || { x: (finite(from.x) + finite(to.x)) / 2, y: (finite(from.y) + finite(to.y)) / 2 };
+        results.push({ door, pathIndex, from, to, point, state: clean(door.state || 'closed') || 'closed' });
       }
     }
     return results;
@@ -203,6 +218,7 @@
     resolveSpaceClaim,
     doorTraversal,
     segmentsIntersect,
+    segmentIntersectionPoint,
     doorSegment,
     doorCrossings,
     mapWithPassableDoors,

--- a/js/vtt/movement-rules.js
+++ b/js/vtt/movement-rules.js
@@ -67,7 +67,7 @@
     const rightRtt = Math.max(0, finite(right.rttMs ?? right.latencyMs, Infinity));
     if (leftRtt !== rightRtt) return leftRtt - rightRtt;
     const leftReceived = Math.max(0, finite(left.receivedAtMs ?? left.receivedAt, Infinity));
-    const rightReceived = Math.max(0, finite(right.receivedAtMs ?? right.receivedAt, Infinity));
+    const rightReceived = Math.max(0, finite(right.receivedAtMs ?? right.latencyMs, Infinity));
     if (leftReceived !== rightReceived) return leftReceived - rightReceived;
     return String(left.tokenId || left.id || '').localeCompare(String(right.tokenId || right.id || ''));
   }
@@ -81,7 +81,7 @@
   function doorTraversal({ mode = 'walk', door = {}, remainingFt = Infinity, dashActive = false } = {}) {
     const state = clean(door.state || door.doorState || (door.open ? 'open' : 'closed')) || 'closed';
     const locked = Boolean(door.locked || state === 'locked');
-    if (state === 'open' || door.open === true) return { valid: true, continueMovement: true, actionRequired: false, noise: 'normal' };
+    if (state === 'open' || state === 'broken' || door.open === true) return { valid: true, continueMovement: true, actionRequired: false, noise: 'normal' };
     if (locked) return { valid: false, continueMovement: false, actionRequired: true, reason: 'DOOR_LOCKED', noise: 'none' };
     const running = dashActive || clean(mode) === 'dash' || clean(mode) === 'run';
     if (running) {

--- a/js/vtt/movement-rules.js
+++ b/js/vtt/movement-rules.js
@@ -1,0 +1,136 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttMovementRules = api;
+})(typeof window !== 'undefined' ? window : globalThis, function () {
+  'use strict';
+
+  const SIZE_ORDER = Object.freeze(['tiny', 'small', 'medium', 'large', 'huge', 'gargantuan']);
+  const AUTHORITY = Object.freeze({ goap: 1, player: 2, dm: 3 });
+  const clean = (value) => String(value ?? '').trim().toLowerCase();
+  const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+  function sizeRank(token = {}) {
+    const raw = clean(token.size || token.sizeCategory || token.actorSize || token.actor?.size || 'medium');
+    const index = SIZE_ORDER.indexOf(raw);
+    return index >= 0 ? index : SIZE_ORDER.indexOf('medium');
+  }
+
+  function relationBetween(a = {}, b = {}, resolver = null) {
+    if (typeof resolver === 'function') {
+      const resolved = clean(resolver(a, b));
+      if (['ally', 'enemy', 'neutral'].includes(resolved)) return resolved;
+    }
+    if (a === b || (a.id != null && b.id != null && String(a.id) === String(b.id))) return 'self';
+    const explicit = clean(a.relations?.[b.id] || b.relations?.[a.id]);
+    if (['ally', 'friendly', 'friend'].includes(explicit)) return 'ally';
+    if (['enemy', 'hostile', 'foe'].includes(explicit)) return 'enemy';
+    for (const key of ['teamId', 'partyId', 'factionId']) {
+      const left = String(a?.[key] ?? '').trim();
+      const right = String(b?.[key] ?? '').trim();
+      if (left && right) return left === right ? 'ally' : 'enemy';
+    }
+    const leftDisposition = clean(a.disposition || a.attitude);
+    const rightDisposition = clean(b.disposition || b.attitude);
+    if (['ally', 'friendly'].includes(leftDisposition) && ['ally', 'friendly'].includes(rightDisposition)) return 'ally';
+    if (leftDisposition === 'hostile' || rightDisposition === 'hostile') return 'enemy';
+    return 'neutral';
+  }
+
+  function canTraverseOccupiedSpace(mover = {}, occupant = {}, options = {}) {
+    const relation = relationBetween(mover, occupant, options.relationResolver);
+    if (relation === 'self') return { valid: true, relation, reason: null };
+    if (relation === 'ally') return { valid: true, relation, reason: null };
+    const sizeDifference = sizeRank(occupant) - sizeRank(mover);
+    if (sizeDifference >= 2) return { valid: true, relation, reason: null, sizeDifference };
+    return { valid: false, relation, reason: relation === 'enemy' ? 'HOSTILE_TOKEN_BLOCKS_PATH' : 'TOKEN_BLOCKS_PATH', sizeDifference };
+  }
+
+  function canEndInOccupiedSpace(mover = {}, occupant = {}) {
+    if (!occupant || mover === occupant || (mover.id != null && occupant.id != null && String(mover.id) === String(occupant.id))) {
+      return { valid: true, reason: null };
+    }
+    return { valid: false, reason: 'OCCUPIED_DESTINATION', token: occupant };
+  }
+
+  function authorityRank(value) {
+    const key = clean(value?.authority || value?.sourceType || value?.type || value);
+    if (key === 'dm' || key === 'gm') return AUTHORITY.dm;
+    if (key === 'player' || key === 'human') return AUTHORITY.player;
+    return AUTHORITY.goap;
+  }
+
+  function compareSpaceClaims(left = {}, right = {}) {
+    const authorityDelta = authorityRank(right) - authorityRank(left);
+    if (authorityDelta) return authorityDelta;
+    const leftRtt = Math.max(0, finite(left.rttMs ?? left.latencyMs, Infinity));
+    const rightRtt = Math.max(0, finite(right.rttMs ?? right.latencyMs, Infinity));
+    if (leftRtt !== rightRtt) return leftRtt - rightRtt;
+    const leftReceived = Math.max(0, finite(left.receivedAtMs ?? left.receivedAt, Infinity));
+    const rightReceived = Math.max(0, finite(right.receivedAtMs ?? right.receivedAt, Infinity));
+    if (leftReceived !== rightReceived) return leftReceived - rightReceived;
+    return String(left.tokenId || left.id || '').localeCompare(String(right.tokenId || right.id || ''));
+  }
+
+  function resolveSpaceClaim(claims = []) {
+    const valid = (Array.isArray(claims) ? claims : []).filter(Boolean);
+    if (!valid.length) return null;
+    return [...valid].sort(compareSpaceClaims)[0];
+  }
+
+  function doorTraversal({ mode = 'walk', door = {}, remainingFt = Infinity, dashActive = false } = {}) {
+    const state = clean(door.state || door.doorState || (door.open ? 'open' : 'closed')) || 'closed';
+    const locked = Boolean(door.locked || state === 'locked');
+    if (state === 'open' || door.open === true) return { valid: true, continueMovement: true, actionRequired: false, noise: 'normal' };
+    if (locked) return { valid: false, continueMovement: false, actionRequired: true, reason: 'DOOR_LOCKED', noise: 'none' };
+    const running = dashActive || clean(mode) === 'dash' || clean(mode) === 'run';
+    if (running) {
+      return {
+        valid: true,
+        continueMovement: Number.isFinite(Number(remainingFt)) ? Number(remainingFt) > 0 : true,
+        actionRequired: false,
+        opensDoor: true,
+        burstOpen: true,
+        noise: 'high',
+        soundEvent: 'DASH_DOOR_BURST',
+      };
+    }
+    return { valid: false, continueMovement: false, actionRequired: true, opensDoor: false, reason: 'DOOR_ACTION_REQUIRED', noise: 'none' };
+  }
+
+  function snapshotTurnStart(token = {}) {
+    return {
+      x: finite(token.x),
+      y: finite(token.y),
+      zLayer: finite(token.zLayer ?? token.gridPosition?.z ?? token.z?.[0]),
+      elevationFt: finite(token.elevationFt),
+      gridPosition: token.gridPosition ? { ...token.gridPosition } : null,
+    };
+  }
+
+  function rememberVisibility({ visibleNow = false, remembered = false, intelligenceAllowsMemory = false, minimapUnlocked = false } = {}) {
+    if (visibleNow) return { layer: 'VISIBLE_NOW', liveActors: true, minimap: Boolean(minimapUnlocked) };
+    if (remembered && intelligenceAllowsMemory) return { layer: 'REMEMBERED', liveActors: false, minimap: Boolean(minimapUnlocked) };
+    return { layer: 'UNKNOWN', liveActors: false, minimap: Boolean(minimapUnlocked) };
+  }
+
+  function zoneShouldPersist({ playerCount = 0, dmSaved = false } = {}) {
+    return Math.max(0, Math.trunc(finite(playerCount))) > 0 || Boolean(dmSaved);
+  }
+
+  return Object.freeze({
+    SIZE_ORDER,
+    AUTHORITY,
+    sizeRank,
+    relationBetween,
+    canTraverseOccupiedSpace,
+    canEndInOccupiedSpace,
+    authorityRank,
+    compareSpaceClaims,
+    resolveSpaceClaim,
+    doorTraversal,
+    snapshotTurnStart,
+    rememberVisibility,
+    zoneShouldPersist,
+  });
+});

--- a/js/vtt/movement-rules.js
+++ b/js/vtt/movement-rules.js
@@ -67,7 +67,7 @@
     const rightRtt = Math.max(0, finite(right.rttMs ?? right.latencyMs, Infinity));
     if (leftRtt !== rightRtt) return leftRtt - rightRtt;
     const leftReceived = Math.max(0, finite(left.receivedAtMs ?? left.receivedAt, Infinity));
-    const rightReceived = Math.max(0, finite(right.receivedAtMs ?? right.latencyMs, Infinity));
+    const rightReceived = Math.max(0, finite(right.receivedAtMs ?? right.receivedAt, Infinity));
     if (leftReceived !== rightReceived) return leftReceived - rightReceived;
     return String(left.tokenId || left.id || '').localeCompare(String(right.tokenId || right.id || ''));
   }

--- a/tests/vtt_map_field_test_hardening.spec.js
+++ b/tests/vtt_map_field_test_hardening.spec.js
@@ -141,19 +141,26 @@ test('hardening: DM drag cannot accidentally enter View As, while a real click e
   observer.stop();
 });
 
-test('hardening: drag preview is local-only and persistence commit exists only in mouseup', () => {
+test('hardening: drag preview is local-only and persistence commit exists only after mouseup traversal', () => {
   const engine = read('js/vtt/engine.js');
   const moveStart = engine.indexOf('handleTokenMouseMove(event)');
-  const upStart = engine.indexOf('handleTokenMouseUp(event)');
-  const centerStart = engine.indexOf('    centerCamera() {', upStart);
+  const animateStart = engine.indexOf('async animateTokenPath', moveStart);
+  const upStart = engine.indexOf('async handleTokenMouseUp(event)', animateStart);
+  const finalizeStart = engine.indexOf('finalizeTokenMove(token, drag, result = {})', upStart);
+  const centerStart = engine.indexOf('    centerCamera() {', finalizeStart);
   expect(moveStart).toBeGreaterThan(-1);
-  expect(upStart).toBeGreaterThan(moveStart);
-  expect(centerStart).toBeGreaterThan(upStart);
-  const moveSection = engine.slice(moveStart, upStart);
-  const upSection = engine.slice(upStart, centerStart);
+  expect(animateStart).toBeGreaterThan(moveStart);
+  expect(upStart).toBeGreaterThan(animateStart);
+  expect(finalizeStart).toBeGreaterThan(upStart);
+  expect(centerStart).toBeGreaterThan(finalizeStart);
+  const moveSection = engine.slice(moveStart, animateStart);
+  const upSection = engine.slice(upStart, finalizeStart);
+  const finalizeSection = engine.slice(finalizeStart, centerStart);
   expect(moveSection).toContain("'vtt:token-preview-moved'");
   expect(moveSection).not.toContain("'vtt:token-moved'");
-  expect((upSection.match(/'vtt:token-moved'/g) || [])).toHaveLength(1);
+  expect(upSection).toContain('this.finalizeTokenMove(token, drag, result)');
+  expect(upSection).not.toContain("new CustomEvent('vtt:token-moved'");
+  expect((finalizeSection.match(/'vtt:token-moved'/g) || [])).toHaveLength(1);
 
   const observer = read('js/vtt/dm-observer.js');
   expect(observer).not.toContain('setInterval(');

--- a/tests/vtt_movement_connectivity.spec.js
+++ b/tests/vtt_movement_connectivity.spec.js
@@ -41,7 +41,8 @@ test('realtime movement creates no remote controller and performs no update whil
   expect(controller.snapshot()).toMatchObject({ connected: false, onlineOnly: true });
   expect(instances).toHaveLength(0);
   expect(controller.schedulePreview({ id: 'p1' })).toBe(false);
-  await expect(controller.finalizeToken({ id: 'p1' }, async () => ({ valid: true }))).rejects.toThrow('VTT_OFFLINE_NO_UPDATE');
+  expect(() => controller.finalizeToken({ id: 'p1' }, async () => ({ valid: true }))).toThrow('VTT_OFFLINE_NO_UPDATE');
+  expect(instances).toHaveLength(0);
 
   connectionRef.emit(true);
   expect(instances).toHaveLength(1);
@@ -53,7 +54,8 @@ test('realtime movement creates no remote controller and performs no update whil
   connectionRef.emit(false);
   expect(instances[0].stops).toBe(1);
   expect(controller.schedulePreview({ id: 'p1' })).toBe(false);
-  await expect(controller.finalizeToken({ id: 'p1' }, async () => ({ valid: true }))).rejects.toThrow('VTT_OFFLINE_NO_UPDATE');
+  expect(() => controller.finalizeToken({ id: 'p1' }, async () => ({ valid: true }))).toThrow('VTT_OFFLINE_NO_UPDATE');
+  expect(instances[0].finalizes).toBe(1);
 
   connectionRef.emit(true);
   expect(instances).toHaveLength(2);

--- a/tests/vtt_movement_connectivity.spec.js
+++ b/tests/vtt_movement_connectivity.spec.js
@@ -1,0 +1,90 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const connectivity = require('../js/vtt/movement-connectivity.js');
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+class ConnectionRef {
+  constructor() { this.handlers = new Set(); this.value = false; }
+  on(event, handler) { if (event === 'value') { this.handlers.add(handler); handler({ val: () => this.value }); } }
+  off(event, handler) { if (event === 'value') this.handlers.delete(handler); }
+  emit(value) { this.value = Boolean(value); for (const handler of [...this.handlers]) handler({ val: () => this.value }); }
+}
+
+test('realtime movement creates no remote controller and performs no update while disconnected', async () => {
+  const connectionRef = new ConnectionRef();
+  const instances = [];
+  const base = {
+    createController() {
+      const state = { starts: 0, stops: 0, previews: 0, finalizes: 0 };
+      instances.push(state);
+      return {
+        start() { state.starts += 1; return { started: true }; },
+        stop() { state.stops += 1; },
+        snapshot() { return { writes: state.previews }; },
+        schedulePreview() { state.previews += 1; return true; },
+        finalizeToken: async () => { state.finalizes += 1; return { valid: true }; },
+        handleIncoming() { return true; },
+        clearIncoming() { return true; },
+        handleCanonicalSync() { return true; },
+        reconcilePlayerSubscriptions() { return true; },
+        previewRefForToken() { return { ref: {} }; },
+      };
+    },
+  };
+  const host = { LuminousVttMovementRealtime: base };
+  connectivity.installRealtime(host);
+  const controller = host.LuminousVttMovementRealtime.createController({ connectionRef });
+  controller.start();
+
+  expect(controller.snapshot()).toMatchObject({ connected: false, onlineOnly: true });
+  expect(instances).toHaveLength(0);
+  expect(controller.schedulePreview({ id: 'p1' })).toBe(false);
+  await expect(controller.finalizeToken({ id: 'p1' }, async () => ({ valid: true }))).rejects.toThrow('VTT_OFFLINE_NO_UPDATE');
+
+  connectionRef.emit(true);
+  expect(instances).toHaveLength(1);
+  expect(instances[0].starts).toBe(1);
+  expect(controller.schedulePreview({ id: 'p1' })).toBe(true);
+  expect(instances[0].previews).toBe(1);
+  await expect(controller.finalizeToken({ id: 'p1' }, async () => ({ valid: true }))).resolves.toMatchObject({ valid: true });
+
+  connectionRef.emit(false);
+  expect(instances[0].stops).toBe(1);
+  expect(controller.schedulePreview({ id: 'p1' })).toBe(false);
+  await expect(controller.finalizeToken({ id: 'p1' }, async () => ({ valid: true }))).rejects.toThrow('VTT_OFFLINE_NO_UPDATE');
+
+  connectionRef.emit(true);
+  expect(instances).toHaveLength(2);
+  expect(instances[1].starts).toBe(1);
+  controller.stop();
+  expect(instances[1].stops).toBe(1);
+});
+
+test('turn origin and Dash action metadata survive a canonical round-trip', () => {
+  const token = {
+    movementTurnStart: { x: 35, y: 35, zLayer: 0, elevationFt: 0, gridPosition: { col: 0, row: 0, z: 0 } },
+    dashActionType: 'quick_action',
+  };
+  const stored = connectivity.turnExtras(token);
+  expect(stored).toEqual({ movementTurnStart: token.movementTurnStart, dashActionType: 'quick_action' });
+
+  const restored = {};
+  connectivity.applyTurnExtras(restored, stored);
+  expect(restored).toEqual(token);
+  stored.movementTurnStart.x = 999;
+  expect(restored.movementTurnStart.x).toBe(35);
+});
+
+test('movement bootstrap gates plans, Dash, reset, round controls and turn persistence on connectivity', () => {
+  const source = read('js/vtt/movement-bootstrap.js');
+  expect(source).toContain("import './movement-connectivity.js'");
+  expect(source).toContain('installRealtime?.(window)');
+  expect(source).toContain("reason: 'VTT_OFFLINE_NO_UPDATE'");
+  expect(source).toContain('if (!movementOnline()) return offlineResult()');
+  expect(source).toContain('assertMovementOnline()');
+  expect(source).toContain("'position/movementTurnStart'");
+  expect(source).toContain("'position/dashActionType'");
+  expect(source).toContain('WORLD · OFFLINE · MOVEMENT LOCKED');
+});

--- a/tests/vtt_movement_destination_claims.spec.js
+++ b/tests/vtt_movement_destination_claims.spec.js
@@ -1,4 +1,6 @@
 const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
 
 require('../js/vtt/movement-rules.js');
 
@@ -63,7 +65,7 @@ class FakeRef {
 
 class FakeDb {
   constructor() { this.store = new Map(); }
-  ref(path) { return new FakeRef(this.store, path); }
+  ref(pathValue) { return new FakeRef(this.store, pathValue); }
 }
 
 function mapData() {
@@ -85,6 +87,7 @@ function movingToken(id, controlSource, rttMs = null) {
     movementRemainingFt: 20,
     movementTurnHistory: [{ path: [{ x: 35, y: 35 }, { x: 105, y: 35 }], costFt: 5, movementType: 'normal' }],
     pendingMovementClaim: {
+      localId: `${id}-move`,
       from: { x: 35, y: 35, zLayer: 0, elevationFt: 0, gridPosition: { col: 0, row: 0, z: 0 } },
       to: { x: 105, y: 35, col: 1, row: 0, zLayer: 0 },
       movementCostFt: 5,
@@ -168,22 +171,59 @@ test('equal authority uses lower RTT as the arbitration tie-break', async () => 
   expect(canonicalWrites).toEqual([expect.objectContaining({ tokenId: 'fast-token' })]);
 });
 
+test('a pre-traversal reservation is reused by canonical save instead of being arbitrated twice', async () => {
+  const db = new FakeDb();
+  const map = mapData();
+  const movementBridge = tokenState.createBridge({
+    db,
+    mapData: map,
+    label: 'player',
+    movementClaimArbitrationMs: 0,
+    movementClaimLeaseMs: 500,
+    movementClaimPostCommitHoldMs: 100,
+  });
+  const player = movingToken('reserved-player', 'player', 20);
+  const cell = claims.cellForClaim(player.pendingMovementClaim, map);
+  const claimPath = `${claims.CLAIM_ROOT}/claim-map/0/${cell.col}_${cell.row}`;
+
+  const reserved = await movementBridge.reserveMovementDestinationClaim(player, player.pendingMovementClaim);
+  expect(reserved).toMatchObject({ valid: true });
+  expect(movementBridge.movementDestinationReservationCount()).toBe(1);
+  const claimId = db.store.get(claimPath).claimId;
+  expect(db.store.get(claimPath)).toMatchObject({ claimId, tokenId: 'reserved-player', locked: true, committed: false });
+
+  await expect(movementBridge.saveToken(player)).resolves.toMatchObject({ destinationClaim: { valid: true, cell } });
+  expect(canonicalWrites).toEqual([expect.objectContaining({ tokenId: 'reserved-player' })]);
+  expect(movementBridge.movementDestinationReservationCount()).toBe(0);
+  expect(db.store.get(claimPath)).toMatchObject({ claimId, tokenId: 'reserved-player', locked: true, committed: true });
+  expect(player.pendingMovementClaim).toBeUndefined();
+});
+
 test('expired stale claim can be replaced but a locked live claim cannot be stolen', async () => {
   const db = new FakeDb();
   const map = mapData();
   const cell = claims.cellForClaim({ to: { x: 105, y: 35, col: 1, row: 0, zLayer: 0 } }, map);
-  const path = `${claims.CLAIM_ROOT}/claim-map/0/${cell.col}_${cell.row}`;
-  db.store.set(path, { claimId: 'stale', tokenId: 'old', authority: 'dm', locked: true, committed: true, expiresAtMs: 0 });
+  const claimPath = `${claims.CLAIM_ROOT}/claim-map/0/${cell.col}_${cell.row}`;
+  db.store.set(claimPath, { claimId: 'stale', tokenId: 'old', authority: 'dm', locked: true, committed: true, expiresAtMs: 0 });
 
   const playerBridge = tokenState.createBridge({ db, mapData: map, label: 'player', movementClaimArbitrationMs: 0, movementClaimLeaseMs: 500, movementClaimPostCommitHoldMs: 100 });
   const player = movingToken('player-token', 'player', 20);
   await expect(playerBridge.saveToken(player)).resolves.toMatchObject({ destinationClaim: { valid: true } });
 
-  const locked = clone(db.store.get(path));
+  const locked = clone(db.store.get(claimPath));
   expect(locked).toMatchObject({ tokenId: 'player-token', locked: true, committed: true });
   const dmBridge = tokenState.createBridge({ db, mapData: map, label: 'dm', isDm: true, movementClaimArbitrationMs: 0, movementClaimLeaseMs: 500, movementClaimPostCommitHoldMs: 100 });
   const dm = movingToken('dm-token', 'dm', 1);
   dm.canonicalScope = 'world';
   await expect(dmBridge.saveToken(dm)).rejects.toThrow('MOVEMENT_DESTINATION_CLAIM_LOST');
   expect(canonicalWrites.filter((entry) => entry.tokenId === 'dm-token')).toHaveLength(0);
+});
+
+test('Escape movement cancellation is wired to cancel motion, release the destination claim and rollback', () => {
+  const source = fs.readFileSync(path.join(__dirname, '..', 'js/vtt/movement-bootstrap.js'), 'utf8');
+  expect(source).toContain("event.key !== 'Escape'");
+  expect(source).toContain('engine.cancelTokenMotion?.()');
+  expect(source).toContain("cancelDestination(token, reason, true)");
+  expect(source).toContain("window.addEventListener('keydown', onKeyDown)");
+  expect(source).toContain("window.removeEventListener('keydown', onKeyDown)");
 });

--- a/tests/vtt_movement_destination_claims.spec.js
+++ b/tests/vtt_movement_destination_claims.spec.js
@@ -1,0 +1,189 @@
+const { test, expect } = require('@playwright/test');
+
+require('../js/vtt/movement-rules.js');
+
+const canonicalWrites = [];
+
+globalThis.LuminousVttTokenState = {
+  PLAYER_ROOT: 'campaña/jugadores',
+  WORLD_ROOT: 'campaña/estado_mundo/vttTokens',
+  firebaseKey: (value, fallback = 'key') => String(value ?? '').replace(/[.#$\[\]\/]/g, '_') || fallback,
+  hostFirebase: () => null,
+  createBridge(options = {}) {
+    return Object.freeze({
+      mapId: options.mapData?.id || 'claim-map',
+      isDm: Boolean(options.isDm),
+      identity: { playerId: options.playerId || 'player', uid: options.uid || 'uid' },
+      start: () => true,
+      stop: () => true,
+      async saveToken(token) {
+        canonicalWrites.push({ bridge: options.label || 'bridge', tokenId: token.id, x: token.x, y: token.y });
+        return { valid: true, scope: token.canonicalScope === 'world' ? 'world' : 'player', key: token.id };
+      },
+      async createWorldToken(token) {
+        canonicalWrites.push({ bridge: options.label || 'bridge', tokenId: token.id, x: token.x, y: token.y });
+        return { valid: true, scope: 'world', key: token.id };
+      },
+    });
+  },
+};
+
+delete require.cache[require.resolve('../js/vtt/movement-destination-claims.js')];
+const claims = require('../js/vtt/movement-destination-claims.js');
+const tokenState = globalThis.LuminousVttTokenState;
+
+function clone(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function snapshot(value) {
+  const copy = clone(value);
+  return { val: () => clone(copy), exists: () => copy != null };
+}
+
+class FakeRef {
+  constructor(store, path) {
+    this.store = store;
+    this.path = path;
+  }
+
+  async transaction(updater) {
+    const current = this.store.has(this.path) ? clone(this.store.get(this.path)) : null;
+    const next = updater(current);
+    if (next === undefined) return { committed: false, snapshot: snapshot(current) };
+    if (next === null) this.store.delete(this.path);
+    else this.store.set(this.path, clone(next));
+    return { committed: true, snapshot: snapshot(next) };
+  }
+
+  async once() {
+    return snapshot(this.store.has(this.path) ? this.store.get(this.path) : null);
+  }
+}
+
+class FakeDb {
+  constructor() { this.store = new Map(); }
+  ref(path) { return new FakeRef(this.store, path); }
+}
+
+function mapData() {
+  return { id: 'claim-map', grid: { cols: 4, rows: 2, size: 70, distancePerCell: 5 }, movement: {}, tokens: [] };
+}
+
+function movingToken(id, controlSource, rttMs = null) {
+  return {
+    id,
+    canonicalScope: 'player',
+    controlSource,
+    networkRttMs: rttMs,
+    x: 105,
+    y: 35,
+    zLayer: 0,
+    z: [0],
+    gridPosition: { col: 1, row: 0, z: 0 },
+    movementState: { roundId: 1, speedFt: 30, remainingFt: 20, dashed: false, mode: 'walk' },
+    movementRemainingFt: 20,
+    movementTurnHistory: [{ path: [{ x: 35, y: 35 }, { x: 105, y: 35 }], costFt: 5, movementType: 'normal' }],
+    pendingMovementClaim: {
+      from: { x: 35, y: 35, zLayer: 0, elevationFt: 0, gridPosition: { col: 0, row: 0, z: 0 } },
+      to: { x: 105, y: 35, col: 1, row: 0, zLayer: 0 },
+      movementCostFt: 5,
+      movementType: 'normal',
+      authority: controlSource,
+      rttMs,
+    },
+  };
+}
+
+function bridge(db, label, isDm = false) {
+  return tokenState.createBridge({
+    db,
+    mapData: mapData(),
+    label,
+    isDm,
+    playerId: label,
+    movementClaimArbitrationMs: 30,
+    movementClaimLeaseMs: 500,
+    movementClaimPostCommitHoldMs: 20,
+  });
+}
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+test.beforeEach(() => { canonicalWrites.length = 0; });
+
+test('simultaneous Player claim replaces GOAP before canonical commit and loser rolls back/refunds', async () => {
+  const db = new FakeDb();
+  const goapBridge = bridge(db, 'goap');
+  const playerBridge = bridge(db, 'player');
+  const goap = movingToken('goap-token', 'goap', 5);
+  const player = movingToken('player-token', 'player', 80);
+
+  const goapSave = goapBridge.saveToken(goap);
+  await delay(5);
+  const playerSave = playerBridge.saveToken(player);
+  const [goapResult, playerResult] = await Promise.allSettled([goapSave, playerSave]);
+
+  expect(goapResult.status).toBe('rejected');
+  expect(goapResult.reason.message).toBe('MOVEMENT_DESTINATION_CLAIM_LOST');
+  expect(playerResult.status).toBe('fulfilled');
+  expect(canonicalWrites).toEqual([expect.objectContaining({ tokenId: 'player-token' })]);
+  expect(goap).toMatchObject({ x: 35, y: 35, movementRemainingFt: 25, gridPosition: { col: 0, row: 0, z: 0 } });
+  expect(goap.movementTurnHistory).toEqual([]);
+  expect(goap.pendingMovementClaim).toBeUndefined();
+});
+
+test('simultaneous DM claim replaces Player regardless of RTT', async () => {
+  const db = new FakeDb();
+  const playerBridge = bridge(db, 'player');
+  const dmBridge = bridge(db, 'dm', true);
+  const player = movingToken('player-token', 'player', 4);
+  const dm = movingToken('dm-token', 'dm', 500);
+  dm.canonicalScope = 'world';
+
+  const playerSave = playerBridge.saveToken(player);
+  await delay(5);
+  const dmSave = dmBridge.saveToken(dm);
+  const [playerResult, dmResult] = await Promise.allSettled([playerSave, dmSave]);
+
+  expect(playerResult.status).toBe('rejected');
+  expect(dmResult.status).toBe('fulfilled');
+  expect(canonicalWrites).toEqual([expect.objectContaining({ tokenId: 'dm-token' })]);
+});
+
+test('equal authority uses lower RTT as the arbitration tie-break', async () => {
+  const db = new FakeDb();
+  const slowBridge = bridge(db, 'slow');
+  const fastBridge = bridge(db, 'fast');
+  const slow = movingToken('slow-token', 'player', 90);
+  const fast = movingToken('fast-token', 'player', 15);
+
+  const slowSave = slowBridge.saveToken(slow);
+  await delay(5);
+  const fastSave = fastBridge.saveToken(fast);
+  const [slowResult, fastResult] = await Promise.allSettled([slowSave, fastSave]);
+
+  expect(slowResult.status).toBe('rejected');
+  expect(fastResult.status).toBe('fulfilled');
+  expect(canonicalWrites).toEqual([expect.objectContaining({ tokenId: 'fast-token' })]);
+});
+
+test('expired stale claim can be replaced but a locked live claim cannot be stolen', async () => {
+  const db = new FakeDb();
+  const map = mapData();
+  const cell = claims.cellForClaim({ to: { x: 105, y: 35, col: 1, row: 0, zLayer: 0 } }, map);
+  const path = `${claims.CLAIM_ROOT}/claim-map/0/${cell.col}_${cell.row}`;
+  db.store.set(path, { claimId: 'stale', tokenId: 'old', authority: 'dm', locked: true, committed: true, expiresAtMs: 0 });
+
+  const playerBridge = tokenState.createBridge({ db, mapData: map, label: 'player', movementClaimArbitrationMs: 0, movementClaimLeaseMs: 500, movementClaimPostCommitHoldMs: 100 });
+  const player = movingToken('player-token', 'player', 20);
+  await expect(playerBridge.saveToken(player)).resolves.toMatchObject({ destinationClaim: { valid: true } });
+
+  const locked = clone(db.store.get(path));
+  expect(locked).toMatchObject({ tokenId: 'player-token', locked: true, committed: true });
+  const dmBridge = tokenState.createBridge({ db, mapData: map, label: 'dm', isDm: true, movementClaimArbitrationMs: 0, movementClaimLeaseMs: 500, movementClaimPostCommitHoldMs: 100 });
+  const dm = movingToken('dm-token', 'dm', 1);
+  dm.canonicalScope = 'world';
+  await expect(dmBridge.saveToken(dm)).rejects.toThrow('MOVEMENT_DESTINATION_CLAIM_LOST');
+  expect(canonicalWrites.filter((entry) => entry.tokenId === 'dm-token')).toHaveLength(0);
+});

--- a/tests/vtt_movement_door_execution.spec.js
+++ b/tests/vtt_movement_door_execution.spec.js
@@ -1,0 +1,35 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+test('movement runtime opens Dash doors through the canonical topology action bridge before committing movement', () => {
+  const source = read('js/vtt/movement-bootstrap.js');
+  const prepareStart = source.indexOf('async function prepareDoorInteractions');
+  const resolveStart = source.indexOf('async function resolveMovementOrder');
+  expect(prepareStart).toBeGreaterThan(0);
+  expect(resolveStart).toBeGreaterThan(prepareStart);
+  const prepareBody = source.slice(prepareStart, resolveStart);
+  expect(prepareBody).toContain("movementRules.doorTraversal({ mode: 'dash'");
+  expect(prepareBody).toContain("runtime.bridge.requestDirectAction(door.id, 'open')");
+  const resolveBody = source.slice(resolveStart, source.indexOf('function resetControlledMovement', resolveStart));
+  expect(resolveBody.indexOf('await prepareDoorInteractions')).toBeLessThan(resolveBody.indexOf('movement.commitMove'));
+  expect(resolveBody).toContain('doorInteractions: doors.interactions');
+  expect(resolveBody).toContain('stopAtDoor: plan.stopAtDoor || null');
+});
+
+test('Engine pauses at door boundary, emits a noise event, then continues traversal', () => {
+  const source = read('js/vtt/engine.js');
+  const animateStart = source.indexOf('async animateTokenPath');
+  const mouseUpStart = source.indexOf('async handleTokenMouseUp');
+  expect(animateStart).toBeGreaterThan(0);
+  expect(mouseUpStart).toBeGreaterThan(animateStart);
+  const animateBody = source.slice(animateStart, mouseUpStart);
+  expect(animateBody).toContain('doorInteractions.filter');
+  expect(animateBody).toContain("CustomEvent('vtt:movement-interaction'");
+  expect(animateBody).toContain("CustomEvent('vtt:sound-event'");
+  expect(animateBody).toContain('await pause(interaction.pauseMs)');
+  expect(animateBody.indexOf('await pause(interaction.pauseMs)')).toBeLessThan(animateBody.indexOf('await moveSegment'));
+  expect(source).toContain("CustomEvent('vtt:movement-stopped-at-door'");
+});

--- a/tests/vtt_movement_door_execution.spec.js
+++ b/tests/vtt_movement_door_execution.spec.js
@@ -4,32 +4,48 @@ const path = require('node:path');
 
 const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
 
-test('movement runtime opens Dash doors through the canonical topology action bridge before committing movement', () => {
+test('movement validates Dash doors before committing and opens them canonically only at the traversal threshold', () => {
   const source = read('js/vtt/movement-bootstrap.js');
-  const prepareStart = source.indexOf('async function prepareDoorInteractions');
+  const validateStart = source.indexOf('function validateDoorInteractions');
+  const executeStart = source.indexOf('async function executeMovementInteraction');
   const resolveStart = source.indexOf('async function resolveMovementOrder');
-  expect(prepareStart).toBeGreaterThan(0);
-  expect(resolveStart).toBeGreaterThan(prepareStart);
-  const prepareBody = source.slice(prepareStart, resolveStart);
-  expect(prepareBody).toContain("movementRules.doorTraversal({ mode: 'dash'");
-  expect(prepareBody).toContain("runtime.bridge.requestDirectAction(door.id, 'open')");
-  const resolveBody = source.slice(resolveStart, source.indexOf('function resetControlledMovement', resolveStart));
-  expect(resolveBody.indexOf('await prepareDoorInteractions')).toBeLessThan(resolveBody.indexOf('movement.commitMove'));
+  expect(validateStart).toBeGreaterThan(0);
+  expect(executeStart).toBeGreaterThan(validateStart);
+  expect(resolveStart).toBeGreaterThan(executeStart);
+
+  const validateBody = source.slice(validateStart, source.indexOf('async function reserveDestination', validateStart));
+  expect(validateBody).toContain("movementRules.doorTraversal({ mode: 'dash'");
+  expect(validateBody).not.toContain("requestDirectAction(door.id, 'open')");
+
+  const executeBody = source.slice(executeStart, resolveStart);
+  expect(executeBody).toContain("runtime.bridge.requestDirectAction(door.id, 'open')");
+  expect(executeBody).toContain('irreversible: true');
+  expect(executeBody).toContain("soundEvent: traversal.soundEvent || interaction.soundEvent || 'DASH_DOOR_BURST'");
+
+  const resolveBody = source.slice(resolveStart, source.indexOf('async function cancelActiveMotion', resolveStart));
+  expect(resolveBody.indexOf('validateDoorInteractions(plan)')).toBeLessThan(resolveBody.indexOf('movement.commitMove'));
   expect(resolveBody).toContain('doorInteractions: doors.interactions');
   expect(resolveBody).toContain('stopAtDoor: plan.stopAtDoor || null');
 });
 
-test('Engine pauses at door boundary, emits a noise event, then continues traversal', () => {
+test('Engine reaches the door threshold, resolves the canonical interaction, emits resolved noise, then continues traversal', () => {
   const source = read('js/vtt/engine.js');
   const animateStart = source.indexOf('async animateTokenPath');
   const mouseUpStart = source.indexOf('async handleTokenMouseUp');
   expect(animateStart).toBeGreaterThan(0);
   expect(mouseUpStart).toBeGreaterThan(animateStart);
   const animateBody = source.slice(animateStart, mouseUpStart);
-  expect(animateBody).toContain('doorInteractions.filter');
+
+  expect(animateBody).toContain('doorInteractions');
+  expect(animateBody).toContain('const threshold =');
+  expect(animateBody).toContain('await moveSegment(segmentStart, threshold)');
+  expect(animateBody).toContain('await this.movementInteractionResolver');
+  expect(animateBody).toContain('resolvedInteraction = { ...interaction, ...resolution.interaction }');
+  expect(animateBody).toContain('if (resolution?.irreversible === true) motion.irreversible = true');
   expect(animateBody).toContain("CustomEvent('vtt:movement-interaction'");
   expect(animateBody).toContain("CustomEvent('vtt:sound-event'");
-  expect(animateBody).toContain('await pause(interaction.pauseMs)');
-  expect(animateBody.indexOf('await pause(interaction.pauseMs)')).toBeLessThan(animateBody.indexOf('await moveSegment'));
+  expect(animateBody).toContain('event: resolvedInteraction.soundEvent');
+  expect(animateBody).toContain('await pause(resolvedInteraction.pauseMs)');
+  expect(animateBody).toContain('const complete = await moveSegment(segmentStart, segmentEnd)');
   expect(source).toContain("CustomEvent('vtt:movement-stopped-at-door'");
 });

--- a/tests/vtt_movement_rules_closure.spec.js
+++ b/tests/vtt_movement_rules_closure.spec.js
@@ -1,0 +1,150 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+require('../js/vtt/topology.js');
+require('../js/vtt/token-interaction.js');
+require('../js/vtt/pathfinding.js');
+require('../js/vtt/movement-engine.js');
+require('../js/vtt/token-state.js');
+require('../js/vtt/token-state-dynamic-patch.js');
+require('../js/vtt/movement-integration-patch.js');
+require('../js/vtt/movement-rules.js');
+require('../js/vtt/movement-rules-runtime.js');
+
+const rules = globalThis.LuminousVttMovementRules;
+const pathfinding = globalThis.LuminousVttPathfinding;
+const movement = globalThis.LuminousVttMovementEngine;
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+function token(id, col, patch = {}) {
+  return {
+    id,
+    x: (col + 0.5) * 70,
+    y: 35,
+    zLayer: 0,
+    z: [0],
+    radius: 10,
+    size: 'medium',
+    speedFt: 30,
+    gridPosition: { col, row: 0, z: 0 },
+    ...patch,
+  };
+}
+
+function lineMap(cols = 5) {
+  return {
+    id: 'movement-rules',
+    grid: { cols, rows: 1, size: 70, distancePerCell: 5 },
+    walls: [],
+    topology: [],
+    tokens: [],
+    movement: { diagonalRule: '5e', blockTokens: true },
+  };
+}
+
+test('space arbitration is deterministic: DM > Player > GOAP, then lower latency and arrival order', () => {
+  const claims = [
+    { tokenId: 'goap', authority: 'goap', rttMs: 1, receivedAtMs: 1 },
+    { tokenId: 'player-slow', authority: 'player', rttMs: 80, receivedAtMs: 5 },
+    { tokenId: 'dm', authority: 'dm', rttMs: 500, receivedAtMs: 20 },
+    { tokenId: 'player-fast', authority: 'player', rttMs: 20, receivedAtMs: 30 },
+  ];
+  expect(rules.resolveSpaceClaim(claims).tokenId).toBe('dm');
+  expect(rules.resolveSpaceClaim(claims.filter((claim) => claim.authority !== 'dm')).tokenId).toBe('player-fast');
+  expect(rules.resolveSpaceClaim([
+    { tokenId: 'late', authority: 'player', rttMs: 20, receivedAtMs: 20 },
+    { tokenId: 'early', authority: 'player', rttMs: 20, receivedAtMs: 10 },
+  ]).tokenId).toBe('early');
+});
+
+test('allies may be traversed but an occupied destination is never legal', () => {
+  const mapData = lineMap(3);
+  const mover = token('mover', 0, { teamId: 'A' });
+  const ally = token('ally', 1, { teamId: 'A' });
+  mapData.tokens = [mover, ally];
+  const through = pathfinding.findPath({ token: mover, start: mover, target: { x: 175, y: 35 }, mapData });
+  expect(through.valid).toBe(true);
+  expect(through.costFt).toBe(10);
+  const endOnAlly = pathfinding.findPath({ token: mover, start: mover, target: ally, mapData });
+  expect(endOnAlly).toMatchObject({ valid: false, reason: 'OCCUPIED_DESTINATION' });
+});
+
+test('hostiles block traversal unless mover is at least two size categories smaller; destination remains forbidden', () => {
+  const mapData = lineMap(3);
+  const medium = token('medium', 0, { teamId: 'A', size: 'medium' });
+  const hostile = token('hostile', 1, { teamId: 'B', size: 'large' });
+  mapData.tokens = [medium, hostile];
+  expect(pathfinding.findPath({ token: medium, start: medium, target: { x: 175, y: 35 }, mapData })).toMatchObject({ valid: false, reason: 'NO_PATH' });
+
+  const small = token('small', 0, { teamId: 'A', size: 'small' });
+  hostile.size = 'large';
+  mapData.tokens = [small, hostile];
+  const through = pathfinding.findPath({ token: small, start: small, target: { x: 175, y: 35 }, mapData });
+  expect(through.valid).toBe(true);
+  expect(pathfinding.findPath({ token: small, start: small, target: hostile, mapData })).toMatchObject({ valid: false, reason: 'OCCUPIED_DESTINATION' });
+});
+
+test('round start is retained, actual path cost is spent, and reset returns to turn origin with fresh base movement', () => {
+  const mapData = lineMap(5);
+  const mover = token('mover', 0, { speedFt: 30 });
+  mapData.tokens = [mover];
+  const world = movement.normalizeWorldState({ mode: 'round', roundId: 11 });
+  movement.beginRound(mover, 11);
+  expect(movement.movementStart(mover)).toMatchObject({ x: 35, y: 35, gridPosition: { col: 0, row: 0, z: 0 } });
+
+  const plan = movement.planMove({ token: mover, start: mover, target: { x: 175, y: 35 }, mapData, worldState: world });
+  expect(plan).toMatchObject({ valid: true, movementCostFt: 10 });
+  expect(movement.commitMove(mover, plan, world)).toMatchObject({ valid: true, remainingFt: 20 });
+  mover.x = 175;
+  mover.gridPosition = { col: 2, row: 0, z: 0 };
+  expect(mover.movementTurnHistory).toHaveLength(1);
+
+  expect(movement.dash(mover, world, { actionType: 'quick_action' })).toMatchObject({ valid: true, actionType: 'quick_action', noise: 'high' });
+  const reset = movement.resetMovement(mover, world);
+  expect(reset).toMatchObject({ valid: true, remainingFt: 30, refundActionType: 'quick_action' });
+  expect(mover).toMatchObject({ x: 35, y: 35, gridPosition: { col: 0, row: 0, z: 0 }, movementRemainingFt: 30 });
+  expect(mover.movementState.dashed).toBe(false);
+  expect(mover.movementTurnHistory).toEqual([]);
+});
+
+test('route over remaining combat movement is rejected instead of clipping or teleporting', () => {
+  const mapData = lineMap(5);
+  const mover = token('mover', 0, { speedFt: 10 });
+  mapData.tokens = [mover];
+  const world = movement.normalizeWorldState({ mode: 'round', roundId: 1 });
+  movement.beginRound(mover, 1);
+  const plan = movement.planMove({ token: mover, start: mover, target: { x: 315, y: 35 }, mapData, worldState: world });
+  expect(plan).toMatchObject({ valid: false, reason: 'INSUFFICIENT_MOVEMENT', movementCostFt: 20, remainingFt: 10 });
+});
+
+test('walk stops at a closed door; Dash bursts an unlocked door with noise and may continue', () => {
+  expect(rules.doorTraversal({ mode: 'walk', door: { state: 'closed', locked: false } })).toMatchObject({ valid: false, actionRequired: true, reason: 'DOOR_ACTION_REQUIRED' });
+  expect(rules.doorTraversal({ mode: 'dash', dashActive: true, remainingFt: 20, door: { state: 'closed', locked: false } })).toMatchObject({ valid: true, opensDoor: true, burstOpen: true, continueMovement: true, noise: 'high', soundEvent: 'DASH_DOOR_BURST' });
+  expect(rules.doorTraversal({ mode: 'dash', dashActive: true, door: { state: 'locked', locked: true } })).toMatchObject({ valid: false, reason: 'DOOR_LOCKED' });
+});
+
+test('memory is stale geometry only, minimap is a separate unlock, and unsaved empty zones may regenerate', () => {
+  expect(rules.rememberVisibility({ visibleNow: true, remembered: true, intelligenceAllowsMemory: true })).toMatchObject({ layer: 'VISIBLE_NOW', liveActors: true });
+  expect(rules.rememberVisibility({ visibleNow: false, remembered: true, intelligenceAllowsMemory: true })).toMatchObject({ layer: 'REMEMBERED', liveActors: false });
+  expect(rules.rememberVisibility({ visibleNow: false, remembered: true, intelligenceAllowsMemory: true, minimapUnlocked: true })).toMatchObject({ layer: 'REMEMBERED', liveActors: false, minimap: true });
+  expect(rules.zoneShouldPersist({ playerCount: 1, dmSaved: false })).toBe(true);
+  expect(rules.zoneShouldPersist({ playerCount: 0, dmSaved: true })).toBe(true);
+  expect(rules.zoneShouldPersist({ playerCount: 0, dmSaved: false })).toBe(false);
+});
+
+test('runtime drag contract keeps token stationary until release and then animates traversal previews', () => {
+  const engineSource = read('js/vtt/engine.js');
+  const bootstrapSource = read('js/vtt/movement-bootstrap.js');
+  expect(engineSource).toContain('if (this.tokenMoveResolver)');
+  expect(engineSource).toContain("CustomEvent('vtt:movement-destination-preview'");
+  expect(engineSource).toContain('await this.tokenMoveResolver');
+  expect(engineSource).toContain('await this.animateTokenPath');
+  expect(engineSource).toContain("traversing: true");
+  expect(bootstrapSource).toContain("import './movement-rules-runtime.js'");
+  expect(bootstrapSource).toContain('engine.setTokenMoveResolver?.(resolveMovementOrder)');
+  expect(bootstrapSource).toContain('movement.commitMove');
+  expect(bootstrapSource).toContain('RESET MOVE');
+  expect(bootstrapSource).toContain("preview.valid ? '#55ff80' : '#ff5f5f'");
+  expect(bootstrapSource).toContain('isActiveCombatTurn(token)');
+});

--- a/tests/vtt_movement_rules_closure.spec.js
+++ b/tests/vtt_movement_rules_closure.spec.js
@@ -82,6 +82,16 @@ test('allies may be traversed but an occupied destination is never legal', () =>
   expect(endOnAlly).toMatchObject({ valid: false, reason: 'OCCUPIED_DESTINATION' });
 });
 
+test('ally radius overlap does not block transit but still blocks the final occupied space', () => {
+  const mapData = lineMap(4);
+  const mover = token('mover', 0, { teamId: 'A', radius: 30 });
+  const ally = token('ally', 1, { teamId: 'A', radius: 30 });
+  mapData.tokens = [mover, ally];
+  const through = pathfinding.findPath({ token: mover, start: mover, target: { x: 245, y: 35 }, mapData });
+  expect(through.valid).toBe(true);
+  expect(pathfinding.findPath({ token: mover, start: mover, target: ally, mapData })).toMatchObject({ valid: false, reason: 'OCCUPIED_DESTINATION' });
+});
+
 test('hostiles block traversal unless mover is at least two size categories smaller; destination remains forbidden', () => {
   const mapData = lineMap(3);
   const medium = token('medium', 0, { teamId: 'A', size: 'medium' });
@@ -111,6 +121,7 @@ test('round start is retained, actual path cost is spent, and reset returns to t
   mover.x = 175;
   mover.gridPosition = { col: 2, row: 0, z: 0 };
   expect(mover.movementTurnHistory).toHaveLength(1);
+  expect(mover.pendingMovementClaim).toMatchObject({ movementCostFt: 10, to: { col: 2, row: 0 } });
 
   expect(movement.dash(mover, world, { actionType: 'quick_action' })).toMatchObject({ valid: true, actionType: 'quick_action', noise: 'high' });
   const reset = movement.resetMovement(mover, world);
@@ -118,6 +129,37 @@ test('round start is retained, actual path cost is spent, and reset returns to t
   expect(mover).toMatchObject({ x: 35, y: 35, gridPosition: { col: 0, row: 0, z: 0 }, movementRemainingFt: 30 });
   expect(mover.movementState.dashed).toBe(false);
   expect(mover.movementTurnHistory).toEqual([]);
+  expect(mover.pendingMovementClaim).toBeUndefined();
+});
+
+test('temporary round-to-free toggle preserves the same round origin, budget and Dash metadata', () => {
+  const mover = token('mover', 0, { speedFt: 30 });
+  const world = movement.normalizeWorldState({ mode: 'round', roundId: 8 });
+  movement.beginRound(mover, 8);
+  expect(movement.dash(mover, world, { actionType: 'action' }).valid).toBe(true);
+  movement.spend(mover, 15, world);
+  const start = movement.movementStart(mover);
+  expect(mover.movementRemainingFt).toBe(45);
+
+  movement.setFreeMode(mover);
+  expect(mover.movementRemainingFt).toBeUndefined();
+  const resumed = movement.ensureRound(mover, world);
+  expect(resumed.remainingFt).toBe(45);
+  expect(movement.movementStart(mover)).toEqual(start);
+  expect(mover.dashActionType).toBe('action');
+});
+
+test('new round clears stale Dash metadata and recreates a missing turn origin', () => {
+  const mover = token('mover', 0, { speedFt: 30 });
+  movement.beginRound(mover, 4);
+  mover.dashActionType = 'quick_action';
+  delete mover.movementTurnStart;
+  const sameRound = movement.ensureRound(mover, { mode: 'round', roundId: 4 });
+  expect(sameRound.roundId).toBe(4);
+  expect(mover.movementTurnStart).toBeTruthy();
+  movement.beginRound(mover, 5);
+  expect(mover.dashActionType).toBeUndefined();
+  expect(mover.activeActionMovementMode).toBeUndefined();
 });
 
 test('route over remaining combat movement is rejected instead of clipping or teleporting', () => {
@@ -128,6 +170,35 @@ test('route over remaining combat movement is rejected instead of clipping or te
   movement.beginRound(mover, 1);
   const plan = movement.planMove({ token: mover, start: mover, target: { x: 315, y: 35 }, mapData, worldState: world });
   expect(plan).toMatchObject({ valid: false, reason: 'INSUFFICIENT_MOVEMENT', movementCostFt: 20, remainingFt: 10 });
+});
+
+test('raw out-of-bounds destinations are rejected before grid snapping can clamp them', () => {
+  const mapData = lineMap(3);
+  const mover = token('mover', 1);
+  mapData.tokens = [mover];
+  for (const target of [
+    { x: -1, y: 35 },
+    { x: 210, y: 35 },
+    { x: 35, y: -1 },
+    { x: 35, y: 70 },
+    { col: -1, row: 0 },
+    { col: 3, row: 0 },
+  ]) {
+    expect(movement.planMove({ token: mover, start: mover, target, mapData, worldState: { mode: 'free' } })).toMatchObject({ valid: false, reason: 'OUT_OF_BOUNDS' });
+  }
+});
+
+test('an active partial vertical route resumes in place without charging a horizontal A* route', () => {
+  const mapData = lineMap(3);
+  const mover = token('mover', 1, {
+    movementRemainingFt: 10,
+    verticalMovement: { routeId: 'stairs-1', fromZ: 0, toZ: 1, progressFt: 10, totalFt: 20, costSpentFt: 10 },
+  });
+  mapData.tokens = [mover];
+  const plan = movement.planMove({ token: mover, start: { x: mover.x, y: mover.y }, target: { x: 175, y: 35 }, mapData, worldState: { mode: 'round', roundId: 1 } });
+  expect(plan).toMatchObject({ valid: true, verticalResume: true, movementCostFt: 0, routeCostFt: 0 });
+  expect(plan.path).toHaveLength(1);
+  expect(plan.path[0]).toMatchObject({ x: mover.x, y: mover.y });
 });
 
 test('walk stops before a closed door instead of rejecting the entire route', () => {
@@ -166,6 +237,7 @@ test('walk/dash door primitive contract matches action and noise rules', () => {
   expect(rules.doorTraversal({ mode: 'walk', door: { state: 'closed', locked: false } })).toMatchObject({ valid: false, actionRequired: true, reason: 'DOOR_ACTION_REQUIRED' });
   expect(rules.doorTraversal({ mode: 'dash', dashActive: true, remainingFt: 20, door: { state: 'closed', locked: false } })).toMatchObject({ valid: true, opensDoor: true, burstOpen: true, continueMovement: true, noise: 'high', soundEvent: 'DASH_DOOR_BURST' });
   expect(rules.doorTraversal({ mode: 'dash', dashActive: true, door: { state: 'locked', locked: true } })).toMatchObject({ valid: false, reason: 'DOOR_LOCKED' });
+  expect(rules.doorTraversal({ mode: 'walk', door: { state: 'broken' } })).toMatchObject({ valid: true, continueMovement: true, actionRequired: false });
 });
 
 test('memory is stale geometry only, minimap is a separate unlock, and unsaved empty zones may regenerate', () => {
@@ -180,6 +252,7 @@ test('memory is stale geometry only, minimap is a separate unlock, and unsaved e
 test('runtime drag contract keeps token stationary until release and then animates traversal previews', () => {
   const engineSource = read('js/vtt/engine.js');
   const bootstrapSource = read('js/vtt/movement-bootstrap.js');
+  const mainSource = read('js/vtt/main.js');
   expect(engineSource).toContain('if (this.tokenMoveResolver)');
   expect(engineSource).toContain("CustomEvent('vtt:movement-destination-preview'");
   expect(engineSource).toContain('await this.tokenMoveResolver');
@@ -191,4 +264,7 @@ test('runtime drag contract keeps token stationary until release and then animat
   expect(bootstrapSource).toContain('RESET MOVE');
   expect(bootstrapSource).toContain("preview.valid ? '#55ff80' : '#ff5f5f'");
   expect(bootstrapSource).toContain('isActiveCombatTurn(token)');
+  expect(mainSource).toContain("import './movement-connectivity.js'");
+  expect(mainSource).toContain("import './movement-destination-claims.js'");
+  expect(mainSource.indexOf("import './movement-destination-claims.js'")).toBeLessThan(mainSource.indexOf('document.addEventListener'));
 });

--- a/tests/vtt_movement_rules_closure.spec.js
+++ b/tests/vtt_movement_rules_closure.spec.js
@@ -11,6 +11,7 @@ require('../js/vtt/token-state-dynamic-patch.js');
 require('../js/vtt/movement-integration-patch.js');
 require('../js/vtt/movement-rules.js');
 require('../js/vtt/movement-rules-runtime.js');
+require('../js/vtt/movement-door-runtime.js');
 
 const rules = globalThis.LuminousVttMovementRules;
 const pathfinding = globalThis.LuminousVttPathfinding;
@@ -40,6 +41,17 @@ function lineMap(cols = 5) {
     topology: [],
     tokens: [],
     movement: { diagonalRule: '5e', blockTokens: true },
+  };
+}
+
+function door(id = 'door-1', state = 'closed') {
+  return {
+    id,
+    type: 'door',
+    from: { col: 1, row: 0 },
+    to: { col: 1, row: 1 },
+    z: [0],
+    state,
   };
 }
 
@@ -118,7 +130,39 @@ test('route over remaining combat movement is rejected instead of clipping or te
   expect(plan).toMatchObject({ valid: false, reason: 'INSUFFICIENT_MOVEMENT', movementCostFt: 20, remainingFt: 10 });
 });
 
-test('walk stops at a closed door; Dash bursts an unlocked door with noise and may continue', () => {
+test('walk stops before a closed door instead of rejecting the entire route', () => {
+  const mapData = lineMap(3);
+  const mover = token('mover', 0, { speedFt: 30 });
+  mapData.tokens = [mover];
+  mapData.topology = [door('door-walk', 'closed')];
+  const plan = movement.planMove({ token: mover, start: mover, target: { x: 175, y: 35 }, mapData, worldState: { mode: 'free' } });
+  expect(plan.valid).toBe(true);
+  expect(plan.complete).toBe(false);
+  expect(plan.movementCostFt).toBe(0);
+  expect(plan.path).toHaveLength(1);
+  expect(plan.stopAtDoor).toMatchObject({ doorId: 'door-walk', state: 'closed', reason: 'DOOR_ACTION_REQUIRED', actionRequired: true });
+});
+
+test('Dash plans through unlocked closed doors, while locked doors stop Dash at the threshold', () => {
+  const mapData = lineMap(3);
+  const mover = token('mover', 0, { speedFt: 30 });
+  mapData.tokens = [mover];
+  mapData.topology = [door('door-dash', 'closed')];
+  const world = movement.normalizeWorldState({ mode: 'round', roundId: 2 });
+  movement.beginRound(mover, 2);
+  expect(movement.dash(mover, world, { actionType: 'action' }).valid).toBe(true);
+  const through = movement.planMove({ token: mover, start: mover, target: { x: 175, y: 35 }, mapData, worldState: world });
+  expect(through).toMatchObject({ valid: true, movementCostFt: 10, dashThroughDoors: true });
+  expect(through.doorInteractions).toEqual([expect.objectContaining({ doorId: 'door-dash', pathIndex: 0, action: 'open', burstOpen: true, noise: 'high', soundEvent: 'DASH_DOOR_BURST' })]);
+
+  mapData.topology = [door('door-locked', 'locked')];
+  const blocked = movement.planMove({ token: mover, start: mover, target: { x: 175, y: 35 }, mapData, worldState: world });
+  expect(blocked.valid).toBe(true);
+  expect(blocked.complete).toBe(false);
+  expect(blocked.stopAtDoor).toMatchObject({ doorId: 'door-locked', state: 'locked', reason: 'DOOR_LOCKED' });
+});
+
+test('walk/dash door primitive contract matches action and noise rules', () => {
   expect(rules.doorTraversal({ mode: 'walk', door: { state: 'closed', locked: false } })).toMatchObject({ valid: false, actionRequired: true, reason: 'DOOR_ACTION_REQUIRED' });
   expect(rules.doorTraversal({ mode: 'dash', dashActive: true, remainingFt: 20, door: { state: 'closed', locked: false } })).toMatchObject({ valid: true, opensDoor: true, burstOpen: true, continueMovement: true, noise: 'high', soundEvent: 'DASH_DOOR_BURST' });
   expect(rules.doorTraversal({ mode: 'dash', dashActive: true, door: { state: 'locked', locked: true } })).toMatchObject({ valid: false, reason: 'DOOR_LOCKED' });

--- a/tests/vtt_multiclient_realtime_field.spec.js
+++ b/tests/vtt_multiclient_realtime_field.spec.js
@@ -349,9 +349,18 @@ test.describe('VTT shared multiclient Realtime field', () => {
 
     const engine = read('js/vtt/engine.js');
     const moveStart = engine.indexOf('handleTokenMouseMove(event)');
-    const upStart = engine.indexOf('handleTokenMouseUp(event)');
-    const centerStart = engine.indexOf('    centerCamera() {', upStart);
-    expect(engine.slice(moveStart, upStart)).not.toContain("'vtt:token-moved'");
-    expect((engine.slice(upStart, centerStart).match(/'vtt:token-moved'/g) || [])).toHaveLength(1);
+    const animateStart = engine.indexOf('async animateTokenPath', moveStart);
+    const upStart = engine.indexOf('async handleTokenMouseUp(event)', animateStart);
+    const finalizeStart = engine.indexOf('finalizeTokenMove(token, drag, result = {})', upStart);
+    const centerStart = engine.indexOf('    centerCamera() {', finalizeStart);
+    expect(moveStart).toBeGreaterThan(-1);
+    expect(animateStart).toBeGreaterThan(moveStart);
+    expect(upStart).toBeGreaterThan(animateStart);
+    expect(finalizeStart).toBeGreaterThan(upStart);
+    expect(centerStart).toBeGreaterThan(finalizeStart);
+    expect(engine.slice(moveStart, animateStart)).not.toContain("'vtt:token-moved'");
+    expect(engine.slice(upStart, finalizeStart)).toContain('this.finalizeTokenMove(token, drag, result)');
+    expect(engine.slice(upStart, finalizeStart)).not.toContain("new CustomEvent('vtt:token-moved'");
+    expect((engine.slice(finalizeStart, centerStart).match(/'vtt:token-moved'/g) || [])).toHaveLength(1);
   });
 });

--- a/tests/vtt_token_drag.spec.js
+++ b/tests/vtt_token_drag.spec.js
@@ -7,6 +7,7 @@ const tokenRules = require('../js/vtt/token-interaction.js');
 const engineSource = read('js/vtt/engine.js');
 const rendererSource = read('js/vtt/renderer.js');
 const cameraSource = read('js/vtt/camera.js');
+const movementBootstrapSource = read('js/vtt/movement-bootstrap.js');
 const htmlSource = read('vtt.html');
 
 const grid = { cols: 10, rows: 10, size: 70 };
@@ -66,6 +67,17 @@ test('VTT loads token interaction before the module engine and uses drag instead
     expect(engineSource).toContain("new CustomEvent('vtt:token-moved'");
     expect(engineSource).not.toContain('playerSpeed = 4');
     expect(engineSource).not.toContain('this.keys = { w: false');
+});
+
+test('movement interactions resolve at the traversal threshold and irreversible mutations lock cancellation', () => {
+    expect(engineSource).toContain('let resolvedInteraction = interaction');
+    expect(engineSource).toContain('resolvedInteraction = { ...interaction, ...resolution.interaction }');
+    expect(engineSource).toContain('if (resolution?.irreversible === true) motion.irreversible = true');
+    expect(engineSource).toContain('event: resolvedInteraction.soundEvent');
+    expect(engineSource).toContain('intensity: resolvedInteraction.noise');
+    expect(movementBootstrapSource).toContain('engine.setMovementInteractionResolver?.(executeMovementInteraction)');
+    expect(movementBootstrapSource).toContain("if (motion.irreversible) return { valid: false, reason: 'MOVEMENT_INTERACTION_COMMITTED' }");
+    expect(movementBootstrapSource).toContain("runtime.bridge.requestDirectAction(door.id, 'open')");
 });
 
 test('camera drag yields to draggable tokens and renderer draws round person tokens', () => {


### PR DESCRIPTION
Cierra las reglas funcionales restantes de Movement sin tocar GOAP.

Incluye:
- drag como selección de destino: la ficha no cambia posición hasta mouseup;
- al soltar se calcula/cobra la ruta A* y se anima el trayecto, emitiendo previews realtime durante la travesía;
- cámara/FOV siguen la posición traversed, no el cursor;
- occupancy: aliados atravesables pero nunca ocupables; hostiles bloquean salvo que el mover sea 2 tamaños menor; ningún destino ocupado es válido;
- arbitraje determinista de reclamos de espacio: DM > Player > GOAP, luego RTT, llegada y tokenId;
- captura del inicio de turno, historial y RESET MOVE que vuelve al origen y restaura Movement base;
- Dash conserva metadata de Action/Quick Action y ruido alto;
- contrato de puertas: Walk se detiene y requiere Action; Dash abre de golpe puerta desbloqueada y produce ruido; locked bloquea;
- memoria visible/recordada separada de actores live y regla de persistencia de Zone;
- ruler verde/rojo con FT sólo para token activo de combate; fuera de eso la ruta es neutra sin FT;
- tests nuevos y gate CI ampliado; mantiene full repository regression.

Criterio de merge: gate focal + full repository regression en verde.