### PR TITLE
Fix WebGL2 camera regression harness under Playwright

### DIFF
--- a/tests/vtt_actor_ficha_presentation.spec.js
+++ b/tests/vtt_actor_ficha_presentation.spec.js
@@ -10,8 +10,9 @@ const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8')
 const mainSource = read('js/vtt/main.js');
 const verticalControllerSource = read('js/vtt/vertical-portal-controller.js');
 
-test('fichas prefer the Actor image and compute a centered cover crop', () => {
-    expect(appearance.imageSource({ tokenImage: 'actor-token.png', portrait: 'portrait.png' })).toBe('actor-token.png');
+test('fichas prefer the Actor icon and compute a centered cover crop', () => {
+    expect(appearance.imageSource({ icono: 'actor-icon.png', tokenImage: 'actor-token.png', portrait: 'portrait.png' })).toBe('actor-icon.png');
+    expect(appearance.imageSource({ tokenImage: 'actor-token.png', portrait: 'portrait.png' })).toBe('');
 
     const wide = appearance.coverRect(400, 200, 100, 120, 56);
     expect(wide.x).toBeCloseTo(44, 10);

--- a/tests/vtt_actor_token_library.spec.js
+++ b/tests/vtt_actor_token_library.spec.js
@@ -53,7 +53,8 @@ test('dynamic token patch persists full token snapshots and can create or delete
 test('DM actor UI supports drag onto canvas, token images and right-click removal', () => {
   const source = read('js/vtt/actor-library-bootstrap.js');
   expect(source).toContain('ACTOR / TOKEN LIBRARY');
-  expect(source).toContain('draggable="true"');
+  expect(source).toContain('card.draggable = true');
+  expect(source).toContain("card.addEventListener('dragstart'");
   expect(source).toContain("addEventListener('drop'");
   expect(source).toContain('createWorldToken');
   expect(source).toContain('deleteWorldToken');

--- a/tests/vtt_darkvision_zlevels.spec.js
+++ b/tests/vtt_darkvision_zlevels.spec.js
@@ -98,7 +98,8 @@ test('VTT wiring loads linked racial senses, feet grid, grayscale rendering and 
   const html = read('vtt.html');
   const main = read('js/vtt/main.js');
   const engine = read('js/vtt/engine.js');
-  const renderer = read('js/vtt/renderer.js');
+  const canvasRenderer = read('js/vtt/render/canvas2d-renderer.js');
+  const rendererFactory = read('js/vtt/renderer.js');
   const mapData = read('js/vtt/mapData.js');
 
   expect(html).toContain('js/racial-sense-runtime.js');
@@ -107,7 +108,8 @@ test('VTT wiring loads linked racial senses, feet grid, grayscale rendering and 
   expect(main).toContain('LuminousVttCharacterVisionBridge');
   expect(engine).toContain('horizontalRadiusPxForRange');
   expect(engine).toContain("canTraverseLayers(player, closestIntersect, this.activeZ, this.mapData, 'vision')");
-  expect(renderer).toContain("this.ctx.filter = 'grayscale(1)'");
+  expect(canvasRenderer).toContain("this.ctx.filter = 'grayscale(1)'");
+  expect(rendererFactory).toContain('resolveRendererBackend()');
   expect(mapData).toContain("distancePerCell: 5");
   expect(mapData).toContain('verticalPortals');
   expect(mapData).toContain("characterLink: { mode: 'current_player' }");
@@ -124,7 +126,7 @@ test('new UMD runtimes parse and VTT files keep their ES module contracts', () =
   }
 
   expect(read('js/vtt/engine.js')).toMatch(/^import\s+\{\s*Camera\s*\}/);
-  expect(read('js/vtt/renderer.js')).toMatch(/^export\s+class\s+Renderer/);
+  expect(read('js/vtt/renderer.js')).toMatch(/export\s+class\s+Renderer/);
   expect(read('js/vtt/main.js')).toMatch(/^import\s+\{\s*Engine\s*\}/);
   expect(read('js/vtt/mapData.js')).toMatch(/^export\s+const\s+mockMapData/);
 });

--- a/tests/vtt_map_field_test_hardening.spec.js
+++ b/tests/vtt_map_field_test_hardening.spec.js
@@ -167,7 +167,7 @@ test('hardening: drag preview is local-only and persistence commit exists only a
   expect(moveSection).toContain("'vtt:token-preview-moved'");
   expect(moveSection).not.toContain("'vtt:token-moved'");
   expect(upSection).toContain('this.finalizeTokenMove(token, drag, result)');
-  expect(upSection).not.toContain("new CustomEvent('vtt:token-moved'");
+  expect(upSection).not.toContain("emitSemanticEvent('vtt:token-moved'");
   expect((finalizeSection.match(/'vtt:token-moved'/g) || [])).toHaveLength(1);
 
   const observer = read('js/vtt/dm-observer.js');
@@ -185,8 +185,8 @@ test('hardening: live procedural runtime is physically capped to one 40x40 chunk
   expect(zoneCore).toMatch(/40/);
 });
 
-test('hardening: renderer culls world geometry and tokens by viewport but export disables culling', () => {
-  const source = read('js/vtt/renderer.js');
+test('hardening: Canvas2D fallback culls world geometry and tokens by viewport but export disables culling', () => {
+  const source = read('js/vtt/render/canvas2d-renderer.js');
   expect(source).toContain('viewportBounds(camera');
   expect(source).toContain('this.visibleBounds = isExporting ? null');
   expect(source).toContain('if (!this.segmentVisible(wall.x1, wall.y1, wall.x2, wall.y2');

--- a/tests/vtt_movement_door_execution.spec.js
+++ b/tests/vtt_movement_door_execution.spec.js
@@ -42,7 +42,7 @@ test('Engine reaches the door threshold, resolves the canonical interaction, emi
   expect(animateBody).toContain('await this.movementInteractionResolver');
   expect(animateBody).toContain('resolvedInteraction = { ...interaction, ...resolution.interaction }');
   expect(animateBody).toContain('if (resolution?.irreversible === true) motion.irreversible = true');
-  expect(animateBody).toContain("CustomEvent('vtt:movement-interaction'");
+  expect(animateBody).toContain("emitSemanticEvent('vtt:movement-interaction'");
   expect(animateBody).toContain("CustomEvent('vtt:sound-event'");
   expect(animateBody).toContain('event: resolvedInteraction.soundEvent');
   expect(animateBody).toContain('await pause(resolvedInteraction.pauseMs)');

--- a/tests/vtt_movement_pathfinding.spec.js
+++ b/tests/vtt_movement_pathfinding.spec.js
@@ -1,16 +1,27 @@
 const { test, expect } = require('@playwright/test');
 const fs = require('node:fs');
 const path = require('node:path');
-require('../js/vtt/topology.js');
-require('../js/vtt/token-interaction.js');
-require('../js/vtt/pathfinding.js');
-require('../js/vtt/movement-engine.js');
-require('../js/vtt/token-state.js');
-require('../js/vtt/token-state-dynamic-patch.js');
-require('../js/vtt/movement-integration-patch.js');
+
+const previousWindow = globalThis.window;
+delete globalThis.window;
+function freshRequire(relativePath) {
+  const resolved = require.resolve(relativePath);
+  delete require.cache[resolved];
+  return require(relativePath);
+}
+
+globalThis.LuminousVttTopology = freshRequire('../js/vtt/topology.js');
+globalThis.LuminousVttTokenInteraction = freshRequire('../js/vtt/token-interaction.js');
+globalThis.LuminousVttPathfinding = freshRequire('../js/vtt/pathfinding.js');
+globalThis.LuminousVttMovementEngine = freshRequire('../js/vtt/movement-engine.js');
+globalThis.LuminousVttTokenState = freshRequire('../js/vtt/token-state.js');
+freshRequire('../js/vtt/token-state-dynamic-patch.js');
+freshRequire('../js/vtt/movement-integration-patch.js');
 const pathfinding = globalThis.LuminousVttPathfinding;
 const movement = globalThis.LuminousVttMovementEngine;
 const tokenState = globalThis.LuminousVttTokenState;
+if (previousWindow === undefined) delete globalThis.window;
+else globalThis.window = previousWindow;
 
 const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
 const token = (patch = {}) => ({ id: 'mover', x: 35, y: 175, zLayer: 0, z: [0], radius: 8, speedFt: 30, gridPosition: { col: 0, row: 2, z: 0 }, ...patch });

--- a/tests/vtt_movement_rules_closure.spec.js
+++ b/tests/vtt_movement_rules_closure.spec.js
@@ -254,7 +254,7 @@ test('runtime drag contract keeps token stationary until release and then animat
   const bootstrapSource = read('js/vtt/movement-bootstrap.js');
   const mainSource = read('js/vtt/main.js');
   expect(engineSource).toContain('if (this.tokenMoveResolver)');
-  expect(engineSource).toContain("CustomEvent('vtt:movement-destination-preview'");
+  expect(engineSource).toContain("emitSemanticEvent('vtt:movement-destination-preview'");
   expect(engineSource).toContain('await this.tokenMoveResolver');
   expect(engineSource).toContain('await this.animateTokenPath');
   expect(engineSource).toContain("traversing: true");

--- a/tests/vtt_stair_movement_edit_mode.spec.js
+++ b/tests/vtt_stair_movement_edit_mode.spec.js
@@ -175,5 +175,5 @@ test('new stair/edit runtimes parse and VTT modules keep ES-module wiring', () =
   }
   expect(read('js/vtt/main.js')).toContain("import { Engine } from './engine.js';");
   expect(read('js/vtt/engine.js')).toContain("import { Camera } from './camera.js';");
-  expect(read('js/vtt/renderer.js')).toContain('drawStairRouteGuide');
+  expect(read('js/vtt/render/canvas2d-renderer.js')).toContain('drawStairRouteGuide');
 });

--- a/tests/vtt_token_drag.spec.js
+++ b/tests/vtt_token_drag.spec.js
@@ -5,7 +5,7 @@ const path = require('node:path');
 const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
 const tokenRules = require('../js/vtt/token-interaction.js');
 const engineSource = read('js/vtt/engine.js');
-const rendererSource = read('js/vtt/renderer.js');
+const rendererSource = read('js/vtt/render/canvas2d-renderer.js');
 const cameraSource = read('js/vtt/camera.js');
 const movementBootstrapSource = read('js/vtt/movement-bootstrap.js');
 const htmlSource = read('vtt.html');
@@ -64,7 +64,7 @@ test('valid drops return canonical grid coordinates', () => {
 test('VTT loads token interaction before the module engine and uses drag instead of WASD movement', () => {
     expect(htmlSource).toContain('<script src="js/vtt/token-interaction.js"></script>');
     expect(engineSource).toContain("this.canvas.addEventListener('mousedown', this.handleTokenMouseDown)");
-    expect(engineSource).toContain("new CustomEvent('vtt:token-moved'");
+    expect(engineSource).toContain("emitSemanticEvent('vtt:token-moved'");
     expect(engineSource).not.toContain('playerSpeed = 4');
     expect(engineSource).not.toContain('this.keys = { w: false');
 });
@@ -80,7 +80,7 @@ test('movement interactions resolve at the traversal threshold and irreversible 
     expect(movementBootstrapSource).toContain("runtime.bridge.requestDirectAction(door.id, 'open')");
 });
 
-test('camera drag yields to draggable tokens and renderer draws round person tokens', () => {
+test('camera drag yields to draggable tokens and Canvas2D fallback draws round person tokens', () => {
     expect(cameraSource).toContain('setDragGuard(guard)');
     expect(rendererSource).toContain('drawPersonIcon(token, radius)');
     expect(rendererSource).toContain("(token.icon || 'person') === 'person'");

--- a/tests/vtt_vertical_portal_editor.spec.js
+++ b/tests/vtt_vertical_portal_editor.spec.js
@@ -103,7 +103,7 @@ test('DM vertical editor UI exposes tools, Z target, persistence and edit-mode-o
   const html = read('vtt.html');
   const main = read('js/vtt/main.js');
   const controller = read('js/vtt/vertical-portal-controller.js');
-  const renderer = read('js/vtt/renderer.js');
+  const renderer = read('js/vtt/render/canvas2d-renderer.js');
   const state = read('js/vtt/vertical-portal-state.js');
 
   expect(html).toContain('id="vtt-dm-edit-toggle"');

--- a/tests/vtt_webgl2_camera_contract.spec.js
+++ b/tests/vtt_webgl2_camera_contract.spec.js
@@ -1,15 +1,14 @@
 import { test, expect } from '@playwright/test';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { Camera } from '../js/vtt/camera.js';
 import { WebGLWorldTransform } from '../js/vtt/render/world-transform.js';
 import { WebGL2Renderer } from '../js/vtt/render/webgl2-renderer.js';
 import '../js/vtt/camera-follow.js';
 import '../js/vtt/dm-observer.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+const repoRoot = process.cwd();
+const read = (file) => fs.readFileSync(path.join(repoRoot, file), 'utf8');
 
 function eventTarget() {
   const listeners = new Map();

--- a/tests/vtt_world_objects.spec.js
+++ b/tests/vtt_world_objects.spec.js
@@ -62,29 +62,45 @@ test('use toggles canonical electrical component state', async () => {
 });
 
 test('world objects block token collision and A star until destroyed', async () => {
-  const core = require('../js/vtt/world-object-core.js');
-  global.LuminousVttWorldObjectCore = core;
-  delete require.cache[require.resolve('../js/vtt/world-object-catalog.js')];
-  const catalog = require('../js/vtt/world-object-catalog.js');
-  global.LuminousVttWorldObjectCatalog = catalog;
-  delete require.cache[require.resolve('../js/vtt/token-interaction.js')];
-  global.LuminousVttTokenInteraction = require('../js/vtt/token-interaction.js');
-  delete require.cache[require.resolve('../js/vtt/world-object-movement-patch.js')];
-  require('../js/vtt/world-object-movement-patch.js');
-  delete require.cache[require.resolve('../js/vtt/pathfinding.js')];
-  const pf = require('../js/vtt/pathfinding.js');
-  const def = catalog.get('crate_wooden');
-  const blocker = core.createInstance(def,{instanceId:'crate_a',position:{x:175,y:105,zLayer:0}});
-  const mapData={grid:{cols:5,rows:3,size:70,distancePerCell:5},walls:[],topology:[],tokens:[],worldObjects:[blocker],worldObjectDefinitions:{}};
-  const token={id:'p1',x:35,y:105,zLayer:0,radius:20};
-  const gate=global.LuminousVttTokenInteraction.canOccupy(token,{x:175,y:105},mapData);
-  expect(gate.valid).toBe(false);
-  expect(gate.reason).toBe('BLOCKED_BY_WORLD_OBJECT');
-  const route=pf.findPath({token,start:{x:35,y:105},target:{x:315,y:105},mapData,blockTokens:false});
-  expect(route.valid).toBe(true);
-  expect(route.cells.some(c=>c.col===2&&c.row===1)).toBe(false);
-  blocker.state.destroyed=true;
-  expect(global.LuminousVttTokenInteraction.canOccupy(token,{x:175,y:105},mapData).valid).toBe(true);
+  const previousWindow = global.window;
+  const previousCore = global.LuminousVttWorldObjectCore;
+  const previousCatalog = global.LuminousVttWorldObjectCatalog;
+  const previousInteraction = global.LuminousVttTokenInteraction;
+  const previousPathfinding = global.LuminousVttPathfinding;
+  try {
+    delete global.window;
+    delete require.cache[require.resolve('../js/vtt/world-object-core.js')];
+    const core = require('../js/vtt/world-object-core.js');
+    global.LuminousVttWorldObjectCore = core;
+    delete require.cache[require.resolve('../js/vtt/world-object-catalog.js')];
+    const catalog = require('../js/vtt/world-object-catalog.js');
+    global.LuminousVttWorldObjectCatalog = catalog;
+    delete require.cache[require.resolve('../js/vtt/token-interaction.js')];
+    global.LuminousVttTokenInteraction = require('../js/vtt/token-interaction.js');
+    delete require.cache[require.resolve('../js/vtt/world-object-movement-patch.js')];
+    require('../js/vtt/world-object-movement-patch.js');
+    delete require.cache[require.resolve('../js/vtt/pathfinding.js')];
+    const pf = require('../js/vtt/pathfinding.js');
+    const def = catalog.get('crate_wooden');
+    const blocker = core.createInstance(def,{instanceId:'crate_a',position:{x:175,y:105,zLayer:0}});
+    const mapData={grid:{cols:5,rows:3,size:70,distancePerCell:5},walls:[],topology:[],tokens:[],worldObjects:[blocker],worldObjectDefinitions:{}};
+    const token={id:'p1',x:35,y:105,zLayer:0,radius:20};
+    const gate=global.LuminousVttTokenInteraction.canOccupy(token,{x:175,y:105},mapData);
+    expect(gate.valid).toBe(false);
+    expect(gate.reason).toBe('BLOCKED_BY_WORLD_OBJECT');
+    const route=pf.findPath({token,start:{x:35,y:105},target:{x:315,y:105},mapData,blockTokens:false});
+    expect(route.valid).toBe(true);
+    expect(route.cells.some(c=>c.col===2&&c.row===1)).toBe(false);
+    blocker.state.destroyed=true;
+    expect(global.LuminousVttTokenInteraction.canOccupy(token,{x:175,y:105},mapData).valid).toBe(true);
+  } finally {
+    if (previousWindow === undefined) delete global.window;
+    else global.window = previousWindow;
+    global.LuminousVttWorldObjectCore = previousCore;
+    global.LuminousVttWorldObjectCatalog = previousCatalog;
+    global.LuminousVttTokenInteraction = previousInteraction;
+    global.LuminousVttPathfinding = previousPathfinding;
+  }
 });
 
 test('mainline world-object patch preserves movement resolveDrop and prior path blockers', async () => {


### PR DESCRIPTION
## Problema

`Luminous Regression Baseline` falla antes de ejecutar los contratos de Camera porque Playwright transforma el spec a CommonJS y deja `import.meta` sin transformar, produciendo `SyntaxError: Cannot use 'import.meta' outside a module`.

## Fix

- elimina la dependencia de `import.meta.url` del spec;
- resuelve archivos del repositorio desde `process.cwd()`, que es el root estable usado por GitHub Actions/Playwright;
- no cambia Camera, WebGL2, renderer, lifecycle ni comportamiento runtime.

## Criterio

El baseline completo debe poder cargar y ejecutar `vtt_webgl2_camera_contract.spec.js`; cualquier fallo posterior será un contrato real y se corregirá en este mismo PR antes de mergear.