### PR TITLE
Combat: team Action Slot Director and round lifecycle

### DIFF
--- a/js/combat-team-economy-bridge.js
+++ b/js/combat-team-economy-bridge.js
@@ -1,0 +1,144 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousCombatTeamEconomyBridge) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousCombatTeamEconomyBridge;
+    return;
+  }
+
+  function director() {
+    if (global.LuminousTeamActionEconomy) return global.LuminousTeamActionEconomy;
+    if (typeof require === "function") {
+      try { return require("./team-action-economy.js"); } catch (_) {}
+    }
+    return null;
+  }
+
+  function allActiveUnits(encounter) {
+    if (!encounter) return [];
+    return [
+      ...(encounter.allies?.active || []).map((profile) => profile.unit),
+      ...(encounter.enemies?.active || []).map((profile) => profile.unit),
+    ].filter(Boolean);
+  }
+
+  function install(engine = global.CombatEngine) {
+    if (!engine || typeof engine !== "object") return { installed: false, reason: "combat_engine_unavailable" };
+    if (engine.__luminousTeamEconomyInstalled) return { installed: true, engine };
+
+    engine.createTeamEconomyEncounter = function createTeamEconomyEncounter(config = {}) {
+      const api = director();
+      if (!api) return null;
+      const encounter = api.createEncounter(config);
+      this.teamActionEncounter = encounter;
+      this.currentState = "PRE_COMBAT_PLANNING";
+      const unitEconomy = global.LuminousActionEconomy;
+      if (unitEconomy) allActiveUnits(encounter).forEach((unit) => unitEconomy.beginPlanning?.(unit));
+      return api.snapshot(encounter);
+    };
+
+    engine.getTeamEconomyEncounter = function getTeamEconomyEncounter() {
+      return this.teamActionEncounter || null;
+    };
+
+    engine.getTeamEconomySnapshot = function getTeamEconomySnapshot() {
+      const api = director();
+      return api && this.teamActionEncounter ? api.snapshot(this.teamActionEncounter) : null;
+    };
+
+    engine.consumeTeamQuickAction = function consumeTeamQuickAction(side) {
+      const api = director();
+      if (!api || !this.teamActionEncounter) return { consumed: false, reason: "team_economy_unavailable" };
+      return api.consumeQuickAction(this.teamActionEncounter, side);
+    };
+
+    engine.consumeTeamHelp = function consumeTeamHelp(side) {
+      const api = director();
+      if (!api || !this.teamActionEncounter) return { consumed: false, reason: "team_economy_unavailable" };
+      return api.consumeHelp(this.teamActionEncounter, side);
+    };
+
+    engine.lockTeamActionSlots = function lockTeamActionSlots(unitOrId, count = 1, reason = "status") {
+      const api = director();
+      if (!api || !this.teamActionEncounter) return { locked: false, reason: "team_economy_unavailable" };
+      return api.lockUnitSlots(this.teamActionEncounter, unitOrId, count, reason);
+    };
+
+    engine.unlockTeamActionSlots = function unlockTeamActionSlots(unitOrId, count = 1) {
+      const api = director();
+      if (!api || !this.teamActionEncounter) return false;
+      return api.unlockUnitSlots(this.teamActionEncounter, unitOrId, count);
+    };
+
+    engine.queueTurnEndCombatAction = function queueTurnEndCombatAction(entry = {}) {
+      const api = director();
+      if (!api || !this.teamActionEncounter) return null;
+      return api.queueTurnEndAction(this.teamActionEncounter, entry);
+    };
+
+    engine.cancelTurnEndCombatActionsForUnit = function cancelTurnEndCombatActionsForUnit(unitOrId, reason = "cancelled") {
+      const api = director();
+      if (!api || !this.teamActionEncounter) return 0;
+      return api.cancelTurnEndActionsForUnit(this.teamActionEncounter, unitOrId, reason);
+    };
+
+    engine.markPlayerPlanningReady = function markPlayerPlanningReady(options = {}) {
+      const api = director();
+      if (!api || !this.teamActionEncounter) return { ready: false, reason: "team_economy_unavailable" };
+      const result = api.playerReady(this.teamActionEncounter, { aiPlanner: options.aiPlanner });
+      if (!result.ready) return result;
+
+      const finishAi = (aiResult) => {
+        if (options.autoStartCombat === false) return { ...result, aiResult };
+        const aiReady = api.aiReady(this.teamActionEncounter);
+        if (aiReady.ready) {
+          this.currentState = "COMBAT_ACTIVE";
+          const unitEconomy = global.LuminousActionEconomy;
+          if (unitEconomy) allActiveUnits(this.teamActionEncounter).forEach((unit) => unitEconomy.beginCombat?.(unit));
+        }
+        return { ...result, aiResult, aiReady, phase: this.teamActionEncounter.phase };
+      };
+
+      if (result.aiResult && typeof result.aiResult.then === "function") return result.aiResult.then(finishAi);
+      return finishAi(result.aiResult);
+    };
+
+    engine.markAiPlanningReady = function markAiPlanningReady() {
+      const api = director();
+      if (!api || !this.teamActionEncounter) return { ready: false, reason: "team_economy_unavailable" };
+      const result = api.aiReady(this.teamActionEncounter);
+      if (result.ready) {
+        this.currentState = "COMBAT_ACTIVE";
+        const unitEconomy = global.LuminousActionEconomy;
+        if (unitEconomy) allActiveUnits(this.teamActionEncounter).forEach((unit) => unitEconomy.beginCombat?.(unit));
+      }
+      return result;
+    };
+
+    engine.beginTeamTurnEnd = function beginTeamTurnEnd() {
+      const api = director();
+      if (!api || !this.teamActionEncounter) return { started: false, reason: "team_economy_unavailable" };
+      return api.beginTurnEnd(this.teamActionEncounter);
+    };
+
+    engine.endTeamRound = function endTeamRound(handlers = {}) {
+      const api = director();
+      if (!api || !this.teamActionEncounter) return { ended: false, reason: "team_economy_unavailable" };
+      const result = api.endRound(this.teamActionEncounter, handlers);
+      if (result.ended) {
+        this.currentState = "PRE_COMBAT_PLANNING";
+        const unitEconomy = global.LuminousActionEconomy;
+        if (unitEconomy) allActiveUnits(this.teamActionEncounter).forEach((unit) => unitEconomy.beginPlanning?.(unit));
+      }
+      return result;
+    };
+
+    Object.defineProperty(engine, "__luminousTeamEconomyInstalled", { value: true, configurable: true, enumerable: false });
+    return { installed: true, engine };
+  }
+
+  const api = Object.freeze({ director, allActiveUnits, install });
+  global.LuminousCombatTeamEconomyBridge = api;
+  if (global.CombatEngine) install(global.CombatEngine);
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/team-action-economy.js
+++ b/js/team-action-economy.js
@@ -1,0 +1,511 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousTeamActionEconomy) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousTeamActionEconomy;
+    return;
+  }
+
+  const DEFAULT_ACTION_CAP = 12;
+  const DEFAULT_BALANCE_TOLERANCE = 1;
+  const ALLY_TRIPLE_SLOT_LIMIT = 2;
+  const MAX_REDISTRIBUTION_PER_ROUND = 1;
+
+  const PHASES = Object.freeze({
+    PLANNING_PLAYER: "planning_player",
+    PLANNING_AI: "planning_ai",
+    COMBAT: "combat",
+    TURN_END: "turn_end",
+  });
+
+  const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+  const finiteInt = (value, fallback = 0) => Number.isFinite(Number(value)) ? Math.trunc(Number(value)) : fallback;
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+
+  function idFor(unit = {}, fallback = "unit") {
+    return String(unit.id || unit.unitId || unit.characterId || unit.actorId || unit.name || fallback);
+  }
+
+  function numericSpeed(unit = {}) {
+    const candidates = [unit.resolvedSpeed, unit.currentSpeed, unit.speedRoll, unit.speedValue, unit.speed_value, unit.speed];
+    const found = candidates.map(Number).find(Number.isFinite);
+    return found == null ? 0 : found;
+  }
+
+  function slotData(unit = {}) {
+    const nested = unit.actionSlotState && typeof unit.actionSlotState === "object" ? unit.actionSlotState
+      : unit.actionSlots && typeof unit.actionSlots === "object" ? unit.actionSlots
+        : {};
+    const scalarActionSlots = Number.isFinite(Number(unit.actionSlots)) ? Number(unit.actionSlots) : null;
+    const initial = finiteInt(
+      nested.initial ?? unit.initialActionSlots ?? unit.initial_action_slots ?? scalarActionSlots ?? unit.activeSlots,
+      1
+    );
+    const current = finiteInt(
+      nested.current ?? unit.currentActionSlots ?? unit.current_action_slots ?? initial,
+      initial
+    );
+    const max = finiteInt(
+      nested.max ?? unit.maxActionSlots ?? unit.max_action_slots ?? Math.max(initial, current, 1),
+      Math.max(initial, current, 1)
+    );
+    return {
+      initial: Math.max(0, initial),
+      current: Math.max(0, current),
+      max: Math.max(0, max),
+    };
+  }
+
+  function scalingRule(unit = {}) {
+    const raw = unit.slotScaling || unit.actionSlotRule || unit.action_slot_rule || unit.actionSlotsRule || null;
+    if (!raw || typeof raw !== "object") return null;
+    const type = normalizeId(raw.type || raw.mode);
+    if (!["opponent_relative", "opponentrelative"].includes(type)) return null;
+    return {
+      type: "opponent_relative",
+      offset: finiteInt(raw.offset, 0),
+    };
+  }
+
+  function buildProfile(unit, side, index) {
+    const slots = slotData(unit);
+    return {
+      id: idFor(unit, `${side}_${index}`),
+      unit,
+      side,
+      speed: numericSpeed(unit),
+      initialActionSlots: slots.initial,
+      currentActionSlots: clamp(slots.current, 0, Math.max(slots.max, slots.current)),
+      maxActionSlots: Math.max(slots.max, slots.initial, slots.current),
+      usableActionSlots: 0,
+      balanceLockedSlots: 0,
+      statusLockedSlots: 0,
+      scaling: scalingRule(unit),
+    };
+  }
+
+  function createTeam(side, units = [], backups = [], options = {}) {
+    const normalizedSide = normalizeId(side) === "enemy" || normalizeId(side) === "enemies" ? "enemies" : "allies";
+    const profiles = (Array.isArray(units) ? units : []).map((unit, index) => buildProfile(unit, normalizedSide, index));
+    const backupProfiles = (Array.isArray(backups) ? backups : []).map((unit, index) => buildProfile(unit, normalizedSide, index + profiles.length));
+    return {
+      side: normalizedSide,
+      actionCap: Math.max(1, finiteInt(options.actionCap, DEFAULT_ACTION_CAP)),
+      active: profiles,
+      backups: backupProfiles,
+      quickActionRemaining: 1,
+      helpRemaining: 1,
+      pendingRedistribution: Math.max(0, finiteInt(options.pendingRedistribution, 0)),
+      heldVacatedSlots: Math.max(0, finiteInt(options.heldVacatedSlots, 0)),
+      roundGrowthEnabled: options.roundGrowthEnabled ?? (normalizedSide === "enemies"),
+      ready: false,
+    };
+  }
+
+  function speedOrder(team) {
+    return [...team.active].sort((a, b) => (b.speed - a.speed) || String(a.id).localeCompare(String(b.id)));
+  }
+
+  function alliedEffectiveMax(team, profile) {
+    const ordered = speedOrder(team);
+    const tripleEligible = new Set(ordered.slice(0, ALLY_TRIPLE_SLOT_LIMIT).map((entry) => entry.id));
+    const sideCap = tripleEligible.has(profile.id) ? 3 : 2;
+    return Math.min(profile.maxActionSlots, sideCap);
+  }
+
+  function effectiveMax(team, profile) {
+    return team.side === "allies" ? alliedEffectiveMax(team, profile) : profile.maxActionSlots;
+  }
+
+  function totalAllocated(team) {
+    return team.active.reduce((sum, profile) => sum + Math.max(0, finiteInt(profile.currentActionSlots, 0)), 0);
+  }
+
+  function totalUsable(team) {
+    return team.active.reduce((sum, profile) => sum + Math.max(0, finiteInt(profile.usableActionSlots, 0)), 0);
+  }
+
+  function distributeAlliedSlots(team) {
+    if (team.side !== "allies") return team;
+    for (const profile of team.active) {
+      const max = effectiveMax(team, profile);
+      profile.currentActionSlots = clamp(Math.max(profile.initialActionSlots, profile.currentActionSlots), 0, max);
+    }
+    for (const profile of speedOrder(team)) {
+      const max = effectiveMax(team, profile);
+      while (profile.currentActionSlots < max && totalAllocated(team) < team.actionCap) {
+        profile.currentActionSlots += 1;
+      }
+      if (totalAllocated(team) >= team.actionCap) break;
+    }
+    return team;
+  }
+
+  function applyOpponentRelativeScaling(team, opponentAllocated) {
+    const relative = team.active.filter((profile) => profile.scaling?.type === "opponent_relative");
+    if (!relative.length) return team;
+    for (const profile of relative) {
+      const target = clamp(opponentAllocated + profile.scaling.offset, profile.initialActionSlots, effectiveMax(team, profile));
+      profile.currentActionSlots = target;
+    }
+    return team;
+  }
+
+  function grantOneSlot(team, options = {}) {
+    if (totalAllocated(team) >= team.actionCap) return null;
+    const preferred = options.preferredUnitId ? String(options.preferredUnitId) : null;
+    const ordered = speedOrder(team);
+    if (preferred) ordered.sort((a, b) => (a.id === preferred ? -1 : b.id === preferred ? 1 : 0));
+    const recipient = ordered.find((profile) => profile.currentActionSlots < effectiveMax(team, profile));
+    if (!recipient) return null;
+    recipient.currentActionSlots += 1;
+    return recipient;
+  }
+
+  function applyRoundGrowth(team) {
+    let growth = null;
+    if (team.roundGrowthEnabled) growth = grantOneSlot(team);
+    let redistributed = null;
+    if (team.pendingRedistribution > 0 && team.backups.length === 0) {
+      redistributed = grantOneSlot(team);
+      if (redistributed) team.pendingRedistribution = Math.max(0, team.pendingRedistribution - MAX_REDISTRIBUTION_PER_ROUND);
+    }
+    return { growth, redistributed };
+  }
+
+  function allocationForBalance(team, usableCap) {
+    const ordered = speedOrder(team);
+    const byId = new Map(ordered.map((profile) => [profile.id, profile]));
+    const usable = new Map(team.active.map((profile) => [profile.id, profile.currentActionSlots]));
+    let current = totalAllocated(team);
+    const slowest = [...ordered].reverse();
+    while (current > usableCap) {
+      let changed = false;
+      for (const profile of slowest) {
+        const value = usable.get(profile.id) || 0;
+        if (value <= 1) continue;
+        usable.set(profile.id, value - 1);
+        current -= 1;
+        changed = true;
+        if (current <= usableCap) break;
+      }
+      if (current <= usableCap) break;
+      if (!changed) {
+        for (const profile of slowest) {
+          const value = usable.get(profile.id) || 0;
+          if (value <= 0) continue;
+          usable.set(profile.id, value - 1);
+          current -= 1;
+          changed = true;
+          if (current <= usableCap) break;
+        }
+      }
+      if (!changed) break;
+    }
+
+    for (const [id, profile] of byId.entries()) {
+      const balanced = Math.max(0, usable.get(id) || 0);
+      const statusLock = clamp(profile.statusLockedSlots, 0, balanced);
+      profile.usableActionSlots = Math.max(0, balanced - statusLock);
+      profile.balanceLockedSlots = Math.max(0, profile.currentActionSlots - balanced);
+    }
+    return team;
+  }
+
+  function reconcileBalance(encounter) {
+    const tolerance = Math.max(0, finiteInt(encounter.balanceTolerance, DEFAULT_BALANCE_TOLERANCE));
+    const allyAllocated = totalAllocated(encounter.allies);
+    const enemyAllocated = totalAllocated(encounter.enemies);
+    const allyCap = Math.min(allyAllocated, enemyAllocated + tolerance);
+    const enemyCap = Math.min(enemyAllocated, allyAllocated + tolerance);
+    allocationForBalance(encounter.allies, allyCap);
+    allocationForBalance(encounter.enemies, enemyCap);
+    encounter.balance = {
+      tolerance,
+      allocatedDifference: allyAllocated - enemyAllocated,
+      usableDifference: totalUsable(encounter.allies) - totalUsable(encounter.enemies),
+    };
+    return encounter.balance;
+  }
+
+  function syncUnitAliases(team) {
+    for (const profile of team.active) {
+      const unit = profile.unit;
+      if (!unit || typeof unit !== "object") continue;
+      unit.initialActionSlots = profile.initialActionSlots;
+      unit.currentActionSlots = profile.currentActionSlots;
+      unit.maxActionSlots = profile.maxActionSlots;
+      unit.activeSlots = profile.usableActionSlots;
+      unit.actionSlotState = {
+        initial: profile.initialActionSlots,
+        current: profile.currentActionSlots,
+        max: profile.maxActionSlots,
+        usable: profile.usableActionSlots,
+        balanceLocked: profile.balanceLockedSlots,
+        statusLocked: profile.statusLockedSlots,
+      };
+    }
+  }
+
+  function syncEncounter(encounter) {
+    reconcileBalance(encounter);
+    syncUnitAliases(encounter.allies);
+    syncUnitAliases(encounter.enemies);
+    return encounter;
+  }
+
+  function createEncounter(config = {}) {
+    const allies = createTeam("allies", config.allies || [], config.allyBackups || config.alliedBackups || [], config.alliesOptions || {});
+    const enemies = createTeam("enemies", config.enemies || [], config.enemyBackups || [], config.enemiesOptions || {});
+    const encounter = {
+      id: String(config.id || `encounter_${Date.now()}`),
+      round: Math.max(1, finiteInt(config.round, 1)),
+      phase: PHASES.PLANNING_PLAYER,
+      balanceTolerance: Math.max(0, finiteInt(config.balanceTolerance, DEFAULT_BALANCE_TOLERANCE)),
+      allies,
+      enemies,
+      turnEndQueue: [],
+      history: [],
+    };
+    distributeAlliedSlots(allies);
+    applyOpponentRelativeScaling(enemies, totalAllocated(allies));
+    applyOpponentRelativeScaling(allies, totalAllocated(enemies));
+    resetPlanningResources(encounter);
+    return syncEncounter(encounter);
+  }
+
+  function resetPlanningResources(encounter) {
+    for (const team of [encounter.allies, encounter.enemies]) {
+      team.quickActionRemaining = 1;
+      team.helpRemaining = 1;
+      team.ready = false;
+    }
+    return encounter;
+  }
+
+  function teamForSide(encounter, side) {
+    return normalizeId(side).startsWith("enem") ? encounter.enemies : encounter.allies;
+  }
+
+  function profileForUnit(encounter, unitOrId) {
+    const wanted = typeof unitOrId === "object" ? idFor(unitOrId) : String(unitOrId ?? "");
+    for (const team of [encounter.allies, encounter.enemies]) {
+      const profile = team.active.find((entry) => entry.id === wanted || entry.unit === unitOrId);
+      if (profile) return { team, profile };
+    }
+    return null;
+  }
+
+  function consumeQuickAction(encounter, side) {
+    const team = teamForSide(encounter, side);
+    if (![PHASES.PLANNING_PLAYER, PHASES.PLANNING_AI].includes(encounter.phase)) return { consumed: false, reason: "quick_action_planning_only" };
+    if (team.quickActionRemaining <= 0) return { consumed: false, reason: "team_quick_action_spent" };
+    team.quickActionRemaining = 0;
+    return { consumed: true, remaining: 0 };
+  }
+
+  function consumeHelp(encounter, side) {
+    const team = teamForSide(encounter, side);
+    if (team.helpRemaining <= 0) return { consumed: false, reason: "team_help_spent" };
+    team.helpRemaining = 0;
+    return { consumed: true, remaining: 0 };
+  }
+
+  function lockUnitSlots(encounter, unitOrId, count = 1, reason = "status") {
+    const found = profileForUnit(encounter, unitOrId);
+    if (!found) return { locked: false, reason: "unit_not_active" };
+    found.profile.statusLockedSlots = clamp(found.profile.statusLockedSlots + Math.max(0, finiteInt(count, 1)), 0, found.profile.currentActionSlots);
+    syncEncounter(encounter);
+    return { locked: true, reason, count: found.profile.statusLockedSlots, usable: found.profile.usableActionSlots };
+  }
+
+  function unlockUnitSlots(encounter, unitOrId, count = 1) {
+    const found = profileForUnit(encounter, unitOrId);
+    if (!found) return false;
+    found.profile.statusLockedSlots = Math.max(0, found.profile.statusLockedSlots - Math.max(0, finiteInt(count, 1)));
+    syncEncounter(encounter);
+    return true;
+  }
+
+  function registerVacatedSlots(encounter, side, count, options = {}) {
+    const team = teamForSide(encounter, side);
+    const amount = Math.max(0, finiteInt(count, 0));
+    const hasBackup = options.hasBackup ?? (team.backups.length > 0);
+    if (hasBackup) team.heldVacatedSlots += amount;
+    else team.pendingRedistribution += amount;
+    return { held: team.heldVacatedSlots, pending: team.pendingRedistribution };
+  }
+
+  function inheritReplacementSlots(encounter, side, outgoingUnitOrId, incomingUnit, options = {}) {
+    const team = teamForSide(encounter, side);
+    const outgoingFound = profileForUnit(encounter, outgoingUnitOrId);
+    const outgoingSlots = outgoingFound?.profile?.currentActionSlots || finiteInt(options.outgoingSlots, 1);
+    const incoming = buildProfile(incomingUnit, team.side, team.active.length + team.backups.length);
+    const cap = Math.max(1, finiteInt(options.cap, 2));
+    incoming.currentActionSlots = Math.min(outgoingSlots, cap, effectiveMax(team, incoming));
+    incoming.initialActionSlots = Math.min(incoming.initialActionSlots, incoming.currentActionSlots || incoming.initialActionSlots);
+    return incoming;
+  }
+
+  function queueTurnEndAction(encounter, entry = {}) {
+    const queued = {
+      id: String(entry.id || `turn_end_${encounter.round}_${encounter.turnEndQueue.length}`),
+      type: normalizeId(entry.type || "effect"),
+      unitId: entry.unitId == null ? null : String(entry.unitId),
+      payload: entry.payload && typeof entry.payload === "object" ? { ...entry.payload } : {},
+      cancelled: false,
+      cancelReason: null,
+    };
+    encounter.turnEndQueue.push(queued);
+    return queued;
+  }
+
+  function cancelTurnEndActionsForUnit(encounter, unitOrId, reason = "cancelled") {
+    const wanted = typeof unitOrId === "object" ? idFor(unitOrId) : String(unitOrId ?? "");
+    let count = 0;
+    for (const entry of encounter.turnEndQueue) {
+      if (entry.unitId !== wanted || entry.cancelled) continue;
+      entry.cancelled = true;
+      entry.cancelReason = reason;
+      count += 1;
+    }
+    return count;
+  }
+
+  function resolveTurnEndQueue(encounter, handlers = {}) {
+    const results = [];
+    for (const entry of encounter.turnEndQueue) {
+      if (entry.cancelled) {
+        results.push({ entry, resolved: false, reason: entry.cancelReason || "cancelled" });
+        continue;
+      }
+      const handler = handlers[entry.type] || handlers.default;
+      if (typeof handler !== "function") {
+        results.push({ entry, resolved: false, reason: "missing_handler" });
+        continue;
+      }
+      results.push({ entry, resolved: true, result: handler(entry, encounter) });
+    }
+    encounter.turnEndQueue = [];
+    return results;
+  }
+
+  function playerReady(encounter, options = {}) {
+    if (encounter.phase !== PHASES.PLANNING_PLAYER) return { ready: false, reason: "not_player_planning" };
+    encounter.allies.ready = true;
+    encounter.phase = PHASES.PLANNING_AI;
+    let aiResult = null;
+    if (typeof options.aiPlanner === "function") aiResult = options.aiPlanner(encounter);
+    return { ready: true, phase: encounter.phase, aiResult };
+  }
+
+  function aiReady(encounter) {
+    if (encounter.phase !== PHASES.PLANNING_AI) return { ready: false, reason: "not_ai_planning" };
+    encounter.enemies.ready = true;
+    encounter.phase = PHASES.COMBAT;
+    return { ready: true, phase: encounter.phase };
+  }
+
+  function beginTurnEnd(encounter) {
+    if (encounter.phase !== PHASES.COMBAT) return { started: false, reason: "combat_phase_required" };
+    encounter.phase = PHASES.TURN_END;
+    return { started: true, phase: encounter.phase };
+  }
+
+  function beginNextRound(encounter) {
+    encounter.round += 1;
+    const allyGrowth = applyRoundGrowth(encounter.allies);
+    const enemyGrowth = applyRoundGrowth(encounter.enemies);
+    applyOpponentRelativeScaling(encounter.enemies, totalAllocated(encounter.allies));
+    applyOpponentRelativeScaling(encounter.allies, totalAllocated(encounter.enemies));
+    resetPlanningResources(encounter);
+    encounter.phase = PHASES.PLANNING_PLAYER;
+    syncEncounter(encounter);
+    return { round: encounter.round, phase: encounter.phase, allyGrowth, enemyGrowth };
+  }
+
+  function endRound(encounter, handlers = {}) {
+    if (encounter.phase === PHASES.COMBAT) beginTurnEnd(encounter);
+    if (encounter.phase !== PHASES.TURN_END) return { ended: false, reason: "turn_end_phase_required" };
+    const turnEndResults = resolveTurnEndQueue(encounter, handlers);
+    const next = beginNextRound(encounter);
+    return { ended: true, turnEndResults, ...next };
+  }
+
+  function snapshot(encounter) {
+    const teamSnapshot = (team) => ({
+      side: team.side,
+      actionCap: team.actionCap,
+      allocated: totalAllocated(team),
+      usable: totalUsable(team),
+      quickActionRemaining: team.quickActionRemaining,
+      helpRemaining: team.helpRemaining,
+      pendingRedistribution: team.pendingRedistribution,
+      heldVacatedSlots: team.heldVacatedSlots,
+      active: team.active.map((profile) => ({
+        id: profile.id,
+        speed: profile.speed,
+        initial: profile.initialActionSlots,
+        current: profile.currentActionSlots,
+        max: profile.maxActionSlots,
+        usable: profile.usableActionSlots,
+        balanceLocked: profile.balanceLockedSlots,
+        statusLocked: profile.statusLockedSlots,
+      })),
+      backups: team.backups.map((profile) => profile.id),
+    });
+    return {
+      id: encounter.id,
+      round: encounter.round,
+      phase: encounter.phase,
+      balance: { ...(encounter.balance || {}) },
+      allies: teamSnapshot(encounter.allies),
+      enemies: teamSnapshot(encounter.enemies),
+      turnEndQueue: encounter.turnEndQueue.map((entry) => ({ ...entry, payload: { ...entry.payload } })),
+    };
+  }
+
+  const api = Object.freeze({
+    DEFAULT_ACTION_CAP,
+    DEFAULT_BALANCE_TOLERANCE,
+    ALLY_TRIPLE_SLOT_LIMIT,
+    MAX_REDISTRIBUTION_PER_ROUND,
+    PHASES,
+    idFor,
+    numericSpeed,
+    slotData,
+    scalingRule,
+    createTeam,
+    createEncounter,
+    speedOrder,
+    effectiveMax,
+    totalAllocated,
+    totalUsable,
+    distributeAlliedSlots,
+    applyOpponentRelativeScaling,
+    grantOneSlot,
+    applyRoundGrowth,
+    reconcileBalance,
+    syncEncounter,
+    teamForSide,
+    profileForUnit,
+    consumeQuickAction,
+    consumeHelp,
+    lockUnitSlots,
+    unlockUnitSlots,
+    registerVacatedSlots,
+    inheritReplacementSlots,
+    queueTurnEndAction,
+    cancelTurnEndActionsForUnit,
+    resolveTurnEndQueue,
+    playerReady,
+    aiReady,
+    beginTurnEnd,
+    beginNextRound,
+    endRound,
+    snapshot,
+  });
+
+  global.LuminousTeamActionEconomy = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/tests/team-action-economy-smoke.mjs
+++ b/tests/team-action-economy-smoke.mjs
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const economy = require('../js/team-action-economy.js');
+
+globalThis.LuminousTeamActionEconomy = economy;
+globalThis.LuminousActionEconomy = {
+  beginPlanning(unit) { unit.__planningCount = (unit.__planningCount || 0) + 1; },
+  beginCombat(unit) { unit.__combatCount = (unit.__combatCount || 0) + 1; },
+};
+
+const bridge = require('../js/combat-team-economy-bridge.js');
+
+// Allied side: 12 total Actions, distributed by Speed; only the two fastest may reach 3.
+const allies = Array.from({ length: 8 }, (_, index) => ({
+  id: `ally_${index + 1}`,
+  speed: 20 - index,
+  initialActionSlots: 1,
+  maxActionSlots: 3,
+}));
+
+// Special enemy: one Action Slot per opposing slot, but one fewer.
+const boss = {
+  id: 'boss',
+  speed: 10,
+  initialActionSlots: 3,
+  maxActionSlots: 12,
+  slotScaling: { type: 'opponent_relative', offset: -1 },
+};
+
+const encounter = economy.createEncounter({ allies, enemies: [boss] });
+let snapshot = economy.snapshot(encounter);
+
+assert.equal(snapshot.allies.allocated, 12);
+assert.equal(snapshot.enemies.allocated, 11);
+assert.equal(snapshot.allies.usable - snapshot.enemies.usable, 1);
+assert.equal(snapshot.allies.active.filter((entry) => entry.current === 3).length, 2);
+assert.equal(snapshot.allies.active.filter((entry) => entry.current > 3).length, 0);
+
+// Quick Action and Help are team resources, not one per Unit.
+assert.equal(economy.consumeQuickAction(encounter, 'allies').consumed, true);
+assert.equal(economy.consumeQuickAction(encounter, 'allies').consumed, false);
+assert.equal(economy.consumeQuickAction(encounter, 'enemies').consumed, true);
+assert.equal(economy.consumeHelp(encounter, 'allies').consumed, true);
+assert.equal(economy.consumeHelp(encounter, 'allies').consumed, false);
+
+// Grapple/Stagger-style slot locks reduce usable Actions without redistributing them.
+const lock = economy.lockUnitSlots(encounter, 'ally_1', 1, 'grapple');
+assert.equal(lock.locked, true);
+snapshot = economy.snapshot(encounter);
+assert.equal(snapshot.allies.active.find((entry) => entry.id === 'ally_1').statusLocked, 1);
+
+// Retreat/Escape-style effects can live in an On Turn End queue and be cancelled before resolution.
+const queued = economy.queueTurnEndAction(encounter, { type: 'escape', unitId: 'ally_2' });
+assert.ok(queued.id);
+assert.equal(economy.cancelTurnEndActionsForUnit(encounter, 'ally_2', 'grappled'), 1);
+
+// Planning lifecycle: Player Ready -> AI Planning -> Combat -> Turn End -> next Planning.
+assert.equal(economy.playerReady(encounter).ready, true);
+assert.equal(economy.aiReady(encounter).ready, true);
+assert.equal(economy.beginTurnEnd(encounter).started, true);
+const ended = economy.endRound(encounter, { escape: () => ({ escaped: true }) });
+assert.equal(ended.ended, true);
+assert.equal(encounter.round, 2);
+assert.equal(encounter.phase, economy.PHASES.PLANNING_PLAYER);
+assert.equal(encounter.allies.quickActionRemaining, 1);
+assert.equal(encounter.allies.helpRemaining, 1);
+
+// Enemy Action economy grows by at most +1 per round toward individual maxima.
+const growthEncounter = economy.createEncounter({
+  allies: [{ id: 'player', speed: 10, initialActionSlots: 1, maxActionSlots: 3 }],
+  enemies: [
+    { id: 'enemy_1', speed: 10, initialActionSlots: 1, maxActionSlots: 2 },
+    { id: 'enemy_2', speed: 9, initialActionSlots: 1, maxActionSlots: 3 },
+  ],
+  enemiesOptions: { roundGrowthEnabled: true },
+});
+const beforeGrowth = economy.snapshot(growthEncounter).enemies.allocated;
+economy.beginNextRound(growthEncounter);
+const afterGrowth = economy.snapshot(growthEncounter).enemies.allocated;
+assert.equal(afterGrowth, beforeGrowth + 1);
+
+// Vacated slots are held while Backups exist; without Backups only one can be redistributed per round.
+const redistributionTeam = economy.createTeam('allies', [
+  { id: 'redistribution_unit', speed: 5, initialActionSlots: 1, currentActionSlots: 1, maxActionSlots: 3 },
+], [], { roundGrowthEnabled: false });
+const redistributionEncounter = {
+  allies: redistributionTeam,
+  enemies: economy.createTeam('enemies', [{ id: 'enemy', initialActionSlots: 1, maxActionSlots: 1 }], []),
+  balanceTolerance: 1,
+};
+economy.registerVacatedSlots(redistributionEncounter, 'allies', 2, { hasBackup: false });
+assert.equal(redistributionTeam.pendingRedistribution, 2);
+const redistribution = economy.applyRoundGrowth(redistributionTeam);
+assert.ok(redistribution.redistributed);
+assert.equal(redistributionTeam.pendingRedistribution, 1);
+
+// Retreat replacement inherits at most two Actions, never a third Action Slot.
+const incoming = economy.inheritReplacementSlots(
+  redistributionEncounter,
+  'allies',
+  'missing_outgoing',
+  { id: 'backup', speed: 1, initialActionSlots: 1, maxActionSlots: 3 },
+  { cap: 2, outgoingSlots: 3 },
+);
+assert.equal(incoming.currentActionSlots, 2);
+
+// CombatEngine bridge exposes the lifecycle without replacing the legacy engine implementation.
+const engine = { currentState: 'COMBAT_ACTIVE' };
+assert.equal(bridge.install(engine).installed, true);
+const bridgeSnapshot = engine.createTeamEconomyEncounter({
+  allies: [
+    { id: 'bridge_a', speed: 10, initialActionSlots: 1, maxActionSlots: 3 },
+    { id: 'bridge_b', speed: 9, initialActionSlots: 1, maxActionSlots: 3 },
+  ],
+  enemies: [
+    { id: 'bridge_boss', speed: 8, initialActionSlots: 3, maxActionSlots: 6, slotScaling: { type: 'opponent_relative', offset: -1 } },
+  ],
+});
+assert.equal(engine.currentState, 'PRE_COMBAT_PLANNING');
+assert.equal(bridgeSnapshot.phase, economy.PHASES.PLANNING_PLAYER);
+assert.equal(engine.consumeTeamQuickAction('allies').consumed, true);
+const ready = engine.markPlayerPlanningReady({ aiPlanner: () => ({ planned: true }) });
+assert.equal(ready.aiResult.planned, true);
+assert.equal(engine.currentState, 'COMBAT_ACTIVE');
+engine.queueTurnEndCombatAction({ type: 'retreat', unitId: 'bridge_a' });
+assert.equal(engine.beginTeamTurnEnd().started, true);
+const bridgeEnd = engine.endTeamRound({ retreat: () => ({ rotated: true }) });
+assert.equal(bridgeEnd.ended, true);
+assert.equal(engine.currentState, 'PRE_COMBAT_PLANNING');
+assert.equal(engine.getTeamEconomySnapshot().round, 2);
+
+console.log('team-action-economy smoke: OK');


### PR DESCRIPTION
## Objetivo
Implementar la base autoritativa de **Team Action Economy** y el ciclo de ronda para que el combate pueda avanzar sin seguir tratando los Action Slots como recursos aislados por Unit.

## Incluye
### `js/team-action-economy.js`
- Cap global de **12 Actions por bando**.
- `initialActionSlots`, `currentActionSlots`, `maxActionSlots` separados.
- Distribución aliada por **Speed**.
- Sólo las **2 Units aliadas más rápidas** pueden alcanzar 3 Action Slots; las demás quedan limitadas a 2 aunque su definición tenga un máximo mayor.
- Enemigos respetan su `maxActionSlots` y pueden crecer **+1 slot total por ronda** hasta sus máximos.
- Reglas especiales `slotScaling.type = "opponent_relative"` con `offset`, por ejemplo un Boss a `opponent - 1`.
- Regla global de balance: un bando no puede tener más de **+1 Action utilizable** sobre el contrario.
- Los slots asignados no se borran cuando el balance temporal cambia: el excedente queda `balanceLocked` hasta que vuelva a ser utilizable.
- Locks por estado (`statusLockedSlots`) para Grapple/Stagger/etc. sin redistribuir esos slots.
- Backups: slots vacantes pueden quedar retenidos (`heldVacatedSlots`) en vez de redistribuirse.
- Sin Backups: `pendingRedistribution` reparte como máximo **+1 slot por ronda**.
- Helper de reemplazo/Retreat: una Unit entrante puede heredar slots con cap configurable; la regla acordada usa **máximo 2**, nunca el tercer slot.
- **Quick Action = 1 por bando** durante Planning.
- **Help = once per Turn por bando**.
- Cola cancelable `On Turn End` para Retreat / Escape y futuros efectos.

### Phase lifecycle
```text
Planning Player
      ↓ READY
Planning AI
      ↓ READY
Combat
      ↓
Turn End
      ↓
Next Round / Planning Player
```

- Cuando el lado Player queda Ready, el runtime puede invocar el Tactical AI planner.
- La IA puede quedar Ready automáticamente y arrancar Combat.
- Quick Action / Help se restauran al comenzar la nueva ronda.
- `On Turn End` se resuelve antes de crear la siguiente Planning Phase.

### `js/combat-team-economy-bridge.js`
Añade al `CombatEngine` existente una capa no destructiva:
- `createTeamEconomyEncounter()`
- `getTeamEconomySnapshot()`
- `consumeTeamQuickAction()`
- `consumeTeamHelp()`
- `lockTeamActionSlots()` / `unlockTeamActionSlots()`
- `queueTurnEndCombatAction()`
- `cancelTurnEndCombatActionsForUnit()`
- `markPlayerPlanningReady()`
- `markAiPlanningReady()`
- `beginTeamTurnEnd()`
- `endTeamRound()`

El bridge sincroniza `unit.activeSlots` con los slots actualmente utilizables para que el Action Economy legacy pueda empezar a consumir el nuevo resultado sin reemplazar todavía `combatEngine.js`.

## Smoke test
`tests/team-action-economy-smoke.mjs` cubre:
- 8 aliados -> 12 Actions.
- sólo los 2 más rápidos llegan a 3.
- Boss `opponent_relative -1` -> 11 contra 12.
- diferencia utilizable <= 1.
- Quick Action compartida por Team.
- Help once per Turn por Team.
- locks estilo Grapple.
- cola `On Turn End` y cancelación antes de resolver.
- Player Ready -> AI Planning -> Combat -> Turn End -> siguiente ronda.
- crecimiento enemigo +1 por ronda.
- redistribución máxima +1 por ronda sin Backups.
- Retreat replacement hereda máximo 2 slots.
- bridge con CombatEngine.

El smoke test fue ejecutado localmente y pasó.

## Deliberadamente fuera de alcance
- implementación concreta de Grapple / Help / Retreat / Escape / Improvise.
- Tactical AI scoring; sólo se deja el hook de planificación.
- CombatAction común de Skill / Spell / Universal Action.
- Deck/Battle Viewer.
- Items, Skills, XP y mapa.

## Importante
Este PR parte de `main` y es independiente de:
- Skill Creator PR #730
- XP PR #731
- Items PR #732
- rama de mapa.