### PR TITLE
Fix VTT long-distance drag main-thread stalls

### DIFF
--- a/.github/workflows/vtt-runtime-drag-performance-field.yml
+++ b/.github/workflows/vtt-runtime-drag-performance-field.yml
@@ -6,6 +6,7 @@ on:
       - 'js/vtt/**'
       - 'vtt.html'
       - 'tests/vtt_realtime_traversal_simplification.spec.js'
+      - 'tests/vtt_procedural_runtime_performance.spec.js'
       - 'playwright.config.cjs'
       - '.github/workflows/vtt-runtime-drag-performance-field.yml'
   push:
@@ -13,6 +14,7 @@ on:
       - 'js/vtt/**'
       - 'vtt.html'
       - 'tests/vtt_realtime_traversal_simplification.spec.js'
+      - 'tests/vtt_procedural_runtime_performance.spec.js'
       - 'playwright.config.cjs'
       - '.github/workflows/vtt-runtime-drag-performance-field.yml'
 
@@ -48,10 +50,10 @@ jobs:
           done
           cat /tmp/vtt-field-server.log
           exit 1
-      - name: Integrated realtime movement field trace
+      - name: Integrated realtime movement and procedural performance field trace
         env:
           VTT_FIELD_URL: http://127.0.0.1:4173/vtt.html
-        run: npx playwright test --config=playwright.config.cjs --workers=1 tests/vtt_realtime_traversal_simplification.spec.js --reporter=line
+        run: npx playwright test --config=playwright.config.cjs --workers=1 tests/vtt_realtime_traversal_simplification.spec.js tests/vtt_procedural_runtime_performance.spec.js --reporter=line
       - name: Server log on failure
         if: failure()
         run: cat /tmp/vtt-field-server.log || true

--- a/js/vtt/movement-direct-route-hotfix.js
+++ b/js/vtt/movement-direct-route-hotfix.js
@@ -1,0 +1,330 @@
+const EPS = 1e-7;
+const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+const clean = (value) => String(value ?? '').trim();
+
+function layerOf(token = {}) {
+  if (Number.isFinite(Number(token.zLayer))) return Number(token.zLayer);
+  if (Number.isFinite(Number(token.gridPosition?.z))) return Number(token.gridPosition.z);
+  if (Array.isArray(token.z) && token.z.length) return Number(token.z[0]) || 0;
+  return 0;
+}
+
+function bucketKey(col, row) {
+  return `${Math.trunc(finite(col))}_${Math.trunc(finite(row))}`;
+}
+
+function addBucketRange(buckets, item, bounds, grid = {}) {
+  const size = Math.max(1, finite(grid.size, 70));
+  const cols = Math.max(1, Math.trunc(finite(grid.cols, 1)));
+  const rows = Math.max(1, Math.trunc(finite(grid.rows, 1)));
+  const minCol = Math.max(0, Math.min(cols - 1, Math.floor(finite(bounds.minX) / size)));
+  const maxCol = Math.max(0, Math.min(cols - 1, Math.floor(finite(bounds.maxX) / size)));
+  const minRow = Math.max(0, Math.min(rows - 1, Math.floor(finite(bounds.minY) / size)));
+  const maxRow = Math.max(0, Math.min(rows - 1, Math.floor(finite(bounds.maxY) / size)));
+  for (let row = minRow; row <= maxRow; row += 1) {
+    for (let col = minCol; col <= maxCol; col += 1) {
+      const key = bucketKey(col, row);
+      const list = buckets.get(key) || [];
+      list.push(item);
+      buckets.set(key, list);
+    }
+  }
+}
+
+function pointSegmentDistance(point = {}, segment = {}) {
+  const px = finite(point.x);
+  const py = finite(point.y);
+  const ax = finite(segment.x1);
+  const ay = finite(segment.y1);
+  const bx = finite(segment.x2);
+  const by = finite(segment.y2);
+  const abx = bx - ax;
+  const aby = by - ay;
+  const lengthSq = (abx * abx) + (aby * aby);
+  if (lengthSq <= EPS) return Math.hypot(px - ax, py - ay);
+  const t = Math.max(0, Math.min(1, (((px - ax) * abx) + ((py - ay) * aby)) / lengthSq));
+  return Math.hypot(px - (ax + (abx * t)), py - (ay + (aby * t)));
+}
+
+function circleIntersectsRect(point = {}, radius = 0, rect = {}) {
+  const x = Math.max(finite(rect.x), Math.min(finite(point.x), finite(rect.x) + finite(rect.width)));
+  const y = Math.max(finite(rect.y), Math.min(finite(point.y), finite(rect.y) + finite(rect.height)));
+  return Math.hypot(finite(point.x) - x, finite(point.y) - y) < Math.max(0, finite(radius));
+}
+
+function tokenRadius(interaction, token, grid) {
+  return Math.max(4, finite(interaction?.tokenRadius?.(token, grid), finite(grid?.size, 70) * 0.4));
+}
+
+function buildDirectContext(host, interaction, token, mapData = {}) {
+  const startedAt = host?.performance?.now?.() ?? Date.now();
+  const grid = mapData.grid || {};
+  const layer = layerOf(token);
+  const radius = tokenRadius(interaction, token, grid);
+  const walls = typeof interaction?.movementWalls === 'function' ? interaction.movementWalls(mapData, token) : [];
+  const wallBuckets = new Map();
+  for (const wall of walls || []) {
+    const extra = radius + (Math.max(0, finite(wall?.thicknessPx)) / 2);
+    addBucketRange(wallBuckets, wall, {
+      minX: Math.min(finite(wall?.x1), finite(wall?.x2)) - extra,
+      maxX: Math.max(finite(wall?.x1), finite(wall?.x2)) + extra,
+      minY: Math.min(finite(wall?.y1), finite(wall?.y2)) - extra,
+      maxY: Math.max(finite(wall?.y1), finite(wall?.y2)) + extra,
+    }, grid);
+  }
+
+  const objectBuckets = new Map();
+  const core = host?.LuminousVttWorldObjectCore;
+  const definitions = {
+    ...(host?.LuminousVttWorldObjectCatalog?.byId || {}),
+    ...(mapData.worldObjectDefinitions || {}),
+  };
+  if (core) {
+    for (const instance of mapData.worldObjects || []) {
+      if (finite(instance?.position?.zLayer) !== layer) continue;
+      const definition = core.resolveDefinition?.(instance, definitions) || null;
+      if (!definition || core.blocksMovement?.(instance, definition) === false) continue;
+      const rect = core.footprintRect?.(instance, definition, grid);
+      if (!rect) continue;
+      const blocker = { instance, definition, rect };
+      addBucketRange(objectBuckets, blocker, {
+        minX: finite(rect.x) - radius,
+        maxX: finite(rect.x) + finite(rect.width) + radius,
+        minY: finite(rect.y) - radius,
+        maxY: finite(rect.y) + finite(rect.height) + radius,
+      }, grid);
+    }
+  }
+
+  const tokens = (mapData.tokens || []).filter((other) => {
+    if (!other || clean(other.id) === clean(token?.id)) return false;
+    if (layerOf(other) !== layer) return false;
+    if (other.blocksMovement === false || other.intangible === true) return false;
+    return true;
+  }).map((other) => ({ token: other, radius: tokenRadius(interaction, other, grid) }));
+
+  return {
+    grid,
+    layer,
+    radius,
+    wallBuckets,
+    objectBuckets,
+    tokens,
+    buildMs: Math.max(0, (host?.performance?.now?.() ?? Date.now()) - startedAt),
+  };
+}
+
+function pointGate(context, token, point, mapData = {}, blockTokens = true) {
+  const grid = context.grid;
+  const size = Math.max(1, finite(grid.size, 70));
+  const cols = Math.max(1, Math.trunc(finite(grid.cols, 1)));
+  const rows = Math.max(1, Math.trunc(finite(grid.rows, 1)));
+  const width = cols * size;
+  const height = rows * size;
+  const x = finite(point?.x, NaN);
+  const y = finite(point?.y, NaN);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return { valid: false, reason: 'INVALID_INPUT' };
+  if (x - context.radius < 0 || y - context.radius < 0 || x + context.radius > width || y + context.radius > height) {
+    return { valid: false, reason: 'OUT_OF_BOUNDS' };
+  }
+
+  const key = bucketKey(Math.floor(x / size), Math.floor(y / size));
+  for (const wall of context.wallBuckets.get(key) || []) {
+    const extra = Math.max(0, finite(wall?.thicknessPx)) / 2;
+    if (pointSegmentDistance({ x, y }, wall) < context.radius + extra) {
+      return { valid: false, reason: 'BLOCKED_BY_WALL', wall };
+    }
+  }
+  for (const blocker of context.objectBuckets.get(key) || []) {
+    if (circleIntersectsRect({ x, y }, context.radius, blocker.rect)) {
+      return {
+        valid: false,
+        reason: 'BLOCKED_BY_WORLD_OBJECT',
+        worldObject: blocker.instance,
+        definition: blocker.definition,
+      };
+    }
+  }
+  if (blockTokens !== false) {
+    for (const entry of context.tokens) {
+      const other = entry.token;
+      if (Math.hypot(finite(other.x) - x, finite(other.y) - y) + EPS < context.radius + entry.radius) {
+        return { valid: false, reason: 'BLOCKED_BY_TOKEN', token: other };
+      }
+    }
+  }
+  return { valid: true };
+}
+
+function directRoute(host, pathfinding, interaction, options = {}, metrics = null) {
+  const { token, start, target, mapData = {} } = options;
+  if (!token || !start || !target || !mapData.grid) return null;
+  const zLayer = Number.isFinite(Number(options.zLayer)) ? Number(options.zLayer) : pathfinding.tokenLayer(token);
+  const startCell = start.col != null && start.row != null
+    ? { col: Math.trunc(Number(start.col)), row: Math.trunc(Number(start.row)) }
+    : pathfinding.cellFromPoint(start, mapData);
+  const targetCell = target.col != null && target.row != null
+    ? { col: Math.trunc(Number(target.col)), row: Math.trunc(Number(target.row)) }
+    : pathfinding.cellFromPoint(target, mapData);
+  const dc = targetCell.col - startCell.col;
+  const dr = targetCell.row - startCell.row;
+  if (!(dc === 0 || dr === 0 || Math.abs(dc) === Math.abs(dr))) return null;
+
+  const context = buildDirectContext(host, interaction, token, mapData);
+  if (metrics) {
+    metrics.contexts += 1;
+    metrics.contextBuildTotalMs += context.buildMs;
+    metrics.contextBuildMaxMs = Math.max(metrics.contextBuildMaxMs, context.buildMs);
+  }
+  const movementMode = options.movementMode || token.movementState?.mode || 'walk';
+  const blockTokens = options.blockTokens ?? mapData.movement?.blockTokens ?? true;
+  const costOptions = { movementMode, blockTokens, diagonalRule: options.diagonalRule };
+  const stepCol = Math.sign(dc);
+  const stepRow = Math.sign(dr);
+  const steps = Math.max(Math.abs(dc), Math.abs(dr));
+  const cells = [{ ...startCell }];
+  let current = { ...startCell };
+  let costFt = 0;
+
+  // Validate terrain/cost once per crossed grid cell. This is dictionary work only;
+  // it deliberately avoids edgePassable/isPathClear and their legacy nested sampling.
+  for (let index = 0; index < steps; index += 1) {
+    const next = { col: current.col + stepCol, row: current.row + stepRow };
+    const terrain = pathfinding.terrainRecord?.(mapData, zLayer, next.col, next.row) || { multiplier: 1 };
+    if (pathfinding.terrainAllows?.(terrain, movementMode) === false) return null;
+    costFt += pathfinding.stepCostFt(current, next, mapData, zLayer, costOptions);
+    cells.push(next);
+    current = next;
+  }
+
+  const fromPoint = pathfinding.pointForCell(startCell, mapData, zLayer);
+  const toPoint = pathfinding.pointForCell(targetCell, mapData, zLayer);
+  const dx = finite(toPoint.x) - finite(fromPoint.x);
+  const dy = finite(toPoint.y) - finite(fromPoint.y);
+  const distance = Math.hypot(dx, dy);
+  const sampleStep = Math.max(6, Math.min(context.radius * 0.65, finite(mapData.grid?.size, 70) * 0.25));
+  const samples = Math.max(1, Math.ceil(distance / sampleStep));
+  for (let index = 0; index <= samples; index += 1) {
+    const t = index / samples;
+    const point = { x: finite(fromPoint.x) + (dx * t), y: finite(fromPoint.y) + (dy * t) };
+    const gate = pointGate(context, token, point, mapData, blockTokens);
+    if (!gate.valid) return null;
+  }
+
+  return {
+    valid: true,
+    reason: null,
+    path: cells.map((cell) => pathfinding.pointForCell(cell, mapData, zLayer)),
+    cells,
+    costFt,
+    visited: 0,
+    fastPath: 'direct-corridor',
+  };
+}
+
+export function installDirectRouteHotfix(host = globalThis) {
+  if (host?.LuminousVttDirectRouteHotfix?.__v1) return host.LuminousVttDirectRouteHotfix;
+
+  let stopped = false;
+  let wrapped = null;
+  let base = null;
+  const metrics = {
+    ensureCalls: 0,
+    findPathCalls: 0,
+    directAttempts: 0,
+    directHits: 0,
+    fallbackCalls: 0,
+    contexts: 0,
+    contextBuildTotalMs: 0,
+    contextBuildMaxMs: 0,
+    directTotalMs: 0,
+    directMaxMs: 0,
+    fallbackTotalMs: 0,
+    fallbackMaxMs: 0,
+  };
+
+  function ensure() {
+    if (stopped) return null;
+    metrics.ensureCalls += 1;
+    const current = host?.LuminousVttPathfinding;
+    if (!current?.findPath) return null;
+    if (current === wrapped) return wrapped;
+    if (current.__directCorridorHotfixV1 && current.__directCorridorBase) {
+      wrapped = current;
+      base = current.__directCorridorBase;
+      return current;
+    }
+
+    base = current;
+    const next = Object.freeze({
+      ...current,
+      __directCorridorHotfixV1: true,
+      __directCorridorBase: current,
+      findPath(options = {}) {
+        metrics.findPathCalls += 1;
+        const interaction = host?.LuminousVttTokenInteraction;
+        const start = host?.performance?.now?.() ?? Date.now();
+        metrics.directAttempts += 1;
+        const direct = interaction ? directRoute(host, current, interaction, options, metrics) : null;
+        const directMs = Math.max(0, (host?.performance?.now?.() ?? Date.now()) - start);
+        metrics.directTotalMs += directMs;
+        metrics.directMaxMs = Math.max(metrics.directMaxMs, directMs);
+        if (direct) {
+          metrics.directHits += 1;
+          return direct;
+        }
+        metrics.fallbackCalls += 1;
+        const fallbackAt = host?.performance?.now?.() ?? Date.now();
+        const result = current.findPath(options);
+        const fallbackMs = Math.max(0, (host?.performance?.now?.() ?? Date.now()) - fallbackAt);
+        metrics.fallbackTotalMs += fallbackMs;
+        metrics.fallbackMaxMs = Math.max(metrics.fallbackMaxMs, fallbackMs);
+        return result;
+      },
+    });
+    host.LuminousVttPathfinding = next;
+    wrapped = next;
+    return next;
+  }
+
+  const refresh = () => ensure();
+  host?.addEventListener?.('mousedown', refresh, true);
+  // This runs after movement-long-drag-hotfix's capture listener because this module
+  // is imported second. It therefore wraps the final pathfinder immediately before
+  // Engine's bubble-phase mouseup resolver executes.
+  host?.addEventListener?.('mouseup', refresh, true);
+  host?.addEventListener?.('vtt:topology-changed', refresh);
+  host?.setTimeout?.(refresh, 0);
+  host?.setTimeout?.(refresh, 250);
+  host?.setTimeout?.(refresh, 1000);
+
+  const api = Object.freeze({
+    __v1: true,
+    ensure,
+    snapshot() {
+      return Object.freeze({
+        ...metrics,
+        avgContextBuildMs: metrics.contexts ? metrics.contextBuildTotalMs / metrics.contexts : 0,
+        avgDirectMs: metrics.directAttempts ? metrics.directTotalMs / metrics.directAttempts : 0,
+        avgFallbackMs: metrics.fallbackCalls ? metrics.fallbackTotalMs / metrics.fallbackCalls : 0,
+        installed: host?.LuminousVttPathfinding?.__directCorridorHotfixV1 === true,
+      });
+    },
+    stop() {
+      if (stopped) return false;
+      stopped = true;
+      host?.removeEventListener?.('mousedown', refresh, true);
+      host?.removeEventListener?.('mouseup', refresh, true);
+      host?.removeEventListener?.('vtt:topology-changed', refresh);
+      if (host.LuminousVttPathfinding === wrapped && base) host.LuminousVttPathfinding = base;
+      if (host.LuminousVttDirectRouteHotfix === api) delete host.LuminousVttDirectRouteHotfix;
+      return true;
+    },
+  });
+
+  host.LuminousVttDirectRouteHotfix = api;
+  ensure();
+  return api;
+}
+
+if (typeof window !== 'undefined') installDirectRouteHotfix(window);

--- a/js/vtt/movement-direct-route-hotfix.js
+++ b/js/vtt/movement-direct-route-hotfix.js
@@ -186,8 +186,6 @@ function directRoute(host, pathfinding, interaction, options = {}, metrics = nul
   let current = { ...startCell };
   let costFt = 0;
 
-  // Validate terrain/cost once per crossed grid cell. This is dictionary work only;
-  // it deliberately avoids edgePassable/isPathClear and their legacy nested sampling.
   for (let index = 0; index < steps; index += 1) {
     const next = { col: current.col + stepCol, row: current.row + stepRow };
     const terrain = pathfinding.terrainRecord?.(mapData, zLayer, next.col, next.row) || { multiplier: 1 };
@@ -227,9 +225,11 @@ export function installDirectRouteHotfix(host = globalThis) {
 
   let stopped = false;
   let wrapped = null;
+  let wrappedFindPath = null;
   let base = null;
   const metrics = {
     ensureCalls: 0,
+    inheritedMarkerRepairs: 0,
     findPathCalls: 0,
     directAttempts: 0,
     directHits: 0,
@@ -243,55 +243,65 @@ export function installDirectRouteHotfix(host = globalThis) {
     fallbackMaxMs: 0,
   };
 
+  function isOwned(current) {
+    return Boolean(current
+      && typeof current.findPath === 'function'
+      && typeof current.__directCorridorFindPath === 'function'
+      && current.findPath === current.__directCorridorFindPath);
+  }
+
   function ensure() {
     if (stopped) return null;
     metrics.ensureCalls += 1;
     const current = host?.LuminousVttPathfinding;
     if (!current?.findPath) return null;
-    if (current === wrapped) return wrapped;
-    if (current.__directCorridorHotfixV1 && current.__directCorridorBase) {
+    if (current === wrapped && current.findPath === wrappedFindPath) return wrapped;
+    if (isOwned(current)) {
       wrapped = current;
-      base = current.__directCorridorBase;
+      wrappedFindPath = current.findPath;
+      base = current.__directCorridorBase || null;
       return current;
     }
+    if (current.__directCorridorHotfixV1 === true) metrics.inheritedMarkerRepairs += 1;
 
     base = current;
+    const directFindPath = function directCorridorFindPath(options = {}) {
+      metrics.findPathCalls += 1;
+      const interaction = host?.LuminousVttTokenInteraction;
+      const startedAt = host?.performance?.now?.() ?? Date.now();
+      metrics.directAttempts += 1;
+      const direct = interaction ? directRoute(host, current, interaction, options, metrics) : null;
+      const directMs = Math.max(0, (host?.performance?.now?.() ?? Date.now()) - startedAt);
+      metrics.directTotalMs += directMs;
+      metrics.directMaxMs = Math.max(metrics.directMaxMs, directMs);
+      if (direct) {
+        metrics.directHits += 1;
+        return direct;
+      }
+      metrics.fallbackCalls += 1;
+      const fallbackAt = host?.performance?.now?.() ?? Date.now();
+      const result = current.findPath(options);
+      const fallbackMs = Math.max(0, (host?.performance?.now?.() ?? Date.now()) - fallbackAt);
+      metrics.fallbackTotalMs += fallbackMs;
+      metrics.fallbackMaxMs = Math.max(metrics.fallbackMaxMs, fallbackMs);
+      return result;
+    };
+
     const next = Object.freeze({
       ...current,
       __directCorridorHotfixV1: true,
       __directCorridorBase: current,
-      findPath(options = {}) {
-        metrics.findPathCalls += 1;
-        const interaction = host?.LuminousVttTokenInteraction;
-        const start = host?.performance?.now?.() ?? Date.now();
-        metrics.directAttempts += 1;
-        const direct = interaction ? directRoute(host, current, interaction, options, metrics) : null;
-        const directMs = Math.max(0, (host?.performance?.now?.() ?? Date.now()) - start);
-        metrics.directTotalMs += directMs;
-        metrics.directMaxMs = Math.max(metrics.directMaxMs, directMs);
-        if (direct) {
-          metrics.directHits += 1;
-          return direct;
-        }
-        metrics.fallbackCalls += 1;
-        const fallbackAt = host?.performance?.now?.() ?? Date.now();
-        const result = current.findPath(options);
-        const fallbackMs = Math.max(0, (host?.performance?.now?.() ?? Date.now()) - fallbackAt);
-        metrics.fallbackTotalMs += fallbackMs;
-        metrics.fallbackMaxMs = Math.max(metrics.fallbackMaxMs, fallbackMs);
-        return result;
-      },
+      __directCorridorFindPath: directFindPath,
+      findPath: directFindPath,
     });
     host.LuminousVttPathfinding = next;
     wrapped = next;
+    wrappedFindPath = directFindPath;
     return next;
   }
 
   const refresh = () => ensure();
   host?.addEventListener?.('mousedown', refresh, true);
-  // This runs after movement-long-drag-hotfix's capture listener because this module
-  // is imported second. It therefore wraps the final pathfinder immediately before
-  // Engine's bubble-phase mouseup resolver executes.
   host?.addEventListener?.('mouseup', refresh, true);
   host?.addEventListener?.('vtt:topology-changed', refresh);
   host?.setTimeout?.(refresh, 0);
@@ -302,12 +312,14 @@ export function installDirectRouteHotfix(host = globalThis) {
     __v1: true,
     ensure,
     snapshot() {
+      const current = host?.LuminousVttPathfinding;
       return Object.freeze({
         ...metrics,
         avgContextBuildMs: metrics.contexts ? metrics.contextBuildTotalMs / metrics.contexts : 0,
         avgDirectMs: metrics.directAttempts ? metrics.directTotalMs / metrics.directAttempts : 0,
         avgFallbackMs: metrics.fallbackCalls ? metrics.fallbackTotalMs / metrics.fallbackCalls : 0,
-        installed: host?.LuminousVttPathfinding?.__directCorridorHotfixV1 === true,
+        installed: isOwned(current),
+        currentFindPathOwned: isOwned(current),
       });
     },
     stop() {

--- a/js/vtt/movement-long-drag-hotfix.js
+++ b/js/vtt/movement-long-drag-hotfix.js
@@ -1,0 +1,454 @@
+const EPS = 1e-7;
+const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+const clean = (value) => String(value ?? '').trim();
+
+function tokenLayer(token = {}) {
+  if (Number.isFinite(Number(token.zLayer))) return Number(token.zLayer);
+  if (Number.isFinite(Number(token.gridPosition?.z))) return Number(token.gridPosition.z);
+  if (Array.isArray(token.z) && token.z.length) return Number(token.z[0]) || 0;
+  return 0;
+}
+
+function bucketKey(col, row) {
+  return `${Math.trunc(finite(col))}_${Math.trunc(finite(row))}`;
+}
+
+function addToBuckets(buckets, item, bounds, grid) {
+  const size = Math.max(1, finite(grid?.size, 70));
+  const cols = Math.max(1, Math.trunc(finite(grid?.cols, 1)));
+  const rows = Math.max(1, Math.trunc(finite(grid?.rows, 1)));
+  const minCol = Math.max(0, Math.min(cols - 1, Math.floor(finite(bounds.minX) / size)));
+  const maxCol = Math.max(0, Math.min(cols - 1, Math.floor(finite(bounds.maxX) / size)));
+  const minRow = Math.max(0, Math.min(rows - 1, Math.floor(finite(bounds.minY) / size)));
+  const maxRow = Math.max(0, Math.min(rows - 1, Math.floor(finite(bounds.maxY) / size)));
+  for (let row = minRow; row <= maxRow; row += 1) {
+    for (let col = minCol; col <= maxCol; col += 1) {
+      const key = bucketKey(col, row);
+      const list = buckets.get(key) || [];
+      list.push(item);
+      buckets.set(key, list);
+    }
+  }
+}
+
+function pointSegmentDistance(point, wall) {
+  const px = finite(point?.x);
+  const py = finite(point?.y);
+  const ax = finite(wall?.x1);
+  const ay = finite(wall?.y1);
+  const bx = finite(wall?.x2);
+  const by = finite(wall?.y2);
+  const abx = bx - ax;
+  const aby = by - ay;
+  const lengthSq = (abx * abx) + (aby * aby);
+  if (lengthSq <= EPS) return Math.hypot(px - ax, py - ay);
+  const t = Math.max(0, Math.min(1, (((px - ax) * abx) + ((py - ay) * aby)) / lengthSq));
+  return Math.hypot(px - (ax + (abx * t)), py - (ay + (aby * t)));
+}
+
+function circleIntersectsRect(point, radius, rect) {
+  const x = Math.max(finite(rect?.x), Math.min(finite(point?.x), finite(rect?.x) + finite(rect?.width)));
+  const y = Math.max(finite(rect?.y), Math.min(finite(point?.y), finite(rect?.y) + finite(rect?.height)));
+  return Math.hypot(finite(point?.x) - x, finite(point?.y) - y) < Math.max(0, finite(radius));
+}
+
+export function installLongDragHotfix(host = globalThis) {
+  if (host?.LuminousVttLongDragHotfix?.__v1) return host.LuminousVttLongDragHotfix;
+
+  let stopped = false;
+  let interactionBase = null;
+  let interactionPatched = null;
+  let pathfindingBase = null;
+  let pathfindingPatched = null;
+  let activeCollision = null;
+  let lastDragCellKey = '';
+  let dragHud = null;
+
+  const metrics = {
+    dragMouseMoves: 0,
+    dragCellUpdates: 0,
+    suppressedMouseMoves: 0,
+    pathCalls: 0,
+    alignedDirectPaths: 0,
+    collisionContexts: 0,
+    collisionBuildTotalMs: 0,
+    collisionBuildMaxMs: 0,
+    wallCandidates: 0,
+    objectCandidates: 0,
+  };
+
+  function liveRuntime() {
+    return host?.LuminousVttRuntime || null;
+  }
+
+  function ensureHud() {
+    if (dragHud?.isConnected) return dragHud;
+    const doc = host?.document;
+    if (!doc?.body) return null;
+    const node = doc.createElement('div');
+    node.id = 'vtt-fast-drag-hud';
+    node.hidden = true;
+    node.style.cssText = 'position:fixed;z-index:36050;pointer-events:none;padding:4px 7px;border:1px solid #fff;background:#090909;color:#fff;font:700 11px monospace;box-shadow:2px 2px 0 #000;transform:translate(12px,12px);will-change:left,top;';
+    doc.body.appendChild(node);
+    dragHud = node;
+    return node;
+  }
+
+  function hideHud() {
+    if (dragHud) dragHud.hidden = true;
+  }
+
+  function cheapDistanceFt(engine, drag, targetCell) {
+    const pathfinding = host?.LuminousVttPathfinding;
+    if (!pathfinding?.cellFromPoint) return 0;
+    const mapData = engine.mapData || {};
+    const startCell = pathfinding.cellFromPoint({ x: drag.originX, y: drag.originY }, mapData);
+    const dx = Math.abs(finite(targetCell?.col) - finite(startCell?.col));
+    const dy = Math.abs(finite(targetCell?.row) - finite(startCell?.row));
+    const feet = Math.max(0.001, finite(mapData.grid?.distancePerCell, 5));
+    const diagonal = clean(mapData.movement?.diagonalRule).toLowerCase();
+    return ['euclidean', 'sqrt2', 'real'].includes(diagonal)
+      ? Math.hypot(dx, dy) * feet
+      : Math.max(dx, dy) * feet;
+  }
+
+  function updateCheapHud(engine, drag, event, cell) {
+    const hud = ensureHud();
+    if (!hud) return;
+    const distance = cheapDistanceFt(engine, drag, cell);
+    hud.textContent = `${Math.round(distance)} ft`;
+    hud.style.left = `${Math.round(finite(event?.clientX))}px`;
+    hud.style.top = `${Math.round(finite(event?.clientY))}px`;
+    hud.hidden = false;
+  }
+
+  function buildCollisionContext(token, mapData, base) {
+    const startedAt = host?.performance?.now?.() ?? Date.now();
+    const grid = mapData?.grid || {};
+    const layer = tokenLayer(token);
+    const radius = Math.max(4, finite(base?.tokenRadius?.(token, grid), finite(grid.size, 70) * 0.4));
+    const walls = typeof base?.movementWalls === 'function' ? base.movementWalls(mapData, token) : [];
+    const wallBuckets = new Map();
+
+    for (const wall of walls || []) {
+      const extra = radius + (Math.max(0, finite(wall?.thicknessPx)) / 2);
+      addToBuckets(wallBuckets, wall, {
+        minX: Math.min(finite(wall?.x1), finite(wall?.x2)) - extra,
+        maxX: Math.max(finite(wall?.x1), finite(wall?.x2)) + extra,
+        minY: Math.min(finite(wall?.y1), finite(wall?.y2)) - extra,
+        maxY: Math.max(finite(wall?.y1), finite(wall?.y2)) + extra,
+      }, grid);
+    }
+
+    const objectBuckets = new Map();
+    const core = host?.LuminousVttWorldObjectCore;
+    const definitions = {
+      ...(host?.LuminousVttWorldObjectCatalog?.byId || {}),
+      ...(mapData?.worldObjectDefinitions || {}),
+    };
+    if (core) {
+      for (const instance of mapData?.worldObjects || []) {
+        if (finite(instance?.position?.zLayer) !== layer) continue;
+        const definition = core.resolveDefinition?.(instance, definitions) || null;
+        if (!definition || core.blocksMovement?.(instance, definition) === false) continue;
+        const rect = core.footprintRect?.(instance, definition, grid);
+        if (!rect) continue;
+        const blocker = { instance, definition, rect };
+        addToBuckets(objectBuckets, blocker, {
+          minX: finite(rect.x) - radius,
+          maxX: finite(rect.x) + finite(rect.width) + radius,
+          minY: finite(rect.y) - radius,
+          maxY: finite(rect.y) + finite(rect.height) + radius,
+        }, grid);
+      }
+    }
+
+    const elapsed = Math.max(0, (host?.performance?.now?.() ?? Date.now()) - startedAt);
+    metrics.collisionContexts += 1;
+    metrics.collisionBuildTotalMs += elapsed;
+    metrics.collisionBuildMaxMs = Math.max(metrics.collisionBuildMaxMs, elapsed);
+    return { mapData, tokenId: clean(token?.id), layer, radius, walls, wallBuckets, objectBuckets };
+  }
+
+  function contextFor(token, mapData) {
+    if (!activeCollision || activeCollision.mapData !== mapData) return null;
+    if (activeCollision.tokenId && clean(token?.id) !== activeCollision.tokenId) return null;
+    if (tokenLayer(token) !== activeCollision.layer) return null;
+    return activeCollision;
+  }
+
+  function optimizedCanOccupy(base, token, point, mapData = {}) {
+    const ctx = contextFor(token, mapData);
+    if (!ctx) return base.canOccupy(token, point, mapData);
+    const bounds = base.gridBounds?.(mapData.grid || {}) || { width: 0, height: 0 };
+    const x = finite(point?.x, NaN);
+    const y = finite(point?.y, NaN);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return { valid: false, reason: 'INVALID_INPUT' };
+    if (x - ctx.radius < 0 || y - ctx.radius < 0 || x + ctx.radius > finite(bounds.width) || y + ctx.radius > finite(bounds.height)) {
+      return { valid: false, reason: 'OUT_OF_BOUNDS' };
+    }
+
+    const size = Math.max(1, finite(mapData.grid?.size, 70));
+    const key = bucketKey(Math.floor(x / size), Math.floor(y / size));
+    const nearbyWalls = ctx.wallBuckets.get(key) || [];
+    metrics.wallCandidates += nearbyWalls.length;
+    for (const wall of nearbyWalls) {
+      const extra = Math.max(0, finite(wall?.thicknessPx)) / 2;
+      if (pointSegmentDistance({ x, y }, wall) < ctx.radius + extra) {
+        return { valid: false, reason: 'BLOCKED_BY_WALL', wall };
+      }
+    }
+
+    const nearbyObjects = ctx.objectBuckets.get(key) || [];
+    metrics.objectCandidates += nearbyObjects.length;
+    for (const blocker of nearbyObjects) {
+      if (circleIntersectsRect({ x, y }, ctx.radius, blocker.rect)) {
+        return {
+          valid: false,
+          reason: 'BLOCKED_BY_WORLD_OBJECT',
+          worldObject: blocker.instance,
+          definition: blocker.definition,
+        };
+      }
+    }
+    return { valid: true, reason: null };
+  }
+
+  function optimizedIsPathClear(base, token, from, to, mapData = {}) {
+    const ctx = contextFor(token, mapData);
+    if (!ctx) return base.isPathClear(token, from, to, mapData);
+    const grid = mapData.grid || {};
+    const dx = finite(to?.x) - finite(from?.x);
+    const dy = finite(to?.y) - finite(from?.y);
+    const distance = Math.hypot(dx, dy);
+    const sampleStep = Math.max(4, Math.min(ctx.radius * 0.5, finite(grid.size, 70) * 0.2));
+    const steps = Math.max(1, Math.ceil(distance / sampleStep));
+    for (let index = 0; index <= steps; index += 1) {
+      const t = index / steps;
+      const point = { x: finite(from?.x) + (dx * t), y: finite(from?.y) + (dy * t) };
+      const gate = optimizedCanOccupy(base, token, point, mapData);
+      if (!gate.valid) return gate;
+    }
+    return { valid: true, reason: null };
+  }
+
+  function ensureInteraction() {
+    const current = host?.LuminousVttTokenInteraction;
+    if (!current) return null;
+    if (current === interactionPatched) return interactionPatched;
+    if (current.__longDragCollisionBroadphaseV1 && current.__longDragCollisionBase) {
+      interactionBase = current.__longDragCollisionBase;
+      interactionPatched = current;
+      return current;
+    }
+
+    interactionBase = current;
+    const patched = Object.freeze({
+      ...current,
+      __longDragCollisionBroadphaseV1: true,
+      __longDragCollisionBase: current,
+      canOccupy(token, point, mapData = {}) {
+        return optimizedCanOccupy(current, token, point, mapData);
+      },
+      isPathClear(token, from, to, mapData = {}) {
+        return optimizedIsPathClear(current, token, from, to, mapData);
+      },
+    });
+    host.LuminousVttTokenInteraction = patched;
+    interactionPatched = patched;
+    return patched;
+  }
+
+  function alignedDirectRoute(base, options = {}) {
+    const { token, start, target, mapData = {} } = options;
+    if (!token || !start || !target || !mapData.grid) return null;
+    const zLayer = Number.isFinite(Number(options.zLayer)) ? Number(options.zLayer) : base.tokenLayer(token);
+    const startCell = start.col != null && start.row != null
+      ? { col: Math.trunc(Number(start.col)), row: Math.trunc(Number(start.row)) }
+      : base.cellFromPoint(start, mapData);
+    const targetCell = target.col != null && target.row != null
+      ? { col: Math.trunc(Number(target.col)), row: Math.trunc(Number(target.row)) }
+      : base.cellFromPoint(target, mapData);
+    const dc = targetCell.col - startCell.col;
+    const dr = targetCell.row - startCell.row;
+    if (!(dc === 0 || dr === 0 || Math.abs(dc) === Math.abs(dr))) return null;
+
+    const passOptions = {
+      movementMode: options.movementMode || 'walk',
+      blockTokens: options.blockTokens,
+      diagonalRule: options.diagonalRule,
+    };
+    const targetPoint = base.pointForCell(targetCell, mapData, zLayer);
+    const targetGate = base.pointPassable(token, targetPoint, mapData, zLayer, passOptions);
+    if (!targetGate.valid) return null;
+
+    const stepCol = Math.sign(dc);
+    const stepRow = Math.sign(dr);
+    const steps = Math.max(Math.abs(dc), Math.abs(dr));
+    const cells = [{ ...startCell }];
+    let current = { ...startCell };
+    let costFt = 0;
+    for (let index = 0; index < steps; index += 1) {
+      const next = { col: current.col + stepCol, row: current.row + stepRow };
+      const edge = base.edgePassable(token, current, next, mapData, zLayer, passOptions);
+      if (!edge.valid) return null;
+      costFt += base.stepCostFt(current, next, mapData, zLayer, passOptions);
+      cells.push(next);
+      current = next;
+    }
+    return {
+      valid: true,
+      reason: null,
+      path: cells.map((cell) => base.pointForCell(cell, mapData, zLayer)),
+      cells,
+      costFt,
+      visited: 0,
+      fastPath: 'aligned-broadphase',
+    };
+  }
+
+  function ensurePathfinding() {
+    const current = host?.LuminousVttPathfinding;
+    if (!current?.findPath) return null;
+    if (current === pathfindingPatched) return current;
+    if (current.__longDragPathfindingV1 && current.__longDragPathfindingBase) {
+      pathfindingBase = current.__longDragPathfindingBase;
+      pathfindingPatched = current;
+      return current;
+    }
+
+    pathfindingBase = current;
+    const patched = Object.freeze({
+      ...current,
+      __longDragPathfindingV1: true,
+      __longDragPathfindingBase: current,
+      findPath(options = {}) {
+        metrics.pathCalls += 1;
+        const interaction = ensureInteraction();
+        const token = options.token;
+        const mapData = options.mapData || {};
+        if (!interaction || !token || !mapData.grid) return current.findPath(options);
+        const previousContext = activeCollision;
+        activeCollision = buildCollisionContext(token, mapData, interaction.__longDragCollisionBase || interactionBase || interaction);
+        try {
+          const direct = alignedDirectRoute(current, options);
+          if (direct) {
+            metrics.alignedDirectPaths += 1;
+            return direct;
+          }
+          return current.findPath(options);
+        } finally {
+          activeCollision = previousContext;
+        }
+      },
+    });
+    host.LuminousVttPathfinding = patched;
+    pathfindingPatched = patched;
+    return patched;
+  }
+
+  function ensureOptimizers() {
+    ensureInteraction();
+    ensurePathfinding();
+  }
+
+  function dragCell(engine, drag, event) {
+    const pathfinding = host?.LuminousVttPathfinding;
+    if (!pathfinding?.cellFromPoint || typeof engine?.eventWorldPoint !== 'function') return null;
+    const world = engine.eventWorldPoint(event);
+    const target = {
+      x: finite(world?.x) - finite(drag?.grabOffsetX),
+      y: finite(world?.y) - finite(drag?.grabOffsetY),
+    };
+    const cell = pathfinding.cellFromPoint(target, engine.mapData || {});
+    return { cell, target };
+  }
+
+  function onMouseDownCapture() {
+    lastDragCellKey = '';
+    ensureOptimizers();
+  }
+
+  function onMouseMoveCapture(event) {
+    const engine = liveRuntime()?.engine;
+    const drag = engine?.tokenDrag;
+    if (!engine || !drag?.token) return;
+    metrics.dragMouseMoves += 1;
+    ensureOptimizers();
+    const resolved = dragCell(engine, drag, event);
+    if (!resolved?.cell) return;
+    const key = [clean(drag.token.id), finite(drag.originX), finite(drag.originY), resolved.cell.col, resolved.cell.row].join(':');
+    if (key !== lastDragCellKey) {
+      lastDragCellKey = key;
+      metrics.dragCellUpdates += 1;
+      updateCheapHud(engine, drag, event, resolved.cell);
+      // Run the canonical engine preview exactly once for the new cell. The original
+      // window mousemove listener and movement-bootstrap planner are blocked below.
+      engine.handleTokenMouseMove?.(event);
+    } else {
+      metrics.suppressedMouseMoves += 1;
+    }
+    // The expensive legacy movement-bootstrap mousemove listener performs a full
+    // planMove from the drag origin on every preview update. Do not let it run.
+    event.stopImmediatePropagation?.();
+  }
+
+  function onMouseUpCapture() {
+    ensureOptimizers();
+    lastDragCellKey = '';
+    hideHud();
+  }
+
+  function onBlur() {
+    lastDragCellKey = '';
+    hideHud();
+  }
+
+  host?.addEventListener?.('mousedown', onMouseDownCapture, true);
+  host?.addEventListener?.('mousemove', onMouseMoveCapture, true);
+  host?.addEventListener?.('mouseup', onMouseUpCapture, true);
+  host?.addEventListener?.('blur', onBlur, true);
+
+  // Prime the wrappers after the initial modules settle. Every drag also refreshes
+  // them because world-object/pathfinding patches can replace the frozen runtimes.
+  const prime = () => { if (!stopped) ensureOptimizers(); };
+  host?.setTimeout?.(prime, 0);
+  host?.setTimeout?.(prime, 250);
+  host?.setTimeout?.(prime, 1000);
+
+  const api = Object.freeze({
+    __v1: true,
+    ensure: ensureOptimizers,
+    snapshot() {
+      return Object.freeze({
+        ...metrics,
+        avgCollisionBuildMs: metrics.collisionContexts
+          ? metrics.collisionBuildTotalMs / metrics.collisionContexts
+          : 0,
+        dragActive: Boolean(liveRuntime()?.engine?.tokenDrag),
+        pathfindingInstalled: host?.LuminousVttPathfinding?.__longDragPathfindingV1 === true,
+        collisionBroadphaseInstalled: host?.LuminousVttTokenInteraction?.__longDragCollisionBroadphaseV1 === true,
+      });
+    },
+    stop() {
+      if (stopped) return false;
+      stopped = true;
+      host?.removeEventListener?.('mousedown', onMouseDownCapture, true);
+      host?.removeEventListener?.('mousemove', onMouseMoveCapture, true);
+      host?.removeEventListener?.('mouseup', onMouseUpCapture, true);
+      host?.removeEventListener?.('blur', onBlur, true);
+      hideHud();
+      dragHud?.remove?.();
+      dragHud = null;
+      if (host.LuminousVttPathfinding === pathfindingPatched && pathfindingBase) host.LuminousVttPathfinding = pathfindingBase;
+      if (host.LuminousVttTokenInteraction === interactionPatched && interactionBase) host.LuminousVttTokenInteraction = interactionBase;
+      if (host.LuminousVttLongDragHotfix === api) delete host.LuminousVttLongDragHotfix;
+      return true;
+    },
+  });
+
+  host.LuminousVttLongDragHotfix = api;
+  return api;
+}
+
+if (typeof window !== 'undefined') installLongDragHotfix(window);

--- a/js/vtt/movement-pathfinding-finalizer.js
+++ b/js/vtt/movement-pathfinding-finalizer.js
@@ -1,4 +1,5 @@
 import './movement-long-drag-hotfix.js';
+import './movement-direct-route-hotfix.js';
 import { installStraightPathfinding } from './movement-navigation-polish.js';
 
 const EPS = 1e-9;
@@ -272,6 +273,7 @@ export function startPathfindingFinalizer(host = globalThis) {
     const engine = host?.LuminousVttRuntime?.engine;
     if (engine?.tokenMoveResolver && host?.LuminousVttPathfinding) {
       finalizePathfinding(host);
+      host?.LuminousVttDirectRouteHotfix?.ensure?.();
       previewGate = installPreviewCellGate(host, engine);
       traversalSimplifier = installRealtimeTraversalSimplifier(host, engine);
       return;
@@ -289,6 +291,7 @@ export function startPathfindingFinalizer(host = globalThis) {
     },
     finalize() {
       const result = finalizePathfinding(host);
+      host?.LuminousVttDirectRouteHotfix?.ensure?.();
       const engine = host?.LuminousVttRuntime?.engine;
       if (engine) {
         previewGate = installPreviewCellGate(host, engine);

--- a/js/vtt/movement-pathfinding-finalizer.js
+++ b/js/vtt/movement-pathfinding-finalizer.js
@@ -1,3 +1,4 @@
+import './movement-long-drag-hotfix.js';
 import { installStraightPathfinding } from './movement-navigation-polish.js';
 
 const EPS = 1e-9;

--- a/js/vtt/movement-pathfinding-finalizer.js
+++ b/js/vtt/movement-pathfinding-finalizer.js
@@ -1,3 +1,4 @@
+import './movement-zero-work-drag.js';
 import './movement-long-drag-hotfix.js';
 import './movement-direct-route-hotfix.js';
 import { installStraightPathfinding } from './movement-navigation-polish.js';
@@ -10,10 +11,6 @@ function finalizePathfinding(host = globalThis) {
   if (!current || typeof current.findPath !== 'function') return null;
   if (current.__runtimeFinalizedPathfindingV3 === true) return current;
 
-  // Several legacy movement wrappers spread the pathfinder object and then replace
-  // findPath. That accidentally preserves the V2 flags even though the V2 function
-  // itself is gone. Clear only those ownership flags, then install V2 around the
-  // final rule-aware surface (terrain + occupancy + edge legality).
   host.LuminousVttPathfinding = Object.freeze({
     ...current,
     __straightRouteTieBreakPatch: false,
@@ -73,10 +70,6 @@ function installPreviewCellGate(host = globalThis, engine = host?.LuminousVttRun
     lastKey = key;
   };
 
-  // Movement preview currently has two mousemove consumers: Engine emits the
-  // semantic destination-preview event, while movement-bootstrap also plans from
-  // window.mousemove. Capture-phase gating removes duplicate same-cell work before
-  // either consumer runs, without touching the final mouseup resolver.
   host.addEventListener?.('mousemove', onMouseMove, true);
   host.addEventListener?.('mousedown', reset, true);
   host.addEventListener?.('mouseup', reset, true);
@@ -154,9 +147,6 @@ function installRealtimeTraversalSimplifier(host = globalThis, engine = host?.Lu
   const patchedAnimate = async function realtimeAnimateTokenPath(token, path = [], options = {}) {
     const points = normalizedPoints(path);
     const interactions = Array.isArray(options.doorInteractions) ? options.doorInteractions : [];
-
-    // Door and other interaction routes keep the authoritative segmented traversal.
-    // Those pauses have gameplay meaning and must not be hidden by the fast visual path.
     if (!token || points.length < 2 || interactions.length) {
       return originalAnimate.call(engine, token, path, options);
     }
@@ -169,9 +159,6 @@ function installRealtimeTraversalSimplifier(host = globalThis, engine = host?.Lu
     const running = mode === 'dash' || mode === 'run';
     const gridSize = Math.max(1, finite(mapData.grid?.size, 70));
     const cells = metrics.total / gridSize;
-
-    // Visual traversal is intentionally short and capped. Distance/cost rules remain
-    // untouched; this controls presentation latency only.
     const defaultPerCell = running ? 9 : 14;
     const defaultMinMs = running ? 55 : 70;
     const defaultMaxMs = running ? 120 : 180;
@@ -222,8 +209,6 @@ function installRealtimeTraversalSimplifier(host = globalThis, engine = host?.Lu
             destination,
             realtimeVisual: true,
           }, {
-            // Rendering follows the RAF, but expensive FOV/fog invalidation waits for
-            // the canonical vtt:token-moved emitted immediately after this completes.
             reason: 'token',
             render: true,
             vision: false,

--- a/js/vtt/movement-zero-work-drag.js
+++ b/js/vtt/movement-zero-work-drag.js
@@ -1,0 +1,122 @@
+const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+const clean = (value) => String(value ?? '').trim();
+
+export function installZeroWorkDrag(host = globalThis) {
+  if (host?.LuminousVttZeroWorkDrag?.__v1) return host.LuminousVttZeroWorkDrag;
+
+  let stopped = false;
+  let lastCellKey = '';
+  let hud = null;
+  const metrics = {
+    pointerMoves: 0,
+    cellChanges: 0,
+    blockedLegacyMouseMoves: 0,
+    worldPreviewCalls: 0,
+    pathfindingCalls: 0,
+  };
+
+  const runtime = () => host?.LuminousVttRuntime || null;
+
+  function ensureHud() {
+    if (hud?.isConnected) return hud;
+    hud = host?.document?.getElementById?.('vtt-fast-drag-hud') || null;
+    if (hud) return hud;
+    const doc = host?.document;
+    if (!doc?.body) return null;
+    hud = doc.createElement('div');
+    hud.id = 'vtt-fast-drag-hud';
+    hud.hidden = true;
+    hud.style.cssText = 'position:fixed;z-index:36050;pointer-events:none;padding:4px 7px;border:1px solid #fff;background:#090909;color:#fff;font:700 11px monospace;box-shadow:2px 2px 0 #000;transform:translate(12px,12px);will-change:left,top;';
+    doc.body.appendChild(hud);
+    return hud;
+  }
+
+  function hideHud() {
+    if (hud) hud.hidden = true;
+  }
+
+  function distanceFt(engine, drag, targetCell) {
+    const pathfinding = host?.LuminousVttPathfinding;
+    if (!pathfinding?.cellFromPoint) return 0;
+    const mapData = engine.mapData || {};
+    const startCell = pathfinding.cellFromPoint({ x: drag.originX, y: drag.originY }, mapData);
+    const dx = Math.abs(finite(targetCell?.col) - finite(startCell?.col));
+    const dy = Math.abs(finite(targetCell?.row) - finite(startCell?.row));
+    const feet = Math.max(0.001, finite(mapData.grid?.distancePerCell, 5));
+    const diagonal = clean(mapData.movement?.diagonalRule).toLowerCase();
+    return ['euclidean', 'sqrt2', 'real'].includes(diagonal)
+      ? Math.hypot(dx, dy) * feet
+      : Math.max(dx, dy) * feet;
+  }
+
+  function onMouseMove(event) {
+    const engine = runtime()?.engine;
+    const drag = engine?.tokenDrag;
+    if (!engine || !drag?.token || typeof engine.eventWorldPoint !== 'function') return;
+
+    metrics.pointerMoves += 1;
+    const pathfinding = host?.LuminousVttPathfinding;
+    if (!pathfinding?.cellFromPoint) return;
+    const world = engine.eventWorldPoint(event);
+    const target = {
+      x: finite(world?.x) - finite(drag.grabOffsetX),
+      y: finite(world?.y) - finite(drag.grabOffsetY),
+    };
+    const cell = pathfinding.cellFromPoint(target, engine.mapData || {});
+    const key = `${clean(drag.token.id)}:${cell.col}:${cell.row}`;
+    const node = ensureHud();
+    if (node) {
+      node.style.left = `${Math.round(finite(event.clientX))}px`;
+      node.style.top = `${Math.round(finite(event.clientY))}px`;
+      if (key !== lastCellKey) {
+        node.textContent = `${Math.round(distanceFt(engine, drag, cell))} ft`;
+        metrics.cellChanges += 1;
+        lastCellKey = key;
+      }
+      node.hidden = false;
+    }
+
+    // Intentionally kill every downstream token-drag mousemove consumer.
+    // Final validation still runs on mouseup. During drag we need cursor feedback,
+    // not pathfinding, world render, FOV, scene-dirty, or route reconstruction.
+    metrics.blockedLegacyMouseMoves += 1;
+    event.stopImmediatePropagation?.();
+  }
+
+  function reset() {
+    lastCellKey = '';
+    hideHud();
+  }
+
+  // Loaded before all other movement drag capture patches. This listener owns token
+  // drag mousemove and prevents legacy listeners from reaching the main thread.
+  host?.addEventListener?.('mousemove', onMouseMove, true);
+  host?.addEventListener?.('mouseup', reset, true);
+  host?.addEventListener?.('blur', reset, true);
+
+  const api = Object.freeze({
+    __v1: true,
+    snapshot() {
+      return Object.freeze({
+        ...metrics,
+        active: Boolean(runtime()?.engine?.tokenDrag),
+        hudVisible: Boolean(hud && !hud.hidden),
+      });
+    },
+    stop() {
+      if (stopped) return false;
+      stopped = true;
+      host?.removeEventListener?.('mousemove', onMouseMove, true);
+      host?.removeEventListener?.('mouseup', reset, true);
+      host?.removeEventListener?.('blur', reset, true);
+      reset();
+      if (host.LuminousVttZeroWorkDrag === api) delete host.LuminousVttZeroWorkDrag;
+      return true;
+    },
+  });
+
+  host.LuminousVttZeroWorkDrag = api;
+  return api;
+}
+
+if (typeof window !== 'undefined') installZeroWorkDrag(window);

--- a/js/vtt/movement-zero-work-drag.js
+++ b/js/vtt/movement-zero-work-drag.js
@@ -13,9 +13,12 @@ export function installZeroWorkDrag(host = globalThis) {
     blockedLegacyMouseMoves: 0,
     worldPreviewCalls: 0,
     pathfindingCalls: 0,
+    handlerTotalMs: 0,
+    handlerMaxMs: 0,
   };
 
   const runtime = () => host?.LuminousVttRuntime || null;
+  const now = () => host?.performance?.now?.() ?? Date.now();
 
   function ensureHud() {
     if (hud?.isConnected) return hud;
@@ -54,33 +57,40 @@ export function installZeroWorkDrag(host = globalThis) {
     const drag = engine?.tokenDrag;
     if (!engine || !drag?.token || typeof engine.eventWorldPoint !== 'function') return;
 
-    metrics.pointerMoves += 1;
-    const pathfinding = host?.LuminousVttPathfinding;
-    if (!pathfinding?.cellFromPoint) return;
-    const world = engine.eventWorldPoint(event);
-    const target = {
-      x: finite(world?.x) - finite(drag.grabOffsetX),
-      y: finite(world?.y) - finite(drag.grabOffsetY),
-    };
-    const cell = pathfinding.cellFromPoint(target, engine.mapData || {});
-    const key = `${clean(drag.token.id)}:${cell.col}:${cell.row}`;
-    const node = ensureHud();
-    if (node) {
-      node.style.left = `${Math.round(finite(event.clientX))}px`;
-      node.style.top = `${Math.round(finite(event.clientY))}px`;
-      if (key !== lastCellKey) {
-        node.textContent = `${Math.round(distanceFt(engine, drag, cell))} ft`;
-        metrics.cellChanges += 1;
-        lastCellKey = key;
+    const startedAt = now();
+    try {
+      metrics.pointerMoves += 1;
+      const pathfinding = host?.LuminousVttPathfinding;
+      if (!pathfinding?.cellFromPoint) return;
+      const world = engine.eventWorldPoint(event);
+      const target = {
+        x: finite(world?.x) - finite(drag.grabOffsetX),
+        y: finite(world?.y) - finite(drag.grabOffsetY),
+      };
+      const cell = pathfinding.cellFromPoint(target, engine.mapData || {});
+      const key = `${clean(drag.token.id)}:${cell.col}:${cell.row}`;
+      const node = ensureHud();
+      if (node) {
+        node.style.left = `${Math.round(finite(event.clientX))}px`;
+        node.style.top = `${Math.round(finite(event.clientY))}px`;
+        if (key !== lastCellKey) {
+          node.textContent = `${Math.round(distanceFt(engine, drag, cell))} ft`;
+          metrics.cellChanges += 1;
+          lastCellKey = key;
+        }
+        node.hidden = false;
       }
-      node.hidden = false;
-    }
 
-    // Intentionally kill every downstream token-drag mousemove consumer.
-    // Final validation still runs on mouseup. During drag we need cursor feedback,
-    // not pathfinding, world render, FOV, scene-dirty, or route reconstruction.
-    metrics.blockedLegacyMouseMoves += 1;
-    event.stopImmediatePropagation?.();
+      // Intentionally kill every downstream token-drag mousemove consumer.
+      // Final validation still runs on mouseup. During drag we need cursor feedback,
+      // not pathfinding, world render, FOV, scene-dirty, or route reconstruction.
+      metrics.blockedLegacyMouseMoves += 1;
+      event.stopImmediatePropagation?.();
+    } finally {
+      const elapsed = Math.max(0, now() - startedAt);
+      metrics.handlerTotalMs += elapsed;
+      metrics.handlerMaxMs = Math.max(metrics.handlerMaxMs, elapsed);
+    }
   }
 
   function reset() {
@@ -99,6 +109,7 @@ export function installZeroWorkDrag(host = globalThis) {
     snapshot() {
       return Object.freeze({
         ...metrics,
+        handlerAvgMs: metrics.pointerMoves ? metrics.handlerTotalMs / metrics.pointerMoves : 0,
         active: Boolean(runtime()?.engine?.tokenDrag),
         hudVisible: Boolean(hud && !hud.hidden),
       });

--- a/js/vtt/procedural-generator-bootstrap.js
+++ b/js/vtt/procedural-generator-bootstrap.js
@@ -8,11 +8,13 @@ import './procedural-building-generator.js';
 import './procedural-building-mix-patch.js';
 import './procedural-generator-core.js';
 import './procedural-map-authoring-patch.js';
+import { installProceduralPerformanceRuntime } from './procedural-performance-runtime.js';
 
 export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine?.mapData}={}){
   if(!runtime?.engine||!mapData)return null;
   if(window.LuminousVttProceduralGeneratorRuntime?.api)return window.LuminousVttProceduralGeneratorRuntime.api;
   window.LuminousVttProceduralMapAuthoringPatch?.install?.();
+  const performanceRuntime=installProceduralPerformanceRuntime({runtime,mapData});
   const core=window.LuminousVttProceduralGenerator,zoneCore=window.LuminousVttProceduralZone,fabric=window.LuminousVttUrbanFabric,buildings=window.LuminousVttProceduralBuildings;
   if(!core||!zoneCore||!fabric||!buildings)throw new Error('PROCEDURAL_GENERATOR_RUNTIME_REQUIRED');
   let lastPlan=null,worker=null,workerSeq=0;
@@ -71,13 +73,13 @@ export function start({runtime=window.LuminousVttRuntime,mapData=runtime?.engine
   }
   async function createZone(options={},applyOptions={}){const plan=await previewAsync(options);apply(plan,{...applyOptions,persist:false});await persist(plan);return plan;}
   const api=Object.freeze({
-    core,zoneCore,fabric,buildings,
+    core,zoneCore,fabric,buildings,performance:performanceRuntime,
     profiles:()=>Object.values(fabric.PROFILES).map(x=>({...x})),
     profile:(id='mixed_urban')=>({...fabric.normalizeProfile(id)}),
     buildingMix:(id='mixed_urban')=>({...buildings.normalizeBuildingMix?.(buildings.WEIGHTS?.[id]||buildings.WEIGHTS?.mixed_urban,id)}),
     preview,previewAsync,apply,persist,createZone,generateAndApply:createZone,getLastPlan:()=>lastPlan,currentMetadata:()=>mapData.procedural||null,
     continuationRequirements:(zone=lastPlan?.zone||mapData.procedural?.zone)=>zone?zoneCore.continuationRequirements(zone):[],validatePlan:(plan=lastPlan)=>plan?.validation||null,
-    stop(){lastPlan=null;for(const request of pendingWorkerRequests.values())request.reject(new Error('PROCEDURAL_GENERATOR_STOPPED'));pendingWorkerRequests.clear();try{worker?.terminate?.();}catch(_){}worker=null;},
+    stop(){lastPlan=null;for(const request of pendingWorkerRequests.values())request.reject(new Error('PROCEDURAL_GENERATOR_STOPPED'));pendingWorkerRequests.clear();try{worker?.terminate?.();}catch(_){}worker=null;performanceRuntime?.stop?.();},
   });
   window.LuminousVttProceduralGeneratorRuntime={api};window.LuminousVttRuntime=Object.freeze({...window.LuminousVttRuntime,procedural:api});return api;
 }

--- a/js/vtt/procedural-performance-runtime.js
+++ b/js/vtt/procedural-performance-runtime.js
@@ -1,5 +1,4 @@
 const finite=(value,fallback=0)=>Number.isFinite(Number(value))?Number(value):fallback;
-const clean=value=>String(value??'').trim();
 
 function pointFrom(value,size=70){
   if(!value||typeof value!=='object')return null;
@@ -89,11 +88,12 @@ export function installProceduralPerformanceRuntime({runtime=globalThis.Luminous
   if(globalThis.LuminousVttProceduralPerformance?.__v1)return globalThis.LuminousVttProceduralPerformance;
   const engine=runtime.engine,renderer=engine.renderer,size=Math.max(1,finite(mapData.grid?.size,70));
   let enabled=true,stopped=false;
-  const metrics={renderFrames:0,cullTotalMs:0,cullMaxMs:0,visionCalls:0,visionFilterTotalMs:0,visionFilterMaxMs:0,lastTotals:null,lastVisible:null,lastVisionTotal:0,lastVisionCandidates:0};
+  const metrics={renderFrames:0,cullPrepTotalMs:0,cullPrepMaxMs:0,frameTotalMs:0,frameMaxMs:0,visionCalls:0,visionFilterTotalMs:0,visionFilterMaxMs:0,lastTotals:null,lastVisible:null,lastVisionTotal:0,lastVisionCandidates:0};
 
   const originalVisionWalls=engine.visionWallsForLayer?.bind(engine);
+  let wrappedVisionWalls=null;
   if(originalVisionWalls){
-    engine.visionWallsForLayer=function proceduralVisionWalls(zLayer){
+    wrappedVisionWalls=function proceduralVisionWalls(zLayer){
       const started=performance.now();
       const all=originalVisionWalls(zLayer)||[];
       if(!enabled||all.length<32){metrics.lastVisionTotal=all.length;metrics.lastVisionCandidates=all.length;return all;}
@@ -107,6 +107,7 @@ export function installProceduralPerformanceRuntime({runtime=globalThis.Luminous
       metrics.visionCalls+=1;metrics.visionFilterTotalMs+=elapsed;metrics.visionFilterMaxMs=Math.max(metrics.visionFilterMaxMs,elapsed);metrics.lastVisionTotal=all.length;metrics.lastVisionCandidates=filtered.length;
       return filtered;
     };
+    engine.visionWallsForLayer=wrappedVisionWalls;
   }
 
   const originalRender=renderer?.render?.bind(renderer);
@@ -116,7 +117,7 @@ export function installProceduralPerformanceRuntime({runtime=globalThis.Luminous
       if(!enabled||isExporting)return originalRender(camera,activeZ,renderData,isExporting);
       const bounds=cameraBounds(engine,camera,2);
       if(!bounds)return originalRender(camera,activeZ,renderData,isExporting);
-      const started=performance.now(),originals={
+      const frameStarted=performance.now(),prepStarted=frameStarted,originals={
         topology:mapData.topology,walls:mapData.walls,structures:mapData.structures,worldObjects:mapData.worldObjects,horizontalPlanes:mapData.horizontalPlanes,surfaceLayers:mapData.surfaceLayers,
       };
       const totals=sceneCounts(mapData,activeZ);
@@ -128,10 +129,11 @@ export function installProceduralPerformanceRuntime({runtime=globalThis.Luminous
         if(Array.isArray(originals.horizontalPlanes))mapData.horizontalPlanes=originals.horizontalPlanes.filter(item=>planeVisible(item,bounds,size));
         if(originals.surfaceLayers)mapData.surfaceLayers=surfaceLayerInBounds(mapData,activeZ,bounds);
         metrics.lastTotals=totals;metrics.lastVisible=sceneCounts(mapData,activeZ);
+        const prepElapsed=performance.now()-prepStarted;metrics.cullPrepTotalMs+=prepElapsed;metrics.cullPrepMaxMs=Math.max(metrics.cullPrepMaxMs,prepElapsed);
         return originalRender(camera,activeZ,renderData,isExporting);
       }finally{
         mapData.topology=originals.topology;mapData.walls=originals.walls;mapData.structures=originals.structures;mapData.worldObjects=originals.worldObjects;mapData.horizontalPlanes=originals.horizontalPlanes;mapData.surfaceLayers=originals.surfaceLayers;
-        const elapsed=performance.now()-started;metrics.renderFrames+=1;metrics.cullTotalMs+=elapsed;metrics.cullMaxMs=Math.max(metrics.cullMaxMs,elapsed);
+        const frameElapsed=performance.now()-frameStarted;metrics.renderFrames+=1;metrics.frameTotalMs+=frameElapsed;metrics.frameMaxMs=Math.max(metrics.frameMaxMs,frameElapsed);
       }
     };
     renderer.render=wrappedRender;
@@ -142,10 +144,10 @@ export function installProceduralPerformanceRuntime({runtime=globalThis.Luminous
     setEnabled(value){enabled=Boolean(value);return enabled;},
     get enabled(){return enabled;},
     bounds:()=>cameraBounds(engine,engine.camera,2),
-    snapshot(){return Object.freeze({...metrics,avgCullMs:metrics.renderFrames?metrics.cullTotalMs/metrics.renderFrames:0,avgVisionFilterMs:metrics.visionCalls?metrics.visionFilterTotalMs/metrics.visionCalls:0,enabled});},
+    snapshot(){return Object.freeze({...metrics,avgCullPrepMs:metrics.renderFrames?metrics.cullPrepTotalMs/metrics.renderFrames:0,avgFrameMs:metrics.renderFrames?metrics.frameTotalMs/metrics.renderFrames:0,avgVisionFilterMs:metrics.visionCalls?metrics.visionFilterTotalMs/metrics.visionCalls:0,enabled});},
     stop(){
       if(stopped)return false;stopped=true;
-      if(originalVisionWalls&&engine.visionWallsForLayer!==originalVisionWalls)engine.visionWallsForLayer=originalVisionWalls;
+      if(wrappedVisionWalls&&engine.visionWallsForLayer===wrappedVisionWalls)engine.visionWallsForLayer=originalVisionWalls;
       if(wrappedRender&&renderer.render===wrappedRender)renderer.render=originalRender;
       if(globalThis.LuminousVttProceduralPerformance===api)delete globalThis.LuminousVttProceduralPerformance;
       return true;

--- a/js/vtt/procedural-performance-runtime.js
+++ b/js/vtt/procedural-performance-runtime.js
@@ -1,0 +1,156 @@
+const finite=(value,fallback=0)=>Number.isFinite(Number(value))?Number(value):fallback;
+const clean=value=>String(value??'').trim();
+
+function pointFrom(value,size=70){
+  if(!value||typeof value!=='object')return null;
+  if(Number.isFinite(Number(value.x))&&Number.isFinite(Number(value.y)))return{x:Number(value.x),y:Number(value.y)};
+  if(Number.isFinite(Number(value.col))&&Number.isFinite(Number(value.row)))return{x:Number(value.col)*size,y:Number(value.row)*size};
+  return null;
+}
+
+function cameraBounds(engine,camera=engine?.camera,paddingCells=2){
+  if(!engine?.canvas||typeof camera?.screenToWorld!=='function')return null;
+  const rect=engine.canvas.getBoundingClientRect?.();
+  const width=Math.max(1,finite(rect?.width,engine.canvas.clientWidth||engine.canvas.width||1));
+  const height=Math.max(1,finite(rect?.height,engine.canvas.clientHeight||engine.canvas.height||1));
+  const a=camera.screenToWorld(0,0),b=camera.screenToWorld(width,height);
+  const pad=Math.max(0,finite(engine.mapData?.grid?.size,70)*paddingCells);
+  return{minX:Math.min(a.x,b.x)-pad,minY:Math.min(a.y,b.y)-pad,maxX:Math.max(a.x,b.x)+pad,maxY:Math.max(a.y,b.y)+pad};
+}
+
+function rectIntersects(bounds,minX,minY,maxX,maxY,padding=0){
+  if(!bounds)return true;
+  const pad=Math.max(0,finite(padding));
+  return !(maxX<bounds.minX-pad||minX>bounds.maxX+pad||maxY<bounds.minY-pad||minY>bounds.maxY+pad);
+}
+
+function segmentVisible(raw,bounds,size,padding=0){
+  if(!bounds||!raw)return true;
+  if([raw.x1,raw.y1,raw.x2,raw.y2].every(v=>Number.isFinite(Number(v)))){
+    return rectIntersects(bounds,Math.min(Number(raw.x1),Number(raw.x2)),Math.min(Number(raw.y1),Number(raw.y2)),Math.max(Number(raw.x1),Number(raw.x2)),Math.max(Number(raw.y1),Number(raw.y2)),padding);
+  }
+  const a=pointFrom(raw.a||raw.from||raw.start||raw.p1,size),b=pointFrom(raw.b||raw.to||raw.end||raw.p2,size);
+  if(!a||!b)return true;
+  return rectIntersects(bounds,Math.min(a.x,b.x),Math.min(a.y,b.y),Math.max(a.x,b.x),Math.max(a.y,b.y),padding);
+}
+
+function structureVisible(raw,bounds,size){
+  if(!raw||!bounds)return true;
+  if(segmentVisible(raw,bounds,size,size))return true;
+  const p=pointFrom(raw.position||raw.gridPosition||raw,size)||pointFrom(raw,size);
+  return p?rectIntersects(bounds,p.x,p.y,p.x,p.y,size*2):true;
+}
+
+function objectVisible(raw,bounds,size){
+  if(!raw||!bounds)return true;
+  const p=pointFrom(raw.position||raw.gridPosition||raw.anchor||raw,size)||pointFrom(raw,size);
+  return p?rectIntersects(bounds,p.x,p.y,p.x,p.y,size*4):true;
+}
+
+function planeVisible(raw,bounds,size){
+  if(!raw||!bounds)return true;
+  const g=raw.footprint||raw.geometry||raw.rect;
+  if(g&&[g.minCol,g.minRow,g.maxCol,g.maxRow].every(v=>Number.isFinite(Number(v)))){
+    return rectIntersects(bounds,Number(g.minCol)*size,Number(g.minRow)*size,(Number(g.maxCol)+1)*size,(Number(g.maxRow)+1)*size,size);
+  }
+  return true;
+}
+
+function surfaceLayerInBounds(mapData,zLayer,bounds){
+  const layers=mapData.surfaceLayers;
+  if(!layers||!bounds)return layers;
+  const key=String(Number(zLayer)||0),source=layers[key];
+  if(!source||typeof source!=='object')return layers;
+  const size=Math.max(1,finite(mapData.grid?.size,70));
+  const cols=Math.max(1,Math.trunc(finite(mapData.grid?.cols,1))),rows=Math.max(1,Math.trunc(finite(mapData.grid?.rows,1)));
+  const minCol=Math.max(0,Math.floor(bounds.minX/size)),maxCol=Math.min(cols-1,Math.floor(bounds.maxX/size));
+  const minRow=Math.max(0,Math.floor(bounds.minY/size)),maxRow=Math.min(rows-1,Math.floor(bounds.maxY/size));
+  const visible={};
+  for(let row=minRow;row<=maxRow;row++)for(let col=minCol;col<=maxCol;col++){
+    const cellKey=`${col}_${row}`;
+    if(source[cellKey]!=null)visible[cellKey]=source[cellKey];
+  }
+  return{...layers,[key]:visible};
+}
+
+function sceneCounts(mapData,zLayer){
+  return{
+    topology:Array.isArray(mapData.topology)?mapData.topology.length:0,
+    walls:Array.isArray(mapData.walls)?mapData.walls.length:0,
+    structures:Array.isArray(mapData.structures)?mapData.structures.length:0,
+    worldObjects:Array.isArray(mapData.worldObjects)?mapData.worldObjects.length:0,
+    horizontalPlanes:Array.isArray(mapData.horizontalPlanes)?mapData.horizontalPlanes.length:0,
+    surfaces:Object.keys(mapData.surfaceLayers?.[String(Number(zLayer)||0)]||{}).length,
+  };
+}
+
+export function installProceduralPerformanceRuntime({runtime=globalThis.LuminousVttRuntime,mapData=runtime?.engine?.mapData}={}){
+  if(!runtime?.engine||!mapData)return null;
+  if(globalThis.LuminousVttProceduralPerformance?.__v1)return globalThis.LuminousVttProceduralPerformance;
+  const engine=runtime.engine,renderer=engine.renderer,size=Math.max(1,finite(mapData.grid?.size,70));
+  let enabled=true,stopped=false;
+  const metrics={renderFrames:0,cullTotalMs:0,cullMaxMs:0,visionCalls:0,visionFilterTotalMs:0,visionFilterMaxMs:0,lastTotals:null,lastVisible:null,lastVisionTotal:0,lastVisionCandidates:0};
+
+  const originalVisionWalls=engine.visionWallsForLayer?.bind(engine);
+  if(originalVisionWalls){
+    engine.visionWallsForLayer=function proceduralVisionWalls(zLayer){
+      const started=performance.now();
+      const all=originalVisionWalls(zLayer)||[];
+      if(!enabled||all.length<32){metrics.lastVisionTotal=all.length;metrics.lastVisionCandidates=all.length;return all;}
+      const viewer=engine.viewerToken?.();
+      if(!viewer){metrics.lastVisionTotal=all.length;metrics.lastVisionCandidates=all.length;return all;}
+      const profile=engine.visionProfile?.(viewer);
+      const radius=Math.max(size*2,finite(profile?.radiusPx,engine.legacyVisionRadius||400))+size*2;
+      const bounds={minX:finite(viewer.x)-radius,minY:finite(viewer.y)-radius,maxX:finite(viewer.x)+radius,maxY:finite(viewer.y)+radius};
+      const filtered=all.filter(wall=>segmentVisible(wall,bounds,size,size));
+      const elapsed=performance.now()-started;
+      metrics.visionCalls+=1;metrics.visionFilterTotalMs+=elapsed;metrics.visionFilterMaxMs=Math.max(metrics.visionFilterMaxMs,elapsed);metrics.lastVisionTotal=all.length;metrics.lastVisionCandidates=filtered.length;
+      return filtered;
+    };
+  }
+
+  const originalRender=renderer?.render?.bind(renderer);
+  let wrappedRender=null;
+  if(originalRender){
+    wrappedRender=function proceduralCulledRender(camera,activeZ,renderData,isExporting=false){
+      if(!enabled||isExporting)return originalRender(camera,activeZ,renderData,isExporting);
+      const bounds=cameraBounds(engine,camera,2);
+      if(!bounds)return originalRender(camera,activeZ,renderData,isExporting);
+      const started=performance.now(),originals={
+        topology:mapData.topology,walls:mapData.walls,structures:mapData.structures,worldObjects:mapData.worldObjects,horizontalPlanes:mapData.horizontalPlanes,surfaceLayers:mapData.surfaceLayers,
+      };
+      const totals=sceneCounts(mapData,activeZ);
+      try{
+        if(Array.isArray(originals.topology))mapData.topology=originals.topology.filter(item=>segmentVisible(item,bounds,size,size));
+        if(Array.isArray(originals.walls))mapData.walls=originals.walls.filter(item=>segmentVisible(item,bounds,size,size));
+        if(Array.isArray(originals.structures))mapData.structures=originals.structures.filter(item=>structureVisible(item,bounds,size));
+        if(Array.isArray(originals.worldObjects))mapData.worldObjects=originals.worldObjects.filter(item=>objectVisible(item,bounds,size));
+        if(Array.isArray(originals.horizontalPlanes))mapData.horizontalPlanes=originals.horizontalPlanes.filter(item=>planeVisible(item,bounds,size));
+        if(originals.surfaceLayers)mapData.surfaceLayers=surfaceLayerInBounds(mapData,activeZ,bounds);
+        metrics.lastTotals=totals;metrics.lastVisible=sceneCounts(mapData,activeZ);
+        return originalRender(camera,activeZ,renderData,isExporting);
+      }finally{
+        mapData.topology=originals.topology;mapData.walls=originals.walls;mapData.structures=originals.structures;mapData.worldObjects=originals.worldObjects;mapData.horizontalPlanes=originals.horizontalPlanes;mapData.surfaceLayers=originals.surfaceLayers;
+        const elapsed=performance.now()-started;metrics.renderFrames+=1;metrics.cullTotalMs+=elapsed;metrics.cullMaxMs=Math.max(metrics.cullMaxMs,elapsed);
+      }
+    };
+    renderer.render=wrappedRender;
+  }
+
+  const api=Object.freeze({
+    __v1:true,
+    setEnabled(value){enabled=Boolean(value);return enabled;},
+    get enabled(){return enabled;},
+    bounds:()=>cameraBounds(engine,engine.camera,2),
+    snapshot(){return Object.freeze({...metrics,avgCullMs:metrics.renderFrames?metrics.cullTotalMs/metrics.renderFrames:0,avgVisionFilterMs:metrics.visionCalls?metrics.visionFilterTotalMs/metrics.visionCalls:0,enabled});},
+    stop(){
+      if(stopped)return false;stopped=true;
+      if(originalVisionWalls&&engine.visionWallsForLayer!==originalVisionWalls)engine.visionWallsForLayer=originalVisionWalls;
+      if(wrappedRender&&renderer.render===wrappedRender)renderer.render=originalRender;
+      if(globalThis.LuminousVttProceduralPerformance===api)delete globalThis.LuminousVttProceduralPerformance;
+      return true;
+    },
+  });
+  globalThis.LuminousVttProceduralPerformance=api;
+  return api;
+}

--- a/js/vtt/procedural-performance-runtime.js
+++ b/js/vtt/procedural-performance-runtime.js
@@ -1,5 +1,10 @@
 const finite=(value,fallback=0)=>Number.isFinite(Number(value))?Number(value):fallback;
 
+function proceduralScene(mapData){
+  const state=mapData?.procedural;
+  return Boolean(state&&(state.signature||state.generatorVersion||state.streaming||state.activeChunkSignature));
+}
+
 function pointFrom(value,size=70){
   if(!value||typeof value!=='object')return null;
   if(Number.isFinite(Number(value.x))&&Number.isFinite(Number(value.y)))return{x:Number(value.x),y:Number(value.y)};
@@ -94,9 +99,9 @@ export function installProceduralPerformanceRuntime({runtime=globalThis.Luminous
   let wrappedVisionWalls=null;
   if(originalVisionWalls){
     wrappedVisionWalls=function proceduralVisionWalls(zLayer){
-      const started=performance.now();
       const all=originalVisionWalls(zLayer)||[];
-      if(!enabled||all.length<32){metrics.lastVisionTotal=all.length;metrics.lastVisionCandidates=all.length;return all;}
+      if(!enabled||!proceduralScene(mapData)||all.length<32){metrics.lastVisionTotal=all.length;metrics.lastVisionCandidates=all.length;return all;}
+      const started=performance.now();
       const viewer=engine.viewerToken?.();
       if(!viewer){metrics.lastVisionTotal=all.length;metrics.lastVisionCandidates=all.length;return all;}
       const profile=engine.visionProfile?.(viewer);
@@ -114,7 +119,7 @@ export function installProceduralPerformanceRuntime({runtime=globalThis.Luminous
   let wrappedRender=null;
   if(originalRender){
     wrappedRender=function proceduralCulledRender(camera,activeZ,renderData,isExporting=false){
-      if(!enabled||isExporting)return originalRender(camera,activeZ,renderData,isExporting);
+      if(!enabled||!proceduralScene(mapData)||isExporting)return originalRender(camera,activeZ,renderData,isExporting);
       const bounds=cameraBounds(engine,camera,2);
       if(!bounds)return originalRender(camera,activeZ,renderData,isExporting);
       const frameStarted=performance.now(),prepStarted=frameStarted,originals={
@@ -143,8 +148,9 @@ export function installProceduralPerformanceRuntime({runtime=globalThis.Luminous
     __v1:true,
     setEnabled(value){enabled=Boolean(value);return enabled;},
     get enabled(){return enabled;},
+    get active(){return enabled&&proceduralScene(mapData);},
     bounds:()=>cameraBounds(engine,engine.camera,2),
-    snapshot(){return Object.freeze({...metrics,avgCullPrepMs:metrics.renderFrames?metrics.cullPrepTotalMs/metrics.renderFrames:0,avgFrameMs:metrics.renderFrames?metrics.frameTotalMs/metrics.renderFrames:0,avgVisionFilterMs:metrics.visionCalls?metrics.visionFilterTotalMs/metrics.visionCalls:0,enabled});},
+    snapshot(){return Object.freeze({...metrics,avgCullPrepMs:metrics.renderFrames?metrics.cullPrepTotalMs/metrics.renderFrames:0,avgFrameMs:metrics.renderFrames?metrics.frameTotalMs/metrics.renderFrames:0,avgVisionFilterMs:metrics.visionCalls?metrics.visionFilterTotalMs/metrics.visionCalls:0,enabled,active:enabled&&proceduralScene(mapData)});},
     stop(){
       if(stopped)return false;stopped=true;
       if(wrappedVisionWalls&&engine.visionWallsForLayer===wrappedVisionWalls)engine.visionWallsForLayer=originalVisionWalls;

--- a/tests/vtt_procedural_runtime_performance.spec.js
+++ b/tests/vtt_procedural_runtime_performance.spec.js
@@ -2,15 +2,6 @@ const { test, expect } = require('@playwright/test');
 
 const URL = process.env.VTT_FIELD_URL || 'http://127.0.0.1:4173/vtt.html';
 
-const countScene = (map, z = 0) => ({
-  topology: Array.isArray(map.topology) ? map.topology.length : 0,
-  walls: Array.isArray(map.walls) ? map.walls.length : 0,
-  structures: Array.isArray(map.structures) ? map.structures.length : 0,
-  worldObjects: Array.isArray(map.worldObjects) ? map.worldObjects.length : 0,
-  horizontalPlanes: Array.isArray(map.horizontalPlanes) ? map.horizontalPlanes.length : 0,
-  surfaces: Object.keys(map.surfaceLayers?.[String(Number(z) || 0)] || {}).length,
-});
-
 test('real procedural chunk culls render collections and localizes FOV wall work', async ({ page }) => {
   test.setTimeout(45000);
   await page.setViewportSize({ width: 1280, height: 720 });
@@ -66,7 +57,14 @@ test('real procedural chunk culls render collections and localizes FOV wall work
       validation: JSON.parse(JSON.stringify(plan.validation || {})),
       signature: plan.signature,
       grid: { cols, rows, size },
-      totals: countScene(map, 0),
+      totals: {
+        topology: Array.isArray(map.topology) ? map.topology.length : 0,
+        walls: Array.isArray(map.walls) ? map.walls.length : 0,
+        structures: Array.isArray(map.structures) ? map.structures.length : 0,
+        worldObjects: Array.isArray(map.worldObjects) ? map.worldObjects.length : 0,
+        horizontalPlanes: Array.isArray(map.horizontalPlanes) ? map.horizontalPlanes.length : 0,
+        surfaces: Object.keys(map.surfaceLayers?.['0'] || {}).length,
+      },
       renderer: engine.renderer?.backend || null,
     };
   });

--- a/tests/vtt_procedural_runtime_performance.spec.js
+++ b/tests/vtt_procedural_runtime_performance.spec.js
@@ -1,0 +1,136 @@
+const { test, expect } = require('@playwright/test');
+
+const URL = process.env.VTT_FIELD_URL || 'http://127.0.0.1:4173/vtt.html';
+
+const countScene = (map, z = 0) => ({
+  topology: Array.isArray(map.topology) ? map.topology.length : 0,
+  walls: Array.isArray(map.walls) ? map.walls.length : 0,
+  structures: Array.isArray(map.structures) ? map.structures.length : 0,
+  worldObjects: Array.isArray(map.worldObjects) ? map.worldObjects.length : 0,
+  horizontalPlanes: Array.isArray(map.horizontalPlanes) ? map.horizontalPlanes.length : 0,
+  surfaces: Object.keys(map.surfaceLayers?.[String(Number(z) || 0)] || {}).length,
+});
+
+test('real procedural chunk culls render collections and localizes FOV wall work', async ({ page }) => {
+  test.setTimeout(45000);
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto(URL, { waitUntil: 'domcontentloaded' });
+
+  await page.waitForFunction(() => Boolean(window.LuminousVttRuntime?.procedural?.previewAsync), null, { timeout: 20000 });
+  await page.waitForFunction(() => Boolean(window.LuminousVttProceduralPerformance?.__v1), null, { timeout: 10000 });
+
+  const setup = await page.evaluate(async () => {
+    const runtime = window.LuminousVttRuntime;
+    const engine = runtime.engine;
+    const map = engine.mapData;
+    const perf = window.LuminousVttProceduralPerformance;
+
+    const plan = await runtime.procedural.previewAsync({
+      profileId: 'mixed_urban',
+      seed: 'field:procedural-runtime-performance:v1',
+      maxAttempts: 8,
+      minBuildings: 3,
+    });
+    runtime.procedural.apply(plan, { replaceScene: true, persist: false });
+
+    const size = Number(map.grid?.size) || 70;
+    const cols = Number(map.grid?.cols) || 40;
+    const rows = Number(map.grid?.rows) || 40;
+    let token = (map.tokens || []).find((entry) => entry.id === 'player1')
+      || (map.tokens || []).find((entry) => entry.viewer === true)
+      || (map.tokens || [])[0];
+    if (!token) {
+      token = { id: 'procedural_perf_viewer', x: 0, y: 0, z: [0], zLayer: 0, gridPosition: { col: 0, row: 0, z: 0 } };
+      map.tokens ||= [];
+      map.tokens.push(token);
+    }
+    const col = Math.max(2, Math.min(cols - 3, Math.floor(cols / 2)));
+    const row = Math.max(2, Math.min(rows - 3, Math.floor(rows / 2)));
+    token.x = (col + 0.5) * size;
+    token.y = (row + 0.5) * size;
+    token.gridPosition = { col, row, z: 0 };
+    token.zLayer = 0;
+    token.z = [0];
+    token.viewer = true;
+    token.senses ||= {};
+    map.ambientLight ||= {};
+    map.ambientLight.level = 'bright';
+    engine.activeZ = 0;
+
+    engine.camera.setZoomBounds?.(0.05, 5);
+    engine.camera.zoom = 1;
+    engine.camera.centerOnWorldPoint?.({ x: token.x, y: token.y });
+    perf.setEnabled(true);
+
+    return {
+      validation: JSON.parse(JSON.stringify(plan.validation || {})),
+      signature: plan.signature,
+      grid: { cols, rows, size },
+      totals: countScene(map, 0),
+      renderer: engine.renderer?.backend || null,
+    };
+  });
+
+  // Let the actual engine loop exercise calculateVision + renderer.render repeatedly.
+  await page.waitForTimeout(750);
+
+  const result = await page.evaluate(() => {
+    const runtime = window.LuminousVttRuntime;
+    const engine = runtime.engine;
+    const map = engine.mapData;
+    const perf = window.LuminousVttProceduralPerformance;
+    const before = perf.snapshot();
+
+    // One explicit calculation makes the field independent from scheduler cadence.
+    const visionStarted = performance.now();
+    const vision = engine.calculateVision();
+    const visionElapsedMs = performance.now() - visionStarted;
+    engine.renderer.render(engine.camera, engine.activeZ, vision, false);
+    const after = perf.snapshot();
+
+    return {
+      before,
+      after,
+      visionElapsedMs,
+      totalsAfter: {
+        topology: Array.isArray(map.topology) ? map.topology.length : 0,
+        walls: Array.isArray(map.walls) ? map.walls.length : 0,
+        structures: Array.isArray(map.structures) ? map.structures.length : 0,
+        worldObjects: Array.isArray(map.worldObjects) ? map.worldObjects.length : 0,
+        horizontalPlanes: Array.isArray(map.horizontalPlanes) ? map.horizontalPlanes.length : 0,
+        surfaces: Object.keys(map.surfaceLayers?.[String(Number(engine.activeZ) || 0)] || {}).length,
+      },
+      fovPoints: Array.isArray(vision?.fovPolygon) ? vision.fovPolygon.length : 0,
+    };
+  });
+
+  const payload = { setup, ...result };
+  console.log('VTT_PROCEDURAL_PERF=' + JSON.stringify(payload));
+
+  expect(setup.validation.valid).toBe(true);
+  expect(setup.renderer).toBe('canvas2d');
+  expect(setup.totals.surfaces, 'real procedural plan must populate surface cells').toBeGreaterThan(500);
+  expect(setup.totals.topology, 'real procedural plan must populate topology').toBeGreaterThan(20);
+
+  expect(result.after.renderFrames, 'procedural culling wrapper must be exercised').toBeGreaterThan(0);
+  expect(result.after.visionCalls, 'vision wall locality filter must be exercised').toBeGreaterThan(0);
+  expect(result.after.lastTotals).toBeTruthy();
+  expect(result.after.lastVisible).toBeTruthy();
+
+  const totalSceneEntries = Object.values(result.after.lastTotals || {}).reduce((sum, value) => sum + Number(value || 0), 0);
+  const visibleSceneEntries = Object.values(result.after.lastVisible || {}).reduce((sum, value) => sum + Number(value || 0), 0);
+  expect(visibleSceneEntries, 'viewport culling must reduce loaded procedural render work').toBeLessThan(totalSceneEntries);
+  expect(result.after.lastVisible.surfaces, 'surface renderer must not scan the whole procedural floor').toBeLessThan(result.after.lastTotals.surfaces);
+
+  expect(result.after.lastVisionTotal).toBeGreaterThan(20);
+  expect(result.after.lastVisionCandidates, 'FOV should intersect only nearby procedural walls').toBeLessThan(result.after.lastVisionTotal);
+  expect(result.after.lastVisionCandidates).toBeGreaterThan(0);
+
+  expect(result.after.cullPrepMaxMs, 'viewport cull preparation should remain frame-cheap').toBeLessThan(25);
+  expect(result.after.visionFilterMaxMs, 'vision locality filtering itself should remain cheap').toBeLessThan(20);
+  expect(result.visionElapsedMs, 'one loaded procedural FOV calculation must not create a long task').toBeLessThan(50);
+
+  // The culling wrapper is temporary only; canonical scene collections must be intact afterwards.
+  expect(result.totalsAfter.topology).toBe(setup.totals.topology);
+  expect(result.totalsAfter.surfaces).toBe(setup.totals.surfaces);
+});

--- a/tests/vtt_realtime_traversal_simplification.spec.js
+++ b/tests/vtt_realtime_traversal_simplification.spec.js
@@ -30,6 +30,7 @@ async function bootLoadedMap(page) {
   await page.waitForFunction(() => Boolean(window.LuminousVttPathfinding?.__runtimeFinalizedPathfindingV3), null, { timeout: 5000 });
   await page.waitForFunction(() => Boolean(window.LuminousVttLongDragHotfix?.__v1), null, { timeout: 5000 });
   await page.waitForFunction(() => Boolean(window.LuminousVttDirectRouteHotfix?.__v1), null, { timeout: 5000 });
+  await page.waitForFunction(() => Boolean(window.LuminousVttZeroWorkDrag?.__v1), null, { timeout: 5000 });
   await page.waitForFunction(() => Boolean(window.LuminousVttRuntime?.engine?.__realtimeTraversalSimplifierV1), null, { timeout: 5000 });
 
   await page.evaluate(() => {
@@ -53,8 +54,6 @@ async function bootLoadedMap(page) {
     delete map.movement.realtimeAnimationMinMs;
     delete map.movement.realtimeAnimationMaxMs;
 
-    // Hundreds of topology records reproduce the real loaded-map cost without
-    // blocking the horizontal test corridor on row 10.
     map.topology = Array.from({ length: 900 }, (_, index) => {
       const row = 40 + (index % 70);
       const col = 1 + ((index * 7) % 115);
@@ -86,20 +85,26 @@ async function bootLoadedMap(page) {
     window.LuminousVttDirectRouteHotfix.ensure();
     const baselineLong = window.LuminousVttLongDragHotfix.snapshot();
     const baselineDirect = window.LuminousVttDirectRouteHotfix.snapshot();
+    const baselineZero = window.LuminousVttZeroWorkDrag.snapshot();
     window.__longDragProbe = {
       baselineLong,
       baselineDirect,
+      baselineZero,
       mouseUpAt: null,
       movedAt: null,
       firstFrameAt: null,
       moved: null,
       rejected: null,
       traversalFrames: 0,
+      destinationPreviewEvents: 0,
     };
 
     window.addEventListener('mouseup', () => {
       window.__longDragProbe.mouseUpAt ??= performance.now();
     }, true);
+    engine.canvas.addEventListener('vtt:movement-destination-preview', () => {
+      window.__longDragProbe.destinationPreviewEvents += 1;
+    });
     engine.canvas.addEventListener('vtt:token-preview-moved', (event) => {
       if (!event.detail?.traversing) return;
       window.__longDragProbe.firstFrameAt ??= performance.now();
@@ -131,20 +136,32 @@ async function dragToColumn(page, targetCol = 70) {
 
   await page.mouse.move(points.start.x, points.start.y);
   await page.mouse.down({ button: 'left' });
-  const dragStarted = Date.now();
-  for (let index = 1; index <= 90; index += 1) {
-    const t = index / 90;
-    await page.mouse.move(
-      points.start.x + ((points.target.x - points.start.x) * t),
-      points.start.y + ((points.target.y - points.start.y) * t),
-    );
-    await page.waitForTimeout(6);
-  }
-  const dragElapsedMs = Date.now() - dragStarted;
+
+  // Generate the stress sweep inside Chrome. Measuring 90 page.mouse.move calls
+  // measures DevTools protocol round-trips, not the browser's drag CPU cost.
+  const syntheticDispatchMs = await page.evaluate(({ start, target }) => {
+    const startedAt = performance.now();
+    for (let index = 1; index <= 90; index += 1) {
+      const t = index / 90;
+      window.dispatchEvent(new MouseEvent('mousemove', {
+        bubbles: true,
+        cancelable: true,
+        clientX: start.x + ((target.x - start.x) * t),
+        clientY: start.y + ((target.y - start.y) * t),
+        buttons: 1,
+      }));
+    }
+    return performance.now() - startedAt;
+  }, points);
+
+  // Put Chromium's real pointer at the same final coordinate before mouseup.
+  await page.mouse.move(points.target.x, points.target.y);
 
   const beforeDrop = await page.evaluate(() => ({
     long: window.LuminousVttLongDragHotfix.snapshot(),
     direct: window.LuminousVttDirectRouteHotfix.snapshot(),
+    zero: window.LuminousVttZeroWorkDrag.snapshot(),
+    destinationPreviewEvents: window.__longDragProbe.destinationPreviewEvents,
     hudVisible: !document.getElementById('vtt-fast-drag-hud')?.hidden,
     hudText: document.getElementById('vtt-fast-drag-hud')?.textContent || '',
   }));
@@ -152,15 +169,21 @@ async function dragToColumn(page, targetCol = 70) {
   await page.mouse.up({ button: 'left' });
   await page.waitForFunction(() => Boolean(window.__longDragProbe?.moved || window.__longDragProbe?.rejected), null, { timeout: 3000 });
 
-  return page.evaluate(({ dragElapsedMs, beforeDrop }) => {
+  return page.evaluate(({ syntheticDispatchMs, beforeDrop }) => {
     const probe = window.__longDragProbe;
     const afterLong = window.LuminousVttLongDragHotfix.snapshot();
     const afterDirect = window.LuminousVttDirectRouteHotfix.snapshot();
+    const afterZero = window.LuminousVttZeroWorkDrag.snapshot();
     return {
-      dragElapsedMs,
+      syntheticDispatchMs,
       beforeDrop,
       afterLong,
       afterDirect,
+      afterZero,
+      zeroPointerMoves: beforeDrop.zero.pointerMoves - probe.baselineZero.pointerMoves,
+      zeroCellChanges: beforeDrop.zero.cellChanges - probe.baselineZero.cellChanges,
+      zeroHandlerTotalMs: beforeDrop.zero.handlerTotalMs - probe.baselineZero.handlerTotalMs,
+      zeroHandlerMaxMs: beforeDrop.zero.handlerMaxMs,
       longPathCallsDuringDrag: beforeDrop.long.pathCalls - probe.baselineLong.pathCalls,
       directPathCallsDuringDrag: beforeDrop.direct.findPathCalls - probe.baselineDirect.findPathCalls,
       directFindPathCalls: afterDirect.findPathCalls - probe.baselineDirect.findPathCalls,
@@ -172,10 +195,10 @@ async function dragToColumn(page, targetCol = 70) {
       moved: probe.moved,
       rejected: probe.rejected,
     };
-  }, { dragElapsedMs, beforeDrop });
+  }, { syntheticDispatchMs, beforeDrop });
 }
 
-test('loaded 120x120 long drag does no pathfinding until drop and does not stall the browser', async ({ page }) => {
+test('loaded 120x120 long drag does no world work until drop and does not stall the browser', async ({ page }) => {
   test.setTimeout(30000);
   await page.setViewportSize({ width: 1920, height: 900 });
   await bootLoadedMap(page);
@@ -186,11 +209,18 @@ test('loaded 120x120 long drag does no pathfinding until drop and does not stall
   expect(result.beforeDrop.long.pathfindingInstalled).toBe(true);
   expect(result.beforeDrop.long.collisionBroadphaseInstalled).toBe(true);
   expect(result.beforeDrop.direct.installed).toBe(true);
+  expect(result.zeroPointerMoves).toBeGreaterThanOrEqual(90);
+  expect(result.zeroCellChanges).toBeGreaterThan(20);
+  expect(result.beforeDrop.destinationPreviewEvents, 'Engine world preview must be completely suppressed while dragging').toBe(0);
   expect(result.longPathCallsDuringDrag, 'mousemove must never run legacy/full pathfinding').toBe(0);
   expect(result.directPathCallsDuringDrag, 'mousemove must never run direct drop validation either').toBe(0);
+  expect(result.beforeDrop.zero.worldPreviewCalls).toBe(0);
+  expect(result.beforeDrop.zero.pathfindingCalls).toBe(0);
   expect(result.beforeDrop.hudVisible, 'cheap drag HUD should remain responsive').toBe(true);
   expect(result.beforeDrop.hudText).toContain('ft');
-  expect(result.dragElapsedMs, '90 pointer updates on a loaded map must stay interactive').toBeLessThan(1800);
+  expect(result.syntheticDispatchMs, '90 in-browser drag events must not block the main thread').toBeLessThan(250);
+  expect(result.zeroHandlerTotalMs, 'all 90+ drag handlers should be tiny in aggregate').toBeLessThan(150);
+  expect(result.zeroHandlerMaxMs, 'one drag handler must never create a visible hitch').toBeLessThan(25);
 
   expect(result.rejected).toBeNull();
   expect(result.moved).toBeTruthy();

--- a/tests/vtt_realtime_traversal_simplification.spec.js
+++ b/tests/vtt_realtime_traversal_simplification.spec.js
@@ -29,6 +29,7 @@ async function bootLoadedMap(page) {
   await page.waitForFunction(() => Boolean(window.LuminousVttRuntime?.engine?.tokenMoveResolver), null, { timeout: 15000 });
   await page.waitForFunction(() => Boolean(window.LuminousVttPathfinding?.__runtimeFinalizedPathfindingV3), null, { timeout: 5000 });
   await page.waitForFunction(() => Boolean(window.LuminousVttLongDragHotfix?.__v1), null, { timeout: 5000 });
+  await page.waitForFunction(() => Boolean(window.LuminousVttDirectRouteHotfix?.__v1), null, { timeout: 5000 });
   await page.waitForFunction(() => Boolean(window.LuminousVttRuntime?.engine?.__realtimeTraversalSimplifierV1), null, { timeout: 5000 });
 
   await page.evaluate(() => {
@@ -82,9 +83,12 @@ async function bootLoadedMap(page) {
     engine.camera.centerOnWorldPoint({ x: 36.5 * size, y: 10.5 * size });
 
     window.LuminousVttLongDragHotfix.ensure();
-    const baseline = window.LuminousVttLongDragHotfix.snapshot();
+    window.LuminousVttDirectRouteHotfix.ensure();
+    const baselineLong = window.LuminousVttLongDragHotfix.snapshot();
+    const baselineDirect = window.LuminousVttDirectRouteHotfix.snapshot();
     window.__longDragProbe = {
-      baseline,
+      baselineLong,
+      baselineDirect,
       mouseUpAt: null,
       movedAt: null,
       firstFrameAt: null,
@@ -139,7 +143,8 @@ async function dragToColumn(page, targetCol = 70) {
   const dragElapsedMs = Date.now() - dragStarted;
 
   const beforeDrop = await page.evaluate(() => ({
-    metrics: window.LuminousVttLongDragHotfix.snapshot(),
+    long: window.LuminousVttLongDragHotfix.snapshot(),
+    direct: window.LuminousVttDirectRouteHotfix.snapshot(),
     hudVisible: !document.getElementById('vtt-fast-drag-hud')?.hidden,
     hudText: document.getElementById('vtt-fast-drag-hud')?.textContent || '',
   }));
@@ -149,14 +154,18 @@ async function dragToColumn(page, targetCol = 70) {
 
   return page.evaluate(({ dragElapsedMs, beforeDrop }) => {
     const probe = window.__longDragProbe;
-    const after = window.LuminousVttLongDragHotfix.snapshot();
+    const afterLong = window.LuminousVttLongDragHotfix.snapshot();
+    const afterDirect = window.LuminousVttDirectRouteHotfix.snapshot();
     return {
       dragElapsedMs,
       beforeDrop,
-      after,
-      pathCallsDuringDrag: beforeDrop.metrics.pathCalls - probe.baseline.pathCalls,
-      totalPathCalls: after.pathCalls - probe.baseline.pathCalls,
-      directPaths: after.alignedDirectPaths - probe.baseline.alignedDirectPaths,
+      afterLong,
+      afterDirect,
+      longPathCallsDuringDrag: beforeDrop.long.pathCalls - probe.baselineLong.pathCalls,
+      directPathCallsDuringDrag: beforeDrop.direct.findPathCalls - probe.baselineDirect.findPathCalls,
+      directFindPathCalls: afterDirect.findPathCalls - probe.baselineDirect.findPathCalls,
+      directHits: afterDirect.directHits - probe.baselineDirect.directHits,
+      fallbackCalls: afterDirect.fallbackCalls - probe.baselineDirect.fallbackCalls,
       mouseUpToFirstFrameMs: probe.firstFrameAt - probe.mouseUpAt,
       mouseUpToMovedMs: probe.movedAt - probe.mouseUpAt,
       traversalFrames: probe.traversalFrames,
@@ -174,18 +183,21 @@ test('loaded 120x120 long drag does no pathfinding until drop and does not stall
   result.route = routeMetrics(result.moved?.path || []);
   console.log('VTT_LONG_DRAG=' + JSON.stringify(result));
 
-  expect(result.beforeDrop.metrics.pathfindingInstalled).toBe(true);
-  expect(result.beforeDrop.metrics.collisionBroadphaseInstalled).toBe(true);
-  expect(result.pathCallsDuringDrag, 'mousemove must never run full pathfinding').toBe(0);
+  expect(result.beforeDrop.long.pathfindingInstalled).toBe(true);
+  expect(result.beforeDrop.long.collisionBroadphaseInstalled).toBe(true);
+  expect(result.beforeDrop.direct.installed).toBe(true);
+  expect(result.longPathCallsDuringDrag, 'mousemove must never run legacy/full pathfinding').toBe(0);
+  expect(result.directPathCallsDuringDrag, 'mousemove must never run direct drop validation either').toBe(0);
   expect(result.beforeDrop.hudVisible, 'cheap drag HUD should remain responsive').toBe(true);
   expect(result.beforeDrop.hudText).toContain('ft');
   expect(result.dragElapsedMs, '90 pointer updates on a loaded map must stay interactive').toBeLessThan(1800);
 
   expect(result.rejected).toBeNull();
   expect(result.moved).toBeTruthy();
-  expect(result.totalPathCalls).toBeGreaterThan(0);
-  expect(result.directPaths, 'legal aligned movement should bypass A* even when terrain overrides exist').toBeGreaterThan(0);
-  expect(result.after.collisionBuildMaxMs, 'collision broadphase should build quickly').toBeLessThan(120);
+  expect(result.directFindPathCalls).toBeGreaterThan(0);
+  expect(result.directHits, 'legal aligned movement should use the direct corridor').toBeGreaterThan(0);
+  expect(result.fallbackCalls, 'clear straight movement must never enter A*').toBe(0);
+  expect(result.afterDirect.contextBuildMaxMs, 'direct collision index should build quickly').toBeLessThan(120);
 
   expect(result.route.startCol).toBe(3);
   expect(result.route.endCol).toBe(70);

--- a/tests/vtt_realtime_traversal_simplification.spec.js
+++ b/tests/vtt_realtime_traversal_simplification.spec.js
@@ -4,21 +4,15 @@ const URL = process.env.VTT_FIELD_URL || 'http://127.0.0.1:4173/vtt.html';
 
 function routeMetrics(path = []) {
   let turns = 0;
-  let reversalsY = 0;
-  let lastDirection = null;
-  let lastDy = 0;
   const rows = [];
+  let lastDirection = null;
   for (let index = 0; index < path.length; index += 1) {
     const point = path[index];
     rows.push(Number(point.row));
     if (!index) continue;
     const previous = path[index - 1];
-    const dx = Math.sign(Number(point.col) - Number(previous.col));
-    const dy = Math.sign(Number(point.row) - Number(previous.row));
-    const direction = `${dx},${dy}`;
+    const direction = `${Math.sign(Number(point.col) - Number(previous.col))},${Math.sign(Number(point.row) - Number(previous.row))}`;
     if (lastDirection && direction !== lastDirection) turns += 1;
-    if (lastDy && dy && lastDy !== dy) reversalsY += 1;
-    if (dy) lastDy = dy;
     lastDirection = direction;
   }
   return {
@@ -26,38 +20,55 @@ function routeMetrics(path = []) {
     startCol: path.length ? Number(path[0].col) : null,
     endCol: path.length ? Number(path[path.length - 1].col) : null,
     turns,
-    reversalsY,
     rowExcursion: rows.length ? Math.max(...rows) - Math.min(...rows) : 0,
   };
 }
 
-async function boot(page) {
+async function bootLoadedMap(page) {
   await page.goto(URL, { waitUntil: 'domcontentloaded' });
   await page.waitForFunction(() => Boolean(window.LuminousVttRuntime?.engine?.tokenMoveResolver), null, { timeout: 15000 });
   await page.waitForFunction(() => Boolean(window.LuminousVttPathfinding?.__runtimeFinalizedPathfindingV3), null, { timeout: 5000 });
+  await page.waitForFunction(() => Boolean(window.LuminousVttLongDragHotfix?.__v1), null, { timeout: 5000 });
   await page.waitForFunction(() => Boolean(window.LuminousVttRuntime?.engine?.__realtimeTraversalSimplifierV1), null, { timeout: 5000 });
 
   await page.evaluate(() => {
     const engine = window.LuminousVttRuntime.engine;
     const map = engine.mapData;
     const token = map.tokens.find((entry) => entry.id === 'player1') || map.tokens[0];
+    const size = Number(map.grid?.size) || 70;
 
+    map.grid.cols = 120;
+    map.grid.rows = 120;
     map.walls = [];
-    map.topology = [];
     map.structures = [];
     map.worldObjects = [];
     map.movement ||= {};
-    map.movement.terrain = {};
-    map.movement.terrainCells = {};
     map.movement.blockTokens = false;
     map.movement.diagonalRule = '5e';
+    map.movement.terrain = { '100_100': { multiplier: 0.5 } };
+    map.movement.terrainCells = {};
     delete map.movement.animationMsPerCell;
     delete map.movement.realtimeAnimationMsPerCell;
     delete map.movement.realtimeAnimationMinMs;
     delete map.movement.realtimeAnimationMaxMs;
 
-    token.x = 3.5 * map.grid.size;
-    token.y = 10.5 * map.grid.size;
+    // Hundreds of topology records reproduce the real loaded-map cost without
+    // blocking the horizontal test corridor on row 10.
+    map.topology = Array.from({ length: 900 }, (_, index) => {
+      const row = 40 + (index % 70);
+      const col = 1 + ((index * 7) % 115);
+      return {
+        id: `perf_wall_${index}`,
+        type: 'wall',
+        from: { col, row },
+        to: { col: Math.min(120, col + 1), row },
+        z: [0],
+        thicknessFt: 0.5,
+      };
+    });
+
+    token.x = 3.5 * size;
+    token.y = 10.5 * size;
     token.gridPosition = { col: 3, row: 10, z: 0 };
     token.zLayer = 0;
     token.z = [0];
@@ -65,143 +76,123 @@ async function boot(page) {
     token.viewer = true;
     engine.activeZ = 0;
 
-    // A navigation benchmark must keep the viewport fixed. This calls the same
-    // manual-pan release hook used by the product without actually changing x/y.
     if (engine.cameraFollowActive === true) engine.camera.manualPanListener?.({ benchmark: true });
-    engine.camera.zoom = 0.7;
-    engine.camera.centerOnWorldPoint({ x: token.x, y: token.y });
+    engine.camera.setZoomBounds?.(0.05, 5);
+    engine.camera.zoom = 0.22;
+    engine.camera.centerOnWorldPoint({ x: 36.5 * size, y: 10.5 * size });
 
-    const pathfinder = window.LuminousVttPathfinding;
-    const probe = window.__realtimeTraversalProbe = {
+    window.LuminousVttLongDragHotfix.ensure();
+    const baseline = window.LuminousVttLongDragHotfix.snapshot();
+    window.__longDragProbe = {
+      baseline,
       mouseUpAt: null,
-      firstFrameAt: null,
       movedAt: null,
-      frameTimes: [],
-      realtimeFrames: 0,
+      firstFrameAt: null,
       moved: null,
       rejected: null,
-      plans: [],
+      traversalFrames: 0,
     };
 
-    const wrappedPathfinder = Object.freeze({
-      ...pathfinder,
-      findPath(args) {
-        const startedAt = performance.now();
-        const result = pathfinder.findPath(args);
-        probe.plans.push({
-          ms: performance.now() - startedAt,
-          valid: Boolean(result?.valid),
-          reason: result?.reason || null,
-          visited: Number(result?.visited ?? -1),
-          fastPath: result?.fastPath || null,
-          cells: Array.isArray(result?.cells) ? result.cells.map(({ col, row }) => ({ col, row })) : [],
-        });
-        return result;
-      },
-    });
-    window.LuminousVttPathfinding = wrappedPathfinder;
-
-    window.addEventListener('mouseup', () => { probe.mouseUpAt ??= performance.now(); }, true);
+    window.addEventListener('mouseup', () => {
+      window.__longDragProbe.mouseUpAt ??= performance.now();
+    }, true);
     engine.canvas.addEventListener('vtt:token-preview-moved', (event) => {
       if (!event.detail?.traversing) return;
-      const now = performance.now();
-      probe.firstFrameAt ??= now;
-      probe.frameTimes.push(now);
-      if (event.detail?.realtimeVisual === true) probe.realtimeFrames += 1;
+      window.__longDragProbe.firstFrameAt ??= performance.now();
+      window.__longDragProbe.traversalFrames += 1;
     });
     engine.canvas.addEventListener('vtt:token-moved', (event) => {
-      probe.movedAt = performance.now();
-      probe.moved = JSON.parse(JSON.stringify(event.detail || {}));
+      window.__longDragProbe.movedAt = performance.now();
+      window.__longDragProbe.moved = JSON.parse(JSON.stringify(event.detail || {}));
     });
     engine.canvas.addEventListener('vtt:movement-order-rejected', (event) => {
-      probe.rejected = JSON.parse(JSON.stringify(event.detail || {}));
+      window.__longDragProbe.rejected = JSON.parse(JSON.stringify(event.detail || {}));
     });
   });
 }
 
-async function dragLongHorizontal(page) {
-  const points = await page.evaluate(() => {
+async function dragToColumn(page, targetCol = 70) {
+  const points = await page.evaluate((col) => {
     const engine = window.LuminousVttRuntime.engine;
     const map = engine.mapData;
     const token = map.tokens.find((entry) => entry.id === 'player1') || map.tokens[0];
     const start = engine.camera.worldToScreen(token.x, token.y);
-    const target = engine.camera.worldToScreen(17.5 * map.grid.size, 10.5 * map.grid.size);
+    const target = engine.camera.worldToScreen((col + 0.5) * map.grid.size, 10.5 * map.grid.size);
     const rect = engine.canvas.getBoundingClientRect();
     return {
       start: { x: rect.left + start.x, y: rect.top + start.y },
       target: { x: rect.left + target.x, y: rect.top + target.y },
     };
-  });
+  }, targetCol);
 
   await page.mouse.move(points.start.x, points.start.y);
   await page.mouse.down({ button: 'left' });
-  for (let index = 1; index <= 36; index += 1) {
-    const t = index / 36;
+  const dragStarted = Date.now();
+  for (let index = 1; index <= 90; index += 1) {
+    const t = index / 90;
     await page.mouse.move(
       points.start.x + ((points.target.x - points.start.x) * t),
       points.start.y + ((points.target.y - points.start.y) * t),
     );
-    await page.waitForTimeout(12);
+    await page.waitForTimeout(6);
   }
-  await page.mouse.up({ button: 'left' });
-  await page.waitForFunction(() => Boolean(window.__realtimeTraversalProbe?.moved || window.__realtimeTraversalProbe?.rejected), null, { timeout: 3000 });
+  const dragElapsedMs = Date.now() - dragStarted;
 
-  return page.evaluate(() => {
-    const probe = window.__realtimeTraversalProbe;
-    const intervals = probe.frameTimes.slice(1).map((value, index) => value - probe.frameTimes[index]).sort((a, b) => a - b);
-    const p95 = intervals.length ? intervals[Math.min(intervals.length - 1, Math.floor(intervals.length * 0.95))] : null;
-    const planMs = probe.plans.map((entry) => entry.ms);
+  const beforeDrop = await page.evaluate(() => ({
+    metrics: window.LuminousVttLongDragHotfix.snapshot(),
+    hudVisible: !document.getElementById('vtt-fast-drag-hud')?.hidden,
+    hudText: document.getElementById('vtt-fast-drag-hud')?.textContent || '',
+  }));
+
+  await page.mouse.up({ button: 'left' });
+  await page.waitForFunction(() => Boolean(window.__longDragProbe?.moved || window.__longDragProbe?.rejected), null, { timeout: 3000 });
+
+  return page.evaluate(({ dragElapsedMs, beforeDrop }) => {
+    const probe = window.__longDragProbe;
+    const after = window.LuminousVttLongDragHotfix.snapshot();
     return {
-      installed: Boolean(window.LuminousVttRuntime.engine.__realtimeTraversalSimplifierV1),
-      runtimeFinalized: Boolean(window.LuminousVttPathfinding?.__runtimeFinalizedPathfindingV3),
-      cameraFollowActive: Boolean(window.LuminousVttRuntime.engine.cameraFollowActive),
+      dragElapsedMs,
+      beforeDrop,
+      after,
+      pathCallsDuringDrag: beforeDrop.metrics.pathCalls - probe.baseline.pathCalls,
+      totalPathCalls: after.pathCalls - probe.baseline.pathCalls,
+      directPaths: after.alignedDirectPaths - probe.baseline.alignedDirectPaths,
       mouseUpToFirstFrameMs: probe.firstFrameAt - probe.mouseUpAt,
       mouseUpToMovedMs: probe.movedAt - probe.mouseUpAt,
-      frameCount: probe.frameTimes.length,
-      realtimeFrames: probe.realtimeFrames,
-      frameIntervalP95Ms: p95,
-      planningCalls: probe.plans.length,
-      planningTotalMs: planMs.reduce((sum, value) => sum + value, 0),
-      planningMaxMs: planMs.length ? Math.max(...planMs) : 0,
-      plans: probe.plans,
+      traversalFrames: probe.traversalFrames,
       moved: probe.moved,
       rejected: probe.rejected,
     };
-  });
+  }, { dragElapsedMs, beforeDrop });
 }
 
-test('real token drag stays straight, plans cheaply, and commits with realtime visual traversal', async ({ page }) => {
-  test.setTimeout(20000);
+test('loaded 120x120 long drag does no pathfinding until drop and does not stall the browser', async ({ page }) => {
+  test.setTimeout(30000);
   await page.setViewportSize({ width: 1920, height: 900 });
-  await boot(page);
-  const result = await dragLongHorizontal(page);
-  const path = result.moved?.path || [];
-  result.route = routeMetrics(path);
-  console.log('VTT_REALTIME_MOVEMENT=' + JSON.stringify(result));
+  await bootLoadedMap(page);
+  const result = await dragToColumn(page, 70);
+  result.route = routeMetrics(result.moved?.path || []);
+  console.log('VTT_LONG_DRAG=' + JSON.stringify(result));
 
-  expect(result.installed).toBe(true);
-  expect(result.runtimeFinalized).toBe(true);
-  expect(result.cameraFollowActive, 'benchmark viewport must remain fixed').toBe(false);
+  expect(result.beforeDrop.metrics.pathfindingInstalled).toBe(true);
+  expect(result.beforeDrop.metrics.collisionBroadphaseInstalled).toBe(true);
+  expect(result.pathCallsDuringDrag, 'mousemove must never run full pathfinding').toBe(0);
+  expect(result.beforeDrop.hudVisible, 'cheap drag HUD should remain responsive').toBe(true);
+  expect(result.beforeDrop.hudText).toContain('ft');
+  expect(result.dragElapsedMs, '90 pointer updates on a loaded map must stay interactive').toBeLessThan(1800);
+
   expect(result.rejected).toBeNull();
   expect(result.moved).toBeTruthy();
+  expect(result.totalPathCalls).toBeGreaterThan(0);
+  expect(result.directPaths, 'legal aligned movement should bypass A* even when terrain overrides exist').toBeGreaterThan(0);
+  expect(result.after.collisionBuildMaxMs, 'collision broadphase should build quickly').toBeLessThan(120);
 
   expect(result.route.startCol).toBe(3);
-  expect(result.route.endCol).toBe(17);
-  expect(result.route.cells).toBe(15);
-  expect(result.route.rowExcursion, 'horizontal route must never leave its source row').toBe(0);
-  expect(result.route.reversalsY, 'horizontal route must never reverse vertically').toBe(0);
-  expect(result.route.turns, 'horizontal route must keep one direction').toBe(0);
+  expect(result.route.endCol).toBe(70);
+  expect(result.route.rowExcursion).toBe(0);
+  expect(result.route.turns).toBe(0);
 
-  const routedPlans = result.plans.filter((plan) => plan.cells.length > 1);
-  expect(routedPlans.length).toBeGreaterThan(0);
-  expect(routedPlans.every((plan) => plan.fastPath === 'aligned')).toBe(true);
-  expect(Math.max(...routedPlans.map((plan) => plan.visited))).toBe(0);
-  expect(result.planningMaxMs, 'single clean-field plan should stay under 10ms').toBeLessThan(10);
-  expect(result.planningTotalMs, 'full drag planning should stay under 50ms').toBeLessThan(50);
-
-  expect(result.frameCount).toBeGreaterThan(2);
-  expect(result.realtimeFrames).toBe(result.frameCount);
-  expect(result.mouseUpToFirstFrameMs, 'movement should visibly start almost immediately after mouseup').toBeLessThan(120);
-  expect(result.mouseUpToMovedMs, '14-cell walk should commit in well under the old 1.2s+ traversal').toBeLessThan(350);
-  expect(result.frameIntervalP95Ms, 'visual traversal should remain near display cadence').toBeLessThan(35);
+  expect(result.mouseUpToFirstFrameMs, 'movement should start immediately after the single drop validation').toBeLessThan(180);
+  expect(result.mouseUpToMovedMs, '67-cell loaded-map move should finish without multi-second blocking').toBeLessThan(650);
+  expect(result.traversalFrames).toBeGreaterThan(2);
 });


### PR DESCRIPTION
## Problema reproducido
El bloqueo no era un timer: el hilo principal hacía trabajo síncrono creciente con la distancia. El drag recalculaba desde el origen repetidamente; las colisiones reconstruían/recorrían paredes + topología muchas veces por muestra; world objects duplicaban sampling; y `movement-rules-runtime` copiaba flags de un pathfinder optimizado con `...spread` mientras reemplazaba su `findPath`, reactivando el A* legacy sin que los guards lo detectaran.

## Runtime simplificado
### Drag = cero trabajo de mundo
Mientras una ficha está agarrada, `mousemove` solo:
- convierte cursor → celda;
- actualiza un HUD DOM de distancia en ft;
- bloquea los consumidores legacy de mousemove.

Durante drag hay explícitamente:
- 0 pathfinding;
- 0 `vtt:movement-destination-preview` del Engine;
- 0 render/scene-dirty del mundo causado por el drag;
- 0 FOV/fog;
- 0 reconstrucción de ruta.

La validación real ocurre una sola vez en `mouseup`.

### Drop = una validación directa barata cuando procede
Para horizontal/vertical/diagonal 45°:
- se construye una snapshot/broadphase de colisiones una sola vez;
- paredes/topología se indexan espacialmente;
- world objects se convierten una sola vez a rects y se indexan;
- el corredor se barre una sola vez;
- terreno/coste se suma por celda con lookups baratos;
- si la línea es legal devuelve direct path con `visited=0`;
- A* queda solo como fallback cuando el corredor directo realmente está bloqueado/no aplica.

La detección del wrapper verifica identidad real de `findPath`; no confía en flags heredados por object spread.

## Procedural loaded-scene performance
La carga procedural tenía un segundo multiplicador independiente del drag:
- surfaces recorrían el piso completo;
- topología/structures/world objects recorrían colecciones cargadas aunque estuvieran fuera de cámara;
- FOV construía rayos desde endpoints de todas las paredes y cada rayo volvía a recorrer todas las paredes, creciendo aproximadamente O(N²).

Se añadió un runtime de performance **solo para escenas procedural**:
- culling por viewport antes de normalizar/dibujar topology, walls, structures, worldObjects, horizontalPlanes y surface cells;
- surfaces visibles se obtienen por lookup directo de celdas del viewport, sin `Object.entries()`/clone del piso completo;
- FOV filtra paredes al radio real de visión antes del loop ray×wall;
- los arrays/objetos canónicos de `mapData` se restauran en `finally`; persistencia sigue viendo la escena completa;
- mapas manuales no activan este culling.

### Field test con procedural real
Chrome real, `previewAsync()` + `apply()` de una seed `mixed_urban` real:
- 232 elementos de topología cargados → 29 procesados por el viewport;
- 1600 surface cells cargadas → 345 procesadas por el viewport;
- 4 horizontal planes → 1 visible;
- FOV: 232 paredes totales → 24 candidatas locales;
- preparación de culling: ~0.4 ms promedio, <1 ms máximo en la corrida final;
- filtro de visión: ~1.9 ms;
- las colecciones canónicas siguen completas después de render.

## Field test de movimiento cargado
Chrome real, grid 120×120, 900 elementos de topología, terrain override, recorrido col 3 → 70 (335 ft).
- 0 pathfinding / world preview durante drag;
- handler de drag ~0.05–0.08 ms promedio/evento en las corridas finales;
- 1 validación al soltar;
- direct hit, 0 fallback A* en línea legal;
- ruta horizontal con 0 giros / 0 excursión vertical.

## Señales CI relevantes
- `VTT Runtime Drag Performance Field`: PASS en el head final (incluye drag cargado + procedural real).
- `VTT Procedural Zone Engine`: Syntax PASS, Chunk streaming performance PASS, Focused contracts PASS.
- `VTT DM Zone Persistence`: Syntax PASS, Focused contracts PASS.
- `VTT DM Map Creator UI`: Live preview crash regression PASS, One-live-chunk performance regression PASS.

Las regresiones generales que siguen rojas corresponden a contratos Legacy preexistentes que buscan strings/ubicaciones de la arquitectura anterior (renderer monolítico, CustomEvent literal, actor card HTML literal, y el loader CommonJS/ESM de `vtt_webgl2_camera_contract.spec.js`).