### PR TITLE
Fix WEBGL-02 camera follow traversal performance

### DIFF
--- a/js/vtt/camera-follow.js
+++ b/js/vtt/camera-follow.js
@@ -156,6 +156,12 @@
     const raf = host?.requestAnimationFrame?.bind(host) || ((fn) => host?.setTimeout?.(() => fn(Date.now()), 16));
     const caf = host?.cancelAnimationFrame?.bind(host) || host?.clearTimeout?.bind(host);
 
+    function syncPerformanceHint() {
+      const active = Boolean(!stopped && enabled && target());
+      engine.cameraFollowActive = active;
+      return active;
+    }
+
     function policyState() {
       const token = target();
       const active = tokenRulesActive({ isDm, mapData, token });
@@ -206,6 +212,7 @@
     }
 
     const emit = (reason = 'sync') => {
+      syncPerformanceHint();
       const detail = { ...state(), reason };
       const EventCtor = host?.CustomEvent || root?.CustomEvent || globalThis.CustomEvent;
       if (typeof EventCtor === 'function') canvas.dispatchEvent(new EventCtor('vtt:camera-follow-changed', { detail }));
@@ -217,32 +224,40 @@
       return [clean(token.id), Number(token.x) || 0, Number(token.y) || 0, layerOf(token)].join('|');
     }
 
-    function center(reason = 'follow') {
+    function center(reason = 'follow', { emitChange = true } = {}) {
       if (!enabled || stopped) return false;
       const token = target();
-      if (!token) return false;
+      if (!token) {
+        syncPerformanceHint();
+        return false;
+      }
       applyPolicy();
       const nextSignature = signature(token);
-      if (nextSignature === lastSignature) return false;
+      if (nextSignature === lastSignature) {
+        syncPerformanceHint();
+        return false;
+      }
       const ok = camera.centerOnWorldPoint?.({ x: token.x, y: token.y }) === true;
       if (ok) {
         lastSignature = nextSignature;
-        emit(reason);
+        if (emitChange) emit(reason);
+        else syncPerformanceHint();
       }
       return ok;
     }
 
-    function sync(reason = 'state-sync', { forceCenter = false } = {}) {
+    function sync(reason = 'state-sync', { forceCenter = false, emitChange = true } = {}) {
       if (stopped) return state();
       const token = target();
       applyPolicy();
+      syncPerformanceHint();
       if (!token) {
         lastSignature = '';
-        emit(reason);
+        if (emitChange) emit(reason);
         return state();
       }
-      if (enabled && (forceCenter || signature(token) !== lastSignature)) center(reason);
-      else if (!enabled && camera.enforceCenterConstraint?.()) emit('look-clamped');
+      if (enabled && (forceCenter || signature(token) !== lastSignature)) center(reason, { emitChange });
+      else if (!enabled && camera.enforceCenterConstraint?.() && emitChange) emit('look-clamped');
       return state();
     }
 
@@ -253,7 +268,9 @@
         followFrame = null;
         const nextReason = pendingFollowReason || 'token-traversal';
         pendingFollowReason = null;
-        sync(nextReason);
+        // Camera.centerOnWorldPoint already emits canonical render-only scene dirty.
+        // Do not also emit the legacy state-change event for every traversal frame.
+        sync(nextReason, { emitChange: false });
       });
     }
 
@@ -262,10 +279,12 @@
       const next = Boolean(value) && Boolean(token);
       if (enabled === next) {
         applyPolicy();
+        syncPerformanceHint();
         if (next && centerNow) center(reason);
         return state();
       }
       enabled = next;
+      syncPerformanceHint();
       applyPolicy(true);
       if (enabled && centerNow) center(reason);
       else emit(reason);
@@ -280,6 +299,7 @@
       targetId = clean(id) || null;
       if (follow && target()) enabled = true;
       lastSignature = '';
+      syncPerformanceHint();
       applyPolicy(true);
       if (enabled) center('target');
       else emit('target');
@@ -289,6 +309,7 @@
     function clearTarget() {
       targetId = null;
       lastSignature = '';
+      syncPerformanceHint();
       applyPolicy(true);
       if (enabled) center('target-clear');
       else emit('target-clear');
@@ -299,6 +320,7 @@
       if (!target()) return false;
       enabled = true;
       lastSignature = '';
+      syncPerformanceHint();
       applyPolicy(true);
       return center('recenter');
     }
@@ -307,13 +329,17 @@
       const policy = applyPolicy();
       if (enabled) {
         enabled = false;
+        syncPerformanceHint();
         emit(policy.active ? 'look-around' : 'manual-pan');
       }
     };
 
     const onTokenMoved = (event) => {
       const token = target();
-      if (!token) return;
+      if (!token) {
+        syncPerformanceHint();
+        return;
+      }
       if (event?.detail?.tokenId != null && clean(event.detail.tokenId) !== clean(token.id)) return;
       if (event?.type === 'vtt:token-preview-moved') {
         // Drag previews never move the camera. Only a confirmed traversal after drop may follow.
@@ -346,11 +372,13 @@
     canvas.addEventListener('vtt:procedural-chunk-loaded', onWorldTransition);
     host?.addEventListener?.('keydown', onKeyDown);
     applyPolicy(true);
+    syncPerformanceHint();
     if (enabled) host?.setTimeout?.(() => sync('initial', { forceCenter: true }), 0);
 
     function stop() {
       if (stopped) return;
       stopped = true;
+      engine.cameraFollowActive = false;
       if (followFrame != null) caf?.(followFrame);
       followFrame = null;
       pendingFollowReason = null;

--- a/js/vtt/performance-guard.js
+++ b/js/vtt/performance-guard.js
@@ -1,5 +1,6 @@
 const DEFAULT_ACTIVE_FRAME_MS = 1000 / 30;
 const DEFAULT_MOVEMENT_FRAME_MS = 1000 / 20;
+const DEFAULT_FOLLOW_MOVEMENT_FRAME_MS = 1000 / 60;
 const DEFAULT_IDLE_FALLBACK_MS = 500;
 
 const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
@@ -55,9 +56,24 @@ function visualAnimationActive(engine, mapData, now = Date.now()) {
     || hasActiveLightingAnimation(mapData, now);
 }
 
+// Expensive vision keeps the conservative cadence that existed before WEBGL-02.
 function activeFrameInterval(engine, activeFrameMs = DEFAULT_ACTIVE_FRAME_MS, movementFrameMs = DEFAULT_MOVEMENT_FRAME_MS) {
   if (engine?.tokenMotion) return Math.max(1, Number(movementFrameMs) || DEFAULT_MOVEMENT_FRAME_MS);
   return Math.max(1, Number(activeFrameMs) || DEFAULT_ACTIVE_FRAME_MS);
+}
+
+// Rendering a followed token is cheap enough in WebGL2 to track the traversal RAF.
+// Only this visual path gets 60 Hz; ordinary movement retains the existing 20 Hz budget.
+function renderFrameInterval(
+  engine,
+  activeFrameMs = DEFAULT_ACTIVE_FRAME_MS,
+  movementFrameMs = DEFAULT_MOVEMENT_FRAME_MS,
+  followMovementFrameMs = DEFAULT_FOLLOW_MOVEMENT_FRAME_MS,
+) {
+  if (engine?.tokenMotion && engine?.cameraFollowActive === true) {
+    return Math.max(1, Number(followMovementFrameMs) || DEFAULT_FOLLOW_MOVEMENT_FRAME_MS);
+  }
+  return activeFrameInterval(engine, activeFrameMs, movementFrameMs);
 }
 
 // Slow compatibility fallback for legacy mutations that do not yet emit vtt:scene-dirty.
@@ -124,6 +140,7 @@ export function installPerformanceGuard({
   runtime = globalThis.LuminousVttRuntime,
   activeFrameMs = DEFAULT_ACTIVE_FRAME_MS,
   movementFrameMs = DEFAULT_MOVEMENT_FRAME_MS,
+  followMovementFrameMs = DEFAULT_FOLLOW_MOVEMENT_FRAME_MS,
   idleFallbackMs = DEFAULT_IDLE_FALLBACK_MS,
 } = {}) {
   const engine = runtime?.engine;
@@ -182,10 +199,17 @@ export function installPerformanceGuard({
     return signature;
   };
 
+  const currentRenderInterval = () => renderFrameInterval(
+    engine,
+    activeFrameMs,
+    movementFrameMs,
+    followMovementFrameMs,
+  );
+
   const nextFrameDelayMs = () => {
     if (stopped) return 0;
     const active = visualAnimationActive(engine, mapData, Date.now());
-    if (active) return activeFrameInterval(engine, activeFrameMs, movementFrameMs);
+    if (active) return currentRenderInterval();
     if (renderDirty || visionDirty) return 0;
     return idleInterval;
   };
@@ -194,7 +218,7 @@ export function installPerformanceGuard({
     const active = Boolean(activeHint) || visualAnimationActive(engine, mapData, Date.now());
     engine.requestFrame?.({
       immediate: !active,
-      delayMs: active ? activeFrameInterval(engine, activeFrameMs, movementFrameMs) : 0,
+      delayMs: active ? currentRenderInterval() : 0,
     });
   };
 
@@ -238,6 +262,8 @@ export function installPerformanceGuard({
       const perfNow = clockNow();
       const wallNow = Date.now();
       const active = visualAnimationActive(engine, mapData, wallNow);
+      // Vision deliberately remains at the conservative movement cadence even
+      // while WebGL2 rendering follows the token at display cadence.
       const minimumInterval = active
         ? activeFrameInterval(engine, activeFrameMs, movementFrameMs)
         : idleInterval;
@@ -264,7 +290,7 @@ export function installPerformanceGuard({
     const perfNow = clockNow();
     const wallNow = Date.now();
     const active = visualAnimationActive(engine, mapData, wallNow);
-    const activeInterval = activeFrameInterval(engine, activeFrameMs, movementFrameMs);
+    const activeInterval = currentRenderInterval();
 
     if (active && (perfNow - lastRenderAt) < activeInterval) {
       metrics.throttled += 1;
@@ -316,6 +342,7 @@ export function installPerformanceGuard({
       visionSaved: metrics.visionSkipped + metrics.dmVisionBypassed,
       activeFrameMs: Math.max(1, Number(activeFrameMs) || DEFAULT_ACTIVE_FRAME_MS),
       movementFrameMs: Math.max(1, Number(movementFrameMs) || DEFAULT_MOVEMENT_FRAME_MS),
+      followMovementFrameMs: Math.max(1, Number(followMovementFrameMs) || DEFAULT_FOLLOW_MOVEMENT_FRAME_MS),
       idleFrameMs: idleInterval,
       fallbackScanMs: idleInterval,
       avgFallbackDurationMs: metrics.fallbackScans > 0

--- a/tests/vtt_camera_follow_performance.spec.js
+++ b/tests/vtt_camera_follow_performance.spec.js
@@ -1,0 +1,149 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const sceneDirty = require('../js/vtt/scene-dirty.js');
+const cameraFollow = require('../js/vtt/camera-follow.js');
+const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+async function loadGuard() {
+  global.LuminousVttSceneDirty = sceneDirty;
+  const tmp = path.join(os.tmpdir(), `luminous-vtt-follow-performance-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.mjs`);
+  fs.writeFileSync(tmp, read('js/vtt/performance-guard.js'));
+  const mod = await import(`${pathToFileURL(tmp).href}?t=${Date.now()}`);
+  return { mod, tmp };
+}
+
+function eventTargetStub() {
+  const listeners = new Map();
+  return {
+    listeners,
+    addEventListener(type, handler) {
+      if (!listeners.has(type)) listeners.set(type, new Set());
+      listeners.get(type).add(handler);
+    },
+    removeEventListener(type, handler) { listeners.get(type)?.delete(handler); },
+    dispatchEvent(event) {
+      for (const handler of [...(listeners.get(event.type) || [])]) handler(event);
+      return true;
+    },
+  };
+}
+
+class FakeCustomEvent {
+  constructor(type, options = {}) { this.type = type; this.detail = options.detail; }
+}
+
+test('followed traversal renders at display cadence while vision stays on the 20 Hz movement budget', async () => {
+  const previousPerformance = Object.getOwnPropertyDescriptor(global, 'performance');
+  let now = 0;
+  Object.defineProperty(global, 'performance', { configurable: true, value: { now: () => now } });
+  const { mod, tmp } = await loadGuard();
+  try {
+    let renders = 0;
+    let visions = 0;
+    let resolver = null;
+    const canvas = eventTargetStub();
+    const mapData = {
+      grid: { cols: 20, rows: 20, size: 70 },
+      tokens: [{ id: 'p1', x: 350, y: 350, zLayer: 0 }],
+      topology: [], walls: [], verticalPortals: [],
+      lighting: { scene: { sources: [], interiors: [], roofs: [], switches: [], transformers: [] } },
+      dmEditMode: { active: false },
+    };
+    const renderer = { render() { renders += 1; } };
+    const engine = {
+      renderer,
+      mapData,
+      canvas,
+      activeZ: 0,
+      tokenDrag: null,
+      tokenMotion: { tokenId: 'p1' },
+      cameraFollowActive: true,
+      camera: { x: 0, y: 0, zoom: 1, isDragging: false },
+      calculateVision() { visions += 1; return { generation: visions }; },
+      setFrameDelayResolver(next) { resolver = typeof next === 'function' ? next : null; },
+      requestFrame() { return true; },
+    };
+
+    const api = mod.installPerformanceGuard({ runtime: { engine, bridge: { isDm: false } } });
+    engine.calculateVision();
+    renderer.render();
+    for (let frame = 0; frame < 12; frame += 1) {
+      now += 17;
+      mapData.tokens[0].x += 1;
+      sceneDirty.emit(canvas, { reason: 'token', render: true, vision: true, active: true, tokenId: 'p1' });
+      engine.calculateVision();
+      renderer.render();
+    }
+
+    expect(renders).toBeGreaterThanOrEqual(12);
+    expect(visions).toBeLessThanOrEqual(5);
+    expect(api.nextFrameDelayMs()).toBeCloseTo(1000 / 60, 3);
+    expect(api.snapshot().movementFrameMs).toBeCloseTo(1000 / 20, 3);
+    expect(api.snapshot().followMovementFrameMs).toBeCloseTo(1000 / 60, 3);
+
+    engine.cameraFollowActive = false;
+    expect(api.nextFrameDelayMs()).toBeCloseTo(1000 / 20, 3);
+    api.stop();
+    expect(resolver).toBeNull();
+  } finally {
+    fs.unlinkSync(tmp);
+    if (previousPerformance) Object.defineProperty(global, 'performance', previousPerformance);
+    else delete global.performance;
+  }
+});
+
+test('confirmed traversal centers camera without emitting a follow state-change event every frame', () => {
+  const canvas = eventTargetStub();
+  const frames = [];
+  const token = { id: 'p1', x: 100, y: 100, zLayer: 0, viewer: true };
+  const mapData = { grid: { size: 70, distancePerCell: 5 }, tokens: [token], lighting: {} };
+  const centers = [];
+  const camera = {
+    x: 0, y: 0, zoom: 1,
+    setZoomBounds() {},
+    setCenterConstraint() {},
+    enforceCenterConstraint() { return false; },
+    setManualPanListener(handler) { this.manualPan = handler; },
+    centerOnWorldPoint(point) { centers.push({ ...point }); return true; },
+  };
+  const engine = { camera, canvas, mapData, cameraFollowActive: false };
+  const runtime = { engine, bridge: { isDm: false } };
+  const host = {
+    LuminousVttRuntime: runtime,
+    CustomEvent: FakeCustomEvent,
+    requestAnimationFrame(callback) { frames.push(callback); return frames.length; },
+    cancelAnimationFrame() {},
+    setTimeout(callback) { callback(); return 1; },
+    addEventListener() {},
+    removeEventListener() {},
+  };
+
+  let followEvents = 0;
+  canvas.addEventListener('vtt:camera-follow-changed', () => { followEvents += 1; });
+  const controller = cameraFollow.createController({ runtime, mapData, root: host });
+  const baselineEvents = followEvents;
+  const baselineCenters = centers.length;
+  expect(engine.cameraFollowActive).toBe(true);
+
+  for (let i = 0; i < 8; i += 1) {
+    token.x += 5;
+    canvas.dispatchEvent(new FakeCustomEvent('vtt:token-preview-moved', {
+      detail: { tokenId: 'p1', traversing: true },
+    }));
+    const frame = frames.shift();
+    frame?.();
+  }
+
+  expect(centers.length).toBeGreaterThan(baselineCenters);
+  expect(followEvents).toBe(baselineEvents);
+
+  controller.toggle();
+  expect(engine.cameraFollowActive).toBe(false);
+  expect(followEvents).toBe(baselineEvents + 1);
+  controller.stop();
+  expect(engine.cameraFollowActive).toBe(false);
+});


### PR DESCRIPTION
## Bug encontrado en checklist manual WEBGL-02
Camera Follow funciona correctamente, pero durante movimiento/traversal confirmado se percibe tirón tanto del lado del jugador como del DM cuando la cámara sigue la ficha.

## Causa
- El token y la cámara avanzan con `requestAnimationFrame`, pero Performance Guard limitaba **render y FOV juntos a 20 Hz** durante `tokenMotion`.
- `camera-follow.js` además emitía `vtt:camera-follow-changed` en cada frame seguido. `Camera.centerOnWorldPoint()` ya emite `vtt:scene-dirty`, por lo que el bridge Legacy generaba una invalidación redundante.

## Fix
- Con `tokenMotion + cameraFollowActive`, el render de token/cámara usa presupuesto de ~60 Hz.
- El cálculo costoso de Vision/FOV conserva el presupuesto anterior de 20 Hz.
- Sin Follow, el movimiento conserva exactamente el presupuesto antiguo de 20 Hz.
- Follow expone una señal ligera `engine.cameraFollowActive` y la limpia al salir de Follow/stop.
- Traversal confirmado sigue centrando la cámara, pero ya no emite `vtt:camera-follow-changed` por cada frame.
- Cambios reales de modo/target (`F`, pan manual, target DM, Home, etc.) siguen emitiendo el evento de estado.
- Se añade regresión para comprobar render fluido + FOV limitado y ausencia de spam de eventos.

## Retest manual
- [ ] Player Follow: mover ficha varias celdas; cámara/token deben verse claramente más fluidos.
- [ ] DM FOLLOW: repetir movimiento; misma mejora.
- [ ] VIEW AS + Follow no introduce tirón extra.
- [ ] F desactiva Follow y vuelve a Look normalmente.
- [ ] Pan manual desactiva Follow normalmente.
- [ ] Drag preview continúa sin mover la cámara.
- [ ] Movimiento confirmado continúa siguiendo la ficha.
- [ ] Visión/Fog no presenta regresiones visibles durante movimiento.
- [ ] CPU no presenta un salto equivalente a recalcular FOV a 60 Hz.

Este PR cierra únicamente el punto ⚠️ Performance de Camera Follow del checklist de WEBGL-02.