### PR TITLE
WEBGL-02 — Camera, viewport, follow y DM observer

### DIFF
--- a/.github/workflows/vtt-performance-guard.yml
+++ b/.github/workflows/vtt-performance-guard.yml
@@ -5,7 +5,10 @@ on:
     paths:
       - 'vtt.html'
       - 'js/vtt/camera.js'
+      - 'js/vtt/camera-follow.js'
+      - 'js/vtt/dm-observer.js'
       - 'js/vtt/engine.js'
+      - 'js/vtt/render/**'
       - 'js/vtt/procedural-chunk-streaming-runtime.js'
       - 'js/vtt/scene-dirty.js'
       - 'js/vtt/scene-dirty-token-state-patch.js'
@@ -20,6 +23,7 @@ on:
       - 'js/vtt/pov-engine.js'
       - 'js/vtt/pov-state.js'
       - 'js/vtt/memory-state.js'
+      - 'tests/vtt_webgl2_camera_contract.spec.js'
       - 'tests/vtt_scene_dirty.spec.js'
       - 'tests/vtt_scene_dirty_bridges.spec.js'
       - 'tests/vtt_scene_dirty_direct_emitters.spec.js'
@@ -51,7 +55,13 @@ jobs:
           node --input-type=module --check < js/vtt/scene-dirty-lighting-patch.js
           node --input-type=module --check < js/vtt/scene-dirty-memory-patch.js
           node --input-type=module --check < js/vtt/camera.js
+          node --check js/vtt/camera-follow.js
+          node --check js/vtt/dm-observer.js
           node --input-type=module --check < js/vtt/engine.js
+          node --input-type=module --check < js/vtt/render/world-transform.js
+          node --input-type=module --check < js/vtt/render/webgl2-renderer.js
+          node --input-type=module --check < js/vtt/render/dm-observer-overlay.js
+          node --input-type=module --check < js/vtt/render/renderer-factory.js
           node --input-type=module --check < js/vtt/procedural-chunk-streaming-runtime.js
           node --check js/vtt/runtime-lifecycle.js
           node --input-type=module --check < js/vtt/performance-guard.js
@@ -61,6 +71,9 @@ jobs:
           node --check tests/vtt_runtime_performance_phase1.spec.js
           node --check tests/vtt_runtime_frame_scheduler.spec.js
           node --check tests/vtt_performance_guard.spec.js
+          node --input-type=module --check < tests/vtt_webgl2_camera_contract.spec.js
+      - name: WebGL2 camera and DM observer contracts
+        run: npx playwright test --workers=1 tests/vtt_webgl2_camera_contract.spec.js
       - name: Canonical scene dirty contracts
         run: >-
           npx playwright test --workers=1

--- a/js/vtt/camera.js
+++ b/js/vtt/camera.js
@@ -74,6 +74,46 @@ export class Camera {
         if (this.enforceCenterConstraint()) this.notifyVisualChange('constraint');
     }
 
+    viewportRect() {
+        const rect = this.canvas?.getBoundingClientRect?.() || null;
+        const rectWidth = Number(rect?.width);
+        const rectHeight = Number(rect?.height);
+        const clientWidth = Number(this.canvas?.clientWidth);
+        const clientHeight = Number(this.canvas?.clientHeight);
+        const backingWidth = Number(this.canvas?.width);
+        const backingHeight = Number(this.canvas?.height);
+        const width = rectWidth > 0 ? rectWidth : clientWidth > 0 ? clientWidth : backingWidth > 0 ? backingWidth : 1;
+        const height = rectHeight > 0 ? rectHeight : clientHeight > 0 ? clientHeight : backingHeight > 0 ? backingHeight : 1;
+        return {
+            left: Number(rect?.left) || 0,
+            top: Number(rect?.top) || 0,
+            width,
+            height,
+        };
+    }
+
+    viewportSize() {
+        const { width, height } = this.viewportRect();
+        return { width, height };
+    }
+
+    clientToScreen(clientX, clientY) {
+        const rect = this.viewportRect();
+        return {
+            x: Number(clientX) - rect.left,
+            y: Number(clientY) - rect.top,
+        };
+    }
+
+    eventToScreen(event = {}) {
+        return this.clientToScreen(event.clientX, event.clientY);
+    }
+
+    eventToWorld(event = {}) {
+        const point = this.eventToScreen(event);
+        return this.screenToWorld(point.x, point.y);
+    }
+
     setZoomBounds(minZoom = 0.1, maxZoom = 5) {
         const min = Number.isFinite(Number(minZoom)) ? Math.max(0.01, Number(minZoom)) : 0.1;
         const max = Number.isFinite(Number(maxZoom)) ? Math.max(min, Number(maxZoom)) : Math.max(min, 5);
@@ -88,9 +128,10 @@ export class Camera {
     }
 
     centerWorldPoint() {
+        const { width, height } = this.viewportSize();
         return {
-            x: (this.canvas.width / (2 * this.zoom)) - this.x,
-            y: (this.canvas.height / (2 * this.zoom)) - this.y,
+            x: (width / (2 * this.zoom)) - this.x,
+            y: (height / (2 * this.zoom)) - this.y,
         };
     }
 
@@ -109,8 +150,9 @@ export class Camera {
         if (!constrained) return false;
         const changed = Math.abs(constrained.x - current.x) > 1e-7 || Math.abs(constrained.y - current.y) > 1e-7;
         if (changed) {
-            this.x = (this.canvas.width / (2 * this.zoom)) - constrained.x;
-            this.y = (this.canvas.height / (2 * this.zoom)) - constrained.y;
+            const { width, height } = this.viewportSize();
+            this.x = (width / (2 * this.zoom)) - constrained.x;
+            this.y = (height / (2 * this.zoom)) - constrained.y;
         }
         return changed;
     }
@@ -177,14 +219,12 @@ export class Camera {
         this.zoom = Math.max(this.minZoom, Math.min(this.maxZoom, proposed));
         if (Math.abs(this.zoom - previousZoom) < 1e-12) return;
 
-        const rect = this.canvas.getBoundingClientRect();
-        const mouseX = e.clientX - rect.left;
-        const mouseY = e.clientY - rect.top;
-        const worldX = (mouseX / previousZoom) - this.x;
-        const worldY = (mouseY / previousZoom) - this.y;
+        const mouse = this.eventToScreen(e);
+        const worldX = (mouse.x / previousZoom) - this.x;
+        const worldY = (mouse.y / previousZoom) - this.y;
 
-        this.x = (mouseX / this.zoom) - worldX;
-        this.y = (mouseY / this.zoom) - worldY;
+        this.x = (mouse.x / this.zoom) - worldX;
+        this.y = (mouse.y / this.zoom) - worldY;
         const clamped = this.enforceCenterConstraint();
         this.notifyVisualChange('zoom', true, { previousZoom, zoom: this.zoom, clamped });
     }
@@ -194,8 +234,9 @@ export class Camera {
         if (!constrained) return false;
         const previousX = this.x;
         const previousY = this.y;
-        this.x = (this.canvas.width / (2 * this.zoom)) - constrained.x;
-        this.y = (this.canvas.height / (2 * this.zoom)) - constrained.y;
+        const { width, height } = this.viewportSize();
+        this.x = (width / (2 * this.zoom)) - constrained.x;
+        this.y = (height / (2 * this.zoom)) - constrained.y;
         if (Math.abs(this.x - previousX) > 1e-7 || Math.abs(this.y - previousY) > 1e-7) {
             this.notifyVisualChange('center', false, { center: constrained, zoom: this.zoom });
         }
@@ -210,12 +251,13 @@ export class Camera {
     }
 
     applyTransform(ctx) {
-        ctx.translate(this.canvas.width / 2, this.canvas.height / 2);
+        const { width, height } = this.viewportSize();
+        ctx.translate(width / 2, height / 2);
         ctx.scale(this.zoom, this.zoom);
-        ctx.translate(-this.canvas.width / 2, -this.canvas.height / 2);
+        ctx.translate(-width / 2, -height / 2);
 
-        ctx.translate(this.x + this.canvas.width / (2 * this.zoom) - this.canvas.width / 2,
-                      this.y + this.canvas.height / (2 * this.zoom) - this.canvas.height / 2);
+        ctx.translate(this.x + width / (2 * this.zoom) - width / 2,
+                      this.y + height / (2 * this.zoom) - height / 2);
     }
 
     applyTransformSimple(ctx) {
@@ -225,8 +267,8 @@ export class Camera {
 
     screenToWorld(screenX, screenY) {
         return {
-            x: (screenX / this.zoom) - this.x,
-            y: (screenY / this.zoom) - this.y,
+            x: (Number(screenX) / this.zoom) - this.x,
+            y: (Number(screenY) / this.zoom) - this.y,
         };
     }
 }

--- a/js/vtt/camera.js
+++ b/js/vtt/camera.js
@@ -229,7 +229,10 @@ export class Camera {
         this.notifyVisualChange('zoom', true, { previousZoom, zoom: this.zoom, clamped });
     }
 
-    centerOnWorldPoint(point = {}) {
+    centerOnWorldPoint(pointOrX = {}, worldY = undefined) {
+        const point = typeof pointOrX === 'object' && pointOrX !== null
+            ? pointOrX
+            : { x: pointOrX, y: worldY };
         const constrained = this.constrainedCenter(point);
         if (!constrained) return false;
         const previousX = this.x;

--- a/js/vtt/dm-observer.js
+++ b/js/vtt/dm-observer.js
@@ -228,31 +228,25 @@
       return Math.max(Number(mapData.grid?.size) || 70, Number(profile?.radiusPx) || 0);
     }
 
-    function drawOutlines() {
-      if (mode === MODES.VIEW_AS || stopped) return;
-      const renderer = engine.renderer;
-      const ctx = renderer?.ctx;
-      const camera = engine.camera;
-      if (!ctx || !camera) return;
+    function outlineData() {
       const lighting = host?.LuminousVttLightingEngine || root?.LuminousVttLightingEngine;
-      ctx.save();
-      camera.applyTransformSimple?.(ctx);
-      for (const token of playerTokensOnLayer()) {
-        const cone = Number(lighting?.visionConeDeg?.(token)) || 120;
-        const facing = Number(token.lookState?.yawDeg ?? lighting?.facingDeg?.(token) ?? token.facingDeg) || 0;
-        const radius = outlineRadius(token);
-        const half = Math.min(180, cone / 2) * Math.PI / 180;
-        const center = facing * Math.PI / 180;
-        ctx.beginPath();
-        ctx.moveTo(Number(token.x) || 0, Number(token.y) || 0);
-        ctx.arc(Number(token.x) || 0, Number(token.y) || 0, radius, center - half, center + half);
-        ctx.closePath();
-        ctx.globalAlpha = clean(token.id) === clean(targetId) ? 0.85 : 0.45;
-        ctx.strokeStyle = token.color || '#d7b151';
-        ctx.lineWidth = clean(token.id) === clean(targetId) ? 3 : 2;
-        ctx.stroke();
-      }
-      ctx.restore();
+      return playerTokensOnLayer().map((token) => ({
+        tokenId: clean(token.id),
+        x: Number(token.x) || 0,
+        y: Number(token.y) || 0,
+        radius: outlineRadius(token),
+        coneDeg: Number(lighting?.visionConeDeg?.(token)) || 120,
+        facingDeg: Number(token.lookState?.yawDeg ?? lighting?.facingDeg?.(token) ?? token.facingDeg) || 0,
+        color: token.color || '#d7b151',
+        selected: clean(token.id) === clean(targetId),
+      }));
+    }
+
+    function drawOutlines() {
+      if (mode === MODES.VIEW_AS || stopped) return 0;
+      const renderer = engine.renderer;
+      if (!renderer || typeof renderer.drawDmObserverOutlines !== 'function') return 0;
+      return renderer.drawDmObserverOutlines(outlineData(), engine.camera) || 0;
     }
 
     function installOutlineRenderer() {

--- a/js/vtt/engine.js
+++ b/js/vtt/engine.js
@@ -56,8 +56,7 @@ export class Engine {
     }
 
     eventWorldPoint(event) {
-        const rect = this.canvas.getBoundingClientRect();
-        return this.camera.screenToWorld(event.clientX - rect.left, event.clientY - rect.top);
+        return this.camera.eventToWorld(event);
     }
 
     tokenAtEvent(event) {
@@ -314,11 +313,36 @@ export class Engine {
 
     centerCamera() {
         const { cols, rows, size } = this.mapData.grid;
-        const mapWidth = cols * size, mapHeight = rows * size;
-        this.camera.x = (this.canvas.width / 2) - (mapWidth / 2);
-        this.camera.y = (this.canvas.height / 2) - (mapHeight / 2);
+        const mapWidth = cols * size;
+        const mapHeight = rows * size;
+        this.camera.centerOnWorldPoint(mapWidth / 2, mapHeight / 2);
     }
-    handleResize() { this.canvas.width = window.innerWidth; this.canvas.height = window.innerHeight; }
+
+    handleResize() {
+        const centerBefore = this.camera.centerWorldPoint();
+        const currentViewport = this.camera.viewportSize();
+        const width = Math.max(1, Number(window.innerWidth) || currentViewport.width || 1);
+        const height = Math.max(1, Number(window.innerHeight) || currentViewport.height || 1);
+
+        if (this.renderer?.backend === 'webgl2') {
+            this.renderer.resize?.(width, height);
+        } else {
+            this.canvas.width = width;
+            this.canvas.height = height;
+            this.renderer?.resize?.(width, height);
+        }
+
+        this.camera.centerOnWorldPoint(centerBefore);
+        globalThis.LuminousVttSceneDirty?.emit?.(this.canvas, {
+            reason: 'resize',
+            render: true,
+            vision: false,
+            active: false,
+            sourceEvent: 'engine:resize',
+            meta: { width, height },
+        });
+    }
+
     start() { if (!this.isRunning) { this.isRunning = true; requestAnimationFrame(this.loop); } }
     stop() { this.cancelTokenMotion(); this.isRunning = false; }
     loop() {

--- a/js/vtt/render/dm-observer-overlay.js
+++ b/js/vtt/render/dm-observer-overlay.js
@@ -1,0 +1,48 @@
+const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+function drawCanvas2DObserverOutlines(renderer, outlines = [], camera = null) {
+    const ctx = renderer?.ctx;
+    if (!ctx || !camera) return 0;
+
+    let drawn = 0;
+    ctx.save();
+    camera.applyTransformSimple?.(ctx);
+    for (const raw of Array.isArray(outlines) ? outlines : []) {
+        const x = finite(raw?.x);
+        const y = finite(raw?.y);
+        const radius = Math.max(0, finite(raw?.radius));
+        if (!(radius > 0)) continue;
+
+        const cone = Math.max(0, Math.min(360, finite(raw?.coneDeg, 120)));
+        const facing = finite(raw?.facingDeg);
+        const half = Math.min(180, cone / 2) * Math.PI / 180;
+        const center = facing * Math.PI / 180;
+
+        ctx.beginPath();
+        ctx.moveTo(x, y);
+        ctx.arc(x, y, radius, center - half, center + half);
+        ctx.closePath();
+        ctx.globalAlpha = raw?.selected ? 0.85 : 0.45;
+        ctx.strokeStyle = raw?.color || '#d7b151';
+        ctx.lineWidth = raw?.selected ? 3 : 2;
+        ctx.stroke();
+        drawn += 1;
+    }
+    ctx.restore();
+    return drawn;
+}
+
+/**
+ * Installs the temporary backend seam used by DM Observer during the staged
+ * Canvas2D -> WebGL2 migration. DM Observer only supplies world-space outline
+ * data; each renderer owns how that data is drawn.
+ */
+export function installDmObserverOverlay(renderer) {
+    if (!renderer || typeof renderer.drawDmObserverOutlines === 'function') return renderer;
+
+    if (renderer.backend === 'canvas2d' && renderer.ctx) {
+        renderer.drawDmObserverOutlines = (outlines, camera) => drawCanvas2DObserverOutlines(renderer, outlines, camera);
+    }
+
+    return renderer;
+}

--- a/js/vtt/render/renderer-factory.js
+++ b/js/vtt/render/renderer-factory.js
@@ -1,10 +1,12 @@
 import { Canvas2DRenderer } from './canvas2d-renderer.js';
+import { installDmObserverOverlay } from './dm-observer-overlay.js';
 import { RENDERER_BACKENDS } from './renderer-backend.js';
 import { WebGL2Renderer } from './webgl2-renderer.js';
 
 export function createRenderer(canvas, mapData, { backend = RENDERER_BACKENDS.CANVAS_2D } = {}) {
-    if (backend === RENDERER_BACKENDS.WEBGL_2) {
-        return new WebGL2Renderer(canvas, mapData);
-    }
-    return new Canvas2DRenderer(canvas, mapData);
+    const renderer = backend === RENDERER_BACKENDS.WEBGL_2
+        ? new WebGL2Renderer(canvas, mapData)
+        : new Canvas2DRenderer(canvas, mapData);
+
+    return installDmObserverOverlay(renderer);
 }

--- a/js/vtt/render/webgl2-renderer.js
+++ b/js/vtt/render/webgl2-renderer.js
@@ -20,11 +20,19 @@ void main() {
     gl_Position = vec4(clip.xy, 0.0, 1.0);
 }`;
 
-const FRAGMENT_SHADER_SOURCE = `#version 300 es
+const GRID_FRAGMENT_SHADER_SOURCE = `#version 300 es
 precision mediump float;
 out vec4 outColor;
 void main() {
     outColor = vec4(1.0, 1.0, 1.0, 0.22);
+}`;
+
+const OVERLAY_FRAGMENT_SHADER_SOURCE = `#version 300 es
+precision mediump float;
+uniform vec4 u_color;
+out vec4 outColor;
+void main() {
+    outColor = u_color;
 }`;
 
 function createLegacyCanvas2DShim() {
@@ -64,6 +72,32 @@ function createLegacyCanvas2DShim() {
 }
 
 const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+function rgba(color, alpha = 1) {
+    const text = String(color || '#d7b151').trim();
+    const short = /^#([0-9a-f]{3})$/i.exec(text);
+    const full = /^#([0-9a-f]{6})$/i.exec(text);
+    let r = 215;
+    let g = 177;
+    let b = 81;
+
+    if (short) {
+        r = parseInt(short[1][0] + short[1][0], 16);
+        g = parseInt(short[1][1] + short[1][1], 16);
+        b = parseInt(short[1][2] + short[1][2], 16);
+    } else if (full) {
+        r = parseInt(full[1].slice(0, 2), 16);
+        g = parseInt(full[1].slice(2, 4), 16);
+        b = parseInt(full[1].slice(4, 6), 16);
+    }
+
+    return new Float32Array([
+        r / 255,
+        g / 255,
+        b / 255,
+        Math.max(0, Math.min(1, finite(alpha, 1))),
+    ]);
+}
 
 export class WebGL2Renderer {
     constructor(canvas, mapData) {
@@ -109,6 +143,7 @@ export class WebGL2Renderer {
 
         this.configureContext();
         this.createGridPipeline();
+        this.createObserverOverlayPipeline();
         this.resize();
     }
 
@@ -126,17 +161,15 @@ export class WebGL2Renderer {
         return shader;
     }
 
-    createGridPipeline() {
+    createProgram(fragmentSource) {
         const gl = this.gl;
-        if (!gl || this.destroyed || this.contextLost) return;
-
         const vertexShader = this.compileShader(gl.VERTEX_SHADER, VERTEX_SHADER_SOURCE);
-        const fragmentShader = this.compileShader(gl.FRAGMENT_SHADER, FRAGMENT_SHADER_SOURCE);
+        const fragmentShader = this.compileShader(gl.FRAGMENT_SHADER, fragmentSource);
         const program = gl.createProgram();
         if (!program) {
             gl.deleteShader(vertexShader);
             gl.deleteShader(fragmentShader);
-            throw new Error('Unable to allocate WebGL2 grid program.');
+            throw new Error('Unable to allocate WebGL2 program.');
         }
 
         gl.attachShader(program, vertexShader);
@@ -150,7 +183,14 @@ export class WebGL2Renderer {
             gl.deleteProgram(program);
             throw new Error(message);
         }
+        return program;
+    }
 
+    createGridPipeline() {
+        const gl = this.gl;
+        if (!gl || this.destroyed || this.contextLost) return;
+
+        const program = this.createProgram(GRID_FRAGMENT_SHADER_SOURCE);
         this.gridProgram = program;
         this.gridBuffer = gl.createBuffer();
         this.gridLocations = {
@@ -159,6 +199,20 @@ export class WebGL2Renderer {
         };
         this.gridSignature = '';
         this.gridVertexCount = 0;
+    }
+
+    createObserverOverlayPipeline() {
+        const gl = this.gl;
+        if (!gl || this.destroyed || this.contextLost) return;
+
+        const program = this.createProgram(OVERLAY_FRAGMENT_SHADER_SOURCE);
+        this.observerOverlayProgram = program;
+        this.observerOverlayBuffer = gl.createBuffer();
+        this.observerOverlayLocations = {
+            position: gl.getAttribLocation(program, 'a_position'),
+            world: gl.getUniformLocation(program, 'u_world'),
+            color: gl.getUniformLocation(program, 'u_color'),
+        };
     }
 
     configureContext() {
@@ -180,6 +234,7 @@ export class WebGL2Renderer {
         this.contextLost = false;
         this.configureContext();
         this.createGridPipeline();
+        this.createObserverOverlayPipeline();
         this.resize();
         this.markAllLayersDirty();
     }
@@ -216,10 +271,31 @@ export class WebGL2Renderer {
         return { width: Math.max(1, width), height: Math.max(1, height) };
     }
 
-    resize(camera = null) {
+    resize(cameraOrWidth = null, requestedHeight = null) {
         if (this.destroyed || !this.gl || this.contextLost) return this.logicalViewport;
-        this.logicalViewport = this.viewportSize(camera);
+
+        const explicitSize = Number.isFinite(Number(cameraOrWidth)) && Number.isFinite(Number(requestedHeight));
+        const camera = explicitSize ? null : cameraOrWidth;
+        this.logicalViewport = explicitSize
+            ? {
+                width: Math.max(1, finite(cameraOrWidth, 1)),
+                height: Math.max(1, finite(requestedHeight, 1)),
+            }
+            : this.viewportSize(camera);
+
         this.devicePixelRatio = Math.max(1, finite(globalThis.devicePixelRatio, 1));
+        const framebufferWidth = Math.max(1, Math.round(this.logicalViewport.width * this.devicePixelRatio));
+        const framebufferHeight = Math.max(1, Math.round(this.logicalViewport.height * this.devicePixelRatio));
+
+        // Width/height are framebuffer pixels. CSS dimensions remain logical pixels,
+        // so Camera and pointer math are independent from devicePixelRatio.
+        if (explicitSize && this.canvas?.style) {
+            this.canvas.style.width = `${this.logicalViewport.width}px`;
+            this.canvas.style.height = `${this.logicalViewport.height}px`;
+        }
+        if (this.canvas.width !== framebufferWidth) this.canvas.width = framebufferWidth;
+        if (this.canvas.height !== framebufferHeight) this.canvas.height = framebufferHeight;
+
         this.gl.viewport(0, 0, this.gl.drawingBufferWidth, this.gl.drawingBufferHeight);
         return this.logicalViewport;
     }
@@ -287,6 +363,50 @@ export class WebGL2Renderer {
         layer.dirty = false;
     }
 
+    observerConeVertices(raw = {}) {
+        const x = finite(raw.x);
+        const y = finite(raw.y);
+        const radius = Math.max(0, finite(raw.radius));
+        if (!(radius > 0)) return new Float32Array();
+
+        const cone = Math.max(0, Math.min(360, finite(raw.coneDeg, 120)));
+        const facing = finite(raw.facingDeg);
+        const start = (facing - (cone / 2)) * Math.PI / 180;
+        const sweep = cone * Math.PI / 180;
+        const segments = Math.max(12, Math.ceil(cone / 6));
+        const vertices = [x, y];
+
+        for (let index = 0; index <= segments; index += 1) {
+            const angle = start + (sweep * index / segments);
+            vertices.push(x + Math.cos(angle) * radius, y + Math.sin(angle) * radius);
+        }
+        vertices.push(x, y);
+        return new Float32Array(vertices);
+    }
+
+    drawDmObserverOutlines(outlines = [], camera = null) {
+        if (this.destroyed || !this.gl || this.contextLost || !this.observerOverlayProgram || !this.observerOverlayBuffer) return 0;
+        if (camera) this.syncWorld(camera);
+
+        const gl = this.gl;
+        gl.useProgram(this.observerOverlayProgram);
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.observerOverlayBuffer);
+        gl.enableVertexAttribArray(this.observerOverlayLocations.position);
+        gl.vertexAttribPointer(this.observerOverlayLocations.position, 2, gl.FLOAT, false, 0, 0);
+        gl.uniformMatrix3fv(this.observerOverlayLocations.world, false, this.world.matrix);
+
+        let drawn = 0;
+        for (const raw of Array.isArray(outlines) ? outlines : []) {
+            const vertices = this.observerConeVertices(raw);
+            if (vertices.length < 6) continue;
+            gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.DYNAMIC_DRAW);
+            gl.uniform4fv(this.observerOverlayLocations.color, rgba(raw?.color, raw?.selected ? 0.85 : 0.45));
+            gl.drawArrays(gl.LINE_STRIP, 0, vertices.length / 2);
+            drawn += 1;
+        }
+        return drawn;
+    }
+
     topologyStyle(element, preview = false) {
         if (preview) return { stroke: '#ffffff', width: 4, dash: [8, 5], label: '' };
         const state = element?.state;
@@ -348,6 +468,7 @@ export class WebGL2Renderer {
             devicePixelRatio: this.devicePixelRatio,
             world: this.world.snapshot(),
             gridVertexCount: this.gridVertexCount,
+            observerOverlayReady: Boolean(this.observerOverlayProgram && this.observerOverlayBuffer),
             layers: [...this.layers.values()].map((layer) => ({ ...layer })),
         };
     }
@@ -363,6 +484,8 @@ export class WebGL2Renderer {
         if (gl && !this.contextLost) {
             if (this.gridBuffer) gl.deleteBuffer(this.gridBuffer);
             if (this.gridProgram) gl.deleteProgram(this.gridProgram);
+            if (this.observerOverlayBuffer) gl.deleteBuffer(this.observerOverlayBuffer);
+            if (this.observerOverlayProgram) gl.deleteProgram(this.observerOverlayProgram);
             const loseContext = gl.getExtension('WEBGL_lose_context');
             loseContext?.loseContext?.();
         }
@@ -374,6 +497,9 @@ export class WebGL2Renderer {
         this.gridLocations = null;
         this.gridSignature = '';
         this.gridVertexCount = 0;
+        this.observerOverlayBuffer = null;
+        this.observerOverlayProgram = null;
+        this.observerOverlayLocations = null;
         this.world = null;
         this.ctx = null;
         this.legacyCanvas2DShim = false;

--- a/js/vtt/render/webgl2-renderer.js
+++ b/js/vtt/render/webgl2-renderer.js
@@ -1,3 +1,5 @@
+import { WebGLWorldTransform } from './world-transform.js';
+
 export const WEBGL2_LAYER_ORDER = Object.freeze([
     'terrain',
     'grid',
@@ -12,13 +14,10 @@ export const WEBGL2_LAYER_ORDER = Object.freeze([
 
 const VERTEX_SHADER_SOURCE = `#version 300 es
 in vec2 a_position;
-uniform vec2 u_resolution;
-uniform vec2 u_camera;
-uniform float u_zoom;
+uniform mat3 u_world;
 void main() {
-    vec2 screen = (a_position + u_camera) * u_zoom;
-    vec2 clip = (screen / u_resolution) * 2.0 - 1.0;
-    gl_Position = vec4(clip.x, -clip.y, 0.0, 1.0);
+    vec3 clip = u_world * vec3(a_position, 1.0);
+    gl_Position = vec4(clip.xy, 0.0, 1.0);
 }`;
 
 const FRAGMENT_SHADER_SOURCE = `#version 300 es
@@ -64,6 +63,8 @@ function createLegacyCanvas2DShim() {
     };
 }
 
+const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
 export class WebGL2Renderer {
     constructor(canvas, mapData) {
         this.canvas = canvas;
@@ -74,6 +75,9 @@ export class WebGL2Renderer {
         this.contextLost = false;
         this.gridSignature = '';
         this.gridVertexCount = 0;
+        this.world = new WebGLWorldTransform();
+        this.logicalViewport = { width: Math.max(1, Number(canvas?.width) || 1), height: Math.max(1, Number(canvas?.height) || 1) };
+        this.devicePixelRatio = 1;
         this.layers = new Map(WEBGL2_LAYER_ORDER.map((name, index) => [name, {
             name,
             order: index,
@@ -151,9 +155,7 @@ export class WebGL2Renderer {
         this.gridBuffer = gl.createBuffer();
         this.gridLocations = {
             position: gl.getAttribLocation(program, 'a_position'),
-            resolution: gl.getUniformLocation(program, 'u_resolution'),
-            camera: gl.getUniformLocation(program, 'u_camera'),
-            zoom: gl.getUniformLocation(program, 'u_zoom'),
+            world: gl.getUniformLocation(program, 'u_world'),
         };
         this.gridSignature = '';
         this.gridVertexCount = 0;
@@ -203,9 +205,37 @@ export class WebGL2Renderer {
         return true;
     }
 
-    resize() {
-        if (this.destroyed || !this.gl || this.contextLost) return;
+    viewportSize(camera = null) {
+        const cameraViewport = camera?.viewportSize?.();
+        if (finite(cameraViewport?.width) > 0 && finite(cameraViewport?.height) > 0) {
+            return { width: finite(cameraViewport.width), height: finite(cameraViewport.height) };
+        }
+        const rect = this.canvas?.getBoundingClientRect?.();
+        const width = finite(rect?.width) || finite(this.canvas?.clientWidth) || finite(this.canvas?.width, 1);
+        const height = finite(rect?.height) || finite(this.canvas?.clientHeight) || finite(this.canvas?.height, 1);
+        return { width: Math.max(1, width), height: Math.max(1, height) };
+    }
+
+    resize(camera = null) {
+        if (this.destroyed || !this.gl || this.contextLost) return this.logicalViewport;
+        this.logicalViewport = this.viewportSize(camera);
+        this.devicePixelRatio = Math.max(1, finite(globalThis.devicePixelRatio, 1));
         this.gl.viewport(0, 0, this.gl.drawingBufferWidth, this.gl.drawingBufferHeight);
+        return this.logicalViewport;
+    }
+
+    syncWorld(camera) {
+        const viewport = this.resize(camera);
+        this.world.sync(camera, viewport);
+        return this.world;
+    }
+
+    worldToScreen(worldX, worldY) {
+        return this.world.worldToScreen(worldX, worldY);
+    }
+
+    screenToWorld(screenX, screenY) {
+        return this.world.screenToWorld(screenX, screenY);
     }
 
     gridVertices() {
@@ -242,7 +272,7 @@ export class WebGL2Renderer {
         this.markLayerDirty('grid');
     }
 
-    drawGrid(camera) {
+    drawGrid() {
         const gl = this.gl;
         const layer = this.layers.get('grid');
         if (!gl || !layer?.visible || !this.gridProgram || !this.gridBuffer) return;
@@ -252,10 +282,7 @@ export class WebGL2Renderer {
         gl.bindBuffer(gl.ARRAY_BUFFER, this.gridBuffer);
         gl.enableVertexAttribArray(this.gridLocations.position);
         gl.vertexAttribPointer(this.gridLocations.position, 2, gl.FLOAT, false, 0, 0);
-
-        gl.uniform2f(this.gridLocations.resolution, gl.drawingBufferWidth, gl.drawingBufferHeight);
-        gl.uniform2f(this.gridLocations.camera, Number(camera?.x) || 0, Number(camera?.y) || 0);
-        gl.uniform1f(this.gridLocations.zoom, Math.max(0.0001, Number(camera?.zoom) || 1));
+        gl.uniformMatrix3fv(this.gridLocations.world, false, this.world.matrix);
         gl.drawArrays(gl.LINES, 0, this.gridVertexCount);
         layer.dirty = false;
     }
@@ -283,11 +310,12 @@ export class WebGL2Renderer {
 
     render(camera, _activeZ, _renderData, _isExporting = false) {
         if (this.destroyed || !this.gl || this.contextLost) return;
-        this.resize();
+        this.syncWorld(camera);
         this.gl.clear(this.gl.COLOR_BUFFER_BIT | this.gl.STENCIL_BUFFER_BIT);
 
-        // Rama 1 proof-of-life: black GPU surface + camera-aware grid only.
-        this.drawGrid(camera);
+        // All GPU world layers consume this renderer-owned transform. The grid is
+        // the first migrated pipeline; later layers must not read camera directly.
+        this.drawGrid();
 
         for (const [name, layer] of this.layers) {
             if (name !== 'grid') layer.dirty = false;
@@ -316,6 +344,9 @@ export class WebGL2Renderer {
                 width: this.gl.drawingBufferWidth,
                 height: this.gl.drawingBufferHeight,
             },
+            logicalViewport: { ...this.logicalViewport },
+            devicePixelRatio: this.devicePixelRatio,
+            world: this.world.snapshot(),
             gridVertexCount: this.gridVertexCount,
             layers: [...this.layers.values()].map((layer) => ({ ...layer })),
         };
@@ -343,6 +374,7 @@ export class WebGL2Renderer {
         this.gridLocations = null;
         this.gridSignature = '';
         this.gridVertexCount = 0;
+        this.world = null;
         this.ctx = null;
         this.legacyCanvas2DShim = false;
         this.gl = null;

--- a/js/vtt/render/world-transform.js
+++ b/js/vtt/render/world-transform.js
@@ -1,0 +1,71 @@
+const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+export class WebGLWorldTransform {
+    constructor() {
+        this.x = 0;
+        this.y = 0;
+        this.zoom = 1;
+        this.viewportWidth = 1;
+        this.viewportHeight = 1;
+        this.matrix = new Float32Array(9);
+        this.sync(null, { width: 1, height: 1 });
+    }
+
+    sync(camera, viewport = {}) {
+        this.x = finite(camera?.x, 0);
+        this.y = finite(camera?.y, 0);
+        this.zoom = Math.max(0.0001, finite(camera?.zoom, 1));
+        this.viewportWidth = Math.max(1, finite(viewport.width, 1));
+        this.viewportHeight = Math.max(1, finite(viewport.height, 1));
+
+        const sx = (2 * this.zoom) / this.viewportWidth;
+        const sy = (-2 * this.zoom) / this.viewportHeight;
+        const tx = ((2 * this.x * this.zoom) / this.viewportWidth) - 1;
+        const ty = 1 - ((2 * this.y * this.zoom) / this.viewportHeight);
+
+        // Column-major mat3 for GLSL: clip = u_world * vec3(world, 1).
+        this.matrix[0] = sx;
+        this.matrix[1] = 0;
+        this.matrix[2] = 0;
+        this.matrix[3] = 0;
+        this.matrix[4] = sy;
+        this.matrix[5] = 0;
+        this.matrix[6] = tx;
+        this.matrix[7] = ty;
+        this.matrix[8] = 1;
+        return this;
+    }
+
+    worldToScreen(worldX, worldY) {
+        return {
+            x: (finite(worldX) + this.x) * this.zoom,
+            y: (finite(worldY) + this.y) * this.zoom,
+        };
+    }
+
+    screenToWorld(screenX, screenY) {
+        return {
+            x: (finite(screenX) / this.zoom) - this.x,
+            y: (finite(screenY) / this.zoom) - this.y,
+        };
+    }
+
+    worldToClip(worldX, worldY) {
+        const screen = this.worldToScreen(worldX, worldY);
+        return {
+            x: ((screen.x / this.viewportWidth) * 2) - 1,
+            y: 1 - ((screen.y / this.viewportHeight) * 2),
+        };
+    }
+
+    snapshot() {
+        return Object.freeze({
+            x: this.x,
+            y: this.y,
+            zoom: this.zoom,
+            viewportWidth: this.viewportWidth,
+            viewportHeight: this.viewportHeight,
+            matrix: Array.from(this.matrix),
+        });
+    }
+}

--- a/tests/vtt_webgl2_camera_contract.spec.js
+++ b/tests/vtt_webgl2_camera_contract.spec.js
@@ -191,3 +191,49 @@ test('CAM-20 Camera.destroy retira listeners registrados', () => {
   expect(win.listeners.get('mousemove')?.size || 0).toBe(0);
   expect(win.listeners.get('mouseup')?.size || 0).toBe(0);
 });
+
+test('CAM-05/08 Engine delega mouse, centrado y resize al contrato de Camera', () => {
+  const engine = read('js/vtt/engine.js');
+
+  expect(engine).toContain('return this.camera.eventToWorld(event);');
+  expect(engine).not.toContain('return this.camera.screenToWorld(event.clientX - rect.left, event.clientY - rect.top);');
+  expect(engine).toContain('this.camera.centerOnWorldPoint(mapWidth / 2, mapHeight / 2);');
+  expect(engine).toContain("if (this.renderer?.backend === 'webgl2')");
+  expect(engine).toContain('this.renderer.resize?.(width, height);');
+  expect(engine).toContain('this.camera.centerOnWorldPoint(centerBefore);');
+});
+
+test('CAM-11/12/13 Camera Follow conserva follow, manual look y hotkeys Legacy', () => {
+  const follow = read('js/vtt/camera-follow.js');
+
+  expect(follow).toContain("camera.centerOnWorldPoint?.({ x: token.x, y: token.y }) === true");
+  expect(follow).toContain('camera.setManualPanListener?.(onManualPan);');
+  expect(follow).toContain("emit(policy.active ? 'look-around' : 'manual-pan');");
+  expect(follow).toContain("event.code === 'KeyF'");
+  expect(follow).toContain("event.code === 'Home'");
+});
+
+test('CAM-14 drag preview no arrastra cámara; traversal confirmado sí puede seguir', () => {
+  const follow = read('js/vtt/camera-follow.js');
+
+  expect(follow).toContain("if (event?.type === 'vtt:token-preview-moved')");
+  expect(follow).toContain('if (!isConfirmedTraversalPreview(event.detail || {})) return;');
+  expect(follow).toContain("queueTraversalSync(event?.detail?.remote ? 'remote-token-traversal' : 'token-traversal');");
+});
+
+test('CAM-16/17/18 DM Observer mantiene selección explícita y VIEW AS solo para Player', () => {
+  const observer = read('js/vtt/dm-observer.js');
+
+  expect(observer).toContain("if (!selectingMode || event.button !== 0 || mapData.dmEditMode?.active) return;");
+  expect(observer).toContain('if (selectingMode === MODES.VIEW_AS && !isPlayerToken(token)) return;');
+  expect(observer).toContain('mapData.lighting.dmPreviewTokenId = mode === MODES.VIEW_AS ? clean(token.id) : null;');
+});
+
+test('CAM-20 lifecycle destruye renderer y camera para evitar listeners/contextos duplicados', () => {
+  const lifecycle = read('js/vtt/runtime-lifecycle.js');
+
+  expect(lifecycle).toContain("globalThis.removeEventListener?.('resize', engine.handleResize)");
+  expect(lifecycle).toContain("engine.canvas?.removeEventListener?.('mousedown', engine.handleTokenMouseDown)");
+  expect(lifecycle).toContain('engine.renderer?.destroy?.();');
+  expect(lifecycle).toContain('engine.camera?.destroy?.();');
+});

--- a/tests/vtt_webgl2_camera_contract.spec.js
+++ b/tests/vtt_webgl2_camera_contract.spec.js
@@ -1,0 +1,193 @@
+import { test, expect } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Camera } from '../js/vtt/camera.js';
+import { WebGLWorldTransform } from '../js/vtt/render/world-transform.js';
+import { WebGL2Renderer } from '../js/vtt/render/webgl2-renderer.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+function eventTarget() {
+  const listeners = new Map();
+  return {
+    listeners,
+    addEventListener(type, handler) {
+      const set = listeners.get(type) || new Set();
+      set.add(handler);
+      listeners.set(type, set);
+    },
+    removeEventListener(type, handler) {
+      listeners.get(type)?.delete(handler);
+    },
+    dispatchEvent() {},
+  };
+}
+
+function makeCanvas({ logicalWidth = 1920, logicalHeight = 1080, dpr = 2, left = 100, top = 50 } = {}) {
+  const target = eventTarget();
+  return {
+    ...target,
+    width: logicalWidth * dpr,
+    height: logicalHeight * dpr,
+    clientWidth: logicalWidth,
+    clientHeight: logicalHeight,
+    style: {},
+    getBoundingClientRect() {
+      return { left, top, width: logicalWidth, height: logicalHeight, right: left + logicalWidth, bottom: top + logicalHeight };
+    },
+  };
+}
+
+function installDomStubs() {
+  const win = eventTarget();
+  globalThis.window = win;
+  globalThis.document = { body: {} };
+  return win;
+}
+
+test('CAM-01/02 worldToScreen y screenToWorld son inversas', () => {
+  installDomStubs();
+  const camera = new Camera(makeCanvas());
+  camera.x = -237.25;
+  camera.y = 91.5;
+  camera.zoom = 2.35;
+
+  const world = { x: 1337.125, y: 742.875 };
+  const screen = camera.worldToScreen(world.x, world.y);
+  const roundTrip = camera.screenToWorld(screen.x, screen.y);
+
+  expect(roundTrip.x).toBeCloseTo(world.x, 10);
+  expect(roundTrip.y).toBeCloseTo(world.y, 10);
+  camera.destroy();
+});
+
+test('CAM-08/09 viewport lógico no usa el framebuffer DPR como coordenada de juego', () => {
+  installDomStubs();
+  const canvas = makeCanvas({ logicalWidth: 1920, logicalHeight: 1080, dpr: 2 });
+  const camera = new Camera(canvas);
+
+  expect(canvas.width).toBe(3840);
+  expect(camera.viewportSize()).toEqual({ width: 1920, height: 1080 });
+
+  camera.zoom = 1.5;
+  expect(camera.centerOnWorldPoint(700, 400)).toBe(true);
+  const screen = camera.worldToScreen(700, 400);
+  expect(screen.x).toBeCloseTo(960, 10);
+  expect(screen.y).toBeCloseTo(540, 10);
+  camera.destroy();
+});
+
+test('CAM-10 centerOnWorldPoint conserva firma Legacy (x,y) y firma nueva ({x,y})', () => {
+  installDomStubs();
+  const camera = new Camera(makeCanvas({ logicalWidth: 1600, logicalHeight: 900, dpr: 1 }));
+  camera.zoom = 2;
+
+  expect(camera.centerOnWorldPoint(300, 250)).toBe(true);
+  expect(camera.worldToScreen(300, 250)).toEqual({ x: 800, y: 450 });
+
+  expect(camera.centerOnWorldPoint({ x: 900, y: 650 })).toBe(true);
+  expect(camera.worldToScreen(900, 650)).toEqual({ x: 800, y: 450 });
+  camera.destroy();
+});
+
+test('CAM-06 zoom permanece anclado al cursor usando CSS pixels', () => {
+  installDomStubs();
+  const canvas = makeCanvas({ logicalWidth: 1920, logicalHeight: 1080, dpr: 2, left: 40, top: 25 });
+  const camera = new Camera(canvas);
+  camera.x = -150;
+  camera.y = 75;
+  camera.zoom = 1.25;
+
+  const event = {
+    clientX: 40 + 875,
+    clientY: 25 + 460,
+    deltaY: -100,
+    preventDefault() {},
+  };
+  const before = camera.eventToWorld(event);
+  camera.onWheel(event);
+  const after = camera.eventToWorld(event);
+
+  expect(after.x).toBeCloseTo(before.x, 10);
+  expect(after.y).toBeCloseTo(before.y, 10);
+  camera.destroy();
+});
+
+test('CAM-03 WebGL world transform conserva exactamente la matemática de Camera', () => {
+  const transform = new WebGLWorldTransform();
+  const camera = { x: -312.5, y: 47.25, zoom: 1.75 };
+  const viewport = { width: 1920, height: 1080 };
+  transform.sync(camera, viewport);
+
+  const point = { x: 1400, y: 920 };
+  const screen = transform.worldToScreen(point.x, point.y);
+  const expectedScreen = {
+    x: (point.x + camera.x) * camera.zoom,
+    y: (point.y + camera.y) * camera.zoom,
+  };
+  expect(screen.x).toBeCloseTo(expectedScreen.x, 10);
+  expect(screen.y).toBeCloseTo(expectedScreen.y, 10);
+
+  const clip = transform.worldToClip(point.x, point.y);
+  expect(clip.x).toBeCloseTo((expectedScreen.x / viewport.width) * 2 - 1, 10);
+  expect(clip.y).toBeCloseTo(1 - (expectedScreen.y / viewport.height) * 2, 10);
+});
+
+test('CAM-15/16 DM observer ya no depende de CanvasRenderingContext2D', () => {
+  const observer = read('js/vtt/dm-observer.js');
+  const factory = read('js/vtt/render/renderer-factory.js');
+  const adapter = read('js/vtt/render/dm-observer-overlay.js');
+  const webgl = read('js/vtt/render/webgl2-renderer.js');
+
+  expect(observer).not.toContain('renderer?.ctx');
+  expect(observer).not.toContain('camera.applyTransformSimple?.(ctx)');
+  expect(observer).toContain('renderer.drawDmObserverOutlines');
+  expect(factory).toContain('installDmObserverOverlay(renderer)');
+  expect(adapter).toContain("renderer.backend === 'canvas2d'");
+  expect(webgl).toContain('drawDmObserverOutlines(outlines = [], camera = null)');
+});
+
+test('CAM-09 WebGL2 resize separa viewport lógico y framebuffer DPR', () => {
+  const webgl = read('js/vtt/render/webgl2-renderer.js');
+  expect(webgl).toContain('framebufferWidth = Math.max(1, Math.round(this.logicalViewport.width * this.devicePixelRatio))');
+  expect(webgl).toContain('framebufferHeight = Math.max(1, Math.round(this.logicalViewport.height * this.devicePixelRatio))');
+  expect(webgl).toContain('this.canvas.width = framebufferWidth');
+  expect(webgl).toContain('this.canvas.height = framebufferHeight');
+});
+
+test('CAM-15 WebGL2 genera geometría world-space para el cono del observer', () => {
+  const vertices = WebGL2Renderer.prototype.observerConeVertices.call({}, {
+    x: 500,
+    y: 300,
+    radius: 140,
+    coneDeg: 120,
+    facingDeg: 0,
+  });
+
+  expect(vertices).toBeInstanceOf(Float32Array);
+  expect(vertices.length).toBeGreaterThan(8);
+  expect(vertices[0]).toBeCloseTo(500, 6);
+  expect(vertices[1]).toBeCloseTo(300, 6);
+  expect(vertices[vertices.length - 2]).toBeCloseTo(500, 6);
+  expect(vertices[vertices.length - 1]).toBeCloseTo(300, 6);
+});
+
+test('CAM-20 Camera.destroy retira listeners registrados', () => {
+  const win = installDomStubs();
+  const canvas = makeCanvas();
+  const camera = new Camera(canvas);
+
+  expect(canvas.listeners.get('mousedown')?.size).toBe(1);
+  expect(canvas.listeners.get('wheel')?.size).toBe(1);
+  expect(win.listeners.get('mousemove')?.size).toBe(1);
+  expect(win.listeners.get('mouseup')?.size).toBe(1);
+
+  camera.destroy();
+
+  expect(canvas.listeners.get('mousedown')?.size || 0).toBe(0);
+  expect(canvas.listeners.get('wheel')?.size || 0).toBe(0);
+  expect(win.listeners.get('mousemove')?.size || 0).toBe(0);
+  expect(win.listeners.get('mouseup')?.size || 0).toBe(0);
+});

--- a/tests/vtt_webgl2_camera_contract.spec.js
+++ b/tests/vtt_webgl2_camera_contract.spec.js
@@ -5,6 +5,8 @@ import { fileURLToPath } from 'node:url';
 import { Camera } from '../js/vtt/camera.js';
 import { WebGLWorldTransform } from '../js/vtt/render/world-transform.js';
 import { WebGL2Renderer } from '../js/vtt/render/webgl2-renderer.js';
+import '../js/vtt/camera-follow.js';
+import '../js/vtt/dm-observer.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
@@ -21,8 +23,18 @@ function eventTarget() {
     removeEventListener(type, handler) {
       listeners.get(type)?.delete(handler);
     },
-    dispatchEvent() {},
+    dispatchEvent(event) {
+      for (const handler of [...(listeners.get(event?.type) || [])]) handler(event);
+      return true;
+    },
   };
+}
+
+class TestCustomEvent {
+  constructor(type, options = {}) {
+    this.type = type;
+    this.detail = options.detail;
+  }
 }
 
 function makeCanvas({ logicalWidth = 1920, logicalHeight = 1080, dpr = 2, left = 100, top = 50 } = {}) {
@@ -42,8 +54,14 @@ function makeCanvas({ logicalWidth = 1920, logicalHeight = 1080, dpr = 2, left =
 
 function installDomStubs() {
   const win = eventTarget();
+  win.CustomEvent = TestCustomEvent;
+  win.setTimeout = (callback) => { callback(); return 1; };
+  win.clearTimeout = () => {};
+  win.requestAnimationFrame = (callback) => { callback(0); return 1; };
+  win.cancelAnimationFrame = () => {};
   globalThis.window = win;
   globalThis.document = { body: {} };
+  globalThis.CustomEvent = TestCustomEvent;
   return win;
 }
 
@@ -60,6 +78,28 @@ test('CAM-01/02 worldToScreen y screenToWorld son inversas', () => {
 
   expect(roundTrip.x).toBeCloseTo(world.x, 10);
   expect(roundTrip.y).toBeCloseTo(world.y, 10);
+  camera.destroy();
+});
+
+test('CAM-04/05 pan conserva desplazamiento visual bajo distintos zoom', () => {
+  installDomStubs();
+  const camera = new Camera(makeCanvas({ logicalWidth: 1600, logicalHeight: 900, dpr: 1 }));
+  camera.zoom = 2;
+  const point = { x: 500, y: 300 };
+  const before = camera.worldToScreen(point.x, point.y);
+  let manualPanCalls = 0;
+  camera.setManualPanListener(() => { manualPanCalls += 1; });
+
+  camera.onMouseDown({ button: 1, clientX: 100, clientY: 100, preventDefault() {} });
+  camera.onMouseMove({ clientX: 200, clientY: 160 });
+  camera.onMouseUp();
+
+  const after = camera.worldToScreen(point.x, point.y);
+  expect(camera.x).toBeCloseTo(50, 10);
+  expect(camera.y).toBeCloseTo(30, 10);
+  expect(after.x - before.x).toBeCloseTo(100, 10);
+  expect(after.y - before.y).toBeCloseTo(60, 10);
+  expect(manualPanCalls).toBe(1);
   camera.destroy();
 });
 
@@ -203,30 +243,92 @@ test('CAM-05/08 Engine delega mouse, centrado y resize al contrato de Camera', (
   expect(engine).toContain('this.camera.centerOnWorldPoint(centerBefore);');
 });
 
-test('CAM-11/12/13 Camera Follow conserva follow, manual look y hotkeys Legacy', () => {
-  const follow = read('js/vtt/camera-follow.js');
+test('CAM-11/12 Camera Follow centra y libera follow al hacer pan manual', () => {
+  const host = installDomStubs();
+  const canvas = makeCanvas({ logicalWidth: 1600, logicalHeight: 900, dpr: 1 });
+  const camera = new Camera(canvas);
+  const token = { id: 'player-1', x: 720, y: 410, viewer: true, zLayer: 0 };
+  const mapData = { tokens: [token], grid: { size: 70, distancePerCell: 5 }, lighting: {} };
+  const runtime = { engine: { camera, canvas, mapData }, bridge: { isDm: false } };
+  const api = globalThis.LuminousVttCameraFollow;
+  const controller = api.createController({ runtime, mapData, root: host });
 
-  expect(follow).toContain("camera.centerOnWorldPoint?.({ x: token.x, y: token.y }) === true");
-  expect(follow).toContain('camera.setManualPanListener?.(onManualPan);');
-  expect(follow).toContain("emit(policy.active ? 'look-around' : 'manual-pan');");
-  expect(follow).toContain("event.code === 'KeyF'");
-  expect(follow).toContain("event.code === 'Home'");
+  controller.setEnabled(true, { reason: 'test', centerNow: true });
+  const centered = camera.worldToScreen(token.x, token.y);
+  expect(centered.x).toBeCloseTo(800, 8);
+  expect(centered.y).toBeCloseTo(450, 8);
+  expect(controller.state().enabled).toBe(true);
+
+  camera.manualPanListener?.({ dx: 10, dy: 0 });
+  expect(controller.state().enabled).toBe(false);
+
+  controller.stop();
+  camera.destroy();
 });
 
-test('CAM-14 drag preview no arrastra cámara; traversal confirmado sí puede seguir', () => {
+test('CAM-13/14 Camera Follow conserva hotkeys y evita seguir drag preview no confirmado', () => {
   const follow = read('js/vtt/camera-follow.js');
 
+  expect(follow).toContain("event.code === 'KeyF'");
+  expect(follow).toContain("event.code === 'Home'");
   expect(follow).toContain("if (event?.type === 'vtt:token-preview-moved')");
   expect(follow).toContain('if (!isConfirmedTraversalPreview(event.detail || {})) return;');
   expect(follow).toContain("queueTraversalSync(event?.detail?.remote ? 'remote-token-traversal' : 'token-traversal');");
 });
 
-test('CAM-16/17/18 DM Observer mantiene selección explícita y VIEW AS solo para Player', () => {
-  const observer = read('js/vtt/dm-observer.js');
+test('CAM-16/17/18 DM Observer solo consume click cuando FOLLOW/VIEW AS están armados', () => {
+  const host = installDomStubs();
+  const canvas = makeCanvas({ logicalWidth: 1280, logicalHeight: 720, dpr: 1 });
+  const player = { id: 'p1', x: 400, y: 300, viewer: true, canonicalScope: 'player', zLayer: 0 };
+  const npc = { id: 'npc1', x: 700, y: 300, canonicalScope: 'npc', zLayer: 0 };
+  const mapData = { tokens: [player, npc], grid: { size: 70 }, lighting: {} };
+  const calls = [];
+  const cameraFollow = {
+    setEnabled(value) { calls.push(['enabled', value]); },
+    clearTarget() { calls.push(['clear']); },
+    setTarget(id) { calls.push(['target', id]); },
+  };
+  const engine = {
+    canvas,
+    mapData,
+    camera: {},
+    tokenAtEvent: (event) => event.hitToken || null,
+    setZLayer() {},
+  };
+  const runtime = { engine, bridge: { isDm: true } };
+  const api = globalThis.LuminousVttDmObserver;
+  const controller = api.createController({ runtime, mapData, cameraFollow, root: host });
 
-  expect(observer).toContain("if (!selectingMode || event.button !== 0 || mapData.dmEditMode?.active) return;");
-  expect(observer).toContain('if (selectingMode === MODES.VIEW_AS && !isPlayerToken(token)) return;');
-  expect(observer).toContain('mapData.lighting.dmPreviewTokenId = mode === MODES.VIEW_AS ? clean(token.id) : null;');
+  let consumed = false;
+  canvas.dispatchEvent({
+    type: 'click', button: 0, hitToken: player,
+    preventDefault() { consumed = true; }, stopPropagation() {}, stopImmediatePropagation() {},
+  });
+  expect(consumed).toBe(false);
+
+  controller.select(api.MODES.FOLLOW);
+  canvas.dispatchEvent({
+    type: 'click', button: 0, hitToken: npc,
+    preventDefault() { consumed = true; }, stopPropagation() {}, stopImmediatePropagation() {},
+  });
+  expect(calls.some(([kind, id]) => kind === 'target' && id === 'npc1')).toBe(true);
+
+  const callCount = calls.length;
+  controller.select(api.MODES.VIEW_AS);
+  canvas.dispatchEvent({
+    type: 'click', button: 0, hitToken: npc,
+    preventDefault() {}, stopPropagation() {}, stopImmediatePropagation() {},
+  });
+  expect(calls.length).toBe(callCount);
+
+  controller.select(api.MODES.VIEW_AS);
+  canvas.dispatchEvent({
+    type: 'click', button: 0, hitToken: player,
+    preventDefault() {}, stopPropagation() {}, stopImmediatePropagation() {},
+  });
+  expect(mapData.lighting.dmPreviewTokenId).toBe('p1');
+
+  controller.stop();
 });
 
 test('CAM-20 lifecycle destruye renderer y camera para evitar listeners/contextos duplicados', () => {


### PR DESCRIPTION
## Objetivo
Cerrar Rama 2 de la migración WebGL2 y dejarla integrada en `main` para prueba manual real.

## Alcance integrado
- Camera con viewport lógico separado del framebuffer GPU.
- `eventToScreen()` / `eventToWorld()` como conversión canónica de input.
- `centerOnWorldPoint()` compatible con firma Legacy `(x, y)` y nueva `{x, y}`.
- `WebGLWorldTransform` como transformación WORLD → SCREEN/CLIP única del backend WebGL2.
- Grid WebGL2 consumiendo matriz global de mundo en vez de `camera.x/y/zoom` por pipeline.
- Resize WebGL2 con DPR sin alterar coordenadas lógicas de gameplay.
- `Engine` sin fórmulas duplicadas de camera para mouse, center y resize.
- Camera Follow conservado: follow/look/free, F, Home, límites por percepción y traversal confirmado.
- DM Observer desacoplado de `CanvasRenderingContext2D`.
- Overlay de conos del DM renderizado por backend, incluido WebGL2.
- FREE / FOLLOW / VIEW AS preservados.
- Click normal del DM no se consume salvo modo de selección Observer armado.
- Lifecycle/cleanup de Camera y renderer.
- CI y pruebas de contrato WebGL2 Camera añadidas.

## Checklist manual en `main`
### Cámara
- [ ] Pan con botón medio funciona.
- [ ] Pan con Space + click izquierdo funciona.
- [ ] Pan conserva velocidad correcta a zoom 0.5 / 1 / 2 / 5.
- [ ] Zoom entra y sale correctamente.
- [ ] El punto bajo el cursor permanece anclado al hacer zoom.
- [ ] Min/max zoom se respetan.
- [ ] Resize de ventana conserva el centro del mundo.
- [ ] No cambia la escala física del mapa.

### Coordenadas e interacción
- [ ] Click sobre token selecciona exactamente ese token con pan/zoom.
- [ ] Drag del token conserva offset de agarre.
- [ ] Mouse no presenta offset en pantalla HiDPI/DPR > 1.
- [ ] WORLD → SCREEN → WORLD no produce drift visible.

### Camera Follow
- [ ] Jugador inicia en Follow cuando corresponde.
- [ ] La cámara sigue el token al moverse.
- [ ] Drag preview no mueve la cámara.
- [ ] Movimiento/traversal confirmado sí actualiza Follow.
- [ ] Pan manual desactiva Follow y entra en Look.
- [ ] `F` alterna Follow/Look.
- [ ] `Home` recentra el token.
- [ ] Cambio de Z conserva tracking.

### DM Observer
- [ ] FREE deja cámara independiente y omnisciente.
- [ ] FOLLOW permite seguir cualquier token.
- [ ] VIEW AS solo acepta token de jugador.
- [ ] VIEW AS activa el POV correcto.
- [ ] Click de selección FOLLOW apunta al token exacto.
- [ ] Click de selección VIEW AS apunta al jugador exacto.
- [ ] Click normal del DM sigue funcionando fuera del modo de selección Observer.
- [ ] Los conos/outlines del DM se dibujan en WebGL2.

### Lifecycle
- [ ] Mapa → Teatro → Mapa funciona.
- [ ] Repetir Mapa → Teatro → Mapa 10 veces no duplica listeners.
- [ ] Un wheel produce un solo cambio de zoom después de varios ciclos.
- [ ] No quedan paneles Observer duplicados.
- [ ] No aparece error por contextos Canvas/WebGL mezclados.

## Fuera de alcance de esta rama
- Migración visual completa de tokens.
- Fog/FOV GPU completo.
- Iluminación/shaders finales.
- Pathfinding.
- Rediseño de reglas de percepción.

## Criterio de cierre
Rama 2 se considera cerrada cuando este PR esté en `main` y el checklist manual anterior pueda ejecutarse contra el VTT integrado.