### PR TITLE
perf(vtt): route visual invalidation through canonical scene dirty events

### DIFF
--- a/.github/workflows/vtt-performance-guard.yml
+++ b/.github/workflows/vtt-performance-guard.yml
@@ -4,11 +4,14 @@ on:
   pull_request:
     paths:
       - 'vtt.html'
+      - 'js/vtt/camera.js'
+      - 'js/vtt/scene-dirty.js'
       - 'js/vtt/runtime-lifecycle.js'
       - 'js/vtt/performance-guard.js'
       - 'js/vtt/lighting-engine.js'
       - 'js/vtt/lighting-defaults-patch.js'
       - 'js/vtt/pov-engine.js'
+      - 'tests/vtt_scene_dirty.spec.js'
       - 'tests/vtt_runtime_performance_phase1.spec.js'
       - 'tests/vtt_runtime_frame_scheduler.spec.js'
       - 'tests/vtt_performance_guard.spec.js'
@@ -32,10 +35,15 @@ jobs:
       - run: npm ci
       - name: Syntax
         run: |
+          node --check js/vtt/scene-dirty.js
+          node --input-type=module --check < js/vtt/camera.js
           node --check js/vtt/runtime-lifecycle.js
           node --input-type=module --check < js/vtt/performance-guard.js
+          node --check tests/vtt_scene_dirty.spec.js
           node --check tests/vtt_runtime_performance_phase1.spec.js
           node --check tests/vtt_runtime_frame_scheduler.spec.js
+      - name: Canonical scene dirty contracts
+        run: npx playwright test --workers=1 tests/vtt_scene_dirty.spec.js
       - name: Frame-coalesced input and adaptive scheduler contracts
         run: >-
           npx playwright test --workers=1

--- a/.github/workflows/vtt-performance-guard.yml
+++ b/.github/workflows/vtt-performance-guard.yml
@@ -16,6 +16,7 @@ on:
       - 'js/vtt/pov-engine.js'
       - 'js/vtt/pov-state.js'
       - 'tests/vtt_scene_dirty.spec.js'
+      - 'tests/vtt_scene_dirty_bridges.spec.js'
       - 'tests/vtt_runtime_performance_phase1.spec.js'
       - 'tests/vtt_runtime_frame_scheduler.spec.js'
       - 'tests/vtt_performance_guard.spec.js'
@@ -45,10 +46,14 @@ jobs:
           node --check js/vtt/runtime-lifecycle.js
           node --input-type=module --check < js/vtt/performance-guard.js
           node --check tests/vtt_scene_dirty.spec.js
+          node --check tests/vtt_scene_dirty_bridges.spec.js
           node --check tests/vtt_runtime_performance_phase1.spec.js
           node --check tests/vtt_runtime_frame_scheduler.spec.js
       - name: Canonical scene dirty contracts
-        run: npx playwright test --workers=1 tests/vtt_scene_dirty.spec.js
+        run: >-
+          npx playwright test --workers=1
+          tests/vtt_scene_dirty.spec.js
+          tests/vtt_scene_dirty_bridges.spec.js
       - name: Frame-coalesced input and adaptive scheduler contracts
         run: >-
           npx playwright test --workers=1

--- a/.github/workflows/vtt-performance-guard.yml
+++ b/.github/workflows/vtt-performance-guard.yml
@@ -6,11 +6,15 @@ on:
       - 'vtt.html'
       - 'js/vtt/camera.js'
       - 'js/vtt/scene-dirty.js'
+      - 'js/vtt/scene-dirty-lighting-patch.js'
       - 'js/vtt/runtime-lifecycle.js'
       - 'js/vtt/performance-guard.js'
       - 'js/vtt/lighting-engine.js'
       - 'js/vtt/lighting-defaults-patch.js'
+      - 'js/vtt/lighting-state.js'
+      - 'js/vtt/environment-light-bridge.js'
       - 'js/vtt/pov-engine.js'
+      - 'js/vtt/pov-state.js'
       - 'tests/vtt_scene_dirty.spec.js'
       - 'tests/vtt_runtime_performance_phase1.spec.js'
       - 'tests/vtt_runtime_frame_scheduler.spec.js'
@@ -36,6 +40,7 @@ jobs:
       - name: Syntax
         run: |
           node --check js/vtt/scene-dirty.js
+          node --input-type=module --check < js/vtt/scene-dirty-lighting-patch.js
           node --input-type=module --check < js/vtt/camera.js
           node --check js/vtt/runtime-lifecycle.js
           node --input-type=module --check < js/vtt/performance-guard.js

--- a/.github/workflows/vtt-performance-guard.yml
+++ b/.github/workflows/vtt-performance-guard.yml
@@ -7,6 +7,7 @@ on:
       - 'js/vtt/camera.js'
       - 'js/vtt/scene-dirty.js'
       - 'js/vtt/scene-dirty-lighting-patch.js'
+      - 'js/vtt/scene-dirty-memory-patch.js'
       - 'js/vtt/runtime-lifecycle.js'
       - 'js/vtt/performance-guard.js'
       - 'js/vtt/lighting-engine.js'
@@ -15,6 +16,7 @@ on:
       - 'js/vtt/environment-light-bridge.js'
       - 'js/vtt/pov-engine.js'
       - 'js/vtt/pov-state.js'
+      - 'js/vtt/memory-state.js'
       - 'tests/vtt_scene_dirty.spec.js'
       - 'tests/vtt_scene_dirty_bridges.spec.js'
       - 'tests/vtt_runtime_performance_phase1.spec.js'
@@ -42,6 +44,7 @@ jobs:
         run: |
           node --check js/vtt/scene-dirty.js
           node --input-type=module --check < js/vtt/scene-dirty-lighting-patch.js
+          node --input-type=module --check < js/vtt/scene-dirty-memory-patch.js
           node --input-type=module --check < js/vtt/camera.js
           node --check js/vtt/runtime-lifecycle.js
           node --input-type=module --check < js/vtt/performance-guard.js

--- a/js/vtt/camera.js
+++ b/js/vtt/camera.js
@@ -50,6 +50,17 @@ export class Camera {
         this.isDragging = false;
     }
 
+    notifyVisualChange(kind, active = false, meta = null) {
+        globalThis.LuminousVttSceneDirty?.emit?.(this.canvas, {
+            reason: 'camera',
+            render: true,
+            vision: false,
+            active: Boolean(active),
+            sourceEvent: `camera:${String(kind || 'change')}`,
+            meta: meta && typeof meta === 'object' ? meta : null,
+        });
+    }
+
     setDragGuard(guard) {
         this.dragGuard = typeof guard === 'function' ? guard : null;
     }
@@ -60,17 +71,19 @@ export class Camera {
 
     setCenterConstraint(constraint) {
         this.centerConstraint = typeof constraint === 'function' ? constraint : null;
-        this.enforceCenterConstraint();
+        if (this.enforceCenterConstraint()) this.notifyVisualChange('constraint');
     }
 
     setZoomBounds(minZoom = 0.1, maxZoom = 5) {
         const min = Number.isFinite(Number(minZoom)) ? Math.max(0.01, Number(minZoom)) : 0.1;
         const max = Number.isFinite(Number(maxZoom)) ? Math.max(min, Number(maxZoom)) : Math.max(min, 5);
         const center = this.centerWorldPoint();
+        const previousZoom = this.zoom;
         this.minZoom = min;
         this.maxZoom = max;
         this.zoom = Math.max(this.minZoom, Math.min(this.maxZoom, this.zoom));
         this.centerOnWorldPoint(center);
+        if (Math.abs(this.zoom - previousZoom) > 1e-12) this.notifyVisualChange('zoom-bounds');
         return { minZoom: this.minZoom, maxZoom: this.maxZoom, zoom: this.zoom };
     }
 
@@ -146,7 +159,9 @@ export class Camera {
 
         this.lastMouseX = e.clientX;
         this.lastMouseY = e.clientY;
-        this.manualPanListener?.({ dx, dy, x: this.x, y: this.y, zoom: this.zoom, clamped, center: this.centerWorldPoint() });
+        const detail = { dx, dy, x: this.x, y: this.y, zoom: this.zoom, clamped, center: this.centerWorldPoint() };
+        this.manualPanListener?.(detail);
+        this.notifyVisualChange('pan', true, detail);
     }
 
     onMouseUp() {
@@ -170,14 +185,20 @@ export class Camera {
 
         this.x = (mouseX / this.zoom) - worldX;
         this.y = (mouseY / this.zoom) - worldY;
-        this.enforceCenterConstraint();
+        const clamped = this.enforceCenterConstraint();
+        this.notifyVisualChange('zoom', true, { previousZoom, zoom: this.zoom, clamped });
     }
 
     centerOnWorldPoint(point = {}) {
         const constrained = this.constrainedCenter(point);
         if (!constrained) return false;
+        const previousX = this.x;
+        const previousY = this.y;
         this.x = (this.canvas.width / (2 * this.zoom)) - constrained.x;
         this.y = (this.canvas.height / (2 * this.zoom)) - constrained.y;
+        if (Math.abs(this.x - previousX) > 1e-7 || Math.abs(this.y - previousY) > 1e-7) {
+            this.notifyVisualChange('center', false, { center: constrained, zoom: this.zoom });
+        }
         return true;
     }
 

--- a/js/vtt/performance-guard.js
+++ b/js/vtt/performance-guard.js
@@ -60,8 +60,8 @@ function activeFrameInterval(engine, activeFrameMs = DEFAULT_ACTIVE_FRAME_MS, mo
   return Math.max(1, Number(activeFrameMs) || DEFAULT_ACTIVE_FRAME_MS);
 }
 
-// Slow compatibility fallback for legacy mutations that do not yet emit a canonical VTT event.
-// The normal render path never builds this signature.
+// Slow compatibility fallback for legacy mutations that do not yet emit vtt:scene-dirty.
+// The normal dirty path never builds this signature.
 export function legacyVisualSignature({ engine = {}, mapData = {} } = {}) {
   const scene = mapData.lighting?.scene || {};
   const camera = engine.camera || {};
@@ -131,6 +131,8 @@ export function installPerformanceGuard({
   const mapData = engine?.mapData;
   if (!engine || !renderer || !mapData || renderer.__performanceGuardInstalled) return null;
 
+  const sceneDirtyApi = globalThis.LuminousVttSceneDirty || null;
+  const sceneDirtyEvent = sceneDirtyApi?.EVENT_NAME || 'vtt:scene-dirty';
   const originalRender = renderer.render.bind(renderer);
   const originalCalculateVision = typeof engine.calculateVision === 'function' ? engine.calculateVision.bind(engine) : null;
   const idleInterval = Math.max(
@@ -149,12 +151,16 @@ export function installPerformanceGuard({
     visionSkipped: 0,
     dmVisionBypassed: 0,
     explicitInvalidations: 0,
+    canonicalInvalidations: 0,
+    renderOnlyInvalidations: 0,
+    visionInvalidations: 0,
     idleCleanSkips: 0,
     fallbackScans: 0,
     fallbackChanges: 0,
     fallbackDurationMs: 0,
     maxFallbackDurationMs: 0,
   };
+  const dirtyByReason = Object.create(null);
 
   let lastRenderAt = -Infinity;
   let lastFallbackScanAt = -Infinity;
@@ -184,42 +190,38 @@ export function installPerformanceGuard({
     return idleInterval;
   };
 
-  const wakeFrame = () => {
-    const active = visualAnimationActive(engine, mapData, Date.now());
+  const wakeFrame = (activeHint = false) => {
+    const active = Boolean(activeHint) || visualAnimationActive(engine, mapData, Date.now());
     engine.requestFrame?.({
       immediate: !active,
       delayMs: active ? activeFrameInterval(engine, activeFrameMs, movementFrameMs) : 0,
     });
   };
 
-  const invalidate = () => {
-    renderDirty = true;
-    visionDirty = true;
+  const markDirty = (detail = {}, { canonical = false } = {}) => {
+    const reason = clean(detail.reason) || 'unknown';
+    const render = detail.render !== false;
+    const vision = detail.vision === true;
+    if (render) renderDirty = true;
+    if (vision) visionDirty = true;
     metrics.explicitInvalidations += 1;
-    wakeFrame();
+    if (canonical) metrics.canonicalInvalidations += 1;
+    if (vision) metrics.visionInvalidations += 1;
+    else if (render) metrics.renderOnlyInvalidations += 1;
+    dirtyByReason[reason] = (dirtyByReason[reason] || 0) + 1;
+    wakeFrame(detail.active === true);
   };
 
-  const interactionInvalidate = () => {
-    if (engine.tokenDrag || engine.tokenMotion || engine.camera?.isDragging || mapData.dmEditMode?.active) invalidate();
-  };
+  const handleSceneDirty = (event) => markDirty(event?.detail || {}, { canonical: true });
+  const invalidate = (detail = {}) => markDirty({
+    reason: detail.reason || 'manual',
+    render: detail.render !== false,
+    vision: detail.vision !== false,
+    active: detail.active === true,
+  });
 
-  const events = [
-    'vtt:token-preview-moved',
-    'vtt:token-moved',
-    'vtt:token-z-transition',
-    'vtt:canonical-tokens-synced',
-    'vtt:camera-follow-changed',
-    'vtt:dm-observer-changed',
-    'vtt:procedural-chunk-loaded',
-    'vtt:procedural-chunk-transition',
-    'vtt:memory-learn',
-  ];
-  events.forEach((name) => engine.canvas?.addEventListener?.(name, invalidate));
-  globalThis.addEventListener?.('resize', invalidate);
-  globalThis.addEventListener?.('wheel', invalidate, { passive: true });
-  globalThis.addEventListener?.('keydown', invalidate);
-  globalThis.addEventListener?.('keyup', invalidate);
-  globalThis.addEventListener?.('mousemove', interactionInvalidate, { passive: true });
+  engine.canvas?.addEventListener?.(sceneDirtyEvent, handleSceneDirty);
+  const legacyBridge = sceneDirtyApi?.installLegacyBridge?.({ canvas: engine.canvas, mapData, host: globalThis }) || null;
   engine.setFrameDelayResolver?.(nextFrameDelayMs);
 
   if (originalCalculateVision) {
@@ -264,8 +266,6 @@ export function installPerformanceGuard({
     const active = visualAnimationActive(engine, mapData, wallNow);
     const activeInterval = activeFrameInterval(engine, activeFrameMs, movementFrameMs);
 
-    // Active visuals remain cadence-limited. Idle visuals are event-driven; the slow fallback
-    // only protects legacy mutations that still bypass canonical VTT events.
     if (active && (perfNow - lastRenderAt) < activeInterval) {
       metrics.throttled += 1;
       return;
@@ -290,7 +290,7 @@ export function installPerformanceGuard({
       metrics.fallbackChanges += 1;
       renderDirty = true;
       visionDirty = true;
-      wakeFrame();
+      wakeFrame(false);
       metrics.skipped += 1;
       return;
     }
@@ -311,6 +311,7 @@ export function installPerformanceGuard({
     nextFrameDelayMs,
     snapshot: () => ({
       ...metrics,
+      dirtyByReason: { ...dirtyByReason },
       savedFrames: metrics.skipped + metrics.throttled,
       visionSaved: metrics.visionSkipped + metrics.dmVisionBypassed,
       activeFrameMs: Math.max(1, Number(activeFrameMs) || DEFAULT_ACTIVE_FRAME_MS),
@@ -326,6 +327,7 @@ export function installPerformanceGuard({
       scheduler: typeof engine.getFrameSchedulerStats === 'function'
         ? engine.getFrameSchedulerStats()
         : null,
+      sceneDirtyBridge: legacyBridge?.snapshot?.() || null,
     }),
     resetMetrics() {
       metrics.calls = 0;
@@ -338,11 +340,15 @@ export function installPerformanceGuard({
       metrics.visionSkipped = 0;
       metrics.dmVisionBypassed = 0;
       metrics.explicitInvalidations = 0;
+      metrics.canonicalInvalidations = 0;
+      metrics.renderOnlyInvalidations = 0;
+      metrics.visionInvalidations = 0;
       metrics.idleCleanSkips = 0;
       metrics.fallbackScans = 0;
       metrics.fallbackChanges = 0;
       metrics.fallbackDurationMs = 0;
       metrics.maxFallbackDurationMs = 0;
+      Object.keys(dirtyByReason).forEach((key) => { delete dirtyByReason[key]; });
     },
     stop() {
       if (stopped) return;
@@ -351,12 +357,8 @@ export function installPerformanceGuard({
       renderer.__performanceGuardInstalled = false;
       if (originalCalculateVision) engine.calculateVision = originalCalculateVision;
       engine.setFrameDelayResolver?.(null);
-      events.forEach((name) => engine.canvas?.removeEventListener?.(name, invalidate));
-      globalThis.removeEventListener?.('resize', invalidate);
-      globalThis.removeEventListener?.('wheel', invalidate);
-      globalThis.removeEventListener?.('keydown', invalidate);
-      globalThis.removeEventListener?.('keyup', invalidate);
-      globalThis.removeEventListener?.('mousemove', interactionInvalidate);
+      engine.canvas?.removeEventListener?.(sceneDirtyEvent, handleSceneDirty);
+      legacyBridge?.stop?.();
     },
   });
 

--- a/js/vtt/scene-dirty-lighting-patch.js
+++ b/js/vtt/scene-dirty-lighting-patch.js
@@ -1,0 +1,41 @@
+import './lighting-state.js';
+import './environment-light-bridge.js';
+import './pov-state.js';
+
+const dirty = globalThis.LuminousVttSceneDirty;
+
+function wrapBridge(apiName, callbackName = 'onChanged', detail = {}) {
+  const current = globalThis[apiName];
+  if (!dirty || !current?.createBridge || current.__sceneDirtyWrapped) return false;
+  const originalCreateBridge = current.createBridge;
+  globalThis[apiName] = Object.freeze({
+    ...current,
+    __sceneDirtyWrapped: true,
+    createBridge(options = {}) {
+      const originalCallback = options?.[callbackName];
+      return originalCreateBridge({
+        ...options,
+        [callbackName](...args) {
+          if (typeof originalCallback === 'function') originalCallback(...args);
+          const canvas = globalThis.document?.getElementById?.('vtt-canvas') || globalThis.LuminousVttRuntime?.engine?.canvas;
+          dirty.emit(canvas, {
+            ...detail,
+            sourceEvent: `${apiName}:${callbackName}`,
+            meta: args[0] && typeof args[0] === 'object' ? args[0] : null,
+          });
+        },
+      });
+    },
+  });
+  return true;
+}
+
+wrapBridge('LuminousVttLightingState', 'onChanged', {
+  reason: 'lighting', render: true, vision: true,
+});
+wrapBridge('LuminousVttEnvironmentLightBridge', 'onChanged', {
+  reason: 'lighting', render: true, vision: true,
+});
+wrapBridge('LuminousVttPovState', 'onChanged', {
+  reason: 'lighting', render: true, vision: true,
+});

--- a/js/vtt/scene-dirty-memory-patch.js
+++ b/js/vtt/scene-dirty-memory-patch.js
@@ -1,0 +1,29 @@
+import './memory-state.js';
+
+const dirty = globalThis.LuminousVttSceneDirty;
+const current = globalThis.LuminousVttMemoryState;
+
+if (dirty && current?.createBridge && !current.__sceneDirtyWrapped) {
+  const originalCreateBridge = current.createBridge;
+  globalThis.LuminousVttMemoryState = Object.freeze({
+    ...current,
+    __sceneDirtyWrapped: true,
+    createBridge(options = {}) {
+      const originalCallback = options?.onChanged;
+      return originalCreateBridge({
+        ...options,
+        onChanged(...args) {
+          if (typeof originalCallback === 'function') originalCallback(...args);
+          const canvas = globalThis.document?.getElementById?.('vtt-canvas') || globalThis.LuminousVttRuntime?.engine?.canvas;
+          dirty.emit(canvas, {
+            reason: 'fog',
+            render: true,
+            vision: false,
+            sourceEvent: 'LuminousVttMemoryState:onChanged',
+            meta: args[0] && typeof args[0] === 'object' ? args[0] : null,
+          });
+        },
+      });
+    },
+  });
+}

--- a/js/vtt/scene-dirty.js
+++ b/js/vtt/scene-dirty.js
@@ -1,0 +1,58 @@
+export const SCENE_DIRTY_EVENT = 'vtt:scene-dirty';
+
+export const SCENE_DIRTY_REASONS = Object.freeze({
+  TOKEN: 'token',
+  CAMERA: 'camera',
+  TOPOLOGY: 'topology',
+  LIGHTING: 'lighting',
+  FOG: 'fog',
+  CHUNK: 'chunk',
+  EDIT: 'edit',
+  RESIZE: 'resize',
+  MEMORY: 'memory',
+  UNKNOWN: 'unknown',
+});
+
+export function normalizeSceneDirty(detail = {}) {
+  const source = detail && typeof detail === 'object' ? detail : {};
+  return Object.freeze({
+    reason: String(source.reason || SCENE_DIRTY_REASONS.UNKNOWN),
+    render: source.render !== false,
+    vision: source.vision === true,
+    active: source.active === true,
+    sourceEvent: source.sourceEvent ? String(source.sourceEvent) : null,
+    tokenId: source.tokenId == null ? null : String(source.tokenId),
+    meta: source.meta && typeof source.meta === 'object' ? source.meta : null,
+  });
+}
+
+export function emitSceneDirty(target, detail = {}) {
+  if (!target?.dispatchEvent) return false;
+  const EventCtor = globalThis.CustomEvent;
+  if (typeof EventCtor !== 'function') return false;
+  target.dispatchEvent(new EventCtor(SCENE_DIRTY_EVENT, { detail: normalizeSceneDirty(detail) }));
+  return true;
+}
+
+export function bridgeSceneDirty(target, sourceEvent, detail = {}) {
+  const eventName = String(sourceEvent || '').trim();
+  if (!eventName || !target?.addEventListener) return () => {};
+  const handler = (event) => emitSceneDirty(target, {
+    ...detail,
+    sourceEvent: eventName,
+    tokenId: event?.detail?.tokenId ?? detail.tokenId,
+    meta: event?.detail || detail.meta || null,
+  });
+  target.addEventListener(eventName, handler);
+  return () => target.removeEventListener?.(eventName, handler);
+}
+
+const api = Object.freeze({
+  EVENT_NAME: SCENE_DIRTY_EVENT,
+  REASONS: SCENE_DIRTY_REASONS,
+  normalize: normalizeSceneDirty,
+  emit: emitSceneDirty,
+  bridge: bridgeSceneDirty,
+});
+
+if (typeof globalThis !== 'undefined') globalThis.LuminousVttSceneDirty = api;

--- a/js/vtt/scene-dirty.js
+++ b/js/vtt/scene-dirty.js
@@ -1,58 +1,142 @@
-export const SCENE_DIRTY_EVENT = 'vtt:scene-dirty';
+(function (root, factory) {
+  'use strict';
+  const api = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.LuminousVttSceneDirty = api;
+})(typeof window !== 'undefined' ? window : globalThis, function (root) {
+  'use strict';
 
-export const SCENE_DIRTY_REASONS = Object.freeze({
-  TOKEN: 'token',
-  CAMERA: 'camera',
-  TOPOLOGY: 'topology',
-  LIGHTING: 'lighting',
-  FOG: 'fog',
-  CHUNK: 'chunk',
-  EDIT: 'edit',
-  RESIZE: 'resize',
-  MEMORY: 'memory',
-  UNKNOWN: 'unknown',
-});
-
-export function normalizeSceneDirty(detail = {}) {
-  const source = detail && typeof detail === 'object' ? detail : {};
-  return Object.freeze({
-    reason: String(source.reason || SCENE_DIRTY_REASONS.UNKNOWN),
-    render: source.render !== false,
-    vision: source.vision === true,
-    active: source.active === true,
-    sourceEvent: source.sourceEvent ? String(source.sourceEvent) : null,
-    tokenId: source.tokenId == null ? null : String(source.tokenId),
-    meta: source.meta && typeof source.meta === 'object' ? source.meta : null,
+  const EVENT_NAME = 'vtt:scene-dirty';
+  const REASONS = Object.freeze({
+    TOKEN: 'token',
+    CAMERA: 'camera',
+    TOPOLOGY: 'topology',
+    LIGHTING: 'lighting',
+    FOG: 'fog',
+    CHUNK: 'chunk',
+    EDIT: 'edit',
+    RESIZE: 'resize',
+    MEMORY: 'memory',
+    UNKNOWN: 'unknown',
   });
-}
 
-export function emitSceneDirty(target, detail = {}) {
-  if (!target?.dispatchEvent) return false;
-  const EventCtor = globalThis.CustomEvent;
-  if (typeof EventCtor !== 'function') return false;
-  target.dispatchEvent(new EventCtor(SCENE_DIRTY_EVENT, { detail: normalizeSceneDirty(detail) }));
-  return true;
-}
+  function normalize(detail = {}) {
+    const source = detail && typeof detail === 'object' ? detail : {};
+    return Object.freeze({
+      reason: String(source.reason || REASONS.UNKNOWN),
+      render: source.render !== false,
+      vision: source.vision === true,
+      active: source.active === true,
+      sourceEvent: source.sourceEvent ? String(source.sourceEvent) : null,
+      tokenId: source.tokenId == null ? null : String(source.tokenId),
+      meta: source.meta && typeof source.meta === 'object' ? source.meta : null,
+    });
+  }
 
-export function bridgeSceneDirty(target, sourceEvent, detail = {}) {
-  const eventName = String(sourceEvent || '').trim();
-  if (!eventName || !target?.addEventListener) return () => {};
-  const handler = (event) => emitSceneDirty(target, {
-    ...detail,
-    sourceEvent: eventName,
-    tokenId: event?.detail?.tokenId ?? detail.tokenId,
-    meta: event?.detail || detail.meta || null,
-  });
-  target.addEventListener(eventName, handler);
-  return () => target.removeEventListener?.(eventName, handler);
-}
+  function eventCtorFor(target) {
+    return target?.ownerDocument?.defaultView?.CustomEvent || root?.CustomEvent || globalThis.CustomEvent;
+  }
 
-const api = Object.freeze({
-  EVENT_NAME: SCENE_DIRTY_EVENT,
-  REASONS: SCENE_DIRTY_REASONS,
-  normalize: normalizeSceneDirty,
-  emit: emitSceneDirty,
-  bridge: bridgeSceneDirty,
+  function emit(target, detail = {}) {
+    if (!target?.dispatchEvent) return false;
+    const EventCtor = eventCtorFor(target);
+    if (typeof EventCtor !== 'function') return false;
+    target.dispatchEvent(new EventCtor(EVENT_NAME, { detail: normalize(detail) }));
+    return true;
+  }
+
+  function bridge(target, sourceEvent, detail = {}) {
+    const eventName = String(sourceEvent || '').trim();
+    if (!eventName || !target?.addEventListener) return () => {};
+    const handler = (event) => emit(target, {
+      ...detail,
+      sourceEvent: eventName,
+      tokenId: event?.detail?.tokenId ?? detail.tokenId,
+      meta: event?.detail || detail.meta || null,
+    });
+    target.addEventListener(eventName, handler);
+    return () => target.removeEventListener?.(eventName, handler);
+  }
+
+  const LEGACY_EVENT_MAP = Object.freeze([
+    ['vtt:token-preview-moved', REASONS.TOKEN, true, true],
+    ['vtt:movement-destination-preview', REASONS.TOKEN, false, true],
+    ['vtt:token-moved', REASONS.TOKEN, true, false],
+    ['vtt:token-z-transition', REASONS.TOKEN, true, false],
+    ['vtt:canonical-tokens-synced', REASONS.TOKEN, true, false],
+    ['vtt:movement-interaction', REASONS.TOPOLOGY, true, false],
+    ['vtt:camera-follow-changed', REASONS.CAMERA, false, false],
+    ['vtt:dm-observer-changed', REASONS.CAMERA, true, false],
+    ['vtt:procedural-chunk-loaded', REASONS.CHUNK, true, false],
+    ['vtt:procedural-chunk-transition', REASONS.CHUNK, true, false],
+    ['vtt:memory-learn', REASONS.MEMORY, false, false],
+    ['vtt:lighting-changed', REASONS.LIGHTING, true, false],
+    ['vtt:fog-changed', REASONS.FOG, false, false],
+    ['vtt:pov-changed', REASONS.LIGHTING, true, false],
+    ['vtt:topology-changed', REASONS.TOPOLOGY, true, false],
+    ['vtt:vertical-portals-changed', REASONS.TOPOLOGY, true, false],
+    ['vtt:dm-edit-changed', REASONS.EDIT, true, false],
+  ]);
+
+  function installLegacyBridge({ canvas, mapData, host = root } = {}) {
+    if (!canvas?.addEventListener) return Object.freeze({ stop() {}, snapshot: () => ({ bridgedEvents: 0 }) });
+    const stops = [];
+    const metrics = { bridgedEvents: 0, resizeInvalidations: 0, editPointerInvalidations: 0 };
+
+    LEGACY_EVENT_MAP.forEach(([eventName, reason, vision, active]) => {
+      const handler = (event) => {
+        metrics.bridgedEvents += 1;
+        emit(canvas, {
+          reason,
+          render: true,
+          vision,
+          active,
+          sourceEvent: eventName,
+          tokenId: event?.detail?.tokenId,
+          meta: event?.detail || null,
+        });
+      };
+      canvas.addEventListener(eventName, handler);
+      stops.push(() => canvas.removeEventListener?.(eventName, handler));
+    });
+
+    const onResize = () => {
+      metrics.resizeInvalidations += 1;
+      emit(canvas, { reason: REASONS.RESIZE, render: true, vision: false, sourceEvent: 'resize' });
+    };
+    host?.addEventListener?.('resize', onResize);
+    stops.push(() => host?.removeEventListener?.('resize', onResize));
+
+    // Temporary authoring bridge. The guard no longer observes raw pointer input.
+    // Remove this when every DM editor emits vtt:scene-dirty directly.
+    const onEditPointerMove = () => {
+      if (!mapData?.dmEditMode?.active) return;
+      metrics.editPointerInvalidations += 1;
+      emit(canvas, { reason: REASONS.EDIT, render: true, vision: false, active: true, sourceEvent: 'mousemove' });
+    };
+    const onEditPointerUp = () => {
+      if (!mapData?.dmEditMode?.active) return;
+      metrics.editPointerInvalidations += 1;
+      emit(canvas, { reason: REASONS.EDIT, render: true, vision: true, sourceEvent: 'mouseup' });
+    };
+    host?.addEventListener?.('mousemove', onEditPointerMove, { passive: true });
+    host?.addEventListener?.('mouseup', onEditPointerUp, { passive: true });
+    stops.push(() => host?.removeEventListener?.('mousemove', onEditPointerMove));
+    stops.push(() => host?.removeEventListener?.('mouseup', onEditPointerUp));
+
+    let stopped = false;
+    return Object.freeze({
+      stop() {
+        if (stopped) return false;
+        stopped = true;
+        while (stops.length) {
+          try { stops.pop()?.(); } catch (_) {}
+        }
+        return true;
+      },
+      snapshot: () => Object.freeze({ ...metrics }),
+    });
+  }
+
+  return Object.freeze({ EVENT_NAME, REASONS, LEGACY_EVENT_MAP, normalize, emit, bridge, installLegacyBridge });
 });
-
-if (typeof globalThis !== 'undefined') globalThis.LuminousVttSceneDirty = api;

--- a/js/vtt/scene-dirty.js
+++ b/js/vtt/scene-dirty.js
@@ -61,6 +61,36 @@
     return () => target.removeEventListener?.(eventName, handler);
   }
 
+  function canvasFor(host = root) {
+    return host?.document?.getElementById?.('vtt-canvas') || null;
+  }
+
+  function wrapStateBridgeApi(apiName, callbackName, detail = {}) {
+    const current = root?.[apiName];
+    if (!current?.createBridge || current.__sceneDirtyWrapped) return false;
+    const originalCreateBridge = current.createBridge;
+    const wrapped = {
+      ...current,
+      __sceneDirtyWrapped: true,
+      createBridge(options = {}) {
+        const originalCallback = options?.[callbackName];
+        return originalCreateBridge({
+          ...options,
+          [callbackName](...args) {
+            if (typeof originalCallback === 'function') originalCallback(...args);
+            emit(canvasFor(root), {
+              ...detail,
+              sourceEvent: `${apiName}:${callbackName}`,
+              meta: args[0] && typeof args[0] === 'object' ? args[0] : null,
+            });
+          },
+        });
+      },
+    };
+    root[apiName] = Object.freeze(wrapped);
+    return true;
+  }
+
   const LEGACY_EVENT_MAP = Object.freeze([
     ['vtt:token-preview-moved', REASONS.TOKEN, true, true],
     ['vtt:movement-destination-preview', REASONS.TOKEN, false, true],
@@ -76,8 +106,6 @@
     ['vtt:lighting-changed', REASONS.LIGHTING, true, false],
     ['vtt:fog-changed', REASONS.FOG, false, false],
     ['vtt:pov-changed', REASONS.LIGHTING, true, false],
-    ['vtt:topology-changed', REASONS.TOPOLOGY, true, false],
-    ['vtt:vertical-portals-changed', REASONS.TOPOLOGY, true, false],
     ['vtt:dm-edit-changed', REASONS.EDIT, true, false],
   ]);
 
@@ -141,5 +169,22 @@
     });
   }
 
-  return Object.freeze({ EVENT_NAME, REASONS, LEGACY_EVENT_MAP, normalize, emit, bridge, installLegacyBridge });
+  wrapStateBridgeApi('LuminousVttStateBridge', 'onTopologyChanged', {
+    reason: REASONS.TOPOLOGY, render: true, vision: true,
+  });
+  wrapStateBridgeApi('LuminousVttVerticalPortalState', 'onChanged', {
+    reason: REASONS.TOPOLOGY, render: true, vision: true,
+  });
+
+  return Object.freeze({
+    EVENT_NAME,
+    REASONS,
+    LEGACY_EVENT_MAP,
+    normalize,
+    emit,
+    bridge,
+    canvasFor,
+    wrapStateBridgeApi,
+    installLegacyBridge,
+  });
 });

--- a/js/vtt/scene-dirty.js
+++ b/js/vtt/scene-dirty.js
@@ -39,9 +39,12 @@
 
   function emit(target, detail = {}) {
     if (!target?.dispatchEvent) return false;
+    const normalized = normalize(detail);
     const EventCtor = eventCtorFor(target);
-    if (typeof EventCtor !== 'function') return false;
-    target.dispatchEvent(new EventCtor(EVENT_NAME, { detail: normalize(detail) }));
+    const event = typeof EventCtor === 'function'
+      ? new EventCtor(EVENT_NAME, { detail: normalized })
+      : { type: EVENT_NAME, detail: normalized };
+    target.dispatchEvent(event);
     return true;
   }
 

--- a/tests/vtt_performance_guard.spec.js
+++ b/tests/vtt_performance_guard.spec.js
@@ -6,8 +6,10 @@ const { pathToFileURL } = require('node:url');
 const { execFileSync } = require('node:child_process');
 
 const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+const sceneDirty = require('../js/vtt/scene-dirty.js');
 
 async function loadGuard() {
+  global.LuminousVttSceneDirty = sceneDirty;
   const tmp = path.join(os.tmpdir(), `luminous-vtt-performance-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.mjs`);
   fs.writeFileSync(tmp, read('js/vtt/performance-guard.js'));
   const mod = await import(`${pathToFileURL(tmp).href}?t=${Date.now()}`);
@@ -16,7 +18,7 @@ async function loadGuard() {
 
 function canvasStub() {
   const listeners = new Map();
-  return {
+  const canvas = {
     width: 1920,
     height: 1080,
     listeners,
@@ -25,8 +27,13 @@ function canvasStub() {
       listeners.get(name).add(fn);
     },
     removeEventListener(name, fn) { listeners.get(name)?.delete(fn); },
-    emit(name, detail = {}) { for (const fn of listeners.get(name) || []) fn({ type: name, detail }); },
+    dispatchEvent(event) {
+      for (const fn of listeners.get(event?.type) || []) fn(event);
+      return true;
+    },
+    emit(name, detail = {}) { return this.dispatchEvent({ type: name, detail }); },
   };
+  return canvas;
 }
 
 function mapStub() {
@@ -42,368 +49,218 @@ function mapStub() {
 async function withFakeClock(run) {
   const previous = Object.getOwnPropertyDescriptor(global, 'performance');
   let now = 0;
-  Object.defineProperty(global, 'performance', {
-    configurable: true,
-    value: { now: () => now },
-  });
-  try {
-    return await run({ advance(ms) { now += Math.max(0, Number(ms) || 0); }, now: () => now });
-  } finally {
+  Object.defineProperty(global, 'performance', { configurable: true, value: { now: () => now } });
+  try { return await run({ advance(ms) { now += Math.max(0, Number(ms) || 0); }, now: () => now }); }
+  finally {
     if (previous) Object.defineProperty(global, 'performance', previous);
     else delete global.performance;
   }
 }
 
-test('idle VTT uses dirty state: explicit invalidation redraws without scanning the map every wake', async () => {
+test('legacy token event is translated once into canonical dirty state', async () => {
   await withFakeClock(async () => {
     const { mod, tmp } = await loadGuard();
     try {
-      let realRenders = 0;
+      let renders = 0;
       const canvas = canvasStub();
-      const renderer = { render() { realRenders += 1; } };
       const mapData = mapStub();
+      const renderer = { render() { renders += 1; } };
       const engine = { renderer, mapData, canvas, camera: { x: 0, y: 0, zoom: 1 }, activeZ: 0, tokenDrag: null, tokenMotion: null };
       const api = mod.installPerformanceGuard({ runtime: { engine, bridge: { isDm: false } } });
-      expect(api).toBeTruthy();
 
-      for (let i = 0; i < 120; i += 1) renderer.render();
-      expect(realRenders).toBe(1);
-      expect(api.snapshot().rendered).toBe(1);
+      renderer.render();
+      for (let i = 0; i < 40; i += 1) renderer.render();
+      expect(renders).toBe(1);
       expect(api.snapshot().fallbackScans).toBe(1);
-      expect(api.snapshot().skipped).toBe(119);
 
       mapData.tokens[0].x += 70;
       canvas.emit('vtt:token-moved', { tokenId: 'p1' });
       renderer.render();
-      expect(realRenders).toBe(2);
-      expect(api.snapshot().explicitInvalidations).toBeGreaterThanOrEqual(1);
-      expect(api.snapshot().fallbackScans).toBe(1);
-
-      mapData.topology.push({ id: 'door-1', type: 'door', state: 'closed', a: { col: 1, row: 1 }, b: { col: 2, row: 1 } });
-      api.invalidate();
-      renderer.render();
-      expect(realRenders).toBe(3);
-      expect(api.snapshot().fallbackScans).toBe(1);
-      expect(api.snapshot().savedFrames).toBeGreaterThanOrEqual(119);
-
+      const stats = api.snapshot();
+      expect(renders).toBe(2);
+      expect(stats.canonicalInvalidations).toBe(1);
+      expect(stats.visionInvalidations).toBe(1);
+      expect(stats.dirtyByReason.token).toBe(1);
+      expect(stats.sceneDirtyBridge.bridgedEvents).toBe(1);
       api.stop();
-    } finally {
-      fs.unlinkSync(tmp);
-    }
+    } finally { fs.unlinkSync(tmp); }
   });
 });
 
-test('slow fallback detects legacy in-place mutations that bypass canonical VTT events', async () => {
+test('render-only canonical camera dirty redraws without recalculating FOV', async () => {
+  const { mod, tmp } = await loadGuard();
+  try {
+    let renders = 0;
+    let visions = 0;
+    const canvas = canvasStub();
+    const mapData = mapStub();
+    const renderer = { render() { renders += 1; } };
+    const engine = {
+      renderer, mapData, canvas, camera: { x: 0, y: 0, zoom: 1 }, activeZ: 0, tokenDrag: null, tokenMotion: null,
+      calculateVision() { visions += 1; return { generation: visions }; },
+    };
+    const api = mod.installPerformanceGuard({ runtime: { engine, bridge: { isDm: false } } });
+    engine.calculateVision();
+    renderer.render();
+    expect(visions).toBe(1);
+    expect(renders).toBe(1);
+
+    sceneDirty.emit(canvas, { reason: 'camera', render: true, vision: false });
+    engine.calculateVision();
+    renderer.render();
+    expect(visions).toBe(1);
+    expect(renders).toBe(2);
+    expect(api.snapshot().renderOnlyInvalidations).toBe(1);
+
+    sceneDirty.emit(canvas, { reason: 'token', render: true, vision: true, tokenId: 'p1' });
+    engine.calculateVision();
+    renderer.render();
+    expect(visions).toBe(2);
+    expect(renders).toBe(3);
+    expect(api.snapshot().visionInvalidations).toBe(1);
+    api.stop();
+  } finally { fs.unlinkSync(tmp); }
+});
+
+test('slow fallback still detects silent legacy in-place mutations', async () => {
   await withFakeClock(async ({ advance }) => {
     const { mod, tmp } = await loadGuard();
     try {
-      let realRenders = 0;
+      let renders = 0;
       const wakeCalls = [];
       const canvas = canvasStub();
-      const renderer = { render() { realRenders += 1; } };
       const mapData = mapStub();
+      const renderer = { render() { renders += 1; } };
       const engine = {
-        renderer,
-        mapData,
-        canvas,
-        camera: { x: 0, y: 0, zoom: 1 },
-        activeZ: 0,
-        tokenDrag: null,
-        tokenMotion: null,
+        renderer, mapData, canvas, camera: { x: 0, y: 0, zoom: 1 }, activeZ: 0, tokenDrag: null, tokenMotion: null,
         requestFrame(options) { wakeCalls.push(options); return true; },
       };
-      const api = mod.installPerformanceGuard({
-        runtime: { engine, bridge: { isDm: false } },
-        idleFallbackMs: 500,
-      });
-
+      const api = mod.installPerformanceGuard({ runtime: { engine, bridge: { isDm: false } }, idleFallbackMs: 500 });
       renderer.render();
-      expect(realRenders).toBe(1);
-      expect(api.snapshot().fallbackScans).toBe(1);
-
       advance(500);
       renderer.render();
-      expect(api.snapshot().fallbackScans).toBe(2);
-      expect(realRenders).toBe(1);
-
       mapData.topology.push({ id: 'legacy-door', type: 'door', state: 'closed' });
       advance(500);
       renderer.render();
-      expect(api.snapshot().fallbackScans).toBe(3);
       expect(api.snapshot().fallbackChanges).toBe(1);
       expect(wakeCalls.at(-1)).toMatchObject({ immediate: true, delayMs: 0 });
-      expect(realRenders).toBe(1);
-
+      expect(renders).toBe(1);
       renderer.render();
-      expect(realRenders).toBe(2);
-
+      expect(renders).toBe(2);
       api.stop();
-    } finally {
-      fs.unlinkSync(tmp);
-    }
+    } finally { fs.unlinkSync(tmp); }
   });
 });
 
-test('a short confirmed token traversal cannot recalculate FOV and render on every animation frame', async () => {
+test('active token traversal keeps 20 Hz guard budget through canonical bridge', async () => {
   const { mod, tmp } = await loadGuard();
   try {
-    let realRenders = 0;
-    let realVision = 0;
+    let renders = 0;
+    let visions = 0;
     const canvas = canvasStub();
-    const renderer = { render() { realRenders += 1; } };
     const mapData = mapStub();
+    const renderer = { render() { renders += 1; } };
     const engine = {
-      renderer,
-      mapData,
-      canvas,
-      camera: { x: 0, y: 0, zoom: 1 },
-      activeZ: 0,
-      tokenDrag: null,
+      renderer, mapData, canvas, camera: { x: 0, y: 0, zoom: 1 }, activeZ: 0, tokenDrag: null,
       tokenMotion: { tokenId: 'p1' },
-      calculateVision() { realVision += 1; return { visible: true, fovPolygon: [], visionRadius: 0 }; },
+      calculateVision() { visions += 1; return { visible: true }; },
     };
     const api = mod.installPerformanceGuard({ runtime: { engine, bridge: { isDm: false } } });
-
     for (let frame = 0; frame < 120; frame += 1) {
-      mapData.tokens[0].x = 350 + (frame * (70 / 119));
+      mapData.tokens[0].x += 0.5;
       canvas.emit('vtt:token-preview-moved', { tokenId: 'p1', traversing: true });
       engine.calculateVision();
       renderer.render();
     }
-
     const stats = api.snapshot();
-    expect(realVision).toBeLessThan(20);
-    expect(realRenders).toBeLessThan(20);
-    expect(stats.visionSaved).toBeGreaterThan(100);
-    expect(stats.savedFrames).toBeGreaterThan(100);
+    expect(visions).toBeLessThan(20);
+    expect(renders).toBeLessThan(20);
     expect(stats.movementFrameMs).toBeCloseTo(50, 4);
     expect(stats.fallbackScans).toBe(0);
+    expect(stats.canonicalInvalidations).toBe(120);
     api.stop();
-  } finally {
-    fs.unlinkSync(tmp);
-  }
+  } finally { fs.unlinkSync(tmp); }
 });
 
-test('DM FREE gets an omniscient render frame without invoking Player FOV calculation', async () => {
+test('DM FREE remains omniscient without invoking Player FOV', async () => {
   const { mod, tmp } = await loadGuard();
   try {
     let realVision = 0;
     const canvas = canvasStub();
-    const renderer = { render() {} };
     const mapData = mapStub();
     const engine = {
-      renderer,
-      mapData,
-      canvas,
-      camera: { x: 0, y: 0, zoom: 1 },
-      activeZ: 0,
-      tokenDrag: null,
-      tokenMotion: null,
+      renderer: { render() {} }, mapData, canvas, camera: { x: 0, y: 0, zoom: 1 }, activeZ: 0, tokenDrag: null, tokenMotion: null,
       calculateVision() { realVision += 1; return { visible: false }; },
     };
     const api = mod.installPerformanceGuard({ runtime: { engine, bridge: { isDm: true } } });
-    const dmVision = engine.calculateVision();
+    expect(engine.calculateVision()).toMatchObject({ visible: true, dmOmniscient: true });
     expect(realVision).toBe(0);
-    expect(dmVision).toMatchObject({ visible: true, dmOmniscient: true, perceptionMode: 'dm-omniscient' });
-    expect(dmVision.fovPolygon).toHaveLength(4);
-    expect(dmVision.visionRadius).toBeGreaterThan(0);
-    expect(api.snapshot().dmVisionBypassed).toBe(1);
-
     mapData.lighting.dmPreviewTokenId = 'p1';
     api.invalidate();
-    const playerPov = engine.calculateVision();
+    expect(engine.calculateVision().dmOmniscient).not.toBe(true);
     expect(realVision).toBe(1);
-    expect(playerPov.dmOmniscient).not.toBe(true);
     api.stop();
-  } finally {
-    fs.unlinkSync(tmp);
-  }
+  } finally { fs.unlinkSync(tmp); }
 });
 
-test('idle dirty invalidation recomputes FOV immediately instead of waiting for the fallback interval', async () => {
-  await withFakeClock(async ({ advance }) => {
-    const { mod, tmp } = await loadGuard();
-    try {
-      let realVision = 0;
-      const canvas = canvasStub();
-      const renderer = { render() {} };
-      const mapData = mapStub();
-      const engine = {
-        renderer,
-        mapData,
-        canvas,
-        camera: { x: 0, y: 0, zoom: 1 },
-        activeZ: 0,
-        tokenDrag: null,
-        tokenMotion: null,
-        calculateVision() {
-          realVision += 1;
-          return { visible: true, generation: realVision };
-        },
-      };
-      const api = mod.installPerformanceGuard({
-        runtime: { engine, bridge: { isDm: false } },
-        idleFallbackMs: 500,
-      });
-
-      const first = engine.calculateVision();
-      expect(realVision).toBe(1);
-      expect(first.generation).toBe(1);
-
-      advance(10);
-      api.invalidate();
-      const second = engine.calculateVision();
-      expect(realVision).toBe(2);
-      expect(second.generation).toBe(2);
-
-      api.stop();
-    } finally {
-      fs.unlinkSync(tmp);
-    }
-  });
-});
-
-test('performance guard reports dirty/fallback costs instead of fingerprint and static-signature churn', async () => {
-  await withFakeClock(async ({ advance }) => {
-    const { mod, tmp } = await loadGuard();
-    try {
-      let realRenders = 0;
-      const canvas = canvasStub();
-      const renderer = { render() { realRenders += 1; } };
-      const mapData = mapStub();
-      const engine = {
-        renderer,
-        mapData,
-        canvas,
-        camera: { x: 0, y: 0, zoom: 1 },
-        activeZ: 0,
-        tokenDrag: null,
-        tokenMotion: null,
-        getInputPerformanceStats() {
-          return { pointerMovesReceived: 9, pointerMovesProcessed: 3, pointerMovesCoalesced: 6, pointerMovePending: false };
-        },
-      };
-      const api = mod.installPerformanceGuard({
-        runtime: { engine, bridge: { isDm: false } },
-        idleFallbackMs: 500,
-      });
-
-      renderer.render();
-      let stats = api.snapshot();
-      expect(realRenders).toBe(1);
-      expect(stats.fallbackScans).toBe(1);
-      expect(stats.fallbackChanges).toBe(0);
-      expect(stats.input).toEqual({ pointerMovesReceived: 9, pointerMovesProcessed: 3, pointerMovesCoalesced: 6, pointerMovePending: false });
-
-      for (let i = 0; i < 20; i += 1) renderer.render();
-      stats = api.snapshot();
-      expect(stats.fallbackScans).toBe(1);
-
-      advance(500);
-      renderer.render();
-      stats = api.snapshot();
-      expect(stats.fallbackScans).toBe(2);
-      expect(stats.fallbackDurationMs).toBeGreaterThanOrEqual(0);
-      expect(stats.maxFallbackDurationMs).toBeGreaterThanOrEqual(0);
-      expect(stats.avgFallbackDurationMs).toBeGreaterThanOrEqual(0);
-
-      const scansBeforeExplicitChange = stats.fallbackScans;
-      api.invalidate();
-      renderer.render();
-      stats = api.snapshot();
-      expect(realRenders).toBe(2);
-      expect(stats.explicitInvalidations).toBe(1);
-      expect(stats.fallbackScans).toBe(scansBeforeExplicitChange);
-
-      api.resetMetrics();
-      stats = api.snapshot();
-      expect(stats.explicitInvalidations).toBe(0);
-      expect(stats.idleCleanSkips).toBe(0);
-      expect(stats.fallbackScans).toBe(0);
-      expect(stats.fallbackChanges).toBe(0);
-      expect(stats.fallbackDurationMs).toBe(0);
-      api.stop();
-    } finally {
-      fs.unlinkSync(tmp);
-    }
-  });
-});
-
-test('performance guard publishes adaptive active cadence, slow idle fallback, and scheduler metrics', async () => {
+test('adaptive cadence remains 30 Hz active, 20 Hz token motion, 500 ms idle', async () => {
   const { mod, tmp } = await loadGuard();
   try {
     const canvas = canvasStub();
-    const renderer = { render() {} };
     const mapData = mapStub();
     let resolver = null;
     const wakeCalls = [];
     const engine = {
-      renderer,
-      mapData,
-      canvas,
-      camera: { x: 0, y: 0, zoom: 1, isDragging: false },
-      activeZ: 0,
-      tokenDrag: null,
-      tokenMotion: null,
+      renderer: { render() {} }, mapData, canvas,
+      camera: { x: 0, y: 0, zoom: 1, isDragging: false }, activeZ: 0, tokenDrag: null, tokenMotion: null,
       calculateVision() { return { visible: true }; },
       setFrameDelayResolver(next) { resolver = typeof next === 'function' ? next : null; return Boolean(resolver); },
       requestFrame(options) { wakeCalls.push(options); return true; },
-      getFrameSchedulerStats() { return { framesScheduled: 8, framesExecuted: 6, delayedWakePending: true }; },
+      getFrameSchedulerStats() { return { framesScheduled: 8, framesExecuted: 6 }; },
     };
-    const api = mod.installPerformanceGuard({
-      runtime: { engine, bridge: { isDm: false } },
-      idleFallbackMs: 500,
-    });
-    expect(resolver).toBeTruthy();
-
+    const api = mod.installPerformanceGuard({ runtime: { engine, bridge: { isDm: false } }, idleFallbackMs: 500 });
     engine.calculateVision();
-    renderer.render();
+    engine.renderer.render();
     expect(api.nextFrameDelayMs()).toBeCloseTo(500, 4);
-
     engine.camera.isDragging = true;
     expect(api.nextFrameDelayMs()).toBeCloseTo(1000 / 30, 4);
-
     engine.tokenMotion = { tokenId: 'p1' };
     expect(api.nextFrameDelayMs()).toBeCloseTo(1000 / 20, 4);
-
     engine.tokenMotion = null;
     engine.camera.isDragging = false;
-    api.invalidate();
+    sceneDirty.emit(canvas, { reason: 'camera', render: true, vision: false });
     expect(wakeCalls.at(-1)).toMatchObject({ immediate: true, delayMs: 0 });
-
-    const stats = api.snapshot();
-    expect(stats.idleFrameMs).toBeCloseTo(500, 4);
-    expect(stats.fallbackScanMs).toBeCloseTo(500, 4);
-    expect(stats.scheduler).toMatchObject({ framesScheduled: 8, framesExecuted: 6, delayedWakePending: true });
-
+    expect(api.snapshot().scheduler).toMatchObject({ framesScheduled: 8, framesExecuted: 6 });
     api.stop();
     expect(resolver).toBeNull();
-  } finally {
-    fs.unlinkSync(tmp);
-  }
+  } finally { fs.unlinkSync(tmp); }
 });
 
-test('performance guard loads after Dynamic Lighting and Fog Memory', () => {
+test('performance guard owns one canonical dirty listener instead of raw input listeners', () => {
+  const source = read('js/vtt/performance-guard.js');
+  expect(source).toContain("'vtt:scene-dirty'");
+  expect(source).toContain('handleSceneDirty');
+  expect(source).toContain('installLegacyBridge');
+  expect(source).not.toContain("globalThis.addEventListener?.('wheel'");
+  expect(source).not.toContain("globalThis.addEventListener?.('keydown'");
+  expect(source).not.toContain("globalThis.addEventListener?.('keyup'");
+  expect(source).not.toContain("globalThis.addEventListener?.('mousemove'");
+  expect(source).not.toContain('createStaticSignatureCache');
+  expect(source).not.toContain('frameFingerprint');
+});
+
+test('scene dirty loads before main and performance guard after lighting/fog', () => {
   const html = read('vtt.html');
+  const dirty = html.indexOf('js/vtt/scene-dirty.js');
+  const main = html.indexOf('js/vtt/main.js');
   const lighting = html.indexOf('js/vtt/dynamic-lighting-bootstrap.js');
   const fog = html.indexOf('js/vtt/fog-memory-bootstrap.js');
   const guard = html.indexOf('js/vtt/performance-guard.js');
-  expect(lighting).toBeGreaterThan(0);
+  expect(dirty).toBeGreaterThan(0);
+  expect(main).toBeGreaterThan(dirty);
+  expect(lighting).toBeGreaterThan(main);
   expect(fog).toBeGreaterThan(lighting);
   expect(guard).toBeGreaterThan(fog);
-});
-
-test('performance guard keeps the legacy safety signature but removes per-wake fingerprint machinery', () => {
-  const source = read('js/vtt/performance-guard.js');
-  expect(source).toContain('legacyVisualSignature');
-  expect(source).toContain('DEFAULT_IDLE_FALLBACK_MS = 500');
-  expect(source).toContain('engine?.tokenMotion || engine?.tokenDrag || engine?.camera?.isDragging');
-  expect(source).toContain('engine.setFrameDelayResolver?.(nextFrameDelayMs)');
-  expect(source).toContain('engine.requestFrame?.({');
-  expect(source).toContain('Idle visuals are event-driven');
-  expect(source).not.toContain('createStaticSignatureCache');
-  expect(source).not.toContain('frameFingerprint');
-  expect(source).not.toContain('STATIC_SIGNATURE_TTL_MS');
 });
 
 test('performance guard parses as an ES module', () => {

--- a/tests/vtt_scene_dirty.spec.js
+++ b/tests/vtt_scene_dirty.spec.js
@@ -1,0 +1,107 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const sceneDirty = require('../js/vtt/scene-dirty.js');
+
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+function eventTargetStub() {
+  const listeners = new Map();
+  return {
+    listeners,
+    addEventListener(name, fn) {
+      if (!listeners.has(name)) listeners.set(name, new Set());
+      listeners.get(name).add(fn);
+    },
+    removeEventListener(name, fn) { listeners.get(name)?.delete(fn); },
+    dispatchEvent(event) {
+      for (const fn of listeners.get(event?.type) || []) fn(event);
+      return true;
+    },
+    emit(name, detail = {}) { return this.dispatchEvent({ type: name, detail }); },
+  };
+}
+
+test('scene dirty normalizes render and vision independently', () => {
+  expect(sceneDirty.normalize({ reason: 'camera' })).toEqual({
+    reason: 'camera', render: true, vision: false, active: false, sourceEvent: null, tokenId: null, meta: null,
+  });
+  expect(sceneDirty.normalize({ reason: 'token', vision: true, active: true, tokenId: 7 })).toMatchObject({
+    reason: 'token', render: true, vision: true, active: true, tokenId: '7',
+  });
+});
+
+test('legacy semantic token event becomes one canonical scene dirty event', () => {
+  const canvas = eventTargetStub();
+  const host = eventTargetStub();
+  const seen = [];
+  canvas.addEventListener(sceneDirty.EVENT_NAME, (event) => seen.push(event.detail));
+  const bridge = sceneDirty.installLegacyBridge({ canvas, mapData: { dmEditMode: { active: false } }, host });
+
+  canvas.emit('vtt:token-moved', { tokenId: 'p1' });
+  expect(seen).toHaveLength(1);
+  expect(seen[0]).toMatchObject({ reason: 'token', render: true, vision: true, active: false, sourceEvent: 'vtt:token-moved', tokenId: 'p1' });
+  expect(bridge.snapshot().bridgedEvents).toBe(1);
+  bridge.stop();
+});
+
+test('legacy adapter does not watch wheel or keyboard and limits raw pointer bridging to DM edit mode', () => {
+  const canvas = eventTargetStub();
+  const host = eventTargetStub();
+  const mapData = { dmEditMode: { active: false } };
+  const seen = [];
+  canvas.addEventListener(sceneDirty.EVENT_NAME, (event) => seen.push(event.detail));
+  const bridge = sceneDirty.installLegacyBridge({ canvas, mapData, host });
+
+  expect(host.listeners.has('wheel')).toBe(false);
+  expect(host.listeners.has('keydown')).toBe(false);
+  expect(host.listeners.has('keyup')).toBe(false);
+  expect(host.listeners.has('resize')).toBe(true);
+  expect(host.listeners.has('mousemove')).toBe(true);
+  expect(host.listeners.has('mouseup')).toBe(true);
+
+  host.emit('mousemove');
+  expect(seen).toHaveLength(0);
+  mapData.dmEditMode.active = true;
+  host.emit('mousemove');
+  host.emit('mouseup');
+  expect(seen).toHaveLength(2);
+  expect(seen[0]).toMatchObject({ reason: 'edit', render: true, vision: false, active: true });
+  expect(seen[1]).toMatchObject({ reason: 'edit', render: true, vision: true, active: false });
+
+  bridge.stop();
+  expect(host.listeners.get('mousemove')?.size || 0).toBe(0);
+  expect(host.listeners.get('mouseup')?.size || 0).toBe(0);
+});
+
+test('camera owns canonical render-only invalidation instead of performance guard raw wheel/mouse observers', () => {
+  const camera = read('js/vtt/camera.js');
+  const guard = read('js/vtt/performance-guard.js');
+  expect(camera).toContain('LuminousVttSceneDirty?.emit');
+  expect(camera).toContain("reason: 'camera'");
+  expect(camera).toContain('vision: false');
+  expect(camera).toContain("this.notifyVisualChange('pan', true");
+  expect(camera).toContain("this.notifyVisualChange('zoom', true");
+  expect(guard).not.toContain("globalThis.addEventListener?.('wheel'");
+  expect(guard).not.toContain("globalThis.addEventListener?.('keydown'");
+  expect(guard).not.toContain("globalThis.addEventListener?.('keyup'");
+  expect(guard).not.toContain("globalThis.addEventListener?.('mousemove'");
+});
+
+test('scene dirty contract loads before main runtime', () => {
+  const html = read('vtt.html');
+  const dirty = html.indexOf('js/vtt/scene-dirty.js');
+  const main = html.indexOf('js/vtt/main.js');
+  expect(dirty).toBeGreaterThan(0);
+  expect(main).toBeGreaterThan(dirty);
+});
+
+test('scene dirty and camera parse cleanly', () => {
+  execFileSync(process.execPath, ['--check', path.join(__dirname, '..', 'js/vtt/scene-dirty.js')], { stdio: 'pipe' });
+  const tmp = path.join(os.tmpdir(), `luminous-vtt-camera-${process.pid}.mjs`);
+  fs.writeFileSync(tmp, read('js/vtt/camera.js'));
+  try { execFileSync(process.execPath, ['--check', tmp], { stdio: 'pipe' }); }
+  finally { fs.unlinkSync(tmp); }
+});

--- a/tests/vtt_scene_dirty_bridges.spec.js
+++ b/tests/vtt_scene_dirty_bridges.spec.js
@@ -67,3 +67,20 @@ test('lighting adapter wraps scene, environment, and POV state before Dynamic Li
   expect(lighting).toBeGreaterThan(lightingPatch);
   expect(guard).toBeGreaterThan(lighting);
 });
+
+test('fog memory adapter is render-only and loads before Fog Memory starts', () => {
+  const patch = read('js/vtt/scene-dirty-memory-patch.js');
+  expect(patch).toContain('LuminousVttMemoryState');
+  expect(patch).toContain("reason: 'fog'");
+  expect(patch).toContain('render: true');
+  expect(patch).toContain('vision: false');
+
+  const html = read('vtt.html');
+  const dirty = html.indexOf('js/vtt/scene-dirty.js');
+  const memoryPatch = html.indexOf('js/vtt/scene-dirty-memory-patch.js');
+  const fog = html.indexOf('js/vtt/fog-memory-bootstrap.js');
+  const guard = html.indexOf('js/vtt/performance-guard.js');
+  expect(memoryPatch).toBeGreaterThan(dirty);
+  expect(fog).toBeGreaterThan(memoryPatch);
+  expect(guard).toBeGreaterThan(fog);
+});

--- a/tests/vtt_scene_dirty_bridges.spec.js
+++ b/tests/vtt_scene_dirty_bridges.spec.js
@@ -1,0 +1,69 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+const sceneDirty = require('../js/vtt/scene-dirty.js');
+
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+function targetStub() {
+  const listeners = new Map();
+  return {
+    addEventListener(name, fn) {
+      if (!listeners.has(name)) listeners.set(name, new Set());
+      listeners.get(name).add(fn);
+    },
+    removeEventListener(name, fn) { listeners.get(name)?.delete(fn); },
+    dispatchEvent(event) {
+      for (const fn of listeners.get(event?.type) || []) fn(event);
+      return true;
+    },
+  };
+}
+
+test('topology state bridge preserves callback and emits canonical vision dirty', () => {
+  const previousDocument = global.document;
+  const previousBridge = global.LuminousVttStateBridge;
+  const canvas = targetStub();
+  const dirtyEvents = [];
+  canvas.addEventListener(sceneDirty.EVENT_NAME, (event) => dirtyEvents.push(event.detail));
+  global.document = { getElementById: (id) => id === 'vtt-canvas' ? canvas : null };
+  global.LuminousVttStateBridge = {
+    createBridge(options = {}) {
+      return { trigger(payload) { options.onTopologyChanged?.(payload); } };
+    },
+  };
+
+  try {
+    expect(sceneDirty.wrapStateBridgeApi('LuminousVttStateBridge', 'onTopologyChanged', {
+      reason: 'topology', render: true, vision: true,
+    })).toBe(true);
+    let originalCalls = 0;
+    const bridge = global.LuminousVttStateBridge.createBridge({ onTopologyChanged() { originalCalls += 1; } });
+    bridge.trigger({ id: 'door-1' });
+    expect(originalCalls).toBe(1);
+    expect(dirtyEvents).toHaveLength(1);
+    expect(dirtyEvents[0]).toMatchObject({ reason: 'topology', render: true, vision: true, sourceEvent: 'LuminousVttStateBridge:onTopologyChanged' });
+  } finally {
+    if (previousDocument === undefined) delete global.document;
+    else global.document = previousDocument;
+    if (previousBridge === undefined) delete global.LuminousVttStateBridge;
+    else global.LuminousVttStateBridge = previousBridge;
+  }
+});
+
+test('lighting adapter wraps scene, environment, and POV state before Dynamic Lighting starts', () => {
+  const patch = read('js/vtt/scene-dirty-lighting-patch.js');
+  expect(patch).toContain("wrapBridge('LuminousVttLightingState'");
+  expect(patch).toContain("wrapBridge('LuminousVttEnvironmentLightBridge'");
+  expect(patch).toContain("wrapBridge('LuminousVttPovState'");
+  expect(patch).toContain("reason: 'lighting', render: true, vision: true");
+
+  const html = read('vtt.html');
+  const dirty = html.indexOf('js/vtt/scene-dirty.js');
+  const lightingPatch = html.indexOf('js/vtt/scene-dirty-lighting-patch.js');
+  const lighting = html.indexOf('js/vtt/dynamic-lighting-bootstrap.js');
+  const guard = html.indexOf('js/vtt/performance-guard.js');
+  expect(lightingPatch).toBeGreaterThan(dirty);
+  expect(lighting).toBeGreaterThan(lightingPatch);
+  expect(guard).toBeGreaterThan(lighting);
+});

--- a/vtt.html
+++ b/vtt.html
@@ -152,6 +152,7 @@
     <script type="module" src="js/vtt/semantic-map-authoring-bootstrap.js"></script>
     <script type="module" src="js/vtt/lighting-defaults-patch.js"></script>
     <script type="module" src="js/vtt/pov-eye-height-patch.js"></script>
+    <script type="module" src="js/vtt/scene-dirty-lighting-patch.js"></script>
     <script type="module" src="js/vtt/dynamic-lighting-bootstrap.js"></script>
     <script type="module" src="js/vtt/horizontal-plane-lighting-patch.js"></script>
     <script type="module" src="js/vtt/horizontal-plane-bootstrap.js"></script>

--- a/vtt.html
+++ b/vtt.html
@@ -140,6 +140,7 @@
     <script src="js/vtt/dm-edit-mode.js"></script>
     <script src="js/vtt/check-portal.js"></script>
     <script src="js/vtt/multiplayer-senses-bridge.js"></script>
+    <script src="js/vtt/scene-dirty.js"></script>
     <script type="module" src="js/vtt/horizontal-plane-preload.js"></script>
     <script type="module" src="js/vtt/main.js"></script>
     <script type="module" src="js/vtt/building-physics-bootstrap.js"></script>

--- a/vtt.html
+++ b/vtt.html
@@ -158,6 +158,7 @@
     <script type="module" src="js/vtt/horizontal-plane-bootstrap.js"></script>
     <script type="module" src="js/vtt/memory-defaults-patch.js"></script>
     <script type="module" src="js/vtt/memory-review-hardening-patch.js"></script>
+    <script type="module" src="js/vtt/scene-dirty-memory-patch.js"></script>
     <script type="module" src="js/vtt/fog-memory-bootstrap.js"></script>
     <script type="module" src="js/vtt/performance-guard.js"></script>
     <script src="js/vtt/ui-shell.js"></script>


### PR DESCRIPTION
## Performance Phase 1D — Canonical Scene Dirty

Simplifica la invalidación visual del VTT después del scheduler adaptativo y dirty-state fallback.

### Cambio principal

`performance-guard.js` deja de observar directamente `wheel`, `keydown`, `keyup`, `mousemove` y una lista de eventos de subsistemas. Ahora consume **un solo contrato**: `vtt:scene-dirty`.

El detalle separa:
- `render`: hay que redibujar;
- `vision`: hay que recalcular FOV;
- `active`: el cambio forma parte de una interacción/animación activa;
- `reason`: token, camera, topology, lighting, fog, chunk, edit, resize o memory.

### Emisores

- Camera emite directamente `camera` como render-only: pan/zoom/center no recalculan FOV.
- StateBridge y VerticalPortalState emiten `topology` con FOV dirty.
- LightingState, EnvironmentLightBridge y PovState emiten `lighting` con FOV dirty antes de Dynamic Lighting.
- MemoryState emite `fog` como render-only antes de Fog Memory.
- Tokens, movement previews, camera-follow, DM observer, chunks y memory-learn usan un adaptador semántico temporal.
- El único raw pointer temporal queda limitado a DM Edit Mode para previews de authoring; `keydown`, `keyup` y `wheel` desaparecen del guard/adaptador.

### Seguridad

- Se conserva el fallback legacy de 500 ms para mutaciones silenciosas que todavía no emitan el contrato.
- Se mantienen 30 Hz cámara/drag, 20 Hz tokenMotion y wake inmediato para dirties idle.
- DM FREE y el caché/throttle de FOV no cambian de semántica.
- `stop()` elimina el listener canónico y desmonta el bridge legacy.

### Tests

- render-only camera dirty no recalcula FOV;
- token/topology/lighting dirty sí invalida visión;
- Fog/Memory dirty es render-only;
- traducción legacy produce un solo evento canónico;
- adapter no escucha wheel/keydown/keyup;
- raw pointer sólo actúa en DM Edit Mode;
- topology/lighting/memory bridge contracts;
- fallback de mutaciones silenciosas;
- cadencias 30/20/500 ms;
- DM FREE;
- orden de carga y sintaxis.

### Validación adicional

Smoke Node del router canónico: PASS. Sintaxis de adapters Lighting/Memory: PASS.