### PR TITLE
Hotfix: estabilizar Rama 3 en prueba de campo

### DIFF
--- a/.github/workflows/vtt-field-stability-hotfix.yml
+++ b/.github/workflows/vtt-field-stability-hotfix.yml
@@ -1,0 +1,29 @@
+name: VTT Field Stability Hotfix
+
+on:
+  pull_request:
+    paths:
+      - 'js/vtt/field-stability-hotfix.js'
+      - 'js/vtt/render/renderer-factory.js'
+      - 'scripts/vtt-field-stability-check.mjs'
+      - '.github/workflows/vtt-field-stability-hotfix.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  field-stability:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Syntax
+        run: |
+          node --input-type=module --check < js/vtt/field-stability-hotfix.js
+          node --input-type=module --check < js/vtt/render/renderer-factory.js
+          node --check scripts/vtt-field-stability-check.mjs
+      - name: Realtime field stability regression
+        run: node scripts/vtt-field-stability-check.mjs

--- a/js/vtt/field-stability-hotfix.js
+++ b/js/vtt/field-stability-hotfix.js
@@ -1,0 +1,352 @@
+const clean = (value) => String(value ?? '').trim();
+
+function hostWindow(root = globalThis) {
+  if (!root) return null;
+  try {
+    if (root.parent && root.parent !== root && root.parent.document) return root.parent;
+  } catch (_) {}
+  return root;
+}
+
+function hostFirebase(root = globalThis) {
+  const host = hostWindow(root);
+  return host?.firebase || root?.firebase || null;
+}
+
+function actorIdForToken(token = {}) {
+  return clean(token.actorId || token.characterLink?.actorId || token.actorRef?.id);
+}
+
+function isPlayerToken(token = {}) {
+  return token.canonicalScope === 'player'
+    || token.actorCategory === 'player'
+    || token.characterLink?.mode === 'player'
+    || String(token.id || '').startsWith('player:');
+}
+
+function actorRecordById(actors = {}, actorId = '') {
+  const wanted = clean(actorId);
+  if (!wanted) return null;
+  if (actors && typeof actors === 'object' && actors[wanted]) return actors[wanted];
+  for (const [key, value] of Object.entries(actors || {})) {
+    const candidate = clean(value?.actorId || value?.id || key);
+    if (candidate === wanted) return value || null;
+  }
+  return null;
+}
+
+/**
+ * Field-stability hotfix for the WebGL2 token branch.
+ *
+ * Goals:
+ * - Raw drag previews never drive camera follow directly.
+ * - Traversal frames render smoothly without recalculating FOV every frame.
+ * - Camera centering during traversal does not emit a duplicate dirty pulse.
+ * - Player tokens inherit Actor.icono from campaña/actores on every client.
+ *
+ * This module is intentionally runtime-side and idempotent so it can be removed
+ * once these guards are folded into Engine/Camera/TokenState proper.
+ */
+export function installFieldStabilityHotfix(root = globalThis) {
+  if (root?.LuminousVttFieldStabilityHotfix?.__v1) return root.LuminousVttFieldStabilityHotfix;
+
+  const metrics = {
+    enginesPatched: 0,
+    rawDragFollowSuspends: 0,
+    traversalVisionSuppressions: 0,
+    traversalCameraDirtySuppressions: 0,
+    visionCacheHits: 0,
+    visionRecomputes: 0,
+    playerIconsHydrated: 0,
+  };
+
+  let stopped = false;
+  let currentEngine = null;
+  let detachEngine = null;
+  let pollTimer = null;
+  let actorRef = null;
+  let actorHandler = null;
+  let actors = {};
+  let dragFollowState = null;
+  let hydrationQueued = false;
+
+  const runtime = () => root?.LuminousVttRuntime || null;
+
+  function emitTokenDirty(engine, tokenId, sourceEvent = 'field-stability:actor-icon') {
+    const dirty = root?.LuminousVttSceneDirty;
+    if (!dirty?.emit || !engine?.canvas) return false;
+    return dirty.emit(engine.canvas, {
+      reason: 'token',
+      render: true,
+      vision: false,
+      active: false,
+      sourceEvent,
+      tokenId: clean(tokenId) || null,
+      meta: { appearance: true },
+    });
+  }
+
+  function hydratePlayerIcons(engine = currentEngine) {
+    if (!engine || stopped) return 0;
+    let changed = 0;
+    for (const token of engine.mapData?.tokens || []) {
+      if (!isPlayerToken(token)) continue;
+      const actorId = actorIdForToken(token);
+      const actor = actorRecordById(actors, actorId);
+      const icono = clean(actor?.icono);
+      if (!icono || clean(token.icono) === icono) continue;
+      token.icono = icono;
+      token.tokenImage = icono;
+      token.portrait = icono;
+      engine.renderer?.syncTokenView?.(token.id);
+      emitTokenDirty(engine, token.id);
+      changed += 1;
+      metrics.playerIconsHydrated += 1;
+    }
+    return changed;
+  }
+
+  function queueHydration() {
+    if (hydrationQueued || stopped) return;
+    hydrationQueued = true;
+    const schedule = root?.queueMicrotask?.bind(root) || ((fn) => Promise.resolve().then(fn));
+    schedule(() => {
+      hydrationQueued = false;
+      hydratePlayerIcons();
+    });
+  }
+
+  function ensureActorSubscription() {
+    if (actorRef || stopped) return;
+    let db = null;
+    try { db = hostFirebase(root)?.database?.() || null; } catch (_) {}
+    if (!db?.ref) return;
+    actorRef = db.ref('campaña/actores');
+    actorHandler = (snapshot) => {
+      actors = snapshot?.val?.() || {};
+      queueHydration();
+    };
+    actorRef.on?.('value', actorHandler);
+  }
+
+  function unpatchEngine() {
+    if (typeof detachEngine === 'function') {
+      try { detachEngine(); } catch (_) {}
+    }
+    detachEngine = null;
+    currentEngine = null;
+  }
+
+  function patchEngine(engine) {
+    if (!engine || engine === currentEngine || engine.__fieldStabilityHotfixV1) return engine;
+    unpatchEngine();
+
+    const canvas = engine.canvas;
+    const camera = engine.camera;
+    const originalEmitSemanticEvent = typeof engine.emitSemanticEvent === 'function'
+      ? engine.emitSemanticEvent.bind(engine)
+      : null;
+    const originalCalculateVision = typeof engine.calculateVision === 'function'
+      ? engine.calculateVision.bind(engine)
+      : null;
+    const originalSetZLayer = typeof engine.setZLayer === 'function'
+      ? engine.setZLayer.bind(engine)
+      : null;
+    const originalCameraNotify = typeof camera?.notifyVisualChange === 'function'
+      ? camera.notifyVisualChange.bind(camera)
+      : null;
+
+    let visionDirty = true;
+    let cachedVision = null;
+    let lastActiveZ = Number(engine.activeZ) || 0;
+
+    if (originalEmitSemanticEvent) {
+      engine.emitSemanticEvent = function fieldStableSemanticEvent(type, detail = {}, dirty = null) {
+        let nextDirty = dirty;
+        if (type === 'vtt:token-preview-moved'
+          && (detail?.traversing === true || detail?.drag === true || detail?.remote === true)) {
+          if (dirty && dirty.vision === true) metrics.traversalVisionSuppressions += 1;
+          nextDirty = dirty ? { ...dirty, vision: false } : dirty;
+        }
+        return originalEmitSemanticEvent(type, detail, nextDirty);
+      };
+    }
+
+    if (originalCalculateVision) {
+      engine.calculateVision = function cachedFieldVision() {
+        const activeZ = Number(engine.activeZ) || 0;
+        if (activeZ !== lastActiveZ) {
+          lastActiveZ = activeZ;
+          visionDirty = true;
+        }
+        if (!visionDirty && cachedVision !== null) {
+          metrics.visionCacheHits += 1;
+          return cachedVision;
+        }
+        cachedVision = originalCalculateVision();
+        visionDirty = false;
+        metrics.visionRecomputes += 1;
+        return cachedVision;
+      };
+    }
+
+    if (originalSetZLayer) {
+      engine.setZLayer = function fieldStableSetZLayer(z) {
+        const before = Number(engine.activeZ) || 0;
+        const result = originalSetZLayer(z);
+        if ((Number(engine.activeZ) || 0) !== before) visionDirty = true;
+        return result;
+      };
+    }
+
+    if (camera && originalCameraNotify) {
+      camera.notifyVisualChange = function fieldStableCameraNotify(kind, active = false, meta = null) {
+        // Traversal already emits one token dirty pulse per RAF. Emitting a second
+        // camera dirty pulse from centerOnWorldPoint doubles render pressure and
+        // caused the field-test snowball on long paths.
+        if (kind === 'center' && engine.tokenMotion) {
+          metrics.traversalCameraDirtySuppressions += 1;
+          return undefined;
+        }
+        return originalCameraNotify(kind, active, meta);
+      };
+    }
+
+    const onSceneDirty = (event) => {
+      const detail = event?.detail || {};
+      if (detail.vision === true) visionDirty = true;
+      if (detail.reason === 'token') queueHydration();
+    };
+    const onCanonicalSync = () => {
+      visionDirty = true;
+      queueHydration();
+    };
+    canvas?.addEventListener?.('vtt:scene-dirty', onSceneDirty);
+    canvas?.addEventListener?.('vtt:canonical-tokens-synced', onCanonicalSync);
+
+    Object.defineProperty(engine, '__fieldStabilityHotfixV1', {
+      configurable: true,
+      value: true,
+    });
+
+    currentEngine = engine;
+    metrics.enginesPatched += 1;
+    ensureActorSubscription();
+    queueHydration();
+
+    detachEngine = () => {
+      canvas?.removeEventListener?.('vtt:scene-dirty', onSceneDirty);
+      canvas?.removeEventListener?.('vtt:canonical-tokens-synced', onCanonicalSync);
+      if (engine.emitSemanticEvent?.name === 'fieldStableSemanticEvent' && originalEmitSemanticEvent) {
+        engine.emitSemanticEvent = originalEmitSemanticEvent;
+      }
+      if (engine.calculateVision?.name === 'cachedFieldVision' && originalCalculateVision) {
+        engine.calculateVision = originalCalculateVision;
+      }
+      if (engine.setZLayer?.name === 'fieldStableSetZLayer' && originalSetZLayer) {
+        engine.setZLayer = originalSetZLayer;
+      }
+      if (camera?.notifyVisualChange?.name === 'fieldStableCameraNotify' && originalCameraNotify) {
+        camera.notifyVisualChange = originalCameraNotify;
+      }
+      try { delete engine.__fieldStabilityHotfixV1; } catch (_) {}
+    };
+
+    return engine;
+  }
+
+  function ensureEngine() {
+    const engine = runtime()?.engine || null;
+    if (engine && engine !== currentEngine) patchEngine(engine);
+    return engine;
+  }
+
+  function suspendRawDragFollow() {
+    const engine = ensureEngine();
+    if (!engine?.tokenDrag || dragFollowState) return false;
+    dragFollowState = {
+      engine,
+      enabled: Boolean(engine.cameraFollowActive),
+    };
+    if (dragFollowState.enabled) {
+      engine.cameraFollowActive = false;
+      metrics.rawDragFollowSuspends += 1;
+    }
+    return true;
+  }
+
+  function restoreRawDragFollow() {
+    const state = dragFollowState;
+    dragFollowState = null;
+    if (!state?.engine) return false;
+    // Restore only the performance hint. CameraFollow remains the authority for
+    // enabled/disabled state and will continue following confirmed traversal.
+    state.engine.cameraFollowActive = Boolean(state.enabled);
+    return true;
+  }
+
+  const onMouseDown = () => {
+    ensureEngine();
+    // Engine creates tokenDrag on the canvas target before this window bubble
+    // listener runs. A microtask also covers alternate listener ordering.
+    const schedule = root?.queueMicrotask?.bind(root) || ((fn) => Promise.resolve().then(fn));
+    schedule(suspendRawDragFollow);
+  };
+  const onMouseUp = () => restoreRawDragFollow();
+  const onBlur = () => restoreRawDragFollow();
+  const onFocus = () => ensureEngine();
+
+  root?.addEventListener?.('mousedown', onMouseDown, false);
+  root?.addEventListener?.('mouseup', onMouseUp, false);
+  root?.addEventListener?.('blur', onBlur, false);
+  root?.addEventListener?.('focus', onFocus, false);
+
+  // Runtime is usually published shortly after renderer construction. Poll only
+  // during bootstrap; user interaction/focus calls ensureEngine afterward.
+  let attempts = 0;
+  const timerApi = root?.setInterval?.bind(root) || setInterval;
+  const clearTimerApi = root?.clearInterval?.bind(root) || clearInterval;
+  pollTimer = timerApi(() => {
+    attempts += 1;
+    ensureEngine();
+    if (currentEngine || attempts >= 120) {
+      clearTimerApi(pollTimer);
+      pollTimer = null;
+    }
+  }, 50);
+
+  const api = Object.freeze({
+    __v1: true,
+    ensure: ensureEngine,
+    hydratePlayerIcons: () => hydratePlayerIcons(ensureEngine()),
+    snapshot: () => Object.freeze({
+      ...metrics,
+      enginePatched: Boolean(currentEngine),
+      rawDragFollowSuspended: Boolean(dragFollowState),
+      actorRecords: Object.keys(actors || {}).length,
+    }),
+    stop() {
+      if (stopped) return false;
+      stopped = true;
+      restoreRawDragFollow();
+      if (pollTimer != null) clearTimerApi(pollTimer);
+      pollTimer = null;
+      root?.removeEventListener?.('mousedown', onMouseDown, false);
+      root?.removeEventListener?.('mouseup', onMouseUp, false);
+      root?.removeEventListener?.('blur', onBlur, false);
+      root?.removeEventListener?.('focus', onFocus, false);
+      unpatchEngine();
+      if (actorRef && actorHandler) actorRef.off?.('value', actorHandler);
+      actorRef = null;
+      actorHandler = null;
+      actors = {};
+      if (root.LuminousVttFieldStabilityHotfix === api) delete root.LuminousVttFieldStabilityHotfix;
+      return true;
+    },
+  });
+
+  root.LuminousVttFieldStabilityHotfix = api;
+  return api;
+}
+
+if (typeof window !== 'undefined') installFieldStabilityHotfix(window);

--- a/js/vtt/render/renderer-factory.js
+++ b/js/vtt/render/renderer-factory.js
@@ -19,7 +19,11 @@ export function createRenderer(canvas, mapData, { backend = RENDERER_BACKENDS.CA
 
     installPersistentTokenViews(renderer);
     installTransientTokenPreview(renderer);
-    installRemoteTokenInterpolation(renderer);
+    installRemoteTokenInterpolation(renderer, {
+        minDurationMs: 120,
+        defaultDurationMs: 160,
+        maxDurationMs: 240,
+    });
     installTokenInteractionViews(renderer);
     installWebGL2TokenLayer(renderer);
     installWebGL2TokenInteractionLayer(renderer);

--- a/js/vtt/render/renderer-factory.js
+++ b/js/vtt/render/renderer-factory.js
@@ -1,5 +1,6 @@
 import '../movement-zero-work-drag.js';
 import '../token-interaction-runtime.js';
+import '../field-stability-hotfix.js';
 import { Canvas2DRenderer } from './canvas2d-renderer.js';
 import { installDmObserverOverlay } from './dm-observer-overlay.js';
 import { installPersistentTokenViews } from './persistent-token-views.js';

--- a/js/vtt/render/webgl2-token-interaction-layer.js
+++ b/js/vtt/render/webgl2-token-interaction-layer.js
@@ -27,50 +27,36 @@ void main() {
     outColor = u_color;
 }`;
 
-function rgb(color, fallback = '#ffffff') {
-    const text = String(color || fallback).trim();
-    const short = /^#([0-9a-f]{3})$/i.exec(text);
-    const full = /^#([0-9a-f]{6})$/i.exec(text);
-    let hex = String(fallback || '#ffffff').replace('#', '');
-    if (short) hex = short[1].split('').map((entry) => entry + entry).join('');
-    else if (full) hex = full[1];
-    if (!/^[0-9a-f]{6}$/i.test(hex)) hex = 'ffffff';
-    return [
-        parseInt(hex.slice(0, 2), 16) / 255,
-        parseInt(hex.slice(2, 4), 16) / 255,
-        parseInt(hex.slice(4, 6), 16) / 255,
-    ];
-}
-
-function brighten(base, amount) {
-    return base.map((channel) => Math.min(1, channel + ((1 - channel) * amount)));
-}
-
+/**
+ * Interaction feedback intentionally uses fixed high-contrast colors instead of
+ * deriving the ring from the token/faction color. Field testing showed the old
+ * brightened-token-color treatment was often indistinguishable from the normal
+ * token border, especially on dark maps.
+ */
 export function tokenInteractionStyle(view) {
     const interaction = view?.interaction || {};
     if (!interaction.hovered && !interaction.selected && !interaction.targeted) return null;
 
-    const base = rgb(view?.token?.color, '#ffffff');
     if (interaction.targeted) {
         return {
-            radiusScale: 1.18,
-            innerRadius: 0.74,
-            color: new Float32Array([...brighten(base, 0.45), 1]),
+            radiusScale: 1.26,
+            innerRadius: 0.62,
+            color: new Float32Array([1.0, 0.18, 0.14, 1.0]),
             state: 'targeted',
         };
     }
     if (interaction.selected) {
         return {
-            radiusScale: 1.14,
-            innerRadius: 0.80,
-            color: new Float32Array([...brighten(base, 0.65), 1]),
+            radiusScale: 1.22,
+            innerRadius: 0.66,
+            color: new Float32Array([0.10, 0.88, 1.0, 1.0]),
             state: 'selected',
         };
     }
     return {
-        radiusScale: 1.08,
-        innerRadius: 0.88,
-        color: new Float32Array([...brighten(base, 0.28), 1]),
+        radiusScale: 1.14,
+        innerRadius: 0.76,
+        color: new Float32Array([1.0, 1.0, 1.0, 0.96]),
         state: 'hovered',
     };
 }

--- a/scripts/vtt-field-stability-check.mjs
+++ b/scripts/vtt-field-stability-check.mjs
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict';
+import { installFieldStabilityHotfix } from '../js/vtt/field-stability-hotfix.js';
+
+class Host extends EventTarget {
+  constructor() {
+    super();
+    this.parent = this;
+    this.CustomEvent = globalThis.CustomEvent;
+    this.performance = globalThis.performance;
+    this.setInterval = setInterval;
+    this.clearInterval = clearInterval;
+    this.queueMicrotask = queueMicrotask;
+    this.actorValueHandler = null;
+    this.firebase = {
+      database: () => ({
+        ref: (path) => ({
+          on: (event, handler) => {
+            if (path === 'campaña/actores' && event === 'value') {
+              this.actorValueHandler = handler;
+              handler({ val: () => ({ actor_a: { id: 'actor_a', icono: 'actor-a.png' } }) });
+            }
+          },
+          off: () => {},
+        }),
+      }),
+    };
+  }
+}
+
+const host = new Host();
+const canvas = new EventTarget();
+let rawVisionCalls = 0;
+let rawCameraDirty = 0;
+const dirtyEvents = [];
+const syncCalls = [];
+
+host.LuminousVttSceneDirty = {
+  emit(target, detail) {
+    dirtyEvents.push(detail);
+    target.dispatchEvent(new CustomEvent('vtt:scene-dirty', { detail }));
+    return true;
+  },
+};
+
+const engine = {
+  canvas,
+  mapData: {
+    tokens: [{
+      id: 'player:p1',
+      actorId: 'actor_a',
+      canonicalScope: 'player',
+      x: 10,
+      y: 20,
+      zLayer: 0,
+    }],
+  },
+  activeZ: 0,
+  cameraFollowActive: true,
+  tokenDrag: null,
+  tokenMotion: null,
+  renderer: {
+    syncTokenView(id) { syncCalls.push(id); return true; },
+  },
+  camera: {
+    notifyVisualChange() { rawCameraDirty += 1; },
+  },
+  emitSemanticEvent(type, detail = {}, dirty = null) {
+    if (dirty) host.LuminousVttSceneDirty.emit(canvas, { ...dirty, sourceEvent: type, tokenId: detail.tokenId || null, meta: detail });
+  },
+  calculateVision() {
+    rawVisionCalls += 1;
+    return { version: rawVisionCalls };
+  },
+  setZLayer(z) {
+    this.activeZ = Number(z) || 0;
+  },
+};
+
+host.LuminousVttRuntime = { engine };
+const hotfix = installFieldStabilityHotfix(host);
+hotfix.ensure();
+await Promise.resolve();
+await Promise.resolve();
+
+// FOV is cached during render-only frames.
+const firstVision = engine.calculateVision();
+for (let index = 0; index < 100; index += 1) assert.equal(engine.calculateVision(), firstVision);
+assert.equal(rawVisionCalls, 1, 'FOV should be computed once while vision is clean');
+
+host.LuminousVttSceneDirty.emit(canvas, { reason: 'token', render: true, vision: false, tokenId: 'player:p1' });
+engine.calculateVision();
+assert.equal(rawVisionCalls, 1, 'render-only token dirty must not recompute FOV');
+
+host.LuminousVttSceneDirty.emit(canvas, { reason: 'token', render: true, vision: true, tokenId: 'player:p1' });
+engine.calculateVision();
+assert.equal(rawVisionCalls, 2, 'vision dirty must recompute FOV exactly once');
+
+// Traversal preview is visual-only; final token-moved remains allowed to invalidate vision.
+dirtyEvents.length = 0;
+engine.emitSemanticEvent('vtt:token-preview-moved', { tokenId: 'player:p1', traversing: true }, { reason: 'token', render: true, vision: true, active: true });
+assert.equal(dirtyEvents.at(-1)?.vision, false, 'traversal frame must not request FOV');
+engine.emitSemanticEvent('vtt:token-moved', { tokenId: 'player:p1' }, { reason: 'token', render: true, vision: true, active: false });
+assert.equal(dirtyEvents.at(-1)?.vision, true, 'final token move must request FOV');
+
+// Camera center dirty is suppressed only while traversal is already producing token frames.
+engine.tokenMotion = { tokenId: 'player:p1' };
+engine.camera.notifyVisualChange('center', false, {});
+assert.equal(rawCameraDirty, 0, 'camera center during traversal must not emit duplicate dirty');
+engine.tokenMotion = null;
+engine.camera.notifyVisualChange('center', false, {});
+assert.equal(rawCameraDirty, 1, 'normal camera center must still notify');
+
+// Raw drag suspends only the camera-follow performance hint and restores it on mouseup.
+engine.tokenDrag = { token: engine.mapData.tokens[0] };
+host.dispatchEvent(new Event('mousedown'));
+await Promise.resolve();
+assert.equal(engine.cameraFollowActive, false, 'raw drag must suspend camera follow');
+host.dispatchEvent(new Event('mouseup'));
+assert.equal(engine.cameraFollowActive, true, 'mouseup must restore camera follow');
+engine.tokenDrag = null;
+
+// Player tactical image comes only from assigned Actor.icono.
+await Promise.resolve();
+assert.equal(engine.mapData.tokens[0].icono, 'actor-a.png');
+assert.equal(engine.mapData.tokens[0].tokenImage, 'actor-a.png');
+assert.equal(engine.mapData.tokens[0].portrait, 'actor-a.png');
+assert.ok(syncCalls.includes('player:p1'));
+
+const snapshot = hotfix.snapshot();
+assert.ok(snapshot.visionCacheHits >= 100);
+assert.ok(snapshot.traversalVisionSuppressions >= 1);
+assert.ok(snapshot.traversalCameraDirtySuppressions >= 1);
+assert.ok(snapshot.playerIconsHydrated >= 1);
+
+hotfix.stop();
+console.log('VTT field stability hotfix: PASS');

--- a/scripts/vtt-field-stability-check.mjs
+++ b/scripts/vtt-field-stability-check.mjs
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import { installFieldStabilityHotfix } from '../js/vtt/field-stability-hotfix.js';
+import { tokenInteractionStyle } from '../js/vtt/render/webgl2-token-interaction-layer.js';
 
 class Host extends EventTarget {
   constructor() {
@@ -125,6 +127,21 @@ assert.equal(engine.mapData.tokens[0].icono, 'actor-a.png');
 assert.equal(engine.mapData.tokens[0].tokenImage, 'actor-a.png');
 assert.equal(engine.mapData.tokens[0].portrait, 'actor-a.png');
 assert.ok(syncCalls.includes('player:p1'));
+
+// Field feedback must be visually unmistakable, not a subtle tint of token color.
+const hover = tokenInteractionStyle({ interaction: { hovered: true }, token: { color: '#111111' } });
+const selected = tokenInteractionStyle({ interaction: { selected: true }, token: { color: '#111111' } });
+const targeted = tokenInteractionStyle({ interaction: { targeted: true }, token: { color: '#111111' } });
+assert.deepEqual(Array.from(hover.color), [1, 1, 1, 0.9599999785423279]);
+assert.ok(selected.color[1] > 0.8 && selected.color[2] > 0.9, 'selection ring must be high-contrast cyan');
+assert.ok(targeted.color[0] > 0.9 && targeted.color[1] < 0.3, 'target ring must be high-contrast red');
+assert.ok(selected.radiusScale > hover.radiusScale);
+
+// Remote movement should be visible long enough to read as interpolation rather than teleport.
+const factorySource = await readFile(new URL('../js/vtt/render/renderer-factory.js', import.meta.url), 'utf8');
+assert.match(factorySource, /minDurationMs:\s*120/);
+assert.match(factorySource, /defaultDurationMs:\s*160/);
+assert.match(factorySource, /maxDurationMs:\s*240/);
 
 const snapshot = hotfix.snapshot();
 assert.ok(snapshot.visionCacheHits >= 100);


### PR DESCRIPTION
## Objetivo
Corregir los bloqueantes encontrados en la checklist de campo de Rama 3 sin ampliar alcance.

## P0 — estabilidad
- Suspende camera-follow sólo durante el drag crudo para evitar feedback cursor→cámara→coordenadas→cámara.
- Los frames de traversal ya no invalidan visión/FOV por frame; la visión se recalcula al commit final.
- Cachea `calculateVision()` entre invalidaciones reales de `vision:true`.
- Suprime el segundo camera-dirty durante traversal cuando el mismo frame ya trae token dirty.
- Hidrata tokens de jugador con `Actor.icono` desde `campaña/actores` en DM y jugador usando una única suscripción compartida.

## P1 — experiencia visual
- Interpolación remota visible: 120–240 ms, retargeteable, sin tocar estado canónico.
- Hover blanco de alto contraste.
- Selección cian gruesa y claramente visible.
- Target rojo claramente visible.

## Gate nuevo
`scripts/vtt-field-stability-check.mjs` valida:
- 100+ frames render-only => 1 cálculo FOV.
- traversal preview => `vision:false`.
- final token move => `vision:true`.
- camera center durante traversal => sin dirty duplicado.
- camera-follow suspendido durante raw drag y restaurado en mouseup.
- player token recibe `Actor.icono`.
- feedback hover/selected/targeted de alto contraste.
- configuración de interpolación 120/160/240 ms.

El workflow independiente `VTT Field Stability Hotfix` pasa en el head final. Los guards legacy continúan afectados por tests/npm eliminados de `main` y no son señal de regresión de este hotfix.