### PR TITLE
Fix VTT offline local token movement

### DIFF
--- a/js/vtt/movement-bootstrap.js
+++ b/js/vtt/movement-bootstrap.js
@@ -95,7 +95,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   }
 
   function statusText() {
-    if (!movementOnline()) return 'WORLD · OFFLINE · MOVEMENT LOCKED';
+    if (!movementOnline()) return 'WORLD · OFFLINE · LOCAL MOVEMENT';
     const state = worldState();
     if (state.mode !== 'round') return 'WORLD · FREE EXPLORATION';
     const token = controlledToken();
@@ -168,7 +168,6 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   }
 
   function planFor(token, start, target) {
-    if (!movementOnline()) return offlineResult();
     return movement.planMove({
       token,
       start,
@@ -249,6 +248,10 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
 
   async function reserveDestination(token) {
     if (!token?.pendingMovementClaim) return { valid: true, skipped: true };
+    if (!movementOnline()) {
+      delete token.pendingMovementClaim;
+      return { valid: true, skipped: true, offline: true };
+    }
     const bridge = runtime.tokenStateBridge;
     if (typeof bridge?.reserveMovementDestinationClaim !== 'function') return { valid: false, reason: 'MOVEMENT_CLAIM_BRIDGE_UNAVAILABLE' };
     try {
@@ -315,9 +318,10 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   }
 
   async function resolveMovementOrder({ token, from, requestedPoint }) {
-    if (!movementOnline()) return offlineResult();
     const plan = planFor(token, from, requestedPoint);
     if (!plan.valid) return plan;
+
+    if (!movementOnline() && Array.isArray(plan.doorInteractions) && plan.doorInteractions.length) return offlineResult();
 
     const doors = validateDoorInteractions(plan);
     if (!doors.valid) return { ...plan, valid: false, reason: doors.reason || 'DOOR_INTERACTION_FAILED' };
@@ -559,7 +563,7 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     prone: (token) => { if (!movementOnline()) return { valid: false, reason: 'VTT_OFFLINE_NO_UPDATE' }; const result = movement.setProne(token, true); updateUi(); return result; },
     stand: (token) => { if (!movementOnline()) return { valid: false, reason: 'VTT_OFFLINE_NO_UPDATE' }; const result = movement.standUp(token, worldState()); updateUi(); return result; },
     setMovementMode: (token, mode) => { if (!movementOnline()) throw new Error('VTT_OFFLINE_NO_UPDATE'); return movement.setMovementMode(token, mode, worldState()); },
-    plan: (options) => movementOnline() ? movement.planMove({ ...options, mapData, worldState: worldState() }) : offlineResult(),
+    plan: (options) => movement.planMove({ ...options, mapData, worldState: worldState() }),
     stop() {
       clearTimeout(noticeTimer);
       engine.cancelTokenMotion?.();

--- a/tests/vtt_movement_connectivity.spec.js
+++ b/tests/vtt_movement_connectivity.spec.js
@@ -79,14 +79,18 @@ test('turn origin and Dash action metadata survive a canonical round-trip', () =
   expect(restored.movementTurnStart.x).toBe(35);
 });
 
-test('movement bootstrap gates plans, Dash, reset, round controls and turn persistence on connectivity', () => {
+test('movement bootstrap allows local planning offline while shared mutations remain connectivity-gated', () => {
   const source = read('js/vtt/movement-bootstrap.js');
   expect(source).toContain("import './movement-connectivity.js'");
   expect(source).toContain('installRealtime?.(window)');
   expect(source).toContain("reason: 'VTT_OFFLINE_NO_UPDATE'");
-  expect(source).toContain('if (!movementOnline()) return offlineResult()');
+  expect(source).not.toContain('if (!movementOnline()) return offlineResult();\n    const plan = planFor(token, from, requestedPoint);');
+  expect(source).not.toContain('function planFor(token, start, target) {\n    if (!movementOnline()) return offlineResult();');
+  expect(source).toContain("return 'WORLD · OFFLINE · LOCAL MOVEMENT'");
+  expect(source).toContain('if (!movementOnline()) {\n      delete token.pendingMovementClaim;\n      return { valid: true, skipped: true, offline: true };');
+  expect(source).toContain('if (!movementOnline() && Array.isArray(plan.doorInteractions) && plan.doorInteractions.length) return offlineResult();');
+  expect(source).toContain('plan: (options) => movement.planMove({ ...options, mapData, worldState: worldState() })');
   expect(source).toContain('assertMovementOnline()');
   expect(source).toContain("'position/movementTurnStart'");
   expect(source).toContain("'position/dashActionType'");
-  expect(source).toContain('WORLD · OFFLINE · MOVEMENT LOCKED');
 });


### PR DESCRIPTION
## Regresión encontrada en checklist manual WEBGL-02
Al intentar mover una ficha en `main` sin conexión realtime, el VTT mostraba `VTT_OFFLINE_NO_UPDATE` y revertía el drag.

## Causa
`movement-bootstrap.js` trataba la falta de Firebase como un rechazo total antes de ejecutar el plan local de movimiento.

## Fix
- El movimiento local offline sigue pasando por `planMove` y `commitMove`.
- Se conservan pathfinding, paredes, ocupación, costes y presupuesto de movimiento.
- Offline omite únicamente la reserva remota de destino.
- Las rutas que requieren una interacción compartida de puerta siguen bloqueadas offline con `VTT_OFFLINE_NO_UPDATE`.
- Realtime preview/finalization, Dash/turn persistence, reset y controles de mundo siguen requiriendo conexión.
- El HUD cambia de `OFFLINE · MOVEMENT LOCKED` a `OFFLINE · LOCAL MOVEMENT`.
- `movement.plan()` vuelve a ser útil offline para validación local.

## Retest manual
- [ ] Sin Firebase/realtime, el HUD muestra `WORLD · OFFLINE · LOCAL MOVEMENT`.
- [ ] Arrastrar una ficha a una celda válida la mueve y no muestra `VTT_OFFLINE_NO_UPDATE`.
- [ ] Arrastrar contra pared/ocupación/ruta inválida sigue siendo rechazado por la regla correspondiente.
- [ ] Una ruta offline que necesita abrir/interactuar con una puerta sigue bloqueada.
- [ ] Al volver online, claims y sincronización realtime continúan funcionando.

Este PR corrige únicamente la regresión encontrada durante el checklist de Rama 2.