### PR TITLE
Fix VTT navigation straightness, smooth traversal, and target marker

### DIFF
--- a/.github/workflows/vtt-navigation-polish.yml
+++ b/.github/workflows/vtt-navigation-polish.yml
@@ -1,0 +1,44 @@
+name: VTT Navigation Polish
+
+on:
+  pull_request:
+    paths:
+      - 'js/vtt/pathfinding.js'
+      - 'js/vtt/movement-navigation-polish.js'
+      - 'js/vtt/movement-realtime.js'
+      - 'js/vtt/movement-connectivity.js'
+      - 'tests/vtt_navigation_polish.spec.js'
+      - 'tests/vtt_movement_destination_realtime.spec.js'
+      - '.github/workflows/vtt-navigation-polish.yml'
+  push:
+    paths:
+      - 'js/vtt/pathfinding.js'
+      - 'js/vtt/movement-navigation-polish.js'
+      - 'js/vtt/movement-realtime.js'
+      - 'js/vtt/movement-connectivity.js'
+      - 'tests/vtt_navigation_polish.spec.js'
+      - 'tests/vtt_movement_destination_realtime.spec.js'
+      - '.github/workflows/vtt-navigation-polish.yml'
+
+jobs:
+  navigation-polish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Syntax
+        run: |
+          node --input-type=module --check < js/vtt/movement-navigation-polish.js
+          node --input-type=module --check < js/vtt/movement-realtime.js
+          node --input-type=module --check < js/vtt/movement-connectivity.js
+          node --check tests/vtt_navigation_polish.spec.js
+          node --check tests/vtt_movement_destination_realtime.spec.js
+      - name: Focused navigation contracts
+        run: npx playwright test --workers=1 tests/vtt_navigation_polish.spec.js tests/vtt_movement_destination_realtime.spec.js

--- a/js/vtt/movement-connectivity.js
+++ b/js/vtt/movement-connectivity.js
@@ -267,7 +267,7 @@
         stop,
         snapshot,
         finalizeToken: (token, saveCanonical) => requireOnline().finalizeToken(token, saveCanonical),
-        schedulePreview: (token) => connected && inner ? inner.schedulePreview(token) : false,
+        schedulePreview: (token, meta) => connected && inner ? inner.schedulePreview(token, meta) : false,
         handleIncoming: (...args) => connected && inner ? inner.handleIncoming(...args) : false,
         clearIncoming: (...args) => connected && inner ? inner.clearIncoming(...args) : false,
         handleCanonicalSync: (...args) => connected && inner ? inner.handleCanonicalSync(...args) : false,

--- a/js/vtt/movement-connectivity.js
+++ b/js/vtt/movement-connectivity.js
@@ -4,6 +4,9 @@
   if (root) {
     root.LuminousVttMovementConnectivity = api;
     api.installTokenState(root);
+    if (typeof window !== 'undefined') {
+      import('./movement-navigation-polish.js').catch((error) => console.error('VTT navigation polish failed to load:', error));
+    }
   }
 })(typeof window !== 'undefined' ? window : globalThis, function () {
   'use strict';

--- a/js/vtt/movement-navigation-polish.js
+++ b/js/vtt/movement-navigation-polish.js
@@ -285,7 +285,9 @@ export function installRuntimeNavigationPolish({ host = globalThis, runtime = ho
       clearMarker(detail.tokenId);
       return;
     }
-    if (detail.destination && detail.traversing) setMarker(detail.tokenId, detail.destination, 'committed');
+    if (detail.destination) {
+      setMarker(detail.tokenId, detail.destination, detail.traversing ? 'committed' : 'preview');
+    }
   }
 
   function onRejected(event) { clearMarker(event?.detail?.tokenId); }

--- a/js/vtt/movement-navigation-polish.js
+++ b/js/vtt/movement-navigation-polish.js
@@ -231,8 +231,8 @@ export function installRuntimeNavigationPolish({ host = globalThis, runtime = ho
   if (engine.__navigationPolishRuntime) return engine.__navigationPolishRuntime;
 
   const markers = new Map();
-  const originalAnimate = engine.animateTokenPath.bind(engine);
-  const originalRender = renderer.render.bind(renderer);
+  const originalAnimate = engine.animateTokenPath;
+  const originalRender = renderer.render;
   let stopped = false;
 
   function setMarker(tokenId, point, phase = 'committed') {
@@ -298,7 +298,7 @@ export function installRuntimeNavigationPolish({ host = globalThis, runtime = ho
     const interactions = Array.isArray(options.doorInteractions) ? options.doorInteractions : [];
     if (!token || points.length < 2 || interactions.length) {
       if (token && points.length) setMarker(token.id, points[points.length - 1], 'committed');
-      const result = await originalAnimate(token, path, options);
+      const result = await originalAnimate.call(engine, token, path, options);
       if (token && result?.valid === false) clearMarker(token.id);
       return result;
     }
@@ -361,8 +361,8 @@ export function installRuntimeNavigationPolish({ host = globalThis, runtime = ho
   };
   engine.animateTokenPath = patchedAnimate;
 
-  renderer.render = function navigationMarkerRender(...args) {
-    const result = originalRender(...args);
+  const patchedRender = function navigationMarkerRender(...args) {
+    const result = originalRender.apply(renderer, args);
     if (stopped || !markers.size) return result;
     const visible = [...markers.values()].filter((marker) => Number(marker.zLayer) === Number(engine.activeZ));
     for (const marker of visible) {
@@ -371,6 +371,7 @@ export function installRuntimeNavigationPolish({ host = globalThis, runtime = ho
     }
     return result;
   };
+  renderer.render = patchedRender;
 
   canvas.addEventListener('vtt:movement-destination-preview', onDestinationPreview);
   canvas.addEventListener('vtt:token-preview-moved', onTokenPreview);
@@ -390,6 +391,9 @@ export function installRuntimeNavigationPolish({ host = globalThis, runtime = ho
       canvas.removeEventListener('vtt:movement-order-rejected', onRejected);
       canvas.removeEventListener('vtt:token-moved', onMoved);
       if (engine.animateTokenPath === patchedAnimate) engine.animateTokenPath = originalAnimate;
+      if (renderer.render === patchedRender) renderer.render = originalRender;
+      if (engine.__navigationPolishRuntime === api) delete engine.__navigationPolishRuntime;
+      if (host.LuminousVttNavigationPolishRuntime === api) delete host.LuminousVttNavigationPolishRuntime;
       return true;
     },
   });

--- a/js/vtt/movement-navigation-polish.js
+++ b/js/vtt/movement-navigation-polish.js
@@ -1,0 +1,406 @@
+const EPS = 1e-9;
+const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+const clean = (value) => String(value ?? '').trim();
+
+function lineDeviation(cell = {}, start = {}, target = {}) {
+  const routeDx = finite(target.col) - finite(start.col);
+  const routeDy = finite(target.row) - finite(start.row);
+  if (Math.abs(routeDx) < EPS && Math.abs(routeDy) < EPS) return 0;
+  const cellDx = finite(cell.col) - finite(start.col);
+  const cellDy = finite(cell.row) - finite(start.row);
+  return Math.abs((cellDx * routeDy) - (cellDy * routeDx)) / Math.max(1, Math.hypot(routeDx, routeDy));
+}
+
+function goalDistance(cell = {}, target = {}) {
+  return Math.hypot(finite(target.col) - finite(cell.col), finite(target.row) - finite(cell.row));
+}
+
+function preferCandidate(base, candidate, current, start, target, f) {
+  if (!current) return true;
+  const candidateKey = base.cellKey(candidate.col, candidate.row);
+  const currentKey = base.cellKey(current.col, current.row);
+  const candidateF = f.get(candidateKey) ?? Infinity;
+  const currentF = f.get(currentKey) ?? Infinity;
+  if (candidateF < currentF - EPS) return true;
+  if (candidateF > currentF + EPS) return false;
+
+  const candidateDeviation = lineDeviation(candidate, start, target);
+  const currentDeviation = lineDeviation(current, start, target);
+  if (candidateDeviation < currentDeviation - EPS) return true;
+  if (candidateDeviation > currentDeviation + EPS) return false;
+
+  const candidateGoal = goalDistance(candidate, target);
+  const currentGoal = goalDistance(current, target);
+  if (candidateGoal < currentGoal - EPS) return true;
+  if (candidateGoal > currentGoal + EPS) return false;
+
+  if (candidate.row !== current.row) return candidate.row < current.row;
+  return candidate.col < current.col;
+}
+
+export function installStraightPathfinding(host = globalThis) {
+  const base = host?.LuminousVttPathfinding;
+  if (!base || base.__straightRouteTieBreakPatch) return base || null;
+
+  function reconstruct(cameFrom, nodes, endKey, mapData, zLayer) {
+    const cells = [];
+    let key = endKey;
+    while (key) {
+      const cell = nodes.get(key);
+      if (!cell) break;
+      cells.push(cell);
+      key = cameFrom.get(key) || null;
+    }
+    cells.reverse();
+    return cells.map((cell) => base.pointForCell(cell, mapData, zLayer));
+  }
+
+  function findPath({ token, start, target, mapData = {}, zLayer = base.tokenLayer(token), movementMode = 'walk', blockTokens, diagonalRule: rule, maxVisited = 20000 } = {}) {
+    if (!token || !mapData.grid || !start || !target) return { valid: false, reason: 'INVALID_INPUT', path: [], costFt: Infinity };
+    const startCell = start.col != null && start.row != null
+      ? { col: Math.trunc(Number(start.col)), row: Math.trunc(Number(start.row)) }
+      : base.cellFromPoint(start, mapData);
+    const targetCell = target.col != null && target.row != null
+      ? { col: Math.trunc(Number(target.col)), row: Math.trunc(Number(target.row)) }
+      : base.cellFromPoint(target, mapData);
+    const options = { movementMode, blockTokens, diagonalRule: rule };
+    const targetPoint = base.pointForCell(targetCell, mapData, zLayer);
+    const targetGate = base.pointPassable(token, targetPoint, mapData, zLayer, options);
+    if (!targetGate.valid) return { valid: false, reason: targetGate.reason || 'TARGET_BLOCKED', path: [], costFt: Infinity, blocker: targetGate };
+
+    const startKey = base.cellKey(startCell.col, startCell.row);
+    const goalKey = base.cellKey(targetCell.col, targetCell.row);
+    if (startKey === goalKey) {
+      return { valid: true, reason: null, path: [base.pointForCell(startCell, mapData, zLayer)], cells: [startCell], costFt: 0, visited: 0 };
+    }
+
+    const open = new Set([startKey]);
+    const nodes = new Map([[startKey, startCell]]);
+    const cameFrom = new Map();
+    const g = new Map([[startKey, 0]]);
+    const f = new Map([[startKey, base.heuristicFt(startCell, targetCell, mapData, options)]]);
+    const limit = Math.max(1, Math.trunc(finite(maxVisited, 20000)));
+    let visited = 0;
+
+    while (open.size && visited < limit) {
+      let currentKey = null;
+      let current = null;
+      for (const key of open) {
+        const candidate = nodes.get(key);
+        if (candidate && preferCandidate(base, candidate, current, startCell, targetCell, f)) {
+          current = candidate;
+          currentKey = key;
+        }
+      }
+      if (!currentKey || !current) break;
+      if (currentKey === goalKey) {
+        const path = reconstruct(cameFrom, nodes, currentKey, mapData, zLayer);
+        return {
+          valid: true,
+          reason: null,
+          path,
+          cells: path.map((point) => ({ col: point.col, row: point.row })),
+          costFt: g.get(currentKey) || 0,
+          visited,
+        };
+      }
+
+      open.delete(currentKey);
+      visited += 1;
+      for (const next of base.neighbors(current, mapData)) {
+        const edge = base.edgePassable(token, current, next, mapData, zLayer, options);
+        if (!edge.valid) continue;
+        const nextKey = base.cellKey(next.col, next.row);
+        const tentative = (g.get(currentKey) ?? Infinity) + base.stepCostFt(current, next, mapData, zLayer, options);
+        if (tentative + EPS >= (g.get(nextKey) ?? Infinity)) continue;
+        cameFrom.set(nextKey, currentKey);
+        nodes.set(nextKey, next);
+        g.set(nextKey, tentative);
+        f.set(nextKey, tentative + base.heuristicFt(next, targetCell, mapData, options));
+        open.add(nextKey);
+      }
+    }
+
+    return { valid: false, reason: visited >= limit ? 'SEARCH_LIMIT' : 'NO_PATH', path: [], cells: [], costFt: Infinity, visited };
+  }
+
+  const patched = Object.freeze({
+    ...base,
+    __straightRouteTieBreakPatch: true,
+    findPath,
+  });
+  host.LuminousVttPathfinding = patched;
+  return patched;
+}
+
+function normalizedPoints(path = []) {
+  return Array.isArray(path)
+    ? path.filter((point) => Number.isFinite(Number(point?.x)) && Number.isFinite(Number(point?.y)))
+      .map((point) => ({ ...point, x: Number(point.x), y: Number(point.y) }))
+    : [];
+}
+
+function polylineMetrics(points = []) {
+  const segments = [];
+  let total = 0;
+  for (let index = 1; index < points.length; index += 1) {
+    const from = points[index - 1];
+    const to = points[index];
+    const length = Math.hypot(to.x - from.x, to.y - from.y);
+    if (!(length > EPS)) continue;
+    const start = total;
+    total += length;
+    segments.push({ from, to, length, start, end: total });
+  }
+  return { segments, total };
+}
+
+function pointAlongPolyline(metrics, distance) {
+  const segments = metrics?.segments || [];
+  if (!segments.length) return null;
+  const wanted = Math.max(0, Math.min(finite(distance), finite(metrics.total)));
+  let segment = segments[segments.length - 1];
+  for (const candidate of segments) {
+    if (wanted <= candidate.end + EPS) { segment = candidate; break; }
+  }
+  const local = segment.length > EPS ? Math.max(0, Math.min(1, (wanted - segment.start) / segment.length)) : 1;
+  return {
+    x: segment.from.x + ((segment.to.x - segment.from.x) * local),
+    y: segment.from.y + ((segment.to.y - segment.from.y) * local),
+  };
+}
+
+function emitDirty(host, engine, tokenId, sourceEvent = 'navigation-target-marker') {
+  host?.LuminousVttSceneDirty?.emit?.(engine?.canvas, {
+    reason: 'token',
+    render: true,
+    vision: false,
+    active: Boolean(engine?.tokenMotion || engine?.tokenDrag),
+    sourceEvent,
+    tokenId,
+  });
+}
+
+function drawCanvasMarker(renderer, camera, marker) {
+  const ctx = renderer?.ctx;
+  if (!ctx || !camera?.applyTransformSimple) return;
+  const zoom = Math.max(0.01, finite(camera.zoom, 1));
+  const outer = 13 / zoom;
+  const inner = 4 / zoom;
+  ctx.save();
+  camera.applyTransformSimple(ctx);
+  ctx.strokeStyle = marker.phase === 'preview' ? '#ffffff' : '#d7b151';
+  ctx.lineWidth = 2 / zoom;
+  ctx.setLineDash(marker.phase === 'preview' ? [4 / zoom, 3 / zoom] : []);
+  ctx.beginPath();
+  ctx.arc(marker.x, marker.y, outer, 0, Math.PI * 2);
+  ctx.stroke();
+  ctx.setLineDash([]);
+  ctx.beginPath();
+  ctx.arc(marker.x, marker.y, inner, 0, Math.PI * 2);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.moveTo(marker.x - outer * 1.35, marker.y);
+  ctx.lineTo(marker.x - outer * 0.65, marker.y);
+  ctx.moveTo(marker.x + outer * 0.65, marker.y);
+  ctx.lineTo(marker.x + outer * 1.35, marker.y);
+  ctx.moveTo(marker.x, marker.y - outer * 1.35);
+  ctx.lineTo(marker.x, marker.y - outer * 0.65);
+  ctx.moveTo(marker.x, marker.y + outer * 0.65);
+  ctx.lineTo(marker.x, marker.y + outer * 1.35);
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawWebGlMarker(renderer, camera, marker) {
+  if (typeof renderer?.drawDmObserverOutlines !== 'function') return;
+  const zoom = Math.max(0.01, finite(camera?.zoom, 1));
+  const color = marker.phase === 'preview' ? '#ffffff' : '#d7b151';
+  renderer.drawDmObserverOutlines([
+    { x: marker.x, y: marker.y, radius: 13 / zoom, coneDeg: 360, facingDeg: 0, color, selected: true },
+    { x: marker.x, y: marker.y, radius: 4 / zoom, coneDeg: 360, facingDeg: 0, color, selected: true },
+  ], camera);
+}
+
+export function installRuntimeNavigationPolish({ host = globalThis, runtime = host?.LuminousVttRuntime } = {}) {
+  const engine = runtime?.engine;
+  const mapData = engine?.mapData;
+  const renderer = engine?.renderer;
+  const canvas = engine?.canvas;
+  if (!engine || !mapData || !renderer || !canvas) return null;
+  if (engine.__navigationPolishRuntime) return engine.__navigationPolishRuntime;
+
+  const markers = new Map();
+  const originalAnimate = engine.animateTokenPath.bind(engine);
+  const originalRender = renderer.render.bind(renderer);
+  let stopped = false;
+
+  function setMarker(tokenId, point, phase = 'committed') {
+    const id = clean(tokenId);
+    if (!id || !Number.isFinite(Number(point?.x)) || !Number.isFinite(Number(point?.y))) return false;
+    const marker = {
+      tokenId: id,
+      x: Number(point.x),
+      y: Number(point.y),
+      zLayer: Number(point.zLayer ?? point.z ?? engine.activeZ) || 0,
+      phase,
+    };
+    markers.set(id, marker);
+    emitDirty(host, engine, id, 'navigation-target-marker:set');
+    return marker;
+  }
+
+  function clearMarker(tokenId) {
+    const id = clean(tokenId);
+    if (!id || !markers.delete(id)) return false;
+    emitDirty(host, engine, id, 'navigation-target-marker:clear');
+    return true;
+  }
+
+  function targetPoint(raw = {}) {
+    const pathfinding = host?.LuminousVttPathfinding;
+    if (!pathfinding || !Number.isFinite(Number(raw?.x)) || !Number.isFinite(Number(raw?.y))) return null;
+    const bounds = pathfinding.gridBounds(mapData);
+    if (Number(raw.x) < 0 || Number(raw.y) < 0 || Number(raw.x) >= bounds.width || Number(raw.y) >= bounds.height) return null;
+    const cell = pathfinding.cellFromPoint(raw, mapData);
+    return pathfinding.pointForCell(cell, mapData, engine.activeZ);
+  }
+
+  function onDestinationPreview(event) {
+    const detail = event?.detail || {};
+    const point = targetPoint(detail.target);
+    if (!point) return clearMarker(detail.tokenId);
+    setMarker(detail.tokenId, point, 'preview');
+  }
+
+  function onTokenPreview(event) {
+    const detail = event?.detail || {};
+    if (detail.reverted || detail.cancelled || detail.expired || detail.cleared) {
+      clearMarker(detail.tokenId);
+      return;
+    }
+    if (detail.destination && detail.traversing) setMarker(detail.tokenId, detail.destination, 'committed');
+  }
+
+  function onRejected(event) { clearMarker(event?.detail?.tokenId); }
+  function onMoved(event) { clearMarker(event?.detail?.tokenId); }
+
+  engine.animateTokenPath = async function polishedAnimateTokenPath(token, path = [], options = {}) {
+    const points = normalizedPoints(path);
+    const interactions = Array.isArray(options.doorInteractions) ? options.doorInteractions : [];
+    if (!token || points.length < 2 || interactions.length) {
+      if (token && points.length) setMarker(token.id, points[points.length - 1], 'committed');
+      return originalAnimate(token, path, options);
+    }
+
+    const metrics = polylineMetrics(points);
+    if (!(metrics.total > EPS)) return { valid: true, complete: true };
+
+    const movement = mapData.movement || {};
+    const mode = String(options.actionMode || token.activeActionMovementMode || 'walk').toLowerCase();
+    const defaultMs = mode === 'dash' || mode === 'run' ? 55 : 90;
+    const msPerCell = Math.max(20, Number(movement.animationMsPerCell) || defaultMs);
+    const gridSize = Math.max(1, Number(mapData.grid?.size) || 70);
+    const durationMs = Math.max(8, msPerCell * (metrics.total / gridSize));
+    const raf = host?.requestAnimationFrame?.bind(host) || ((fn) => host?.setTimeout?.(() => fn(Date.now()), 16));
+    const caf = host?.cancelAnimationFrame?.bind(host) || host?.clearTimeout?.bind(host);
+    const endpoint = points[points.length - 1];
+    const destination = { x: endpoint.x, y: endpoint.y, z: Number(endpoint.z ?? endpoint.zLayer ?? token.zLayer ?? 0) || 0 };
+    const motion = { cancelled: false, irreversible: false, frameId: null, tokenId: token.id, destination };
+    engine.tokenMotion = motion;
+    setMarker(token.id, destination, 'committed');
+
+    token.x = points[0].x;
+    token.y = points[0].y;
+    const startAt = host?.performance?.now?.() ?? Date.now();
+
+    try {
+      const complete = await new Promise((resolve) => {
+        const step = (nowValue) => {
+          if (motion.cancelled) return resolve(false);
+          const elapsed = Math.max(0, Number(nowValue) - startAt);
+          const t = Math.min(1, elapsed / durationMs);
+          const next = pointAlongPolyline(metrics, metrics.total * t) || endpoint;
+          token.x = next.x;
+          token.y = next.y;
+          const detail = {
+            tokenId: token.id,
+            x: token.x,
+            y: token.y,
+            z: Number(token.zLayer ?? token.gridPosition?.z ?? token.z?.[0] ?? 0),
+            traversing: true,
+            actionMode: mode,
+            destination,
+          };
+          engine.emitSemanticEvent?.('vtt:token-preview-moved', detail, {
+            reason: 'token', render: true, vision: true, active: true,
+          });
+          if (t >= 1) return resolve(true);
+          motion.frameId = raf(step);
+        };
+        motion.frameId = raf(step);
+      });
+      return complete
+        ? { valid: true, complete: true, irreversible: false }
+        : { valid: false, reason: 'MOVEMENT_CANCELLED', complete: false };
+    } finally {
+      if (motion.frameId != null && motion.cancelled) caf?.(motion.frameId);
+      if (engine.tokenMotion === motion) engine.tokenMotion = null;
+    }
+  };
+
+  renderer.render = function navigationMarkerRender(...args) {
+    const result = originalRender(...args);
+    if (stopped || !markers.size) return result;
+    const visible = [...markers.values()].filter((marker) => Number(marker.zLayer) === Number(engine.activeZ));
+    for (const marker of visible) {
+      if (renderer.backend === 'webgl2') drawWebGlMarker(renderer, engine.camera, marker);
+      else drawCanvasMarker(renderer, engine.camera, marker);
+    }
+    return result;
+  };
+
+  canvas.addEventListener('vtt:movement-destination-preview', onDestinationPreview);
+  canvas.addEventListener('vtt:token-preview-moved', onTokenPreview);
+  canvas.addEventListener('vtt:movement-order-rejected', onRejected);
+  canvas.addEventListener('vtt:token-moved', onMoved);
+
+  const api = Object.freeze({
+    markers,
+    setMarker,
+    clearMarker,
+    stop() {
+      if (stopped) return false;
+      stopped = true;
+      markers.clear();
+      canvas.removeEventListener('vtt:movement-destination-preview', onDestinationPreview);
+      canvas.removeEventListener('vtt:token-preview-moved', onTokenPreview);
+      canvas.removeEventListener('vtt:movement-order-rejected', onRejected);
+      canvas.removeEventListener('vtt:token-moved', onMoved);
+      if (engine.animateTokenPath === polishedAnimateTokenPath) engine.animateTokenPath = originalAnimate;
+      return true;
+    },
+  });
+
+  // Keep a stable lifecycle seam without mutating the frozen top-level runtime object.
+  engine.__navigationPolishRuntime = api;
+  host.LuminousVttNavigationPolishRuntime = api;
+  return api;
+}
+
+function startWhenRuntimeReady(host = globalThis) {
+  let attempts = 0;
+  const tryStart = () => {
+    const runtime = host?.LuminousVttRuntime;
+    if (runtime?.engine?.renderer) {
+      installRuntimeNavigationPolish({ host, runtime });
+      return;
+    }
+    attempts += 1;
+    if (attempts < 160) host?.setTimeout?.(tryStart, 25);
+  };
+  tryStart();
+}
+
+installStraightPathfinding(globalThis);
+if (typeof window !== 'undefined') startWhenRuntimeReady(window);

--- a/js/vtt/movement-navigation-polish.js
+++ b/js/vtt/movement-navigation-polish.js
@@ -238,16 +238,22 @@ export function installRuntimeNavigationPolish({ host = globalThis, runtime = ho
   function setMarker(tokenId, point, phase = 'committed') {
     const id = clean(tokenId);
     if (!id || !Number.isFinite(Number(point?.x)) || !Number.isFinite(Number(point?.y))) return false;
-    const marker = {
+    const next = {
       tokenId: id,
       x: Number(point.x),
       y: Number(point.y),
       zLayer: Number(point.zLayer ?? point.z ?? engine.activeZ) || 0,
       phase,
     };
-    markers.set(id, marker);
+    const previous = markers.get(id);
+    if (previous
+      && Math.abs(previous.x - next.x) < 0.01
+      && Math.abs(previous.y - next.y) < 0.01
+      && previous.zLayer === next.zLayer
+      && previous.phase === next.phase) return previous;
+    markers.set(id, next);
     emitDirty(host, engine, id, 'navigation-target-marker:set');
-    return marker;
+    return next;
   }
 
   function clearMarker(tokenId) {
@@ -285,12 +291,14 @@ export function installRuntimeNavigationPolish({ host = globalThis, runtime = ho
   function onRejected(event) { clearMarker(event?.detail?.tokenId); }
   function onMoved(event) { clearMarker(event?.detail?.tokenId); }
 
-  engine.animateTokenPath = async function polishedAnimateTokenPath(token, path = [], options = {}) {
+  const patchedAnimate = async function polishedAnimateTokenPath(token, path = [], options = {}) {
     const points = normalizedPoints(path);
     const interactions = Array.isArray(options.doorInteractions) ? options.doorInteractions : [];
     if (!token || points.length < 2 || interactions.length) {
       if (token && points.length) setMarker(token.id, points[points.length - 1], 'committed');
-      return originalAnimate(token, path, options);
+      const result = await originalAnimate(token, path, options);
+      if (token && result?.valid === false) clearMarker(token.id);
+      return result;
     }
 
     const metrics = polylineMetrics(points);
@@ -340,6 +348,7 @@ export function installRuntimeNavigationPolish({ host = globalThis, runtime = ho
         };
         motion.frameId = raf(step);
       });
+      if (!complete) clearMarker(token.id);
       return complete
         ? { valid: true, complete: true, irreversible: false }
         : { valid: false, reason: 'MOVEMENT_CANCELLED', complete: false };
@@ -348,6 +357,7 @@ export function installRuntimeNavigationPolish({ host = globalThis, runtime = ho
       if (engine.tokenMotion === motion) engine.tokenMotion = null;
     }
   };
+  engine.animateTokenPath = patchedAnimate;
 
   renderer.render = function navigationMarkerRender(...args) {
     const result = originalRender(...args);
@@ -377,12 +387,11 @@ export function installRuntimeNavigationPolish({ host = globalThis, runtime = ho
       canvas.removeEventListener('vtt:token-preview-moved', onTokenPreview);
       canvas.removeEventListener('vtt:movement-order-rejected', onRejected);
       canvas.removeEventListener('vtt:token-moved', onMoved);
-      if (engine.animateTokenPath === polishedAnimateTokenPath) engine.animateTokenPath = originalAnimate;
+      if (engine.animateTokenPath === patchedAnimate) engine.animateTokenPath = originalAnimate;
       return true;
     },
   });
 
-  // Keep a stable lifecycle seam without mutating the frozen top-level runtime object.
   engine.__navigationPolishRuntime = api;
   host.LuminousVttNavigationPolishRuntime = api;
   return api;

--- a/js/vtt/movement-realtime.js
+++ b/js/vtt/movement-realtime.js
@@ -50,6 +50,12 @@
     return 0;
   }
 
+  function normalizeDestination(value = null, fallbackZ = 0) {
+    if (!value || !Number.isFinite(Number(value.x)) || !Number.isFinite(Number(value.y))) return null;
+    const z = Number.isFinite(Number(value.zLayer ?? value.z)) ? Number(value.zLayer ?? value.z) : Number(fallbackZ) || 0;
+    return { x: Number(value.x), y: Number(value.y), zLayer: z };
+  }
+
   function playerKeyForToken(token = {}, current = {}) {
     return clean(token.canonicalPlayerKey || token.playerId || (token.characterLink?.mode === 'current_player' ? current.playerId : ''));
   }
@@ -98,7 +104,7 @@
     const current = meta.current || {};
     const playerKey = playerKeyForToken(token, current);
     return {
-      schemaVersion: 1,
+      schemaVersion: 2,
       scope: isPlayerToken(token, current) ? 'player' : 'world',
       tokenId: clean(token.id) || null,
       playerKey: playerKey || null,
@@ -106,6 +112,9 @@
       y: finite(token.y),
       zLayer: tokenLayer(token),
       elevationFt: finite(token.elevationFt),
+      destination: normalizeDestination(meta.destination, tokenLayer(token)),
+      aiming: Boolean(meta.aiming),
+      traversing: Boolean(meta.traversing),
       sequence: Math.max(0, Math.trunc(finite(meta.sequence))),
       committed: Boolean(meta.committed),
       sessionId: clean(meta.sessionId) || null,
@@ -204,6 +213,9 @@
           scope: preview?.scope || null,
           playerKey: preview?.playerKey || null,
           sequence: preview?.sequence ?? null,
+          destination: normalizeDestination(preview?.destination, tokenLayer(token)),
+          aiming: Boolean(preview?.aiming),
+          traversing: Boolean(preview?.traversing),
           ...detail,
         },
       }));
@@ -221,12 +233,13 @@
       if (active.preview?.committed) {
         activeRemotePreviews.delete(key);
         clearExpiry(key);
+        dispatchPreview(active.token, active.preview, { expired: true, cleared: true, destination: null });
         return;
       }
       restoreCanonical(active.token);
       activeRemotePreviews.delete(key);
       clearExpiry(key);
-      dispatchPreview(active.token, active.preview, { expired: true, reverted: true });
+      dispatchPreview(active.token, active.preview, { expired: true, reverted: true, destination: null });
     }
 
     function armExpiry(key, preview, token) {
@@ -248,7 +261,9 @@
       activeRemotePreviews.delete(key);
       if (!active.preview?.committed) {
         restoreCanonical(active.token);
-        dispatchPreview(active.token, active.preview, { reverted: true, cleared: true });
+        dispatchPreview(active.token, active.preview, { reverted: true, cleared: true, destination: null });
+      } else {
+        dispatchPreview(active.token, active.preview, { committed: true, cleared: true, destination: null });
       }
     }
 
@@ -266,7 +281,14 @@
         droppedStale += 1;
         return;
       }
-      const normalized = { ...preview, scope, playerKey: playerKey || preview.playerKey || null };
+      const normalized = {
+        ...preview,
+        scope,
+        playerKey: playerKey || preview.playerKey || null,
+        destination: normalizeDestination(preview.destination, preview.zLayer),
+        aiming: Boolean(preview.aiming),
+        traversing: Boolean(preview.traversing),
+      };
       const token = tokenForPreview(normalized, playerKey);
       if (!token) {
         activeRemotePreviews.set(key, { token: null, preview: normalized });
@@ -279,7 +301,12 @@
       applyPreview(token, normalized);
       activeRemotePreviews.set(key, { token, preview: normalized });
       armExpiry(key, normalized, token);
-      dispatchPreview(token, normalized, { committed: Boolean(normalized.committed) });
+      dispatchPreview(token, normalized, {
+        committed: Boolean(normalized.committed),
+        destination: normalized.destination,
+        aiming: normalized.aiming,
+        traversing: normalized.traversing,
+      });
     }
 
     function subscribe(ref, event, handler) {
@@ -328,7 +355,12 @@
         if (!token) continue;
         active.token = token;
         applyPreview(token, active.preview);
-        dispatchPreview(token, active.preview, { canonicalRefresh: true });
+        dispatchPreview(token, active.preview, {
+          canonicalRefresh: true,
+          destination: active.preview?.destination || null,
+          aiming: Boolean(active.preview?.aiming),
+          traversing: Boolean(active.preview?.traversing),
+        });
         activeRemotePreviews.set(key, active);
       }
     }
@@ -359,7 +391,7 @@
       return tracked;
     }
 
-    function writePayload(token, { committed = false } = {}) {
+    function writePayload(token, { committed = false, destination = null, aiming = false, traversing = false } = {}) {
       const target = previewRefForToken(token);
       if (!target?.ref?.set) return Promise.resolve({ valid: false, reason: 'PREVIEW_WRITE_UNAVAILABLE' });
       const sentAtMs = Math.max(0, Math.trunc(now()));
@@ -368,6 +400,9 @@
         current,
         sequence: ++sequence,
         committed,
+        destination,
+        aiming,
+        traversing,
         sessionId,
         sentAtMs,
         expiresAtMs: committed ? 0 : sentAtMs + previewTtlMs,
@@ -394,34 +429,44 @@
 
     function cancelPending(token) {
       const key = logicalTokenKey(token, current);
-      if (!key) return;
-      const state = pending.get(key);
+      if (!key) return null;
+      const state = pending.get(key) || null;
       if (state?.timer != null) clearTimeoutFn(state.timer);
       pending.delete(key);
+      return state;
     }
 
     function sendNow(token) {
       const key = logicalTokenKey(token, current);
       if (!key) return Promise.resolve({ valid: false, reason: 'TOKEN_KEY_REQUIRED' });
-      const state = pending.get(key) || { lastSentAt: -Infinity, timer: null, token };
+      const state = pending.get(key) || { lastSentAt: -Infinity, timer: null, token, destination: null, aiming: false, traversing: false };
       if (state.timer != null) clearTimeoutFn(state.timer);
       state.timer = null;
       state.lastSentAt = now();
       state.token = token;
       pending.set(key, state);
-      return writePayload(token);
+      return writePayload(token, {
+        destination: state.destination,
+        aiming: state.aiming,
+        traversing: state.traversing,
+      });
     }
 
-    function schedulePreview(token) {
+    function schedulePreview(token, meta = {}) {
       const key = logicalTokenKey(token, current);
-      if (!key || !previewRefForToken(token)) return;
-      const state = pending.get(key) || { lastSentAt: -Infinity, timer: null, token };
+      if (!key || !previewRefForToken(token)) return false;
+      const state = pending.get(key) || { lastSentAt: -Infinity, timer: null, token, destination: null, aiming: false, traversing: false };
       state.token = token;
+      if (Object.prototype.hasOwnProperty.call(meta, 'destination')) {
+        state.destination = normalizeDestination(meta.destination, tokenLayer(token));
+      }
+      if (Object.prototype.hasOwnProperty.call(meta, 'aiming')) state.aiming = Boolean(meta.aiming);
+      if (Object.prototype.hasOwnProperty.call(meta, 'traversing')) state.traversing = Boolean(meta.traversing);
       const elapsed = now() - finite(state.lastSentAt, -Infinity);
       if (elapsed >= throttleMs && state.timer == null) {
         pending.set(key, state);
         void sendNow(token).catch((error) => console.error('VTT realtime movement preview failed:', error));
-        return;
+        return true;
       }
       if (state.timer == null) {
         const delay = Math.max(0, throttleMs - Math.max(0, elapsed));
@@ -433,19 +478,48 @@
         }, delay);
       }
       pending.set(key, state);
+      return true;
+    }
+
+    function tokenFromEvent(event) {
+      const tokenId = clean(event?.detail?.tokenId);
+      return (mapData.tokens || []).find((entry) => clean(entry.id) === tokenId) || null;
+    }
+
+    function handleDestinationPreview(event) {
+      if (stopped || event?.detail?.remote) return;
+      const token = tokenFromEvent(event);
+      if (!token) return;
+      schedulePreview(token, {
+        destination: event?.detail?.target || null,
+        aiming: true,
+        traversing: false,
+      });
     }
 
     function handleLocalPreview(event) {
       if (stopped || event?.detail?.remote) return;
-      const tokenId = clean(event?.detail?.tokenId);
-      const token = (mapData.tokens || []).find((entry) => clean(entry.id) === tokenId);
+      const token = tokenFromEvent(event);
       if (!token) return;
       if (event?.detail?.reverted) {
         cancelPending(token);
         void clearPayload(token).catch((error) => console.error('VTT realtime movement rollback failed:', error));
         return;
       }
-      schedulePreview(token);
+      const meta = {
+        aiming: false,
+        traversing: event?.detail?.traversing === true,
+      };
+      if (Object.prototype.hasOwnProperty.call(event?.detail || {}, 'destination')) meta.destination = event.detail.destination;
+      schedulePreview(token, meta);
+    }
+
+    function handleMovementRejected(event) {
+      if (stopped || event?.detail?.remote) return;
+      const token = tokenFromEvent(event);
+      if (!token) return;
+      cancelPending(token);
+      void clearPayload(token).catch((error) => console.error('VTT realtime movement rejection cleanup failed:', error));
     }
 
     function handleCanonicalSync() {
@@ -456,14 +530,17 @@
 
     async function finalizeToken(token, saveCanonical) {
       if (!token || typeof saveCanonical !== 'function') throw new Error('MOVEMENT_FINALIZER_REQUIRED');
+      const key = logicalTokenKey(token, current);
+      const pendingState = key ? pending.get(key) : null;
+      const destination = normalizeDestination(pendingState?.destination, tokenLayer(token));
       cancelPending(token);
       const previewTarget = previewRefForToken(token);
       if (!previewTarget) return saveCanonical();
-      await writePayload(token);
+      await writePayload(token, { destination, aiming: false, traversing: false });
       try {
         const result = await saveCanonical();
         cacheCanonical(token);
-        await writePayload(token, { committed: true });
+        await writePayload(token, { committed: true, destination, aiming: false, traversing: false });
         await clearPayload(token);
         return result;
       } catch (error) {
@@ -482,7 +559,9 @@
         subscribe(worldPreviewRoot(), 'child_changed', (snapshot) => handleIncoming(snapshot?.val?.() || null));
         subscribe(worldPreviewRoot(), 'child_removed', (snapshot) => clearIncoming(snapshot?.val?.() || { tokenId: snapshot?.key || null }));
       }
+      canvas?.addEventListener?.('vtt:movement-destination-preview', handleDestinationPreview);
       canvas?.addEventListener?.('vtt:token-preview-moved', handleLocalPreview);
+      canvas?.addEventListener?.('vtt:movement-order-rejected', handleMovementRejected);
       canvas?.addEventListener?.('vtt:canonical-tokens-synced', handleCanonicalSync);
       Promise.resolve().then(reconcilePlayerSubscriptions);
       return snapshot();
@@ -498,7 +577,9 @@
       for (const off of rootSubscriptions.splice(0)) off();
       for (const off of playerSubscriptions.values()) off();
       playerSubscriptions.clear();
+      canvas?.removeEventListener?.('vtt:movement-destination-preview', handleDestinationPreview);
       canvas?.removeEventListener?.('vtt:token-preview-moved', handleLocalPreview);
+      canvas?.removeEventListener?.('vtt:movement-order-rejected', handleMovementRejected);
       canvas?.removeEventListener?.('vtt:canonical-tokens-synced', handleCanonicalSync);
     }
 
@@ -542,6 +623,7 @@
     firebaseKey,
     identity,
     tokenLayer,
+    normalizeDestination,
     playerKeyForToken,
     isPlayerToken,
     logicalTokenKey,

--- a/js/vtt/pathfinding.js
+++ b/js/vtt/pathfinding.js
@@ -149,6 +149,44 @@
     return Math.max(dx, dy) * feetPerCell;
   }
 
+  // A* can have many equal-cost routes under the 5e rule because a diagonal costs
+  // the same as an orthogonal step. This score is deliberately NOT added to g/f:
+  // it only breaks exact cost ties so movement accounting remains byte-for-byte 5e.
+  function directLineDeviation(cell = {}, start = {}, target = {}) {
+    const routeDx = finite(target.col) - finite(start.col);
+    const routeDy = finite(target.row) - finite(start.row);
+    if (Math.abs(routeDx) < EPS && Math.abs(routeDy) < EPS) return 0;
+    const cellDx = finite(cell.col) - finite(start.col);
+    const cellDy = finite(cell.row) - finite(start.row);
+    return Math.abs((cellDx * routeDy) - (cellDy * routeDx)) / Math.max(1, Math.hypot(routeDx, routeDy));
+  }
+
+  function goalDistance(cell = {}, target = {}) {
+    return Math.hypot(finite(target.col) - finite(cell.col), finite(target.row) - finite(cell.row));
+  }
+
+  function preferOpenCandidate(candidate, current, start, target, f) {
+    if (!current) return true;
+    const candidateF = f.get(cellKey(candidate.col, candidate.row)) ?? Infinity;
+    const currentF = f.get(cellKey(current.col, current.row)) ?? Infinity;
+    if (candidateF < currentF - EPS) return true;
+    if (candidateF > currentF + EPS) return false;
+
+    const candidateDeviation = directLineDeviation(candidate, start, target);
+    const currentDeviation = directLineDeviation(current, start, target);
+    if (candidateDeviation < currentDeviation - EPS) return true;
+    if (candidateDeviation > currentDeviation + EPS) return false;
+
+    const candidateGoalDistance = goalDistance(candidate, target);
+    const currentGoalDistance = goalDistance(current, target);
+    if (candidateGoalDistance < currentGoalDistance - EPS) return true;
+    if (candidateGoalDistance > currentGoalDistance + EPS) return false;
+
+    // Final deterministic tie-break. It does not affect cost or route legality.
+    if (candidate.row !== current.row) return candidate.row < current.row;
+    return candidate.col < current.col;
+  }
+
   function neighbors(cell, mapData = {}) {
     const { cols, rows } = gridBounds(mapData);
     const result = [];
@@ -195,13 +233,16 @@
     let visited = 0;
 
     while (open.size && visited < Math.max(1, Math.trunc(finite(maxVisited, 20000)))) {
-      let currentKey = null, currentScore = Infinity;
+      let currentKey = null;
+      let current = null;
       for (const key of open) {
-        const score = f.get(key) ?? Infinity;
-        if (score < currentScore) { currentScore = score; currentKey = key; }
+        const candidate = nodes.get(key);
+        if (candidate && preferOpenCandidate(candidate, current, startCell, targetCell, f)) {
+          current = candidate;
+          currentKey = key;
+        }
       }
-      if (!currentKey) break;
-      const current = nodes.get(currentKey);
+      if (!currentKey || !current) break;
       if (currentKey === goalKey) {
         const path = reconstruct(cameFrom, nodes, currentKey, mapData, zLayer);
         return { valid: true, reason: null, path, cells: path.map((point) => ({ col: point.col, row: point.row })), costFt: g.get(currentKey) || 0, visited };
@@ -237,6 +278,7 @@
 
   return Object.freeze({
     gridBounds, cellKey, cellFromPoint, pointForCell, tokenLayer, terrainRecord, terrainAllows, pointPassable,
-    edgePassable, diagonalRule, baseStepCostFt, stepCostFt, heuristicFt, neighbors, findPath, pathCostFt,
+    edgePassable, diagonalRule, baseStepCostFt, stepCostFt, heuristicFt, directLineDeviation, goalDistance,
+    neighbors, findPath, pathCostFt,
   });
 });

--- a/tests/vtt_movement_destination_realtime.spec.js
+++ b/tests/vtt_movement_destination_realtime.spec.js
@@ -1,0 +1,196 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+function freshRequire(relativePath) {
+  const file = path.join(__dirname, '..', relativePath);
+  delete require.cache[require.resolve(file)];
+  return require(file);
+}
+
+async function loadPolish() {
+  const source = fs.readFileSync(path.join(__dirname, '..', 'js/vtt/movement-navigation-polish.js'), 'utf8');
+  const tmp = path.join(os.tmpdir(), `luminous-navigation-realtime-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.mjs`);
+  fs.writeFileSync(tmp, source);
+  const mod = await import(`${pathToFileURL(tmp).href}?t=${Date.now()}`);
+  return { mod, tmp };
+}
+
+class FakeCustomEvent {
+  constructor(type, init = {}) {
+    this.type = type;
+    this.detail = init.detail || {};
+  }
+}
+
+function eventCanvas() {
+  const listeners = new Map();
+  return {
+    addEventListener(name, fn) {
+      if (!listeners.has(name)) listeners.set(name, new Set());
+      listeners.get(name).add(fn);
+    },
+    removeEventListener(name, fn) { listeners.get(name)?.delete(fn); },
+    dispatchEvent(event) {
+      for (const fn of listeners.get(event?.type) || []) fn(event);
+      return true;
+    },
+  };
+}
+
+function installRuntimePathfinding() {
+  global.LuminousVttTokenInteraction = undefined;
+  global.LuminousVttPathfinding = freshRequire('js/vtt/pathfinding.js');
+  global.LuminousVttMovementEngine = freshRequire('js/vtt/movement-engine.js');
+  global.LuminousVttTokenState = null;
+  freshRequire('js/vtt/movement-integration-patch.js');
+  return global.LuminousVttPathfinding;
+}
+
+test('realtime preview carries ephemeral destination metadata without adding it to canonical token position', () => {
+  const realtime = freshRequire('js/vtt/movement-realtime.js');
+  const token = {
+    id: 'player-token',
+    canonicalScope: 'player',
+    canonicalPlayerKey: 'alice',
+    playerId: 'alice',
+    x: 105,
+    y: 175,
+    zLayer: 0,
+    elevationFt: 0,
+  };
+
+  const preview = realtime.previewFromToken(token, {
+    current: { uid: 'alice-uid', playerId: 'alice' },
+    destination: { x: 525, y: 315, zLayer: 0 },
+    aiming: true,
+    traversing: false,
+    sequence: 7,
+    sessionId: 'alice-session',
+    sentAtMs: 1000,
+    expiresAtMs: 2800,
+  });
+
+  expect(preview).toMatchObject({
+    scope: 'player',
+    playerKey: 'alice',
+    destination: { x: 525, y: 315, zLayer: 0 },
+    aiming: true,
+    traversing: false,
+  });
+
+  const canonicalPosition = realtime.snapshotPosition(token);
+  expect(canonicalPosition).not.toHaveProperty('destination');
+  expect(canonicalPosition).not.toHaveProperty('aiming');
+  expect(canonicalPosition).not.toHaveProperty('traversing');
+});
+
+test('DM receives player aiming/traversal destination and target marker clears with preview lifecycle', async () => {
+  installRuntimePathfinding();
+  const realtime = freshRequire('js/vtt/movement-realtime.js');
+  const { mod, tmp } = await loadPolish();
+  try {
+    mod.installStraightPathfinding(global);
+    const canvas = eventCanvas();
+    const token = {
+      id: 'player-token',
+      canonicalScope: 'player',
+      canonicalPlayerKey: 'alice',
+      playerId: 'alice',
+      x: 105,
+      y: 105,
+      zLayer: 0,
+    };
+    const mapData = {
+      id: 'realtime-test',
+      grid: { cols: 30, rows: 30, size: 70, distancePerCell: 5 },
+      movement: { diagonalRule: '5e', blockTokens: false, terrain: {} },
+      tokens: [token],
+    };
+    const renderer = {
+      backend: 'webgl2',
+      render() {},
+      drawDmObserverOutlines(outlines) { this.lastOutlines = outlines; },
+    };
+    const engine = {
+      mapData,
+      canvas,
+      renderer,
+      camera: { zoom: 1 },
+      activeZ: 0,
+      tokenMotion: null,
+      tokenDrag: null,
+      async animateTokenPath() { return { valid: true, complete: true }; },
+    };
+    const host = {
+      CustomEvent: FakeCustomEvent,
+      LuminousVttPathfinding: global.LuminousVttPathfinding,
+      LuminousVttSceneDirty: { emit() {} },
+      setTimeout,
+      clearTimeout,
+    };
+
+    const markerApi = mod.installRuntimeNavigationPolish({ host, runtime: { engine } });
+    const controller = realtime.createController({
+      root: host,
+      mapData,
+      canvas,
+      engine,
+      identity: { uid: 'dm-uid', playerId: 'dm' },
+      isDm: true,
+      now: () => 1000,
+      setTimeoutFn: () => 1,
+      clearTimeoutFn() {},
+    });
+
+    const aiming = {
+      schemaVersion: 2,
+      scope: 'player',
+      tokenId: 'player-token',
+      playerKey: 'alice',
+      x: 105,
+      y: 105,
+      zLayer: 0,
+      destination: { x: 525, y: 315, zLayer: 0 },
+      aiming: true,
+      traversing: false,
+      sequence: 1,
+      sessionId: 'alice-session',
+      expiresAtMs: 2800,
+      committed: false,
+    };
+    controller.handleIncoming(aiming, 'alice');
+    expect(markerApi.markers.get('player-token')).toMatchObject({
+      x: 525,
+      y: 315,
+      zLayer: 0,
+      phase: 'preview',
+    });
+
+    const traversing = {
+      ...aiming,
+      x: 245,
+      sequence: 2,
+      aiming: false,
+      traversing: true,
+    };
+    controller.handleIncoming(traversing, 'alice');
+    expect(token.x).toBe(245);
+    expect(markerApi.markers.get('player-token')).toMatchObject({
+      x: 525,
+      y: 315,
+      phase: 'committed',
+    });
+
+    renderer.render();
+    expect(renderer.lastOutlines?.length).toBe(2);
+
+    controller.clearIncoming(traversing, 'alice');
+    expect(markerApi.markers.has('player-token')).toBe(false);
+    expect(token.x).toBe(105);
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});

--- a/tests/vtt_navigation_polish.spec.js
+++ b/tests/vtt_navigation_polish.spec.js
@@ -215,3 +215,55 @@ test('destination marker snaps during drag, clears on rejection, and door intera
     fs.unlinkSync(tmp);
   }
 });
+
+test('navigation polish stop restores exact engine and renderer functions and permits clean reinstall', async () => {
+  installRuntimePathfinding();
+  const { mod, tmp } = await loadPolish();
+  try {
+    mod.installStraightPathfinding(global);
+    const canvas = canvasStub();
+    const map = mapData();
+    const host = {
+      LuminousVttPathfinding: global.LuminousVttPathfinding,
+      LuminousVttSceneDirty: { emit() {} },
+      setTimeout,
+      clearTimeout,
+    };
+    const originalRender = function originalRender() { return 'rendered'; };
+    const originalAnimate = async function originalAnimate() { return { valid: true, complete: true }; };
+    const renderer = { backend: 'webgl2', render: originalRender, drawDmObserverOutlines() {} };
+    const engine = {
+      mapData: map,
+      canvas,
+      renderer,
+      camera: { zoom: 1 },
+      activeZ: 0,
+      tokenMotion: null,
+      tokenDrag: null,
+      animateTokenPath: originalAnimate,
+    };
+
+    const first = mod.installRuntimeNavigationPolish({ host, runtime: { engine } });
+    expect(engine.animateTokenPath).not.toBe(originalAnimate);
+    expect(renderer.render).not.toBe(originalRender);
+    expect(engine.__navigationPolishRuntime).toBe(first);
+    expect(host.LuminousVttNavigationPolishRuntime).toBe(first);
+
+    expect(first.stop()).toBe(true);
+    expect(engine.animateTokenPath).toBe(originalAnimate);
+    expect(renderer.render).toBe(originalRender);
+    expect(engine.__navigationPolishRuntime).toBeUndefined();
+    expect(host.LuminousVttNavigationPolishRuntime).toBeUndefined();
+    for (const listeners of canvas.listeners.values()) expect(listeners.size).toBe(0);
+
+    const second = mod.installRuntimeNavigationPolish({ host, runtime: { engine } });
+    expect(second).not.toBe(first);
+    expect(engine.animateTokenPath).not.toBe(originalAnimate);
+    expect(renderer.render).not.toBe(originalRender);
+    expect(second.stop()).toBe(true);
+    expect(engine.animateTokenPath).toBe(originalAnimate);
+    expect(renderer.render).toBe(originalRender);
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});

--- a/tests/vtt_navigation_polish.spec.js
+++ b/tests/vtt_navigation_polish.spec.js
@@ -1,0 +1,217 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+function freshRequire(relativePath) {
+  const file = path.join(__dirname, '..', relativePath);
+  delete require.cache[require.resolve(file)];
+  return require(file);
+}
+
+async function loadPolish() {
+  const source = fs.readFileSync(path.join(__dirname, '..', 'js/vtt/movement-navigation-polish.js'), 'utf8');
+  const tmp = path.join(os.tmpdir(), `luminous-navigation-polish-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.mjs`);
+  fs.writeFileSync(tmp, source);
+  const mod = await import(`${pathToFileURL(tmp).href}?t=${Date.now()}`);
+  return { mod, tmp };
+}
+
+function mapData() {
+  return {
+    grid: { cols: 30, rows: 30, size: 70, distancePerCell: 5 },
+    movement: { diagonalRule: '5e', blockTokens: false, terrain: {} },
+    tokens: [],
+  };
+}
+
+function installRuntimePathfinding() {
+  global.LuminousVttTokenInteraction = undefined;
+  global.LuminousVttPathfinding = freshRequire('js/vtt/pathfinding.js');
+  global.LuminousVttMovementEngine = freshRequire('js/vtt/movement-engine.js');
+  global.LuminousVttTokenState = null;
+  freshRequire('js/vtt/movement-integration-patch.js');
+  return global.LuminousVttPathfinding;
+}
+
+function canvasStub() {
+  const listeners = new Map();
+  return {
+    listeners,
+    addEventListener(name, fn) {
+      if (!listeners.has(name)) listeners.set(name, new Set());
+      listeners.get(name).add(fn);
+    },
+    removeEventListener(name, fn) { listeners.get(name)?.delete(fn); },
+    dispatch(name, detail = {}) {
+      for (const fn of listeners.get(name) || []) fn({ type: name, detail });
+    },
+  };
+}
+
+test('5e equal-cost navigation prefers an unobstructed straight line without changing cost', async () => {
+  const base = installRuntimePathfinding();
+  const { mod, tmp } = await loadPolish();
+  try {
+    const runtime = mod.installStraightPathfinding(global);
+    expect(runtime.__straightRouteTieBreakPatch).toBe(true);
+    const map = mapData();
+    const token = { id: 'p1', x: 0, y: 0, zLayer: 0 };
+
+    const horizontal = runtime.findPath({ token, start: { col: 2, row: 8 }, target: { col: 15, row: 8 }, mapData: map, blockTokens: false });
+    expect(horizontal.valid).toBe(true);
+    expect(horizontal.cells.every((cell) => cell.row === 8)).toBe(true);
+    expect(horizontal.costFt).toBe(65);
+
+    const vertical = runtime.findPath({ token, start: { col: 11, row: 3 }, target: { col: 11, row: 17 }, mapData: map, blockTokens: false });
+    expect(vertical.valid).toBe(true);
+    expect(vertical.cells.every((cell) => cell.col === 11)).toBe(true);
+    expect(vertical.costFt).toBe(70);
+
+    const diagonal = runtime.findPath({ token, start: { col: 3, row: 3 }, target: { col: 10, row: 10 }, mapData: map, blockTokens: false });
+    expect(diagonal.valid).toBe(true);
+    expect(diagonal.cells.every((cell) => cell.col - cell.row === 0)).toBe(true);
+    expect(diagonal.costFt).toBe(35);
+
+    // The integration patch still supplies its cheap-terrain admissible heuristic.
+    expect(runtime.heuristicFt({ col: 0, row: 0 }, { col: 10, row: 0 }, map)).toBeCloseTo(base.heuristicFt({ col: 0, row: 0 }, { col: 10, row: 0 }, map), 8);
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});
+
+test('straightness is only a tie-break: obstacles still detour and repeated plans are deterministic', async () => {
+  installRuntimePathfinding();
+  const { mod, tmp } = await loadPolish();
+  try {
+    const runtime = mod.installStraightPathfinding(global);
+    const map = mapData();
+    map.movement.terrain['8_8'] = { blocked: true };
+    const token = { id: 'p1', x: 0, y: 0, zLayer: 0 };
+    const options = { token, start: { col: 2, row: 8 }, target: { col: 15, row: 8 }, mapData: map, blockTokens: false };
+    const first = runtime.findPath(options);
+    const second = runtime.findPath(options);
+    expect(first.valid).toBe(true);
+    expect(first.cells.some((cell) => cell.row !== 8)).toBe(true);
+    expect(first.cells).toEqual(second.cells);
+    expect(first.costFt).toBe(second.costFt);
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});
+
+test('normal movement uses one continuous polyline timeline and marker survives until canonical move', async () => {
+  installRuntimePathfinding();
+  const { mod, tmp } = await loadPolish();
+  try {
+    mod.installStraightPathfinding(global);
+    const canvas = canvasStub();
+    const map = mapData();
+    map.movement.animationMsPerCell = 90;
+    const token = { id: 'p1', x: 35, y: 35, zLayer: 0 };
+    map.tokens.push(token);
+
+    let now = 0;
+    let frames = 0;
+    const emitted = [];
+    const host = {
+      LuminousVttPathfinding: global.LuminousVttPathfinding,
+      LuminousVttSceneDirty: { emit() {} },
+      performance: { now: () => now },
+      requestAnimationFrame(fn) {
+        frames += 1;
+        const id = frames;
+        queueMicrotask(() => { now += 16; fn(now); });
+        return id;
+      },
+      cancelAnimationFrame() {},
+      setTimeout,
+      clearTimeout,
+    };
+    const renderer = {
+      backend: 'webgl2',
+      render() {},
+      drawDmObserverOutlines(outlines) { this.lastOutlines = outlines; },
+    };
+    const engine = {
+      mapData: map,
+      canvas,
+      renderer,
+      camera: { zoom: 1 },
+      activeZ: 0,
+      tokenMotion: null,
+      tokenDrag: null,
+      async animateTokenPath() { throw new Error('segmented fallback should not run for normal paths'); },
+      emitSemanticEvent(type, detail) { emitted.push({ type, detail }); canvas.dispatch(type, detail); },
+    };
+    const api = mod.installRuntimeNavigationPolish({ host, runtime: { engine } });
+    const route = [
+      { x: 35, y: 35, z: 0 },
+      { x: 105, y: 35, z: 0 },
+      { x: 175, y: 35, z: 0 },
+      { x: 245, y: 35, z: 0 },
+      { x: 315, y: 35, z: 0 },
+      { x: 385, y: 35, z: 0 },
+    ];
+
+    const result = await engine.animateTokenPath(token, route, { actionMode: 'walk', doorInteractions: [] });
+    expect(result).toMatchObject({ valid: true, complete: true });
+    expect(token.x).toBeCloseTo(385, 6);
+    expect(token.y).toBeCloseTo(35, 6);
+    expect(frames).toBe(Math.ceil((5 * 90) / 16));
+    expect(emitted.length).toBe(frames);
+    expect(api.markers.get('p1')).toMatchObject({ x: 385, y: 35, phase: 'committed' });
+
+    renderer.render();
+    expect(renderer.lastOutlines?.length).toBe(2);
+    canvas.dispatch('vtt:token-moved', { tokenId: 'p1' });
+    expect(api.markers.has('p1')).toBe(false);
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});
+
+test('destination marker snaps during drag, clears on rejection, and door interactions keep legacy animation', async () => {
+  installRuntimePathfinding();
+  const { mod, tmp } = await loadPolish();
+  try {
+    mod.installStraightPathfinding(global);
+    const canvas = canvasStub();
+    const map = mapData();
+    const token = { id: 'p1', x: 35, y: 35, zLayer: 0 };
+    map.tokens.push(token);
+    let fallbackCalls = 0;
+    const host = {
+      LuminousVttPathfinding: global.LuminousVttPathfinding,
+      LuminousVttSceneDirty: { emit() {} },
+      setTimeout,
+      clearTimeout,
+    };
+    const renderer = { backend: 'canvas2d', render() {}, ctx: {}, };
+    const engine = {
+      mapData: map,
+      canvas,
+      renderer,
+      camera: { zoom: 1 },
+      activeZ: 0,
+      tokenMotion: null,
+      tokenDrag: null,
+      async animateTokenPath() { fallbackCalls += 1; return { valid: true, complete: true }; },
+    };
+    const api = mod.installRuntimeNavigationPolish({ host, runtime: { engine } });
+
+    canvas.dispatch('vtt:movement-destination-preview', { tokenId: 'p1', target: { x: 222, y: 91 } });
+    expect(api.markers.get('p1')).toMatchObject({ x: 245, y: 105, phase: 'preview' });
+    canvas.dispatch('vtt:movement-order-rejected', { tokenId: 'p1', reason: 'NO_PATH' });
+    expect(api.markers.has('p1')).toBe(false);
+
+    const route = [{ x: 35, y: 35, z: 0 }, { x: 105, y: 35, z: 0 }];
+    const result = await engine.animateTokenPath(token, route, { doorInteractions: [{ pathIndex: 0, type: 'door' }] });
+    expect(result.valid).toBe(true);
+    expect(fallbackCalls).toBe(1);
+    expect(api.markers.get('p1')).toMatchObject({ x: 105, y: 35, phase: 'committed' });
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});


### PR DESCRIPTION
## Bugs encontrados en el retest de WEBGL-02

Camera Follow mejoró, pero el movimiento todavía mostraba dos problemas perceptibles:

1. Una orden horizontal/vertical podía convertirse en pequeños zigzags diagonales. Cuanto más larga la ruta, más oportunidades tenía A* de escoger esos empates.
2. La animación suave recorría cada celda como un segmento/Promise independiente. En rutas largas eso introducía micro-pausas entre waypoints y hacía menos claro hacia dónde estaba viajando la ficha.

## Causa 1 — empate de A* bajo regla 5e

En la regla `5e`, un paso diagonal y uno ortogonal pueden tener el mismo coste. Varias rutas distintas pueden terminar con el mismo `g/f`, y el algoritmo no tenía criterio geométrico para escoger la más recta.

## Fix 1 — straightness como desempate, no como coste

- Se conserva exactamente el coste y la legalidad 5e.
- El desempate entre candidatos con el mismo `f` prefiere menor desviación respecto a la línea inicio→objetivo, luego menor distancia restante y finalmente un orden determinista de celda.
- La desviación **no se suma** a `g`, `f` ni al coste final.
- Obstáculos, terreno, tokens, paredes y corner-cut continúan decidiendo si una ruta es válida.
- El wrapper se instala sobre el Pathfinding final después de `movement-integration-patch.js`, conservando el heuristic admisible de terreno barato.

## Fix 2 — traversal continuo

Para movimientos normales sin interacciones:

- toda la polilínea usa un único timeline de `requestAnimationFrame`;
- la velocidad se calcula por distancia total recorrida;
- ya no se reinicia el reloj de animación en cada celda/waypoint;
- se conserva `engine.tokenMotion` y los eventos `vtt:token-preview-moved`, por lo que Camera Follow, Vision/FOV throttling y realtime siguen usando sus contratos actuales.

Si la ruta contiene una interacción (por ejemplo una puerta), se conserva la animación segmentada Legacy para permitir pausas/interacciones reales.

## Fix 3 — marker de destino local + realtime Player↔DM

Se añade un retículo world-space:

- durante drag muestra la celda destino snapped;
- mientras la ficha viaja permanece en el destino confirmado;
- tamaño visual estable con cualquier zoom;
- Canvas2D tiene fallback propio;
- WebGL2 reutiliza el overlay GPU ya existente, sin duplicar matemática de Camera;
- se limpia al llegar, rechazar, cancelar, revertir o expirar;
- las invalidaciones del marker son `render:true / vision:false`;
- no vuelve a invalidar si el destino no cambió.

El preview realtime ahora transporta metadata efímera `destination`, `aiming` y `traversing`. Así el DM puede ver el objetivo que está marcando/moviendo un Player desde otro cliente. Esa metadata vive únicamente en `vttMovementPreview`: **no se guarda en la posición canónica ni en los datos permanentes del personaje/token**.

## Regresiones añadidas

- Horizontal 5e permanece horizontal.
- Vertical permanece vertical.
- Diagonal real permanece diagonal.
- Costes 5e no cambian.
- Obstáculo sigue obligando a desvío.
- Planes repetidos son deterministas.
- Ruta normal usa timeline continuo.
- Marker permanece hasta `vtt:token-moved`.
- Marker se limpia en rechazo.
- Rutas con puerta conservan fallback segmentado.
- Preview Player contiene destination/aiming/traversing sin contaminar posición canónica.
- DM recibe destino Player, cambia preview→committed durante traversal y lo limpia al terminar/cancelar.

## Retest manual

- [ ] Arrastrar 15–20 celdas horizontalmente: ruta visualmente recta.
- [ ] Repetir verticalmente.
- [ ] Arrastrar diagonalmente: sigue usando diagonales cuando corresponde.
- [ ] Colocar obstáculo en la línea: navigation hace el desvío necesario.
- [ ] Movimiento largo: no hay micro-pausa visible en cada waypoint.
- [ ] Marker aparece mientras se apunta/arrastra.
- [ ] Marker queda fijo en destino mientras la ficha viaja.
- [ ] Marker desaparece al llegar/rechazar/cancelar.
- [ ] En dos clientes, Player apunta y DM ve el mismo marker.
- [ ] En dos clientes, el marker del DM pasa de preview a traversal y desaparece al finalizar.
- [ ] Repetir orden local como DM.
- [ ] Follow ON sigue la ficha sin regresión de performance.
- [ ] Ruta con puerta conserva interacción/pausa válida.

Este PR no cambia Camera, DM Observer, Fog/FOV, reglas de gasto de movimiento ni el coste de diagonales.