### PR TITLE
perf(vtt): unify player visibility mask and POV controls

### DIFF
--- a/.github/workflows/vtt-camera-pov-observer.yml
+++ b/.github/workflows/vtt-camera-pov-observer.yml
@@ -8,6 +8,9 @@ on:
       - 'js/vtt/map-hud-bootstrap.js'
       - 'js/vtt/main.js'
       - 'js/vtt/lighting-engine.js'
+      - 'js/vtt/dynamic-lighting-bootstrap.js'
+      - 'js/vtt/fog-memory-bootstrap.js'
+      - 'js/vtt/visibility-mask-core.js'
       - 'js/vtt/pov-*.js'
       - 'js/vtt/token-state.js'
       - 'js/vtt/player-discovery-*.js'
@@ -30,7 +33,12 @@ on:
       - 'js/vtt/dm-observer.js'
       - 'js/vtt/map-hud-bootstrap.js'
       - 'js/vtt/main.js'
+      - 'js/vtt/dynamic-lighting-bootstrap.js'
+      - 'js/vtt/fog-memory-bootstrap.js'
+      - 'js/vtt/visibility-mask-core.js'
+      - 'js/vtt/pov-*.js'
       - 'tests/vtt_camera*.spec.js'
+      - 'tests/vtt_*pov*.spec.js'
       - '.github/workflows/vtt-camera-pov-observer.yml'
 
 permissions:
@@ -53,8 +61,14 @@ jobs:
         run: |
           node --check js/vtt/camera-follow.js
           node --check js/vtt/dm-observer.js
+          node --check js/vtt/visibility-mask-core.js
+          node --check js/vtt/pov-controller.js
+          node --check js/vtt/pov-renderer.js
+          node --input-type=module --check < js/vtt/dynamic-lighting-bootstrap.js
+          node --input-type=module --check < js/vtt/fog-memory-bootstrap.js
           node --input-type=module --check < js/vtt/map-hud-bootstrap.js
           node --input-type=module --check < js/vtt/main.js
+          node --check tests/vtt_pov_visibility_mask.spec.js
           node --check tests/vtt_camera_pov_observer_field.spec.js
           node --check tests/vtt_camera_pov_observer_realtime.spec.js
       - name: Install Chromium
@@ -62,6 +76,7 @@ jobs:
       - name: Focused camera POV observer field and realtime contracts
         run: >-
           npx playwright test --workers=1
+          tests/vtt_pov_visibility_mask.spec.js
           tests/vtt_camera_pov_observer_field.spec.js
           tests/vtt_camera_pov_observer_realtime.spec.js
           tests/vtt_camera_perception.spec.js

--- a/.github/workflows/vtt-multiclient-realtime-field.yml
+++ b/.github/workflows/vtt-multiclient-realtime-field.yml
@@ -93,22 +93,22 @@ jobs:
         run: npm ci
       - name: Syntax
         run: |
-          node --check js/vtt/main.js
-          node --check js/vtt/token-state.js
-          node --check js/vtt/physical-state-patch.js
-          node --check js/vtt/camera-follow.js
-          node --check js/vtt/dm-observer.js
-          node --check js/vtt/performance-guard.js
-          node --check js/vtt/movement-realtime.js
-          node --check js/vtt/movement-connectivity.js
-          node --check js/vtt/movement-destination-claims.js
-          node --check js/vtt/movement-door-runtime.js
-          node --check js/vtt/movement-rules.js
-          node --check js/vtt/movement-rules-runtime.js
-          node --check js/vtt/jump-fall-physics.js
-          node --check js/vtt/jump-fall-checks.js
-          node --check js/vtt/jump-fall-damage.js
-          node --check js/vtt/jump-fall-bootstrap.js
+          node --input-type=module --check < js/vtt/main.js
+          node --input-type=module --check < js/vtt/token-state.js
+          node --input-type=module --check < js/vtt/physical-state-patch.js
+          node --input-type=module --check < js/vtt/camera-follow.js
+          node --input-type=module --check < js/vtt/dm-observer.js
+          node --input-type=module --check < js/vtt/performance-guard.js
+          node --input-type=module --check < js/vtt/movement-realtime.js
+          node --input-type=module --check < js/vtt/movement-connectivity.js
+          node --input-type=module --check < js/vtt/movement-destination-claims.js
+          node --input-type=module --check < js/vtt/movement-door-runtime.js
+          node --input-type=module --check < js/vtt/movement-rules.js
+          node --input-type=module --check < js/vtt/movement-rules-runtime.js
+          node --input-type=module --check < js/vtt/jump-fall-physics.js
+          node --input-type=module --check < js/vtt/jump-fall-checks.js
+          node --input-type=module --check < js/vtt/jump-fall-damage.js
+          node --input-type=module --check < js/vtt/jump-fall-bootstrap.js
           node --check tests/vtt_multiclient_realtime_field.spec.js
           node --check tests/vtt_movement_realtime.spec.js
           node --check tests/vtt_movement_connectivity.spec.js

--- a/js/background-narratives/package.json
+++ b/js/background-narratives/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/js/vtt/dynamic-lighting-bootstrap.js
+++ b/js/vtt/dynamic-lighting-bootstrap.js
@@ -5,6 +5,7 @@ import './lighting-state.js';
 import './lighting-controller.js';
 import './pov-engine.js';
 import './pov-state.js';
+import './visibility-mask-core.js';
 import './pov-controller.js';
 import './pov-renderer.js';
 
@@ -33,7 +34,8 @@ ready(() => {
   const povStateApi = window.LuminousVttPovState;
   const povControllerApi = window.LuminousVttPovController;
   const povRenderer = window.LuminousVttPovRenderer;
-  if (!light || !stateApi || !envApi || !controllerApi || !pov || !povStateApi || !povControllerApi || !povRenderer) {
+  const visibility = window.LuminousVttVisibilityMaskCore;
+  if (!light || !stateApi || !envApi || !controllerApi || !pov || !povStateApi || !povControllerApi || !povRenderer || !visibility) {
     console.error('Dynamic Lighting: one or more runtimes are unavailable.');
     return;
   }
@@ -49,16 +51,28 @@ ready(() => {
     if (!Number.isFinite(Number(token.visionConeDeg))) token.visionConeDeg = light.DEFAULT_VISION_CONE_DEG;
   });
 
-  const perceptionCache = { key: '', tiles: [] };
+  const perceptionCache = {
+    key: '',
+    tiles: [],
+    generation: 0,
+    requests: 0,
+    computed: 0,
+    hits: 0,
+  };
+  const offscreenCache = { canvas: null, ctx: null, width: 0, height: 0 };
   let lightingController = null;
   let povController = null;
+
+  function invalidateVisibility() {
+    perceptionCache.key = '';
+  }
 
   const lightingStateBridge = stateApi.createBridge({
     mapData,
     isDm: bridge.isDm,
     notify: (message, mode) => runtime.controller?.notify?.(message, mode),
     onChanged: () => {
-      perceptionCache.key = '';
+      invalidateVisibility();
       lightingController?.handleSceneChanged?.();
       povController?.handleSceneChanged?.();
     },
@@ -67,12 +81,12 @@ ready(() => {
   const povStateBridge = povStateApi.createBridge({
     mapData,
     isDm: bridge.isDm,
-    onChanged: () => { perceptionCache.key = ''; },
+    onChanged: invalidateVisibility,
   });
 
   const environmentLightBridge = envApi.createBridge({
     mapData,
-    onChanged: () => { perceptionCache.key = ''; },
+    onChanged: invalidateVisibility,
   });
 
   function controlledViewers() {
@@ -127,35 +141,20 @@ ready(() => {
 
   function environment() { return mapData.lighting?.environment || { state: { light: mapData.ambientLight?.level || 'bright' } }; }
 
-  function mapFingerprint(viewers, viewZ, lookUp, now) {
-    const tokens = (mapData.tokens || []).map((token) => [
-      token.id,
-      Number(token.x) || 0,
-      Number(token.y) || 0,
-      light.layerOf(token),
-      light.elevationFt(token, mapData),
-      Number(token.lookDeg ?? token.facingDeg) || 0,
-      Number(token.eyeHeightFt) || pov.DEFAULT_EYE_HEIGHT_FT,
-    ]);
+  function movingLightTick(now) {
     const moving = (scene().sources || []).some((source) => source.motion && !light.interpolateMotion(source.motion, now).complete);
-    return JSON.stringify({
-      z: viewZ,
-      lookUp: Boolean(lookUp),
-      viewers: viewers.map((viewer) => [
-        viewer.id,
-        viewer.x,
-        viewer.y,
-        light.layerOf(viewer),
-        light.elevationFt(viewer, mapData),
-        viewer.lookDeg ?? viewer.facingDeg,
-        viewer.eyeHeightFt,
-        viewer.visionConeDeg,
-        viewer.senses?.darkvisionFt,
-      ]),
-      tokens,
+    return moving ? Math.floor(now / 50) : 0;
+  }
+
+  function visibilityFingerprint(viewers, viewZ, lookUp, now) {
+    return visibility.visibilityFingerprint({
+      viewers,
+      viewZ,
+      lookUp,
+      mapData,
       scene: scene(),
-      env: environment()?.state,
-      motionTick: moving ? Math.floor(now / 50) : 0,
+      environment: environment()?.state || null,
+      motionTick: movingLightTick(now),
     });
   }
 
@@ -192,13 +191,50 @@ ready(() => {
     return tiles;
   }
 
-  function perceptionTiles(viewers, viewZ, now, lookUp) {
-    const key = mapFingerprint(viewers, viewZ, lookUp, now);
-    if (key !== perceptionCache.key) {
+  function visibilityMask(viewers, viewZ, now = Date.now(), lookUp = false) {
+    perceptionCache.requests += 1;
+    const key = visibilityFingerprint(viewers, viewZ, lookUp, now);
+    if (key === perceptionCache.key) {
+      perceptionCache.hits += 1;
+    } else {
       perceptionCache.key = key;
       perceptionCache.tiles = computeTiles(viewers, viewZ, now, lookUp);
+      perceptionCache.generation += 1;
+      perceptionCache.computed += 1;
+      mapData.pov ||= {};
+      mapData.pov.dirty = false;
     }
-    return perceptionCache.tiles;
+    return Object.freeze({
+      key: perceptionCache.key,
+      generation: perceptionCache.generation,
+      viewZ: Number(viewZ) || 0,
+      lookUp: Boolean(lookUp),
+      tiles: perceptionCache.tiles,
+    });
+  }
+
+  function visibilityMetrics() {
+    return Object.freeze({
+      requests: perceptionCache.requests,
+      computed: perceptionCache.computed,
+      cacheHits: perceptionCache.hits,
+      generation: perceptionCache.generation,
+      tileCount: perceptionCache.tiles.length,
+    });
+  }
+
+  function ensureOffscreen() {
+    if (!offscreenCache.canvas) {
+      offscreenCache.canvas = document.createElement('canvas');
+      offscreenCache.ctx = offscreenCache.canvas.getContext('2d');
+    }
+    if (offscreenCache.width !== canvas.width || offscreenCache.height !== canvas.height) {
+      offscreenCache.width = canvas.width;
+      offscreenCache.height = canvas.height;
+      offscreenCache.canvas.width = canvas.width;
+      offscreenCache.canvas.height = canvas.height;
+    }
+    return offscreenCache;
   }
 
   function withRendererContext(targetCanvas, targetCtx, fn) {
@@ -251,7 +287,7 @@ ready(() => {
       renderer.drawWalls(renderZ, false);
       renderer.drawTopology(renderZ, false);
       renderer.drawTokens(renderZ);
-      povRenderer.drawIndicators(renderer, renderZ);
+      povRenderer.drawIndicators(renderer, renderZ, { isDm: bridge.isDm, viewers: options.viewers || [] });
       drawLightEffects(targetCtx, renderZ, now, bridge.isDm && !mapData.lighting?.dmPreviewTokenId);
       if (options.lookUp) (options.viewers || []).forEach((viewer) => povRenderer.drawLookUpAnchor(targetCtx, viewer, mapData));
       if (includeGuides) {
@@ -275,17 +311,15 @@ ready(() => {
     const requestedLookUp = povController.lookUpHeld();
     const viewZ = povController.viewLayer(activeZ);
     const lookUp = requestedLookUp && Number(viewZ) !== Number(activeZ);
-    const offscreen = document.createElement('canvas');
-    offscreen.width = canvas.width; offscreen.height = canvas.height;
-    const offctx = offscreen.getContext('2d');
-    drawBaseScene(offscreen, offctx, viewZ, now, false, { lookUp, viewers });
+    const offscreen = ensureOffscreen();
+    drawBaseScene(offscreen.canvas, offscreen.ctx, viewZ, now, false, { lookUp, viewers });
 
     renderer.ctx.clearRect(0, 0, canvas.width, canvas.height);
     renderer.ctx.fillStyle = '#000'; renderer.ctx.fillRect(0, 0, canvas.width, canvas.height);
-    const tiles = perceptionTiles(viewers, viewZ, now, lookUp);
-    povController.setLookUpBlocked(requestedLookUp && (!lookUp || tiles.length === 0));
+    const mask = visibilityMask(viewers, viewZ, now, lookUp);
+    povController.setLookUpBlocked(requestedLookUp && (!lookUp || mask.tiles.length === 0));
     const zoom = camera.zoom;
-    for (const tile of tiles) {
+    for (const tile of mask.tiles) {
       const sx = (tile.x + camera.x) * zoom;
       const sy = (tile.y + camera.y) * zoom;
       const sw = tile.w * zoom + 1;
@@ -297,7 +331,7 @@ ready(() => {
       else if (mode === 'normal_dim') renderer.ctx.filter = 'brightness(.68) contrast(.92)';
       else if (mode === 'near_dim') renderer.ctx.filter = 'brightness(.45) contrast(.88)';
       else renderer.ctx.filter = 'none';
-      renderer.ctx.drawImage(offscreen, sx, sy, sw, sh, sx, sy, sw, sh);
+      renderer.ctx.drawImage(offscreen.canvas, sx, sy, sw, sh, sx, sy, sw, sh);
       const source = sourceForPerception(tile.perception);
       if (source && !tile.perception.monochrome) {
         renderer.ctx.globalCompositeOperation = 'screen'; renderer.ctx.globalAlpha = tile.perception.level === 'bright' ? 0.10 : 0.06;
@@ -334,7 +368,7 @@ ready(() => {
   canvas.addEventListener('vtt:token-moved', updateFacingFromMove);
 
   const bodyFacingKeyHandler = (event) => {
-    if (!['[', ']'].includes(event.key) || event.ctrlKey || event.metaKey || event.altKey) return;
+    if (!['[', ']'].includes(event.key) || event.shiftKey || event.ctrlKey || event.metaKey || event.altKey) return;
     const token = controlledViewers()[0] || null;
     if (!token) return;
     token.facingDeg = light.normalizeAngleDeg(Number(token.facingDeg || 0) + (event.key === '[' ? -15 : 15));
@@ -353,6 +387,9 @@ ready(() => {
       controller: lightingController,
       controlledViewers,
       perceptionAtPoint: (viewer, point) => pov.perceptionAtPoint(viewer, point, scene(), mapData, environment()),
+      visibilityMask: (viewers = controlledViewers(), zLayer = engine.activeZ, options = {}) => visibilityMask(viewers, zLayer, options.now ?? Date.now(), Boolean(options.lookUp)),
+      visibilityMetrics,
+      invalidateVisibility,
     }),
     pov: Object.freeze({
       engine: pov,
@@ -372,5 +409,7 @@ ready(() => {
     povStateBridge.stop();
     lightingStateBridge.stop();
     renderer.render = originalRender;
+    offscreenCache.canvas = null;
+    offscreenCache.ctx = null;
   }, { once: true });
 });

--- a/js/vtt/fog-memory-bootstrap.js
+++ b/js/vtt/fog-memory-bootstrap.js
@@ -12,7 +12,8 @@ ready(() => {
   const memory = window.LuminousVttMemoryEngine;
   const stateApi = window.LuminousVttMemoryState;
   const memoryRenderer = window.LuminousVttMemoryRenderer;
-  if (!runtime?.engine || !runtime?.pov || !runtime?.lighting || !memory || !stateApi || !memoryRenderer) {
+  const visibility = window.LuminousVttVisibilityMaskCore;
+  if (!runtime?.engine || !runtime?.pov || !runtime?.lighting || !runtime.lighting.visibilityMask || !memory || !stateApi || !memoryRenderer || !visibility) {
     console.error('Fog Memory: required VTT runtimes are unavailable.');
     return;
   }
@@ -30,7 +31,7 @@ ready(() => {
   let dirty = false;
   let saveTimer = null;
   let lastProfileAt = 0;
-  let visibilityCache = { at: 0, zLayer: null, lookUp: false, signature: '', cells: new Set() };
+  let visibleCellCache = { maskKey: '', cells: new Set() };
   let lastObservedSignature = '';
 
   function previewToken() {
@@ -119,46 +120,12 @@ ready(() => {
     return runtime.pov.controlledViewers?.() || runtime.lighting.controlledViewers?.() || [];
   }
 
-  function viewerSignature(viewers, zLayer, lookUp) {
-    const scene = mapData.lighting?.scene || {};
-    return JSON.stringify({
-      zLayer,
-      lookUp,
-      viewers: viewers.map((viewer) => [viewer.id, viewer.x, viewer.y, viewer.zLayer, viewer.elevationFt, viewer.lookDeg, viewer.visionConeDeg, viewer.senses?.darkvisionFt]),
-      topology: (mapData.topology || []).map((element) => [element.id, element.state]),
-      walls: (mapData.walls || []).length,
-      scene: [scene.sources, scene.interiors, scene.roofs].map((list) => JSON.stringify(list || [])),
-      env: mapData.lighting?.environment?.state || null,
-    });
-  }
-
-  function pointAtCell(col, row, zLayer) {
-    const size = Math.max(1, Number(mapData.grid?.size) || 70);
-    const elevationFt = runtime.lighting.engine.elevationForLayer(mapData, zLayer);
-    return { x: (col + .5) * size, y: (row + .5) * size, zLayer, elevationFt };
-  }
-
   function visibleCells(viewers, zLayer, lookUp) {
-    const now = Date.now();
-    const signature = viewerSignature(viewers, zLayer, lookUp);
-    if (visibilityCache.signature === signature && now - visibilityCache.at < 100) return visibilityCache.cells;
-    const cells = new Set();
-    const cols = Math.max(1, Math.trunc(Number(mapData.grid?.cols) || 1));
-    const rows = Math.max(1, Math.trunc(Number(mapData.grid?.rows) || 1));
-    for (let row = 0; row < rows; row += 1) {
-      for (let col = 0; col < cols; col += 1) {
-        const point = pointAtCell(col, row, zLayer);
-        let visible = false;
-        for (const viewer of viewers) {
-          const perception = lookUp
-            ? runtime.pov.lookUpPerceptionAtPoint?.(viewer, point)
-            : runtime.lighting.perceptionAtPoint?.(viewer, point);
-          if (perception?.visible) { visible = true; break; }
-        }
-        if (visible) cells.add(memory.cellKey(col, row));
-      }
-    }
-    visibilityCache = { at: now, zLayer, lookUp, signature, cells };
+    const mask = runtime.lighting.visibilityMask(viewers, zLayer, { lookUp, now: Date.now() });
+    if (!mask?.key) return new Set();
+    if (visibleCellCache.maskKey === mask.key) return visibleCellCache.cells;
+    const cells = visibility.cellsFromTiles(mask.tiles, mapData, memory.cellKey);
+    visibleCellCache = { maskKey: mask.key, cells };
     return cells;
   }
 

--- a/js/vtt/pov-controller.js
+++ b/js/vtt/pov-controller.js
@@ -14,17 +14,25 @@
     if (!canvas || !engine || !mapData || !stateBridge) throw new Error('POV_CONTROLLER_INPUT_REQUIRED');
     const doc = root?.document;
     const pov = root?.LuminousVttPovEngine;
+    const visibility = root?.LuminousVttVisibilityMaskCore;
     if (!pov) throw new Error('POV_ENGINE_REQUIRED');
+    const LOOK_STEP_DEG = visibility?.DEFAULT_LOOK_STEP_DEG || 2;
+    const LOOK_THROTTLE_MS = visibility?.DEFAULT_LOOK_THROTTLE_MS || 50;
+    const LOOK_BUTTON_STEP_DEG = 15;
     const listeners = [];
     mapData.pov ||= {};
     if (typeof mapData.pov.lookLocked !== 'boolean') mapData.pov.lookLocked = false;
     if (typeof mapData.pov.lookUpHeld !== 'boolean') mapData.pov.lookUpHeld = false;
+    if (!Number.isFinite(Number(mapData.pov.revision))) mapData.pov.revision = 0;
     mapData.pov.lookUpBlocked = false;
     mapData.lighting ||= {};
     mapData.lighting.scene ||= { sources: [], interiors: [], transformers: [], switches: [] };
     mapData.lighting.scene.roofs ||= [];
 
     let saveTimer = null;
+    let lookUpdateTimer = null;
+    let pendingLookDeg = null;
+    let lastLookAppliedAt = -Infinity;
     let roofToolActive = false;
     let roofDragStart = null;
     let selectedRoofId = null;
@@ -37,6 +45,15 @@
     function activeLookToken() { return controlled()[0] || null; }
     function lookLocked() { return Boolean(mapData.pov.lookLocked); }
     function lookUpHeld() { return Boolean(mapData.pov.lookUpHeld); }
+    function nowMs() { return root?.performance?.now?.() ?? Date.now(); }
+    function normalizeAngle(value) { return visibility?.normalizeAngleDeg?.(value) ?? pov.normalizeAngleDeg?.(value) ?? (((num(value) % 360) + 360) % 360); }
+    function quantizeAngle(value) { return visibility?.quantizeAngleDeg?.(value, LOOK_STEP_DEG) ?? normalizeAngle(Math.round(normalizeAngle(value) / LOOK_STEP_DEG) * LOOK_STEP_DEG); }
+    function angleChanged(previous, next) {
+      if (visibility?.meaningfulAngleChange) return visibility.meaningfulAngleChange(previous, next, LOOK_STEP_DEG);
+      let delta = Math.abs(normalizeAngle(next) - normalizeAngle(previous));
+      if (delta > 180) delta = 360 - delta;
+      return delta >= LOOK_STEP_DEG - 1e-9;
+    }
 
     function eventWorldPoint(event) {
       if (typeof engine.eventWorldPoint === 'function') return engine.eventWorldPoint(event);
@@ -60,8 +77,10 @@
         const style = doc.createElement('style');
         style.id = 'vtt-pov-runtime-style';
         style.textContent = `
-          .vtt-pov-status{position:fixed;left:50%;bottom:18px;transform:translateX(-50%);z-index:30020;background:#0b0b0b;border:1px solid #aaa;color:#fff;padding:6px 10px;font:700 11px monospace;pointer-events:none;box-shadow:3px 3px 0 #000}
+          .vtt-pov-status{position:fixed;left:50%;bottom:76px;transform:translateX(-50%);z-index:30020;background:#0b0b0b;border:1px solid #aaa;color:#fff;padding:5px 9px;font:700 10px monospace;pointer-events:none;box-shadow:3px 3px 0 #000}
           .vtt-pov-status[data-mode="blocked"]{border-color:#ff6b6b}.vtt-pov-status[data-mode="up"]{border-color:#8bd8ff}.vtt-pov-status[data-mode="locked"]{border-color:#ffe38b}
+          .vtt-pov-controls{position:fixed;left:50%;bottom:101px;transform:translateX(-50%);z-index:30021;display:flex;gap:4px;background:rgba(11,11,11,.94);border:1px solid #59636c;padding:4px;box-shadow:3px 3px 0 #000}
+          .vtt-pov-controls button{border:1px solid #59636c;background:#11161a;color:#dce3e8;font:700 9px monospace;padding:5px 7px;cursor:pointer}.vtt-pov-controls button:hover{border-color:#d7b151;color:#d7b151}.vtt-pov-controls button:disabled{opacity:.35;cursor:not-allowed}.vtt-pov-controls [data-pov-action="lock"].is-active{border-color:#ffe38b;color:#ffe38b}
           .vtt-pov-roof-panel{position:fixed;right:18px;top:86px;z-index:31500;width:280px;background:#111;border:2px solid #fff;color:#fff;padding:12px;font:12px monospace;box-shadow:6px 6px 0 #000}
           .vtt-pov-roof-panel[hidden]{display:none}.vtt-pov-roof-panel label{display:grid;gap:4px;margin:8px 0}.vtt-pov-roof-panel input{background:#080808;color:#fff;border:1px solid #777;padding:6px}
         `;
@@ -72,6 +91,16 @@
         badge.id = 'vtt-pov-status';
         badge.className = 'vtt-pov-status';
         doc.body.appendChild(badge);
+      }
+      if (!doc.getElementById('vtt-pov-controls')) {
+        const controls = doc.createElement('nav');
+        controls.id = 'vtt-pov-controls';
+        controls.className = 'vtt-pov-controls';
+        controls.setAttribute('aria-label', 'View direction controls');
+        controls.innerHTML = '<button type="button" data-pov-action="left" title="Shift+[">VIEW ◀</button><button type="button" data-pov-action="lock" title="E">VIEW FREE</button><button type="button" data-pov-action="right" title="Shift+]">VIEW ▶</button>';
+        controls.addEventListener('click', onPovControlsClick);
+        listeners.push(() => controls.removeEventListener('click', onPovControlsClick));
+        doc.body.appendChild(controls);
       }
       if (isDm && !doc.getElementById('vtt-pov-roof-editor')) {
         const panel = doc.createElement('aside');
@@ -101,9 +130,26 @@
       toolbar.appendChild(button);
     }
 
+    function syncControls() {
+      const controls = doc?.getElementById('vtt-pov-controls');
+      if (!controls) return;
+      const hasToken = Boolean(activeLookToken()) && !editActive();
+      controls.hidden = Boolean(isDm && !hasToken);
+      for (const button of controls.querySelectorAll('button')) button.disabled = !hasToken;
+      const lockButton = controls.querySelector('[data-pov-action="lock"]');
+      if (lockButton) {
+        lockButton.textContent = lookLocked() ? 'VIEW LOCKED' : 'VIEW FREE';
+        lockButton.classList.toggle('is-active', lookLocked());
+      }
+    }
+
     function updateStatus() {
       const badge = doc?.getElementById('vtt-pov-status');
       if (!badge) return;
+      syncControls();
+      const currentToken = activeLookToken();
+      if (isDm && !currentToken) { badge.hidden = true; return; }
+      badge.hidden = false;
       if (lookUpHeld() && mapData.pov.lookUpBlocked) {
         badge.textContent = 'Q · LOOK UP · BLOCKED';
         badge.dataset.mode = 'blocked';
@@ -115,7 +161,9 @@
         badge.dataset.mode = target == null ? 'blocked' : 'up';
         return;
       }
-      badge.textContent = lookLocked() ? 'E · LOOK LOCKED' : 'E · LOOK FREE';
+      const token = currentToken;
+      const angle = token ? Math.round(normalizeAngle(token.lookDeg ?? token.facingDeg)) : null;
+      badge.textContent = token ? `${lookLocked() ? 'E · LOOK LOCKED' : 'E · LOOK FREE'} · ${angle}°` : 'POV · NO VIEWER';
       badge.dataset.mode = lookLocked() ? 'locked' : 'free';
     }
 
@@ -128,13 +176,78 @@
       }, 120) || null;
     }
 
+    function dispatchPovChanged(reason, token) {
+      mapData.pov.dirty = true;
+      mapData.pov.revision = (Number(mapData.pov.revision) || 0) + 1;
+      root?.LuminousVttPerformanceGuard?.invalidate?.();
+      const EventCtor = root?.CustomEvent || browserRoot?.CustomEvent || globalThis.CustomEvent;
+      if (typeof EventCtor === 'function') {
+        canvas.dispatchEvent?.(new EventCtor('vtt:pov-changed', {
+          detail: { reason, tokenId: token?.id || null, lookDeg: token?.lookDeg ?? null, revision: mapData.pov.revision },
+        }));
+      }
+    }
+
+    function applyLookDeg(value, { reason = 'look', force = false } = {}) {
+      if (editActive()) return false;
+      const token = activeLookToken();
+      if (!token) return false;
+      const next = quantizeAngle(value);
+      const previous = Number(token.lookDeg ?? token.facingDeg);
+      if (!force && !angleChanged(previous, next)) return false;
+      if (Math.abs((visibility?.signedAngleDeltaDeg?.(next, previous)) ?? (next - previous)) < 1e-9) return false;
+      token.lookDeg = next;
+      lastLookAppliedAt = nowMs();
+      scheduleSave(token);
+      dispatchPovChanged(reason, token);
+      updateStatus();
+      return true;
+    }
+
+    function flushPendingLook() {
+      lookUpdateTimer = null;
+      if (pendingLookDeg == null) return false;
+      const value = pendingLookDeg;
+      pendingLookDeg = null;
+      return applyLookDeg(value, { reason: 'mouse-look' });
+    }
+
+    function queueLookDeg(value) {
+      const next = quantizeAngle(value);
+      const token = activeLookToken();
+      if (!token || !angleChanged(token.lookDeg ?? token.facingDeg, next)) return false;
+      const elapsed = nowMs() - lastLookAppliedAt;
+      if (elapsed >= LOOK_THROTTLE_MS && lookUpdateTimer == null) return applyLookDeg(next, { reason: 'mouse-look' });
+      pendingLookDeg = next;
+      if (lookUpdateTimer == null) {
+        const delay = Math.max(0, LOOK_THROTTLE_MS - Math.max(0, elapsed));
+        lookUpdateTimer = root.setTimeout?.(flushPendingLook, delay) || null;
+      }
+      return false;
+    }
+
     function updateLookFromPoint(point) {
       if (lookLocked() || editActive()) return false;
       const token = activeLookToken();
       if (!token) return false;
-      token.lookDeg = pov.angleToPointDeg(token, point);
-      scheduleSave(token);
-      return true;
+      return queueLookDeg(pov.angleToPointDeg(token, point));
+    }
+
+    function rotateLook(deltaDeg = LOOK_BUTTON_STEP_DEG) {
+      if (editActive()) return false;
+      const token = activeLookToken();
+      if (!token) return false;
+      pendingLookDeg = null;
+      if (lookUpdateTimer != null) root.clearTimeout?.(lookUpdateTimer);
+      lookUpdateTimer = null;
+      return applyLookDeg(Number(token.lookDeg ?? token.facingDeg) + Number(deltaDeg || 0), { reason: 'look-step', force: true });
+    }
+
+    function onPovControlsClick(event) {
+      const action = event.target?.closest?.('[data-pov-action]')?.dataset?.povAction;
+      if (action === 'left') rotateLook(-LOOK_BUTTON_STEP_DEG);
+      else if (action === 'right') rotateLook(LOOK_BUTTON_STEP_DEG);
+      else if (action === 'lock') toggleLookLock();
     }
 
     function toggleLookLock() {
@@ -146,8 +259,11 @@
     }
 
     function setLookUpHeld(value) {
-      mapData.pov.lookUpHeld = Boolean(value);
+      const next = Boolean(value);
+      if (next === mapData.pov.lookUpHeld) return mapData.pov.lookUpHeld;
+      mapData.pov.lookUpHeld = next;
       if (!mapData.pov.lookUpHeld) mapData.pov.lookUpBlocked = false;
+      dispatchPovChanged(next ? 'look-up-start' : 'look-up-stop', activeLookToken());
       updateStatus();
       return mapData.pov.lookUpHeld;
     }
@@ -171,12 +287,22 @@
     function onPointerMove(event) {
       if (event.buttons) return;
       if (roofToolActive && editActive()) return;
-      if (updateLookFromPoint(eventWorldPoint(event))) mapData.pov.dirty = true;
+      updateLookFromPoint(eventWorldPoint(event));
     }
 
     function onKeyDown(event) {
       if (isTypingTarget(event.target) || event.ctrlKey || event.metaKey || event.altKey) return;
       const key = String(event.key || '').toLowerCase();
+      if (event.shiftKey && event.code === 'BracketLeft' && !event.repeat) {
+        rotateLook(-LOOK_BUTTON_STEP_DEG);
+        event.preventDefault();
+        return;
+      }
+      if (event.shiftKey && event.code === 'BracketRight' && !event.repeat) {
+        rotateLook(LOOK_BUTTON_STEP_DEG);
+        event.preventDefault();
+        return;
+      }
       if (key === 'e' && !event.repeat) {
         toggleLookLock();
         event.preventDefault();
@@ -196,6 +322,9 @@
 
     function onWindowBlur() {
       if (lookUpHeld()) setLookUpHeld(false);
+      pendingLookDeg = null;
+      if (lookUpdateTimer != null) root.clearTimeout?.(lookUpdateTimer);
+      lookUpdateTimer = null;
       roofDragStart = null;
       mapData.pov.roofPreviewPoint = null;
     }
@@ -334,6 +463,7 @@
 
     injectUi();
     canvas.addEventListener('mousemove', onPointerMove); listeners.push(() => canvas.removeEventListener('mousemove', onPointerMove));
+    canvas.addEventListener('vtt:dm-observer-changed', updateStatus); listeners.push(() => canvas.removeEventListener('vtt:dm-observer-changed', updateStatus));
     canvas.addEventListener('mousemove', onRoofPreviewMove, true); listeners.push(() => canvas.removeEventListener('mousemove', onRoofPreviewMove, true));
     canvas.addEventListener('mousedown', onRoofMouseDown, true); listeners.push(() => canvas.removeEventListener('mousedown', onRoofMouseDown, true));
     root.addEventListener('mouseup', onRoofMouseUp, true); listeners.push(() => root.removeEventListener('mouseup', onRoofMouseUp, true));
@@ -344,12 +474,19 @@
     function stop() {
       listeners.splice(0).forEach((fn) => fn());
       if (saveTimer != null) root.clearTimeout?.(saveTimer);
+      if (lookUpdateTimer != null) root.clearTimeout?.(lookUpdateTimer);
       saveTimer = null;
+      lookUpdateTimer = null;
+      pendingLookDeg = null;
       setLookUpHeld(false);
       closeRoofEditor();
+      doc?.getElementById('vtt-pov-controls')?.remove?.();
     }
 
     return Object.freeze({
+      LOOK_STEP_DEG,
+      LOOK_THROTTLE_MS,
+      LOOK_BUTTON_STEP_DEG,
       activeLookToken,
       lookLocked,
       lookUpHeld,
@@ -358,6 +495,8 @@
       setLookUpBlocked,
       viewLayer,
       updateLookFromPoint,
+      applyLookDeg,
+      rotateLook,
       renderEditorGuides,
       handleSceneChanged,
       installRoofButton,

--- a/js/vtt/pov-renderer.js
+++ b/js/vtt/pov-renderer.js
@@ -52,14 +52,19 @@
     ctx.restore();
   }
 
-  function drawIndicators(renderer, zLayer) {
+  function drawIndicators(renderer, zLayer, options = {}) {
     const ctx = renderer?.ctx;
     const mapData = renderer?.mapData;
     if (!ctx || !mapData) return;
     const tokenRules = browserRoot?.LuminousVttTokenInteraction;
+    const debug = mapData.pov?.debugIndicators === true;
+    if (options.isDm && !debug) return;
+    const viewerIds = new Set((Array.isArray(options.viewers) ? options.viewers : []).map((token) => String(token?.id || '')));
     for (const token of mapData.tokens || []) {
       const onLayer = tokenRules?.tokenOnLayer ? tokenRules.tokenOnLayer(token, zLayer) : tokenLayer(token) === Number(zLayer);
       if (!onLayer) continue;
+      const isViewer = viewerIds.has(String(token.id || '')) || token.viewer === true || token.characterLink?.mode === 'current_player';
+      if (!debug && !isViewer) continue;
       drawLookIndicator(ctx, token, tokenRadius(token, mapData));
     }
   }

--- a/js/vtt/visibility-mask-core.js
+++ b/js/vtt/visibility-mask-core.js
@@ -1,0 +1,143 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttVisibilityMaskCore = api;
+})(typeof window !== 'undefined' ? window : globalThis, function () {
+  'use strict';
+
+  const DEFAULT_LOOK_STEP_DEG = 2;
+  const DEFAULT_LOOK_THROTTLE_MS = 50;
+
+  const num = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const clean = (value) => String(value ?? '').trim();
+
+  function normalizeAngleDeg(value) {
+    const angle = num(value, 0) % 360;
+    return angle < 0 ? angle + 360 : angle;
+  }
+
+  function signedAngleDeltaDeg(a, b) {
+    let delta = normalizeAngleDeg(a) - normalizeAngleDeg(b);
+    if (delta > 180) delta -= 360;
+    if (delta < -180) delta += 360;
+    return delta;
+  }
+
+  function quantizeAngleDeg(value, stepDeg = DEFAULT_LOOK_STEP_DEG) {
+    const step = Math.max(0.1, num(stepDeg, DEFAULT_LOOK_STEP_DEG));
+    return normalizeAngleDeg(Math.round(normalizeAngleDeg(value) / step) * step);
+  }
+
+  function meaningfulAngleChange(previous, next, stepDeg = DEFAULT_LOOK_STEP_DEG) {
+    if (!Number.isFinite(Number(previous))) return true;
+    return Math.abs(signedAngleDeltaDeg(quantizeAngleDeg(next, stepDeg), quantizeAngleDeg(previous, stepDeg))) >= Math.max(0.1, num(stepDeg, DEFAULT_LOOK_STEP_DEG)) - 1e-9;
+  }
+
+  function viewerSignature(viewer = {}) {
+    return [
+      clean(viewer.id),
+      num(viewer.x),
+      num(viewer.y),
+      num(viewer.zLayer ?? viewer.gridPosition?.z ?? viewer.z?.[0]),
+      num(viewer.elevationFt),
+      quantizeAngleDeg(viewer.lookDeg ?? viewer.facingDeg),
+      num(viewer.eyeHeightFt, 5),
+      num(viewer.visionConeDeg, 120),
+      num(viewer.senses?.darkvisionFt ?? viewer.darkvisionFt),
+    ];
+  }
+
+  function topologySignature(mapData = {}) {
+    return (Array.isArray(mapData.topology) ? mapData.topology : []).map((element) => [
+      clean(element?.id),
+      clean(element?.type),
+      clean(element?.state),
+      num(element?.zLayer ?? element?.z),
+      num(element?.a?.col ?? element?.x1),
+      num(element?.a?.row ?? element?.y1),
+      num(element?.b?.col ?? element?.x2),
+      num(element?.b?.row ?? element?.y2),
+      element?.blocksVision !== false,
+    ]);
+  }
+
+  function wallsSignature(mapData = {}) {
+    return (Array.isArray(mapData.walls) ? mapData.walls : []).map((wall) => [
+      clean(wall?.id), num(wall?.x1), num(wall?.y1), num(wall?.x2), num(wall?.y2), wall?.z ?? wall?.zLayer ?? 0, wall?.blocksVision !== false,
+    ]);
+  }
+
+  function portalsSignature(mapData = {}) {
+    return (Array.isArray(mapData.verticalPortals) ? mapData.verticalPortals : []).map((portal) => [
+      clean(portal?.id), clean(portal?.type), clean(portal?.state), portal?.from?.z ?? portal?.fromZ ?? null, portal?.to?.z ?? portal?.toZ ?? null,
+    ]);
+  }
+
+  function lightSceneSignature(scene = {}) {
+    const sources = (Array.isArray(scene.sources) ? scene.sources : []).map((source) => [
+      clean(source?.id), num(source?.x), num(source?.y), num(source?.zLayer), num(source?.elevationFt), source?.enabled !== false,
+      source?.functional !== false, num(source?.brightFt), num(source?.dimAdditionalFt), clean(source?.shape), num(source?.directionDeg),
+      num(source?.coneDeg), clean(source?.circuitId), source?.motion?.startedAt ?? null, source?.motion?.durationMs ?? null,
+    ]);
+    const interiors = (Array.isArray(scene.interiors) ? scene.interiors : []).map((zone) => [
+      clean(zone?.id), num(zone?.x1 ?? zone?.x), num(zone?.y1 ?? zone?.y), num(zone?.x2 ?? (num(zone?.x) + num(zone?.width))),
+      num(zone?.y2 ?? (num(zone?.y) + num(zone?.height))), num(zone?.zLayer), clean(zone?.baseLight), zone?.roof?.present !== false,
+      zone?.roof?.transparent === true,
+    ]);
+    const roofs = (Array.isArray(scene.roofs) ? scene.roofs : []).map((roof) => [
+      clean(roof?.id), num(roof?.x1 ?? roof?.x), num(roof?.y1 ?? roof?.y), num(roof?.x2 ?? (num(roof?.x) + num(roof?.width))),
+      num(roof?.y2 ?? (num(roof?.y) + num(roof?.height))), num(roof?.zLayer), num(roof?.elevationFt), roof?.transparent === true,
+    ]);
+    const switches = (Array.isArray(scene.switches) ? scene.switches : []).map((entry) => [clean(entry?.id), clean(entry?.circuitId), clean(entry?.state), entry?.enabled !== false]);
+    const transformers = (Array.isArray(scene.transformers) ? scene.transformers : []).map((entry) => [clean(entry?.id), entry?.powered !== false, entry?.damaged === true, entry?.circuits || []]);
+    return { sources, interiors, roofs, switches, transformers };
+  }
+
+  function visibilityFingerprint({ viewers = [], viewZ = 0, lookUp = false, mapData = {}, scene = {}, environment = null, motionTick = 0 } = {}) {
+    return JSON.stringify({
+      z: num(viewZ),
+      lookUp: Boolean(lookUp),
+      viewers: (Array.isArray(viewers) ? viewers : []).map(viewerSignature),
+      topology: topologySignature(mapData),
+      walls: wallsSignature(mapData),
+      portals: portalsSignature(mapData),
+      scene: lightSceneSignature(scene),
+      environment,
+      motionTick: num(motionTick),
+    });
+  }
+
+  function cellsFromTiles(tiles = [], mapData = {}, cellKey = (col, row) => `${col},${row}`) {
+    const size = Math.max(1, num(mapData.grid?.size, 70));
+    const cols = Math.max(1, Math.trunc(num(mapData.grid?.cols, 1)));
+    const rows = Math.max(1, Math.trunc(num(mapData.grid?.rows, 1)));
+    const result = new Set();
+    for (const tile of Array.isArray(tiles) ? tiles : []) {
+      const x1 = num(tile?.x), y1 = num(tile?.y), x2 = x1 + Math.max(0, num(tile?.w)), y2 = y1 + Math.max(0, num(tile?.h));
+      const minCol = Math.max(0, Math.min(cols - 1, Math.floor(x1 / size)));
+      const maxCol = Math.max(0, Math.min(cols - 1, Math.floor(Math.max(x1, x2 - 1e-6) / size)));
+      const minRow = Math.max(0, Math.min(rows - 1, Math.floor(y1 / size)));
+      const maxRow = Math.max(0, Math.min(rows - 1, Math.floor(Math.max(y1, y2 - 1e-6) / size)));
+      for (let row = minRow; row <= maxRow; row += 1) {
+        for (let col = minCol; col <= maxCol; col += 1) result.add(cellKey(col, row));
+      }
+    }
+    return result;
+  }
+
+  return Object.freeze({
+    DEFAULT_LOOK_STEP_DEG,
+    DEFAULT_LOOK_THROTTLE_MS,
+    normalizeAngleDeg,
+    signedAngleDeltaDeg,
+    quantizeAngleDeg,
+    meaningfulAngleChange,
+    viewerSignature,
+    topologySignature,
+    wallsSignature,
+    portalsSignature,
+    lightSceneSignature,
+    visibilityFingerprint,
+    cellsFromTiles,
+  });
+});

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "bugs": {
     "url": "https://github.com/sokcrow/Luminos-Character-Maker/issues"
   },

--- a/tests/background_narratives.spec.js
+++ b/tests/background_narratives.spec.js
@@ -1,8 +1,11 @@
 "use strict";
 
 const assert = require("node:assert/strict");
-const rules = require("../js/character-build-rules.js");
+const rulesModule = require("../js/character-build-rules.js");
+const rules = rulesModule?.BACKGROUNDS ? rulesModule : globalThis.LuminousCharacterBuildRules;
 const catalog = require("../js/background-narratives/catalog.js");
+
+assert.ok(rules?.BACKGROUNDS, "character-build-rules debe exponer su API por CommonJS o globalThis");
 
 require("../js/background-narratives/templates-meta.js");
 require("../js/background-narratives/templates-ideal.js");

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/tests/vtt_map_field_test_hardening.spec.js
+++ b/tests/vtt_map_field_test_hardening.spec.js
@@ -102,7 +102,7 @@ test('hardening: a player-linked actor exists once even across actors, NPC migra
   }
 });
 
-test('hardening: DM drag cannot accidentally enter View As, while a real click enters 120 degree POV', () => {
+test('hardening: DM drag and normal clicks remain FREE, while explicit View As enters 120 degree POV', () => {
   delete require.cache[require.resolve('../js/vtt/dm-observer.js')];
   const observerApi = require('../js/vtt/dm-observer.js');
   const canvas = new MockTarget();
@@ -132,11 +132,18 @@ test('hardening: DM drag cannot accidentally enter View As, while a real click e
   canvas.dispatchEvent(syntheticClick);
   expect(observer.state().mode).toBe('free');
   expect(mapData.lighting.dmPreviewTokenId).toBe(null);
-  expect(syntheticClick.defaultPrevented).toBe(true);
+  expect(syntheticClick.defaultPrevented).toBe(false);
 
-  canvas.dispatchEvent(new MockCustomEvent('mousedown', { clientX: 132, clientY: 100, button: 0 }));
-  canvas.dispatchEvent(new MockCustomEvent('mouseup', { clientX: 132, clientY: 100, button: 0 }));
-  canvas.dispatchEvent(new MockCustomEvent('click', { clientX: 132, clientY: 100, button: 0 }));
+  const normalClick = new MockCustomEvent('click', { clientX: 132, clientY: 100, button: 0 });
+  canvas.dispatchEvent(normalClick);
+  expect(observer.state().mode).toBe('free');
+  expect(mapData.lighting.dmPreviewTokenId).toBe(null);
+  expect(normalClick.defaultPrevented).toBe(false);
+
+  observer.select(observerApi.MODES.VIEW_AS);
+  const viewAsClick = new MockCustomEvent('click', { clientX: 132, clientY: 100, button: 0 });
+  canvas.dispatchEvent(viewAsClick);
+  expect(viewAsClick.defaultPrevented).toBe(true);
   expect(observer.state().mode).toBe('view_as');
   expect(mapData.lighting.dmPreviewTokenId).toBe('p4');
   observer.stop();

--- a/tests/vtt_map_field_test_hardening.spec.js
+++ b/tests/vtt_map_field_test_hardening.spec.js
@@ -12,6 +12,7 @@ class MockCustomEvent {
     this.button = init.button ?? 0;
     this.clientX = init.clientX ?? init.detail?.clientX ?? 0;
     this.clientY = init.clientY ?? init.detail?.clientY ?? 0;
+    this.defaultPrevented = false;
   }
   preventDefault() { this.defaultPrevented = true; }
   stopPropagation() { this.propagationStopped = true; }

--- a/tests/vtt_persistent_fog_memory.spec.js
+++ b/tests/vtt_persistent_fog_memory.spec.js
@@ -152,12 +152,15 @@ test('Fog memory renderer never samples the live scene image for remembered area
   expect(renderer).toContain('MINIMAP');
 });
 
-test('runtime integrates PoV observation, last-known memory, minimap and DM controls after dynamic lighting', () => {
+test('runtime integrates shared PoV visibility, last-known memory, minimap and DM controls after dynamic lighting', () => {
   const html = read('vtt.html');
   const bootstrap = read('js/vtt/fog-memory-bootstrap.js');
   const topologyController = read('js/vtt/topology-controller.js');
   expect(html.indexOf('dynamic-lighting-bootstrap.js')).toBeLessThan(html.indexOf('fog-memory-bootstrap.js'));
-  expect(bootstrap).toContain('runtime.pov.lookUpPerceptionAtPoint');
+  expect(bootstrap).toContain('runtime.lighting.visibilityMask');
+  expect(bootstrap).toContain('visibility.cellsFromTiles');
+  expect(bootstrap).toContain('{ lookUp, now: Date.now() }');
+  expect(bootstrap).not.toContain('runtime.pov.lookUpPerceptionAtPoint');
   expect(bootstrap).toContain('memory.observeDungeon');
   expect(bootstrap).toContain('rememberKeyDoorRelation');
   expect(bootstrap).toContain('rememberWorldPlace');

--- a/tests/vtt_pov_visibility_mask.spec.js
+++ b/tests/vtt_pov_visibility_mask.spec.js
@@ -1,0 +1,112 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+const visibility = require('../js/vtt/visibility-mask-core.js');
+
+class Emitter {
+  constructor() { this.listeners = new Map(); }
+  addEventListener(name, fn) { if (!this.listeners.has(name)) this.listeners.set(name, new Set()); this.listeners.get(name).add(fn); }
+  removeEventListener(name, fn) { this.listeners.get(name)?.delete(fn); }
+  dispatchEvent(event) { for (const fn of this.listeners.get(event.type) || []) fn(event); return true; }
+}
+class LocalCustomEvent { constructor(type, init = {}) { this.type = type; this.detail = init.detail || {}; } }
+
+test('visibility fingerprint ignores unrelated token motion but invalidates for viewer or vision blockers', () => {
+  const viewer = { id: 'p1', x: 35, y: 35, zLayer: 0, lookDeg: 0, visionConeDeg: 120, senses: { darkvisionFt: 60 } };
+  const base = {
+    viewers: [viewer], viewZ: 0, lookUp: false,
+    mapData: { tokens: [{ id: 'npc', x: 100, y: 100 }], topology: [{ id: 'd1', type: 'door', state: 'closed', zLayer: 0 }], walls: [], verticalPortals: [] },
+    scene: { sources: [], interiors: [], roofs: [], switches: [], transformers: [] }, environment: { light: 'bright' }, motionTick: 0,
+  };
+  const first = visibility.visibilityFingerprint(base);
+  const npcMoved = visibility.visibilityFingerprint({ ...base, mapData: { ...base.mapData, tokens: [{ id: 'npc', x: 900, y: 900 }] } });
+  const viewerMoved = visibility.visibilityFingerprint({ ...base, viewers: [{ ...viewer, x: 70 }] });
+  const doorOpened = visibility.visibilityFingerprint({ ...base, mapData: { ...base.mapData, topology: [{ id: 'd1', type: 'door', state: 'open', zLayer: 0 }] } });
+  expect(npcMoved).toBe(first);
+  expect(viewerMoved).not.toBe(first);
+  expect(doorOpened).not.toBe(first);
+});
+
+test('visibility mask core quantizes look to 2 degrees and converts visible tiles into Fog cells', () => {
+  expect(visibility.quantizeAngleDeg(13.1)).toBe(14);
+  expect(visibility.quantizeAngleDeg(359.4)).toBe(0);
+  expect(visibility.meaningfulAngleChange(10, 10.8)).toBe(false);
+  expect(visibility.meaningfulAngleChange(10, 12.1)).toBe(true);
+  const cells = visibility.cellsFromTiles([
+    { x: 0, y: 0, w: 35, h: 35 },
+    { x: 70, y: 70, w: 35, h: 35 },
+  ], { grid: { size: 70, cols: 4, rows: 4 } }, (col, row) => `${col}:${row}`);
+  expect([...cells].sort()).toEqual(['0:0', '1:1']);
+});
+
+test('POV mouse updates are quantized/throttled while buttons rotate View immediately', () => {
+  const visibilityPath = require.resolve('../js/vtt/visibility-mask-core.js');
+  const controllerPath = require.resolve('../js/vtt/pov-controller.js');
+  delete require.cache[visibilityPath]; delete require.cache[controllerPath];
+  const visibilityApi = require(visibilityPath);
+  const controllerApi = require(controllerPath);
+  const canvas = new Emitter();
+  const host = new Emitter();
+  let now = 0;
+  const timers = [];
+  const token = { id: 'p1', x: 0, y: 0, zLayer: 0, lookDeg: 0, facingDeg: 0 };
+  host.CustomEvent = LocalCustomEvent;
+  host.performance = { now: () => now };
+  host.setTimeout = (fn, delay) => { timers.push({ fn, delay }); return timers.length; };
+  host.clearTimeout = () => {};
+  host.LuminousVttVisibilityMaskCore = visibilityApi;
+  host.LuminousVttPovEngine = {
+    angleToPointDeg(_token, point) { return point.angle; },
+    normalizeAngleDeg: visibilityApi.normalizeAngleDeg,
+    nextLayer() { return null; },
+    pointInRect() { return false; },
+    normalizeRect(v) { return v; },
+    elevationForLayer() { return 0; },
+    DEFAULT_CEILING_HEIGHT_FT: 10,
+  };
+  const controller = controllerApi.createController({
+    canvas, engine: { activeZ: 0, mapData: {}, camera: {} },
+    mapData: { grid: { size: 70, cols: 10, rows: 10 }, lighting: { scene: { roofs: [] } }, tokens: [token], pov: {} },
+    stateBridge: { saveLook: async () => {} }, getControlledViewers: () => [token], root: host,
+  });
+  controller.updateLookFromPoint({ angle: 1.1 });
+  expect(token.lookDeg).toBe(2);
+  now = 10;
+  controller.updateLookFromPoint({ angle: 3.1 });
+  expect(token.lookDeg).toBe(2);
+  expect(timers.length).toBeGreaterThan(0);
+  now = 50;
+  timers.at(-1).fn();
+  expect(token.lookDeg).toBe(4);
+  controller.rotateLook(15);
+  expect(token.lookDeg).toBe(20);
+  controller.stop();
+});
+
+test('Dynamic Lighting owns the mask once and Fog Memory reuses it instead of solving every cell again', () => {
+  const lighting = read('js/vtt/dynamic-lighting-bootstrap.js');
+  const fog = read('js/vtt/fog-memory-bootstrap.js');
+  expect(lighting).toContain("import './visibility-mask-core.js'");
+  expect(lighting).toContain('function visibilityMask(');
+  expect(lighting).toContain('const offscreenCache = { canvas: null');
+  expect(lighting).toContain('const offscreen = ensureOffscreen()');
+  expect(lighting).not.toContain("const offscreen = document.createElement('canvas')");
+  expect(fog).toContain('runtime.lighting.visibilityMask(viewers, zLayer');
+  expect(fog).toContain('visibility.cellsFromTiles(mask.tiles');
+  expect(fog).not.toContain('runtime.lighting.perceptionAtPoint?.(viewer, point)');
+  expect(fog).not.toContain('for (let row = 0; row < rows; row += 1)');
+});
+
+test('Player render only draws a compact look indicator; full cone/radius geometry remains DM/debug responsibility', () => {
+  const renderer = read('js/vtt/pov-renderer.js');
+  const controller = read('js/vtt/pov-controller.js');
+  expect(renderer).toContain('if (options.isDm && !debug) return');
+  expect(renderer).toContain('if (!debug && !isViewer) continue');
+  expect(controller).toContain('VIEW ◀');
+  expect(controller).toContain('VIEW ▶');
+  expect(controller).toContain("event.code === 'BracketLeft'");
+  expect(controller).toContain("event.code === 'BracketRight'");
+  expect(controller).toContain('LOOK_THROTTLE_MS');
+});


### PR DESCRIPTION
## Summary
- centralize Player visibility into one shared mask consumed by Dynamic Lighting and Fog/Memory
- stop Fog from running a second full-grid perception solve
- stop unrelated NPC movement from invalidating Player visibility cache
- reuse one offscreen canvas instead of allocating a new canvas every render
- quantize mouse View to 2° and throttle POV invalidation to 50 ms
- add real VIEW ◀ / VIEW ▶ controls plus Shift+[ / Shift+] while bare [ / ] remains body facing
- keep Player render free of full cone/radius debug geometry; DM observer remains responsible for debug cone outlines
- expose visibility metrics/cache generation for performance diagnostics

## Performance contract
Player visibility recomputes only when the viewer, blockers, lighting/environment, floor/look-up state, or moving light tick changes. Camera pan/zoom and unrelated NPC movement reuse the cached mask. Fog derives remembered/visible cells from that same mask rather than re-querying perception.

## Tests
Adds one focused `vtt_pov_visibility_mask.spec.js` suite and reuses the existing POV/Dynamic Lighting/Fog/Performance regression gate, followed by the existing full repository regression.