### PR TITLE
perf/ci(vtt): coalesce pointer input and focus regression checks

### DIFF
--- a/.github/workflows/background-narratives.yml
+++ b/.github/workflows/background-narratives.yml
@@ -6,7 +6,10 @@ on:
       - "js/background-narratives/**"
       - "js/character-build-rules.js"
       - "js/injury-equipment-runtime.js"
-      - "tests/**"
+      - "tests/background_narratives.spec.js"
+      - "tests/character_manager_domain_extensions.spec.js"
+      - "tests/character_manager_engine.spec.js"
+      - "tests/player_stats_ability_bar.spec.js"
       - ".github/workflows/background-narratives.yml"
   push:
     branches: [main]
@@ -14,7 +17,11 @@ on:
       - "js/background-narratives/**"
       - "js/character-build-rules.js"
       - "js/injury-equipment-runtime.js"
-      - "tests/**"
+      - "tests/background_narratives.spec.js"
+      - "tests/character_manager_domain_extensions.spec.js"
+      - "tests/character_manager_engine.spec.js"
+      - "tests/player_stats_ability_bar.spec.js"
+      - ".github/workflows/background-narratives.yml"
 
 permissions:
   contents: read
@@ -25,16 +32,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
-
       - name: Install dependencies
         run: npm ci
-
       - name: Check patched syntax
         run: |
           node --check js/background-narratives/catalog.js
@@ -55,14 +59,13 @@ jobs:
           node --check tests/character_manager_domain_extensions.spec.js
           node --check tests/character_manager_engine.spec.js
           node --check tests/player_stats_ability_bar.spec.js
-
       - name: Narrative contract
         run: node tests/background_narratives.spec.js
-
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
-
-      - name: Repository regression suite
+      - name: Focused narrative character integration contracts
         run: >-
-          npx playwright test --workers=1 --grep-invert
-          "status builder catalog exposes elemental statuses and runtime|DM Studio uses racial Stats for derived HP and persists base/effective layers|player Stats HUD displays and rolls from the effective racial Score|DM Studio keeps Base editable and shows Effective racial Score|Skill builder UI flow|Status builder UI flow"
+          npx playwright test --workers=1
+          tests/character_manager_domain_extensions.spec.js
+          tests/character_manager_engine.spec.js
+          tests/player_stats_ability_bar.spec.js

--- a/.github/workflows/global-map-foundation.yml
+++ b/.github/workflows/global-map-foundation.yml
@@ -14,7 +14,7 @@ on:
       - "tests/regional_world_graph*.spec.js"
       - "tests/regional_travel*.spec.js"
       - "tests/vtt_world_streaming_lifecycle.spec.js"
-      - "tests/vtt_performance_guard.spec.js"
+      - "tests/vtt_procedural_chunk_streaming_performance.spec.js"
       - ".github/workflows/global-map-foundation.yml"
   push:
     branches: [main]
@@ -50,7 +50,7 @@ jobs:
           node --check tests/global_map_realtime.spec.js
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
-      - name: Focused global regional streaming and performance contracts
+      - name: Focused global regional and streaming contracts
         run: >-
           npx playwright test --workers=1
           tests/global_map_foundation.spec.js
@@ -60,7 +60,4 @@ jobs:
           tests/regional_travel_engine.spec.js
           tests/regional_travel_realtime.spec.js
           tests/vtt_world_streaming_lifecycle.spec.js
-          tests/vtt_performance_guard.spec.js
           tests/vtt_procedural_chunk_streaming_performance.spec.js
-      - name: Full repository regression
-        run: npx playwright test --workers=1

--- a/.github/workflows/luminous-regression-baseline.yml
+++ b/.github/workflows/luminous-regression-baseline.yml
@@ -1,3 +1,4 @@
+# CI policy: subsystem workflows own focused contracts; this workflow owns the single full-suite safety net.
 name: Luminous Regression Baseline
 
 on:

--- a/.github/workflows/luminous-regression-baseline.yml
+++ b/.github/workflows/luminous-regression-baseline.yml
@@ -1,0 +1,54 @@
+name: Luminous Regression Baseline
+
+on:
+  pull_request:
+    paths:
+      - 'js/**'
+      - 'css/**'
+      - 'data/**'
+      - '*.html'
+      - 'tests/**'
+      - 'database.rules.json'
+      - 'storage.rules'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/**'
+  push:
+    branches: [main]
+    paths:
+      - 'js/**'
+      - 'css/**'
+      - 'data/**'
+      - '*.html'
+      - 'tests/**'
+      - 'database.rules.json'
+      - 'storage.rules'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+concurrency:
+  group: luminous-regression-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  full-regression:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Full repository regression
+        run: npx playwright test --workers=1

--- a/.github/workflows/regional-local-transition.yml
+++ b/.github/workflows/regional-local-transition.yml
@@ -17,8 +17,8 @@ on:
       - "tests/regional_world_graph*.spec.js"
       - "tests/regional_travel*.spec.js"
       - "tests/world_time_scheduler*.spec.js"
+      - "tests/scene_time_engine.spec.js"
       - "tests/vtt_world_streaming_lifecycle.spec.js"
-      - "tests/vtt_performance_guard.spec.js"
       - "tests/vtt_procedural_chunk_streaming_performance.spec.js"
       - ".github/workflows/regional-local-transition.yml"
   push:
@@ -63,7 +63,7 @@ jobs:
           node -e "JSON.parse(require('fs').readFileSync('database.rules.json','utf8'))"
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
-      - name: Focused regional-local realtime and performance contracts
+      - name: Focused regional-local boundary and streaming contracts
         run: >-
           npx playwright test --workers=1
           tests/regional_local_transition.spec.js
@@ -78,7 +78,4 @@ jobs:
           tests/scene_time_engine.spec.js
           tests/theatre_realtime.spec.js
           tests/vtt_world_streaming_lifecycle.spec.js
-          tests/vtt_performance_guard.spec.js
           tests/vtt_procedural_chunk_streaming_performance.spec.js
-      - name: Full repository regression
-        run: npx playwright test --workers=1

--- a/.github/workflows/regional-travel-engine.yml
+++ b/.github/workflows/regional-travel-engine.yml
@@ -9,8 +9,8 @@ on:
       - "js/vtt/world-streaming-*.js"
       - "tests/regional_travel*.spec.js"
       - "tests/world_time_scheduler*.spec.js"
+      - "tests/scene_time_engine.spec.js"
       - "tests/vtt_world_streaming_lifecycle.spec.js"
-      - "tests/vtt_performance_guard.spec.js"
       - "tests/vtt_procedural_chunk_streaming_performance.spec.js"
       - ".github/workflows/regional-travel-engine.yml"
   push:
@@ -48,7 +48,7 @@ jobs:
           node --check tests/regional_travel_realtime.spec.js
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
-      - name: Focused regional realtime and performance contracts
+      - name: Focused regional realtime and streaming contracts
         run: >-
           npx playwright test --workers=1
           tests/regional_travel_engine.spec.js
@@ -58,7 +58,4 @@ jobs:
           tests/scene_time_engine.spec.js
           tests/theatre_realtime.spec.js
           tests/vtt_world_streaming_lifecycle.spec.js
-          tests/vtt_performance_guard.spec.js
           tests/vtt_procedural_chunk_streaming_performance.spec.js
-      - name: Full repository regression
-        run: npx playwright test --workers=1

--- a/.github/workflows/regional-world-graph.yml
+++ b/.github/workflows/regional-world-graph.yml
@@ -11,8 +11,8 @@ on:
       - "tests/regional_world_graph*.spec.js"
       - "tests/regional_travel*.spec.js"
       - "tests/world_time_scheduler*.spec.js"
+      - "tests/scene_time_engine.spec.js"
       - "tests/vtt_world_streaming_lifecycle.spec.js"
-      - "tests/vtt_performance_guard.spec.js"
       - "tests/vtt_procedural_chunk_streaming_performance.spec.js"
       - ".github/workflows/regional-world-graph.yml"
   push:
@@ -53,7 +53,7 @@ jobs:
           node --check tests/regional_world_graph_realtime.spec.js
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
-      - name: Focused graph realtime and performance contracts
+      - name: Focused graph realtime and streaming contracts
         run: >-
           npx playwright test --workers=1
           tests/regional_world_graph.spec.js
@@ -65,7 +65,4 @@ jobs:
           tests/scene_time_engine.spec.js
           tests/theatre_realtime.spec.js
           tests/vtt_world_streaming_lifecycle.spec.js
-          tests/vtt_performance_guard.spec.js
           tests/vtt_procedural_chunk_streaming_performance.spec.js
-      - name: Full repository regression
-        run: npx playwright test --workers=1

--- a/.github/workflows/vtt-building-archetypes.yml
+++ b/.github/workflows/vtt-building-archetypes.yml
@@ -3,7 +3,8 @@ name: VTT Building Archetypes
 on:
   pull_request:
     paths:
-      - 'js/vtt/**'
+      - 'js/vtt/building-archetype-*.js'
+      - 'js/vtt/semantic-map-bootstrap.js'
       - 'tests/vtt_building_archetypes.spec.js'
       - '.github/workflows/vtt-building-archetypes.yml'
   workflow_dispatch:
@@ -25,9 +26,7 @@ jobs:
           node --input-type=module --check < js/vtt/building-archetype-authoring-bootstrap.js
           node --input-type=module --check < js/vtt/semantic-map-bootstrap.js
           node --check tests/vtt_building_archetypes.spec.js
-      - name: Focused contracts
-        run: npx playwright test tests/vtt_building_archetypes.spec.js tests/vtt_building_semantic_model.spec.js tests/vtt_semantic_map_foundation.spec.js tests/vtt_building_physics_closure.spec.js tests/vtt_ramp_foundation.spec.js tests/vtt_elevator_lift_foundation.spec.js tests/vtt_roof_ceiling_foundation.spec.js tests/vtt_floor_openings_foundation.spec.js tests/vtt_stair_builder_foundation.spec.js tests/vtt_vertical_portal_editor.spec.js tests/vtt_structure_primitives.spec.js tests/vtt_map_hud_physical.spec.js --workers=1
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
-      - name: Repository regression
-        run: npx playwright test --workers=1
+      - name: Focused building archetype integration contracts
+        run: npx playwright test tests/vtt_building_archetypes.spec.js tests/vtt_building_semantic_model.spec.js tests/vtt_semantic_map_foundation.spec.js tests/vtt_building_physics_closure.spec.js tests/vtt_ramp_foundation.spec.js tests/vtt_elevator_lift_foundation.spec.js tests/vtt_roof_ceiling_foundation.spec.js tests/vtt_floor_openings_foundation.spec.js tests/vtt_stair_builder_foundation.spec.js tests/vtt_vertical_portal_editor.spec.js tests/vtt_structure_primitives.spec.js tests/vtt_map_hud_physical.spec.js --workers=1

--- a/.github/workflows/vtt-building-navigation-graph.yml
+++ b/.github/workflows/vtt-building-navigation-graph.yml
@@ -3,7 +3,8 @@ name: VTT Building Navigation Graph
 on:
   pull_request:
     paths:
-      - 'js/vtt/**'
+      - 'js/vtt/building-navigation-*.js'
+      - 'js/vtt/semantic-map-bootstrap.js'
       - 'tests/vtt_building_navigation_graph.spec.js'
       - '.github/workflows/vtt-building-navigation-graph.yml'
   workflow_dispatch:
@@ -25,9 +26,7 @@ jobs:
           node --input-type=module --check < js/vtt/building-navigation-authoring-bootstrap.js
           node --input-type=module --check < js/vtt/semantic-map-bootstrap.js
           node --check tests/vtt_building_navigation_graph.spec.js
-      - name: Focused contracts
-        run: npx playwright test tests/vtt_building_navigation_graph.spec.js tests/vtt_building_archetypes.spec.js tests/vtt_building_semantic_model.spec.js tests/vtt_semantic_map_foundation.spec.js tests/vtt_building_physics_closure.spec.js tests/vtt_ramp_foundation.spec.js tests/vtt_elevator_lift_foundation.spec.js tests/vtt_roof_ceiling_foundation.spec.js tests/vtt_floor_openings_foundation.spec.js tests/vtt_stair_builder_foundation.spec.js tests/vtt_vertical_portal_editor.spec.js tests/vtt_structure_primitives.spec.js tests/vtt_map_hud_physical.spec.js --workers=1
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
-      - name: Repository regression
-        run: npx playwright test --workers=1
+      - name: Focused building navigation integration contracts
+        run: npx playwright test tests/vtt_building_navigation_graph.spec.js tests/vtt_building_archetypes.spec.js tests/vtt_building_semantic_model.spec.js tests/vtt_semantic_map_foundation.spec.js tests/vtt_building_physics_closure.spec.js tests/vtt_ramp_foundation.spec.js tests/vtt_elevator_lift_foundation.spec.js tests/vtt_roof_ceiling_foundation.spec.js tests/vtt_floor_openings_foundation.spec.js tests/vtt_stair_builder_foundation.spec.js tests/vtt_vertical_portal_editor.spec.js tests/vtt_structure_primitives.spec.js tests/vtt_map_hud_physical.spec.js --workers=1

--- a/.github/workflows/vtt-building-physics.yml
+++ b/.github/workflows/vtt-building-physics.yml
@@ -3,7 +3,7 @@ name: VTT Building Physics Closure
 on:
   pull_request:
     paths:
-      - 'js/vtt/**'
+      - 'js/vtt/building-physics-*.js'
       - 'vtt.html'
       - 'tests/vtt_building_physics_closure.spec.js'
       - '.github/workflows/vtt-building-physics.yml'
@@ -24,9 +24,7 @@ jobs:
           node --check js/vtt/building-physics-core.js
           node --input-type=module --check < js/vtt/building-physics-bootstrap.js
           node --check tests/vtt_building_physics_closure.spec.js
-      - name: Focused contracts
-        run: npx playwright test tests/vtt_building_physics_closure.spec.js tests/vtt_ramp_foundation.spec.js tests/vtt_elevator_lift_foundation.spec.js tests/vtt_roof_ceiling_foundation.spec.js tests/vtt_floor_openings_foundation.spec.js tests/vtt_stair_builder_foundation.spec.js tests/vtt_vertical_portal_editor.spec.js tests/vtt_structure_primitives.spec.js tests/vtt_map_hud_physical.spec.js --workers=1
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
-      - name: Repository regression
-        run: npx playwright test --workers=1
+      - name: Focused building physics and vertical integration contracts
+        run: npx playwright test tests/vtt_building_physics_closure.spec.js tests/vtt_ramp_foundation.spec.js tests/vtt_elevator_lift_foundation.spec.js tests/vtt_roof_ceiling_foundation.spec.js tests/vtt_floor_openings_foundation.spec.js tests/vtt_stair_builder_foundation.spec.js tests/vtt_vertical_portal_editor.spec.js tests/vtt_structure_primitives.spec.js tests/vtt_map_hud_physical.spec.js --workers=1

--- a/.github/workflows/vtt-building-semantic-model.yml
+++ b/.github/workflows/vtt-building-semantic-model.yml
@@ -3,7 +3,9 @@ name: VTT Building Semantic Model
 on:
   pull_request:
     paths:
-      - 'js/vtt/**'
+      - 'js/vtt/semantic-map-core.js'
+      - 'js/vtt/semantic-map-bootstrap.js'
+      - 'js/vtt/building-semantic-*.js'
       - 'tests/vtt_building_semantic_model.spec.js'
       - '.github/workflows/vtt-building-semantic-model.yml'
   workflow_dispatch:
@@ -26,9 +28,7 @@ jobs:
           node --input-type=module --check < js/vtt/building-semantic-bootstrap.js
           node --input-type=module --check < js/vtt/building-semantic-authoring-bootstrap.js
           node --check tests/vtt_building_semantic_model.spec.js
-      - name: Focused contracts
-        run: npx playwright test tests/vtt_building_semantic_model.spec.js tests/vtt_semantic_map_foundation.spec.js tests/vtt_building_physics_closure.spec.js tests/vtt_ramp_foundation.spec.js tests/vtt_elevator_lift_foundation.spec.js tests/vtt_roof_ceiling_foundation.spec.js tests/vtt_floor_openings_foundation.spec.js tests/vtt_stair_builder_foundation.spec.js tests/vtt_vertical_portal_editor.spec.js tests/vtt_structure_primitives.spec.js tests/vtt_map_hud_physical.spec.js --workers=1
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
-      - name: Repository regression
-        run: npx playwright test --workers=1
+      - name: Focused building semantic integration contracts
+        run: npx playwright test tests/vtt_building_semantic_model.spec.js tests/vtt_semantic_map_foundation.spec.js tests/vtt_building_physics_closure.spec.js tests/vtt_ramp_foundation.spec.js tests/vtt_elevator_lift_foundation.spec.js tests/vtt_roof_ceiling_foundation.spec.js tests/vtt_floor_openings_foundation.spec.js tests/vtt_stair_builder_foundation.spec.js tests/vtt_vertical_portal_editor.spec.js tests/vtt_structure_primitives.spec.js tests/vtt_map_hud_physical.spec.js --workers=1

--- a/.github/workflows/vtt-camera-pov-observer.yml
+++ b/.github/workflows/vtt-camera-pov-observer.yml
@@ -23,7 +23,6 @@ on:
       - 'tests/vtt_*fog*.spec.js'
       - 'tests/regional_local_transition*.spec.js'
       - 'tests/vtt_world_streaming_lifecycle.spec.js'
-      - 'tests/vtt_performance_guard.spec.js'
       - 'tests/vtt_procedural_chunk_streaming_performance.spec.js'
       - '.github/workflows/vtt-camera-pov-observer.yml'
   push:
@@ -95,7 +94,4 @@ jobs:
           tests/regional_local_transition_realtime.spec.js
           tests/vtt_world_streaming_lifecycle.spec.js
           tests/vtt_map_hud_physical.spec.js
-          tests/vtt_performance_guard.spec.js
           tests/vtt_procedural_chunk_streaming_performance.spec.js
-      - name: Full repository regression
-        run: npx playwright test --workers=1

--- a/.github/workflows/vtt-elevator-lift.yml
+++ b/.github/workflows/vtt-elevator-lift.yml
@@ -3,7 +3,7 @@ name: VTT Elevator Lift Foundation
 on:
   pull_request:
     paths:
-      - 'js/vtt/**'
+      - 'js/vtt/elevator-*.js'
       - 'vtt.html'
       - 'tests/vtt_elevator_lift_foundation.spec.js'
       - 'tests/vtt_elevator_authority.spec.js'
@@ -36,9 +36,7 @@ jobs:
           node --input-type=module --check < js/vtt/elevator-support-runtime.js
           node --check tests/vtt_elevator_lift_foundation.spec.js
           node --check tests/vtt_elevator_authority.spec.js
-      - name: Focused contracts
-        run: npx playwright test tests/vtt_elevator_lift_foundation.spec.js tests/vtt_elevator_authority.spec.js tests/vtt_roof_ceiling_foundation.spec.js tests/vtt_floor_openings_foundation.spec.js tests/vtt_stair_builder_foundation.spec.js tests/vtt_vertical_portal_editor.spec.js tests/vtt_map_hud_physical.spec.js --workers=1
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
-      - name: Repository regression
-        run: npx playwright test --workers=1
+      - name: Focused elevator and vertical integration contracts
+        run: npx playwright test tests/vtt_elevator_lift_foundation.spec.js tests/vtt_elevator_authority.spec.js tests/vtt_roof_ceiling_foundation.spec.js tests/vtt_floor_openings_foundation.spec.js tests/vtt_stair_builder_foundation.spec.js tests/vtt_vertical_portal_editor.spec.js tests/vtt_map_hud_physical.spec.js --workers=1

--- a/.github/workflows/vtt-floor-openings.yml
+++ b/.github/workflows/vtt-floor-openings.yml
@@ -3,7 +3,9 @@ name: VTT Floor Openings Foundation
 on:
   pull_request:
     paths:
-      - 'js/vtt/**'
+      - 'js/vtt/floor-opening-*.js'
+      - 'js/vtt/structure-bootstrap.js'
+      - 'js/vtt/structure-authoring-patch.js'
       - 'tests/vtt_floor_openings_foundation.spec.js'
       - '.github/workflows/vtt-floor-openings.yml'
   workflow_dispatch:
@@ -27,9 +29,7 @@ jobs:
           node --input-type=module --check < js/vtt/structure-bootstrap.js
           node --check js/vtt/structure-authoring-patch.js
           node --check tests/vtt_floor_openings_foundation.spec.js
-      - name: Focused contracts
-        run: npx playwright test tests/vtt_floor_openings_foundation.spec.js tests/vtt_stair_builder_foundation.spec.js tests/vtt_structure_primitives.spec.js tests/vtt_surface_foundation.spec.js tests/vtt_vertical_portal_editor.spec.js tests/vtt_map_hud_physical.spec.js --workers=1
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
-      - name: Repository regression
-        run: npx playwright test --workers=1
+      - name: Focused floor-opening and vertical integration contracts
+        run: npx playwright test tests/vtt_floor_openings_foundation.spec.js tests/vtt_stair_builder_foundation.spec.js tests/vtt_structure_primitives.spec.js tests/vtt_surface_foundation.spec.js tests/vtt_vertical_portal_editor.spec.js tests/vtt_map_hud_physical.spec.js --workers=1

--- a/.github/workflows/vtt-map-field-test-hardening.yml
+++ b/.github/workflows/vtt-map-field-test-hardening.yml
@@ -22,7 +22,6 @@ on:
       - 'tests/vtt_world_streaming_lifecycle.spec.js'
       - 'tests/vtt_map_simulation*.spec.js'
       - 'tests/vtt_procedural_chunk_streaming_performance.spec.js'
-      - 'tests/vtt_performance_guard.spec.js'
       - '.github/workflows/vtt-map-field-test-hardening.yml'
   push:
     branches: [main]
@@ -72,7 +71,7 @@ jobs:
           node -e "JSON.parse(require('fs').readFileSync('database.rules.json','utf8'))"
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
-      - name: Focused field hardening and realtime performance contracts
+      - name: Focused field hardening and realtime contracts
         run: >-
           npx playwright test --workers=1
           tests/vtt_map_field_test_hardening.spec.js
@@ -87,6 +86,3 @@ jobs:
           tests/vtt_map_simulation_persistence.spec.js
           tests/vtt_map_simulation_realtime.spec.js
           tests/vtt_procedural_chunk_streaming_performance.spec.js
-          tests/vtt_performance_guard.spec.js
-      - name: Full repository regression
-        run: npx playwright test --workers=1

--- a/.github/workflows/vtt-map-field-test-sandbox.yml
+++ b/.github/workflows/vtt-map-field-test-sandbox.yml
@@ -27,7 +27,6 @@ on:
       - 'tests/vtt_player_discovery*.spec.js'
       - 'tests/vtt_procedural_chunk_streaming_performance.spec.js'
       - 'tests/vtt_camera*.spec.js'
-      - 'tests/vtt_performance_guard.spec.js'
       - '.github/workflows/vtt-map-field-test-sandbox.yml'
   push:
     branches: [main]
@@ -74,7 +73,7 @@ jobs:
           node -e "JSON.parse(require('fs').readFileSync('database.rules.json','utf8'))"
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
-      - name: Field sandbox, regional, streaming, fog, camera and performance contracts
+      - name: Field sandbox regional streaming fog and camera contracts
         run: >-
           npx playwright test --workers=1
           tests/vtt_map_field_test_sandbox.spec.js
@@ -94,6 +93,3 @@ jobs:
           tests/vtt_procedural_chunk_streaming_performance.spec.js
           tests/vtt_camera_pov_observer_field.spec.js
           tests/vtt_camera_pov_observer_realtime.spec.js
-          tests/vtt_performance_guard.spec.js
-      - name: Full repository regression
-        run: npx playwright test --workers=1

--- a/.github/workflows/vtt-map-simulation-persistence.yml
+++ b/.github/workflows/vtt-map-simulation-persistence.yml
@@ -13,7 +13,6 @@ on:
       - 'tests/vtt_player_discovery*.spec.js'
       - 'tests/vtt_world_streaming_lifecycle.spec.js'
       - 'tests/vtt_world_objects.spec.js'
-      - 'tests/vtt_performance_guard.spec.js'
       - 'tests/vtt_procedural_chunk_streaming_performance.spec.js'
       - 'tests/regional_local_transition*.spec.js'
       - '.github/workflows/vtt-map-simulation-persistence.yml'
@@ -62,7 +61,7 @@ jobs:
           node -e "JSON.parse(require('fs').readFileSync('database.rules.json','utf8'))"
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
-      - name: Focused simulation discovery realtime persistence and performance contracts
+      - name: Focused simulation discovery realtime and persistence contracts
         run: >-
           npx playwright test --workers=1
           tests/vtt_map_simulation_bubbles.spec.js
@@ -71,10 +70,7 @@ jobs:
           tests/vtt_player_discovery_realtime.spec.js
           tests/vtt_world_streaming_lifecycle.spec.js
           tests/vtt_world_objects.spec.js
-          tests/vtt_performance_guard.spec.js
           tests/vtt_procedural_chunk_streaming_performance.spec.js
           tests/regional_local_transition.spec.js
           tests/regional_local_transition_realtime.spec.js
           tests/regional_local_transition_bootstrap.spec.js
-      - name: Full repository regression
-        run: npx playwright test --workers=1

--- a/.github/workflows/vtt-map-theatre-lifecycle.yml
+++ b/.github/workflows/vtt-map-theatre-lifecycle.yml
@@ -6,8 +6,10 @@ on:
       - 'js/instance-control.js'
       - 'js/vtt/main.js'
       - 'js/vtt/runtime-lifecycle.js'
+      - 'js/vtt/performance-guard.js'
       - 'js/vtt/dm-map-lazy-loader.js'
       - 'tests/vtt_map_theatre_lifecycle.spec.js'
+      - 'tests/vtt_runtime_performance_phase1.spec.js'
       - 'tests/vtt_instance_activation.spec.js'
       - 'tests/vtt_*realtime.spec.js'
       - 'tests/vtt_performance_guard.spec.js'
@@ -19,8 +21,10 @@ on:
       - 'js/instance-control.js'
       - 'js/vtt/main.js'
       - 'js/vtt/runtime-lifecycle.js'
+      - 'js/vtt/performance-guard.js'
       - 'js/vtt/dm-map-lazy-loader.js'
       - 'tests/vtt_map_theatre_lifecycle.spec.js'
+      - 'tests/vtt_runtime_performance_phase1.spec.js'
       - '.github/workflows/vtt-map-theatre-lifecycle.yml'
 
 permissions:
@@ -43,15 +47,18 @@ jobs:
         run: |
           node --check js/instance-control.js
           node --check js/vtt/runtime-lifecycle.js
+          node --input-type=module --check < js/vtt/performance-guard.js
           node --check js/vtt/dm-map-lazy-loader.js
           node --input-type=module --check < js/vtt/main.js
           node --check tests/vtt_map_theatre_lifecycle.spec.js
+          node --check tests/vtt_runtime_performance_phase1.spec.js
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
-      - name: Lifecycle realtime and performance contracts
+      - name: Lifecycle realtime and frame-performance contracts
         run: >-
           npx playwright test --workers=1
           tests/vtt_map_theatre_lifecycle.spec.js
+          tests/vtt_runtime_performance_phase1.spec.js
           tests/vtt_instance_activation.spec.js
           tests/vtt_token_drag.spec.js
           tests/vtt_canonical_token_state.spec.js
@@ -61,5 +68,3 @@ jobs:
           tests/vtt_map_simulation_realtime.spec.js
           tests/vtt_performance_guard.spec.js
           tests/theatre_realtime.spec.js
-      - name: Full repository regression
-        run: npx playwright test --workers=1

--- a/.github/workflows/vtt-multiclient-realtime-field.yml
+++ b/.github/workflows/vtt-multiclient-realtime-field.yml
@@ -13,7 +13,6 @@ on:
       - 'js/vtt/engine.js'
       - 'js/vtt/camera-follow.js'
       - 'js/vtt/dm-observer.js'
-      - 'js/vtt/performance-guard.js'
       - 'js/vtt/movement-bootstrap.js'
       - 'js/vtt/movement-realtime.js'
       - 'js/vtt/movement-connectivity.js'
@@ -41,7 +40,6 @@ on:
       - 'tests/vtt_map_field_test_hardening.spec.js'
       - 'tests/regional_local_transition_realtime.spec.js'
       - 'tests/vtt_token_drag.spec.js'
-      - 'tests/vtt_performance_guard.spec.js'
       - 'tests/vtt_map_theatre_lifecycle.spec.js'
       - '.github/workflows/vtt-multiclient-realtime-field.yml'
   push:
@@ -53,7 +51,6 @@ on:
       - 'js/vtt/engine.js'
       - 'js/vtt/camera-follow.js'
       - 'js/vtt/dm-observer.js'
-      - 'js/vtt/performance-guard.js'
       - 'js/vtt/movement-bootstrap.js'
       - 'js/vtt/movement-realtime.js'
       - 'js/vtt/movement-connectivity.js'
@@ -72,7 +69,6 @@ on:
       - 'tests/vtt_movement_rules_closure.spec.js'
       - 'tests/vtt_jump_fall_physics.spec.js'
       - 'tests/vtt_camera_pov_observer_realtime.spec.js'
-      - 'tests/vtt_performance_guard.spec.js'
       - '.github/workflows/vtt-multiclient-realtime-field.yml'
 
 permissions:
@@ -98,7 +94,6 @@ jobs:
           node --input-type=module --check < js/vtt/physical-state-patch.js
           node --input-type=module --check < js/vtt/camera-follow.js
           node --input-type=module --check < js/vtt/dm-observer.js
-          node --input-type=module --check < js/vtt/performance-guard.js
           node --input-type=module --check < js/vtt/movement-realtime.js
           node --input-type=module --check < js/vtt/movement-connectivity.js
           node --input-type=module --check < js/vtt/movement-destination-claims.js
@@ -116,10 +111,9 @@ jobs:
           node --check tests/vtt_movement_rules_closure.spec.js
           node --check tests/vtt_jump_fall_physics.spec.js
           node --check tests/vtt_camera_pov_observer_realtime.spec.js
-          node --check tests/vtt_performance_guard.spec.js
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
-      - name: Multiclient movement jump fall camera DM and performance contracts
+      - name: Multiclient movement jump fall camera and DM contracts
         run: >-
           npx playwright test --workers=1
           tests/vtt_movement_realtime.spec.js
@@ -138,7 +132,4 @@ jobs:
           tests/vtt_map_field_test_hardening.spec.js
           tests/regional_local_transition_realtime.spec.js
           tests/vtt_token_drag.spec.js
-          tests/vtt_performance_guard.spec.js
           tests/vtt_map_theatre_lifecycle.spec.js
-      - name: Full repository regression
-        run: npx playwright test --workers=1

--- a/.github/workflows/vtt-performance-guard.yml
+++ b/.github/workflows/vtt-performance-guard.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     paths:
       - 'vtt.html'
+      - 'js/vtt/runtime-lifecycle.js'
       - 'js/vtt/performance-guard.js'
       - 'js/vtt/lighting-engine.js'
       - 'js/vtt/lighting-defaults-patch.js'
       - 'js/vtt/pov-engine.js'
+      - 'tests/vtt_runtime_performance_phase1.spec.js'
       - 'tests/vtt_performance_guard.spec.js'
       - 'tests/vtt_vision_cone_runtime.spec.js'
       - '.github/workflows/vtt-performance-guard.yml'
@@ -28,10 +30,15 @@ jobs:
           cache: npm
       - run: npm ci
       - name: Syntax
-        run: node --input-type=module --check < js/vtt/performance-guard.js
+        run: |
+          node --check js/vtt/runtime-lifecycle.js
+          node --input-type=module --check < js/vtt/performance-guard.js
+          node --check tests/vtt_runtime_performance_phase1.spec.js
+      - name: Frame-coalesced input contract
+        run: npx playwright test tests/vtt_runtime_performance_phase1.spec.js
       - name: Vision cone 120 degree regression
         run: npx playwright test tests/vtt_vision_cone_runtime.spec.js
-      - name: Idle render budget
+      - name: Idle render and instrumentation budget
         run: npx playwright test tests/vtt_performance_guard.spec.js
       - name: Lighting/Fog focused regression
         run: >-

--- a/.github/workflows/vtt-ramp-foundation.yml
+++ b/.github/workflows/vtt-ramp-foundation.yml
@@ -3,7 +3,7 @@ name: VTT Ramp Foundation
 on:
   pull_request:
     paths:
-      - 'js/vtt/**'
+      - 'js/vtt/ramp-*.js'
       - 'vtt.html'
       - 'tests/vtt_ramp_foundation.spec.js'
       - '.github/workflows/vtt-ramp-foundation.yml'
@@ -29,9 +29,7 @@ jobs:
           node --input-type=module --check < js/vtt/ramp-autostart.js
           node --input-type=module --check < js/vtt/ramp-authoring-bootstrap.js
           node --check tests/vtt_ramp_foundation.spec.js
-      - name: Focused contracts
-        run: npx playwright test tests/vtt_ramp_foundation.spec.js tests/vtt_elevator_lift_foundation.spec.js tests/vtt_roof_ceiling_foundation.spec.js tests/vtt_floor_openings_foundation.spec.js tests/vtt_stair_builder_foundation.spec.js tests/vtt_vertical_portal_editor.spec.js tests/vtt_map_hud_physical.spec.js --workers=1
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
-      - name: Repository regression
-        run: npx playwright test --workers=1
+      - name: Focused ramp and vertical integration contracts
+        run: npx playwright test tests/vtt_ramp_foundation.spec.js tests/vtt_elevator_lift_foundation.spec.js tests/vtt_roof_ceiling_foundation.spec.js tests/vtt_floor_openings_foundation.spec.js tests/vtt_stair_builder_foundation.spec.js tests/vtt_vertical_portal_editor.spec.js tests/vtt_map_hud_physical.spec.js --workers=1

--- a/.github/workflows/vtt-roof-ceiling.yml
+++ b/.github/workflows/vtt-roof-ceiling.yml
@@ -3,7 +3,7 @@ name: VTT Roof Ceiling Foundation
 on:
   pull_request:
     paths:
-      - 'js/vtt/**'
+      - 'js/vtt/horizontal-plane-*.js'
       - 'vtt.html'
       - 'tests/vtt_roof_ceiling_foundation.spec.js'
       - '.github/workflows/vtt-roof-ceiling.yml'
@@ -28,9 +28,7 @@ jobs:
           node --input-type=module --check < js/vtt/horizontal-plane-lighting-patch.js
           node --input-type=module --check < js/vtt/horizontal-plane-bootstrap.js
           node --check tests/vtt_roof_ceiling_foundation.spec.js
-      - name: Focused contracts
-        run: npx playwright test tests/vtt_roof_ceiling_foundation.spec.js tests/vtt_floor_openings_foundation.spec.js tests/vtt_stair_builder_foundation.spec.js tests/vtt_structure_primitives.spec.js tests/vtt_surface_foundation.spec.js tests/vtt_vertical_portal_editor.spec.js tests/vtt_map_hud_physical.spec.js --workers=1
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
-      - name: Repository regression
-        run: npx playwright test --workers=1
+      - name: Focused roof ceiling and vertical integration contracts
+        run: npx playwright test tests/vtt_roof_ceiling_foundation.spec.js tests/vtt_floor_openings_foundation.spec.js tests/vtt_stair_builder_foundation.spec.js tests/vtt_structure_primitives.spec.js tests/vtt_surface_foundation.spec.js tests/vtt_vertical_portal_editor.spec.js tests/vtt_map_hud_physical.spec.js --workers=1

--- a/.github/workflows/vtt-semantic-map-foundation.yml
+++ b/.github/workflows/vtt-semantic-map-foundation.yml
@@ -3,7 +3,7 @@ name: VTT Semantic Map Foundation
 on:
   pull_request:
     paths:
-      - 'js/vtt/**'
+      - 'js/vtt/semantic-map-*.js'
       - 'vtt.html'
       - 'tests/vtt_semantic_map_foundation.spec.js'
       - '.github/workflows/vtt-semantic-map-foundation.yml'
@@ -27,9 +27,7 @@ jobs:
           node --input-type=module --check < js/vtt/semantic-map-bootstrap.js
           node --input-type=module --check < js/vtt/semantic-map-authoring-bootstrap.js
           node --check tests/vtt_semantic_map_foundation.spec.js
-      - name: Focused contracts
-        run: npx playwright test tests/vtt_semantic_map_foundation.spec.js tests/vtt_building_physics_closure.spec.js tests/vtt_ramp_foundation.spec.js tests/vtt_elevator_lift_foundation.spec.js tests/vtt_roof_ceiling_foundation.spec.js tests/vtt_floor_openings_foundation.spec.js tests/vtt_stair_builder_foundation.spec.js tests/vtt_vertical_portal_editor.spec.js tests/vtt_structure_primitives.spec.js tests/vtt_map_hud_physical.spec.js --workers=1
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
-      - name: Repository regression
-        run: npx playwright test --workers=1
+      - name: Focused semantic map integration contracts
+        run: npx playwright test tests/vtt_semantic_map_foundation.spec.js tests/vtt_building_physics_closure.spec.js tests/vtt_ramp_foundation.spec.js tests/vtt_elevator_lift_foundation.spec.js tests/vtt_roof_ceiling_foundation.spec.js tests/vtt_floor_openings_foundation.spec.js tests/vtt_stair_builder_foundation.spec.js tests/vtt_vertical_portal_editor.spec.js tests/vtt_structure_primitives.spec.js tests/vtt_map_hud_physical.spec.js --workers=1

--- a/.github/workflows/vtt-world-token-multiclient-stress.yml
+++ b/.github/workflows/vtt-world-token-multiclient-stress.yml
@@ -9,7 +9,6 @@ on:
       - 'tests/vtt_multiclient_realtime_field.spec.js'
       - 'tests/vtt_canonical_token_state.spec.js'
       - 'tests/vtt_map_field_test_hardening.spec.js'
-      - 'tests/vtt_performance_guard.spec.js'
       - 'tests/vtt_map_theatre_lifecycle.spec.js'
       - '.github/workflows/vtt-world-token-multiclient-stress.yml'
   push:
@@ -50,7 +49,4 @@ jobs:
           tests/vtt_multiclient_realtime_field.spec.js
           tests/vtt_canonical_token_state.spec.js
           tests/vtt_map_field_test_hardening.spec.js
-          tests/vtt_performance_guard.spec.js
           tests/vtt_map_theatre_lifecycle.spec.js
-      - name: Full repository regression
-        run: npx playwright test --workers=1

--- a/.github/workflows/world-time-scheduler.yml
+++ b/.github/workflows/world-time-scheduler.yml
@@ -6,7 +6,10 @@ on:
       - "js/scene-time-*.js"
       - "js/world-time-scheduler-*.js"
       - "database.rules.json"
-      - "tests/**"
+      - "tests/world_time_scheduler*.spec.js"
+      - "tests/scene_time_engine.spec.js"
+      - "tests/theatre_realtime.spec.js"
+      - "tests/vtt_world_streaming_lifecycle.spec.js"
       - ".github/workflows/world-time-scheduler.yml"
   push:
     branches: [main]
@@ -15,6 +18,7 @@ on:
       - "js/world-time-scheduler-*.js"
       - "database.rules.json"
       - "tests/world_time_scheduler*.spec.js"
+      - "tests/scene_time_engine.spec.js"
       - ".github/workflows/world-time-scheduler.yml"
 
 permissions:
@@ -26,16 +30,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
-
       - name: Install dependencies
         run: npm ci
-
       - name: Syntax and rules
         run: |
           node --check js/world-time-scheduler-core.js
@@ -44,11 +45,9 @@ jobs:
           node --check tests/world_time_scheduler.spec.js
           node --check tests/world_time_scheduler_realtime.spec.js
           node -e "JSON.parse(require('fs').readFileSync('database.rules.json','utf8'))"
-
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
-
-      - name: Focused clock realtime and performance contracts
+      - name: Focused clock realtime contracts
         run: >-
           npx playwright test --workers=1
           tests/world_time_scheduler.spec.js
@@ -56,8 +55,3 @@ jobs:
           tests/scene_time_engine.spec.js
           tests/theatre_realtime.spec.js
           tests/vtt_world_streaming_lifecycle.spec.js
-          tests/vtt_performance_guard.spec.js
-          tests/vtt_procedural_chunk_streaming_performance.spec.js
-
-      - name: Full repository regression
-        run: npx playwright test --workers=1

--- a/js/vtt/performance-guard.js
+++ b/js/vtt/performance-guard.js
@@ -5,6 +5,7 @@ const STATIC_SIGNATURE_TTL_MS = 100;
 
 const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
 const clean = (value) => String(value ?? '');
+const clockNow = () => globalThis.performance?.now?.() ?? Date.now();
 
 function tokenSignature(tokens = []) {
   return (Array.isArray(tokens) ? tokens : []).map((token) => [
@@ -95,15 +96,16 @@ function activeFrameInterval(engine, activeFrameMs = DEFAULT_ACTIVE_FRAME_MS, mo
   return Math.max(1, Number(activeFrameMs) || DEFAULT_ACTIVE_FRAME_MS);
 }
 
-export function createStaticSignatureCache(mapData, ttlMs = STATIC_SIGNATURE_TTL_MS) {
+export function createStaticSignatureCache(mapData, ttlMs = STATIC_SIGNATURE_TTL_MS, onScan = null) {
   let at = -Infinity;
   let value = '';
   let forceSerial = 0;
   return Object.freeze({
     invalidate() { forceSerial += 1; at = -Infinity; },
-    value(now = performance.now()) {
+    value(now = clockNow()) {
       if ((now - at) < ttlMs) return value;
       at = now;
+      const scanStartedAt = clockNow();
       const scene = mapData.lighting?.scene || {};
       value = JSON.stringify({
         serial: forceSerial,
@@ -121,6 +123,9 @@ export function createStaticSignatureCache(mapData, ttlMs = STATIC_SIGNATURE_TTL
         chunk: mapData.procedural?.activeChunkSignature || mapData.procedural?.streaming?.activeChunk || null,
         edit: Boolean(mapData.dmEditMode?.active),
       });
+      if (typeof onScan === 'function') {
+        try { onScan(Math.max(0, clockNow() - scanStartedAt)); } catch (_) {}
+      }
       return value;
     },
   });
@@ -153,7 +158,6 @@ export function installPerformanceGuard({
 
   const originalRender = renderer.render.bind(renderer);
   const originalCalculateVision = typeof engine.calculateVision === 'function' ? engine.calculateVision.bind(engine) : null;
-  const signatureCache = createStaticSignatureCache(mapData);
   const metrics = {
     calls: 0,
     rendered: 0,
@@ -164,7 +168,19 @@ export function installPerformanceGuard({
     visionComputed: 0,
     visionSkipped: 0,
     dmVisionBypassed: 0,
+    staticSignatureRequests: 0,
+    staticSignatureScans: 0,
+    staticSignatureDurationMs: 0,
+    maxStaticSignatureDurationMs: 0,
+    fingerprintCalls: 0,
+    fingerprintDurationMs: 0,
+    maxFingerprintDurationMs: 0,
   };
+  const signatureCache = createStaticSignatureCache(mapData, STATIC_SIGNATURE_TTL_MS, (durationMs) => {
+    metrics.staticSignatureScans += 1;
+    metrics.staticSignatureDurationMs += durationMs;
+    metrics.maxStaticSignatureDurationMs = Math.max(metrics.maxStaticSignatureDurationMs, durationMs);
+  });
   let lastFingerprint = '';
   let lastRenderAt = -Infinity;
   let lastIdleScanAt = -Infinity;
@@ -214,7 +230,7 @@ export function installPerformanceGuard({
         return visionCache;
       }
 
-      const perfNow = globalThis.performance?.now?.() ?? Date.now();
+      const perfNow = clockNow();
       const wallNow = Date.now();
       const active = visualAnimationActive(engine, mapData, wallNow);
       const minimumInterval = active
@@ -240,7 +256,7 @@ export function installPerformanceGuard({
 
   renderer.render = function guardedRender(...args) {
     metrics.calls += 1;
-    const perfNow = globalThis.performance?.now?.() ?? Date.now();
+    const perfNow = clockNow();
     const wallNow = Date.now();
     const active = visualAnimationActive(engine, mapData, wallNow);
     const activeInterval = activeFrameInterval(engine, activeFrameMs, movementFrameMs);
@@ -258,7 +274,14 @@ export function installPerformanceGuard({
     }
 
     lastIdleScanAt = perfNow;
-    const fingerprint = frameFingerprint({ engine, mapData, now: wallNow, staticSignature: signatureCache.value(perfNow) });
+    metrics.staticSignatureRequests += 1;
+    const staticSignature = signatureCache.value(perfNow);
+    const fingerprintStartedAt = clockNow();
+    const fingerprint = frameFingerprint({ engine, mapData, now: wallNow, staticSignature });
+    const fingerprintDurationMs = Math.max(0, clockNow() - fingerprintStartedAt);
+    metrics.fingerprintCalls += 1;
+    metrics.fingerprintDurationMs += fingerprintDurationMs;
+    metrics.maxFingerprintDurationMs = Math.max(metrics.maxFingerprintDurationMs, fingerprintDurationMs);
     const changed = renderDirty || fingerprint !== lastFingerprint;
     if (!changed && !active) {
       metrics.skipped += 1;
@@ -282,6 +305,15 @@ export function installPerformanceGuard({
       visionSaved: metrics.visionSkipped + metrics.dmVisionBypassed,
       activeFrameMs: Math.max(1, Number(activeFrameMs) || DEFAULT_ACTIVE_FRAME_MS),
       movementFrameMs: Math.max(1, Number(movementFrameMs) || DEFAULT_MOVEMENT_FRAME_MS),
+      avgStaticSignatureDurationMs: metrics.staticSignatureScans > 0
+        ? metrics.staticSignatureDurationMs / metrics.staticSignatureScans
+        : 0,
+      avgFingerprintDurationMs: metrics.fingerprintCalls > 0
+        ? metrics.fingerprintDurationMs / metrics.fingerprintCalls
+        : 0,
+      input: typeof engine.getInputPerformanceStats === 'function'
+        ? engine.getInputPerformanceStats()
+        : null,
     }),
     resetMetrics() {
       metrics.calls = 0;
@@ -293,6 +325,13 @@ export function installPerformanceGuard({
       metrics.visionComputed = 0;
       metrics.visionSkipped = 0;
       metrics.dmVisionBypassed = 0;
+      metrics.staticSignatureRequests = 0;
+      metrics.staticSignatureScans = 0;
+      metrics.staticSignatureDurationMs = 0;
+      metrics.maxStaticSignatureDurationMs = 0;
+      metrics.fingerprintCalls = 0;
+      metrics.fingerprintDurationMs = 0;
+      metrics.maxFingerprintDurationMs = 0;
     },
     stop() {
       if (stopped) return;

--- a/js/vtt/runtime-lifecycle.js
+++ b/js/vtt/runtime-lifecycle.js
@@ -18,16 +18,167 @@
     else globalThis.clearTimeout?.(frameId);
   };
 
+  const numeric = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+  function sensesKey(value) {
+    if (value == null) return '';
+    if (typeof value !== 'object') return String(value);
+    try { return JSON.stringify(value); }
+    catch (_) { return String(value); }
+  }
+
+  function captureVisionState(engine) {
+    const player = engine?.viewerToken?.() || null;
+    const profile = player && typeof engine?.visionProfile === 'function'
+      ? engine.visionProfile(player)
+      : null;
+    const mapData = engine?.mapData || {};
+    const grid = mapData.grid || null;
+    const walls = mapData.walls || null;
+    const topology = mapData.topology || null;
+    const portals = mapData.verticalPortals || null;
+
+    return {
+      player,
+      playerId: String(player?.id ?? ''),
+      x: numeric(player?.x),
+      y: numeric(player?.y),
+      z: numeric(player?.zLayer ?? player?.gridPosition?.z ?? player?.z?.[0]),
+      elevationFt: numeric(player?.elevationFt),
+      activeZ: numeric(engine?.activeZ),
+      profileVisible: Boolean(profile?.visible),
+      profileRadiusPx: numeric(profile?.radiusPx),
+      profileMonochrome: Boolean(profile?.monochrome),
+      profileMode: String(profile?.mode ?? ''),
+      profileCrossLayer: Boolean(profile?.crossLayer),
+      profileSenses: sensesKey(profile?.senses),
+      walls,
+      wallCount: Array.isArray(walls) ? walls.length : 0,
+      topology,
+      topologyCount: Array.isArray(topology) ? topology.length : 0,
+      portals,
+      portalCount: Array.isArray(portals) ? portals.length : 0,
+      grid,
+      gridSize: numeric(grid?.size),
+      gridDistance: numeric(grid?.distancePerCell),
+    };
+  }
+
+  function sameVisionState(left, right) {
+    if (!left || !right) return false;
+    return left.player === right.player
+      && left.playerId === right.playerId
+      && left.x === right.x
+      && left.y === right.y
+      && left.z === right.z
+      && left.elevationFt === right.elevationFt
+      && left.activeZ === right.activeZ
+      && left.profileVisible === right.profileVisible
+      && left.profileRadiusPx === right.profileRadiusPx
+      && left.profileMonochrome === right.profileMonochrome
+      && left.profileMode === right.profileMode
+      && left.profileCrossLayer === right.profileCrossLayer
+      && left.profileSenses === right.profileSenses
+      && left.walls === right.walls
+      && left.wallCount === right.wallCount
+      && left.topology === right.topology
+      && left.topologyCount === right.topologyCount
+      && left.portals === right.portals
+      && left.portalCount === right.portalCount
+      && left.grid === right.grid
+      && left.gridSize === right.gridSize
+      && left.gridDistance === right.gridDistance;
+  }
+
   function hardenEngineRuntime(engine, { log = console, isDisposed = () => false } = {}) {
     if (!engine || engine.__lifecycleHardened) return engine || null;
 
     const wasRunning = Boolean(engine.isRunning);
+    const originalTokenMouseMove = engine.handleTokenMouseMove;
     engine.isRunning = false;
     engine.frameId = null;
     engine.destroyed = false;
     engine.__lifecycleHardened = true;
 
     let handoffFrameId = null;
+    let pointerFrameId = null;
+    let pendingPointerMove = null;
+    let cachedVisionState = null;
+    let cachedVisionData = null;
+    let visionDirty = true;
+
+    const performanceStats = {
+      frames: 0,
+      visionCalculations: 0,
+      visionCacheHits: 0,
+      pointerMovesReceived: 0,
+      pointerMovesProcessed: 0,
+    };
+
+    const invalidateVision = () => {
+      visionDirty = true;
+      return true;
+    };
+
+    engine.invalidateVision = invalidateVision;
+    engine.getPerformanceStats = () => ({ ...performanceStats });
+
+    const tokenAffectsViewerVision = (event) => {
+      const tokenId = event?.detail?.tokenId;
+      if (tokenId == null) return true;
+      const viewer = engine.viewerToken?.();
+      return !viewer?.id || String(viewer.id) === String(tokenId);
+    };
+
+    const handleTokenVisionChange = (event) => {
+      if (tokenAffectsViewerVision(event)) invalidateVision();
+    };
+    const handleCanonicalTokenSync = () => invalidateVision();
+
+    engine.canvas?.addEventListener?.('vtt:token-preview-moved', handleTokenVisionChange);
+    engine.canvas?.addEventListener?.('vtt:token-moved', handleTokenVisionChange);
+    engine.canvas?.addEventListener?.('vtt:token-z-transition', handleTokenVisionChange);
+    engine.canvas?.addEventListener?.('vtt:canonical-tokens-synced', handleCanonicalTokenSync);
+
+    if (typeof originalTokenMouseMove === 'function') {
+      try { globalThis.removeEventListener?.('mousemove', originalTokenMouseMove); } catch (_) {}
+
+      engine.handleTokenMouseMove = function frameCoalescedTokenMouseMove(event) {
+        if (engine.destroyed || isDisposed()) return;
+        performanceStats.pointerMovesReceived += 1;
+        pendingPointerMove = {
+          clientX: numeric(event?.clientX),
+          clientY: numeric(event?.clientY),
+          target: event?.target || engine.canvas || null,
+        };
+        if (pointerFrameId != null) return;
+
+        pointerFrameId = requestFrame(() => {
+          pointerFrameId = null;
+          const next = pendingPointerMove;
+          pendingPointerMove = null;
+          if (!next || engine.destroyed || isDisposed()) return;
+          performanceStats.pointerMovesProcessed += 1;
+          originalTokenMouseMove(next);
+        });
+      };
+
+      globalThis.addEventListener?.('mousemove', engine.handleTokenMouseMove);
+    }
+
+    function renderDataForFrame() {
+      const nextState = captureVisionState(engine);
+      if (!visionDirty && sameVisionState(cachedVisionState, nextState)) {
+        performanceStats.visionCacheHits += 1;
+        return cachedVisionData;
+      }
+
+      performanceStats.visionCalculations += 1;
+      cachedVisionData = engine.calculateVision();
+      cachedVisionState = nextState;
+      visionDirty = false;
+      return cachedVisionData;
+    }
 
     engine.start = function startLifecycleHardenedEngine() {
       if (engine.destroyed || isDisposed() || engine.isRunning || engine.frameId != null) return false;
@@ -48,6 +199,11 @@
         cancelFrame(engine.frameId);
         engine.frameId = null;
       }
+      if (pointerFrameId != null) {
+        cancelFrame(pointerFrameId);
+        pointerFrameId = null;
+      }
+      pendingPointerMove = null;
 
       engine.tokenDrag = null;
       if (engine.canvas?.style) engine.canvas.style.cursor = 'default';
@@ -58,7 +214,8 @@
       engine.frameId = null;
       if (!engine.isRunning || engine.destroyed || isDisposed()) return;
 
-      const renderData = engine.calculateVision();
+      performanceStats.frames += 1;
+      const renderData = renderDataForFrame();
       if (!engine.isExporting) {
         engine.renderer.render(engine.camera, engine.activeZ, renderData, engine.isExporting);
       }
@@ -77,9 +234,15 @@
       try { engine.canvas?.removeEventListener?.('mousedown', engine.handleTokenMouseDown); } catch (_) {}
       try { globalThis.removeEventListener?.('mousemove', engine.handleTokenMouseMove); } catch (_) {}
       try { globalThis.removeEventListener?.('mouseup', engine.handleTokenMouseUp); } catch (_) {}
+      try { engine.canvas?.removeEventListener?.('vtt:token-preview-moved', handleTokenVisionChange); } catch (_) {}
+      try { engine.canvas?.removeEventListener?.('vtt:token-moved', handleTokenVisionChange); } catch (_) {}
+      try { engine.canvas?.removeEventListener?.('vtt:token-z-transition', handleTokenVisionChange); } catch (_) {}
+      try { engine.canvas?.removeEventListener?.('vtt:canonical-tokens-synced', handleCanonicalTokenSync); } catch (_) {}
       try { engine.camera?.destroy?.(); }
       catch (error) { log?.warn?.('VTT camera destroy failed.', error); }
 
+      cachedVisionState = null;
+      cachedVisionData = null;
       engine.tokenDrag = null;
       engine.tokenControlResolver = null;
       engine.tokenMoveResolver = null;

--- a/js/vtt/runtime-lifecycle.js
+++ b/js/vtt/runtime-lifecycle.js
@@ -18,78 +18,6 @@
     else globalThis.clearTimeout?.(frameId);
   };
 
-  const numeric = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
-
-  function sensesKey(value) {
-    if (value == null) return '';
-    if (typeof value !== 'object') return String(value);
-    try { return JSON.stringify(value); }
-    catch (_) { return String(value); }
-  }
-
-  function captureVisionState(engine) {
-    const player = engine?.viewerToken?.() || null;
-    const profile = player && typeof engine?.visionProfile === 'function'
-      ? engine.visionProfile(player)
-      : null;
-    const mapData = engine?.mapData || {};
-    const grid = mapData.grid || null;
-    const walls = mapData.walls || null;
-    const topology = mapData.topology || null;
-    const portals = mapData.verticalPortals || null;
-
-    return {
-      player,
-      playerId: String(player?.id ?? ''),
-      x: numeric(player?.x),
-      y: numeric(player?.y),
-      z: numeric(player?.zLayer ?? player?.gridPosition?.z ?? player?.z?.[0]),
-      elevationFt: numeric(player?.elevationFt),
-      activeZ: numeric(engine?.activeZ),
-      profileVisible: Boolean(profile?.visible),
-      profileRadiusPx: numeric(profile?.radiusPx),
-      profileMonochrome: Boolean(profile?.monochrome),
-      profileMode: String(profile?.mode ?? ''),
-      profileCrossLayer: Boolean(profile?.crossLayer),
-      profileSenses: sensesKey(profile?.senses),
-      walls,
-      wallCount: Array.isArray(walls) ? walls.length : 0,
-      topology,
-      topologyCount: Array.isArray(topology) ? topology.length : 0,
-      portals,
-      portalCount: Array.isArray(portals) ? portals.length : 0,
-      grid,
-      gridSize: numeric(grid?.size),
-      gridDistance: numeric(grid?.distancePerCell),
-    };
-  }
-
-  function sameVisionState(left, right) {
-    if (!left || !right) return false;
-    return left.player === right.player
-      && left.playerId === right.playerId
-      && left.x === right.x
-      && left.y === right.y
-      && left.z === right.z
-      && left.elevationFt === right.elevationFt
-      && left.activeZ === right.activeZ
-      && left.profileVisible === right.profileVisible
-      && left.profileRadiusPx === right.profileRadiusPx
-      && left.profileMonochrome === right.profileMonochrome
-      && left.profileMode === right.profileMode
-      && left.profileCrossLayer === right.profileCrossLayer
-      && left.profileSenses === right.profileSenses
-      && left.walls === right.walls
-      && left.wallCount === right.wallCount
-      && left.topology === right.topology
-      && left.topologyCount === right.topologyCount
-      && left.portals === right.portals
-      && left.portalCount === right.portalCount
-      && left.grid === right.grid
-      && left.gridSize === right.gridSize
-      && left.gridDistance === right.gridDistance;
-  }
-
   function hardenEngineRuntime(engine, { log = console, isDisposed = () => false } = {}) {
     if (!engine || engine.__lifecycleHardened) return engine || null;
 
@@ -103,54 +31,26 @@
     let handoffFrameId = null;
     let pointerFrameId = null;
     let pendingPointerMove = null;
-    let cachedVisionState = null;
-    let cachedVisionData = null;
-    let visionDirty = true;
 
-    const performanceStats = {
-      frames: 0,
-      visionCalculations: 0,
-      visionCacheHits: 0,
+    const inputPerformanceStats = {
       pointerMovesReceived: 0,
       pointerMovesProcessed: 0,
+      pointerMovesCoalesced: 0,
     };
 
-    const invalidateVision = () => {
-      visionDirty = true;
-      return true;
-    };
-
-    engine.invalidateVision = invalidateVision;
-    engine.getPerformanceStats = () => ({ ...performanceStats });
-
-    const tokenAffectsViewerVision = (event) => {
-      const tokenId = event?.detail?.tokenId;
-      if (tokenId == null) return true;
-      const viewer = engine.viewerToken?.();
-      return !viewer?.id || String(viewer.id) === String(tokenId);
-    };
-
-    const handleTokenVisionChange = (event) => {
-      if (tokenAffectsViewerVision(event)) invalidateVision();
-    };
-    const handleCanonicalTokenSync = () => invalidateVision();
-
-    engine.canvas?.addEventListener?.('vtt:token-preview-moved', handleTokenVisionChange);
-    engine.canvas?.addEventListener?.('vtt:token-moved', handleTokenVisionChange);
-    engine.canvas?.addEventListener?.('vtt:token-z-transition', handleTokenVisionChange);
-    engine.canvas?.addEventListener?.('vtt:canonical-tokens-synced', handleCanonicalTokenSync);
+    engine.getInputPerformanceStats = () => ({
+      ...inputPerformanceStats,
+      pointerMovePending: pointerFrameId != null,
+    });
 
     if (typeof originalTokenMouseMove === 'function') {
       try { globalThis.removeEventListener?.('mousemove', originalTokenMouseMove); } catch (_) {}
 
       engine.handleTokenMouseMove = function frameCoalescedTokenMouseMove(event) {
         if (engine.destroyed || isDisposed()) return;
-        performanceStats.pointerMovesReceived += 1;
-        pendingPointerMove = {
-          clientX: numeric(event?.clientX),
-          clientY: numeric(event?.clientY),
-          target: event?.target || engine.canvas || null,
-        };
+        inputPerformanceStats.pointerMovesReceived += 1;
+        if (pendingPointerMove != null) inputPerformanceStats.pointerMovesCoalesced += 1;
+        pendingPointerMove = event;
         if (pointerFrameId != null) return;
 
         pointerFrameId = requestFrame(() => {
@@ -158,26 +58,12 @@
           const next = pendingPointerMove;
           pendingPointerMove = null;
           if (!next || engine.destroyed || isDisposed()) return;
-          performanceStats.pointerMovesProcessed += 1;
+          inputPerformanceStats.pointerMovesProcessed += 1;
           originalTokenMouseMove(next);
         });
       };
 
       globalThis.addEventListener?.('mousemove', engine.handleTokenMouseMove);
-    }
-
-    function renderDataForFrame() {
-      const nextState = captureVisionState(engine);
-      if (!visionDirty && sameVisionState(cachedVisionState, nextState)) {
-        performanceStats.visionCacheHits += 1;
-        return cachedVisionData;
-      }
-
-      performanceStats.visionCalculations += 1;
-      cachedVisionData = engine.calculateVision();
-      cachedVisionState = nextState;
-      visionDirty = false;
-      return cachedVisionData;
     }
 
     engine.start = function startLifecycleHardenedEngine() {
@@ -214,8 +100,7 @@
       engine.frameId = null;
       if (!engine.isRunning || engine.destroyed || isDisposed()) return;
 
-      performanceStats.frames += 1;
-      const renderData = renderDataForFrame();
+      const renderData = engine.calculateVision();
       if (!engine.isExporting) {
         engine.renderer.render(engine.camera, engine.activeZ, renderData, engine.isExporting);
       }
@@ -234,15 +119,9 @@
       try { engine.canvas?.removeEventListener?.('mousedown', engine.handleTokenMouseDown); } catch (_) {}
       try { globalThis.removeEventListener?.('mousemove', engine.handleTokenMouseMove); } catch (_) {}
       try { globalThis.removeEventListener?.('mouseup', engine.handleTokenMouseUp); } catch (_) {}
-      try { engine.canvas?.removeEventListener?.('vtt:token-preview-moved', handleTokenVisionChange); } catch (_) {}
-      try { engine.canvas?.removeEventListener?.('vtt:token-moved', handleTokenVisionChange); } catch (_) {}
-      try { engine.canvas?.removeEventListener?.('vtt:token-z-transition', handleTokenVisionChange); } catch (_) {}
-      try { engine.canvas?.removeEventListener?.('vtt:canonical-tokens-synced', handleCanonicalTokenSync); } catch (_) {}
       try { engine.camera?.destroy?.(); }
       catch (error) { log?.warn?.('VTT camera destroy failed.', error); }
 
-      cachedVisionState = null;
-      cachedVisionData = null;
       engine.tokenDrag = null;
       engine.tokenControlResolver = null;
       engine.tokenMoveResolver = null;

--- a/tests/vtt_performance_guard.spec.js
+++ b/tests/vtt_performance_guard.spec.js
@@ -147,6 +147,62 @@ test('DM FREE gets an omniscient render frame without invoking Player FOV calcul
   }
 });
 
+test('performance guard reports fingerprint, static scan, and input costs without changing render decisions', async () => {
+  const { mod, tmp } = await loadGuard();
+  try {
+    let realRenders = 0;
+    const canvas = canvasStub();
+    const renderer = { render() { realRenders += 1; } };
+    const mapData = mapStub();
+    const engine = {
+      renderer,
+      mapData,
+      canvas,
+      camera: { x: 0, y: 0, zoom: 1 },
+      activeZ: 0,
+      tokenDrag: null,
+      tokenMotion: null,
+      getInputPerformanceStats() {
+        return { pointerMovesReceived: 9, pointerMovesProcessed: 3, pointerMovesCoalesced: 6, pointerMovePending: false };
+      },
+    };
+    const api = mod.installPerformanceGuard({ runtime: { engine, bridge: { isDm: false } } });
+
+    renderer.render();
+    let stats = api.snapshot();
+    expect(realRenders).toBe(1);
+    expect(stats.staticSignatureRequests).toBe(1);
+    expect(stats.staticSignatureScans).toBe(1);
+    expect(stats.fingerprintCalls).toBe(1);
+    expect(stats.staticSignatureDurationMs).toBeGreaterThanOrEqual(0);
+    expect(stats.maxStaticSignatureDurationMs).toBeGreaterThanOrEqual(0);
+    expect(stats.avgStaticSignatureDurationMs).toBeGreaterThanOrEqual(0);
+    expect(stats.fingerprintDurationMs).toBeGreaterThanOrEqual(0);
+    expect(stats.maxFingerprintDurationMs).toBeGreaterThanOrEqual(0);
+    expect(stats.avgFingerprintDurationMs).toBeGreaterThanOrEqual(0);
+    expect(stats.input).toEqual({ pointerMovesReceived: 9, pointerMovesProcessed: 3, pointerMovesCoalesced: 6, pointerMovePending: false });
+
+    api.invalidate();
+    renderer.render();
+    stats = api.snapshot();
+    expect(realRenders).toBe(2);
+    expect(stats.staticSignatureRequests).toBe(2);
+    expect(stats.staticSignatureScans).toBe(2);
+    expect(stats.fingerprintCalls).toBe(2);
+
+    api.resetMetrics();
+    stats = api.snapshot();
+    expect(stats.staticSignatureRequests).toBe(0);
+    expect(stats.staticSignatureScans).toBe(0);
+    expect(stats.fingerprintCalls).toBe(0);
+    expect(stats.staticSignatureDurationMs).toBe(0);
+    expect(stats.fingerprintDurationMs).toBe(0);
+    api.stop();
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});
+
 test('performance guard loads after Dynamic Lighting and Fog Memory', () => {
   const html = read('vtt.html');
   const lighting = html.indexOf('js/vtt/dynamic-lighting-bootstrap.js');

--- a/tests/vtt_runtime_performance_phase1.spec.js
+++ b/tests/vtt_runtime_performance_phase1.spec.js
@@ -42,40 +42,11 @@ function withFakeFrames(run) {
   }
 }
 
-function fakeCanvas() {
-  const listeners = new Map();
-  return {
-    style: {},
-    addEventListener(type, handler) {
-      if (!listeners.has(type)) listeners.set(type, new Set());
-      listeners.get(type).add(handler);
-    },
-    removeEventListener(type, handler) {
-      listeners.get(type)?.delete(handler);
-    },
-    dispatchEvent(event) {
-      for (const handler of listeners.get(event.type) || []) handler(event);
-    },
-  };
-}
-
 function fakeEngine() {
-  const canvas = fakeCanvas();
-  const viewer = { id: 'viewer', x: 100, y: 100, zLayer: 0, elevationFt: 0 };
-  let visionCalls = 0;
-  let renderCalls = 0;
   let pointerCalls = 0;
   let lastPointer = null;
-
   const engine = {
-    canvas,
-    mapData: {
-      grid: { size: 70, distancePerCell: 5 },
-      walls: [],
-      topology: [],
-      verticalPortals: [],
-    },
-    activeZ: 0,
+    canvas: { style: {}, addEventListener() {}, removeEventListener() {} },
     isRunning: false,
     isExporting: false,
     tokenDrag: null,
@@ -84,22 +55,8 @@ function fakeEngine() {
     movementInteractionResolver: null,
     tokenMotion: null,
     camera: { destroy() {} },
-    renderer: { render() { renderCalls += 1; } },
-    viewerToken() { return viewer; },
-    visionProfile() {
-      return {
-        visible: true,
-        radiusPx: 420,
-        monochrome: false,
-        mode: 'normal',
-        crossLayer: false,
-        senses: { darkvisionFt: 60 },
-      };
-    },
-    calculateVision() {
-      visionCalls += 1;
-      return { tokenPos: { x: viewer.x, y: viewer.y }, fovPolygon: [] };
-    },
+    renderer: { render() {} },
+    calculateVision() { return null; },
     cancelTokenMotion() {},
     handleResize() {},
     handleTokenMouseDown() {},
@@ -110,77 +67,77 @@ function fakeEngine() {
     handleTokenMouseUp() {},
     loop() {},
   };
-
   return {
     engine,
-    viewer,
-    counts: () => ({ visionCalls, renderCalls, pointerCalls, lastPointer }),
+    counts: () => ({ pointerCalls, lastPointer }),
   };
 }
 
-test('hardened VTT loop reuses vision while viewer and topology stay unchanged', () => {
-  withFakeFrames(({ nextFrame }) => {
-    const { engine, viewer, counts } = fakeEngine();
-    lifecycleApi.hardenEngineRuntime(engine);
-
-    expect(engine.start()).toBe(true);
-    expect(nextFrame()).toBe(true);
-    expect(counts()).toMatchObject({ visionCalls: 1, renderCalls: 1 });
-
-    expect(nextFrame()).toBe(true);
-    expect(nextFrame()).toBe(true);
-    expect(counts()).toMatchObject({ visionCalls: 1, renderCalls: 3 });
-
-    viewer.x += 70;
-    expect(nextFrame()).toBe(true);
-    expect(counts()).toMatchObject({ visionCalls: 2, renderCalls: 4 });
-
-    engine.mapData.topology = [{ id: 'door-1', type: 'door', state: 'closed' }];
-    expect(nextFrame()).toBe(true);
-    expect(counts()).toMatchObject({ visionCalls: 3, renderCalls: 5 });
-
-    const stats = engine.getPerformanceStats();
-    expect(stats.frames).toBe(5);
-    expect(stats.visionCalculations).toBe(3);
-    expect(stats.visionCacheHits).toBe(2);
-    engine.stop();
-  });
-});
-
-test('explicit vision invalidation forces a fresh visibility calculation', () => {
-  withFakeFrames(({ nextFrame }) => {
-    const { engine, counts } = fakeEngine();
-    lifecycleApi.hardenEngineRuntime(engine);
-    engine.start();
-
-    nextFrame();
-    nextFrame();
-    expect(counts().visionCalls).toBe(1);
-
-    engine.invalidateVision();
-    nextFrame();
-    expect(counts().visionCalls).toBe(2);
-    engine.stop();
-  });
-});
-
-test('token mousemove work is coalesced to the newest pointer position once per frame', () => {
+test('token mousemove work is coalesced to the newest native event once per frame', () => {
   withFakeFrames(({ nextFrame }) => {
     const { engine, counts } = fakeEngine();
     lifecycleApi.hardenEngineRuntime(engine);
 
-    engine.handleTokenMouseMove({ clientX: 10, clientY: 20 });
-    engine.handleTokenMouseMove({ clientX: 30, clientY: 40 });
-    engine.handleTokenMouseMove({ clientX: 50, clientY: 60 });
+    const first = { clientX: 10, clientY: 20, marker: 'first' };
+    const second = { clientX: 30, clientY: 40, marker: 'second' };
+    const latest = { clientX: 50, clientY: 60, marker: 'latest' };
+    engine.handleTokenMouseMove(first);
+    engine.handleTokenMouseMove(second);
+    engine.handleTokenMouseMove(latest);
 
     expect(counts().pointerCalls).toBe(0);
+    expect(engine.getInputPerformanceStats()).toEqual({
+      pointerMovesReceived: 3,
+      pointerMovesProcessed: 0,
+      pointerMovesCoalesced: 2,
+      pointerMovePending: true,
+    });
+
     expect(nextFrame()).toBe(true);
     expect(counts().pointerCalls).toBe(1);
-    expect(counts().lastPointer).toMatchObject({ clientX: 50, clientY: 60 });
+    expect(counts().lastPointer).toBe(latest);
+    expect(engine.getInputPerformanceStats()).toEqual({
+      pointerMovesReceived: 3,
+      pointerMovesProcessed: 1,
+      pointerMovesCoalesced: 2,
+      pointerMovePending: false,
+    });
 
-    const stats = engine.getPerformanceStats();
-    expect(stats.pointerMovesReceived).toBe(3);
-    expect(stats.pointerMovesProcessed).toBe(1);
     engine.destroy();
+  });
+});
+
+test('stop cancels pending pointer work instead of processing stale drag input', () => {
+  withFakeFrames(({ nextFrame }) => {
+    const { engine, counts } = fakeEngine();
+    lifecycleApi.hardenEngineRuntime(engine);
+
+    engine.handleTokenMouseMove({ clientX: 100, clientY: 200 });
+    expect(engine.getInputPerformanceStats().pointerMovePending).toBe(true);
+
+    engine.stop();
+    expect(engine.getInputPerformanceStats().pointerMovePending).toBe(false);
+    expect(nextFrame()).toBe(false);
+    expect(counts().pointerCalls).toBe(0);
+  });
+});
+
+test('destroy cancels pending pointer work and ignores later pointer input', () => {
+  withFakeFrames(({ nextFrame }) => {
+    const { engine, counts } = fakeEngine();
+    lifecycleApi.hardenEngineRuntime(engine);
+
+    engine.handleTokenMouseMove({ clientX: 120, clientY: 220 });
+    expect(engine.destroy()).toBe(true);
+    expect(nextFrame()).toBe(false);
+    expect(counts().pointerCalls).toBe(0);
+
+    engine.handleTokenMouseMove({ clientX: 140, clientY: 240 });
+    expect(engine.getInputPerformanceStats()).toEqual({
+      pointerMovesReceived: 1,
+      pointerMovesProcessed: 0,
+      pointerMovesCoalesced: 0,
+      pointerMovePending: false,
+    });
   });
 });

--- a/tests/vtt_runtime_performance_phase1.spec.js
+++ b/tests/vtt_runtime_performance_phase1.spec.js
@@ -1,0 +1,186 @@
+const { test, expect } = require('@playwright/test');
+const lifecycleApi = require('../js/vtt/runtime-lifecycle.js');
+
+function withFakeFrames(run) {
+  const previous = {
+    requestAnimationFrame: global.requestAnimationFrame,
+    cancelAnimationFrame: global.cancelAnimationFrame,
+    addEventListener: global.addEventListener,
+    removeEventListener: global.removeEventListener,
+  };
+  const frames = [];
+  let nextId = 1;
+  global.requestAnimationFrame = (callback) => {
+    const frame = { id: nextId++, callback, cancelled: false };
+    frames.push(frame);
+    return frame.id;
+  };
+  global.cancelAnimationFrame = (id) => {
+    const frame = frames.find((entry) => entry.id === id);
+    if (frame) frame.cancelled = true;
+  };
+  global.addEventListener = () => {};
+  global.removeEventListener = () => {};
+
+  const nextFrame = () => {
+    while (frames.length) {
+      const frame = frames.shift();
+      if (frame.cancelled) continue;
+      frame.callback(16.7);
+      return true;
+    }
+    return false;
+  };
+
+  try {
+    return run({ frames, nextFrame });
+  } finally {
+    global.requestAnimationFrame = previous.requestAnimationFrame;
+    global.cancelAnimationFrame = previous.cancelAnimationFrame;
+    global.addEventListener = previous.addEventListener;
+    global.removeEventListener = previous.removeEventListener;
+  }
+}
+
+function fakeCanvas() {
+  const listeners = new Map();
+  return {
+    style: {},
+    addEventListener(type, handler) {
+      if (!listeners.has(type)) listeners.set(type, new Set());
+      listeners.get(type).add(handler);
+    },
+    removeEventListener(type, handler) {
+      listeners.get(type)?.delete(handler);
+    },
+    dispatchEvent(event) {
+      for (const handler of listeners.get(event.type) || []) handler(event);
+    },
+  };
+}
+
+function fakeEngine() {
+  const canvas = fakeCanvas();
+  const viewer = { id: 'viewer', x: 100, y: 100, zLayer: 0, elevationFt: 0 };
+  let visionCalls = 0;
+  let renderCalls = 0;
+  let pointerCalls = 0;
+  let lastPointer = null;
+
+  const engine = {
+    canvas,
+    mapData: {
+      grid: { size: 70, distancePerCell: 5 },
+      walls: [],
+      topology: [],
+      verticalPortals: [],
+    },
+    activeZ: 0,
+    isRunning: false,
+    isExporting: false,
+    tokenDrag: null,
+    tokenControlResolver: null,
+    tokenMoveResolver: null,
+    movementInteractionResolver: null,
+    tokenMotion: null,
+    camera: { destroy() {} },
+    renderer: { render() { renderCalls += 1; } },
+    viewerToken() { return viewer; },
+    visionProfile() {
+      return {
+        visible: true,
+        radiusPx: 420,
+        monochrome: false,
+        mode: 'normal',
+        crossLayer: false,
+        senses: { darkvisionFt: 60 },
+      };
+    },
+    calculateVision() {
+      visionCalls += 1;
+      return { tokenPos: { x: viewer.x, y: viewer.y }, fovPolygon: [] };
+    },
+    cancelTokenMotion() {},
+    handleResize() {},
+    handleTokenMouseDown() {},
+    handleTokenMouseMove(event) {
+      pointerCalls += 1;
+      lastPointer = event;
+    },
+    handleTokenMouseUp() {},
+    loop() {},
+  };
+
+  return {
+    engine,
+    viewer,
+    counts: () => ({ visionCalls, renderCalls, pointerCalls, lastPointer }),
+  };
+}
+
+test('hardened VTT loop reuses vision while viewer and topology stay unchanged', () => {
+  withFakeFrames(({ nextFrame }) => {
+    const { engine, viewer, counts } = fakeEngine();
+    lifecycleApi.hardenEngineRuntime(engine);
+
+    expect(engine.start()).toBe(true);
+    expect(nextFrame()).toBe(true);
+    expect(counts()).toMatchObject({ visionCalls: 1, renderCalls: 1 });
+
+    expect(nextFrame()).toBe(true);
+    expect(nextFrame()).toBe(true);
+    expect(counts()).toMatchObject({ visionCalls: 1, renderCalls: 3 });
+
+    viewer.x += 70;
+    expect(nextFrame()).toBe(true);
+    expect(counts()).toMatchObject({ visionCalls: 2, renderCalls: 4 });
+
+    engine.mapData.topology = [{ id: 'door-1', type: 'door', state: 'closed' }];
+    expect(nextFrame()).toBe(true);
+    expect(counts()).toMatchObject({ visionCalls: 3, renderCalls: 5 });
+
+    const stats = engine.getPerformanceStats();
+    expect(stats.frames).toBe(5);
+    expect(stats.visionCalculations).toBe(3);
+    expect(stats.visionCacheHits).toBe(2);
+    engine.stop();
+  });
+});
+
+test('explicit vision invalidation forces a fresh visibility calculation', () => {
+  withFakeFrames(({ nextFrame }) => {
+    const { engine, counts } = fakeEngine();
+    lifecycleApi.hardenEngineRuntime(engine);
+    engine.start();
+
+    nextFrame();
+    nextFrame();
+    expect(counts().visionCalls).toBe(1);
+
+    engine.invalidateVision();
+    nextFrame();
+    expect(counts().visionCalls).toBe(2);
+    engine.stop();
+  });
+});
+
+test('token mousemove work is coalesced to the newest pointer position once per frame', () => {
+  withFakeFrames(({ nextFrame }) => {
+    const { engine, counts } = fakeEngine();
+    lifecycleApi.hardenEngineRuntime(engine);
+
+    engine.handleTokenMouseMove({ clientX: 10, clientY: 20 });
+    engine.handleTokenMouseMove({ clientX: 30, clientY: 40 });
+    engine.handleTokenMouseMove({ clientX: 50, clientY: 60 });
+
+    expect(counts().pointerCalls).toBe(0);
+    expect(nextFrame()).toBe(true);
+    expect(counts().pointerCalls).toBe(1);
+    expect(counts().lastPointer).toMatchObject({ clientX: 50, clientY: 60 });
+
+    const stats = engine.getPerformanceStats();
+    expect(stats.pointerMovesReceived).toBe(3);
+    expect(stats.pointerMovesProcessed).toBe(1);
+    engine.destroy();
+  });
+});


### PR DESCRIPTION
## Performance Phase 1A + CI contract migration

Este PR aplica el primer cambio de performance medible sobre el VTT actual y adapta la matriz de checks al nuevo enfoque: contratos enfocados por subsistema + una sola regresión global.

### 1. Input de token agrupado por frame

`runtime-lifecycle.js` conserva únicamente el evento `mousemove` más reciente pendiente y ejecuta el handler real como máximo una vez por `requestAnimationFrame`.

Métricas:

```js
LuminousVttRuntime.engine.getInputPerformanceStats()
```

- `pointerMovesReceived`
- `pointerMovesProcessed`
- `pointerMovesCoalesced`
- `pointerMovePending`

`stop()` y `destroy()` cancelan trabajo pendiente para evitar drag/input obsoleto después de abandonar el runtime.

### 2. Una sola autoridad para visión/render

`runtime-lifecycle.js` NO mantiene un segundo caché de FOV. El intento inicial se retiró tras detectar que podía dejar visión obsoleta ante mutaciones in-place de topología/portales.

`performance-guard.js` continúa siendo la única autoridad para throttling/caché de visión y render, incluyendo DM FREE / DM preview.

### 3. Instrumentación de hot paths

`LuminousVttPerformanceGuard.snapshot()` incorpora métricas para medir:

- solicitudes y scans reales de static signature
- tiempo total/promedio/máximo de static signature
- llamadas y tiempo total/promedio/máximo de frame fingerprint
- métricas de input coalesced cuando están disponibles

Esto permite escoger el siguiente cuello de botella con datos reales.

## Nueva arquitectura de checks

Se adaptaron los 23 workflows especializados que disparaba este cambio.

Regla nueva:

```text
Cambio de subsistema
      ↓
Check enfocado
      ↓
Contratos semánticos del subsistema

+ una sola vez

Luminous Regression Baseline
      ↓
Full repository regression
```

### Cambios de CI

- Se eliminaron `Full repository regression` / `Repository regression` duplicados de los workflows especializados.
- Se retiró `vtt_performance_guard.spec.js` como dependencia de checks que no son dueños de performance.
- Se reemplazaron triggers amplios como `js/vtt/**` por rutas del dominio en rampas, techos, pisos, elevadores, building semantics/navigation/physics, etc.
- `World Time Scheduler` y `Background Narratives` ya no usan `tests/**` como trigger indiscriminado.
- `VTT Performance Guard` prueba explícitamente `tests/vtt_runtime_performance_phase1.spec.js`.
- `VTT Map Theatre Lifecycle` incluye el contrato frame-aware y ya no vuelve a ejecutar todo el repo.
- Se añadió `.github/workflows/luminous-regression-baseline.yml` como única red de seguridad global, con `cancel-in-progress` para runs globales obsoletos.

## Tests nuevos / reforzados

### `tests/vtt_runtime_performance_phase1.spec.js`
- múltiples mousemoves se reducen al evento más reciente del frame
- `stop()` cancela input pendiente
- `destroy()` cancela input pendiente e ignora eventos tardíos
- métricas received/processed/coalesced

### `tests/vtt_performance_guard.spec.js`
- regresiones de idle render, token traversal y DM FREE
- instrumentación de fingerprint/static signatures
- exposición de métricas de input
- `resetMetrics()`

## Lo que NO cambia

- reglas de movimiento/pathfinding
- lógica visual de FOV
- DM FREE / View As
- persistencia/Firebase
- formato de saves
- renderer visual
- cámara
- Dynamic Lighting/Fog
- Pixi/ECS/GOAP

## Estado

GitHub reconoce la nueva matriz como 23 checks especializados + `Luminous Regression Baseline`. El PR es mergeable; los jobs pendientes dependen de disponibilidad de runners, no de conflictos de código.