### PR TITLE
perf(vtt): replace idle RAF churn with adaptive frame scheduler

### DIFF
--- a/.github/workflows/vtt-performance-guard.yml
+++ b/.github/workflows/vtt-performance-guard.yml
@@ -10,6 +10,7 @@ on:
       - 'js/vtt/lighting-defaults-patch.js'
       - 'js/vtt/pov-engine.js'
       - 'tests/vtt_runtime_performance_phase1.spec.js'
+      - 'tests/vtt_runtime_frame_scheduler.spec.js'
       - 'tests/vtt_performance_guard.spec.js'
       - 'tests/vtt_vision_cone_runtime.spec.js'
       - '.github/workflows/vtt-performance-guard.yml'
@@ -34,15 +35,19 @@ jobs:
           node --check js/vtt/runtime-lifecycle.js
           node --input-type=module --check < js/vtt/performance-guard.js
           node --check tests/vtt_runtime_performance_phase1.spec.js
-      - name: Frame-coalesced input contract
-        run: npx playwright test tests/vtt_runtime_performance_phase1.spec.js
+          node --check tests/vtt_runtime_frame_scheduler.spec.js
+      - name: Frame-coalesced input and adaptive scheduler contracts
+        run: >-
+          npx playwright test --workers=1
+          tests/vtt_runtime_performance_phase1.spec.js
+          tests/vtt_runtime_frame_scheduler.spec.js
       - name: Vision cone 120 degree regression
         run: npx playwright test tests/vtt_vision_cone_runtime.spec.js
-      - name: Idle render and instrumentation budget
+      - name: Idle render scheduler and instrumentation budget
         run: npx playwright test tests/vtt_performance_guard.spec.js
       - name: Lighting/Fog focused regression
         run: >-
-          npx playwright test
+          npx playwright test --workers=1
           tests/vtt_dynamic_lighting.spec.js
           tests/vtt_dynamic_lighting_runtime.spec.js
           tests/vtt_pov*.spec.js

--- a/js/vtt/performance-guard.js
+++ b/js/vtt/performance-guard.js
@@ -88,7 +88,8 @@ export function dmOmniscientVision(mapData = {}) {
 }
 
 function visualAnimationActive(engine, mapData, now = Date.now()) {
-  return Boolean(engine?.tokenMotion || engine?.tokenDrag) || hasActiveLightingAnimation(mapData, now);
+  return Boolean(engine?.tokenMotion || engine?.tokenDrag || engine?.camera?.isDragging)
+    || hasActiveLightingAnimation(mapData, now);
 }
 
 function activeFrameInterval(engine, activeFrameMs = DEFAULT_ACTIVE_FRAME_MS, movementFrameMs = DEFAULT_MOVEMENT_FRAME_MS) {
@@ -158,6 +159,10 @@ export function installPerformanceGuard({
 
   const originalRender = renderer.render.bind(renderer);
   const originalCalculateVision = typeof engine.calculateVision === 'function' ? engine.calculateVision.bind(engine) : null;
+  const idleInterval = Math.max(
+    Math.max(1, Number(activeFrameMs) || DEFAULT_ACTIVE_FRAME_MS),
+    Number(idleScanMs) || DEFAULT_IDLE_SCAN_MS,
+  );
   const metrics = {
     calls: 0,
     rendered: 0,
@@ -191,14 +196,31 @@ export function installPerformanceGuard({
   let visionDirty = true;
   let stopped = false;
 
+  const nextFrameDelayMs = () => {
+    if (stopped) return 0;
+    const active = visualAnimationActive(engine, mapData, Date.now());
+    if (active) return activeFrameInterval(engine, activeFrameMs, movementFrameMs);
+    if (renderDirty || visionDirty) return 0;
+    return idleInterval;
+  };
+
+  const wakeFrame = () => {
+    const active = visualAnimationActive(engine, mapData, Date.now());
+    engine.requestFrame?.({
+      immediate: !active,
+      delayMs: active ? activeFrameInterval(engine, activeFrameMs, movementFrameMs) : 0,
+    });
+  };
+
   const invalidate = () => {
     renderDirty = true;
     visionDirty = true;
     signatureCache.invalidate();
+    wakeFrame();
   };
 
   const interactionInvalidate = () => {
-    if (engine.tokenDrag || engine.tokenMotion || mapData.dmEditMode?.active) invalidate();
+    if (engine.tokenDrag || engine.tokenMotion || engine.camera?.isDragging || mapData.dmEditMode?.active) invalidate();
   };
 
   const events = [
@@ -218,6 +240,7 @@ export function installPerformanceGuard({
   globalThis.addEventListener?.('keydown', invalidate);
   globalThis.addEventListener?.('keyup', invalidate);
   globalThis.addEventListener?.('mousemove', interactionInvalidate, { passive: true });
+  engine.setFrameDelayResolver?.(nextFrameDelayMs);
 
   if (originalCalculateVision) {
     engine.calculateVision = function guardedCalculateVision(...args) {
@@ -260,10 +283,9 @@ export function installPerformanceGuard({
     const wallNow = Date.now();
     const active = visualAnimationActive(engine, mapData, wallNow);
     const activeInterval = activeFrameInterval(engine, activeFrameMs, movementFrameMs);
-    const idleInterval = Math.max(Math.max(1, Number(activeFrameMs) || DEFAULT_ACTIVE_FRAME_MS), Number(idleScanMs) || DEFAULT_IDLE_SCAN_MS);
 
-    // Important: reject excess animation frames before building token/topology JSON signatures.
-    // Token interpolation stays RAF-smooth, but Dynamic Lighting/Fog heavy work is capped at 20 Hz during tokenMotion.
+    // The lifecycle scheduler already targets these cadences. Keep these checks as a safety net
+    // for explicit wakeups and runtimes that do not expose the adaptive scheduler yet.
     if (active && (perfNow - lastRenderAt) < activeInterval) {
       metrics.throttled += 1;
       return;
@@ -299,12 +321,14 @@ export function installPerformanceGuard({
 
   const api = Object.freeze({
     invalidate,
+    nextFrameDelayMs,
     snapshot: () => ({
       ...metrics,
       savedFrames: metrics.skipped + metrics.throttled,
       visionSaved: metrics.visionSkipped + metrics.dmVisionBypassed,
       activeFrameMs: Math.max(1, Number(activeFrameMs) || DEFAULT_ACTIVE_FRAME_MS),
       movementFrameMs: Math.max(1, Number(movementFrameMs) || DEFAULT_MOVEMENT_FRAME_MS),
+      idleFrameMs: idleInterval,
       avgStaticSignatureDurationMs: metrics.staticSignatureScans > 0
         ? metrics.staticSignatureDurationMs / metrics.staticSignatureScans
         : 0,
@@ -313,6 +337,9 @@ export function installPerformanceGuard({
         : 0,
       input: typeof engine.getInputPerformanceStats === 'function'
         ? engine.getInputPerformanceStats()
+        : null,
+      scheduler: typeof engine.getFrameSchedulerStats === 'function'
+        ? engine.getFrameSchedulerStats()
         : null,
     }),
     resetMetrics() {
@@ -339,6 +366,7 @@ export function installPerformanceGuard({
       renderer.render = originalRender;
       renderer.__performanceGuardInstalled = false;
       if (originalCalculateVision) engine.calculateVision = originalCalculateVision;
+      engine.setFrameDelayResolver?.(null);
       events.forEach((name) => engine.canvas?.removeEventListener?.(name, invalidate));
       globalThis.removeEventListener?.('resize', invalidate);
       globalThis.removeEventListener?.('wheel', invalidate);

--- a/js/vtt/runtime-lifecycle.js
+++ b/js/vtt/runtime-lifecycle.js
@@ -18,6 +18,8 @@
     else globalThis.clearTimeout?.(frameId);
   };
 
+  const nowMs = () => globalThis.performance?.now?.() ?? Date.now();
+
   function hardenEngineRuntime(engine, { log = console, isDisposed = () => false } = {}) {
     if (!engine || engine.__lifecycleHardened) return engine || null;
 
@@ -31,17 +33,92 @@
     let handoffFrameId = null;
     let pointerFrameId = null;
     let pendingPointerMove = null;
+    let frameDelayTimerId = null;
+    let frameDelayDueAt = Infinity;
+    let frameDelayResolver = null;
 
     const inputPerformanceStats = {
       pointerMovesReceived: 0,
       pointerMovesProcessed: 0,
       pointerMovesCoalesced: 0,
     };
+    const schedulerStats = {
+      framesScheduled: 0,
+      framesExecuted: 0,
+      delayedFramesScheduled: 0,
+      immediateWakeups: 0,
+      delayedWakeupsPulledForward: 0,
+    };
 
     engine.getInputPerformanceStats = () => ({
       ...inputPerformanceStats,
       pointerMovePending: pointerFrameId != null,
     });
+
+    engine.getFrameSchedulerStats = () => ({
+      ...schedulerStats,
+      framePending: engine.frameId != null,
+      delayedWakePending: frameDelayTimerId != null,
+      nextDelayedWakeInMs: frameDelayTimerId != null
+        ? Math.max(0, frameDelayDueAt - nowMs())
+        : null,
+    });
+
+    const clearDelayedFrame = () => {
+      if (frameDelayTimerId == null) return false;
+      globalThis.clearTimeout?.(frameDelayTimerId);
+      frameDelayTimerId = null;
+      frameDelayDueAt = Infinity;
+      return true;
+    };
+
+    const scheduleFrame = (delayMs = 0) => {
+      if (engine.destroyed || isDisposed() || !engine.isRunning || engine.frameId != null) return false;
+      const delay = Math.max(0, Number(delayMs) || 0);
+      const targetDueAt = nowMs() + delay;
+
+      if (frameDelayTimerId != null) {
+        if (frameDelayDueAt <= targetDueAt + 1) return false;
+        clearDelayedFrame();
+        schedulerStats.delayedWakeupsPulledForward += 1;
+      }
+
+      if (delay <= 1) {
+        schedulerStats.framesScheduled += 1;
+        engine.frameId = requestFrame(engine.loop);
+        return true;
+      }
+
+      schedulerStats.framesScheduled += 1;
+      schedulerStats.delayedFramesScheduled += 1;
+      frameDelayDueAt = targetDueAt;
+      frameDelayTimerId = globalThis.setTimeout?.(() => {
+        frameDelayTimerId = null;
+        frameDelayDueAt = Infinity;
+        if (engine.destroyed || isDisposed() || !engine.isRunning || engine.frameId != null) return;
+        engine.frameId = requestFrame(engine.loop);
+      }, delay) ?? null;
+      return frameDelayTimerId != null;
+    };
+
+    engine.setFrameDelayResolver = function setFrameDelayResolver(resolver) {
+      frameDelayResolver = typeof resolver === 'function' ? resolver : null;
+      engine.requestFrame?.({ immediate: true });
+      return Boolean(frameDelayResolver);
+    };
+
+    engine.requestFrame = function requestLifecycleFrame(options = {}) {
+      if (engine.destroyed || isDisposed() || !engine.isRunning || engine.frameId != null) return false;
+      const immediate = options?.immediate !== false;
+      const requestedDelay = Number(options?.delayMs);
+      const delay = immediate
+        ? 0
+        : (Number.isFinite(requestedDelay)
+          ? Math.max(0, requestedDelay)
+          : Math.max(0, Number(frameDelayResolver?.()) || 0));
+      if (immediate && clearDelayedFrame()) schedulerStats.immediateWakeups += 1;
+      return scheduleFrame(delay);
+    };
 
     if (typeof originalTokenMouseMove === 'function') {
       try { globalThis.removeEventListener?.('mousemove', originalTokenMouseMove); } catch (_) {}
@@ -67,10 +144,9 @@
     }
 
     engine.start = function startLifecycleHardenedEngine() {
-      if (engine.destroyed || isDisposed() || engine.isRunning || engine.frameId != null) return false;
+      if (engine.destroyed || isDisposed() || engine.isRunning || engine.frameId != null || frameDelayTimerId != null) return false;
       engine.isRunning = true;
-      engine.frameId = requestFrame(engine.loop);
-      return true;
+      return scheduleFrame(0);
     };
 
     engine.stop = function stopLifecycleHardenedEngine() {
@@ -85,6 +161,7 @@
         cancelFrame(engine.frameId);
         engine.frameId = null;
       }
+      clearDelayedFrame();
       if (pointerFrameId != null) {
         cancelFrame(pointerFrameId);
         pointerFrameId = null;
@@ -99,6 +176,7 @@
     engine.loop = function lifecycleHardenedLoop() {
       engine.frameId = null;
       if (!engine.isRunning || engine.destroyed || isDisposed()) return;
+      schedulerStats.framesExecuted += 1;
 
       const renderData = engine.calculateVision();
       if (!engine.isExporting) {
@@ -106,7 +184,8 @@
       }
 
       if (engine.isRunning && !engine.destroyed && !isDisposed()) {
-        engine.frameId = requestFrame(engine.loop);
+        const nextDelay = Math.max(0, Number(frameDelayResolver?.()) || 0);
+        scheduleFrame(nextDelay);
       }
     };
 
@@ -122,6 +201,7 @@
       try { engine.camera?.destroy?.(); }
       catch (error) { log?.warn?.('VTT camera destroy failed.', error); }
 
+      frameDelayResolver = null;
       engine.tokenDrag = null;
       engine.tokenControlResolver = null;
       engine.tokenMoveResolver = null;
@@ -131,7 +211,7 @@
     };
 
     // main.js can schedule the legacy bound RAF before LuminousVttRuntime is published.
-    // Keep isRunning=false until that old callback drains, then restart with the owned RAF loop.
+    // Keep isRunning=false until that old callback drains, then restart with the owned scheduler.
     if (wasRunning && !isDisposed()) {
       handoffFrameId = requestFrame(() => {
         handoffFrameId = null;

--- a/tests/vtt_performance_guard.spec.js
+++ b/tests/vtt_performance_guard.spec.js
@@ -203,6 +203,56 @@ test('performance guard reports fingerprint, static scan, and input costs withou
   }
 });
 
+test('performance guard publishes adaptive frame cadence and scheduler metrics', async () => {
+  const { mod, tmp } = await loadGuard();
+  try {
+    const canvas = canvasStub();
+    const renderer = { render() {} };
+    const mapData = mapStub();
+    let resolver = null;
+    const wakeCalls = [];
+    const engine = {
+      renderer,
+      mapData,
+      canvas,
+      camera: { x: 0, y: 0, zoom: 1, isDragging: false },
+      activeZ: 0,
+      tokenDrag: null,
+      tokenMotion: null,
+      calculateVision() { return { visible: true }; },
+      setFrameDelayResolver(next) { resolver = typeof next === 'function' ? next : null; return Boolean(resolver); },
+      requestFrame(options) { wakeCalls.push(options); return true; },
+      getFrameSchedulerStats() { return { framesScheduled: 8, framesExecuted: 6, delayedWakePending: true }; },
+    };
+    const api = mod.installPerformanceGuard({ runtime: { engine, bridge: { isDm: false } } });
+    expect(resolver).toBeTruthy();
+
+    engine.calculateVision();
+    renderer.render();
+    expect(api.nextFrameDelayMs()).toBeCloseTo(1000 / 15, 4);
+
+    engine.camera.isDragging = true;
+    expect(api.nextFrameDelayMs()).toBeCloseTo(1000 / 30, 4);
+
+    engine.tokenMotion = { tokenId: 'p1' };
+    expect(api.nextFrameDelayMs()).toBeCloseTo(1000 / 20, 4);
+
+    engine.tokenMotion = null;
+    engine.camera.isDragging = false;
+    api.invalidate();
+    expect(wakeCalls.at(-1)).toMatchObject({ immediate: true, delayMs: 0 });
+
+    const stats = api.snapshot();
+    expect(stats.idleFrameMs).toBeCloseTo(1000 / 15, 4);
+    expect(stats.scheduler).toMatchObject({ framesScheduled: 8, framesExecuted: 6, delayedWakePending: true });
+
+    api.stop();
+    expect(resolver).toBeNull();
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});
+
 test('performance guard loads after Dynamic Lighting and Fog Memory', () => {
   const html = read('vtt.html');
   const lighting = html.indexOf('js/vtt/dynamic-lighting-bootstrap.js');
@@ -222,10 +272,11 @@ test('performance guard keeps visual rule inputs and caps active movement before
   expect(source).toContain('DEFAULT_ACTIVE_FRAME_MS = 1000 / 30');
   expect(source).toContain('DEFAULT_MOVEMENT_FRAME_MS = 1000 / 20');
   expect(source).toContain('DEFAULT_IDLE_SCAN_MS = 1000 / 15');
-  expect(source).toContain('engine?.tokenMotion || engine?.tokenDrag');
+  expect(source).toContain('engine?.tokenMotion || engine?.tokenDrag || engine?.camera?.isDragging');
   expect(source).toContain('if (engine?.tokenMotion)');
-  expect(source).toContain('Dynamic Lighting/Fog heavy work is capped at 20 Hz during tokenMotion');
-  expect(source).toContain('reject excess animation frames before building token/topology JSON signatures');
+  expect(source).toContain('engine.setFrameDelayResolver?.(nextFrameDelayMs)');
+  expect(source).toContain('engine.requestFrame?.({');
+  expect(source).toContain('The lifecycle scheduler already targets these cadences');
 });
 
 test('performance guard parses as an ES module', () => {

--- a/tests/vtt_runtime_frame_scheduler.spec.js
+++ b/tests/vtt_runtime_frame_scheduler.spec.js
@@ -1,0 +1,201 @@
+const { test, expect } = require('@playwright/test');
+const lifecycleApi = require('../js/vtt/runtime-lifecycle.js');
+
+function withFakeScheduler(run) {
+  const previous = {
+    requestAnimationFrame: global.requestAnimationFrame,
+    cancelAnimationFrame: global.cancelAnimationFrame,
+    setTimeout: global.setTimeout,
+    clearTimeout: global.clearTimeout,
+    addEventListener: global.addEventListener,
+    removeEventListener: global.removeEventListener,
+    performance: Object.getOwnPropertyDescriptor(global, 'performance'),
+  };
+
+  let now = 0;
+  let nextId = 1;
+  const frames = [];
+  const timers = [];
+
+  global.requestAnimationFrame = (callback) => {
+    const frame = { id: nextId++, callback, cancelled: false };
+    frames.push(frame);
+    return frame.id;
+  };
+  global.cancelAnimationFrame = (id) => {
+    const frame = frames.find((entry) => entry.id === id);
+    if (frame) frame.cancelled = true;
+  };
+  global.setTimeout = (callback, delay = 0) => {
+    const timer = { id: nextId++, callback, dueAt: now + Math.max(0, Number(delay) || 0), cancelled: false };
+    timers.push(timer);
+    return timer.id;
+  };
+  global.clearTimeout = (id) => {
+    const timer = timers.find((entry) => entry.id === id);
+    if (timer) timer.cancelled = true;
+  };
+  global.addEventListener = () => {};
+  global.removeEventListener = () => {};
+  Object.defineProperty(global, 'performance', {
+    configurable: true,
+    value: { now: () => now },
+  });
+
+  const nextFrame = () => {
+    while (frames.length) {
+      const frame = frames.shift();
+      if (frame.cancelled) continue;
+      frame.callback(now);
+      return true;
+    }
+    return false;
+  };
+
+  const flushDueTimers = () => {
+    let ran = false;
+    while (true) {
+      const due = timers
+        .filter((timer) => !timer.cancelled && timer.dueAt <= now)
+        .sort((left, right) => left.dueAt - right.dueAt || left.id - right.id)[0];
+      if (!due) break;
+      due.cancelled = true;
+      due.callback();
+      ran = true;
+    }
+    return ran;
+  };
+
+  const advance = (ms) => {
+    now += Math.max(0, Number(ms) || 0);
+    flushDueTimers();
+  };
+
+  try {
+    return run({ frames, timers, nextFrame, advance, now: () => now });
+  } finally {
+    global.requestAnimationFrame = previous.requestAnimationFrame;
+    global.cancelAnimationFrame = previous.cancelAnimationFrame;
+    global.setTimeout = previous.setTimeout;
+    global.clearTimeout = previous.clearTimeout;
+    global.addEventListener = previous.addEventListener;
+    global.removeEventListener = previous.removeEventListener;
+    if (previous.performance) Object.defineProperty(global, 'performance', previous.performance);
+    else delete global.performance;
+  }
+}
+
+function fakeEngine() {
+  let renders = 0;
+  let visions = 0;
+  const engine = {
+    canvas: { style: {}, addEventListener() {}, removeEventListener() {} },
+    isRunning: false,
+    isExporting: false,
+    tokenDrag: null,
+    tokenControlResolver: null,
+    tokenMoveResolver: null,
+    movementInteractionResolver: null,
+    tokenMotion: null,
+    camera: { destroy() {} },
+    renderer: { render() { renders += 1; } },
+    calculateVision() { visions += 1; return { visible: true }; },
+    cancelTokenMotion() {},
+    handleResize() {},
+    handleTokenMouseDown() {},
+    handleTokenMouseMove() {},
+    handleTokenMouseUp() {},
+    loop() {},
+  };
+  return { engine, counts: () => ({ renders, visions }) };
+}
+
+test('idle engine schedules a delayed wake instead of chaining RAF forever', () => {
+  withFakeScheduler(({ nextFrame, advance }) => {
+    const { engine, counts } = fakeEngine();
+    lifecycleApi.hardenEngineRuntime(engine);
+    engine.setFrameDelayResolver(() => 1000 / 15);
+
+    expect(engine.start()).toBe(true);
+    expect(nextFrame()).toBe(true);
+    expect(counts()).toEqual({ renders: 1, visions: 1 });
+
+    let stats = engine.getFrameSchedulerStats();
+    expect(stats.delayedWakePending).toBe(true);
+    expect(stats.delayedFramesScheduled).toBe(1);
+    expect(stats.framesExecuted).toBe(1);
+
+    advance(60);
+    expect(nextFrame()).toBe(false);
+    advance(7);
+    expect(nextFrame()).toBe(true);
+    expect(counts()).toEqual({ renders: 2, visions: 2 });
+
+    stats = engine.getFrameSchedulerStats();
+    expect(stats.framesExecuted).toBe(2);
+    expect(stats.delayedFramesScheduled).toBe(2);
+    engine.stop();
+  });
+});
+
+test('explicit invalidation pulls an idle delayed wake forward immediately', () => {
+  withFakeScheduler(({ nextFrame }) => {
+    const { engine } = fakeEngine();
+    lifecycleApi.hardenEngineRuntime(engine);
+    engine.setFrameDelayResolver(() => 1000 / 15);
+    engine.start();
+    expect(nextFrame()).toBe(true);
+    expect(engine.getFrameSchedulerStats().delayedWakePending).toBe(true);
+
+    expect(engine.requestFrame({ immediate: true })).toBe(true);
+    let stats = engine.getFrameSchedulerStats();
+    expect(stats.delayedWakePending).toBe(false);
+    expect(stats.framePending).toBe(true);
+    expect(stats.immediateWakeups).toBe(1);
+
+    expect(nextFrame()).toBe(true);
+    stats = engine.getFrameSchedulerStats();
+    expect(stats.framesExecuted).toBe(2);
+    engine.stop();
+  });
+});
+
+test('active cadence can pull idle wake earlier without repeated events postponing it', () => {
+  withFakeScheduler(({ nextFrame, advance }) => {
+    const { engine } = fakeEngine();
+    lifecycleApi.hardenEngineRuntime(engine);
+    engine.setFrameDelayResolver(() => 1000 / 15);
+    engine.start();
+    nextFrame();
+
+    expect(engine.requestFrame({ immediate: false, delayMs: 1000 / 30 })).toBe(true);
+    let stats = engine.getFrameSchedulerStats();
+    expect(stats.delayedWakeupsPulledForward).toBe(1);
+
+    advance(10);
+    expect(engine.requestFrame({ immediate: false, delayMs: 1000 / 30 })).toBe(false);
+    advance(24);
+    expect(nextFrame()).toBe(true);
+
+    stats = engine.getFrameSchedulerStats();
+    expect(stats.framesExecuted).toBe(2);
+    engine.stop();
+  });
+});
+
+test('stop cancels delayed scheduler wake and prevents stale frames', () => {
+  withFakeScheduler(({ nextFrame, advance }) => {
+    const { engine, counts } = fakeEngine();
+    lifecycleApi.hardenEngineRuntime(engine);
+    engine.setFrameDelayResolver(() => 1000 / 15);
+    engine.start();
+    nextFrame();
+    expect(engine.getFrameSchedulerStats().delayedWakePending).toBe(true);
+
+    engine.stop();
+    expect(engine.getFrameSchedulerStats().delayedWakePending).toBe(false);
+    advance(1000);
+    expect(nextFrame()).toBe(false);
+    expect(counts()).toEqual({ renders: 1, visions: 1 });
+  });
+});


### PR DESCRIPTION
## Performance Phase 1B — Adaptive Frame Scheduler

Este PR elimina el siguiente desperdicio medido del VTT: aunque `performance-guard.js` podía saltar FOV/render redundante, `Engine.loop()` seguía despertando al navegador en cada RAF para preguntar si había trabajo.

Phase 1B conserva las reglas actuales y cambia únicamente **cuándo se despierta el frame runtime**.

## Nuevo modelo

```text
Evento / estado
     │
     ▼
Performance Guard
     │
     ├─ tokenMotion ─────────► ~20 Hz / 50 ms
     ├─ camera/token drag ───► ~30 Hz / 33 ms
     ├─ luz animada ─────────► ~30 Hz / 33 ms
     ├─ cambio idle ─────────► wake inmediato
     └─ idle estable ────────► safety scan ~15 Hz / 66.7 ms
```

No pasamos todavía a un renderer 100% event-only. Se conserva el scan idle de 15 Hz como red de seguridad mientras todavía existen mutaciones legacy que no emiten eventos canónicos.

## `runtime-lifecycle.js`

Añade un scheduler propiedad del lifecycle:

- `engine.setFrameDelayResolver(resolver)`
- `engine.requestFrame(options)`
- `engine.getFrameSchedulerStats()`
- wake inmediato puede cancelar un timer idle retrasado
- una cadencia activa puede adelantar un wake idle
- eventos activos repetidos no posponen un frame que ya estaba programado antes
- `stop()` cancela RAF, timer retrasado y pointer RAF
- `destroy()` elimina el resolver

Métricas:

- `framesScheduled`
- `framesExecuted`
- `delayedFramesScheduled`
- `immediateWakeups`
- `delayedWakeupsPulledForward`

## `performance-guard.js`

El guard sigue siendo la única autoridad de throttling/caché visual.

Ahora además:

- considera `camera.isDragging` como actividad visual;
- expone `nextFrameDelayMs()`;
- despierta el scheduler al invalidar;
- conserva los checks existentes como safety net;
- publica métricas del scheduler dentro de `snapshot()`;
- al detenerse libera el frame resolver.

## Tests

Nuevo `tests/vtt_runtime_frame_scheduler.spec.js`:

- idle usa wake retrasado en vez de encadenar RAF continuamente;
- invalidación idle adelanta el wake inmediatamente;
- una actividad de 30 Hz adelanta un timer idle;
- eventos repetidos no aplazan el frame activo;
- `stop()` cancela timers y frames obsoletos.

`tests/vtt_performance_guard.spec.js` también valida:

- 15 Hz idle;
- 30 Hz camera drag;
- 20 Hz tokenMotion;
- wake inmediato en cambio idle;
- exposición de métricas del scheduler.

## No cambia

- FOV rules
- Dynamic Lighting/Fog semantics
- movement/pathfinding
- renderer visual
- Firebase
- saves
- Theatre
- mapa persistente
- Pixi/ECS/GOAP

## Dependencia

Este PR está basado temporalmente sobre `hotfix/restore-tracked-regression-tests` (#711) para mantener un diff limpio y poder ejecutar la red de tests restaurada. Una vez #711 entre a `main`, este PR puede retargetearse a `main` sin cambiar su contenido funcional.