### PR TITLE
Combat: resolve CombatAction through legacy combat engine

### DIFF
--- a/js/combat-action-engine-bridge.js
+++ b/js/combat-action-engine-bridge.js
@@ -1,0 +1,37 @@
+(function (global) {
+  "use strict";
+
+  const BRIDGE_FLAG = "__luminousCombatActionPowerBridge";
+
+  function installCombatActionPowerBridge(engine) {
+    const target = engine || global.CombatEngine;
+    if (!target || typeof target.calculateFinalPower !== "function") return { installed: false, reason: "combat_engine_unavailable" };
+    if (target[BRIDGE_FLAG]) return { installed: true, alreadyInstalled: true, engine: target };
+
+    const original = target.calculateFinalPower;
+    target.calculateFinalPower = function (skill, headsFlipped, unit) {
+      const value = original.call(this, skill, headsFlipped, unit);
+      const bonus = Number(skill?.__combatActionFinalPowerBonus || 0);
+      return Number.isFinite(bonus) ? value + bonus : value;
+    };
+    Object.defineProperty(target, BRIDGE_FLAG, {
+      value: { originalCalculateFinalPower: original },
+      configurable: true,
+      enumerable: false,
+    });
+    return { installed: true, alreadyInstalled: false, engine: target };
+  }
+
+  function uninstallCombatActionPowerBridge(engine) {
+    const target = engine || global.CombatEngine;
+    const state = target?.[BRIDGE_FLAG];
+    if (!target || !state?.originalCalculateFinalPower) return false;
+    target.calculateFinalPower = state.originalCalculateFinalPower;
+    try { delete target[BRIDGE_FLAG]; } catch (_) {}
+    return true;
+  }
+
+  const api = Object.freeze({ installCombatActionPowerBridge, uninstallCombatActionPowerBridge });
+  global.LuminousCombatActionEngineBridge = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/combat-action-resolver.js
+++ b/js/combat-action-resolver.js
@@ -1,0 +1,425 @@
+(function (global) {
+  "use strict";
+
+  const schema = global.LuminousCombatAction || (typeof require === "function" ? require("./combat-action-schema.js") : null);
+  const bridge = global.LuminousCombatActionEngineBridge || (typeof require === "function" ? require("./combat-action-engine-bridge.js") : null);
+  if (!schema) return;
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const asArray = (value) => value == null ? [] : (Array.isArray(value) ? value : [value]);
+
+  function entityId(entity = {}) {
+    return String(entity.id ?? entity.unitId ?? entity.characterId ?? "").trim();
+  }
+
+  function unitById(context = {}, id) {
+    const wanted = String(id ?? "");
+    if (!wanted) return null;
+    const units = Array.isArray(context.units) ? context.units : Object.values(context.combatData || {});
+    return units.find((unit) => entityId(unit) === wanted) || null;
+  }
+
+  function currentPhase(context = {}) {
+    return schema.normalizePhase(context.phase || context.currentPhase || context.state, schema.PHASES.COMBAT_PHASE);
+  }
+
+  function sourceDefinition(action = {}) {
+    return clone(action.metadata?.sourceDefinition || {});
+  }
+
+  function finalPowerBonus(action = {}) {
+    return asArray(action.modifiers).reduce((sum, modifier) => {
+      if (normalizeId(modifier?.type) !== "final_power") return sum;
+      const amount = Number(modifier.amount || 0);
+      return Number.isFinite(amount) ? sum + amount : sum;
+    }, 0);
+  }
+
+  function definitionForEngine(action = {}) {
+    const definition = sourceDefinition(action);
+    definition.id = definition.id || action.source?.id;
+    definition.__combatActionFinalPowerBonus = finalPowerBonus(action);
+    if (action.targeting?.mode && ["aoe", "multi", "indiscriminate"].includes(action.targeting.mode)) {
+      definition.targeting_type = "Focused Attack";
+      definition.targetingType = "Focused Attack";
+    }
+    return definition;
+  }
+
+  function isStaggered(unit = {}) {
+    if (unit.isStaggered === true || unit.staggered === true) return true;
+    const statuses = unit.statusEffects || unit.statuses || {};
+    if (Array.isArray(statuses)) return statuses.some((entry) => normalizeId(entry?.id || entry) === "staggered" || normalizeId(entry?.id || entry) === "stagger");
+    return Boolean(statuses.staggered || statuses.stagger);
+  }
+
+  function terminal(action = {}) {
+    return action.state === "resolved" || action.state === "cancelled";
+  }
+
+  function phaseGate(action, context) {
+    const phase = currentPhase(context);
+    if (action.phase.executesAt !== phase) {
+      return { allowed: false, pending: true, reason: "wrong_phase", expected: action.phase.executesAt, actual: phase };
+    }
+    return { allowed: true, pending: false, phase };
+  }
+
+  function sideForActor(actor = {}) {
+    const raw = normalizeId(actor.side || actor.team || actor.faction || actor.faccion);
+    if (raw.includes("enemy") || raw.includes("enem")) return "enemies";
+    return "allies";
+  }
+
+  function consumeEconomy(action, actor, context = {}) {
+    if (action.economy.cost === schema.ECONOMY_COSTS.ACTION) return { consumed: true, reason: null };
+
+    if (action.economy.cost === schema.ECONOMY_COSTS.QUICK_ACTION) {
+      const economy = context.teamEconomy || global.LuminousTeamActionEconomy;
+      if (economy?.consumeQuickAction && context.encounter) {
+        return economy.consumeQuickAction(context.encounter, sideForActor(actor));
+      }
+      if (typeof context.consumeQuickAction === "function") return context.consumeQuickAction({ action, actor, context });
+      return { consumed: false, reason: "team_quick_action_runtime_required" };
+    }
+
+    if (action.economy.cost === schema.ECONOMY_COSTS.REACTION) {
+      if (typeof context.consumeReaction === "function") return context.consumeReaction({ action, actor, context });
+      const legacy = global.LuminousActionEconomy;
+      if (legacy?.consume) {
+        const ok = legacy.consume(actor, "reaction", { phase: "combat" });
+        return { consumed: Boolean(ok), reason: ok ? null : "reaction_unavailable" };
+      }
+      return { consumed: false, reason: "reaction_runtime_required" };
+    }
+
+    return { consumed: true, reason: null };
+  }
+
+  function consumeHelpBudget(actor, context = {}) {
+    const economy = context.teamEconomy || global.LuminousTeamActionEconomy;
+    if (economy?.consumeHelp && context.encounter) return economy.consumeHelp(context.encounter, sideForActor(actor));
+    if (typeof context.consumeHelp === "function") return context.consumeHelp({ actor, context });
+    return { consumed: false, reason: "team_help_runtime_required" };
+  }
+
+  function resolveResourceHandler(resource, context = {}) {
+    const direct = context.resourceHandlers?.[resource.type];
+    if (direct) return direct;
+
+    if (resource.type === "spell_slot") {
+      const runtime = context.spellRuntime || global.LuminousSpellcastingRuntime;
+      if (!runtime) return null;
+      const slotLevel = Number(resource.metadata?.slotLevel || 0);
+      const classId = resource.id;
+      return {
+        validate({ actor }) {
+          if (typeof runtime.canSpendSpellSlot !== "function") return { available: false, reason: "spell_slot_validator_unavailable" };
+          return runtime.canSpendSpellSlot(actor, classId, slotLevel);
+        },
+        consume({ actor }) {
+          if (typeof runtime.spendSpellSlot !== "function") return { spent: 0, reason: "spell_slot_consumer_unavailable" };
+          return runtime.spendSpellSlot(actor, classId, slotLevel);
+        },
+      };
+    }
+    return null;
+  }
+
+  function validateResources(action, actor, context = {}) {
+    const checks = [];
+    for (const resource of action.resources || []) {
+      const handler = resolveResourceHandler(resource, context);
+      if (!handler?.validate) return { available: false, reason: "resource_handler_missing", resource, checks };
+      const result = handler.validate({ action, actor, resource, context }) || {};
+      checks.push({ resource, result });
+      if (result.available === false || result.valid === false || result.canUse === false) {
+        return { available: false, reason: result.reason || "resource_unavailable", resource, checks };
+      }
+    }
+    return { available: true, checks };
+  }
+
+  function consumeResources(action, actor, context = {}) {
+    const consumed = [];
+    for (const resource of action.resources || []) {
+      const handler = resolveResourceHandler(resource, context);
+      if (!handler?.consume) return { consumed: false, reason: "resource_consumer_missing", resource, results: consumed };
+      const result = handler.consume({ action, actor, resource, context }) || {};
+      consumed.push({ resource, result });
+      if (result.success === false || result.consumed === false || result.available === false) {
+        return { consumed: false, reason: result.reason || "resource_consume_failed", resource, results: consumed };
+      }
+    }
+    return { consumed: true, results: consumed };
+  }
+
+  function resolveTargets(action, context = {}) {
+    const candidates = asArray(context.targetCandidates || context.units || Object.values(context.combatData || {}));
+    const selection = schema.resolveTargetSelection(action, candidates, { random: context.random });
+    const targets = selection.targetIds.map((id) => unitById(context, id)).filter(Boolean);
+    return { ...selection, targets };
+  }
+
+  function cloneAttackSkill(skill = {}) {
+    const next = clone(skill);
+    if (Array.isArray(next.coins)) next.coins = next.coins.map((coin) => ({ ...coin }));
+    next.targeting_type = "Focused Attack";
+    next.targetingType = "Focused Attack";
+    return next;
+  }
+
+  function resolveDirectAttack(action, actor, targets, context = {}, options = {}) {
+    const engine = context.engine || global.CombatEngine;
+    if (!engine?.resolveUnilateralWithCounter) return { resolved: false, reason: "unilateral_resolver_unavailable", results: [] };
+    bridge?.installCombatActionPowerBridge?.(engine);
+    const baseSkill = options.skill || definitionForEngine(action);
+    const results = [];
+    for (let index = 0; index < targets.length; index++) {
+      const target = targets[index];
+      const skill = cloneAttackSkill(baseSkill);
+      const result = engine.resolveUnilateralWithCounter(actor, skill, target, null, {
+        skipUseHooks: options.skipUseHooks === true || index > 0,
+        clashResult: options.clashResult || null,
+        clashCount: options.clashCount || 0,
+        mitigationPenalty: options.mitigationPenalty,
+        combatants: context.units || Object.values(context.combatData || {}),
+      });
+      results.push({ targetId: entityId(target), result });
+    }
+    return { resolved: true, results };
+  }
+
+  function resolveClashPair(actionInput, opposingInput, context = {}) {
+    const engine = context.engine || global.CombatEngine;
+    if (!engine?.resolveStandardClash) return { resolved: false, reason: "clash_resolver_unavailable" };
+    bridge?.installCombatActionPowerBridge?.(engine);
+
+    const actionA = schema.normalizeCombatAction(actionInput);
+    const actionB = schema.normalizeCombatAction(opposingInput);
+    const unitA = unitById(context, actionA.actorId);
+    const unitB = unitById(context, actionB.actorId);
+    if (!unitA || !unitB) return { resolved: false, reason: "clash_actor_missing", actions: [actionA, actionB] };
+
+    const gateB = phaseGate(actionB, context);
+    if (!gateB.allowed || terminal(actionB)) {
+      const targetResolution = resolveTargets(actionA, context);
+      const targets = targetResolution.targets.length ? targetResolution.targets : [unitB];
+      const attack = resolveDirectAttack(actionA, unitA, targets, context, { skill: definitionForEngine(actionA) });
+      actionA.state = attack.resolved ? "resolved" : "locked";
+      return { resolved: Boolean(attack.resolved), type: "unopposed", reason: gateB.reason || "opposing_action_unavailable", attack, actions: [actionA, actionB], resolvedActionIds: attack.resolved ? [actionA.id] : [] };
+    }
+
+    if (isStaggered(unitB)) {
+      const cancelled = schema.cancelCombatAction(actionB, { type: "stagger" }).action;
+      const targetResolution = resolveTargets(actionA, context);
+      let targets = targetResolution.targets;
+      if (!targets.some((target) => entityId(target) === entityId(unitB))) targets.unshift(unitB);
+      const attack = resolveDirectAttack(actionA, unitA, targets.slice(0, Math.max(1, actionA.targeting.attackWeight)), context, { skill: definitionForEngine(actionA) });
+      actionA.state = attack.resolved ? "resolved" : "locked";
+      return { resolved: Boolean(attack.resolved), type: "unopposed", reason: "opposing_action_cancelled_by_stagger", attack, actions: [actionA, cancelled], resolvedActionIds: attack.resolved ? [actionA.id, cancelled.id] : [cancelled.id] };
+    }
+
+    const resourcesA = validateResources(actionA, unitA, context);
+    const resourcesB = validateResources(actionB, unitB, context);
+    if (!resourcesA.available || !resourcesB.available) {
+      return { resolved: false, reason: !resourcesA.available ? resourcesA.reason : resourcesB.reason, resourcesA, resourcesB, actions: [actionA, actionB] };
+    }
+
+    const economyA = consumeEconomy(actionA, unitA, context);
+    const economyB = consumeEconomy(actionB, unitB, context);
+    if (economyA.consumed === false || economyB.consumed === false) {
+      return { resolved: false, reason: economyA.consumed === false ? economyA.reason : economyB.reason, economyA, economyB, actions: [actionA, actionB] };
+    }
+
+    const consumedA = consumeResources(actionA, unitA, context);
+    const consumedB = consumeResources(actionB, unitB, context);
+    if (!consumedA.consumed || !consumedB.consumed) {
+      return { resolved: false, reason: !consumedA.consumed ? consumedA.reason : consumedB.reason, consumedA, consumedB, actions: [actionA, actionB] };
+    }
+
+    const skillA = definitionForEngine(actionA);
+    const skillB = definitionForEngine(actionB);
+    const clash = engine.resolveStandardClash(unitA, skillA, unitB, skillB);
+    const winner = clash.winner;
+    let attack = null;
+    let winningAction = null;
+    let losingAction = null;
+
+    if (winner === "A" || winner === "B") {
+      winningAction = winner === "A" ? actionA : actionB;
+      losingAction = winner === "A" ? actionB : actionA;
+      const winningUnit = winner === "A" ? unitA : unitB;
+      const losingUnit = winner === "A" ? unitB : unitA;
+      const winningSkill = winner === "A" ? skillA : skillB;
+      const targetResolution = resolveTargets(winningAction, context);
+      let targets = targetResolution.targets;
+      if (!targets.some((target) => entityId(target) === entityId(losingUnit))) targets.unshift(losingUnit);
+      targets = targets.slice(0, Math.max(1, winningAction.targeting.attackWeight));
+      const aoe = schema.resolveAoeOutcome(winningAction, true);
+      if (aoe.allowed) {
+        attack = resolveDirectAttack(winningAction, winningUnit, targets, context, {
+          skill: winningSkill,
+          skipUseHooks: true,
+          clashResult: "Win",
+          clashCount: clash.clashLogs?.length || 0,
+          mitigationPenalty: clash.mitigationPenalty,
+        });
+      }
+    }
+
+    actionA.state = "resolved";
+    actionB.state = "resolved";
+    return {
+      resolved: true,
+      type: "clash",
+      winner,
+      clash,
+      attack,
+      winningActionId: winningAction?.id || null,
+      losingActionId: losingAction?.id || null,
+      resources: { A: consumedA, B: consumedB },
+      economy: { A: economyA, B: economyB },
+      actions: [actionA, actionB],
+      resolvedActionIds: [actionA.id, actionB.id],
+    };
+  }
+
+  function rollSaveHeads(engine, target, context = {}) {
+    if (typeof context.rollSaveHeads === "function") return context.rollSaveHeads(target, context);
+    const probability = typeof engine?.getCoinProbability === "function" ? engine.getCoinProbability(target.sp || 0) : 50;
+    const random = typeof context.random === "function" ? context.random : Math.random;
+    return Array.from({ length: 5 }, () => random() * 100 < probability);
+  }
+
+  function resolveSave(action, actor, targets, context = {}) {
+    const engine = context.engine || global.CombatEngine;
+    if (!engine?.resolveSpell) return { resolved: false, reason: "save_resolver_unavailable", results: [] };
+    const spell = definitionForEngine(action);
+    spell.statUsed = action.resolution.save?.abilityId;
+    spell.saveDC = Number(action.resolution.save?.dc || 0);
+    const results = targets.map((target) => ({
+      targetId: entityId(target),
+      result: engine.resolveSpell(spell, target, rollSaveHeads(engine, target, context)),
+    }));
+    return { resolved: true, type: "save", results };
+  }
+
+  function resolveCheck(action, actor, targets, context = {}) {
+    if (typeof context.checkResolver !== "function") return { resolved: false, reason: "check_resolver_required" };
+    return { resolved: true, type: "check", result: context.checkResolver({ action, actor, targets, context }) };
+  }
+
+  function resolveContest(action, actor, targets, context = {}) {
+    if (action.source.type === "universal" && normalizeId(action.source.id) === "grapple" && global.LuminousConditionRuntime?.grapple && targets[0]) {
+      return { resolved: true, type: "contest", result: global.LuminousConditionRuntime.grapple(actor, targets[0], { combatAction: action, context }) };
+    }
+    if (typeof context.contestResolver !== "function") return { resolved: false, reason: "contest_resolver_required" };
+    return { resolved: true, type: "contest", result: context.contestResolver({ action, actor, targets, context }) };
+  }
+
+  function applyAutomaticEffects(action, actor, targets, context = {}) {
+    const results = [];
+    for (const effect of action.effects || []) {
+      const type = normalizeId(effect.type);
+      if (type === "modify_combat_action") {
+        const actionMap = context.actionMap || {};
+        const targetAction = actionMap[effect.targetActionId] || (typeof context.getActionById === "function" ? context.getActionById(effect.targetActionId) : null);
+        if (!targetAction) { results.push({ effect, applied: false, reason: "target_action_missing" }); continue; }
+        const applied = schema.applyHelpModifier(targetAction, { amount: effect.modifier?.amount ?? 1, fromActorId: actor && entityId(actor) });
+        if (applied.applied && actionMap[effect.targetActionId]) actionMap[effect.targetActionId] = applied.action;
+        results.push({ effect, ...applied });
+        continue;
+      }
+      const handler = context.effectHandlers?.[type] || context.effectHandler;
+      if (typeof handler === "function") results.push({ effect, result: handler({ action, actor, targets, effect, context }), applied: true });
+      else results.push({ effect, applied: false, reason: "effect_handler_missing" });
+    }
+    return results;
+  }
+
+  function resolveAutomatic(action, actor, targets, context = {}) {
+    if (action.source.type === "universal" && normalizeId(action.source.id) === "help") {
+      const budget = consumeHelpBudget(actor, context);
+      if (budget.consumed === false) return { resolved: false, reason: budget.reason || "team_help_spent", budget };
+    }
+    const effects = applyAutomaticEffects(action, actor, targets, context);
+    const structuralFailure = effects.find((entry) => ["retreat", "escape"].includes(normalizeId(entry.effect?.type)) && entry.applied === false);
+    if (structuralFailure) return { resolved: false, type: "automatic", reason: structuralFailure.reason || "structural_effect_unhandled", effects };
+    return { resolved: true, type: "automatic", effects };
+  }
+
+  function resolveCombatAction(input = {}, context = {}) {
+    let action = schema.normalizeCombatAction(input);
+    const validation = schema.validateCombatAction(action);
+    if (!validation.valid) return { resolved: false, reason: "invalid_action", errors: validation.errors, action };
+    action = validation.action;
+    if (terminal(action)) return { resolved: action.state === "resolved", reason: "terminal_state", action };
+
+    const gate = phaseGate(action, context);
+    if (!gate.allowed) return { resolved: false, pending: gate.pending, reason: gate.reason, expectedPhase: gate.expected, actualPhase: gate.actual, action };
+
+    const actor = unitById(context, action.actorId);
+    if (!actor) return { resolved: false, reason: "actor_missing", action };
+    if (isStaggered(actor)) {
+      const cancelled = schema.cancelCombatAction(action, { type: "stagger" });
+      return { resolved: false, cancelled: true, reason: "stagger", action: cancelled.action };
+    }
+
+    if (action.resolution.type === "clash" && context.opposingAction) {
+      return resolveClashPair(action, context.opposingAction, context);
+    }
+
+    const resourceGate = validateResources(action, actor, context);
+    if (!resourceGate.available) return { resolved: false, reason: resourceGate.reason, resourceGate, action };
+    const economy = consumeEconomy(action, actor, context);
+    if (economy.consumed === false) return { resolved: false, reason: economy.reason || "economy_unavailable", economy, action };
+    const resources = consumeResources(action, actor, context);
+    if (!resources.consumed) return { resolved: false, reason: resources.reason, resources, economy, action };
+
+    action.state = "resolving";
+    const targetResolution = resolveTargets(action, context);
+    const targets = targetResolution.targets;
+    let resolution;
+
+    if (action.resolution.type === "clash") {
+      resolution = resolveDirectAttack(action, actor, targets, context, { skill: definitionForEngine(action) });
+    } else if (action.resolution.type === "unopposed") {
+      resolution = resolveDirectAttack(action, actor, targets, context, { skill: definitionForEngine(action) });
+    } else if (action.resolution.type === "save") {
+      resolution = resolveSave(action, actor, targets, context);
+    } else if (action.resolution.type === "check") {
+      resolution = resolveCheck(action, actor, targets, context);
+    } else if (action.resolution.type === "contest") {
+      resolution = resolveContest(action, actor, targets, context);
+    } else {
+      resolution = resolveAutomatic(action, actor, targets, context);
+    }
+
+    if (resolution?.resolved === false) {
+      action.state = "locked";
+      return { resolved: false, reason: resolution.reason || "resolution_failed", resolution, resources, economy, action };
+    }
+    action.state = "resolved";
+    return { resolved: true, action, resolution, resources, economy, targetResolution, resolvedActionIds: [action.id] };
+  }
+
+  const api = Object.freeze({
+    currentPhase,
+    consumeEconomy,
+    validateResources,
+    consumeResources,
+    resolveTargets,
+    resolveDirectAttack,
+    resolveClashPair,
+    resolveSave,
+    resolveCheck,
+    resolveContest,
+    resolveAutomatic,
+    resolveCombatAction,
+  });
+
+  global.LuminousCombatActionResolver = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/tests/combat-action-resolver-smoke.mjs
+++ b/tests/combat-action-resolver-smoke.mjs
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const schema = require('../js/combat-action-schema.js');
+globalThis.LuminousCombatAction = schema;
+const adapters = require('../js/combat-action-adapters.js');
+globalThis.LuminousCombatActionAdapters = adapters;
+const bridge = require('../js/combat-action-engine-bridge.js');
+globalThis.LuminousCombatActionEngineBridge = bridge;
+const resolver = require('../js/combat-action-resolver.js');
+
+let clashCalls = 0;
+let attackCalls = 0;
+const engine = {
+  calculateFinalPower(skill, heads) { return Number(skill.basePower || 0) + Number(heads || 0); },
+  resolveStandardClash() { clashCalls++; return { winner: 'A', clashLogs: [{}, {}], mitigationPenalty: 0 }; },
+  resolveUnilateralWithCounter(attacker, skill, defender, counter, options) {
+    attackCalls++;
+    defender.hp = (defender.hp ?? 20) - 3;
+    return { damageTaken: 3, attackLogs: [{ target: defender.id }], options, bonus: skill.__combatActionFinalPowerBonus || 0 };
+  },
+  resolveSpell(spell, target, heads) { return { isSuccess: target.id === 'e2', dc: spell.saveDC, heads }; },
+  getCoinProbability() { return 50; },
+};
+
+const a = { id:'a', faction:'allies', hp:20, sp:0 };
+const b = { id:'b', faction:'enemies', hp:20, sp:0 };
+const e2 = { id:'e2', faction:'enemies', hp:20, sp:0 };
+const units = [a,b,e2];
+const resourceLog = [];
+const resourceHandlers = {
+  trait_use: {
+    validate: () => ({ available:true }),
+    consume: ({resource}) => { resourceLog.push(resource.id); return { consumed:true }; },
+  }
+};
+const common = { phase:'combat_phase', units, engine, resourceHandlers, random: () => 0 };
+
+bridge.installCombatActionPowerBridge(engine);
+assert.equal(engine.calculateFinalPower({basePower:4,__combatActionFinalPowerBonus:1}, 2), 7);
+
+const actionA = adapters.compileSkillToCombatAction(a, { id:'slash', basePower:4, coinPower:2, coinAmount:1, attackWeight:2, isClashable:true, resourceCosts:[{type:'trait_use',id:'useA',amount:1}] }, { targetId:'b', targetIds:['b','e2'] });
+const actionB = adapters.compileSkillToCombatAction(b, { id:'guard_hit', basePower:3, coinPower:2, coinAmount:1, isClashable:true, resourceCosts:[{type:'trait_use',id:'useB',amount:1}] }, { targetId:'a', isAi:true });
+const clash = resolver.resolveCombatAction(actionA, { ...common, opposingAction: actionB });
+assert.equal(clash.resolved, true);
+assert.equal(clash.type, 'clash');
+assert.equal(clash.winner, 'A');
+assert.deepEqual(resourceLog.sort(), ['useA','useB']);
+assert.equal(clashCalls, 1);
+assert.equal(attackCalls, 2);
+assert.deepEqual(clash.resolvedActionIds.sort(), [actionA.id, actionB.id].sort());
+
+clashCalls = 0; attackCalls = 0;
+b.isStaggered = true;
+const staggerA = adapters.compileSkillToCombatAction(a, { id:'s2', basePower:4, coinAmount:1, attackWeight:1, isClashable:true }, { targetId:'b' });
+const staggerB = adapters.compileSkillToCombatAction(b, { id:'s3', basePower:4, coinAmount:1, isClashable:true }, { targetId:'a', isAi:true });
+const staggerResult = resolver.resolveCombatAction(staggerA, { ...common, opposingAction: staggerB });
+assert.equal(staggerResult.resolved, true);
+assert.equal(staggerResult.type, 'unopposed');
+assert.equal(staggerResult.actions[1].state, 'cancelled');
+assert.equal(clashCalls, 0);
+assert.equal(attackCalls, 1);
+b.isStaggered = false;
+
+const save = adapters.compileSpellToCombatAction(a, { id:'wave', slotLevel:0, saveAbility:'dexterity', targetType:'area', attackWeight:2 }, { saveDC:14, targetIds:['b','e2'] });
+const saveResult = resolver.resolveCombatAction(save, common);
+assert.equal(saveResult.resolved, true);
+assert.equal(saveResult.resolution.results.length, 2);
+assert.equal(saveResult.resolution.results[0].result.isSuccess, false);
+assert.equal(saveResult.resolution.results[1].result.isSuccess, true);
+assert.equal(schema.canReceiveHelp(save), false);
+
+const targetAction = adapters.compileSkillToCombatAction(a, { id:'helped', isClashable:true }, { targetId:'b' });
+const help = adapters.compileUniversalAction({id:'ally2',faction:'allies'}, 'help', { targetUnitId:'a', targetActionId:targetAction.id, targetActionSlotId:'a_slot_0' });
+let helpBudget = 1;
+const actionMap = { [targetAction.id]: targetAction };
+const helpResult = resolver.resolveCombatAction(help, {
+  ...common,
+  units:[...units,{id:'ally2',faction:'allies',hp:10}],
+  actionMap,
+  consumeHelp: () => helpBudget-- > 0 ? {consumed:true} : {consumed:false,reason:'team_help_spent'}
+});
+assert.equal(helpResult.resolved, true);
+assert.equal(actionMap[targetAction.id].modifiers.at(-1).type, 'final_power');
+assert.equal(actionMap[targetAction.id].modifiers.at(-1).amount, 1);
+
+const retreat = adapters.compileUniversalAction(a, 'retreat');
+const tooEarly = resolver.resolveCombatAction(retreat, common);
+assert.equal(tooEarly.pending, true);
+const retreatResult = resolver.resolveCombatAction(retreat, {
+  ...common,
+  phase:'on_turn_end',
+  effectHandlers:{ retreat: ({effect}) => ({ swapped:true, cap:effect.inheritActionSlotsCap }) }
+});
+assert.equal(retreatResult.resolved, true);
+assert.equal(retreatResult.resolution.effects[0].result.cap, 2);
+
+const checkAction = schema.createCombatAction({ actorId:'a', source:{type:'universal',id:'improvise'}, phase:{executesAt:'combat_phase'}, targeting:{mode:'self',allegiance:'self'}, resolution:{type:'check',check:{stat:'strength',threshold:12}} });
+const checkResult = resolver.resolveCombatAction(checkAction, { ...common, checkResolver:()=>({pass:true,total:14}) });
+assert.equal(checkResult.resolved, true);
+assert.equal(checkResult.resolution.result.pass, true);
+
+console.log('combat-action-resolver smoke: ok');


### PR DESCRIPTION
## Objetivo
Añadir el **Combat Resolver** que toma `CombatAction` y orquesta las piezas ya existentes de `CombatEngine` sin duplicar Clash, monedas, daño, Save ni Stagger.

Este PR es **stacked sobre `feature/combat-action-contract` / PR #734** para que el diff sólo muestre el resolver.

## Incluye
### `js/combat-action-resolver.js`
- Valida fase exacta antes de ejecutar.
- Stagger cancela la Action pendiente y conserva `cancelReason`.
- Resuelve Actor y Targets desde `CombatAction`.
- Consume recursos sólo después de validarlos.
- En Clash valida primero los recursos de **ambas** Actions antes de gastar ninguno.
- Si la Action opuesta ya está cancelada / fuera de fase / Staggered, convierte el enfrentamiento en **Unopposed**.
- `clash` -> usa `CombatEngine.resolveStandardClash()` y después `resolveUnilateralWithCounter()` para el ganador.
- `unopposed` -> usa `resolveUnilateralWithCounter()`.
- `save` -> usa `CombatEngine.resolveSpell()` por target; Saves multi-target son independientes.
- `check` -> hook `checkResolver` para no inventar otra matemática.
- `contest` -> Grapple puede usar `LuminousConditionRuntime.grapple`; otros Contests usan `contestResolver`.
- `automatic` -> Help integrado; Retreat/Escape requieren handler estructural.
- Devuelve `resolvedActionIds` para que una Action usada en Clash no se vuelva a ejecutar cuando la cola llegue al slot opuesto.

## Action Economy
- Action normal: el slot ya fue reservado por Planning; el resolver no lo cobra dos veces.
- Quick Action: usa `LuminousTeamActionEconomy.consumeQuickAction()` cuando el encounter está disponible.
- Reaction: usa handler de Reaction o fallback al runtime legacy de Reaction por Unit.
- Help: consume el presupuesto `once per Turn / Team` antes de aplicar el +1.

## Recursos
- `spell_slot` tiene adaptador automático contra `LuminousSpellcastingRuntime.canSpendSpellSlot/spendSpellSlot`.
- Otros recursos (`trait_use`, Item Charges, Ammo, SP, etc.) entran por `resourceHandlers` para que el runtime propietario siga siendo autoritativo.

## AoE / Attack Weight
`CombatAction` ya decide los Targets. El resolver fuerza la Skill legacy a `Focused Attack` durante cada hit para impedir que el código viejo vuelva a seleccionar AoE por `grid_pos`, `skillRange` o geometría física.

Para Clash AoE:
1. sólo el Main Target participa en el Clash;
2. si el atacante gana, se ejecuta el hit directo contra los Targets ya seleccionados por Attack Weight;
3. si pierde el Clash, no se ejecuta ese AoE ofensivo.

## Final Power bridge
### `js/combat-action-engine-bridge.js`
El `CombatEngine.calculateFinalPower()` existente no conoce los modificadores temporales de `CombatAction`.

El bridge añade `__combatActionFinalPowerBonus` **después** del cálculo legacy. Esto permite que Help sea realmente:

```text
+1 Final Power
```

y no una mutación permanente de `basePower` de la Skill/Spell.

## Tests
`tests/combat-action-resolver-smoke.mjs` cubre:
- bridge de Final Power;
- Clash A vs B;
- validación/consumo de recursos de ambos lados;
- Attack Weight 2 -> Main + secondary direct hit;
- Stagger del oponente -> cancelación + Unopposed;
- Save independiente en dos Targets;
- Help -> +1 Final Power a una sola CombatAction;
- Retreat sólo resuelve `On Turn End` y hereda cap 2 vía handler;
- Check delegado al resolver correspondiente.

El smoke test fue ejecutado localmente y pasó.

## Fuera de alcance
- fórmula nueva de Checks/Contests: se reutiliza/injecta el runtime correspondiente;
- implementación final de Retreat/Escape swap/presence: se conecta con Team Action Economy en el siguiente bridge;
- Battle Viewer;
- Deck/hand;
- Tactical AI planner;
- Item completion.

## Dependencias / orden
```text
#733 Team Action Economy
#734 CombatAction contract
        ↓
este PR: Combat Resolver
        ↓
Action Queue / Planner bridge
        ↓
Deck -> Slots -> Battle Viewer
        ↓
Tactical AI
```