### PR TITLE
Combat: canonical CombatAction contract and source adapters

### DIFF
--- a/js/combat-action-adapters.js
+++ b/js/combat-action-adapters.js
@@ -1,0 +1,327 @@
+(function (global) {
+  "use strict";
+
+  const schema = global.LuminousCombatAction || (typeof require === "function" ? require("./combat-action-schema.js") : null);
+  if (!schema) return;
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const asArray = (value) => value == null ? [] : (Array.isArray(value) ? value : [value]);
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const intOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Math.trunc(Number(value)) : fallback;
+
+  function actorIdOf(actor = {}, options = {}) {
+    return String(options.actorId ?? actor.id ?? actor.unitId ?? actor.characterId ?? "").trim();
+  }
+
+  function planningPhase(options = {}) {
+    return options.isAi === true ? schema.PHASES.PLANNING_PHASE_AI : schema.PHASES.PLANNING_PHASE_PLAYER;
+  }
+
+  function baseInput(actor, sourceType, sourceId, options = {}) {
+    return {
+      actorId: actorIdOf(actor, options),
+      actionSlotId: options.actionSlotId ?? options.slotId ?? null,
+      source: { type: sourceType, id: String(sourceId ?? "") },
+      phase: {
+        selectedAt: options.selectedAt || planningPhase(options),
+        executesAt: options.executesAt || schema.PHASES.COMBAT_PHASE,
+      },
+      economy: { cost: options.cost || schema.ECONOMY_COSTS.ACTION },
+      targeting: options.targeting || {},
+      resolution: options.resolution || { type: "automatic" },
+      resources: options.resources || [],
+      modifiers: options.modifiers || [],
+      effects: options.effects || [],
+      metadata: options.metadata || {},
+    };
+  }
+
+  function skillResolution(skill = {}) {
+    if (skill.save || skill.savingThrow || skill.saving_throw || skill.saveAbility || skill.save_ability) {
+      const raw = skill.save || skill.savingThrow || skill.saving_throw || {};
+      return {
+        type: "save",
+        save: {
+          abilityId: normalizeId(raw.abilityId || raw.ability || raw.stat || skill.saveAbility || skill.save_ability),
+          dc: numberOr(raw.dc ?? skill.saveDC ?? skill.save_dc, 0),
+          onSuccess: normalizeId(raw.onSuccess || raw.on_success || skill.saveOnSuccess || "negates") || "negates",
+        },
+      };
+    }
+    if (skill.check || skill.threshold != null) {
+      return {
+        type: "check",
+        check: {
+          stat: normalizeId(skill.check?.stat || skill.statUsed || skill.stat_used || skill.scalingStat || skill.scaling_stat),
+          skill: normalizeId(skill.check?.skill || skill.skillUsed || skill.skill_used),
+          threshold: numberOr(skill.check?.threshold ?? skill.threshold, 0),
+        },
+      };
+    }
+    if (skill.contest) return { type: "contest", contest: clone(skill.contest) };
+    const isUnclashable = skill.isUnclashable === true || skill.is_unclashable === true;
+    const isClashable = skill.isClashable !== false && skill.is_clashable !== false && !isUnclashable;
+    return { type: isClashable ? "clash" : "unopposed" };
+  }
+
+  function skillTargeting(skill = {}, options = {}) {
+    const rawType = normalizeId(skill.targetingType || skill.targeting_type || "focused_attack");
+    const indiscriminate = skill.isIndiscriminate === true || skill.is_indiscriminate === true || rawType.includes("indiscriminate");
+    const weight = Math.max(1, intOr(skill.attackWeight ?? skill.atkWeight ?? skill.weight, 1));
+    let mode = "single";
+    if (indiscriminate) mode = "indiscriminate";
+    else if (weight > 1 || rawType.includes("aoe") || rawType.includes("area") || rawType.includes("volley")) mode = "aoe";
+    return {
+      allegiance: options.allegiance || (skill.targetAlly === true || skill.target_ally === true ? "ally" : "enemy"),
+      mode,
+      mainTargetId: options.mainTargetId ?? options.targetId ?? null,
+      targetIds: options.targetIds || [],
+      attackWeight: weight,
+      indiscriminate,
+      criteria: options.criteria || null,
+    };
+  }
+
+  function compileSkillToCombatAction(actor, rawSkill = {}, options = {}) {
+    const skill = global.LuminousCombatSkillSchema?.normalizeCombatSkill
+      ? global.LuminousCombatSkillSchema.normalizeCombatSkill(rawSkill)
+      : rawSkill;
+    const sourceId = skill.id || skill.skillId || options.sourceId || "skill";
+    return schema.createCombatAction({
+      ...baseInput(actor, "skill", sourceId, options),
+      targeting: skillTargeting(skill, options),
+      resolution: options.resolution || skillResolution(skill),
+      effects: options.effects || clone(skill.effects || []),
+      modifiers: options.modifiers || [],
+      resources: options.resources || asArray(skill.resourceCosts || skill.resource_costs),
+      metadata: {
+        ...(options.metadata || {}),
+        name: skill.name || skill.nombre || sourceId,
+        basePower: numberOr(skill.basePower ?? skill.base_power, 0),
+        coinPower: numberOr(skill.coinPower ?? skill.coin_power, 0),
+        coinAmount: Math.max(0, intOr(skill.coinAmount ?? skill.coin_count ?? skill.coinCount, 0)),
+        coinType: skill.coinType || skill.coin_type || null,
+        damageType: skill.damageType || skill.dmgType || skill.attackType || skill.tipo_dano || null,
+        sinAffinity: skill.sinAffinity || skill.affinity || skill.sin || skill.pecado || null,
+        scalingStat: skill.scalingStat || skill.scaling_stat || null,
+        statUsed: skill.statUsed || skill.stat_used || null,
+        skillUsed: skill.skillUsed || skill.skill_used || null,
+        defenseSubtype: skill.defenseSubtype || skill.defense_subtype || null,
+        sourceDefinition: clone(skill),
+      },
+    });
+  }
+
+  function spellTargeting(spell = {}, options = {}) {
+    const raw = normalizeId(spell.targetType || spell.target_type || spell.targetingType || spell.targeting_type || "single");
+    const attackWeight = Math.max(1, intOr(spell.attackWeight ?? spell.atkWeight ?? spell.atk_weight, 1));
+    let mode = "single";
+    if (raw === "self") mode = "self";
+    else if (["multi", "allies", "enemies"].includes(raw)) mode = "multi";
+    else if (["area", "aoe"].includes(raw) || attackWeight > 1) mode = "aoe";
+    if (spell.isIndiscriminate === true || spell.is_indiscriminate === true) mode = "indiscriminate";
+    let allegiance = options.allegiance || "enemy";
+    if (raw === "self") allegiance = "self";
+    else if (raw === "allies") allegiance = "ally";
+    else if (raw === "enemies") allegiance = "enemy";
+    return {
+      allegiance,
+      mode,
+      mainTargetId: options.mainTargetId ?? options.targetId ?? null,
+      targetIds: options.targetIds || [],
+      attackWeight,
+      indiscriminate: mode === "indiscriminate",
+    };
+  }
+
+  function spellResolution(spell = {}, options = {}) {
+    const rawSave = spell.save || spell.savingThrow || spell.saving_throw || {};
+    const abilityId = normalizeId(rawSave.abilityId || rawSave.ability || rawSave.stat || spell.saveAbility || spell.save_ability);
+    if (abilityId) {
+      return {
+        type: "save",
+        save: {
+          abilityId,
+          dc: numberOr(options.saveDC ?? rawSave.dc ?? spell.saveDC ?? spell.save_dc, 0),
+          onSuccess: normalizeId(rawSave.onSuccess || rawSave.on_success || spell.saveOnSuccess || "negates") || "negates",
+        },
+      };
+    }
+    if (spell.check || spell.threshold != null) {
+      return {
+        type: "check",
+        check: {
+          stat: normalizeId(spell.check?.stat || spell.statUsed || spell.stat_used),
+          skill: normalizeId(spell.check?.skill || spell.skillUsed || spell.skill_used),
+          threshold: numberOr(spell.check?.threshold ?? spell.threshold, 0),
+        },
+      };
+    }
+    if (spell.isUnclashable === true || spell.is_unclashable === true) return { type: "unopposed" };
+    return { type: "clash" };
+  }
+
+  function spellResources(spell = {}, options = {}) {
+    if (Array.isArray(options.resources)) return options.resources;
+    const resources = asArray(spell.resourceCosts || spell.resource_costs);
+    const slotLevel = Math.max(0, intOr(options.slotLevel ?? spell.slotLevel ?? spell.level ?? spell.spellLevel, 0));
+    const cantrip = spell.cantrip === true || slotLevel === 0;
+    if (!cantrip) {
+      resources.push({
+        owner: "source",
+        type: "spell_slot",
+        id: String(options.classId || spell.sourceClassId || spell.classId || spell.class_id || ""),
+        amount: 1,
+        metadata: { slotLevel },
+      });
+    }
+    return resources;
+  }
+
+  function compileSpellToCombatAction(actor, spell = {}, options = {}) {
+    const sourceId = spell.id || spell.spellId || options.sourceId || "spell";
+    return schema.createCombatAction({
+      ...baseInput(actor, "spell", sourceId, options),
+      targeting: spellTargeting(spell, options),
+      resolution: options.resolution || spellResolution(spell, options),
+      resources: spellResources(spell, options),
+      effects: options.effects || clone(spell.effects || []),
+      modifiers: options.modifiers || [],
+      metadata: {
+        ...(options.metadata || {}),
+        name: spell.name || spell.nombre || sourceId,
+        slotLevel: Math.max(0, intOr(options.slotLevel ?? spell.slotLevel ?? spell.level ?? spell.spellLevel, 0)),
+        cantrip: spell.cantrip === true || Math.max(0, intOr(options.slotLevel ?? spell.slotLevel ?? spell.level ?? spell.spellLevel, 0)) === 0,
+        concentration: spell.concentration === true,
+        castingTime: spell.castingTime || spell.casting_time || null,
+        sourceClassId: options.classId || spell.sourceClassId || spell.classId || spell.class_id || null,
+        sourceDefinition: clone(spell),
+      },
+    });
+  }
+
+  function compileTraitToCombatAction(actor, trait = {}, options = {}) {
+    const sourceId = trait.id || trait.traitId || options.sourceId || "trait";
+    const resources = options.resources || asArray(trait.resourceCosts || trait.resource_costs);
+    const maxUses = trait.uses ?? trait.maxUses ?? trait.max_uses;
+    if (maxUses != null && !resources.some((resource) => normalizeId(resource.type) === "trait_use")) {
+      resources.push({ owner: "source", type: "trait_use", id: String(sourceId), amount: 1 });
+    }
+    return schema.createCombatAction({
+      ...baseInput(actor, "trait", sourceId, options),
+      resolution: options.resolution || trait.resolution || { type: "automatic" },
+      targeting: options.targeting || trait.targeting || { mode: "self", allegiance: "self" },
+      resources,
+      effects: options.effects || clone(trait.effects || []),
+      metadata: { ...(options.metadata || {}), name: trait.name || trait.nombre || sourceId, sourceDefinition: clone(trait) },
+    });
+  }
+
+  function compileReactionToCombatAction(actor, source = {}, options = {}) {
+    const sourceType = normalizeId(options.sourceType || source.sourceType || source.source_type || "trait");
+    const prepared = normalizeId(options.mode || options.reactionMode) === "prepared";
+    let action;
+    if (sourceType === "skill") action = compileSkillToCombatAction(actor, source, { ...options, cost: "reaction" });
+    else if (sourceType === "spell") action = compileSpellToCombatAction(actor, source, { ...options, cost: "reaction" });
+    else action = compileTraitToCombatAction(actor, source, { ...options, cost: "reaction" });
+    action.economy.cost = schema.ECONOMY_COSTS.REACTION;
+    action.phase.selectedAt = prepared ? planningPhase(options) : schema.PHASES.COMBAT_PHASE;
+    action.phase.executesAt = schema.PHASES.COMBAT_PHASE;
+    action.reaction = {
+      mode: prepared ? "prepared" : "adaptive",
+      trigger: clone(options.trigger || source.trigger || null),
+    };
+    return action;
+  }
+
+  function compileUniversalAction(actor, actionId, options = {}) {
+    const id = normalizeId(actionId);
+    const base = baseInput(actor, "universal", id, options);
+    if (id === "grapple") {
+      return schema.createCombatAction({
+        ...base,
+        targeting: { allegiance: "enemy", mode: "single", mainTargetId: options.targetId || null, targetIds: options.targetIds || [] },
+        resolution: {
+          type: "contest",
+          contest: {
+            attacker: { choices: [{ stat: "strength" }, { skill: "athletics" }] },
+            defender: { choices: [{ stat: "dexterity" }, { skill: "acrobatics" }] },
+            maintenance: {
+              phase: schema.PHASES.ON_TURN_END,
+              attacker: { choices: [{ stat: "strength" }, { skill: "athletics" }] },
+              defender: { choices: [{ stat: "strength" }, { skill: "athletics" }] },
+            },
+            tieRule: "defender_wins",
+          },
+        },
+        metadata: { ...(options.metadata || {}), universalRule: "grapple" },
+      });
+    }
+    if (id === "help") {
+      return schema.createCombatAction({
+        ...base,
+        targeting: { allegiance: "ally", mode: "single", mainTargetId: options.targetUnitId || options.targetId || null },
+        resolution: { type: "automatic" },
+        effects: [{
+          type: "modify_combat_action",
+          targetActionId: options.targetActionId || null,
+          modifier: { source: "help_final_power", type: "final_power", amount: 1 },
+        }],
+        metadata: { ...(options.metadata || {}), universalRule: "help", targetActionSlotId: options.targetActionSlotId || null, oncePerTurnPerTeam: true },
+      });
+    }
+    if (id === "retreat") {
+      return schema.createCombatAction({
+        ...base,
+        phase: { selectedAt: planningPhase(options), executesAt: schema.PHASES.ON_TURN_END },
+        targeting: { allegiance: "self", mode: "self" },
+        resolution: { type: "automatic" },
+        effects: [{ type: "retreat", inheritActionSlotsCap: 2, healHp: false, healSp: false }],
+        metadata: { ...(options.metadata || {}), universalRule: "retreat", cancelableBeforeExecution: true },
+      });
+    }
+    if (id === "escape") {
+      return schema.createCombatAction({
+        ...base,
+        phase: { selectedAt: planningPhase(options), executesAt: schema.PHASES.ON_TURN_END },
+        targeting: { allegiance: "self", mode: "self" },
+        resolution: { type: "automatic" },
+        effects: [{ type: "escape", leavesEncounter: true, deniesXp: true }],
+        metadata: { ...(options.metadata || {}), universalRule: "escape", cancelableBeforeExecution: true },
+      });
+    }
+    if (id === "improvise") {
+      return schema.createCombatAction({
+        ...base,
+        targeting: options.targeting || { allegiance: "enemy", mode: "single", mainTargetId: options.targetId || null },
+        resolution: options.resolution || { type: "automatic" },
+        effects: options.effects || [],
+        metadata: { ...(options.metadata || {}), universalRule: "improvise", dmAdjudicated: true, intent: options.intent || null },
+      });
+    }
+    return schema.createCombatAction({ ...base, targeting: options.targeting || {}, resolution: options.resolution || { type: "automatic" } });
+  }
+
+  function compileSourceToCombatAction(actor, source = {}, options = {}) {
+    const type = normalizeId(options.sourceType || source.sourceType || source.source_type || source.kind || source.type);
+    if (type === "skill") return compileSkillToCombatAction(actor, source, options);
+    if (type === "spell") return compileSpellToCombatAction(actor, source, options);
+    if (type === "trait") return compileTraitToCombatAction(actor, source, options);
+    if (type === "reaction") return compileReactionToCombatAction(actor, source, options);
+    if (type === "universal" || type === "universal_action") return compileUniversalAction(actor, options.actionId || source.actionId || source.id, options);
+    return schema.createCombatAction(baseInput(actor, type || "item", source.id || options.sourceId || "action", options));
+  }
+
+  const api = Object.freeze({
+    compileSkillToCombatAction,
+    compileSpellToCombatAction,
+    compileTraitToCombatAction,
+    compileReactionToCombatAction,
+    compileUniversalAction,
+    compileSourceToCombatAction,
+  });
+
+  global.LuminousCombatActionAdapters = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/combat-action-schema.js
+++ b/js/combat-action-schema.js
@@ -1,0 +1,330 @@
+(function (global) {
+  "use strict";
+
+  const SCHEMA_VERSION = 1;
+
+  const PHASES = Object.freeze({
+    ON_TURN_START: "on_turn_start",
+    PLANNING_PHASE_PLAYER: "planning_phase_player",
+    PLANNING_PHASE_AI: "planning_phase_ai",
+    COMBAT_START: "combat_start",
+    COMBAT_PHASE: "combat_phase",
+    COMBAT_END: "combat_end",
+    ON_TURN_END: "on_turn_end",
+  });
+
+  const ECONOMY_COSTS = Object.freeze({
+    ACTION: "action",
+    QUICK_ACTION: "quick_action",
+    REACTION: "reaction",
+  });
+
+  const SOURCE_TYPES = Object.freeze(["skill", "spell", "trait", "universal", "item"]);
+  const RESOLUTION_TYPES = Object.freeze(["clash", "unopposed", "save", "check", "contest", "automatic"]);
+  const TARGET_MODES = Object.freeze(["self", "single", "multi", "aoe", "indiscriminate"]);
+  const TARGET_ALLEGIANCE = Object.freeze(["self", "ally", "enemy", "neutral"]);
+  const ACTION_STATES = Object.freeze(["planned", "locked", "resolving", "resolved", "cancelled"]);
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const finiteNumber = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const finiteInt = (value, fallback = 0) => Number.isFinite(Number(value)) ? Math.trunc(Number(value)) : fallback;
+  const asArray = (value) => value == null ? [] : (Array.isArray(value) ? value : [value]);
+
+  function normalizePhase(value, fallback = PHASES.COMBAT_PHASE) {
+    const id = normalizeId(value);
+    const aliases = {
+      on_turn_start: PHASES.ON_TURN_START,
+      turn_start: PHASES.ON_TURN_START,
+      round_start: PHASES.ON_TURN_START,
+      planning_phase_player: PHASES.PLANNING_PHASE_PLAYER,
+      planning_player: PHASES.PLANNING_PHASE_PLAYER,
+      player_planning: PHASES.PLANNING_PHASE_PLAYER,
+      planning: PHASES.PLANNING_PHASE_PLAYER,
+      planning_phase_ai: PHASES.PLANNING_PHASE_AI,
+      playing_phase_ai: PHASES.PLANNING_PHASE_AI,
+      planning_ai: PHASES.PLANNING_PHASE_AI,
+      ai_planning: PHASES.PLANNING_PHASE_AI,
+      combat_start: PHASES.COMBAT_START,
+      combat_phase: PHASES.COMBAT_PHASE,
+      combat: PHASES.COMBAT_PHASE,
+      combat_end: PHASES.COMBAT_END,
+      on_turn_end: PHASES.ON_TURN_END,
+      turn_end: PHASES.ON_TURN_END,
+      round_end: PHASES.ON_TURN_END,
+    };
+    return aliases[id] || fallback;
+  }
+
+  function normalizeEconomyCost(value) {
+    const id = normalizeId(value || ECONOMY_COSTS.ACTION);
+    return Object.values(ECONOMY_COSTS).includes(id) ? id : ECONOMY_COSTS.ACTION;
+  }
+
+  function normalizeSource(source = {}) {
+    const type = normalizeId(source.type || source.sourceType || "universal");
+    return {
+      type: SOURCE_TYPES.includes(type) ? type : "universal",
+      id: String(source.id ?? source.sourceId ?? "").trim(),
+      definitionId: source.definitionId == null ? null : String(source.definitionId),
+    };
+  }
+
+  function normalizeTargeting(targeting = {}) {
+    const rawMode = normalizeId(targeting.mode || targeting.targetingMode || targeting.targetingType || "single");
+    const rawAllegiance = normalizeId(targeting.allegiance || targeting.targetAllegiance || "enemy");
+    const isIndiscriminate = targeting.indiscriminate === true || rawMode === "indiscriminate";
+    const mode = isIndiscriminate ? "indiscriminate" : (TARGET_MODES.includes(rawMode) ? rawMode : "single");
+    const allegiance = TARGET_ALLEGIANCE.includes(rawAllegiance) ? rawAllegiance : (mode === "self" ? "self" : "enemy");
+    const mainTargetId = targeting.mainTargetId ?? targeting.targetId ?? null;
+    const targetIds = asArray(targeting.targetIds).map(String).filter(Boolean);
+    if (mainTargetId != null && !targetIds.includes(String(mainTargetId))) targetIds.unshift(String(mainTargetId));
+    return {
+      allegiance,
+      mode,
+      mainTargetId: mainTargetId == null ? null : String(mainTargetId),
+      targetIds,
+      attackWeight: Math.max(1, finiteInt(targeting.attackWeight ?? targeting.atkWeight, 1)),
+      indiscriminate: isIndiscriminate,
+      criteria: targeting.criteria && typeof targeting.criteria === "object" ? clone(targeting.criteria) : null,
+    };
+  }
+
+  function normalizeResolution(resolution = {}) {
+    const type = normalizeId(resolution.type || "automatic");
+    const normalized = {
+      ...clone(resolution),
+      type: RESOLUTION_TYPES.includes(type) ? type : "automatic",
+    };
+    if (normalized.type === "save") {
+      normalized.save = {
+        abilityId: normalizeId(resolution.save?.abilityId || resolution.abilityId || resolution.stat),
+        dc: finiteNumber(resolution.save?.dc ?? resolution.dc, 0),
+        onSuccess: normalizeId(resolution.save?.onSuccess || resolution.onSuccess || "negates") || "negates",
+      };
+    }
+    if (normalized.type === "check") {
+      normalized.check = {
+        stat: normalizeId(resolution.check?.stat || resolution.stat),
+        skill: normalizeId(resolution.check?.skill || resolution.skill),
+        threshold: finiteNumber(resolution.check?.threshold ?? resolution.threshold, 0),
+      };
+    }
+    if (normalized.type === "contest") {
+      normalized.contest = {
+        attacker: clone(resolution.contest?.attacker || resolution.attacker || {}),
+        defender: clone(resolution.contest?.defender || resolution.defender || {}),
+        tieRule: normalizeId(resolution.contest?.tieRule || resolution.tieRule || "defender_wins") || "defender_wins",
+      };
+    }
+    return normalized;
+  }
+
+  function normalizeResourceCost(resource = {}) {
+    const type = normalizeId(resource.type || resource.resourceType);
+    return {
+      owner: normalizeId(resource.owner || "source") || "source",
+      type,
+      id: resource.id == null ? null : String(resource.id),
+      amount: Math.max(0, finiteNumber(resource.amount ?? resource.value, 1)),
+      metadata: resource.metadata && typeof resource.metadata === "object" ? clone(resource.metadata) : null,
+    };
+  }
+
+  function createCombatAction(input = {}) {
+    const actorId = String(input.actorId ?? input.actor?.id ?? input.actor?.unitId ?? "").trim();
+    const actionSlotId = input.actionSlotId == null ? null : String(input.actionSlotId);
+    const source = normalizeSource(input.source || input);
+    const selectedAt = normalizePhase(input.phase?.selectedAt ?? input.selectedAt,
+      input.isAi === true ? PHASES.PLANNING_PHASE_AI : PHASES.PLANNING_PHASE_PLAYER);
+    const executesAt = normalizePhase(input.phase?.executesAt ?? input.executesAt, PHASES.COMBAT_PHASE);
+    const action = {
+      id: String(input.id || `${actorId || "unit"}_${source.type}_${normalizeId(source.id || "action")}_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`),
+      schemaVersion: SCHEMA_VERSION,
+      source,
+      actorId,
+      actionSlotId,
+      economy: { cost: normalizeEconomyCost(input.economy?.cost ?? input.cost) },
+      phase: { selectedAt, executesAt },
+      targeting: normalizeTargeting(input.targeting || {}),
+      resolution: normalizeResolution(input.resolution || {}),
+      resources: asArray(input.resources).map(normalizeResourceCost).filter((entry) => entry.type),
+      modifiers: asArray(input.modifiers).map(clone),
+      effects: asArray(input.effects).map(clone),
+      reaction: input.reaction && typeof input.reaction === "object" ? clone(input.reaction) : null,
+      metadata: input.metadata && typeof input.metadata === "object" ? clone(input.metadata) : {},
+      state: ACTION_STATES.includes(normalizeId(input.state)) ? normalizeId(input.state) : "planned",
+      cancelReason: input.cancelReason ? clone(input.cancelReason) : null,
+    };
+    return action;
+  }
+
+  function normalizeCombatAction(input = {}) {
+    return createCombatAction(input);
+  }
+
+  function validateCombatAction(input = {}) {
+    const action = normalizeCombatAction(input);
+    const errors = [];
+    if (!action.actorId) errors.push("actorId_required");
+    if (!action.source.id) errors.push("source_id_required");
+    if (!SOURCE_TYPES.includes(action.source.type)) errors.push("invalid_source_type");
+    if (!RESOLUTION_TYPES.includes(action.resolution.type)) errors.push("invalid_resolution_type");
+    if (!Object.values(ECONOMY_COSTS).includes(action.economy.cost)) errors.push("invalid_economy_cost");
+    if (!Object.values(PHASES).includes(action.phase.selectedAt) || !Object.values(PHASES).includes(action.phase.executesAt)) errors.push("invalid_phase");
+    if (action.economy.cost === ECONOMY_COSTS.QUICK_ACTION && ![PHASES.PLANNING_PHASE_PLAYER, PHASES.PLANNING_PHASE_AI].includes(action.phase.executesAt)) {
+      errors.push("quick_action_must_execute_in_planning");
+    }
+    if (action.economy.cost === ECONOMY_COSTS.REACTION && action.phase.executesAt !== PHASES.COMBAT_PHASE) errors.push("reaction_must_execute_in_combat_phase");
+    if (action.resolution.type === "save" && !action.resolution.save?.abilityId) errors.push("save_ability_required");
+    return { valid: errors.length === 0, errors, action };
+  }
+
+  function canReceiveHelp(input = {}) {
+    const action = normalizeCombatAction(input);
+    return action.resolution.type === "clash" || action.resolution.type === "check";
+  }
+
+  function applyHelpModifier(input = {}, options = {}) {
+    const action = normalizeCombatAction(input);
+    if (!canReceiveHelp(action)) return { applied: false, reason: "action_not_help_eligible", action };
+    if (action.state === "cancelled" || action.state === "resolved") return { applied: false, reason: "action_not_pending", action };
+    const existing = action.modifiers.some((modifier) => normalizeId(modifier?.source || modifier?.type) === "help_final_power");
+    if (existing) return { applied: false, reason: "help_already_applied", action };
+    action.modifiers.push({
+      source: "help_final_power",
+      type: "final_power",
+      amount: finiteNumber(options.amount, 1),
+      fromActorId: options.fromActorId || null,
+      teamUse: true,
+    });
+    return { applied: true, action };
+  }
+
+  function setActionState(input = {}, nextState) {
+    const action = normalizeCombatAction(input);
+    const state = normalizeId(nextState);
+    if (!ACTION_STATES.includes(state)) return { changed: false, reason: "invalid_state", action };
+    if (action.state === "cancelled" || action.state === "resolved") return { changed: false, reason: "terminal_state", action };
+    action.state = state;
+    if (state !== "cancelled") action.cancelReason = null;
+    return { changed: true, action };
+  }
+
+  function cancelCombatAction(input = {}, reason = {}) {
+    const action = normalizeCombatAction(input);
+    if (["resolved", "cancelled"].includes(action.state)) return { cancelled: false, reason: "terminal_state", action };
+    action.state = "cancelled";
+    action.cancelReason = typeof reason === "string" ? { type: normalizeId(reason) || "cancelled" } : clone(reason || { type: "cancelled" });
+    return { cancelled: true, action };
+  }
+
+  function cancelPendingActions(actions = [], actorId, reason = { type: "stagger" }) {
+    const id = String(actorId ?? "");
+    return asArray(actions).map((raw) => {
+      const action = normalizeCombatAction(raw);
+      if (action.actorId !== id || ["resolved", "cancelled"].includes(action.state)) return action;
+      return cancelCombatAction(action, reason).action;
+    });
+  }
+
+  function validateResourcesContract(resources = []) {
+    const errors = [];
+    const normalized = asArray(resources).map(normalizeResourceCost);
+    normalized.forEach((resource, index) => {
+      if (!resource.type) errors.push(`resource_${index}_type_required`);
+      if (resource.amount < 0) errors.push(`resource_${index}_amount_invalid`);
+    });
+    return { valid: errors.length === 0, errors, resources: normalized };
+  }
+
+  function targetIdOf(unit = {}) {
+    return String(unit.id ?? unit.unitId ?? unit.characterId ?? "").trim();
+  }
+
+  function resolveTargetSelection(actionInput = {}, candidates = [], options = {}) {
+    const action = normalizeCombatAction(actionInput);
+    const targeting = action.targeting;
+    const weight = Math.max(1, targeting.attackWeight);
+    const list = asArray(candidates).filter(Boolean);
+    const byId = new Map(list.map((unit) => [targetIdOf(unit), unit]).filter(([id]) => id));
+    let mainTargetId = targeting.mainTargetId;
+    let chosen = [];
+
+    if (targeting.mode === "self") {
+      return { action, mainTargetId: action.actorId, targetIds: [action.actorId] };
+    }
+
+    const candidateIds = list.map(targetIdOf).filter(Boolean);
+    const random = typeof options.random === "function" ? options.random : Math.random;
+    const randomPick = (pool) => pool.length ? pool[Math.min(pool.length - 1, Math.floor(random() * pool.length))] : null;
+
+    if (targeting.indiscriminate || targeting.mode === "indiscriminate") {
+      mainTargetId = randomPick(candidateIds);
+      const remaining = candidateIds.filter((id) => id !== mainTargetId);
+      chosen = mainTargetId ? [mainTargetId] : [];
+      while (chosen.length < weight && remaining.length) {
+        const id = randomPick(remaining);
+        chosen.push(id);
+        remaining.splice(remaining.indexOf(id), 1);
+      }
+    } else {
+      if (!mainTargetId || !byId.has(String(mainTargetId))) mainTargetId = targeting.targetIds.find((id) => byId.has(String(id))) || candidateIds[0] || null;
+      chosen = mainTargetId ? [String(mainTargetId)] : [];
+      for (const id of targeting.targetIds) {
+        const value = String(id);
+        if (chosen.length >= weight) break;
+        if (byId.has(value) && !chosen.includes(value)) chosen.push(value);
+      }
+      for (const id of candidateIds) {
+        if (chosen.length >= weight) break;
+        if (!chosen.includes(id) && ["multi", "aoe"].includes(targeting.mode)) chosen.push(id);
+      }
+    }
+
+    action.targeting.mainTargetId = mainTargetId == null ? null : String(mainTargetId);
+    action.targeting.targetIds = chosen.slice(0, weight);
+    return { action, mainTargetId: action.targeting.mainTargetId, targetIds: [...action.targeting.targetIds] };
+  }
+
+  function resolveAoeOutcome(actionInput = {}, mainClashWon) {
+    const action = normalizeCombatAction(actionInput);
+    const targets = [...action.targeting.targetIds];
+    if (action.resolution.type === "save") {
+      return { allowed: true, mode: "independent_saves", targetIds: targets };
+    }
+    if (["aoe", "multi", "indiscriminate"].includes(action.targeting.mode) && action.resolution.type === "clash") {
+      return mainClashWon
+        ? { allowed: true, mode: "direct_secondary_hits", targetIds: targets }
+        : { allowed: false, mode: "main_clash_lost", targetIds: [] };
+    }
+    return { allowed: true, mode: "normal", targetIds: targets };
+  }
+
+  const api = Object.freeze({
+    SCHEMA_VERSION,
+    PHASES,
+    ECONOMY_COSTS,
+    SOURCE_TYPES,
+    RESOLUTION_TYPES,
+    TARGET_MODES,
+    TARGET_ALLEGIANCE,
+    ACTION_STATES,
+    normalizePhase,
+    normalizeResourceCost,
+    createCombatAction,
+    normalizeCombatAction,
+    validateCombatAction,
+    canReceiveHelp,
+    applyHelpModifier,
+    setActionState,
+    cancelCombatAction,
+    cancelPendingActions,
+    validateResourcesContract,
+    resolveTargetSelection,
+    resolveAoeOutcome,
+  });
+
+  global.LuminousCombatAction = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/tests/combat-action-smoke.mjs
+++ b/tests/combat-action-smoke.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const schema = require('../js/combat-action-schema.js');
+const adapters = require('../js/combat-action-adapters.js');
+
+const actor = { id: 'a1' };
+const skill = {
+  id: 's1', name: 'Wide Slash', basePower: 4, coinPower: 3, coinAmount: 2,
+  attackWeight: 3, isClashable: true, isIndiscriminate: false,
+};
+const action = adapters.compileSkillToCombatAction(actor, skill, { actionSlotId: 'a1_slot_0', targetId: 'e1', targetIds: ['e1','e2','e3'] });
+assert.equal(action.economy.cost, 'action');
+assert.equal(action.resolution.type, 'clash');
+assert.equal(action.targeting.attackWeight, 3);
+assert.equal(schema.canReceiveHelp(action), true);
+const helped = schema.applyHelpModifier(action, { fromActorId: 'a2' });
+assert.equal(helped.applied, true);
+assert.equal(helped.action.modifiers.at(-1).amount, 1);
+
+const saveSpell = { id: 'fire_wave', slotLevel: 3, targetType: 'area', attackWeight: 4, saveAbility: 'dexterity' };
+const spellAction = adapters.compileSpellToCombatAction(actor, saveSpell, { saveDC: 15, classId: 'wizard', targetIds: ['e1','e2','e3','e4'] });
+assert.equal(spellAction.resolution.type, 'save');
+assert.equal(schema.canReceiveHelp(spellAction), false);
+assert.equal(spellAction.resources[0].type, 'spell_slot');
+assert.equal(spellAction.resources[0].metadata.slotLevel, 3);
+
+const retreat = adapters.compileUniversalAction(actor, 'retreat');
+assert.equal(retreat.phase.executesAt, 'on_turn_end');
+assert.equal(retreat.effects[0].inheritActionSlotsCap, 2);
+assert.equal(retreat.effects[0].healHp, false);
+
+const escape = adapters.compileUniversalAction(actor, 'escape');
+assert.equal(escape.effects[0].deniesXp, true);
+const cancelled = schema.cancelCombatAction(escape, { type: 'stagger' });
+assert.equal(cancelled.action.state, 'cancelled');
+assert.equal(cancelled.action.cancelReason.type, 'stagger');
+
+const preparedReaction = adapters.compileReactionToCombatAction(actor, { id: 'counter', sourceType: 'trait', uses: 1 }, { mode: 'prepared', trigger: { type: 'on_targeted' } });
+assert.equal(preparedReaction.economy.cost, 'reaction');
+assert.equal(preparedReaction.phase.selectedAt, 'planning_phase_player');
+assert.equal(preparedReaction.phase.executesAt, 'combat_phase');
+assert.equal(preparedReaction.reaction.mode, 'prepared');
+assert.equal(preparedReaction.resources[0].type, 'trait_use');
+
+const indiscriminate = adapters.compileSkillToCombatAction(actor, { id:'wild', attackWeight:3, isIndiscriminate:true, isClashable:true });
+const selection = schema.resolveTargetSelection(indiscriminate, [{id:'e1'},{id:'e2'},{id:'e3'},{id:'e4'}], { random: () => 0 });
+assert.deepEqual(selection.targetIds, ['e1','e2','e3']);
+
+const aoeOutcomeWin = schema.resolveAoeOutcome(action, true);
+assert.equal(aoeOutcomeWin.mode, 'direct_secondary_hits');
+const aoeOutcomeLose = schema.resolveAoeOutcome(action, false);
+assert.equal(aoeOutcomeLose.allowed, false);
+const saveOutcome = schema.resolveAoeOutcome(spellAction, false);
+assert.equal(saveOutcome.mode, 'independent_saves');
+
+console.log('combat-action smoke: ok');


### PR DESCRIPTION
## Objetivo
Crear el contrato común `CombatAction` para que Skills, Spells, Traits, Reactions y Universal Actions hablen el mismo idioma antes de conectarlos al resolver de combate.

## Incluye
### `js/combat-action-schema.js`
- Fases canónicas:
  - `on_turn_start`
  - `planning_phase_player`
  - `planning_phase_ai`
  - `combat_start`
  - `combat_phase`
  - `combat_end`
  - `on_turn_end`
- Economía: `action`, `quick_action`, `reaction`.
- Regla fija: **1 Action = 1 Action Slot**.
- Tipos de resolución:
  - `clash`
  - `unopposed`
  - `save`
  - `check`
  - `contest`
  - `automatic`
- Targeting sin rango físico:
  - `self`, `single`, `multi`, `aoe`, `indiscriminate`
  - `Attack Weight` limita cuántas Units entran en la Action.
  - Indiscriminate selecciona targets aleatoriamente.
- Help sólo puede aplicar a `check` o `clash` y añade `+1 Final Power` a esa Action concreta.
- Save Actions no aceptan Help.
- Para AoE de Clash: si el Main Target pierde el Clash, los secundarios reciben el impacto directo; si el atacante pierde el Main Clash, el AoE no impacta.
- Para Save AoE: cada target hace Save independiente.
- Estados: `planned`, `locked`, `resolving`, `resolved`, `cancelled`.
- Cancelación conserva `cancelReason`, incluyendo Stagger/Grapple.
- Contrato genérico de recursos sin consumirlos directamente (`spell_slot`, `trait_use`, item/ammo/SP futuros).

### `js/combat-action-adapters.js`
- `compileSkillToCombatAction()`
- `compileSpellToCombatAction()`
- `compileTraitToCombatAction()`
- `compileReactionToCombatAction()`
- `compileUniversalAction()`
- `compileSourceToCombatAction()`

## Universal Actions compiladas
- Grapple -> `contest`, ejecuta en Combat Phase.
- Help -> `automatic`, +1 Final Power a un Action Slot aliado elegible.
- Retreat -> `automatic`, ejecuta `On Turn End`, no cura HP/SP, replacement hereda máximo 2 slots.
- Escape -> `automatic`, ejecuta `On Turn End`, sale del Encounter y niega XP; puede cancelarse antes de resolver.
- Improvise -> resolución y efectos definidos por el DM usando el mismo contrato.

## Reactions
- Prepared: se selecciona en Planning Phase y se ejecuta en Combat Phase cuando dispara el trigger.
- Adaptive: se selecciona y ejecuta en Combat Phase.
- Reactions pueden venir de Skill / Spell / Trait y usan el mismo `CombatAction`.

## Recursos
`CombatAction` sólo declara costos; el runtime dueño valida/consume:
- Spell Slot -> Spell Runtime
- Trait Uses -> Trait Runtime
- Item Charges / Ammo -> Item Runtime
- SP -> Combat/Spell Runtime

## Tests
`tests/combat-action-smoke.mjs` cubre:
- Skill Clash + Attack Weight.
- Help +1 y elegibilidad.
- Save Spell sin Help y con Spell Slot declarado.
- Retreat On Turn End / cap de 2 slots.
- Escape + cancelación por Stagger.
- Prepared Reaction + Trait Uses.
- Indiscriminate random.
- AoE Clash y Save multi-target.

El smoke test fue ejecutado localmente y pasó.

## Fuera de alcance
- Resolver real de Clash / Save / Check / Contest.
- consumo real de recursos.
- integración visual con Battle Viewer.
- Deck/hand.
- Tactical AI scoring.
- Items completion.

## Integración siguiente
```text
Team Action Economy (#733)
        +
CombatAction contract (este PR)
        ↓
Combat Resolver
        ↓
Deck / Planner / Battle Viewer / Tactical AI
```

Este PR parte de `main` y no toca mapa, Items, XP ni Skill Creator UI.