### PR TITLE
Fix VTT equal-cost zigzag and navigation planning performance

### DIFF
--- a/.github/workflows/vtt-navigation-polish.yml
+++ b/.github/workflows/vtt-navigation-polish.yml
@@ -8,6 +8,7 @@ on:
       - 'js/vtt/movement-realtime.js'
       - 'js/vtt/movement-connectivity.js'
       - 'tests/vtt_navigation_polish.spec.js'
+      - 'tests/vtt_navigation_equal_cost_regression.spec.js'
       - 'tests/vtt_movement_destination_realtime.spec.js'
       - '.github/workflows/vtt-navigation-polish.yml'
   push:
@@ -17,6 +18,7 @@ on:
       - 'js/vtt/movement-realtime.js'
       - 'js/vtt/movement-connectivity.js'
       - 'tests/vtt_navigation_polish.spec.js'
+      - 'tests/vtt_navigation_equal_cost_regression.spec.js'
       - 'tests/vtt_movement_destination_realtime.spec.js'
       - '.github/workflows/vtt-navigation-polish.yml'
 
@@ -39,6 +41,7 @@ jobs:
           node --input-type=module --check < js/vtt/movement-realtime.js
           node --input-type=module --check < js/vtt/movement-connectivity.js
           node --check tests/vtt_navigation_polish.spec.js
+          node --check tests/vtt_navigation_equal_cost_regression.spec.js
           node --check tests/vtt_movement_destination_realtime.spec.js
       - name: Focused navigation contracts
-        run: npx playwright test --workers=1 tests/vtt_navigation_polish.spec.js tests/vtt_movement_destination_realtime.spec.js
+        run: npx playwright test --workers=1 tests/vtt_navigation_polish.spec.js tests/vtt_navigation_equal_cost_regression.spec.js tests/vtt_movement_destination_realtime.spec.js

--- a/js/vtt/movement-navigation-polish.js
+++ b/js/vtt/movement-navigation-polish.js
@@ -15,32 +15,117 @@ function goalDistance(cell = {}, target = {}) {
   return Math.hypot(finite(target.col) - finite(cell.col), finite(target.row) - finite(cell.row));
 }
 
-function preferCandidate(base, candidate, current, start, target, f) {
-  if (!current) return true;
-  const candidateKey = base.cellKey(candidate.col, candidate.row);
-  const currentKey = base.cellKey(current.col, current.row);
-  const candidateF = f.get(candidateKey) ?? Infinity;
-  const currentF = f.get(currentKey) ?? Infinity;
-  if (candidateF < currentF - EPS) return true;
-  if (candidateF > currentF + EPS) return false;
+function compareQuality(a = {}, b = {}) {
+  const deviationA = finite(a.deviation, Infinity);
+  const deviationB = finite(b.deviation, Infinity);
+  if (deviationA < deviationB - EPS) return -1;
+  if (deviationA > deviationB + EPS) return 1;
+  const turnsA = finite(a.turns, Infinity);
+  const turnsB = finite(b.turns, Infinity);
+  if (turnsA < turnsB) return -1;
+  if (turnsA > turnsB) return 1;
+  return 0;
+}
 
-  const candidateDeviation = lineDeviation(candidate, start, target);
-  const currentDeviation = lineDeviation(current, start, target);
-  if (candidateDeviation < currentDeviation - EPS) return true;
-  if (candidateDeviation > currentDeviation + EPS) return false;
+function nextQuality(parent = {}, current = {}, next = {}, start = {}, target = {}) {
+  const dx = Math.sign(finite(next.col) - finite(current.col));
+  const dy = Math.sign(finite(next.row) - finite(current.row));
+  const hasDirection = Number.isFinite(Number(parent.lastDx)) && Number.isFinite(Number(parent.lastDy));
+  const changedDirection = hasDirection && (Number(parent.lastDx) !== dx || Number(parent.lastDy) !== dy);
+  return {
+    deviation: finite(parent.deviation) + lineDeviation(next, start, target),
+    turns: Math.max(0, Math.trunc(finite(parent.turns))) + (changedDirection ? 1 : 0),
+    lastDx: dx,
+    lastDy: dy,
+  };
+}
 
-  const candidateGoal = goalDistance(candidate, target);
-  const currentGoal = goalDistance(current, target);
-  if (candidateGoal < currentGoal - EPS) return true;
-  if (candidateGoal > currentGoal + EPS) return false;
+class MinHeap {
+  constructor(compare) {
+    this.items = [];
+    this.compare = compare;
+  }
 
-  if (candidate.row !== current.row) return candidate.row < current.row;
-  return candidate.col < current.col;
+  get size() { return this.items.length; }
+
+  push(value) {
+    const items = this.items;
+    items.push(value);
+    let index = items.length - 1;
+    while (index > 0) {
+      const parent = Math.floor((index - 1) / 2);
+      if (this.compare(items[parent], items[index]) <= 0) break;
+      [items[parent], items[index]] = [items[index], items[parent]];
+      index = parent;
+    }
+  }
+
+  pop() {
+    const items = this.items;
+    if (!items.length) return null;
+    const first = items[0];
+    const last = items.pop();
+    if (items.length && last) {
+      items[0] = last;
+      let index = 0;
+      while (true) {
+        const left = index * 2 + 1;
+        const right = left + 1;
+        let smallest = index;
+        if (left < items.length && this.compare(items[left], items[smallest]) < 0) smallest = left;
+        if (right < items.length && this.compare(items[right], items[smallest]) < 0) smallest = right;
+        if (smallest === index) break;
+        [items[index], items[smallest]] = [items[smallest], items[index]];
+        index = smallest;
+      }
+    }
+    return first;
+  }
+}
+
+function hasTerrainOverrides(mapData = {}) {
+  const movement = mapData.movement || {};
+  const hasEntries = (value) => Boolean(value && typeof value === 'object' && Object.keys(value).length);
+  return hasEntries(movement.terrain) || hasEntries(movement.terrainCells);
+}
+
+function alignedDirectPath(base, { token, startCell, targetCell, mapData, zLayer, options }) {
+  if (hasTerrainOverrides(mapData)) return null;
+  const dc = targetCell.col - startCell.col;
+  const dr = targetCell.row - startCell.row;
+  const aligned = dc === 0 || dr === 0 || Math.abs(dc) === Math.abs(dr);
+  if (!aligned) return null;
+
+  const stepCol = Math.sign(dc);
+  const stepRow = Math.sign(dr);
+  const steps = Math.max(Math.abs(dc), Math.abs(dr));
+  const cells = [{ ...startCell }];
+  let current = { ...startCell };
+  let costFt = 0;
+
+  for (let index = 0; index < steps; index += 1) {
+    const next = { col: current.col + stepCol, row: current.row + stepRow };
+    const edge = base.edgePassable(token, current, next, mapData, zLayer, options);
+    if (!edge.valid) return null;
+    costFt += base.stepCostFt(current, next, mapData, zLayer, options);
+    cells.push(next);
+    current = next;
+  }
+
+  return {
+    valid: true,
+    reason: null,
+    path: cells.map((cell) => base.pointForCell(cell, mapData, zLayer)),
+    cells,
+    costFt,
+    visited: 0,
+    fastPath: 'aligned',
+  };
 }
 
 export function installStraightPathfinding(host = globalThis) {
   const base = host?.LuminousVttPathfinding;
-  if (!base || base.__straightRouteTieBreakPatch) return base || null;
+  if (!base || base.__straightRouteTieBreakPatchV2) return base || null;
 
   function reconstruct(cameFrom, nodes, endKey, mapData, zLayer) {
     const cells = [];
@@ -74,25 +159,48 @@ export function installStraightPathfinding(host = globalThis) {
       return { valid: true, reason: null, path: [base.pointForCell(startCell, mapData, zLayer)], cells: [startCell], costFt: 0, visited: 0 };
     }
 
-    const open = new Set([startKey]);
+    const direct = alignedDirectPath(base, { token, startCell, targetCell, mapData, zLayer, options });
+    if (direct) return direct;
+
+    let sequence = 0;
+    const compareEntries = (a, b) => {
+      if (a.f < b.f - EPS) return -1;
+      if (a.f > b.f + EPS) return 1;
+      const qualityOrder = compareQuality(a.quality, b.quality);
+      if (qualityOrder) return qualityOrder;
+      if (a.goal < b.goal - EPS) return -1;
+      if (a.goal > b.goal + EPS) return 1;
+      if (a.cell.row !== b.cell.row) return a.cell.row - b.cell.row;
+      if (a.cell.col !== b.cell.col) return a.cell.col - b.cell.col;
+      return a.sequence - b.sequence;
+    };
+
+    const heap = new MinHeap(compareEntries);
     const nodes = new Map([[startKey, startCell]]);
     const cameFrom = new Map();
     const g = new Map([[startKey, 0]]);
-    const f = new Map([[startKey, base.heuristicFt(startCell, targetCell, mapData, options)]]);
+    const qualities = new Map([[startKey, { deviation: 0, turns: 0, lastDx: null, lastDy: null }]]);
+    const versions = new Map([[startKey, 1]]);
+    heap.push({
+      key: startKey,
+      cell: startCell,
+      g: 0,
+      f: base.heuristicFt(startCell, targetCell, mapData, options),
+      quality: qualities.get(startKey),
+      goal: goalDistance(startCell, targetCell),
+      version: 1,
+      sequence: sequence += 1,
+    });
+
     const limit = Math.max(1, Math.trunc(finite(maxVisited, 20000)));
     let visited = 0;
 
-    while (open.size && visited < limit) {
-      let currentKey = null;
-      let current = null;
-      for (const key of open) {
-        const candidate = nodes.get(key);
-        if (candidate && preferCandidate(base, candidate, current, startCell, targetCell, f)) {
-          current = candidate;
-          currentKey = key;
-        }
-      }
-      if (!currentKey || !current) break;
+    while (heap.size && visited < limit) {
+      const entry = heap.pop();
+      if (!entry || versions.get(entry.key) !== entry.version) continue;
+      const currentKey = entry.key;
+      const current = entry.cell;
+
       if (currentKey === goalKey) {
         const path = reconstruct(cameFrom, nodes, currentKey, mapData, zLayer);
         return {
@@ -105,19 +213,37 @@ export function installStraightPathfinding(host = globalThis) {
         };
       }
 
-      open.delete(currentKey);
       visited += 1;
+      const currentQuality = qualities.get(currentKey) || { deviation: 0, turns: 0, lastDx: null, lastDy: null };
       for (const next of base.neighbors(current, mapData)) {
         const edge = base.edgePassable(token, current, next, mapData, zLayer, options);
         if (!edge.valid) continue;
         const nextKey = base.cellKey(next.col, next.row);
         const tentative = (g.get(currentKey) ?? Infinity) + base.stepCostFt(current, next, mapData, zLayer, options);
-        if (tentative + EPS >= (g.get(nextKey) ?? Infinity)) continue;
+        const existingG = g.get(nextKey) ?? Infinity;
+        const candidateQuality = nextQuality(currentQuality, current, next, startCell, targetCell);
+        const existingQuality = qualities.get(nextKey);
+        const cheaper = tentative < existingG - EPS;
+        const equalButStraighter = Math.abs(tentative - existingG) <= EPS
+          && (!existingQuality || compareQuality(candidateQuality, existingQuality) < 0);
+        if (!cheaper && !equalButStraighter) continue;
+
         cameFrom.set(nextKey, currentKey);
         nodes.set(nextKey, next);
         g.set(nextKey, tentative);
-        f.set(nextKey, tentative + base.heuristicFt(next, targetCell, mapData, options));
-        open.add(nextKey);
+        qualities.set(nextKey, candidateQuality);
+        const version = (versions.get(nextKey) || 0) + 1;
+        versions.set(nextKey, version);
+        heap.push({
+          key: nextKey,
+          cell: next,
+          g: tentative,
+          f: tentative + base.heuristicFt(next, targetCell, mapData, options),
+          quality: candidateQuality,
+          goal: goalDistance(next, targetCell),
+          version,
+          sequence: sequence += 1,
+        });
       }
     }
 
@@ -127,6 +253,7 @@ export function installStraightPathfinding(host = globalThis) {
   const patched = Object.freeze({
     ...base,
     __straightRouteTieBreakPatch: true,
+    __straightRouteTieBreakPatchV2: true,
     findPath,
   });
   host.LuminousVttPathfinding = patched;

--- a/tests/vtt_navigation_equal_cost_regression.spec.js
+++ b/tests/vtt_navigation_equal_cost_regression.spec.js
@@ -1,0 +1,162 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+function freshRequire(relativePath) {
+  const file = path.join(__dirname, '..', relativePath);
+  delete require.cache[require.resolve(file)];
+  return require(file);
+}
+
+async function loadPolish() {
+  const source = fs.readFileSync(path.join(__dirname, '..', 'js/vtt/movement-navigation-polish.js'), 'utf8');
+  const tmp = path.join(os.tmpdir(), `luminous-navigation-equal-cost-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.mjs`);
+  fs.writeFileSync(tmp, source);
+  const mod = await import(`${pathToFileURL(tmp).href}?t=${Date.now()}`);
+  return { mod, tmp };
+}
+
+function createMap() {
+  return {
+    grid: { cols: 60, rows: 40, size: 70, distancePerCell: 5 },
+    movement: { diagonalRule: '5e', blockTokens: false, terrain: {} },
+    tokens: [],
+  };
+}
+
+function installIntegratedPathfinding() {
+  global.LuminousVttTokenInteraction = undefined;
+  global.LuminousVttPathfinding = freshRequire('js/vtt/pathfinding.js');
+  global.LuminousVttMovementEngine = freshRequire('js/vtt/movement-engine.js');
+  global.LuminousVttTokenState = null;
+  freshRequire('js/vtt/movement-integration-patch.js');
+  return global.LuminousVttPathfinding;
+}
+
+function directionChanges(cells) {
+  let previous = null;
+  let turns = 0;
+  for (let index = 1; index < cells.length; index += 1) {
+    const dx = Math.sign(cells[index].col - cells[index - 1].col);
+    const dy = Math.sign(cells[index].row - cells[index - 1].row);
+    const direction = `${dx},${dy}`;
+    if (previous != null && direction !== previous) turns += 1;
+    previous = direction;
+  }
+  return turns;
+}
+
+test('long horizontal and vertical drags use the aligned fast path without zigzag', async () => {
+  installIntegratedPathfinding();
+  const { mod, tmp } = await loadPolish();
+  try {
+    const runtime = mod.installStraightPathfinding(global);
+    const map = createMap();
+    const token = { id: 'player-1', x: 0, y: 0, zLayer: 0 };
+
+    const horizontal = runtime.findPath({
+      token,
+      start: { col: 42, row: 17 },
+      target: { col: 3, row: 17 },
+      mapData: map,
+      blockTokens: false,
+    });
+    expect(horizontal.valid).toBe(true);
+    expect(horizontal.fastPath).toBe('aligned');
+    expect(horizontal.visited).toBe(0);
+    expect(horizontal.cells).toHaveLength(40);
+    expect(horizontal.cells.every((cell) => cell.row === 17)).toBe(true);
+    expect(directionChanges(horizontal.cells)).toBe(0);
+    expect(horizontal.costFt).toBe(195);
+
+    const vertical = runtime.findPath({
+      token,
+      start: { col: 21, row: 34 },
+      target: { col: 21, row: 4 },
+      mapData: map,
+      blockTokens: false,
+    });
+    expect(vertical.valid).toBe(true);
+    expect(vertical.fastPath).toBe('aligned');
+    expect(vertical.visited).toBe(0);
+    expect(vertical.cells.every((cell) => cell.col === 21)).toBe(true);
+    expect(directionChanges(vertical.cells)).toBe(0);
+    expect(vertical.costFt).toBe(150);
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});
+
+test('5e equal-cost relaxation replaces zigzag predecessors on long oblique routes', async () => {
+  installIntegratedPathfinding();
+  const { mod, tmp } = await loadPolish();
+  try {
+    const runtime = mod.installStraightPathfinding(global);
+    const map = createMap();
+    const token = { id: 'player-1', x: 0, y: 0, zLayer: 0 };
+
+    const result = runtime.findPath({
+      token,
+      start: { col: 4, row: 17 },
+      target: { col: 44, row: 21 },
+      mapData: map,
+      blockTokens: false,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.costFt).toBe(200);
+    expect(result.cells[0]).toEqual({ col: 4, row: 17 });
+    expect(result.cells.at(-1)).toEqual({ col: 44, row: 21 });
+
+    const rows = result.cells.map((cell) => cell.row);
+    expect(rows.every((row) => row >= 17 && row <= 21)).toBe(true);
+    for (let index = 1; index < rows.length; index += 1) {
+      expect(rows[index]).toBeGreaterThanOrEqual(rows[index - 1]);
+    }
+
+    const reverse = runtime.findPath({
+      token,
+      start: { col: 44, row: 21 },
+      target: { col: 4, row: 17 },
+      mapData: map,
+      blockTokens: false,
+    });
+    expect(reverse.valid).toBe(true);
+    const reverseRows = reverse.cells.map((cell) => cell.row);
+    for (let index = 1; index < reverseRows.length; index += 1) {
+      expect(reverseRows[index]).toBeLessThanOrEqual(reverseRows[index - 1]);
+    }
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});
+
+test('an obstacle disables the direct fast path and still produces a legal deterministic detour', async () => {
+  installIntegratedPathfinding();
+  const { mod, tmp } = await loadPolish();
+  try {
+    const runtime = mod.installStraightPathfinding(global);
+    const map = createMap();
+    map.movement.terrain['22_17'] = { blocked: true };
+    const token = { id: 'player-1', x: 0, y: 0, zLayer: 0 };
+    const options = {
+      token,
+      start: { col: 4, row: 17 },
+      target: { col: 44, row: 17 },
+      mapData: map,
+      blockTokens: false,
+    };
+
+    const first = runtime.findPath(options);
+    const second = runtime.findPath(options);
+    expect(first.valid).toBe(true);
+    expect(first.fastPath).toBeUndefined();
+    expect(first.cells.some((cell) => cell.row !== 17)).toBe(true);
+    expect(first.cells).toEqual(second.cells);
+    expect(first.costFt).toBe(second.costFt);
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});


### PR DESCRIPTION
## Retest failure after #721

The manual WEBGL-02 retest still reproduced two issues:

1. Long straight movement could still render a real zigzag route under the 5e equal-cost rule.
2. Navigation planning remained expensive enough to cause visible drag/follow performance problems.

## Root cause

The previous straightness patch only broke ties when selecting the next open A* node. During relaxation, an equal-cost but straighter predecessor was still rejected by `tentative >= existingG`, so a cell could keep a zigzag predecessor permanently.

The implementation also scanned the whole open set to select the best node, which scales poorly for repeated drag planning.

## Fix V2

- Equal movement cost remains the primary criterion; 5e cost accounting is unchanged.
- When `g` is exactly equal, relaxation can now replace `cameFrom` if the new predecessor has lower cumulative deviation from the direct line, then fewer direction changes.
- A binary min-heap replaces repeated full open-set scans.
- Clean horizontal, vertical, and 45-degree paths use a validated aligned fast path with `visited: 0` when no custom terrain overrides are present.
- Walls, occupancy, corner-cut and edge validation are still checked on the aligned path. If blocked, planning falls back to A*.
- Custom terrain disables the aligned shortcut so cheaper detours remain discoverable.

## Regression coverage

A new focused contract reproduces the field case:

- 39-cell reverse horizontal route: one direction only, no zigzag, `visited: 0`.
- 30-cell vertical route: one direction only, `visited: 0`.
- Long non-45-degree 5e route: row progression is monotonic, so equal-cost relaxation cannot oscillate up/down.
- Reverse oblique route is also monotonic.
- A blocked straight line disables the shortcut and still returns a deterministic legal detour.

## Manual retest after merge

- [ ] Repeat the exact straight drag that previously produced the dashed hump/zigzag.
- [ ] Drag 15–30 cells horizontally and vertically.
- [ ] Compare responsiveness while moving the target within the map.
- [ ] Test a long oblique route.
- [ ] Add a wall/blocked cell and verify the route detours only when needed.
- [ ] Repeat with Follow ON as Player and DM.