### PR TITLE
perf(vtt): move token and chunk invalidation off legacy dirty bridge

### DIFF
--- a/.github/workflows/vtt-performance-guard.yml
+++ b/.github/workflows/vtt-performance-guard.yml
@@ -5,7 +5,10 @@ on:
     paths:
       - 'vtt.html'
       - 'js/vtt/camera.js'
+      - 'js/vtt/engine.js'
+      - 'js/vtt/procedural-chunk-streaming-runtime.js'
       - 'js/vtt/scene-dirty.js'
+      - 'js/vtt/scene-dirty-token-state-patch.js'
       - 'js/vtt/scene-dirty-lighting-patch.js'
       - 'js/vtt/scene-dirty-memory-patch.js'
       - 'js/vtt/runtime-lifecycle.js'
@@ -19,6 +22,7 @@ on:
       - 'js/vtt/memory-state.js'
       - 'tests/vtt_scene_dirty.spec.js'
       - 'tests/vtt_scene_dirty_bridges.spec.js'
+      - 'tests/vtt_scene_dirty_direct_emitters.spec.js'
       - 'tests/vtt_runtime_performance_phase1.spec.js'
       - 'tests/vtt_runtime_frame_scheduler.spec.js'
       - 'tests/vtt_performance_guard.spec.js'
@@ -43,20 +47,26 @@ jobs:
       - name: Syntax
         run: |
           node --check js/vtt/scene-dirty.js
+          node --input-type=module --check < js/vtt/scene-dirty-token-state-patch.js
           node --input-type=module --check < js/vtt/scene-dirty-lighting-patch.js
           node --input-type=module --check < js/vtt/scene-dirty-memory-patch.js
           node --input-type=module --check < js/vtt/camera.js
+          node --input-type=module --check < js/vtt/engine.js
+          node --input-type=module --check < js/vtt/procedural-chunk-streaming-runtime.js
           node --check js/vtt/runtime-lifecycle.js
           node --input-type=module --check < js/vtt/performance-guard.js
           node --check tests/vtt_scene_dirty.spec.js
           node --check tests/vtt_scene_dirty_bridges.spec.js
+          node --check tests/vtt_scene_dirty_direct_emitters.spec.js
           node --check tests/vtt_runtime_performance_phase1.spec.js
           node --check tests/vtt_runtime_frame_scheduler.spec.js
+          node --check tests/vtt_performance_guard.spec.js
       - name: Canonical scene dirty contracts
         run: >-
           npx playwright test --workers=1
           tests/vtt_scene_dirty.spec.js
           tests/vtt_scene_dirty_bridges.spec.js
+          tests/vtt_scene_dirty_direct_emitters.spec.js
       - name: Frame-coalesced input and adaptive scheduler contracts
         run: >-
           npx playwright test --workers=1

--- a/js/vtt/engine.js
+++ b/js/vtt/engine.js
@@ -35,6 +35,17 @@ export class Engine {
     setTokenMoveResolver(resolver) { this.tokenMoveResolver = typeof resolver === 'function' ? resolver : null; }
     setMovementInteractionResolver(resolver) { this.movementInteractionResolver = typeof resolver === 'function' ? resolver : null; }
 
+    emitSemanticEvent(type, detail = {}, dirty = null) {
+        this.canvas.dispatchEvent(new CustomEvent(type, { detail }));
+        if (!dirty) return;
+        globalThis.LuminousVttSceneDirty?.emit?.(this.canvas, {
+            ...dirty,
+            sourceEvent: type,
+            tokenId: detail?.tokenId ?? dirty.tokenId ?? null,
+            meta: detail,
+        });
+    }
+
     init() {
         window.addEventListener('resize', this.handleResize);
         this.canvas.addEventListener('mousedown', this.handleTokenMouseDown);
@@ -89,16 +100,18 @@ export class Engine {
         const target = { x: worldPoint.x - this.tokenDrag.grabOffsetX, y: worldPoint.y - this.tokenDrag.grabOffsetY };
         this.canvas.style.cursor = 'grabbing';
         if (this.tokenMoveResolver) {
-            this.canvas.dispatchEvent(new CustomEvent('vtt:movement-destination-preview', {
-                detail: { tokenId: token.id, from: { x: this.tokenDrag.originX, y: this.tokenDrag.originY, z: this.tokenDrag.originZ }, target },
-            }));
+            const detail = { tokenId: token.id, from: { x: this.tokenDrag.originX, y: this.tokenDrag.originY, z: this.tokenDrag.originZ }, target };
+            this.emitSemanticEvent('vtt:movement-destination-preview', detail, {
+                reason: 'token', render: true, vision: false, active: true,
+            });
             return;
         }
         token.x = target.x;
         token.y = target.y;
-        this.canvas.dispatchEvent(new CustomEvent('vtt:token-preview-moved', {
-            detail: { tokenId: token.id, x: token.x, y: token.y, z: Number(token.zLayer ?? token.gridPosition?.z ?? token.z?.[0] ?? 0) },
-        }));
+        const detail = { tokenId: token.id, x: token.x, y: token.y, z: Number(token.zLayer ?? token.gridPosition?.z ?? token.z?.[0] ?? 0) };
+        this.emitSemanticEvent('vtt:token-preview-moved', detail, {
+            reason: 'token', render: true, vision: true, active: true,
+        });
     }
 
     async animateTokenPath(token, path = [], options = {}) {
@@ -125,9 +138,10 @@ export class Engine {
                 const t = Math.min(1, elapsed / durationMs);
                 token.x = Number(from.x) + ((Number(to.x) - Number(from.x)) * t);
                 token.y = Number(from.y) + ((Number(to.y) - Number(from.y)) * t);
-                this.canvas.dispatchEvent(new CustomEvent('vtt:token-preview-moved', {
-                    detail: { tokenId: token.id, x: token.x, y: token.y, z: Number(token.zLayer ?? token.gridPosition?.z ?? token.z?.[0] ?? 0), traversing: true, actionMode: mode },
-                }));
+                const detail = { tokenId: token.id, x: token.x, y: token.y, z: Number(token.zLayer ?? token.gridPosition?.z ?? token.z?.[0] ?? 0), traversing: true, actionMode: mode };
+                this.emitSemanticEvent('vtt:token-preview-moved', detail, {
+                    reason: 'token', render: true, vision: true, active: true,
+                });
                 if (t >= 1) return resolve(true);
                 motion.frameId = raf(step);
             };
@@ -171,9 +185,10 @@ export class Engine {
                         }
                         if (resolution?.irreversible === true) motion.irreversible = true;
                     }
-                    this.canvas.dispatchEvent(new CustomEvent('vtt:movement-interaction', {
-                        detail: { tokenId: token.id, x: token.x, y: token.y, actionMode: mode, ...resolvedInteraction },
-                    }));
+                    const interactionDetail = { tokenId: token.id, x: token.x, y: token.y, actionMode: mode, ...resolvedInteraction };
+                    this.emitSemanticEvent('vtt:movement-interaction', interactionDetail, {
+                        reason: 'topology', render: true, vision: true, active: false,
+                    });
                     if (resolvedInteraction.soundEvent) {
                         this.canvas.dispatchEvent(new CustomEvent('vtt:sound-event', {
                             detail: {
@@ -248,7 +263,10 @@ export class Engine {
             token.zLayer = drag.originZ;
             token.z = [drag.originZ];
             token.elevationFt = drag.originElevationFt;
-            this.canvas.dispatchEvent(new CustomEvent('vtt:token-preview-moved', { detail: { tokenId: token.id, x: token.x, y: token.y, z: drag.originZ, reverted: true } }));
+            const detail = { tokenId: token.id, x: token.x, y: token.y, z: drag.originZ, reverted: true };
+            this.emitSemanticEvent('vtt:token-preview-moved', detail, {
+                reason: 'token', render: true, vision: true, active: true,
+            });
         }
         this.canvas.style.cursor = this.tokenAtEvent(event) ? 'grab' : 'default';
     }
@@ -267,25 +285,31 @@ export class Engine {
         };
         const transition = this.verticalMovementRules?.transitionOnDrop?.(token, { x: token.x, y: token.y }, this.mapData) || { valid: false, reason: 'NO_VERTICAL_TRANSITION' };
         if (transition.valid && transition.complete && token.viewer === true) this.setZLayer(transition.targetZ);
-        this.canvas.dispatchEvent(new CustomEvent('vtt:token-moved', {
-            detail: {
-                tokenId: token.id,
-                from: { x: drag.originX, y: drag.originY, z: drag.originZ, elevationFt: drag.originElevationFt },
-                to: { x: token.x, y: token.y, ...token.gridPosition, elevationFt: token.elevationFt ?? 0, verticalMovement: token.verticalMovement || null },
-                path: Array.isArray(result.path) ? result.path : [],
-                routeCostFt: result.routeCostFt ?? result.costFt ?? null,
-                movementCostFt: result.movementCostFt ?? result.costFt ?? null,
-                movementMode: result.movementMode || result.mode || null,
-                actionMode: result.actionMode || null,
-                transition: transition.valid ? { routeId: transition.route?.id || null, complete: Boolean(transition.complete), targetZ: transition.targetZ, costSpentFt: transition.costSpentFt ?? null } : null,
-            },
-        }));
+        const moveDetail = {
+            tokenId: token.id,
+            from: { x: drag.originX, y: drag.originY, z: drag.originZ, elevationFt: drag.originElevationFt },
+            to: { x: token.x, y: token.y, ...token.gridPosition, elevationFt: token.elevationFt ?? 0, verticalMovement: token.verticalMovement || null },
+            path: Array.isArray(result.path) ? result.path : [],
+            routeCostFt: result.routeCostFt ?? result.costFt ?? null,
+            movementCostFt: result.movementCostFt ?? result.costFt ?? null,
+            movementMode: result.movementMode || result.mode || null,
+            actionMode: result.actionMode || null,
+            transition: transition.valid ? { routeId: transition.route?.id || null, complete: Boolean(transition.complete), targetZ: transition.targetZ, costSpentFt: transition.costSpentFt ?? null } : null,
+        };
+        this.emitSemanticEvent('vtt:token-moved', moveDetail, {
+            reason: 'token', render: true, vision: true, active: false,
+        });
         if (result.stopAtDoor) {
             this.canvas.dispatchEvent(new CustomEvent('vtt:movement-stopped-at-door', {
                 detail: { tokenId: token.id, x: token.x, y: token.y, z: token.zLayer, ...result.stopAtDoor },
             }));
         }
-        if (transition.valid) this.canvas.dispatchEvent(new CustomEvent('vtt:token-z-transition', { detail: { tokenId: token.id, ...transition } }));
+        if (transition.valid) {
+            const transitionDetail = { tokenId: token.id, ...transition };
+            this.emitSemanticEvent('vtt:token-z-transition', transitionDetail, {
+                reason: 'token', render: true, vision: true, active: false,
+            });
+        }
     }
 
     centerCamera() {

--- a/js/vtt/procedural-chunk-streaming-runtime.js
+++ b/js/vtt/procedural-chunk-streaming-runtime.js
@@ -42,6 +42,12 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
   function stateRef(){return db?.ref?.(`${STATE_ROOT}/${mapId}`)||null;}
   function requestRootRef(){return db?.ref?.(`${REQUEST_ROOT}/${mapId}`)||null;}
   function subscribe(ref,event,handler){if(!ref?.on)return;ref.on(event,handler);subscriptions.push(()=>ref.off(event,handler));}
+  function emitSemantic(type,detail){engine.canvas?.dispatchEvent?.(new CustomEvent(type,{detail}));}
+  function emitDirty(sourceEvent,detail={}){
+    window.LuminousVttSceneDirty?.emit?.(engine.canvas,{
+      reason:'chunk',render:true,vision:true,active:false,sourceEvent,tokenId:detail?.tokenId??null,meta:detail,
+    });
+  }
 
   async function publishChunkState(desc,plan){
     if(!isDm||!stateRef())return false;
@@ -67,8 +73,11 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
 
   function dispatchTransitionMove(token,from,transition,next){
     if(!token)return;
-    engine.canvas?.dispatchEvent?.(new CustomEvent('vtt:token-moved',{detail:{tokenId:token.id,from,to:{x:token.x,y:token.y,...token.gridPosition,elevationFt:token.elevationFt??0},chunkTransition:{from:transition.from,to:next.activeChunk,edges:transition.exit.edges}}}));
-    engine.canvas?.dispatchEvent?.(new CustomEvent('vtt:procedural-chunk-transition',{detail:{tokenId:token.id,from:transition.from,to:next.activeChunk,edges:transition.exit.edges}}));
+    const moveDetail={tokenId:token.id,from,to:{x:token.x,y:token.y,...token.gridPosition,elevationFt:token.elevationFt??0},chunkTransition:{from:transition.from,to:next.activeChunk,edges:transition.exit.edges}};
+    const transitionDetail={tokenId:token.id,from:transition.from,to:next.activeChunk,edges:transition.exit.edges};
+    emitSemantic('vtt:token-moved',moveDetail);
+    emitSemantic('vtt:procedural-chunk-transition',transitionDetail);
+    emitDirty('vtt:procedural-chunk-transition',transitionDetail);
   }
 
   async function activateChunk(desc,coord,{tokenId=null,requestedPoint=null,exit=null,persist=isDm,publish=isDm,center=true}={}){
@@ -83,7 +92,9 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
         token.x=safe.x;token.y=safe.y;const z=Number(token.zLayer??token.gridPosition?.z??token.z?.[0]??0);token.zLayer=z;token.z=[z];token.gridPosition={col:safe.col,row:safe.row,z};if(center)centerOnToken(token);
       }else if(center)engine.centerCamera?.();
       redraw();if(persist)await persistChunk(plan);if(publish)await publishChunkState(next,plan);
-      engine.canvas?.dispatchEvent?.(new CustomEvent('vtt:procedural-chunk-loaded',{detail:{chunk:clone(next.activeChunk),logical:{cols:next.chunkCols,rows:next.chunkRows},signature:plan.signature}}));
+      const loadedDetail={chunk:clone(next.activeChunk),logical:{cols:next.chunkCols,rows:next.chunkRows},signature:plan.signature};
+      emitSemantic('vtt:procedural-chunk-loaded',loadedDetail);
+      emitDirty('vtt:procedural-chunk-loaded',loadedDetail);
       return{descriptor:next,plan,token};
     }finally{transitioning=false;}
   }

--- a/js/vtt/procedural-chunk-streaming-runtime.js
+++ b/js/vtt/procedural-chunk-streaming-runtime.js
@@ -77,7 +77,6 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
     const transitionDetail={tokenId:token.id,from:transition.from,to:next.activeChunk,edges:transition.exit.edges};
     emitSemantic('vtt:token-moved',moveDetail);
     emitSemantic('vtt:procedural-chunk-transition',transitionDetail);
-    emitDirty('vtt:procedural-chunk-transition',transitionDetail);
   }
 
   async function activateChunk(desc,coord,{tokenId=null,requestedPoint=null,exit=null,persist=isDm,publish=isDm,center=true}={}){
@@ -104,7 +103,9 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
     transitioning=true;
     try{
       let desc=buildDescriptor(previewPlan,size);desc=core.withChunkSeed(desc,{col:0,row:0},previewPlan.seed);desc=core.withActiveChunk(desc,{col:0,row:0});
-      procedural.apply(previewPlan,{replaceScene:true,persist:false});writeStreamingMetadata(desc,previewPlan);activePlan=previewPlan;engine.centerCamera?.();redraw('procedural-stream-created');await persistChunk(previewPlan);await publishChunkState(desc,previewPlan);
+      procedural.apply(previewPlan,{replaceScene:true,persist:false});writeStreamingMetadata(desc,previewPlan);activePlan=previewPlan;engine.centerCamera?.();redraw('procedural-stream-created');
+      const createdDetail={chunk:clone(desc.activeChunk),logical:{cols:desc.chunkCols,rows:desc.chunkRows},signature:previewPlan.signature};emitDirty('procedural-stream-created',createdDetail);
+      await persistChunk(previewPlan);await publishChunkState(desc,previewPlan);
       mapData.proceduralEditor&&(mapData.proceduralEditor.previewPlan=null);if(mapData.proceduralEditor)mapData.proceduralEditor.previewGenerationError=null;
       doc.getElementById(PANEL_ID)?.querySelector('[data-proc-close]')?.click();notify(`Zona ${size}×${size} creada en streaming · activo 40×40 · chunk 1,1`,'success');
       return{descriptor:desc,plan:previewPlan,token:null};

--- a/js/vtt/scene-dirty-token-state-patch.js
+++ b/js/vtt/scene-dirty-token-state-patch.js
@@ -1,0 +1,28 @@
+const dirty = globalThis.LuminousVttSceneDirty;
+const current = globalThis.LuminousVttTokenState;
+
+if (dirty && current?.createBridge && !current.__sceneDirtyWrapped) {
+  const originalCreateBridge = current.createBridge;
+  globalThis.LuminousVttTokenState = Object.freeze({
+    ...current,
+    __sceneDirtyWrapped: true,
+    createBridge(options = {}) {
+      const originalCallback = options?.onTokensChanged;
+      return originalCreateBridge({
+        ...options,
+        onTokensChanged(change = {}) {
+          if (typeof originalCallback === 'function') originalCallback(change);
+          const canvas = globalThis.document?.getElementById?.('vtt-canvas') || globalThis.LuminousVttRuntime?.engine?.canvas;
+          dirty.emit(canvas, {
+            reason: 'token',
+            render: true,
+            vision: true,
+            active: false,
+            sourceEvent: 'LuminousVttTokenState:onTokensChanged',
+            meta: change && typeof change === 'object' ? change : null,
+          });
+        },
+      });
+    },
+  });
+}

--- a/js/vtt/scene-dirty-token-state-patch.js
+++ b/js/vtt/scene-dirty-token-state-patch.js
@@ -1,3 +1,5 @@
+import './token-state-dynamic-patch.js';
+
 const dirty = globalThis.LuminousVttSceneDirty;
 const current = globalThis.LuminousVttTokenState;
 

--- a/js/vtt/scene-dirty.js
+++ b/js/vtt/scene-dirty.js
@@ -91,17 +91,11 @@
     return true;
   }
 
+  // Compatibility only for subsystems that have not yet migrated to vtt:scene-dirty.
+  // Token movement/sync and procedural chunk streaming now emit the canonical contract directly.
   const LEGACY_EVENT_MAP = Object.freeze([
-    ['vtt:token-preview-moved', REASONS.TOKEN, true, true],
-    ['vtt:movement-destination-preview', REASONS.TOKEN, false, true],
-    ['vtt:token-moved', REASONS.TOKEN, true, false],
-    ['vtt:token-z-transition', REASONS.TOKEN, true, false],
-    ['vtt:canonical-tokens-synced', REASONS.TOKEN, true, false],
-    ['vtt:movement-interaction', REASONS.TOPOLOGY, true, false],
     ['vtt:camera-follow-changed', REASONS.CAMERA, false, false],
     ['vtt:dm-observer-changed', REASONS.CAMERA, true, false],
-    ['vtt:procedural-chunk-loaded', REASONS.CHUNK, true, false],
-    ['vtt:procedural-chunk-transition', REASONS.CHUNK, true, false],
     ['vtt:memory-learn', REASONS.MEMORY, false, false],
     ['vtt:lighting-changed', REASONS.LIGHTING, true, false],
     ['vtt:fog-changed', REASONS.FOG, false, false],

--- a/tests/vtt_performance_guard.spec.js
+++ b/tests/vtt_performance_guard.spec.js
@@ -57,7 +57,7 @@ async function withFakeClock(run) {
   }
 }
 
-test('legacy token event is translated once into canonical dirty state', async () => {
+test('direct canonical token dirty invalidates without using the legacy bridge', async () => {
   await withFakeClock(async () => {
     const { mod, tmp } = await loadGuard();
     try {
@@ -74,14 +74,14 @@ test('legacy token event is translated once into canonical dirty state', async (
       expect(api.snapshot().fallbackScans).toBe(1);
 
       mapData.tokens[0].x += 70;
-      canvas.emit('vtt:token-moved', { tokenId: 'p1' });
+      sceneDirty.emit(canvas, { reason: 'token', render: true, vision: true, tokenId: 'p1', sourceEvent: 'vtt:token-moved' });
       renderer.render();
       const stats = api.snapshot();
       expect(renders).toBe(2);
       expect(stats.canonicalInvalidations).toBe(1);
       expect(stats.visionInvalidations).toBe(1);
       expect(stats.dirtyByReason.token).toBe(1);
-      expect(stats.sceneDirtyBridge.bridgedEvents).toBe(1);
+      expect(stats.sceneDirtyBridge.bridgedEvents).toBe(0);
       api.stop();
     } finally { fs.unlinkSync(tmp); }
   });
@@ -152,7 +152,7 @@ test('slow fallback still detects silent legacy in-place mutations', async () =>
   });
 });
 
-test('active token traversal keeps 20 Hz guard budget through canonical bridge', async () => {
+test('active token traversal keeps 20 Hz guard budget through direct canonical dirty events', async () => {
   const { mod, tmp } = await loadGuard();
   try {
     let renders = 0;
@@ -168,7 +168,7 @@ test('active token traversal keeps 20 Hz guard budget through canonical bridge',
     const api = mod.installPerformanceGuard({ runtime: { engine, bridge: { isDm: false } } });
     for (let frame = 0; frame < 120; frame += 1) {
       mapData.tokens[0].x += 0.5;
-      canvas.emit('vtt:token-preview-moved', { tokenId: 'p1', traversing: true });
+      sceneDirty.emit(canvas, { reason: 'token', render: true, vision: true, active: true, tokenId: 'p1', sourceEvent: 'vtt:token-preview-moved' });
       engine.calculateVision();
       renderer.render();
     }
@@ -178,6 +178,7 @@ test('active token traversal keeps 20 Hz guard budget through canonical bridge',
     expect(stats.movementFrameMs).toBeCloseTo(50, 4);
     expect(stats.fallbackScans).toBe(0);
     expect(stats.canonicalInvalidations).toBe(120);
+    expect(stats.sceneDirtyBridge.bridgedEvents).toBe(0);
     api.stop();
   } finally { fs.unlinkSync(tmp); }
 });
@@ -252,12 +253,14 @@ test('performance guard owns one canonical dirty listener instead of raw input l
 test('scene dirty loads before main and performance guard after lighting/fog', () => {
   const html = read('vtt.html');
   const dirty = html.indexOf('js/vtt/scene-dirty.js');
+  const tokenPatch = html.indexOf('js/vtt/scene-dirty-token-state-patch.js');
   const main = html.indexOf('js/vtt/main.js');
   const lighting = html.indexOf('js/vtt/dynamic-lighting-bootstrap.js');
   const fog = html.indexOf('js/vtt/fog-memory-bootstrap.js');
   const guard = html.indexOf('js/vtt/performance-guard.js');
   expect(dirty).toBeGreaterThan(0);
-  expect(main).toBeGreaterThan(dirty);
+  expect(tokenPatch).toBeGreaterThan(dirty);
+  expect(main).toBeGreaterThan(tokenPatch);
   expect(lighting).toBeGreaterThan(main);
   expect(fog).toBeGreaterThan(lighting);
   expect(guard).toBeGreaterThan(fog);

--- a/tests/vtt_scene_dirty.spec.js
+++ b/tests/vtt_scene_dirty.spec.js
@@ -33,16 +33,30 @@ test('scene dirty normalizes render and vision independently', () => {
   });
 });
 
-test('legacy semantic token event becomes one canonical scene dirty event', () => {
+test('migrated token and chunk events no longer pass through the legacy bridge', () => {
   const canvas = eventTargetStub();
   const host = eventTargetStub();
   const seen = [];
   canvas.addEventListener(sceneDirty.EVENT_NAME, (event) => seen.push(event.detail));
   const bridge = sceneDirty.installLegacyBridge({ canvas, mapData: { dmEditMode: { active: false } }, host });
 
-  canvas.emit('vtt:token-moved', { tokenId: 'p1' });
+  const migrated = [
+    'vtt:token-preview-moved',
+    'vtt:movement-destination-preview',
+    'vtt:token-moved',
+    'vtt:token-z-transition',
+    'vtt:canonical-tokens-synced',
+    'vtt:movement-interaction',
+    'vtt:procedural-chunk-loaded',
+    'vtt:procedural-chunk-transition',
+  ];
+  migrated.forEach((name) => canvas.emit(name, { tokenId: 'p1' }));
+  expect(seen).toHaveLength(0);
+  expect(bridge.snapshot().bridgedEvents).toBe(0);
+
+  canvas.emit('vtt:camera-follow-changed', { tokenId: 'p1' });
   expect(seen).toHaveLength(1);
-  expect(seen[0]).toMatchObject({ reason: 'token', render: true, vision: true, active: false, sourceEvent: 'vtt:token-moved', tokenId: 'p1' });
+  expect(seen[0]).toMatchObject({ reason: 'camera', render: true, vision: false, sourceEvent: 'vtt:camera-follow-changed', tokenId: 'p1' });
   expect(bridge.snapshot().bridgedEvents).toBe(1);
   bridge.stop();
 });
@@ -90,12 +104,14 @@ test('camera owns canonical render-only invalidation instead of performance guar
   expect(guard).not.toContain("globalThis.addEventListener?.('mousemove'");
 });
 
-test('scene dirty contract loads before main runtime', () => {
+test('scene dirty token state patch loads before main runtime', () => {
   const html = read('vtt.html');
   const dirty = html.indexOf('js/vtt/scene-dirty.js');
+  const tokenPatch = html.indexOf('js/vtt/scene-dirty-token-state-patch.js');
   const main = html.indexOf('js/vtt/main.js');
   expect(dirty).toBeGreaterThan(0);
-  expect(main).toBeGreaterThan(dirty);
+  expect(tokenPatch).toBeGreaterThan(dirty);
+  expect(main).toBeGreaterThan(tokenPatch);
 });
 
 test('scene dirty and camera parse cleanly', () => {

--- a/tests/vtt_scene_dirty_direct_emitters.spec.js
+++ b/tests/vtt_scene_dirty_direct_emitters.spec.js
@@ -38,13 +38,14 @@ test('movement engine preserves semantic events and emits direct dirty semantics
   expect(source).toContain('LuminousVttSceneDirty?.emit');
 });
 
-test('procedural chunk streaming keeps domain events and emits one chunk dirty per loaded/transition action', () => {
+test('procedural chunk streaming coalesces transition invalidation through the loaded chunk dirty', () => {
   const source = read('js/vtt/procedural-chunk-streaming-runtime.js');
   expect(source).toContain("emitSemantic('vtt:token-moved',moveDetail)");
   expect(source).toContain("emitSemantic('vtt:procedural-chunk-transition',transitionDetail)");
-  expect(source).toContain("emitDirty('vtt:procedural-chunk-transition',transitionDetail)");
+  expect(source).not.toContain("emitDirty('vtt:procedural-chunk-transition',transitionDetail)");
   expect(source).toContain("emitSemantic('vtt:procedural-chunk-loaded',loadedDetail)");
   expect(source).toContain("emitDirty('vtt:procedural-chunk-loaded',loadedDetail)");
+  expect(source).toContain("emitDirty('procedural-stream-created',createdDetail)");
   expect(source).toContain("reason:'chunk',render:true,vision:true");
 });
 

--- a/tests/vtt_scene_dirty_direct_emitters.spec.js
+++ b/tests/vtt_scene_dirty_direct_emitters.spec.js
@@ -1,0 +1,64 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+const sceneDirty = require('../js/vtt/scene-dirty.js');
+
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+test('movement and chunk semantic events are removed from the legacy translation map', () => {
+  const names = sceneDirty.LEGACY_EVENT_MAP.map(([name]) => name);
+  const migrated = [
+    'vtt:token-preview-moved',
+    'vtt:movement-destination-preview',
+    'vtt:token-moved',
+    'vtt:token-z-transition',
+    'vtt:canonical-tokens-synced',
+    'vtt:movement-interaction',
+    'vtt:procedural-chunk-loaded',
+    'vtt:procedural-chunk-transition',
+  ];
+  migrated.forEach((name) => expect(names).not.toContain(name));
+  expect(names).toContain('vtt:camera-follow-changed');
+  expect(names).toContain('vtt:dm-observer-changed');
+  expect(names).toContain('vtt:dm-edit-changed');
+  expect(names).toHaveLength(7);
+});
+
+test('movement engine preserves semantic events and emits direct dirty semantics', () => {
+  const source = read('js/vtt/engine.js');
+  expect(source).toContain('emitSemanticEvent(type, detail = {}, dirty = null)');
+  expect(source).toContain("this.emitSemanticEvent('vtt:movement-destination-preview'");
+  expect(source).toContain("reason: 'token', render: true, vision: false, active: true");
+  expect(source).toContain("this.emitSemanticEvent('vtt:token-preview-moved'");
+  expect(source).toContain("reason: 'token', render: true, vision: true, active: true");
+  expect(source).toContain("this.emitSemanticEvent('vtt:movement-interaction'");
+  expect(source).toContain("reason: 'topology', render: true, vision: true, active: false");
+  expect(source).toContain("this.emitSemanticEvent('vtt:token-moved'");
+  expect(source).toContain("this.emitSemanticEvent('vtt:token-z-transition'");
+  expect(source).toContain('LuminousVttSceneDirty?.emit');
+});
+
+test('procedural chunk streaming keeps domain events and emits one chunk dirty per loaded/transition action', () => {
+  const source = read('js/vtt/procedural-chunk-streaming-runtime.js');
+  expect(source).toContain("emitSemantic('vtt:token-moved',moveDetail)");
+  expect(source).toContain("emitSemantic('vtt:procedural-chunk-transition',transitionDetail)");
+  expect(source).toContain("emitDirty('vtt:procedural-chunk-transition',transitionDetail)");
+  expect(source).toContain("emitSemantic('vtt:procedural-chunk-loaded',loadedDetail)");
+  expect(source).toContain("emitDirty('vtt:procedural-chunk-loaded',loadedDetail)");
+  expect(source).toContain("reason:'chunk',render:true,vision:true");
+});
+
+test('token state dirty patch wraps the final dynamic token bridge before main creates it', () => {
+  const patch = read('js/vtt/scene-dirty-token-state-patch.js');
+  const html = read('vtt.html');
+  expect(patch).toContain("import './token-state-dynamic-patch.js'");
+  expect(patch).toContain("sourceEvent: 'LuminousVttTokenState:onTokensChanged'");
+  expect(patch).toContain("reason: 'token'");
+  expect(patch).toContain('vision: true');
+
+  const dirty = html.indexOf('js/vtt/scene-dirty.js');
+  const tokenPatch = html.indexOf('js/vtt/scene-dirty-token-state-patch.js');
+  const main = html.indexOf('js/vtt/main.js');
+  expect(tokenPatch).toBeGreaterThan(dirty);
+  expect(main).toBeGreaterThan(tokenPatch);
+});

--- a/vtt.html
+++ b/vtt.html
@@ -141,6 +141,7 @@
     <script src="js/vtt/check-portal.js"></script>
     <script src="js/vtt/multiplayer-senses-bridge.js"></script>
     <script src="js/vtt/scene-dirty.js"></script>
+    <script type="module" src="js/vtt/scene-dirty-token-state-patch.js"></script>
     <script type="module" src="js/vtt/horizontal-plane-preload.js"></script>
     <script type="module" src="js/vtt/main.js"></script>
     <script type="module" src="js/vtt/building-physics-bootstrap.js"></script>


### PR DESCRIPTION
## Performance Phase 1E — Direct dirty emitters

Retira del adaptador legacy los hot paths que ya pueden emitir `vtt:scene-dirty` desde su propio subsistema.

### Migrado a emisión directa
- movement destination preview → token / render-only / active
- token preview / traversal → token / render + FOV / active
- movement interaction → topology / render + FOV
- token moved → token / render + FOV
- token Z transition → token / render + FOV
- canonical TokenState sync, incluyendo world/dynamic tokens → token / render + FOV
- procedural chunk load/create/transition → chunk / render + FOV

Los eventos semánticos existentes se conservan para persistencia y otros consumidores.

### Legacy bridge
`LEGACY_EVENT_MAP` baja de 15 a 7 entradas. Se mantienen únicamente:
- camera-follow
- DM observer
- memory-learn
- lighting-changed
- fog-changed
- pov-changed
- dm-edit-changed

También se conserva el puente raw mousemove/mouseup limitado a DM Edit Mode y el fallback silencioso de 500 ms.

### Detalles de seguridad
- `Engine.emitSemanticEvent()` despacha primero el evento de dominio y luego el canonical dirty.
- El patch de TokenState importa primero `token-state-dynamic-patch.js` y envuelve la versión final para no perder cambios de NPC/world tokens.
- El cruce procedural conserva `vtt:token-moved` + `vtt:procedural-chunk-transition`; la invalidación se coalesce en el `procedural-chunk-loaded` producido por la misma activación, evitando un segundo dirty redundante.
- Crear una zona streamed también emite dirty de chunk aunque no pase por `activateChunk()`.
- No se cambian Firebase, reglas de movimiento, renderer ni formato de datos.

### Tests / CI
- eventos migrados ya no son traducidos por legacy bridge
- cámara todavía conserva compatibilidad legacy
- contratos directos de movement/chunks/token sync
- guard recibe canonical token dirties sin incrementar `bridgedEvents`
- recorrido activo conserva presupuesto 20 Hz
- sintaxis de engine/chunk/token patch
- regresiones existentes de FOV, lighting/fog y scheduler