### PR TITLE
Fix DM actor library realtime flicker

### DIFF
--- a/js/vtt/actor-library-bootstrap.js
+++ b/js/vtt/actor-library-bootstrap.js
@@ -7,10 +7,12 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   const engine = runtime.engine;
   const tokenBridge = runtime.tokenStateBridge;
   const imageCache = new Map();
-  const libraryBridge = stateApi.createBridge({ onChanged: () => renderList() });
+  const cardNodes = new Map();
   let filter = 'all';
   let search = '';
   let selectedActorKey = '';
+  let lastListSignature = '';
+  const libraryBridge = stateApi.createBridge({ onChanged: (list) => renderList(list) });
 
   function tokenImage(token) {
     const url = String(token?.tokenImage || token?.portrait || '').trim();
@@ -66,25 +68,122 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
     panel.querySelector('[data-actor-filter]')?.addEventListener('change', (event) => { filter = event.target.value; renderList(); });
   }
 
-  function actorsVisible() {
-    return libraryBridge.list().filter((actor) => {
+  function actorsVisible(source = libraryBridge.list()) {
+    return (source || []).filter((actor) => {
       if (filter !== 'all' && actor.category !== filter) return false;
       if (search && !`${actor.name} ${actor.actorId} ${actor.category}`.toLowerCase().includes(search)) return false;
       return true;
     });
   }
 
-  function renderList() {
+  function actorCardSignature(actor) {
+    return JSON.stringify([actor.key, actor.name, actor.category, actor.scope, actor.portrait || '']);
+  }
+
+  function listSignature(list = []) {
+    return JSON.stringify((list || []).map((actor) => actorCardSignature(actor)));
+  }
+
+  function makeThumb(actor) {
+    if (actor.portrait) {
+      const image = document.createElement('img');
+      image.className = 'vtt-actor-thumb';
+      image.alt = '';
+      image.dataset.actorThumb = '1';
+      image.dataset.actorSrc = actor.portrait;
+      image.src = actor.portrait;
+      return image;
+    }
+    const fallback = document.createElement('div');
+    fallback.className = 'vtt-actor-thumb';
+    fallback.dataset.actorThumb = '1';
+    return fallback;
+  }
+
+  function createActorCard(actor) {
+    const card = document.createElement('article');
+    card.className = 'vtt-actor-card';
+    card.draggable = true;
+    card.dataset.actorKey = actor.key;
+    card.appendChild(makeThumb(actor));
+
+    const info = document.createElement('div');
+    const name = document.createElement('strong');
+    name.dataset.actorName = '1';
+    const br = document.createElement('br');
+    const meta = document.createElement('small');
+    meta.dataset.actorMeta = '1';
+    info.append(name, br, meta);
+    card.appendChild(info);
+
+    card.addEventListener('dragstart', (event) => {
+      selectedActorKey = card.dataset.actorKey;
+      event.dataTransfer?.setData('text/x-luminous-actor', selectedActorKey);
+      if (event.dataTransfer) event.dataTransfer.effectAllowed = 'copy';
+    });
+    cardNodes.set(actor.key, card);
+    return card;
+  }
+
+  function updateActorCard(card, actor) {
+    card.dataset.actorKey = actor.key;
+    const name = card.querySelector('[data-actor-name]');
+    const meta = card.querySelector('[data-actor-meta]');
+    if (name && name.textContent !== actor.name) name.textContent = actor.name;
+    const metaText = `${actor.category.toUpperCase()} · ${actor.scope}`;
+    if (meta && meta.textContent !== metaText) meta.textContent = metaText;
+
+    let thumb = card.querySelector('[data-actor-thumb]');
+    if (actor.portrait) {
+      if (!(thumb instanceof HTMLImageElement)) {
+        const replacement = makeThumb(actor);
+        thumb?.replaceWith(replacement);
+        thumb = replacement;
+      } else if (thumb.dataset.actorSrc !== actor.portrait) {
+        thumb.dataset.actorSrc = actor.portrait;
+        thumb.src = actor.portrait;
+      }
+    } else if (thumb instanceof HTMLImageElement) {
+      const replacement = makeThumb(actor);
+      thumb.replaceWith(replacement);
+    }
+    card.dataset.actorRender = actorCardSignature(actor);
+  }
+
+  function renderList(source = libraryBridge.list()) {
     const node = document.getElementById('vtt-actor-list');
     if (!node) return;
-    const list = actorsVisible();
-    node.innerHTML = list.length ? list.map((actor) => `<article class="vtt-actor-card" draggable="true" data-actor-key="${actor.key}">${actor.portrait ? `<img class="vtt-actor-thumb" src="${actor.portrait}" alt="">` : '<div class="vtt-actor-thumb"></div>'}<div><strong>${actor.name}</strong><br><small>${actor.category.toUpperCase()} · ${actor.scope}</small></div></article>`).join('') : '<div class="vtt-actor-empty">No actors match this filter.</div>';
-    node.querySelectorAll('[data-actor-key]').forEach((card) => {
-      card.addEventListener('dragstart', (event) => {
-        selectedActorKey = card.dataset.actorKey;
-        event.dataTransfer?.setData('text/x-luminous-actor', selectedActorKey);
-        if (event.dataTransfer) event.dataTransfer.effectAllowed = 'copy';
-      });
+    const list = actorsVisible(source);
+    const signature = listSignature(list);
+    if (signature === lastListSignature) return;
+    lastListSignature = signature;
+
+    const wanted = new Set(list.map((actor) => actor.key));
+    for (const [key, card] of [...cardNodes.entries()]) {
+      if (wanted.has(key)) continue;
+      card.remove();
+      cardNodes.delete(key);
+    }
+
+    let empty = node.querySelector('[data-actor-empty]');
+    if (!list.length) {
+      if (!empty) {
+        empty = document.createElement('div');
+        empty.className = 'vtt-actor-empty';
+        empty.dataset.actorEmpty = '1';
+        empty.textContent = 'No actors match this filter.';
+        node.appendChild(empty);
+      }
+      return;
+    }
+    empty?.remove();
+
+    list.forEach((actor, index) => {
+      let card = cardNodes.get(actor.key);
+      if (!card) card = createActorCard(actor);
+      if (card.dataset.actorRender !== actorCardSignature(actor)) updateActorCard(card, actor);
+      const expected = node.children[index] || null;
+      if (expected !== card) node.insertBefore(card, expected);
     });
   }
 
@@ -137,8 +236,6 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
   }
 
   async function onContextMenu(event) {
-    // The VTT owns right-click interaction on its canvas. Prevent the browser's
-    // native image/canvas menu first, even when the token itself is not removable.
     event.preventDefault();
     event.stopPropagation();
 
@@ -165,6 +262,8 @@ export function start({ runtime = window.LuminousVttRuntime, mapData = runtime?.
       engine.canvas.removeEventListener('drop', onDrop);
       engine.canvas.removeEventListener('contextmenu', onContextMenu);
       engine.renderer.drawPersonIcon = originalPersonIcon;
+      cardNodes.clear();
+      lastListSignature = '';
       document.getElementById('vtt-actor-library-toggle')?.remove();
       document.getElementById('vtt-actor-library-panel')?.remove();
       document.getElementById('vtt-actor-library-style')?.remove();

--- a/js/vtt/actor-library-state.js
+++ b/js/vtt/actor-library-state.js
@@ -20,37 +20,88 @@
     return null;
   }
 
+  function actorLibrarySignature(list = []) {
+    return JSON.stringify((list || []).map((actor) => ({
+      key: actor.key,
+      scope: actor.scope,
+      sourceId: actor.sourceId,
+      actorId: actor.actorId,
+      linkedActorId: actor.linkedActorId,
+      playerId: actor.playerId,
+      ownerUid: actor.ownerUid,
+      name: actor.name,
+      category: actor.category,
+      portrait: actor.portrait,
+      tokenImage: actor.tokenImage,
+      icono: actor.icono,
+      color: actor.color,
+      backgroundColor: actor.backgroundColor,
+      iconColor: actor.iconColor,
+      size: actor.size,
+      radius: actor.radius,
+      speedFt: actor.speedFt,
+      movement: actor.movement,
+      senses: actor.senses,
+    })));
+  }
+
   function createBridge({ onChanged, root = browserRoot } = {}) {
     const actorRuntime = runtime(root);
     if (!actorRuntime) throw new Error('ACTOR_LIBRARY_RUNTIME_REQUIRED');
     const db = hostFirebase(root)?.database?.() || null;
     const subscriptions = [];
     let players = {}, actors = {}, npcs = {}, started = false;
-
-    function subscribe(path, assign) {
-      if (!db) return;
-      const ref = db.ref(path);
-      const handler = (snapshot) => { assign(snapshot.val() || {}); if (typeof onChanged === 'function') onChanged(list()); };
-      ref.on('value', handler);
-      subscriptions.push(() => ref.off('value', handler));
-    }
+    let lastSignature = null;
 
     function list() { return actorRuntime.mergeCollections({ players, actors, npcs }); }
     function get(key) { return list().find((actor) => actor.key === key) || null; }
 
+    function emitIfChanged() {
+      const current = list();
+      const signature = actorLibrarySignature(current);
+      if (signature === lastSignature) return false;
+      lastSignature = signature;
+      if (typeof onChanged === 'function') onChanged(current);
+      return true;
+    }
+
+    function subscribe(path, assign) {
+      if (!db) return;
+      const ref = db.ref(path);
+      const handler = (snapshot) => {
+        assign(snapshot.val() || {});
+        emitIfChanged();
+      };
+      ref.on('value', handler);
+      subscriptions.push(() => ref.off('value', handler));
+    }
+
     function start() {
       if (started) return true;
       started = true;
+      lastSignature = null;
       if (!db) return false;
       subscribe(PLAYERS_ROOT, (value) => { players = value; });
       subscribe(ACTORS_ROOT, (value) => { actors = value; });
       subscribe(NPCS_ROOT, (value) => { npcs = value; });
       return true;
     }
-    function stop() { subscriptions.splice(0).forEach((unsubscribe) => unsubscribe()); started = false; }
+    function stop() {
+      subscriptions.splice(0).forEach((unsubscribe) => unsubscribe());
+      started = false;
+      lastSignature = null;
+    }
 
-    return Object.freeze({ start, stop, list, get, applyPlayers: (value) => { players = value || {}; }, applyActors: (value) => { actors = value || {}; }, applyNpcs: (value) => { npcs = value || {}; } });
+    return Object.freeze({
+      start,
+      stop,
+      list,
+      get,
+      applyPlayers: (value) => { players = value || {}; },
+      applyActors: (value) => { actors = value || {}; },
+      applyNpcs: (value) => { npcs = value || {}; },
+    });
   }
 
-  return Object.freeze({ PLAYERS_ROOT, ACTORS_ROOT, NPCS_ROOT, hostWindow, hostFirebase, createBridge });
+  return Object.freeze({ PLAYERS_ROOT, ACTORS_ROOT, NPCS_ROOT, hostWindow, hostFirebase, actorLibrarySignature, createBridge });
 });

--- a/tests/vtt_actor_library_flicker.spec.js
+++ b/tests/vtt_actor_library_flicker.spec.js
@@ -1,0 +1,76 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const actorLibrary = require('../js/vtt/actor-library.js');
+const actorState = require('../js/vtt/actor-library-state.js');
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+class Ref {
+  constructor() { this.handlers = new Set(); }
+  on(event, handler) { if (event === 'value') this.handlers.add(handler); }
+  off(event, handler) { if (event === 'value') this.handlers.delete(handler); }
+  emit(value) { for (const handler of [...this.handlers]) handler({ val: () => value }); }
+}
+
+function fakeRoot() {
+  const refs = new Map();
+  const refFor = (key) => {
+    if (!refs.has(key)) refs.set(key, new Ref());
+    return refs.get(key);
+  };
+  return {
+    refs,
+    root: {
+      LuminousVttActorLibrary: actorLibrary,
+      firebase: { database: () => ({ ref: refFor }) },
+    },
+  };
+}
+
+test('actor library ignores player realtime changes that do not affect the actor card/token definition', () => {
+  const { root, refs } = fakeRoot();
+  const changes = [];
+  const bridge = actorState.createBridge({ root, onChanged: (list) => changes.push(list) });
+  bridge.start();
+
+  refs.get(actorState.PLAYERS_ROOT).emit({
+    p1: {
+      characterName: 'Agatha',
+      icono: '/img/agatha.png',
+      vttTokenState: { mapA: { position: { x: 10, y: 20 } } },
+    },
+  });
+  expect(changes).toHaveLength(1);
+  expect(changes[0][0]).toMatchObject({ name: 'Agatha', portrait: '/img/agatha.png' });
+
+  refs.get(actorState.PLAYERS_ROOT).emit({
+    p1: {
+      characterName: 'Agatha',
+      icono: '/img/agatha.png',
+      vttTokenState: { mapA: { position: { x: 200, y: 350 } } },
+    },
+  });
+  expect(changes).toHaveLength(1);
+
+  refs.get(actorState.PLAYERS_ROOT).emit({
+    p1: {
+      characterName: 'Agatha Renamed',
+      icono: '/img/agatha.png',
+      vttTokenState: { mapA: { position: { x: 200, y: 350 } } },
+    },
+  });
+  expect(changes).toHaveLength(2);
+  expect(changes[1][0].name).toBe('Agatha Renamed');
+
+  bridge.stop();
+});
+
+test('DM actor menu reconciles keyed cards instead of replacing the full list HTML', () => {
+  const source = read('js/vtt/actor-library-bootstrap.js');
+  expect(source).toContain('const cardNodes = new Map()');
+  expect(source).toContain('let lastListSignature');
+  expect(source).toContain('if (signature === lastListSignature) return');
+  expect(source).toContain('node.insertBefore(card, expected)');
+  expect(source).not.toContain('node.innerHTML = list.length');
+});


### PR DESCRIPTION
## Bug
El menú DM `ACTORS` parpadeaba constantemente mientras estaba abierto.

## Causa
`actor-library-state.js` escucha `campaña/jugadores`, `campaña/actores` y `campaña/base_datos_npcs`. Cualquier cambio realtime —incluyendo posición/estado VTT del jugador— disparaba `renderList()`. A su vez, `renderList()` reconstruía toda la lista mediante `innerHTML`, destruyendo y recreando todas las cards e imágenes.

## Fix
- `ActorLibraryState` calcula una firma solo con campos relevantes de la definición del actor/token y no notifica por cambios efímeros como posición realtime almacenada en `raw`.
- El panel DM conserva cards por `actor.key` y hace reconciliación incremental.
- Si la lista visible no cambió, `renderList()` no toca el DOM.
- Los `<img>` existentes se conservan y solo cambia `src` cuando cambia realmente el icono del actor.
- Se añade prueba de regresión que mueve un jugador en datos realtime sin permitir un nuevo render de la librería.

## Checklist manual
- [ ] Abrir ACTORS y dejarlo abierto: no debe parpadear.
- [ ] Mover una ficha PLAYER repetidamente: ACTORS debe permanecer estable.
- [ ] Cambiar nombre/icono de un actor: solo esa card debe actualizarse.
- [ ] Search y filtros siguen funcionando.
- [ ] Drag de actor al mapa sigue funcionando.
- [ ] Cerrar/abrir ACTORS no duplica cards ni listeners.