### PR TITLE
Harden VTT runtime lifecycle before NPC simulation

### DIFF
--- a/js/vtt/runtime-lifecycle.js
+++ b/js/vtt/runtime-lifecycle.js
@@ -6,17 +6,142 @@
 })(typeof window !== 'undefined' ? window : globalThis, function () {
   'use strict';
 
+  const requestFrame = (callback) => (
+    globalThis.requestAnimationFrame
+      ? globalThis.requestAnimationFrame(callback)
+      : globalThis.setTimeout?.(() => callback(Date.now()), 16)
+  );
+
+  const cancelFrame = (frameId) => {
+    if (frameId == null) return;
+    if (globalThis.cancelAnimationFrame) globalThis.cancelAnimationFrame(frameId);
+    else globalThis.clearTimeout?.(frameId);
+  };
+
+  function hardenEngineRuntime(engine, { log = console, isDisposed = () => false } = {}) {
+    if (!engine || engine.__lifecycleHardened) return engine || null;
+
+    const wasRunning = Boolean(engine.isRunning);
+    engine.isRunning = false;
+    engine.frameId = null;
+    engine.destroyed = false;
+    engine.__lifecycleHardened = true;
+
+    let handoffFrameId = null;
+
+    engine.start = function startLifecycleHardenedEngine() {
+      if (engine.destroyed || isDisposed() || engine.isRunning || engine.frameId != null) return false;
+      engine.isRunning = true;
+      engine.frameId = requestFrame(engine.loop);
+      return true;
+    };
+
+    engine.stop = function stopLifecycleHardenedEngine() {
+      engine.cancelTokenMotion?.();
+      engine.isRunning = false;
+
+      if (handoffFrameId != null) {
+        cancelFrame(handoffFrameId);
+        handoffFrameId = null;
+      }
+      if (engine.frameId != null) {
+        cancelFrame(engine.frameId);
+        engine.frameId = null;
+      }
+
+      engine.tokenDrag = null;
+      if (engine.canvas?.style) engine.canvas.style.cursor = 'default';
+      return true;
+    };
+
+    engine.loop = function lifecycleHardenedLoop() {
+      engine.frameId = null;
+      if (!engine.isRunning || engine.destroyed || isDisposed()) return;
+
+      const renderData = engine.calculateVision();
+      if (!engine.isExporting) {
+        engine.renderer.render(engine.camera, engine.activeZ, renderData, engine.isExporting);
+      }
+
+      if (engine.isRunning && !engine.destroyed && !isDisposed()) {
+        engine.frameId = requestFrame(engine.loop);
+      }
+    };
+
+    engine.destroy = function destroyLifecycleHardenedEngine() {
+      if (engine.destroyed) return false;
+      engine.destroyed = true;
+      engine.stop();
+
+      try { globalThis.removeEventListener?.('resize', engine.handleResize); } catch (_) {}
+      try { engine.canvas?.removeEventListener?.('mousedown', engine.handleTokenMouseDown); } catch (_) {}
+      try { globalThis.removeEventListener?.('mousemove', engine.handleTokenMouseMove); } catch (_) {}
+      try { globalThis.removeEventListener?.('mouseup', engine.handleTokenMouseUp); } catch (_) {}
+      try { engine.camera?.destroy?.(); }
+      catch (error) { log?.warn?.('VTT camera destroy failed.', error); }
+
+      engine.tokenDrag = null;
+      engine.tokenControlResolver = null;
+      engine.tokenMoveResolver = null;
+      engine.movementInteractionResolver = null;
+      engine.tokenMotion = null;
+      return true;
+    };
+
+    // main.js can schedule the legacy bound RAF before LuminousVttRuntime is published.
+    // Keep isRunning=false until that old callback drains, then restart with the owned RAF loop.
+    if (wasRunning && !isDisposed()) {
+      handoffFrameId = requestFrame(() => {
+        handoffFrameId = null;
+        if (!engine.destroyed && !isDisposed()) engine.start();
+      });
+    }
+
+    return engine;
+  }
+
   function createLifecycle({ log = console } = {}) {
     let disposed = false;
     let reason = '';
+    let attachTimer = null;
 
     const isDisposed = () => disposed;
     const getReason = () => reason;
+
+    function attachEngineHardening() {
+      let attempts = 0;
+      const tryAttach = () => {
+        attachTimer = null;
+        if (disposed) return;
+
+        const runtime = globalThis.LuminousVttRuntime;
+        if (runtime?.engine) {
+          hardenEngineRuntime(runtime.engine, { log, isDisposed });
+          return;
+        }
+
+        attempts += 1;
+        if (attempts < 80) attachTimer = globalThis.setTimeout?.(tryAttach, 25) ?? null;
+      };
+      queueMicrotask(tryAttach);
+    }
 
     function dispose(nextReason = 'runtime-disposed') {
       if (disposed) return false;
       disposed = true;
       reason = String(nextReason || 'runtime-disposed');
+
+      if (attachTimer != null) {
+        globalThis.clearTimeout?.(attachTimer);
+        attachTimer = null;
+      }
+
+      try { globalThis.LuminousVttPerformanceGuard?.stop?.(); }
+      catch (error) { log?.warn?.('VTT performance guard teardown failed.', error); }
+
+      try { globalThis.LuminousVttRuntime?.engine?.destroy?.(); }
+      catch (error) { log?.warn?.('VTT engine teardown failed.', error); }
+
       return true;
     }
 
@@ -54,8 +179,9 @@
       return { status: 'started', label: taskLabel, runtime };
     }
 
+    attachEngineHardening();
     return Object.freeze({ dispose, getReason, isDisposed, run });
   }
 
-  return Object.freeze({ createLifecycle });
+  return Object.freeze({ createLifecycle, hardenEngineRuntime });
 });

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/tests/vtt_runtime_lifecycle_25_cycles.spec.js
+++ b/tests/vtt_runtime_lifecycle_25_cycles.spec.js
@@ -1,0 +1,74 @@
+const { test, expect } = require('@playwright/test');
+const lifecycleApi = require('../js/vtt/runtime-lifecycle.js');
+
+function engineStub() {
+  return {
+    isRunning: false,
+    isExporting: false,
+    activeZ: 0,
+    tokenDrag: null,
+    tokenMotion: null,
+    handleResize() {},
+    handleTokenMouseDown() {},
+    handleTokenMouseMove() {},
+    handleTokenMouseUp() {},
+    cancelTokenMotion() { this.tokenMotion = null; return true; },
+    calculateVision() { return null; },
+    renderer: { render() {} },
+    canvas: {
+      style: { cursor: 'default' },
+      removeEventListener() {},
+    },
+    camera: { destroy() {} },
+  };
+}
+
+test('25 lifecycle cycles leave no active RAF or live Engine behind', async () => {
+  const previousRuntime = globalThis.LuminousVttRuntime;
+  const previousGuard = globalThis.LuminousVttPerformanceGuard;
+  const previousRaf = globalThis.requestAnimationFrame;
+  const previousCaf = globalThis.cancelAnimationFrame;
+  const previousRemove = globalThis.removeEventListener;
+
+  let nextFrameId = 1;
+  const frames = new Map();
+  let guardStops = 0;
+
+  globalThis.requestAnimationFrame = (callback) => {
+    const id = nextFrameId++;
+    frames.set(id, callback);
+    return id;
+  };
+  globalThis.cancelAnimationFrame = (id) => frames.delete(id);
+  globalThis.removeEventListener = () => {};
+
+  try {
+    for (let cycle = 0; cycle < 25; cycle += 1) {
+      const engine = engineStub();
+      globalThis.LuminousVttRuntime = { engine };
+      globalThis.LuminousVttPerformanceGuard = { stop() { guardStops += 1; } };
+
+      const lifecycle = lifecycleApi.createLifecycle({ log: console });
+      await Promise.resolve();
+
+      expect(engine.__lifecycleHardened).toBe(true);
+      expect(engine.start()).toBe(true);
+      expect(engine.frameId).not.toBeNull();
+      expect(frames.size).toBe(1);
+
+      expect(lifecycle.dispose(`cycle-${cycle}`)).toBe(true);
+      expect(engine.destroyed).toBe(true);
+      expect(engine.isRunning).toBe(false);
+      expect(engine.frameId).toBeNull();
+      expect(frames.size).toBe(0);
+    }
+
+    expect(guardStops).toBe(25);
+  } finally {
+    globalThis.LuminousVttRuntime = previousRuntime;
+    globalThis.LuminousVttPerformanceGuard = previousGuard;
+    globalThis.requestAnimationFrame = previousRaf;
+    globalThis.cancelAnimationFrame = previousCaf;
+    globalThis.removeEventListener = previousRemove;
+  }
+});

--- a/tests/vtt_runtime_lifecycle_hardening.spec.js
+++ b/tests/vtt_runtime_lifecycle_hardening.spec.js
@@ -1,0 +1,184 @@
+const { test, expect } = require('@playwright/test');
+
+const lifecycleApi = require('../js/vtt/runtime-lifecycle.js');
+
+function createEngineStub() {
+  const canvasRemoved = [];
+  let cameraDestroyCalls = 0;
+  let renders = 0;
+  let visionCalls = 0;
+  let motionCancels = 0;
+
+  const engine = {
+    isRunning: true,
+    isExporting: false,
+    activeZ: 0,
+    tokenDrag: { token: { id: 'p1' } },
+    tokenMotion: { tokenId: 'p1' },
+    tokenControlResolver() {},
+    tokenMoveResolver() {},
+    movementInteractionResolver() {},
+    handleResize() {},
+    handleTokenMouseDown() {},
+    handleTokenMouseMove() {},
+    handleTokenMouseUp() {},
+    canvas: {
+      style: { cursor: 'grabbing' },
+      removeEventListener(name, fn) { canvasRemoved.push([name, fn]); },
+    },
+    camera: {
+      destroy() { cameraDestroyCalls += 1; },
+    },
+    renderer: {
+      render() { renders += 1; },
+    },
+    calculateVision() {
+      visionCalls += 1;
+      return { visible: true };
+    },
+    cancelTokenMotion() {
+      motionCancels += 1;
+      this.tokenMotion = null;
+      return true;
+    },
+  };
+
+  return {
+    engine,
+    canvasRemoved,
+    cameraDestroyCalls: () => cameraDestroyCalls,
+    renders: () => renders,
+    visionCalls: () => visionCalls,
+    motionCancels: () => motionCancels,
+  };
+}
+
+test('hardened Engine owns exactly one RAF and stop cancels it', () => {
+  const previousRaf = globalThis.requestAnimationFrame;
+  const previousCaf = globalThis.cancelAnimationFrame;
+  const frames = new Map();
+  const cancelled = [];
+  let nextFrameId = 1;
+
+  globalThis.requestAnimationFrame = (callback) => {
+    const id = nextFrameId++;
+    frames.set(id, callback);
+    return id;
+  };
+  globalThis.cancelAnimationFrame = (id) => {
+    cancelled.push(id);
+    frames.delete(id);
+  };
+
+  const state = createEngineStub();
+  try {
+    lifecycleApi.hardenEngineRuntime(state.engine, { isDisposed: () => false });
+
+    expect(state.engine.__lifecycleHardened).toBe(true);
+    expect(state.engine.frameId).toBeNull();
+    expect(state.engine.isRunning).toBe(false);
+
+    const handoffId = [...frames.keys()][0];
+    const handoff = frames.get(handoffId);
+    frames.delete(handoffId);
+    handoff();
+
+    expect(state.engine.isRunning).toBe(true);
+    expect(state.engine.frameId).not.toBeNull();
+    const ownedFrameId = state.engine.frameId;
+    expect(frames.has(ownedFrameId)).toBe(true);
+
+    expect(state.engine.start()).toBe(false);
+    expect(state.engine.frameId).toBe(ownedFrameId);
+
+    const frame = frames.get(ownedFrameId);
+    frames.delete(ownedFrameId);
+    frame();
+    expect(state.visionCalls()).toBe(1);
+    expect(state.renders()).toBe(1);
+    expect(state.engine.frameId).not.toBeNull();
+    expect(state.engine.frameId).not.toBe(ownedFrameId);
+
+    const pendingFrame = state.engine.frameId;
+    expect(state.engine.stop()).toBe(true);
+    expect(state.engine.isRunning).toBe(false);
+    expect(state.engine.frameId).toBeNull();
+    expect(cancelled).toContain(pendingFrame);
+    expect(state.motionCancels()).toBe(1);
+  } finally {
+    globalThis.requestAnimationFrame = previousRaf;
+    globalThis.cancelAnimationFrame = previousCaf;
+  }
+});
+
+test('Engine destroy is idempotent and owns listener/camera cleanup', () => {
+  const previousRaf = globalThis.requestAnimationFrame;
+  const previousCaf = globalThis.cancelAnimationFrame;
+  const previousRemove = globalThis.removeEventListener;
+  const removed = [];
+  let nextFrameId = 1;
+
+  globalThis.requestAnimationFrame = () => nextFrameId++;
+  globalThis.cancelAnimationFrame = () => {};
+  globalThis.removeEventListener = (name, fn) => removed.push([name, fn]);
+
+  const state = createEngineStub();
+  state.engine.isRunning = false;
+  try {
+    lifecycleApi.hardenEngineRuntime(state.engine, { isDisposed: () => false });
+    expect(state.engine.destroy()).toBe(true);
+    expect(state.engine.destroy()).toBe(false);
+
+    expect(state.engine.destroyed).toBe(true);
+    expect(state.engine.isRunning).toBe(false);
+    expect(state.engine.frameId).toBeNull();
+    expect(state.cameraDestroyCalls()).toBe(1);
+    expect(state.canvasRemoved.some(([name]) => name === 'mousedown')).toBe(true);
+    expect(removed.map(([name]) => name)).toEqual(expect.arrayContaining(['resize', 'mousemove', 'mouseup']));
+    expect(state.engine.tokenControlResolver).toBeNull();
+    expect(state.engine.tokenMoveResolver).toBeNull();
+    expect(state.engine.movementInteractionResolver).toBeNull();
+    expect(state.engine.tokenDrag).toBeNull();
+    expect(state.engine.tokenMotion).toBeNull();
+    expect(state.engine.canvas.style.cursor).toBe('default');
+  } finally {
+    globalThis.requestAnimationFrame = previousRaf;
+    globalThis.cancelAnimationFrame = previousCaf;
+    globalThis.removeEventListener = previousRemove;
+  }
+});
+
+test('lifecycle dispose stops performance guard and destroys Engine exactly once', async () => {
+  const previousRuntime = globalThis.LuminousVttRuntime;
+  const previousGuard = globalThis.LuminousVttPerformanceGuard;
+  const previousRaf = globalThis.requestAnimationFrame;
+  const previousCaf = globalThis.cancelAnimationFrame;
+
+  globalThis.requestAnimationFrame = () => 1;
+  globalThis.cancelAnimationFrame = () => {};
+
+  const state = createEngineStub();
+  state.engine.isRunning = false;
+  let guardStops = 0;
+  globalThis.LuminousVttRuntime = { engine: state.engine };
+  globalThis.LuminousVttPerformanceGuard = { stop() { guardStops += 1; } };
+
+  try {
+    const lifecycle = lifecycleApi.createLifecycle({ log: console });
+    await Promise.resolve();
+
+    expect(state.engine.__lifecycleHardened).toBe(true);
+    expect(lifecycle.dispose('test-dispose')).toBe(true);
+    expect(lifecycle.dispose('second-dispose')).toBe(false);
+    expect(lifecycle.isDisposed()).toBe(true);
+    expect(lifecycle.getReason()).toBe('test-dispose');
+    expect(guardStops).toBe(1);
+    expect(state.engine.destroyed).toBe(true);
+    expect(state.cameraDestroyCalls()).toBe(1);
+  } finally {
+    globalThis.LuminousVttRuntime = previousRuntime;
+    globalThis.LuminousVttPerformanceGuard = previousGuard;
+    globalThis.requestAnimationFrame = previousRaf;
+    globalThis.cancelAnimationFrame = previousCaf;
+  }
+});


### PR DESCRIPTION
## Summary
- hardens the live VTT Engine instance so it owns exactly one RAF loop
- prevents duplicate `start()` loops
- makes `stop()` cancel pending RAF + token motion
- adds idempotent `destroy()` cleanup for Engine listeners, camera and resolvers
- makes lifecycle disposal stop the performance guard and destroy the Engine centrally
- preserves late async runtime protection
- adds regression tests for RAF ownership, teardown idempotency and dispose behavior

## Branch cleanup
Rebuilt cleanly on current main to remove stale history/configuration drift. The PR now contains only runtime lifecycle hardening plus focused CommonJS test scoping and lifecycle regressions.

## Related
Closes part of #698. Remaining acceptance work is repeated Map -> Theatre -> Map stress testing and broader runtime/subscription leak verification before NPC simulation is enabled.