### PR TITLE
Combat: integrate round planning, Speed queue and resolver lifecycle

### DIFF
--- a/.github/workflows/combat-runtime-smoke.yml
+++ b/.github/workflows/combat-runtime-smoke.yml
@@ -30,3 +30,5 @@ jobs:
         run: node tests/combat-action-queue-smoke.mjs
       - name: Combat Runtime Integration smoke
         run: node tests/combat-runtime-integration-smoke.mjs
+      - name: Combat Runtime Rules smoke
+        run: node tests/combat-runtime-rules-smoke.mjs

--- a/.github/workflows/combat-runtime-smoke.yml
+++ b/.github/workflows/combat-runtime-smoke.yml
@@ -1,0 +1,32 @@
+name: Combat Runtime Smoke
+
+on:
+  push:
+    branches:
+      - feature/combat-runtime-integration
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  combat-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Combat Skill schema smoke
+        run: node tests/combat-skill-schema-smoke.mjs
+      - name: Team action economy smoke
+        run: node tests/team-action-economy-smoke.mjs
+      - name: CombatAction schema smoke
+        run: node tests/combat-action-smoke.mjs
+      - name: CombatAction resolver smoke
+        run: node tests/combat-action-resolver-smoke.mjs
+      - name: Combat Action Queue smoke
+        run: node tests/combat-action-queue-smoke.mjs
+      - name: Combat Runtime Integration smoke
+        run: node tests/combat-runtime-integration-smoke.mjs

--- a/docs/combat-runtime-integration.md
+++ b/docs/combat-runtime-integration.md
@@ -1,0 +1,45 @@
+# Combat Runtime Integration
+
+This milestone connects canonical `CombatAction` definitions to round planning, Speed order, Clash interception and the existing combat resolver.
+
+## Round lifecycle
+
+`ON_TURN_START` → `PLANNING_PHASE_PLAYER` → `PLANNING_PHASE_AI` → `COMBAT_START` → `COMBAT_PHASE` → `COMBAT_END` → `ON_TURN_END`.
+
+Speed and equal-Speed random placement are snapshotted at `ON_TURN_START` and remain frozen for the round. Normal Units share one Speed across every Action Slot. Abnormality Parts may provide their own Speed for the Actions belonging to that Part.
+
+## Action ordering and Clash
+
+Actions execute from highest frozen Speed to lowest. Equal-Speed sources use the random placement generated at turn start; no secondary stat or actor ID is a gameplay tie-breaker.
+
+A Unit may force a Clash against an Action that is not targeting it only when its frozen Speed is strictly greater than the target Action's Speed. A Unit that is already the target may Clash regardless of relative Speed.
+
+## Action Slots and team resources
+
+Normal Actions require an `actionSlotId`. A slot cannot contain two unresolved Actions and a Unit cannot plan more Actions than its usable Action Slot count.
+
+Quick Action and Help are once per side per round. Reaction is once per Unit per round unless the Unit exposes a higher reaction limit. When a TeamActionEconomy encounter is present it remains authoritative; otherwise the runtime keeps equivalent local budgets.
+
+## Volley targeting
+
+Focused targeting keeps every Coin on the focused target. If that target becomes unavailable during the Skill, remaining Coins are cancelled.
+
+Unfocused Volley selects a target for every Coin. It avoids the previous target while another valid option exists; if only one valid target remains, subsequent Coins may continue hitting it. With Attack Weight greater than one, Unfocused Volley stays inside the originally marked target group and does not replace dead marked targets with outside targets. Indiscriminate expands the valid selection pool but never includes the Skill user.
+
+## Cancellation
+
+Stagger or another action-blocking state cancels every unresolved Action of the affected Unit. If it occurs during Coin-by-Coin execution, the current Action stops at that point; resolved Coins are not reverted.
+
+A Clash that becomes unilateral because its opponent is already cancelled, unavailable or Staggered still validates and consumes the active Action's economy/resources before attacking.
+
+## Grapple, Retreat and Escape
+
+A successful Grapple cancels the target's unresolved Actions and locks exactly one Action Slot on both participants when TeamActionEconomy is available.
+
+Retreat resolves at `ON_TURN_END`. With a backup it swaps to the next backup and the replacement inherits at most two Action Slots. Without a backup the Unit leaves `encounter.active` for the entire following round and returns for the round after that without being treated as a backup swap.
+
+Escape resolves at `ON_TURN_END`, removes the Unit from active encounter play and sets `eligibleForXp = false`.
+
+## Verification
+
+`.github/workflows/combat-runtime-smoke.yml` runs schema, team economy, resolver, queue, lifecycle and runtime-rules smoke tests on every push to the integration branch and on pull requests to `main`.

--- a/js/combat-action-queue.js
+++ b/js/combat-action-queue.js
@@ -1,0 +1,296 @@
+(function (global) {
+  "use strict";
+
+  const PHASE_COMBAT = "combat_phase";
+  const SIDE_A = "allies";
+  const SIDE_B = "enemies";
+
+  const asArray = (value) => value == null ? [] : (Array.isArray(value) ? value : [value]);
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  const finiteNumber = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+  function entityId(entity = {}) {
+    return String(entity.id ?? entity.unitId ?? entity.characterId ?? entity.actorId ?? "").trim();
+  }
+
+  function sideOf(entity = {}) {
+    const raw = normalizeId(entity.side || entity.team || entity.faction || entity.faccion);
+    return raw.includes("enemy") || raw.includes("enem") ? SIDE_B : SIDE_A;
+  }
+
+  function partIdOf(action = {}) {
+    return String(
+      action.partId ?? action.abnormalityPartId ?? action.metadata?.partId ?? action.metadata?.abnormalityPartId ?? ""
+    ).trim() || null;
+  }
+
+  function numericSpeed(entity = {}) {
+    const candidates = [entity.resolvedSpeed, entity.currentSpeed, entity.speedRoll, entity.speedValue, entity.speed_value, entity.speed];
+    const found = candidates.map(Number).find(Number.isFinite);
+    return found == null ? 0 : found;
+  }
+
+  function partCollection(unit = {}) {
+    const raw = unit.parts || unit.abnormalityParts || unit.bodyParts || unit.body_parts || [];
+    if (Array.isArray(raw)) return raw;
+    if (raw && typeof raw === "object") return Object.entries(raw).map(([id, value]) => ({ id, ...(value || {}) }));
+    return [];
+  }
+
+  function findPart(unit = {}, partId) {
+    if (!partId) return null;
+    const wanted = String(partId);
+    return partCollection(unit).find((part) => String(part.id ?? part.partId ?? part.key ?? part.name ?? "") === wanted) || null;
+  }
+
+  function speedSourceKey(actorId, partId) {
+    return partId ? `${actorId}::part::${partId}` : `${actorId}::unit`;
+  }
+
+  function resolveRoundSpeed(unit = {}, action = {}) {
+    const partId = partIdOf(action);
+    const part = findPart(unit, partId);
+    return part ? numericSpeed(part) : numericSpeed(unit);
+  }
+
+  function slotIndexOf(action = {}, fallback = 0) {
+    const raw = action.metadata?.actionSlotIndex ?? action.slotIndex ?? action.actionSlotIndex;
+    if (Number.isFinite(Number(raw))) return Math.max(0, Math.trunc(Number(raw)));
+    const match = String(action.actionSlotId || "").match(/(?:slot[_-]?)?(\d+)$/i);
+    return match ? Math.max(0, Number(match[1])) : fallback;
+  }
+
+  function terminal(action = {}) {
+    return action.state === "resolved" || action.state === "cancelled";
+  }
+
+  function queueable(action = {}) {
+    const executesAt = normalizeId(action.phase?.executesAt || action.executesAt || PHASE_COMBAT);
+    return executesAt === PHASE_COMBAT && !terminal(action);
+  }
+
+  function unitMap(units = []) {
+    return new Map(asArray(units).map((unit) => [entityId(unit), unit]).filter(([id]) => id));
+  }
+
+  function buildRoundOrder(config = {}) {
+    const random = typeof config.random === "function" ? config.random : Math.random;
+    const unitsById = unitMap(config.units);
+    const sourceState = new Map();
+    const entries = [];
+
+    asArray(config.actions).forEach((action, inputIndex) => {
+      if (!queueable(action)) return;
+      const actorId = String(action.actorId || "");
+      const unit = unitsById.get(actorId);
+      if (!unit) return;
+      const partId = partIdOf(action);
+      const key = speedSourceKey(actorId, partId);
+      let source = sourceState.get(key);
+      if (!source) {
+        source = {
+          key,
+          actorId,
+          partId,
+          side: sideOf(unit),
+          speed: resolveRoundSpeed(unit, action),
+          tieRoll: finiteNumber(random(), 0),
+          inputIndex,
+        };
+        sourceState.set(key, source);
+      }
+      entries.push({
+        action,
+        actionId: String(action.id || `action_${inputIndex}`),
+        actorId,
+        partId,
+        sourceKey: key,
+        side: source.side,
+        speed: source.speed,
+        tieRoll: source.tieRoll,
+        slotIndex: slotIndexOf(action, inputIndex),
+        inputIndex,
+      });
+    });
+
+    const compareExecution = (a, b) =>
+      (b.speed - a.speed) ||
+      (a.tieRoll - b.tieRoll) ||
+      (a.sourceKey === b.sourceKey ? a.slotIndex - b.slotIndex : 0) ||
+      (a.inputIndex - b.inputIndex);
+
+    entries.sort(compareExecution);
+
+    const sourceList = [...sourceState.values()];
+    const sideA = sourceList
+      .filter((source) => source.side === SIDE_A)
+      .sort((a, b) => (b.speed - a.speed) || (a.tieRoll - b.tieRoll) || (a.inputIndex - b.inputIndex));
+    const sideB = sourceList
+      .filter((source) => source.side === SIDE_B)
+      .sort((a, b) => (a.speed - b.speed) || (a.tieRoll - b.tieRoll) || (a.inputIndex - b.inputIndex));
+
+    return {
+      phase: PHASE_COMBAT,
+      entries,
+      layout: { [SIDE_A]: sideA, [SIDE_B]: sideB },
+      speedSources: Object.fromEntries(sourceList.map((source) => [source.key, { ...source }])),
+      getEntry(actionId) {
+        return entries.find((entry) => entry.actionId === String(actionId)) || null;
+      },
+      getSpeed(actorId, partId = null) {
+        return sourceState.get(speedSourceKey(String(actorId), partId))?.speed ?? null;
+      },
+    };
+  }
+
+  function actionTargetsActor(action = {}, actorId) {
+    const wanted = String(actorId ?? "");
+    if (!wanted) return false;
+    const ids = asArray(action.targeting?.targetIds).map(String);
+    const main = action.targeting?.mainTargetId == null ? null : String(action.targeting.mainTargetId);
+    return main === wanted || ids.includes(wanted);
+  }
+
+  function canForceClash(config = {}) {
+    const interceptor = config.interceptorEntry || config.interceptor;
+    const target = config.targetEntry || config.target;
+    if (!interceptor || !target) return false;
+    if (interceptor.actorId === target.actorId) return false;
+    if (actionTargetsActor(target.action || target, interceptor.actorId)) return true;
+    const interceptorSpeed = finiteNumber(interceptor.speed, 0);
+    const targetSpeed = finiteNumber(target.speed, 0);
+    return interceptorSpeed > targetSpeed;
+  }
+
+  function cancelActorActions(queue, actorId, reason = { type: "stagger" }, options = {}) {
+    const wanted = String(actorId ?? "");
+    const partId = options.partId == null ? null : String(options.partId);
+    const cancelled = [];
+    for (const entry of queue?.entries || []) {
+      if (entry.actorId !== wanted) continue;
+      if (partId != null && entry.partId !== partId) continue;
+      const action = entry.action;
+      if (terminal(action)) continue;
+      action.state = "cancelled";
+      action.cancelReason = typeof reason === "string" ? { type: normalizeId(reason) || "cancelled" } : { ...(reason || { type: "cancelled" }) };
+      cancelled.push(action.id);
+    }
+    return cancelled;
+  }
+
+  function isTargetAvailable(target = {}) {
+    if (!target || !entityId(target)) return false;
+    if (target.defeated === true || target.dead === true || target.removed === true || target.escaped === true) return false;
+    if (Number.isFinite(Number(target.hp)) && Number(target.hp) <= 0) return false;
+    return true;
+  }
+
+  function sameSide(a = {}, b = {}) {
+    return sideOf(a) === sideOf(b);
+  }
+
+  function volleyMode(action = {}) {
+    const raw = normalizeId(
+      action.targeting?.volley ||
+      action.metadata?.volley ||
+      action.metadata?.sourceDefinition?.volley ||
+      action.metadata?.sourceDefinition?.volleyMode ||
+      action.metadata?.sourceDefinition?.targetingType ||
+      action.metadata?.sourceDefinition?.targeting_type ||
+      "focused"
+    );
+    return raw.includes("unfocused") ? "unfocused" : "focused";
+  }
+
+  function initialMarkedTargetIds(action = {}) {
+    const ids = [];
+    const main = action.targeting?.mainTargetId;
+    if (main != null) ids.push(String(main));
+    for (const id of asArray(action.targeting?.targetIds)) {
+      const value = String(id);
+      if (value && !ids.includes(value)) ids.push(value);
+    }
+    return ids.filter((id) => id !== String(action.actorId || ""));
+  }
+
+  function targetPool(action = {}, units = [], options = {}) {
+    const actor = asArray(units).find((unit) => entityId(unit) === String(action.actorId || "")) || null;
+    const available = asArray(units).filter((unit) => entityId(unit) !== String(action.actorId || "") && (options.isAvailable || isTargetAvailable)(unit));
+    const weight = Math.max(1, Math.trunc(Number(action.targeting?.attackWeight || 1)));
+    const marked = initialMarkedTargetIds(action);
+
+    if (weight > 1 && marked.length) {
+      const markedSet = new Set(marked);
+      return available.filter((unit) => markedSet.has(entityId(unit)));
+    }
+
+    const indiscriminate = action.targeting?.indiscriminate === true || normalizeId(action.targeting?.mode) === "indiscriminate";
+    if (indiscriminate) return available;
+
+    const allegiance = normalizeId(action.targeting?.allegiance || "enemy");
+    if (!actor) return available;
+    if (allegiance === "ally") return available.filter((unit) => sameSide(actor, unit));
+    if (allegiance === "neutral") return available.filter((unit) => normalizeId(unit.faction || unit.side || unit.team) === "neutral");
+    return available.filter((unit) => !sameSide(actor, unit));
+  }
+
+  function selectCoinTarget(action = {}, units = [], state = {}, options = {}) {
+    const mode = volleyMode(action);
+    const availableById = new Map(asArray(units).filter((unit) => (options.isAvailable || isTargetAvailable)(unit)).map((unit) => [entityId(unit), unit]));
+
+    if (mode === "focused") {
+      const targetId = String(state.focusedTargetId || action.targeting?.mainTargetId || initialMarkedTargetIds(action)[0] || "");
+      if (!targetId || targetId === String(action.actorId || "") || !availableById.has(targetId)) {
+        return { targetId: null, cancelled: true, reason: "focused_target_unavailable", state: { ...state, focusedTargetId: targetId || null } };
+      }
+      return { targetId, cancelled: false, state: { ...state, focusedTargetId: targetId, previousTargetId: targetId } };
+    }
+
+    const pool = targetPool(action, units, options);
+    if (!pool.length) return { targetId: null, cancelled: true, reason: "no_available_targets", state: { ...state } };
+    const previous = String(state.previousTargetId || "");
+    let choices = pool;
+    if (pool.length > 1 && previous) {
+      const withoutPrevious = pool.filter((unit) => entityId(unit) !== previous);
+      if (withoutPrevious.length) choices = withoutPrevious;
+    }
+    const random = typeof options.random === "function" ? options.random : Math.random;
+    const index = Math.min(choices.length - 1, Math.floor(Math.max(0, finiteNumber(random(), 0)) * choices.length));
+    const targetId = entityId(choices[index]);
+    return { targetId, cancelled: false, state: { ...state, previousTargetId: targetId } };
+  }
+
+  function retargetStatus(action = {}, units = [], options = {}) {
+    const mode = volleyMode(action);
+    const pool = targetPool(action, units, options);
+    if (mode === "unfocused") return pool.length ? { executable: true, mode, requiresRetarget: false } : { executable: false, mode, reason: "no_available_targets" };
+    const mainId = String(action.targeting?.mainTargetId || "");
+    const target = asArray(units).find((unit) => entityId(unit) === mainId);
+    if (target && (options.isAvailable || isTargetAvailable)(target)) return { executable: true, mode, requiresRetarget: false };
+    return pool.length
+      ? { executable: false, mode, requiresRetarget: true, candidates: pool.map(entityId) }
+      : { executable: false, mode, requiresRetarget: false, reason: "no_available_targets" };
+  }
+
+  const api = Object.freeze({
+    PHASE_COMBAT,
+    SIDE_A,
+    SIDE_B,
+    entityId,
+    sideOf,
+    partIdOf,
+    resolveRoundSpeed,
+    buildRoundOrder,
+    actionTargetsActor,
+    canForceClash,
+    cancelActorActions,
+    volleyMode,
+    targetPool,
+    selectCoinTarget,
+    retargetStatus,
+    isTargetAvailable,
+  });
+
+  global.LuminousCombatActionQueue = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/combat-action-queue.js
+++ b/js/combat-action-queue.js
@@ -18,6 +18,10 @@
     return raw.includes("enemy") || raw.includes("enem") ? SIDE_B : SIDE_A;
   }
 
+  function partIdentity(part = {}) {
+    return String(part.id ?? part.partId ?? part.key ?? part.name ?? "").trim() || null;
+  }
+
   function partIdOf(action = {}) {
     return String(
       action.partId ?? action.abnormalityPartId ?? action.metadata?.partId ?? action.metadata?.abnormalityPartId ?? ""
@@ -40,7 +44,7 @@
   function findPart(unit = {}, partId) {
     if (!partId) return null;
     const wanted = String(partId);
-    return partCollection(unit).find((part) => String(part.id ?? part.partId ?? part.key ?? part.name ?? "") === wanted) || null;
+    return partCollection(unit).find((part) => partIdentity(part) === wanted) || null;
   }
 
   function speedSourceKey(actorId, partId) {
@@ -51,6 +55,41 @@
     const partId = partIdOf(action);
     const part = findPart(unit, partId);
     return part ? numericSpeed(part) : numericSpeed(unit);
+  }
+
+  function snapshotSpeedSources(units = [], options = {}) {
+    const random = typeof options.random === "function" ? options.random : Math.random;
+    const snapshot = {};
+    asArray(units).forEach((unit, inputIndex) => {
+      const actorId = entityId(unit);
+      if (!actorId) return;
+      const side = sideOf(unit);
+      const unitKey = speedSourceKey(actorId, null);
+      snapshot[unitKey] = {
+        key: unitKey,
+        actorId,
+        partId: null,
+        side,
+        speed: numericSpeed(unit),
+        tieRoll: finiteNumber(random(), 0),
+        inputIndex,
+      };
+      partCollection(unit).forEach((part, partIndex) => {
+        const partId = partIdentity(part);
+        if (!partId) return;
+        const key = speedSourceKey(actorId, partId);
+        snapshot[key] = {
+          key,
+          actorId,
+          partId,
+          side,
+          speed: numericSpeed(part),
+          tieRoll: finiteNumber(random(), 0),
+          inputIndex: inputIndex * 1000 + partIndex + 1,
+        };
+      });
+    });
+    return snapshot;
   }
 
   function slotIndexOf(action = {}, fallback = 0) {
@@ -76,6 +115,7 @@
   function buildRoundOrder(config = {}) {
     const random = typeof config.random === "function" ? config.random : Math.random;
     const unitsById = unitMap(config.units);
+    const frozenSnapshot = config.speedSnapshot && typeof config.speedSnapshot === "object" ? config.speedSnapshot : null;
     const sourceState = new Map();
     const entries = [];
 
@@ -88,7 +128,16 @@
       const key = speedSourceKey(actorId, partId);
       let source = sourceState.get(key);
       if (!source) {
-        source = {
+        const frozen = frozenSnapshot?.[key];
+        source = frozen ? {
+          key,
+          actorId,
+          partId,
+          side: frozen.side || sideOf(unit),
+          speed: finiteNumber(frozen.speed, resolveRoundSpeed(unit, action)),
+          tieRoll: finiteNumber(frozen.tieRoll, 0),
+          inputIndex: finiteNumber(frozen.inputIndex, inputIndex),
+        } : {
           key,
           actorId,
           partId,
@@ -279,7 +328,9 @@
     entityId,
     sideOf,
     partIdOf,
+    speedSourceKey,
     resolveRoundSpeed,
+    snapshotSpeedSources,
     buildRoundOrder,
     actionTargetsActor,
     canForceClash,

--- a/js/combat-action-resolver.js
+++ b/js/combat-action-resolver.js
@@ -191,6 +191,37 @@
     return { resolved: true, results };
   }
 
+  function resolvePreparedUnopposed(action, actor, targets, context = {}, options = {}) {
+    if (terminal(action)) return { resolved: action.state === "resolved", reason: "terminal_state", action };
+    if (isStaggered(actor)) {
+      const cancelled = schema.cancelCombatAction(action, { type: "stagger" }).action;
+      return { resolved: false, cancelled: true, reason: "stagger", action: cancelled };
+    }
+
+    const resourceGate = validateResources(action, actor, context);
+    if (!resourceGate.available) return { resolved: false, reason: resourceGate.reason, resourceGate, action };
+
+    const economy = consumeEconomy(action, actor, context);
+    if (economy.consumed === false) return { resolved: false, reason: economy.reason || "economy_unavailable", economy, resourceGate, action };
+
+    const resources = consumeResources(action, actor, context);
+    if (!resources.consumed) return { resolved: false, reason: resources.reason, resources, economy, resourceGate, action };
+
+    action.state = "resolving";
+    const attack = resolveDirectAttack(action, actor, targets, context, options);
+    action.state = attack.resolved ? "resolved" : "locked";
+    return {
+      resolved: Boolean(attack.resolved),
+      reason: attack.resolved ? null : attack.reason,
+      attack,
+      resources,
+      economy,
+      resourceGate,
+      action,
+      resolvedActionIds: attack.resolved ? [action.id] : [],
+    };
+  }
+
   function resolveClashPair(actionInput, opposingInput, context = {}) {
     const engine = context.engine || global.CombatEngine;
     if (!engine?.resolveStandardClash) return { resolved: false, reason: "clash_resolver_unavailable" };
@@ -202,13 +233,22 @@
     const unitB = unitById(context, actionB.actorId);
     if (!unitA || !unitB) return { resolved: false, reason: "clash_actor_missing", actions: [actionA, actionB] };
 
+    if (isStaggered(unitA)) {
+      const cancelled = schema.cancelCombatAction(actionA, { type: "stagger" }).action;
+      return { resolved: false, cancelled: true, reason: "stagger", actions: [cancelled, actionB], resolvedActionIds: [cancelled.id] };
+    }
+
     const gateB = phaseGate(actionB, context);
     if (!gateB.allowed || terminal(actionB)) {
       const targetResolution = resolveTargets(actionA, context);
       const targets = targetResolution.targets.length ? targetResolution.targets : [unitB];
-      const attack = resolveDirectAttack(actionA, unitA, targets, context, { skill: definitionForEngine(actionA) });
-      actionA.state = attack.resolved ? "resolved" : "locked";
-      return { resolved: Boolean(attack.resolved), type: "unopposed", reason: gateB.reason || "opposing_action_unavailable", attack, actions: [actionA, actionB], resolvedActionIds: attack.resolved ? [actionA.id] : [] };
+      const prepared = resolvePreparedUnopposed(actionA, unitA, targets, context, { skill: definitionForEngine(actionA) });
+      return {
+        ...prepared,
+        type: "unopposed",
+        reason: prepared.resolved ? (gateB.reason || "opposing_action_unavailable") : prepared.reason,
+        actions: [prepared.action || actionA, actionB],
+      };
     }
 
     if (isStaggered(unitB)) {
@@ -216,9 +256,15 @@
       const targetResolution = resolveTargets(actionA, context);
       let targets = targetResolution.targets;
       if (!targets.some((target) => entityId(target) === entityId(unitB))) targets.unshift(unitB);
-      const attack = resolveDirectAttack(actionA, unitA, targets.slice(0, Math.max(1, actionA.targeting.attackWeight)), context, { skill: definitionForEngine(actionA) });
-      actionA.state = attack.resolved ? "resolved" : "locked";
-      return { resolved: Boolean(attack.resolved), type: "unopposed", reason: "opposing_action_cancelled_by_stagger", attack, actions: [actionA, cancelled], resolvedActionIds: attack.resolved ? [actionA.id, cancelled.id] : [cancelled.id] };
+      targets = targets.slice(0, Math.max(1, actionA.targeting.attackWeight));
+      const prepared = resolvePreparedUnopposed(actionA, unitA, targets, context, { skill: definitionForEngine(actionA) });
+      return {
+        ...prepared,
+        type: "unopposed",
+        reason: prepared.resolved ? "opposing_action_cancelled_by_stagger" : prepared.reason,
+        actions: [prepared.action || actionA, cancelled],
+        resolvedActionIds: prepared.resolved ? [actionA.id, cancelled.id] : [cancelled.id],
+      };
     }
 
     const resourcesA = validateResources(actionA, unitA, context);
@@ -412,6 +458,7 @@
     consumeResources,
     resolveTargets,
     resolveDirectAttack,
+    resolvePreparedUnopposed,
     resolveClashPair,
     resolveSave,
     resolveCheck,

--- a/js/combat-action-resolver.js
+++ b/js/combat-action-resolver.js
@@ -3,6 +3,7 @@
 
   const schema = global.LuminousCombatAction || (typeof require === "function" ? require("./combat-action-schema.js") : null);
   const bridge = global.LuminousCombatActionEngineBridge || (typeof require === "function" ? require("./combat-action-engine-bridge.js") : null);
+  const queueApi = global.LuminousCombatActionQueue || (typeof require === "function" ? (() => { try { return require("./combat-action-queue.js"); } catch (_) { return null; } })() : null);
   if (!schema) return;
 
   const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
@@ -170,11 +171,89 @@
     return next;
   }
 
+  function coinDefinitions(skill = {}) {
+    if (Array.isArray(skill.coins) && skill.coins.length) return skill.coins.map((coin) => ({ ...coin }));
+    const count = Math.max(0, Math.trunc(Number(skill.coinAmount ?? skill.coin_count ?? skill.coinCount ?? 0)));
+    return Array.from({ length: count }, (_, index) => ({ index }));
+  }
+
+  function skillForCoin(baseSkill = {}, coin = {}, index = 0) {
+    const skill = cloneAttackSkill(baseSkill);
+    skill.coins = [{ ...coin, index: 0, originalIndex: coin.originalIndex ?? coin.index ?? index }];
+    skill.coinAmount = 1;
+    skill.coin_count = 1;
+    skill.coinCount = 1;
+    skill.__combatActionCoinIndex = index;
+    return skill;
+  }
+
+  function resolveCoinwiseAttack(action, actor, context = {}, options = {}, baseSkill = {}) {
+    const engine = context.engine || global.CombatEngine;
+    const q = context.combatActionQueue || queueApi;
+    if (!engine?.resolveUnilateralWithCounter || !q?.selectCoinTarget) return null;
+    const coins = coinDefinitions(baseSkill);
+    if (!coins.length) return null;
+
+    let state = {};
+    const results = [];
+    for (let index = 0; index < coins.length; index++) {
+      if (isStaggered(actor)) {
+        return { resolved: false, cancelled: true, partial: results.length > 0, reason: "stagger", results, remainingCoins: coins.length - index };
+      }
+
+      const selected = q.selectCoinTarget(action, context.units || Object.values(context.combatData || {}), state, {
+        random: context.random,
+        isAvailable: context.isTargetAvailable,
+      });
+      state = selected.state || state;
+      if (selected.cancelled || !selected.targetId) {
+        return {
+          resolved: false,
+          cancelled: true,
+          partial: results.length > 0,
+          reason: selected.reason || "target_unavailable",
+          results,
+          remainingCoins: coins.length - index,
+        };
+      }
+
+      const target = unitById(context, selected.targetId);
+      if (!target) {
+        return { resolved: false, cancelled: true, partial: results.length > 0, reason: "target_missing", results, remainingCoins: coins.length - index };
+      }
+
+      const skill = skillForCoin(baseSkill, coins[index], index);
+      const result = engine.resolveUnilateralWithCounter(actor, skill, target, null, {
+        skipUseHooks: options.skipUseHooks === true || index > 0,
+        clashResult: options.clashResult || null,
+        clashCount: options.clashCount || 0,
+        mitigationPenalty: options.mitigationPenalty,
+        combatants: context.units || Object.values(context.combatData || {}),
+        combatActionCoinIndex: index,
+      });
+      results.push({ targetId: entityId(target), coinIndex: index, result });
+
+      if (isStaggered(actor)) {
+        return { resolved: false, cancelled: true, partial: true, reason: "stagger", results, remainingCoins: coins.length - index - 1 };
+      }
+    }
+    return { resolved: true, coinwise: true, results, remainingCoins: 0 };
+  }
+
   function resolveDirectAttack(action, actor, targets, context = {}, options = {}) {
     const engine = context.engine || global.CombatEngine;
     if (!engine?.resolveUnilateralWithCounter) return { resolved: false, reason: "unilateral_resolver_unavailable", results: [] };
     bridge?.installCombatActionPowerBridge?.(engine);
     const baseSkill = options.skill || definitionForEngine(action);
+    const q = context.combatActionQueue || queueApi;
+    const volley = q?.volleyMode ? q.volleyMode(action) : "focused";
+    const attackWeight = Math.max(1, Number(action.targeting?.attackWeight || 1));
+    const coinwiseAllowed = context.coinwiseResolution === true && q?.selectCoinTarget && (volley === "unfocused" || (volley === "focused" && attackWeight === 1 && targets.length <= 1));
+    if (coinwiseAllowed) {
+      const coinwise = resolveCoinwiseAttack(action, actor, context, options, baseSkill);
+      if (coinwise) return coinwise;
+    }
+
     const results = [];
     for (let index = 0; index < targets.length; index++) {
       const target = targets[index];
@@ -187,6 +266,7 @@
         combatants: context.units || Object.values(context.combatData || {}),
       });
       results.push({ targetId: entityId(target), result });
+      if (isStaggered(actor)) return { resolved: false, cancelled: true, partial: true, reason: "stagger", results };
     }
     return { resolved: true, results };
   }
@@ -195,7 +275,7 @@
     if (terminal(action)) return { resolved: action.state === "resolved", reason: "terminal_state", action };
     if (isStaggered(actor)) {
       const cancelled = schema.cancelCombatAction(action, { type: "stagger" }).action;
-      return { resolved: false, cancelled: true, reason: "stagger", action: cancelled };
+      return { resolved: false, cancelled: true, reason: "stagger", action: cancelled, resolvedActionIds: [cancelled.id] };
     }
 
     const resourceGate = validateResources(action, actor, context);
@@ -209,6 +289,11 @@
 
     action.state = "resolving";
     const attack = resolveDirectAttack(action, actor, targets, context, options);
+    if (attack.cancelled) {
+      action.state = "cancelled";
+      action.cancelReason = { type: attack.reason || "cancelled_during_resolution" };
+      return { resolved: false, cancelled: true, partial: attack.partial === true, reason: attack.reason, attack, resources, economy, resourceGate, action, resolvedActionIds: [action.id] };
+    }
     action.state = attack.resolved ? "resolved" : "locked";
     return {
       resolved: Boolean(attack.resolved),
@@ -263,7 +348,7 @@
         type: "unopposed",
         reason: prepared.resolved ? "opposing_action_cancelled_by_stagger" : prepared.reason,
         actions: [prepared.action || actionA, cancelled],
-        resolvedActionIds: prepared.resolved ? [actionA.id, cancelled.id] : [cancelled.id],
+        resolvedActionIds: [...new Set([...(prepared.resolvedActionIds || []), cancelled.id])],
       };
     }
 
@@ -317,6 +402,10 @@
 
     actionA.state = "resolved";
     actionB.state = "resolved";
+    if (attack?.cancelled && winningAction) {
+      winningAction.state = "cancelled";
+      winningAction.cancelReason = { type: attack.reason || "cancelled_during_resolution" };
+    }
     return {
       resolved: true,
       type: "clash",
@@ -410,7 +499,7 @@
     if (!actor) return { resolved: false, reason: "actor_missing", action };
     if (isStaggered(actor)) {
       const cancelled = schema.cancelCombatAction(action, { type: "stagger" });
-      return { resolved: false, cancelled: true, reason: "stagger", action: cancelled.action };
+      return { resolved: false, cancelled: true, reason: "stagger", action: cancelled.action, resolvedActionIds: [cancelled.action.id] };
     }
 
     if (action.resolution.type === "clash" && context.opposingAction) {
@@ -443,6 +532,11 @@
       resolution = resolveAutomatic(action, actor, targets, context);
     }
 
+    if (resolution?.cancelled) {
+      action.state = "cancelled";
+      action.cancelReason = { type: resolution.reason || "cancelled_during_resolution" };
+      return { resolved: false, cancelled: true, partial: resolution.partial === true, reason: resolution.reason, resolution, resources, economy, action, targetResolution, resolvedActionIds: [action.id] };
+    }
     if (resolution?.resolved === false) {
       action.state = "locked";
       return { resolved: false, reason: resolution.reason || "resolution_failed", resolution, resources, economy, action };
@@ -458,6 +552,7 @@
     consumeResources,
     resolveTargets,
     resolveDirectAttack,
+    resolveCoinwiseAttack,
     resolvePreparedUnopposed,
     resolveClashPair,
     resolveSave,

--- a/js/combat-runtime-integration.js
+++ b/js/combat-runtime-integration.js
@@ -35,6 +35,17 @@
     return action.state === "resolved" || action.state === "cancelled";
   }
 
+  function isUnitActive(runtime, unit = {}) {
+    if (!unit || !entityId(unit)) return false;
+    if (unit.defeated === true || unit.dead === true || unit.removed === true || unit.escaped === true) return false;
+    const absentThrough = Number(unit.combatAbsentThroughRound ?? unit.absentThroughRound ?? -1);
+    return !Number.isFinite(absentThrough) || runtime.round > absentThrough;
+  }
+
+  function activeUnits(runtime) {
+    return runtime.units.filter((unit) => isUnitActive(runtime, unit));
+  }
+
   function createRuntime(config = {}) {
     const units = asArray(config.units).filter(Boolean);
     return {
@@ -67,6 +78,28 @@
     return runtime.phase;
   }
 
+  function runtimeTargetAvailable(runtime, target, context = {}) {
+    if (!isUnitActive(runtime, target)) return false;
+    if (typeof context.isTargetAvailable === "function") return context.isTargetAvailable(target, runtime) !== false;
+    return queueApi.isTargetAvailable(target);
+  }
+
+  function resolverContext(runtime, context = {}, phase = runtime.phase, extra = {}) {
+    return {
+      ...context,
+      ...extra,
+      phase,
+      units: activeUnits(runtime),
+      encounter: runtime.encounter,
+      teamEconomy: context.teamEconomy || teamEconomy,
+      actionMap: runtime.actionMap,
+      random: runtime.random,
+      coinwiseResolution: context.coinwiseResolution !== false,
+      combatActionQueue: context.combatActionQueue || queueApi,
+      isTargetAvailable: (target) => runtimeTargetAvailable(runtime, target, context),
+    };
+  }
+
   function beginTurn(runtime, options = {}) {
     setPhase(runtime, schema.PHASES.ON_TURN_START);
     runtime.playerReady = false;
@@ -78,10 +111,10 @@
     runtime.preparedReactions = [];
 
     if (typeof options.onTurnStart === "function") {
-      for (const unit of runtime.units) options.onTurnStart({ unit, runtime });
+      for (const unit of activeUnits(runtime)) options.onTurnStart({ unit, runtime });
     }
 
-    runtime.speedSnapshot = queueApi.snapshotSpeedSources(runtime.units, { random: runtime.random });
+    runtime.speedSnapshot = queueApi.snapshotSpeedSources(activeUnits(runtime), { random: runtime.random });
     record(runtime, "speed_snapshot", { speedSnapshot: runtime.speedSnapshot });
     setPhase(runtime, schema.PHASES.PLANNING_PHASE_PLAYER);
     if (runtime.encounter) runtime.encounter.phase = teamEconomy?.PHASES?.PLANNING_PLAYER || "planning_player";
@@ -97,11 +130,42 @@
     return side === queueApi.SIDE_B ? schema.PHASES.PLANNING_PHASE_AI : schema.PHASES.PLANNING_PHASE_PLAYER;
   }
 
+  function availableSlotCount(runtime, actorId) {
+    if (runtime.encounter && teamEconomy?.profileForUnit) {
+      const found = teamEconomy.profileForUnit(runtime.encounter, actorId);
+      if (found?.profile) return Math.max(0, Number(found.profile.usableActionSlots ?? found.profile.currentActionSlots ?? 0));
+    }
+    const unit = unitById(runtime, actorId);
+    if (!unit) return 0;
+    const values = [unit.actionSlotState?.usable, unit.activeSlots, unit.currentActionSlots, unit.actionSlotState?.current];
+    const found = values.map(Number).find(Number.isFinite);
+    return found == null ? Infinity : Math.max(0, found);
+  }
+
+  function validateActionSlot(runtime, action) {
+    if (action.economy.cost !== schema.ECONOMY_COSTS.ACTION) return { valid: true };
+    if (!action.actionSlotId) return { valid: false, reason: "action_slot_required" };
+    const duplicate = runtime.actions.find((entry) =>
+      entry.actorId === action.actorId &&
+      entry.economy.cost === schema.ECONOMY_COSTS.ACTION &&
+      entry.actionSlotId === action.actionSlotId &&
+      !terminal(entry)
+    );
+    if (duplicate) return { valid: false, reason: "action_slot_already_used", conflictingActionId: duplicate.id };
+    const used = runtime.actions.filter((entry) => entry.actorId === action.actorId && entry.economy.cost === schema.ECONOMY_COSTS.ACTION && !terminal(entry)).length;
+    const available = availableSlotCount(runtime, action.actorId);
+    if (Number.isFinite(available) && used >= available) return { valid: false, reason: "no_usable_action_slots", available, used };
+    return { valid: true, available, used };
+  }
+
   function registerAction(runtime, input = {}, options = {}) {
     const action = schema.normalizeCombatAction(input);
     const validation = schema.validateCombatAction(action);
     if (!validation.valid) return { registered: false, reason: "invalid_action", errors: validation.errors, action };
     const normalized = validation.action;
+    const actor = unitById(runtime, normalized.actorId);
+    if (!actor) return { registered: false, reason: "actor_missing", action: normalized };
+    if (!isUnitActive(runtime, actor)) return { registered: false, reason: "actor_inactive", action: normalized };
     const side = sideForAction(runtime, normalized);
     const expectedPlanning = planningPhaseForSide(side);
 
@@ -121,24 +185,19 @@
     if (normalized.economy.cost === schema.ECONOMY_COSTS.QUICK_ACTION) {
       normalized.phase.selectedAt = runtime.phase;
       normalized.phase.executesAt = runtime.phase;
-      const result = resolver.resolveCombatAction(normalized, {
-        ...options.context,
-        phase: runtime.phase,
-        units: runtime.units,
-        encounter: runtime.encounter,
-        teamEconomy: options.context?.teamEconomy || teamEconomy,
-        actionMap: runtime.actionMap,
-        random: runtime.random,
-      });
+      const result = resolver.resolveCombatAction(normalized, resolverContext(runtime, options.context || {}, runtime.phase));
       runtime.actionMap[normalized.id] = result.action || normalized;
       asArray(result.resolvedActionIds).forEach((id) => runtime.resolvedActionIds.add(String(id)));
       record(runtime, "quick_action", { actionId: normalized.id, resolved: result.resolved, reason: result.reason || null });
       return { registered: Boolean(result.resolved), immediate: true, action: result.action || normalized, result };
     }
 
+    const slotGate = validateActionSlot(runtime, normalized);
+    if (!slotGate.valid) return { registered: false, ...slotGate, action: normalized };
+
     runtime.actions.push(normalized);
     runtime.actionMap[normalized.id] = normalized;
-    record(runtime, "action_registered", { actionId: normalized.id, actorId: normalized.actorId, side });
+    record(runtime, "action_registered", { actionId: normalized.id, actorId: normalized.actorId, side, actionSlotId: normalized.actionSlotId });
     return { registered: true, action: normalized };
   }
 
@@ -161,7 +220,7 @@
     record(runtime, "player_ready", { lockedActionIds });
 
     let aiActions = [];
-    if (typeof options.aiPlanner === "function") aiActions = asArray(options.aiPlanner({ runtime, units: runtime.units, actions: runtime.actions }));
+    if (typeof options.aiPlanner === "function") aiActions = asArray(options.aiPlanner({ runtime, units: activeUnits(runtime), actions: runtime.actions }));
     const registeredAi = aiActions.map((action) => registerAction(runtime, action, { context: options.context })).filter((entry) => entry.registered);
     return { ready: true, phase: runtime.phase, lockedActionIds, registeredAi };
   }
@@ -178,7 +237,7 @@
 
   function previewQueue(runtime) {
     return queueApi.buildRoundOrder({
-      units: runtime.units,
+      units: activeUnits(runtime),
       actions: runtime.actions.filter((action) => action.economy.cost !== schema.ECONOMY_COSTS.REACTION),
       speedSnapshot: runtime.speedSnapshot,
       random: runtime.random,
@@ -217,10 +276,12 @@
     return { linked: true, interceptorActionId: interceptor.id, targetActionId: target.id };
   }
 
-  function beginCombatPhase(runtime) {
+  function beginCombatPhase(runtime, context = {}) {
     if (!runtime.playerReady || !runtime.aiReady) return { started: false, reason: "planning_not_ready" };
     if (runtime.phase !== schema.PHASES.COMBAT_START) return { started: false, reason: "combat_start_required", phase: runtime.phase };
     runtime.queue = previewQueue(runtime);
+    record(runtime, "combat_start", { queue: runtime.queue.entries.map((entry) => entry.actionId) });
+    if (typeof context.onCombatStart === "function") context.onCombatStart({ runtime, queue: runtime.queue });
     setPhase(runtime, schema.PHASES.COMBAT_PHASE);
     record(runtime, "combat_phase_started", { queue: runtime.queue.entries.map((entry) => entry.actionId) });
     return { started: true, phase: runtime.phase, queue: runtime.queue };
@@ -257,7 +318,7 @@
 
   function applyBlockingStates(runtime, context = {}) {
     const cancelled = [];
-    for (const unit of runtime.units) {
+    for (const unit of activeUnits(runtime)) {
       const blocked = isStaggered(unit) || (typeof context.isActionBlocked === "function" && context.isActionBlocked({ unit, runtime }) === true);
       if (!blocked) continue;
       const reason = isStaggered(unit) ? { type: "stagger" } : { type: "action_blocked" };
@@ -267,7 +328,7 @@
   }
 
   function applyRetarget(runtime, action, context = {}) {
-    const status = queueApi.retargetStatus(action, runtime.units, { isAvailable: context.isTargetAvailable });
+    const status = queueApi.retargetStatus(action, activeUnits(runtime), { isAvailable: (target) => runtimeTargetAvailable(runtime, target, context) });
     if (status.executable) return { ready: true, action };
     if (!status.requiresRetarget) {
       action.state = "cancelled";
@@ -305,14 +366,7 @@
 
     for (const reaction of runtime.preparedReactions) {
       if (terminal(reaction) || !matcher(reaction.reaction?.trigger, event, reaction, runtime)) continue;
-      const result = resolver.resolveCombatAction(reaction, {
-        ...context,
-        phase: schema.PHASES.COMBAT_PHASE,
-        units: runtime.units,
-        encounter: runtime.encounter,
-        actionMap: runtime.actionMap,
-        random: runtime.random,
-      });
+      const result = resolver.resolveCombatAction(reaction, resolverContext(runtime, context, schema.PHASES.COMBAT_PHASE));
       syncResultActions(runtime, result);
       results.push({ mode: "prepared", actionId: reaction.id, result });
     }
@@ -326,14 +380,7 @@
         reaction.phase.executesAt = schema.PHASES.COMBAT_PHASE;
         reaction.reaction = { ...(reaction.reaction || {}), mode: "adaptive" };
         runtime.actionMap[reaction.id] = reaction;
-        const result = resolver.resolveCombatAction(reaction, {
-          ...context,
-          phase: schema.PHASES.COMBAT_PHASE,
-          units: runtime.units,
-          encounter: runtime.encounter,
-          actionMap: runtime.actionMap,
-          random: runtime.random,
-        });
+        const result = resolver.resolveCombatAction(reaction, resolverContext(runtime, context, schema.PHASES.COMBAT_PHASE));
         syncResultActions(runtime, result);
         results.push({ mode: "adaptive", actionId: reaction.id, result });
       }
@@ -341,6 +388,29 @@
 
     if (results.length) record(runtime, "reactions_resolved", { eventType: event.type || null, actionIds: results.map((entry) => entry.actionId) });
     return results;
+  }
+
+  function grappleSucceeded(action, result = {}) {
+    if (action.source?.type !== "universal" || normalizeId(action.source?.id) !== "grapple") return false;
+    const payload = result.resolution?.result ?? result.result ?? {};
+    if (payload === true) return true;
+    if (payload?.success === true || payload?.succeeded === true || payload?.attackerWon === true || payload?.grappled === true) return true;
+    const winner = normalizeId(payload?.winner || payload?.result);
+    return ["attacker", "a", "success", "win", "won"].includes(winner);
+  }
+
+  function applyGrappleOutcome(runtime, action, result = {}) {
+    if (!grappleSucceeded(action, result)) return null;
+    const targetId = String(action.targeting?.mainTargetId || action.targeting?.targetIds?.[0] || "");
+    if (!targetId) return null;
+    const cancelledActionIds = cancelActorPending(runtime, targetId, { type: "grapple" });
+    const locks = [];
+    if (runtime.encounter && teamEconomy?.lockUnitSlots) {
+      locks.push(teamEconomy.lockUnitSlots(runtime.encounter, action.actorId, 1, "grapple"));
+      locks.push(teamEconomy.lockUnitSlots(runtime.encounter, targetId, 1, "grapple"));
+    }
+    record(runtime, "grapple_applied", { actorId: action.actorId, targetId, cancelledActionIds });
+    return { targetId, cancelledActionIds, locks };
   }
 
   function resolveQueueEntry(runtime, entry, context = {}) {
@@ -358,20 +428,13 @@
     const opposingAction = opposingId ? runtime.actionMap[opposingId] || null : null;
     triggerReactions(runtime, { type: "before_action", actionId: action.id, actorId: action.actorId }, context);
 
-    const result = resolver.resolveCombatAction(action, {
-      ...context,
-      phase: schema.PHASES.COMBAT_PHASE,
-      units: runtime.units,
-      encounter: runtime.encounter,
-      actionMap: runtime.actionMap,
-      opposingAction,
-      random: runtime.random,
-    });
+    const result = resolver.resolveCombatAction(action, resolverContext(runtime, context, schema.PHASES.COMBAT_PHASE, { opposingAction }));
     syncResultActions(runtime, result);
+    const grapple = applyGrappleOutcome(runtime, result.action || action, result);
     applyBlockingStates(runtime, context);
     triggerReactions(runtime, { type: "after_action", actionId: action.id, actorId: action.actorId, result }, context);
     record(runtime, "action_resolved", { actionId: action.id, resolved: result.resolved, reason: result.reason || null, type: result.type || result.resolution?.type || action.resolution.type });
-    return result;
+    return grapple ? { ...result, grapple } : result;
   }
 
   function resolveCombatPhase(runtime, context = {}) {
@@ -385,8 +448,70 @@
       }
     }
     setPhase(runtime, schema.PHASES.COMBAT_END);
-    record(runtime, "combat_phase_complete", { resolvedActionIds: [...runtime.resolvedActionIds] });
+    record(runtime, "combat_end", { resolvedActionIds: [...runtime.resolvedActionIds] });
+    if (typeof context.onCombatEnd === "function") context.onCombatEnd({ runtime, results });
     return { completed: true, phase: runtime.phase, results };
+  }
+
+  function teamForUnit(runtime, unit) {
+    if (!runtime.encounter || !teamEconomy?.teamForSide) return null;
+    return teamEconomy.teamForSide(runtime.encounter, queueApi.sideOf(unit));
+  }
+
+  function replaceRuntimeUnit(runtime, outgoing, incoming) {
+    const index = runtime.units.indexOf(outgoing);
+    if (index >= 0) runtime.units.splice(index, 1, incoming);
+    else runtime.units.push(incoming);
+  }
+
+  function defaultRetreat(runtime, actor, effect = {}) {
+    const side = queueApi.sideOf(actor);
+    const team = teamForUnit(runtime, actor);
+    if (team && teamEconomy?.profileForUnit) {
+      const found = teamEconomy.profileForUnit(runtime.encounter, actor);
+      if (team.backups?.length) {
+        const backupProfile = team.backups.shift();
+        const incomingUnit = backupProfile.unit;
+        const incoming = teamEconomy.inheritReplacementSlots
+          ? teamEconomy.inheritReplacementSlots(runtime.encounter, side, actor, incomingUnit, { cap: effect.inheritActionSlotsCap || 2 })
+          : backupProfile;
+        const activeIndex = team.active.indexOf(found.profile);
+        if (activeIndex >= 0) team.active.splice(activeIndex, 1, incoming);
+        found.profile.statusLockedSlots = 0;
+        found.profile.usableActionSlots = 0;
+        team.backups.push(found.profile);
+        replaceRuntimeUnit(runtime, actor, incomingUnit);
+        teamEconomy.syncEncounter?.(runtime.encounter);
+        return { retreated: true, replaced: true, outgoingUnitId: entityId(actor), incomingUnitId: entityId(incomingUnit), inheritedSlots: incoming.currentActionSlots };
+      }
+    }
+
+    actor.combatAbsentThroughRound = runtime.round + 1;
+    return { retreated: true, replaced: false, absentThroughRound: actor.combatAbsentThroughRound };
+  }
+
+  function defaultEscape(runtime, actor) {
+    actor.escaped = true;
+    actor.eligibleForXp = false;
+    const team = teamForUnit(runtime, actor);
+    if (team && teamEconomy?.profileForUnit) {
+      const found = teamEconomy.profileForUnit(runtime.encounter, actor);
+      if (found?.profile) {
+        const index = team.active.indexOf(found.profile);
+        if (index >= 0) team.active.splice(index, 1);
+        teamEconomy.registerVacatedSlots?.(runtime.encounter, team.side, found.profile.currentActionSlots || 1, { hasBackup: team.backups?.length > 0 });
+        teamEconomy.syncEncounter?.(runtime.encounter);
+      }
+    }
+    return { escaped: true, unitId: entityId(actor), eligibleForXp: false };
+  }
+
+  function turnEndEffectHandlers(runtime, context = {}) {
+    return {
+      ...(context.effectHandlers || {}),
+      retreat: context.effectHandlers?.retreat || (({ actor, effect }) => defaultRetreat(runtime, actor, effect)),
+      escape: context.effectHandlers?.escape || (({ actor }) => defaultEscape(runtime, actor)),
+    };
   }
 
   function resolveTurnEnd(runtime, context = {}) {
@@ -397,14 +522,15 @@
     const ordered = [...turnEndActions].sort((a, b) => {
       const aPart = queueApi.partIdOf(a);
       const bPart = queueApi.partIdOf(b);
-      const aSpeed = runtime.speedSnapshot?.[queueApi.speedSourceKey(a.actorId, aPart)]?.speed ?? 0;
-      const bSpeed = runtime.speedSnapshot?.[queueApi.speedSourceKey(b.actorId, bPart)]?.speed ?? 0;
-      return bSpeed - aSpeed;
+      const aSource = runtime.speedSnapshot?.[queueApi.speedSourceKey(a.actorId, aPart)];
+      const bSource = runtime.speedSnapshot?.[queueApi.speedSourceKey(b.actorId, bPart)];
+      return (Number(bSource?.speed || 0) - Number(aSource?.speed || 0)) || (Number(aSource?.tieRoll || 0) - Number(bSource?.tieRoll || 0));
     });
 
+    const effectHandlers = turnEndEffectHandlers(runtime, context);
     for (const action of ordered) {
       const unit = unitById(runtime, action.actorId);
-      const blocked = !unit || isStaggered(unit) || (typeof context.isTurnEndBlocked === "function" && context.isTurnEndBlocked({ action, unit, runtime }) === true);
+      const blocked = !unit || !isUnitActive(runtime, unit) || isStaggered(unit) || (typeof context.isTurnEndBlocked === "function" && context.isTurnEndBlocked({ action, unit, runtime }) === true);
       if (blocked) {
         action.state = "cancelled";
         action.cancelReason = { type: !unit ? "actor_missing" : (isStaggered(unit) ? "stagger" : "turn_end_blocked") };
@@ -413,14 +539,7 @@
         results.push({ actionId: action.id, resolved: false, cancelled: true, reason: action.cancelReason.type });
         continue;
       }
-      const result = resolver.resolveCombatAction(action, {
-        ...context,
-        phase: schema.PHASES.ON_TURN_END,
-        units: runtime.units,
-        encounter: runtime.encounter,
-        actionMap: runtime.actionMap,
-        random: runtime.random,
-      });
+      const result = resolver.resolveCombatAction(action, resolverContext(runtime, { ...context, effectHandlers }, schema.PHASES.ON_TURN_END));
       syncResultActions(runtime, result);
       results.push({ actionId: action.id, ...result });
     }
@@ -441,7 +560,11 @@
 
   const api = Object.freeze({
     createRuntime,
+    activeUnits,
+    isUnitActive,
     beginTurn,
+    availableSlotCount,
+    validateActionSlot,
     registerAction,
     playerPlanningReady,
     aiPlanningReady,
@@ -450,8 +573,11 @@
     beginCombatPhase,
     cancelActorPending,
     triggerReactions,
+    applyGrappleOutcome,
     resolveQueueEntry,
     resolveCombatPhase,
+    defaultRetreat,
+    defaultEscape,
     resolveTurnEnd,
     nextRound,
   });

--- a/js/combat-runtime-integration.js
+++ b/js/combat-runtime-integration.js
@@ -10,30 +10,17 @@
   const asArray = (value) => value == null ? [] : (Array.isArray(value) ? value : [value]);
   const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
 
-  function entityId(entity = {}) {
-    return queueApi.entityId(entity);
-  }
-
-  function unitById(runtime, id) {
-    const wanted = String(id ?? "");
-    return runtime.units.find((unit) => entityId(unit) === wanted) || null;
-  }
+  function entityId(entity = {}) { return queueApi.entityId(entity); }
+  function unitById(runtime, id) { const wanted = String(id ?? ""); return runtime.units.find((unit) => entityId(unit) === wanted) || null; }
 
   function isStaggered(unit = {}) {
     if (unit.isStaggered === true || unit.staggered === true) return true;
     const statuses = unit.statusEffects || unit.statuses || {};
-    if (Array.isArray(statuses)) {
-      return statuses.some((entry) => {
-        const id = normalizeId(entry?.id || entry);
-        return id === "stagger" || id === "staggered";
-      });
-    }
+    if (Array.isArray(statuses)) return statuses.some((entry) => ["stagger", "staggered"].includes(normalizeId(entry?.id || entry)));
     return Boolean(statuses.stagger || statuses.staggered);
   }
 
-  function terminal(action = {}) {
-    return action.state === "resolved" || action.state === "cancelled";
-  }
+  function terminal(action = {}) { return action.state === "resolved" || action.state === "cancelled"; }
 
   function isUnitActive(runtime, unit = {}) {
     if (!unit || !entityId(unit)) return false;
@@ -42,9 +29,7 @@
     return !Number.isFinite(absentThrough) || runtime.round > absentThrough;
   }
 
-  function activeUnits(runtime) {
-    return runtime.units.filter((unit) => isUnitActive(runtime, unit));
-  }
+  function activeUnits(runtime) { return runtime.units.filter((unit) => isUnitActive(runtime, unit)); }
 
   function createRuntime(config = {}) {
     const units = asArray(config.units).filter(Boolean);
@@ -63,6 +48,12 @@
       resolvedActionIds: new Set(),
       playerReady: false,
       aiReady: false,
+      teamResources: {
+        [queueApi.SIDE_A]: { quickActionRemaining: 1, helpRemaining: 1 },
+        [queueApi.SIDE_B]: { quickActionRemaining: 1, helpRemaining: 1 },
+      },
+      reactionRemaining: {},
+      retreatReserve: [],
       history: [],
     };
   }
@@ -73,9 +64,38 @@
     return entry;
   }
 
-  function setPhase(runtime, phase) {
-    runtime.phase = schema.normalizePhase(phase, phase);
-    return runtime.phase;
+  function setPhase(runtime, phase) { runtime.phase = schema.normalizePhase(phase, phase); return runtime.phase; }
+
+  function resetLocalEconomy(runtime) {
+    for (const side of [queueApi.SIDE_A, queueApi.SIDE_B]) runtime.teamResources[side] = { quickActionRemaining: 1, helpRemaining: 1 };
+    runtime.reactionRemaining = {};
+    for (const unit of activeUnits(runtime)) {
+      const max = Number(unit.reactionsPerRound ?? unit.reactionMax ?? unit.maxReactions ?? 1);
+      runtime.reactionRemaining[entityId(unit)] = Number.isFinite(max) ? Math.max(0, Math.trunc(max)) : 1;
+    }
+  }
+
+  function consumeLocalQuick(runtime, side) {
+    const bucket = runtime.teamResources[side] || runtime.teamResources[queueApi.SIDE_A];
+    if (![schema.PHASES.PLANNING_PHASE_PLAYER, schema.PHASES.PLANNING_PHASE_AI].includes(runtime.phase)) return { consumed: false, reason: "quick_action_planning_only" };
+    if (bucket.quickActionRemaining <= 0) return { consumed: false, reason: "team_quick_action_spent" };
+    bucket.quickActionRemaining = 0;
+    return { consumed: true, remaining: 0 };
+  }
+
+  function consumeLocalHelp(runtime, side) {
+    const bucket = runtime.teamResources[side] || runtime.teamResources[queueApi.SIDE_A];
+    if (bucket.helpRemaining <= 0) return { consumed: false, reason: "team_help_spent" };
+    bucket.helpRemaining = 0;
+    return { consumed: true, remaining: 0 };
+  }
+
+  function consumeLocalReaction(runtime, actorId) {
+    const id = String(actorId || "");
+    const remaining = Number(runtime.reactionRemaining[id] ?? 0);
+    if (remaining <= 0) return { consumed: false, reason: "reaction_unavailable" };
+    runtime.reactionRemaining[id] = remaining - 1;
+    return { consumed: true, remaining: runtime.reactionRemaining[id] };
   }
 
   function runtimeTargetAvailable(runtime, target, context = {}) {
@@ -97,6 +117,9 @@
       coinwiseResolution: context.coinwiseResolution !== false,
       combatActionQueue: context.combatActionQueue || queueApi,
       isTargetAvailable: (target) => runtimeTargetAvailable(runtime, target, context),
+      consumeQuickAction: context.consumeQuickAction || (({ actor }) => consumeLocalQuick(runtime, queueApi.sideOf(actor))),
+      consumeHelp: context.consumeHelp || (({ actor }) => consumeLocalHelp(runtime, queueApi.sideOf(actor))),
+      consumeReaction: context.consumeReaction || (({ actor }) => consumeLocalReaction(runtime, entityId(actor))),
     };
   }
 
@@ -109,11 +132,8 @@
     runtime.actions = [];
     runtime.actionMap = {};
     runtime.preparedReactions = [];
-
-    if (typeof options.onTurnStart === "function") {
-      for (const unit of activeUnits(runtime)) options.onTurnStart({ unit, runtime });
-    }
-
+    resetLocalEconomy(runtime);
+    if (typeof options.onTurnStart === "function") for (const unit of activeUnits(runtime)) options.onTurnStart({ unit, runtime });
     runtime.speedSnapshot = queueApi.snapshotSpeedSources(activeUnits(runtime), { random: runtime.random });
     record(runtime, "speed_snapshot", { speedSnapshot: runtime.speedSnapshot });
     setPhase(runtime, schema.PHASES.PLANNING_PHASE_PLAYER);
@@ -121,14 +141,8 @@
     return runtime.speedSnapshot;
   }
 
-  function sideForAction(runtime, action) {
-    const unit = unitById(runtime, action.actorId);
-    return unit ? queueApi.sideOf(unit) : queueApi.SIDE_A;
-  }
-
-  function planningPhaseForSide(side) {
-    return side === queueApi.SIDE_B ? schema.PHASES.PLANNING_PHASE_AI : schema.PHASES.PLANNING_PHASE_PLAYER;
-  }
+  function sideForAction(runtime, action) { const unit = unitById(runtime, action.actorId); return unit ? queueApi.sideOf(unit) : queueApi.SIDE_A; }
+  function planningPhaseForSide(side) { return side === queueApi.SIDE_B ? schema.PHASES.PLANNING_PHASE_AI : schema.PHASES.PLANNING_PHASE_PLAYER; }
 
   function availableSlotCount(runtime, actorId) {
     if (runtime.encounter && teamEconomy?.profileForUnit) {
@@ -145,12 +159,7 @@
   function validateActionSlot(runtime, action) {
     if (action.economy.cost !== schema.ECONOMY_COSTS.ACTION) return { valid: true };
     if (!action.actionSlotId) return { valid: false, reason: "action_slot_required" };
-    const duplicate = runtime.actions.find((entry) =>
-      entry.actorId === action.actorId &&
-      entry.economy.cost === schema.ECONOMY_COSTS.ACTION &&
-      entry.actionSlotId === action.actionSlotId &&
-      !terminal(entry)
-    );
+    const duplicate = runtime.actions.find((entry) => entry.actorId === action.actorId && entry.economy.cost === schema.ECONOMY_COSTS.ACTION && entry.actionSlotId === action.actionSlotId && !terminal(entry));
     if (duplicate) return { valid: false, reason: "action_slot_already_used", conflictingActionId: duplicate.id };
     const used = runtime.actions.filter((entry) => entry.actorId === action.actorId && entry.economy.cost === schema.ECONOMY_COSTS.ACTION && !terminal(entry)).length;
     const available = availableSlotCount(runtime, action.actorId);
@@ -168,10 +177,7 @@
     if (!isUnitActive(runtime, actor)) return { registered: false, reason: "actor_inactive", action: normalized };
     const side = sideForAction(runtime, normalized);
     const expectedPlanning = planningPhaseForSide(side);
-
-    if (normalized.economy.cost !== schema.ECONOMY_COSTS.REACTION && runtime.phase !== expectedPlanning) {
-      return { registered: false, reason: "wrong_planning_phase", expectedPhase: expectedPlanning, actualPhase: runtime.phase, action: normalized };
-    }
+    if (normalized.economy.cost !== schema.ECONOMY_COSTS.REACTION && runtime.phase !== expectedPlanning) return { registered: false, reason: "wrong_planning_phase", expectedPhase: expectedPlanning, actualPhase: runtime.phase, action: normalized };
 
     if (normalized.economy.cost === schema.ECONOMY_COSTS.REACTION && normalizeId(normalized.reaction?.mode) === "prepared") {
       if (runtime.phase !== expectedPlanning) return { registered: false, reason: "prepared_reaction_planning_only", action: normalized };
@@ -194,7 +200,6 @@
 
     const slotGate = validateActionSlot(runtime, normalized);
     if (!slotGate.valid) return { registered: false, ...slotGate, action: normalized };
-
     runtime.actions.push(normalized);
     runtime.actionMap[normalized.id] = normalized;
     record(runtime, "action_registered", { actionId: normalized.id, actorId: normalized.actorId, side, actionSlotId: normalized.actionSlotId });
@@ -218,7 +223,6 @@
     if (runtime.encounter && teamEconomy?.playerReady) teamEconomy.playerReady(runtime.encounter);
     setPhase(runtime, schema.PHASES.PLANNING_PHASE_AI);
     record(runtime, "player_ready", { lockedActionIds });
-
     let aiActions = [];
     if (typeof options.aiPlanner === "function") aiActions = asArray(options.aiPlanner({ runtime, units: activeUnits(runtime), actions: runtime.actions }));
     const registeredAi = aiActions.map((action) => registerAction(runtime, action, { context: options.context })).filter((entry) => entry.registered);
@@ -236,12 +240,7 @@
   }
 
   function previewQueue(runtime) {
-    return queueApi.buildRoundOrder({
-      units: activeUnits(runtime),
-      actions: runtime.actions.filter((action) => action.economy.cost !== schema.ECONOMY_COSTS.REACTION),
-      speedSnapshot: runtime.speedSnapshot,
-      random: runtime.random,
-    });
+    return queueApi.buildRoundOrder({ units: activeUnits(runtime), actions: runtime.actions.filter((action) => action.economy.cost !== schema.ECONOMY_COSTS.REACTION), speedSnapshot: runtime.speedSnapshot, random: runtime.random });
   }
 
   function unlinkClash(runtime, action) {
@@ -258,18 +257,13 @@
     const target = runtime.actionMap[String(targetActionId)];
     if (!interceptor || !target) return { linked: false, reason: "action_missing" };
     if (interceptor.resolution.type !== "clash" || target.resolution.type !== "clash") return { linked: false, reason: "clash_action_required" };
-
     const preview = previewQueue(runtime);
     const interceptorEntry = preview.getEntry(interceptor.id);
     const targetEntry = preview.getEntry(target.id);
     if (!interceptorEntry || !targetEntry) return { linked: false, reason: "queue_entry_missing" };
     if (interceptorEntry.side === targetEntry.side) return { linked: false, reason: "opposing_side_required" };
-    if (!queueApi.canForceClash({ interceptorEntry, targetEntry })) {
-      return { linked: false, reason: "insufficient_speed_to_force_clash", interceptorSpeed: interceptorEntry.speed, targetSpeed: targetEntry.speed };
-    }
-
-    unlinkClash(runtime, interceptor);
-    unlinkClash(runtime, target);
+    if (!queueApi.canForceClash({ interceptorEntry, targetEntry })) return { linked: false, reason: "insufficient_speed_to_force_clash", interceptorSpeed: interceptorEntry.speed, targetSpeed: targetEntry.speed };
+    unlinkClash(runtime, interceptor); unlinkClash(runtime, target);
     interceptor.metadata = { ...(interceptor.metadata || {}), opposingActionId: target.id };
     target.metadata = { ...(target.metadata || {}), opposingActionId: interceptor.id, clashedByActionId: interceptor.id };
     record(runtime, "clash_linked", { interceptorActionId: interceptor.id, targetActionId: target.id });
@@ -294,10 +288,9 @@
       runtime.actionMap[action.id] = action;
       const index = runtime.actions.findIndex((entry) => entry.id === action.id);
       if (index >= 0) runtime.actions[index] = action;
-      if (runtime.queue) {
-        const entry = runtime.queue.getEntry(action.id);
-        if (entry) entry.action = action;
-      }
+      const reactionIndex = runtime.preparedReactions.findIndex((entry) => entry.id === action.id);
+      if (reactionIndex >= 0) runtime.preparedReactions[reactionIndex] = action;
+      if (runtime.queue) { const entry = runtime.queue.getEntry(action.id); if (entry) entry.action = action; }
       updates.push(action.id);
     }
     asArray(result.resolvedActionIds).forEach((id) => runtime.resolvedActionIds.add(String(id)));
@@ -307,11 +300,7 @@
   function cancelActorPending(runtime, actorId, reason = { type: "stagger" }, options = {}) {
     if (!runtime.queue) return [];
     const cancelled = queueApi.cancelActorActions(runtime.queue, actorId, reason, options);
-    for (const id of cancelled) {
-      const entry = runtime.queue.getEntry(id);
-      if (entry) runtime.actionMap[id] = entry.action;
-      runtime.resolvedActionIds.add(String(id));
-    }
+    for (const id of cancelled) { const entry = runtime.queue.getEntry(id); if (entry) runtime.actionMap[id] = entry.action; runtime.resolvedActionIds.add(String(id)); }
     if (cancelled.length) record(runtime, "actions_cancelled", { actorId: String(actorId), actionIds: cancelled, reason });
     return cancelled;
   }
@@ -321,8 +310,7 @@
     for (const unit of activeUnits(runtime)) {
       const blocked = isStaggered(unit) || (typeof context.isActionBlocked === "function" && context.isActionBlocked({ unit, runtime }) === true);
       if (!blocked) continue;
-      const reason = isStaggered(unit) ? { type: "stagger" } : { type: "action_blocked" };
-      cancelled.push(...cancelActorPending(runtime, entityId(unit), reason));
+      cancelled.push(...cancelActorPending(runtime, entityId(unit), isStaggered(unit) ? { type: "stagger" } : { type: "action_blocked" }));
     }
     return cancelled;
   }
@@ -331,19 +319,12 @@
     const status = queueApi.retargetStatus(action, activeUnits(runtime), { isAvailable: (target) => runtimeTargetAvailable(runtime, target, context) });
     if (status.executable) return { ready: true, action };
     if (!status.requiresRetarget) {
-      action.state = "cancelled";
-      action.cancelReason = { type: status.reason || "target_unavailable" };
-      runtime.resolvedActionIds.add(action.id);
+      action.state = "cancelled"; action.cancelReason = { type: status.reason || "target_unavailable" }; runtime.resolvedActionIds.add(action.id);
       return { ready: false, cancelled: true, reason: status.reason || "target_unavailable", action };
     }
-
-    if (typeof context.chooseRetarget !== "function") {
-      return { ready: false, pending: true, reason: "retarget_required", candidates: status.candidates, action };
-    }
+    if (typeof context.chooseRetarget !== "function") return { ready: false, pending: true, reason: "retarget_required", candidates: status.candidates, action };
     const targetId = context.chooseRetarget({ action, candidates: status.candidates, runtime });
-    if (!targetId || !status.candidates.includes(String(targetId))) {
-      return { ready: false, pending: true, reason: "retarget_required", candidates: status.candidates, action };
-    }
+    if (!targetId || !status.candidates.includes(String(targetId))) return { ready: false, pending: true, reason: "retarget_required", candidates: status.candidates, action };
     const previous = asArray(action.targeting.targetIds).map(String).filter((id) => id !== String(action.targeting.mainTargetId || ""));
     action.targeting.mainTargetId = String(targetId);
     action.targeting.targetIds = [String(targetId), ...previous.filter((id) => id !== String(targetId))].slice(0, Math.max(1, Number(action.targeting.attackWeight || 1)));
@@ -355,25 +336,22 @@
     if (!trigger || !event) return false;
     const triggerType = normalizeId(trigger.type || trigger.event || trigger.trigger);
     const eventType = normalizeId(event.type || event.event);
-    if (!triggerType || !eventType) return false;
-    return triggerType === eventType;
+    return Boolean(triggerType && eventType && triggerType === eventType);
   }
 
   function triggerReactions(runtime, event = {}, context = {}) {
     if (runtime.phase !== schema.PHASES.COMBAT_PHASE) return [];
     const results = [];
     const matcher = typeof context.reactionTriggerMatcher === "function" ? context.reactionTriggerMatcher : defaultTriggerMatch;
-
-    for (const reaction of runtime.preparedReactions) {
+    for (const stored of runtime.preparedReactions) {
+      const reaction = runtime.actionMap[stored.id] || stored;
       if (terminal(reaction) || !matcher(reaction.reaction?.trigger, event, reaction, runtime)) continue;
       const result = resolver.resolveCombatAction(reaction, resolverContext(runtime, context, schema.PHASES.COMBAT_PHASE));
       syncResultActions(runtime, result);
       results.push({ mode: "prepared", actionId: reaction.id, result });
     }
-
     if (typeof context.getAdaptiveReactions === "function") {
-      const adaptive = asArray(context.getAdaptiveReactions({ event, runtime }));
-      for (const raw of adaptive) {
+      for (const raw of asArray(context.getAdaptiveReactions({ event, runtime }))) {
         const reaction = schema.normalizeCombatAction(raw);
         reaction.economy.cost = schema.ECONOMY_COSTS.REACTION;
         reaction.phase.selectedAt = schema.PHASES.COMBAT_PHASE;
@@ -385,7 +363,6 @@
         results.push({ mode: "adaptive", actionId: reaction.id, result });
       }
     }
-
     if (results.length) record(runtime, "reactions_resolved", { eventType: event.type || null, actionIds: results.map((entry) => entry.actionId) });
     return results;
   }
@@ -393,10 +370,8 @@
   function grappleSucceeded(action, result = {}) {
     if (action.source?.type !== "universal" || normalizeId(action.source?.id) !== "grapple") return false;
     const payload = result.resolution?.result ?? result.result ?? {};
-    if (payload === true) return true;
-    if (payload?.success === true || payload?.succeeded === true || payload?.attackerWon === true || payload?.grappled === true) return true;
-    const winner = normalizeId(payload?.winner || payload?.result);
-    return ["attacker", "a", "success", "win", "won"].includes(winner);
+    if (payload === true || payload?.success === true || payload?.succeeded === true || payload?.attackerWon === true || payload?.grappled === true) return true;
+    return ["attacker", "a", "success", "win", "won"].includes(normalizeId(payload?.winner || payload?.result));
   }
 
   function applyGrappleOutcome(runtime, action, result = {}) {
@@ -416,18 +391,14 @@
   function resolveQueueEntry(runtime, entry, context = {}) {
     let action = runtime.actionMap[entry.actionId] || entry.action;
     if (!action || terminal(action) || runtime.resolvedActionIds.has(action.id)) return { skipped: true, reason: "already_terminal", action };
-
     applyBlockingStates(runtime, context);
     action = runtime.actionMap[entry.actionId] || entry.action;
     if (terminal(action) || runtime.resolvedActionIds.has(action.id)) return { skipped: true, reason: "cancelled_before_resolution", action };
-
     const retarget = applyRetarget(runtime, action, context);
     if (!retarget.ready) return retarget;
-
     const opposingId = action.metadata?.opposingActionId;
     const opposingAction = opposingId ? runtime.actionMap[opposingId] || null : null;
     triggerReactions(runtime, { type: "before_action", actionId: action.id, actorId: action.actorId }, context);
-
     const result = resolver.resolveCombatAction(action, resolverContext(runtime, context, schema.PHASES.COMBAT_PHASE, { opposingAction }));
     syncResultActions(runtime, result);
     const grapple = applyGrappleOutcome(runtime, result.action || action, result);
@@ -443,9 +414,7 @@
     for (const entry of runtime.queue.entries) {
       const result = resolveQueueEntry(runtime, entry, context);
       results.push({ actionId: entry.actionId, result });
-      if (result?.pending && result.reason === "retarget_required") {
-        return { completed: false, pending: true, reason: "retarget_required", actionId: entry.actionId, candidates: result.candidates, results };
-      }
+      if (result?.pending && result.reason === "retarget_required") return { completed: false, pending: true, reason: "retarget_required", actionId: entry.actionId, candidates: result.candidates, results };
     }
     setPhase(runtime, schema.PHASES.COMBAT_END);
     record(runtime, "combat_end", { resolvedActionIds: [...runtime.resolvedActionIds] });
@@ -453,16 +422,8 @@
     return { completed: true, phase: runtime.phase, results };
   }
 
-  function teamForUnit(runtime, unit) {
-    if (!runtime.encounter || !teamEconomy?.teamForSide) return null;
-    return teamEconomy.teamForSide(runtime.encounter, queueApi.sideOf(unit));
-  }
-
-  function replaceRuntimeUnit(runtime, outgoing, incoming) {
-    const index = runtime.units.indexOf(outgoing);
-    if (index >= 0) runtime.units.splice(index, 1, incoming);
-    else runtime.units.push(incoming);
-  }
+  function teamForUnit(runtime, unit) { return !runtime.encounter || !teamEconomy?.teamForSide ? null : teamEconomy.teamForSide(runtime.encounter, queueApi.sideOf(unit)); }
+  function replaceRuntimeUnit(runtime, outgoing, incoming) { const index = runtime.units.indexOf(outgoing); if (index >= 0) runtime.units.splice(index, 1, incoming); else runtime.units.push(incoming); }
 
   function defaultRetreat(runtime, actor, effect = {}) {
     const side = queueApi.sideOf(actor);
@@ -472,33 +433,26 @@
       if (team.backups?.length) {
         const backupProfile = team.backups.shift();
         const incomingUnit = backupProfile.unit;
-        const incoming = teamEconomy.inheritReplacementSlots
-          ? teamEconomy.inheritReplacementSlots(runtime.encounter, side, actor, incomingUnit, { cap: effect.inheritActionSlotsCap || 2 })
-          : backupProfile;
+        const incoming = teamEconomy.inheritReplacementSlots ? teamEconomy.inheritReplacementSlots(runtime.encounter, side, actor, incomingUnit, { cap: effect.inheritActionSlotsCap || 2 }) : backupProfile;
         const activeIndex = team.active.indexOf(found.profile);
         if (activeIndex >= 0) team.active.splice(activeIndex, 1, incoming);
-        found.profile.statusLockedSlots = 0;
-        found.profile.usableActionSlots = 0;
-        team.backups.push(found.profile);
+        found.profile.statusLockedSlots = 0; found.profile.usableActionSlots = 0; team.backups.push(found.profile);
         replaceRuntimeUnit(runtime, actor, incomingUnit);
         teamEconomy.syncEncounter?.(runtime.encounter);
         return { retreated: true, replaced: true, outgoingUnitId: entityId(actor), incomingUnitId: entityId(incomingUnit), inheritedSlots: incoming.currentActionSlots };
       }
     }
-
     actor.combatAbsentThroughRound = runtime.round + 1;
     return { retreated: true, replaced: false, absentThroughRound: actor.combatAbsentThroughRound };
   }
 
   function defaultEscape(runtime, actor) {
-    actor.escaped = true;
-    actor.eligibleForXp = false;
+    actor.escaped = true; actor.eligibleForXp = false;
     const team = teamForUnit(runtime, actor);
     if (team && teamEconomy?.profileForUnit) {
       const found = teamEconomy.profileForUnit(runtime.encounter, actor);
       if (found?.profile) {
-        const index = team.active.indexOf(found.profile);
-        if (index >= 0) team.active.splice(index, 1);
+        const index = team.active.indexOf(found.profile); if (index >= 0) team.active.splice(index, 1);
         teamEconomy.registerVacatedSlots?.(runtime.encounter, team.side, found.profile.currentActionSlots || 1, { hasBackup: team.backups?.length > 0 });
         teamEconomy.syncEncounter?.(runtime.encounter);
       }
@@ -507,11 +461,7 @@
   }
 
   function turnEndEffectHandlers(runtime, context = {}) {
-    return {
-      ...(context.effectHandlers || {}),
-      retreat: context.effectHandlers?.retreat || (({ actor, effect }) => defaultRetreat(runtime, actor, effect)),
-      escape: context.effectHandlers?.escape || (({ actor }) => defaultEscape(runtime, actor)),
-    };
+    return { ...(context.effectHandlers || {}), retreat: context.effectHandlers?.retreat || (({ actor, effect }) => defaultRetreat(runtime, actor, effect)), escape: context.effectHandlers?.escape || (({ actor }) => defaultEscape(runtime, actor)) };
   }
 
   function resolveTurnEnd(runtime, context = {}) {
@@ -520,28 +470,22 @@
     const results = [];
     const turnEndActions = runtime.actions.filter((action) => action.phase.executesAt === schema.PHASES.ON_TURN_END && !terminal(action));
     const ordered = [...turnEndActions].sort((a, b) => {
-      const aPart = queueApi.partIdOf(a);
-      const bPart = queueApi.partIdOf(b);
-      const aSource = runtime.speedSnapshot?.[queueApi.speedSourceKey(a.actorId, aPart)];
-      const bSource = runtime.speedSnapshot?.[queueApi.speedSourceKey(b.actorId, bPart)];
+      const aSource = runtime.speedSnapshot?.[queueApi.speedSourceKey(a.actorId, queueApi.partIdOf(a))];
+      const bSource = runtime.speedSnapshot?.[queueApi.speedSourceKey(b.actorId, queueApi.partIdOf(b))];
       return (Number(bSource?.speed || 0) - Number(aSource?.speed || 0)) || (Number(aSource?.tieRoll || 0) - Number(bSource?.tieRoll || 0));
     });
-
     const effectHandlers = turnEndEffectHandlers(runtime, context);
     for (const action of ordered) {
       const unit = unitById(runtime, action.actorId);
       const blocked = !unit || !isUnitActive(runtime, unit) || isStaggered(unit) || (typeof context.isTurnEndBlocked === "function" && context.isTurnEndBlocked({ action, unit, runtime }) === true);
       if (blocked) {
-        action.state = "cancelled";
-        action.cancelReason = { type: !unit ? "actor_missing" : (isStaggered(unit) ? "stagger" : "turn_end_blocked") };
-        runtime.actionMap[action.id] = action;
-        runtime.resolvedActionIds.add(action.id);
+        action.state = "cancelled"; action.cancelReason = { type: !unit ? "actor_missing" : (isStaggered(unit) ? "stagger" : "turn_end_blocked") };
+        runtime.actionMap[action.id] = action; runtime.resolvedActionIds.add(action.id);
         results.push({ actionId: action.id, resolved: false, cancelled: true, reason: action.cancelReason.type });
         continue;
       }
       const result = resolver.resolveCombatAction(action, resolverContext(runtime, { ...context, effectHandlers }, schema.PHASES.ON_TURN_END));
-      syncResultActions(runtime, result);
-      results.push({ actionId: action.id, ...result });
+      syncResultActions(runtime, result); results.push({ actionId: action.id, ...result });
     }
     record(runtime, "turn_end_complete", { actionIds: results.map((entry) => entry.actionId) });
     return { completed: true, phase: runtime.phase, results };
@@ -550,36 +494,16 @@
   function nextRound(runtime, options = {}) {
     if (runtime.phase !== schema.PHASES.ON_TURN_END) return { started: false, reason: "turn_end_required" };
     runtime.round += 1;
-    if (runtime.encounter && teamEconomy?.beginNextRound) {
-      teamEconomy.beginNextRound(runtime.encounter);
-      runtime.round = runtime.encounter.round;
-    }
+    if (runtime.encounter && teamEconomy?.beginNextRound) { teamEconomy.beginNextRound(runtime.encounter); runtime.round = runtime.encounter.round; }
     beginTurn(runtime, options);
     return { started: true, round: runtime.round, phase: runtime.phase, speedSnapshot: runtime.speedSnapshot };
   }
 
   const api = Object.freeze({
-    createRuntime,
-    activeUnits,
-    isUnitActive,
-    beginTurn,
-    availableSlotCount,
-    validateActionSlot,
-    registerAction,
-    playerPlanningReady,
-    aiPlanningReady,
-    previewQueue,
-    linkClash,
-    beginCombatPhase,
-    cancelActorPending,
-    triggerReactions,
-    applyGrappleOutcome,
-    resolveQueueEntry,
-    resolveCombatPhase,
-    defaultRetreat,
-    defaultEscape,
-    resolveTurnEnd,
-    nextRound,
+    createRuntime, activeUnits, isUnitActive, beginTurn, availableSlotCount, validateActionSlot, registerAction,
+    playerPlanningReady, aiPlanningReady, previewQueue, linkClash, beginCombatPhase, cancelActorPending,
+    triggerReactions, applyGrappleOutcome, resolveQueueEntry, resolveCombatPhase, defaultRetreat, defaultEscape,
+    resolveTurnEnd, nextRound,
   });
 
   global.LuminousCombatRuntimeIntegration = api;

--- a/js/combat-runtime-integration.js
+++ b/js/combat-runtime-integration.js
@@ -1,0 +1,461 @@
+(function (global) {
+  "use strict";
+
+  const schema = global.LuminousCombatAction || (typeof require === "function" ? require("./combat-action-schema.js") : null);
+  const queueApi = global.LuminousCombatActionQueue || (typeof require === "function" ? require("./combat-action-queue.js") : null);
+  const resolver = global.LuminousCombatActionResolver || (typeof require === "function" ? require("./combat-action-resolver.js") : null);
+  const teamEconomy = global.LuminousTeamActionEconomy || (typeof require === "function" ? (() => { try { return require("./team-action-economy.js"); } catch (_) { return null; } })() : null);
+  if (!schema || !queueApi || !resolver) return;
+
+  const asArray = (value) => value == null ? [] : (Array.isArray(value) ? value : [value]);
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+
+  function entityId(entity = {}) {
+    return queueApi.entityId(entity);
+  }
+
+  function unitById(runtime, id) {
+    const wanted = String(id ?? "");
+    return runtime.units.find((unit) => entityId(unit) === wanted) || null;
+  }
+
+  function isStaggered(unit = {}) {
+    if (unit.isStaggered === true || unit.staggered === true) return true;
+    const statuses = unit.statusEffects || unit.statuses || {};
+    if (Array.isArray(statuses)) {
+      return statuses.some((entry) => {
+        const id = normalizeId(entry?.id || entry);
+        return id === "stagger" || id === "staggered";
+      });
+    }
+    return Boolean(statuses.stagger || statuses.staggered);
+  }
+
+  function terminal(action = {}) {
+    return action.state === "resolved" || action.state === "cancelled";
+  }
+
+  function createRuntime(config = {}) {
+    const units = asArray(config.units).filter(Boolean);
+    return {
+      id: String(config.id || `combat_runtime_${Date.now()}`),
+      round: Math.max(1, Number(config.round || config.encounter?.round || 1)),
+      phase: schema.PHASES.ON_TURN_START,
+      units,
+      encounter: config.encounter || null,
+      random: typeof config.random === "function" ? config.random : Math.random,
+      speedSnapshot: null,
+      actions: [],
+      actionMap: {},
+      preparedReactions: [],
+      queue: null,
+      resolvedActionIds: new Set(),
+      playerReady: false,
+      aiReady: false,
+      history: [],
+    };
+  }
+
+  function record(runtime, type, payload = {}) {
+    const entry = { round: runtime.round, phase: runtime.phase, type, ...payload };
+    runtime.history.push(entry);
+    return entry;
+  }
+
+  function setPhase(runtime, phase) {
+    runtime.phase = schema.normalizePhase(phase, phase);
+    return runtime.phase;
+  }
+
+  function beginTurn(runtime, options = {}) {
+    setPhase(runtime, schema.PHASES.ON_TURN_START);
+    runtime.playerReady = false;
+    runtime.aiReady = false;
+    runtime.queue = null;
+    runtime.resolvedActionIds = new Set();
+    runtime.actions = [];
+    runtime.actionMap = {};
+    runtime.preparedReactions = [];
+
+    if (typeof options.onTurnStart === "function") {
+      for (const unit of runtime.units) options.onTurnStart({ unit, runtime });
+    }
+
+    runtime.speedSnapshot = queueApi.snapshotSpeedSources(runtime.units, { random: runtime.random });
+    record(runtime, "speed_snapshot", { speedSnapshot: runtime.speedSnapshot });
+    setPhase(runtime, schema.PHASES.PLANNING_PHASE_PLAYER);
+    if (runtime.encounter) runtime.encounter.phase = teamEconomy?.PHASES?.PLANNING_PLAYER || "planning_player";
+    return runtime.speedSnapshot;
+  }
+
+  function sideForAction(runtime, action) {
+    const unit = unitById(runtime, action.actorId);
+    return unit ? queueApi.sideOf(unit) : queueApi.SIDE_A;
+  }
+
+  function planningPhaseForSide(side) {
+    return side === queueApi.SIDE_B ? schema.PHASES.PLANNING_PHASE_AI : schema.PHASES.PLANNING_PHASE_PLAYER;
+  }
+
+  function registerAction(runtime, input = {}, options = {}) {
+    const action = schema.normalizeCombatAction(input);
+    const validation = schema.validateCombatAction(action);
+    if (!validation.valid) return { registered: false, reason: "invalid_action", errors: validation.errors, action };
+    const normalized = validation.action;
+    const side = sideForAction(runtime, normalized);
+    const expectedPlanning = planningPhaseForSide(side);
+
+    if (normalized.economy.cost !== schema.ECONOMY_COSTS.REACTION && runtime.phase !== expectedPlanning) {
+      return { registered: false, reason: "wrong_planning_phase", expectedPhase: expectedPlanning, actualPhase: runtime.phase, action: normalized };
+    }
+
+    if (normalized.economy.cost === schema.ECONOMY_COSTS.REACTION && normalizeId(normalized.reaction?.mode) === "prepared") {
+      if (runtime.phase !== expectedPlanning) return { registered: false, reason: "prepared_reaction_planning_only", action: normalized };
+      normalized.state = "locked";
+      runtime.preparedReactions.push(normalized);
+      runtime.actionMap[normalized.id] = normalized;
+      record(runtime, "prepared_reaction", { actionId: normalized.id, actorId: normalized.actorId });
+      return { registered: true, preparedReaction: true, action: normalized };
+    }
+
+    if (normalized.economy.cost === schema.ECONOMY_COSTS.QUICK_ACTION) {
+      normalized.phase.selectedAt = runtime.phase;
+      normalized.phase.executesAt = runtime.phase;
+      const result = resolver.resolveCombatAction(normalized, {
+        ...options.context,
+        phase: runtime.phase,
+        units: runtime.units,
+        encounter: runtime.encounter,
+        teamEconomy: options.context?.teamEconomy || teamEconomy,
+        actionMap: runtime.actionMap,
+        random: runtime.random,
+      });
+      runtime.actionMap[normalized.id] = result.action || normalized;
+      asArray(result.resolvedActionIds).forEach((id) => runtime.resolvedActionIds.add(String(id)));
+      record(runtime, "quick_action", { actionId: normalized.id, resolved: result.resolved, reason: result.reason || null });
+      return { registered: Boolean(result.resolved), immediate: true, action: result.action || normalized, result };
+    }
+
+    runtime.actions.push(normalized);
+    runtime.actionMap[normalized.id] = normalized;
+    record(runtime, "action_registered", { actionId: normalized.id, actorId: normalized.actorId, side });
+    return { registered: true, action: normalized };
+  }
+
+  function lockActionsForSide(runtime, side) {
+    const locked = [];
+    for (const action of runtime.actions) {
+      if (sideForAction(runtime, action) !== side || terminal(action)) continue;
+      if (action.state === "planned") action.state = "locked";
+      locked.push(action.id);
+    }
+    return locked;
+  }
+
+  function playerPlanningReady(runtime, options = {}) {
+    if (runtime.phase !== schema.PHASES.PLANNING_PHASE_PLAYER) return { ready: false, reason: "not_player_planning" };
+    const lockedActionIds = lockActionsForSide(runtime, queueApi.SIDE_A);
+    runtime.playerReady = true;
+    if (runtime.encounter && teamEconomy?.playerReady) teamEconomy.playerReady(runtime.encounter);
+    setPhase(runtime, schema.PHASES.PLANNING_PHASE_AI);
+    record(runtime, "player_ready", { lockedActionIds });
+
+    let aiActions = [];
+    if (typeof options.aiPlanner === "function") aiActions = asArray(options.aiPlanner({ runtime, units: runtime.units, actions: runtime.actions }));
+    const registeredAi = aiActions.map((action) => registerAction(runtime, action, { context: options.context })).filter((entry) => entry.registered);
+    return { ready: true, phase: runtime.phase, lockedActionIds, registeredAi };
+  }
+
+  function aiPlanningReady(runtime) {
+    if (runtime.phase !== schema.PHASES.PLANNING_PHASE_AI) return { ready: false, reason: "not_ai_planning" };
+    const lockedActionIds = lockActionsForSide(runtime, queueApi.SIDE_B);
+    runtime.aiReady = true;
+    if (runtime.encounter && teamEconomy?.aiReady) teamEconomy.aiReady(runtime.encounter);
+    setPhase(runtime, schema.PHASES.COMBAT_START);
+    record(runtime, "ai_ready", { lockedActionIds });
+    return { ready: true, phase: runtime.phase, lockedActionIds };
+  }
+
+  function previewQueue(runtime) {
+    return queueApi.buildRoundOrder({
+      units: runtime.units,
+      actions: runtime.actions.filter((action) => action.economy.cost !== schema.ECONOMY_COSTS.REACTION),
+      speedSnapshot: runtime.speedSnapshot,
+      random: runtime.random,
+    });
+  }
+
+  function unlinkClash(runtime, action) {
+    const otherId = action?.metadata?.opposingActionId;
+    if (!otherId) return;
+    const other = runtime.actionMap[otherId];
+    if (other?.metadata?.opposingActionId === action.id) delete other.metadata.opposingActionId;
+    if (other?.metadata?.clashedByActionId === action.id) delete other.metadata.clashedByActionId;
+    delete action.metadata.opposingActionId;
+  }
+
+  function linkClash(runtime, interceptorActionId, targetActionId) {
+    const interceptor = runtime.actionMap[String(interceptorActionId)];
+    const target = runtime.actionMap[String(targetActionId)];
+    if (!interceptor || !target) return { linked: false, reason: "action_missing" };
+    if (interceptor.resolution.type !== "clash" || target.resolution.type !== "clash") return { linked: false, reason: "clash_action_required" };
+
+    const preview = previewQueue(runtime);
+    const interceptorEntry = preview.getEntry(interceptor.id);
+    const targetEntry = preview.getEntry(target.id);
+    if (!interceptorEntry || !targetEntry) return { linked: false, reason: "queue_entry_missing" };
+    if (interceptorEntry.side === targetEntry.side) return { linked: false, reason: "opposing_side_required" };
+    if (!queueApi.canForceClash({ interceptorEntry, targetEntry })) {
+      return { linked: false, reason: "insufficient_speed_to_force_clash", interceptorSpeed: interceptorEntry.speed, targetSpeed: targetEntry.speed };
+    }
+
+    unlinkClash(runtime, interceptor);
+    unlinkClash(runtime, target);
+    interceptor.metadata = { ...(interceptor.metadata || {}), opposingActionId: target.id };
+    target.metadata = { ...(target.metadata || {}), opposingActionId: interceptor.id, clashedByActionId: interceptor.id };
+    record(runtime, "clash_linked", { interceptorActionId: interceptor.id, targetActionId: target.id });
+    return { linked: true, interceptorActionId: interceptor.id, targetActionId: target.id };
+  }
+
+  function beginCombatPhase(runtime) {
+    if (!runtime.playerReady || !runtime.aiReady) return { started: false, reason: "planning_not_ready" };
+    if (runtime.phase !== schema.PHASES.COMBAT_START) return { started: false, reason: "combat_start_required", phase: runtime.phase };
+    runtime.queue = previewQueue(runtime);
+    setPhase(runtime, schema.PHASES.COMBAT_PHASE);
+    record(runtime, "combat_phase_started", { queue: runtime.queue.entries.map((entry) => entry.actionId) });
+    return { started: true, phase: runtime.phase, queue: runtime.queue };
+  }
+
+  function syncResultActions(runtime, result = {}) {
+    const updates = [];
+    for (const action of asArray(result.actions).concat(result.action ? [result.action] : [])) {
+      if (!action?.id) continue;
+      runtime.actionMap[action.id] = action;
+      const index = runtime.actions.findIndex((entry) => entry.id === action.id);
+      if (index >= 0) runtime.actions[index] = action;
+      if (runtime.queue) {
+        const entry = runtime.queue.getEntry(action.id);
+        if (entry) entry.action = action;
+      }
+      updates.push(action.id);
+    }
+    asArray(result.resolvedActionIds).forEach((id) => runtime.resolvedActionIds.add(String(id)));
+    return updates;
+  }
+
+  function cancelActorPending(runtime, actorId, reason = { type: "stagger" }, options = {}) {
+    if (!runtime.queue) return [];
+    const cancelled = queueApi.cancelActorActions(runtime.queue, actorId, reason, options);
+    for (const id of cancelled) {
+      const entry = runtime.queue.getEntry(id);
+      if (entry) runtime.actionMap[id] = entry.action;
+      runtime.resolvedActionIds.add(String(id));
+    }
+    if (cancelled.length) record(runtime, "actions_cancelled", { actorId: String(actorId), actionIds: cancelled, reason });
+    return cancelled;
+  }
+
+  function applyBlockingStates(runtime, context = {}) {
+    const cancelled = [];
+    for (const unit of runtime.units) {
+      const blocked = isStaggered(unit) || (typeof context.isActionBlocked === "function" && context.isActionBlocked({ unit, runtime }) === true);
+      if (!blocked) continue;
+      const reason = isStaggered(unit) ? { type: "stagger" } : { type: "action_blocked" };
+      cancelled.push(...cancelActorPending(runtime, entityId(unit), reason));
+    }
+    return cancelled;
+  }
+
+  function applyRetarget(runtime, action, context = {}) {
+    const status = queueApi.retargetStatus(action, runtime.units, { isAvailable: context.isTargetAvailable });
+    if (status.executable) return { ready: true, action };
+    if (!status.requiresRetarget) {
+      action.state = "cancelled";
+      action.cancelReason = { type: status.reason || "target_unavailable" };
+      runtime.resolvedActionIds.add(action.id);
+      return { ready: false, cancelled: true, reason: status.reason || "target_unavailable", action };
+    }
+
+    if (typeof context.chooseRetarget !== "function") {
+      return { ready: false, pending: true, reason: "retarget_required", candidates: status.candidates, action };
+    }
+    const targetId = context.chooseRetarget({ action, candidates: status.candidates, runtime });
+    if (!targetId || !status.candidates.includes(String(targetId))) {
+      return { ready: false, pending: true, reason: "retarget_required", candidates: status.candidates, action };
+    }
+    const previous = asArray(action.targeting.targetIds).map(String).filter((id) => id !== String(action.targeting.mainTargetId || ""));
+    action.targeting.mainTargetId = String(targetId);
+    action.targeting.targetIds = [String(targetId), ...previous.filter((id) => id !== String(targetId))].slice(0, Math.max(1, Number(action.targeting.attackWeight || 1)));
+    record(runtime, "action_retargeted", { actionId: action.id, targetId: String(targetId) });
+    return { ready: true, retargeted: true, action };
+  }
+
+  function defaultTriggerMatch(trigger, event) {
+    if (!trigger || !event) return false;
+    const triggerType = normalizeId(trigger.type || trigger.event || trigger.trigger);
+    const eventType = normalizeId(event.type || event.event);
+    if (!triggerType || !eventType) return false;
+    return triggerType === eventType;
+  }
+
+  function triggerReactions(runtime, event = {}, context = {}) {
+    if (runtime.phase !== schema.PHASES.COMBAT_PHASE) return [];
+    const results = [];
+    const matcher = typeof context.reactionTriggerMatcher === "function" ? context.reactionTriggerMatcher : defaultTriggerMatch;
+
+    for (const reaction of runtime.preparedReactions) {
+      if (terminal(reaction) || !matcher(reaction.reaction?.trigger, event, reaction, runtime)) continue;
+      const result = resolver.resolveCombatAction(reaction, {
+        ...context,
+        phase: schema.PHASES.COMBAT_PHASE,
+        units: runtime.units,
+        encounter: runtime.encounter,
+        actionMap: runtime.actionMap,
+        random: runtime.random,
+      });
+      syncResultActions(runtime, result);
+      results.push({ mode: "prepared", actionId: reaction.id, result });
+    }
+
+    if (typeof context.getAdaptiveReactions === "function") {
+      const adaptive = asArray(context.getAdaptiveReactions({ event, runtime }));
+      for (const raw of adaptive) {
+        const reaction = schema.normalizeCombatAction(raw);
+        reaction.economy.cost = schema.ECONOMY_COSTS.REACTION;
+        reaction.phase.selectedAt = schema.PHASES.COMBAT_PHASE;
+        reaction.phase.executesAt = schema.PHASES.COMBAT_PHASE;
+        reaction.reaction = { ...(reaction.reaction || {}), mode: "adaptive" };
+        runtime.actionMap[reaction.id] = reaction;
+        const result = resolver.resolveCombatAction(reaction, {
+          ...context,
+          phase: schema.PHASES.COMBAT_PHASE,
+          units: runtime.units,
+          encounter: runtime.encounter,
+          actionMap: runtime.actionMap,
+          random: runtime.random,
+        });
+        syncResultActions(runtime, result);
+        results.push({ mode: "adaptive", actionId: reaction.id, result });
+      }
+    }
+
+    if (results.length) record(runtime, "reactions_resolved", { eventType: event.type || null, actionIds: results.map((entry) => entry.actionId) });
+    return results;
+  }
+
+  function resolveQueueEntry(runtime, entry, context = {}) {
+    let action = runtime.actionMap[entry.actionId] || entry.action;
+    if (!action || terminal(action) || runtime.resolvedActionIds.has(action.id)) return { skipped: true, reason: "already_terminal", action };
+
+    applyBlockingStates(runtime, context);
+    action = runtime.actionMap[entry.actionId] || entry.action;
+    if (terminal(action) || runtime.resolvedActionIds.has(action.id)) return { skipped: true, reason: "cancelled_before_resolution", action };
+
+    const retarget = applyRetarget(runtime, action, context);
+    if (!retarget.ready) return retarget;
+
+    const opposingId = action.metadata?.opposingActionId;
+    const opposingAction = opposingId ? runtime.actionMap[opposingId] || null : null;
+    triggerReactions(runtime, { type: "before_action", actionId: action.id, actorId: action.actorId }, context);
+
+    const result = resolver.resolveCombatAction(action, {
+      ...context,
+      phase: schema.PHASES.COMBAT_PHASE,
+      units: runtime.units,
+      encounter: runtime.encounter,
+      actionMap: runtime.actionMap,
+      opposingAction,
+      random: runtime.random,
+    });
+    syncResultActions(runtime, result);
+    applyBlockingStates(runtime, context);
+    triggerReactions(runtime, { type: "after_action", actionId: action.id, actorId: action.actorId, result }, context);
+    record(runtime, "action_resolved", { actionId: action.id, resolved: result.resolved, reason: result.reason || null, type: result.type || result.resolution?.type || action.resolution.type });
+    return result;
+  }
+
+  function resolveCombatPhase(runtime, context = {}) {
+    if (runtime.phase !== schema.PHASES.COMBAT_PHASE || !runtime.queue) return { completed: false, reason: "combat_phase_required" };
+    const results = [];
+    for (const entry of runtime.queue.entries) {
+      const result = resolveQueueEntry(runtime, entry, context);
+      results.push({ actionId: entry.actionId, result });
+      if (result?.pending && result.reason === "retarget_required") {
+        return { completed: false, pending: true, reason: "retarget_required", actionId: entry.actionId, candidates: result.candidates, results };
+      }
+    }
+    setPhase(runtime, schema.PHASES.COMBAT_END);
+    record(runtime, "combat_phase_complete", { resolvedActionIds: [...runtime.resolvedActionIds] });
+    return { completed: true, phase: runtime.phase, results };
+  }
+
+  function resolveTurnEnd(runtime, context = {}) {
+    if (runtime.phase !== schema.PHASES.COMBAT_END && runtime.phase !== schema.PHASES.ON_TURN_END) return { completed: false, reason: "combat_end_required" };
+    setPhase(runtime, schema.PHASES.ON_TURN_END);
+    const results = [];
+    const turnEndActions = runtime.actions.filter((action) => action.phase.executesAt === schema.PHASES.ON_TURN_END && !terminal(action));
+    const ordered = [...turnEndActions].sort((a, b) => {
+      const aPart = queueApi.partIdOf(a);
+      const bPart = queueApi.partIdOf(b);
+      const aSpeed = runtime.speedSnapshot?.[queueApi.speedSourceKey(a.actorId, aPart)]?.speed ?? 0;
+      const bSpeed = runtime.speedSnapshot?.[queueApi.speedSourceKey(b.actorId, bPart)]?.speed ?? 0;
+      return bSpeed - aSpeed;
+    });
+
+    for (const action of ordered) {
+      const unit = unitById(runtime, action.actorId);
+      const blocked = !unit || isStaggered(unit) || (typeof context.isTurnEndBlocked === "function" && context.isTurnEndBlocked({ action, unit, runtime }) === true);
+      if (blocked) {
+        action.state = "cancelled";
+        action.cancelReason = { type: !unit ? "actor_missing" : (isStaggered(unit) ? "stagger" : "turn_end_blocked") };
+        runtime.actionMap[action.id] = action;
+        runtime.resolvedActionIds.add(action.id);
+        results.push({ actionId: action.id, resolved: false, cancelled: true, reason: action.cancelReason.type });
+        continue;
+      }
+      const result = resolver.resolveCombatAction(action, {
+        ...context,
+        phase: schema.PHASES.ON_TURN_END,
+        units: runtime.units,
+        encounter: runtime.encounter,
+        actionMap: runtime.actionMap,
+        random: runtime.random,
+      });
+      syncResultActions(runtime, result);
+      results.push({ actionId: action.id, ...result });
+    }
+    record(runtime, "turn_end_complete", { actionIds: results.map((entry) => entry.actionId) });
+    return { completed: true, phase: runtime.phase, results };
+  }
+
+  function nextRound(runtime, options = {}) {
+    if (runtime.phase !== schema.PHASES.ON_TURN_END) return { started: false, reason: "turn_end_required" };
+    runtime.round += 1;
+    if (runtime.encounter && teamEconomy?.beginNextRound) {
+      teamEconomy.beginNextRound(runtime.encounter);
+      runtime.round = runtime.encounter.round;
+    }
+    beginTurn(runtime, options);
+    return { started: true, round: runtime.round, phase: runtime.phase, speedSnapshot: runtime.speedSnapshot };
+  }
+
+  const api = Object.freeze({
+    createRuntime,
+    beginTurn,
+    registerAction,
+    playerPlanningReady,
+    aiPlanningReady,
+    previewQueue,
+    linkClash,
+    beginCombatPhase,
+    cancelActorPending,
+    triggerReactions,
+    resolveQueueEntry,
+    resolveCombatPhase,
+    resolveTurnEnd,
+    nextRound,
+  });
+
+  global.LuminousCombatRuntimeIntegration = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/combat-runtime-integration.js
+++ b/js/combat-runtime-integration.js
@@ -58,12 +58,7 @@
     };
   }
 
-  function record(runtime, type, payload = {}) {
-    const entry = { round: runtime.round, phase: runtime.phase, type, ...payload };
-    runtime.history.push(entry);
-    return entry;
-  }
-
+  function record(runtime, type, payload = {}) { const entry = { round: runtime.round, phase: runtime.phase, type, ...payload }; runtime.history.push(entry); return entry; }
   function setPhase(runtime, phase) { runtime.phase = schema.normalizePhase(phase, phase); return runtime.phase; }
 
   function resetLocalEconomy(runtime) {
@@ -106,14 +101,9 @@
 
   function resolverContext(runtime, context = {}, phase = runtime.phase, extra = {}) {
     return {
-      ...context,
-      ...extra,
-      phase,
-      units: activeUnits(runtime),
-      encounter: runtime.encounter,
-      teamEconomy: context.teamEconomy || teamEconomy,
-      actionMap: runtime.actionMap,
-      random: runtime.random,
+      ...context, ...extra, phase,
+      units: activeUnits(runtime), encounter: runtime.encounter, teamEconomy: context.teamEconomy || teamEconomy,
+      actionMap: runtime.actionMap, random: runtime.random,
       coinwiseResolution: context.coinwiseResolution !== false,
       combatActionQueue: context.combatActionQueue || queueApi,
       isTargetAvailable: (target) => runtimeTargetAvailable(runtime, target, context),
@@ -125,13 +115,8 @@
 
   function beginTurn(runtime, options = {}) {
     setPhase(runtime, schema.PHASES.ON_TURN_START);
-    runtime.playerReady = false;
-    runtime.aiReady = false;
-    runtime.queue = null;
-    runtime.resolvedActionIds = new Set();
-    runtime.actions = [];
-    runtime.actionMap = {};
-    runtime.preparedReactions = [];
+    runtime.playerReady = false; runtime.aiReady = false; runtime.queue = null; runtime.resolvedActionIds = new Set();
+    runtime.actions = []; runtime.actionMap = {}; runtime.preparedReactions = [];
     resetLocalEconomy(runtime);
     if (typeof options.onTurnStart === "function") for (const unit of activeUnits(runtime)) options.onTurnStart({ unit, runtime });
     runtime.speedSnapshot = queueApi.snapshotSpeedSources(activeUnits(runtime), { random: runtime.random });
@@ -181,16 +166,13 @@
 
     if (normalized.economy.cost === schema.ECONOMY_COSTS.REACTION && normalizeId(normalized.reaction?.mode) === "prepared") {
       if (runtime.phase !== expectedPlanning) return { registered: false, reason: "prepared_reaction_planning_only", action: normalized };
-      normalized.state = "locked";
-      runtime.preparedReactions.push(normalized);
-      runtime.actionMap[normalized.id] = normalized;
+      normalized.state = "locked"; runtime.preparedReactions.push(normalized); runtime.actionMap[normalized.id] = normalized;
       record(runtime, "prepared_reaction", { actionId: normalized.id, actorId: normalized.actorId });
       return { registered: true, preparedReaction: true, action: normalized };
     }
 
     if (normalized.economy.cost === schema.ECONOMY_COSTS.QUICK_ACTION) {
-      normalized.phase.selectedAt = runtime.phase;
-      normalized.phase.executesAt = runtime.phase;
+      normalized.phase.selectedAt = runtime.phase; normalized.phase.executesAt = runtime.phase;
       const result = resolver.resolveCombatAction(normalized, resolverContext(runtime, options.context || {}, runtime.phase));
       runtime.actionMap[normalized.id] = result.action || normalized;
       asArray(result.resolvedActionIds).forEach((id) => runtime.resolvedActionIds.add(String(id)));
@@ -200,8 +182,7 @@
 
     const slotGate = validateActionSlot(runtime, normalized);
     if (!slotGate.valid) return { registered: false, ...slotGate, action: normalized };
-    runtime.actions.push(normalized);
-    runtime.actionMap[normalized.id] = normalized;
+    runtime.actions.push(normalized); runtime.actionMap[normalized.id] = normalized;
     record(runtime, "action_registered", { actionId: normalized.id, actorId: normalized.actorId, side, actionSlotId: normalized.actionSlotId });
     return { registered: true, action: normalized };
   }
@@ -221,8 +202,7 @@
     const lockedActionIds = lockActionsForSide(runtime, queueApi.SIDE_A);
     runtime.playerReady = true;
     if (runtime.encounter && teamEconomy?.playerReady) teamEconomy.playerReady(runtime.encounter);
-    setPhase(runtime, schema.PHASES.PLANNING_PHASE_AI);
-    record(runtime, "player_ready", { lockedActionIds });
+    setPhase(runtime, schema.PHASES.PLANNING_PHASE_AI); record(runtime, "player_ready", { lockedActionIds });
     let aiActions = [];
     if (typeof options.aiPlanner === "function") aiActions = asArray(options.aiPlanner({ runtime, units: activeUnits(runtime), actions: runtime.actions }));
     const registeredAi = aiActions.map((action) => registerAction(runtime, action, { context: options.context })).filter((entry) => entry.registered);
@@ -234,18 +214,14 @@
     const lockedActionIds = lockActionsForSide(runtime, queueApi.SIDE_B);
     runtime.aiReady = true;
     if (runtime.encounter && teamEconomy?.aiReady) teamEconomy.aiReady(runtime.encounter);
-    setPhase(runtime, schema.PHASES.COMBAT_START);
-    record(runtime, "ai_ready", { lockedActionIds });
+    setPhase(runtime, schema.PHASES.COMBAT_START); record(runtime, "ai_ready", { lockedActionIds });
     return { ready: true, phase: runtime.phase, lockedActionIds };
   }
 
-  function previewQueue(runtime) {
-    return queueApi.buildRoundOrder({ units: activeUnits(runtime), actions: runtime.actions.filter((action) => action.economy.cost !== schema.ECONOMY_COSTS.REACTION), speedSnapshot: runtime.speedSnapshot, random: runtime.random });
-  }
+  function previewQueue(runtime) { return queueApi.buildRoundOrder({ units: activeUnits(runtime), actions: runtime.actions.filter((action) => action.economy.cost !== schema.ECONOMY_COSTS.REACTION), speedSnapshot: runtime.speedSnapshot, random: runtime.random }); }
 
   function unlinkClash(runtime, action) {
-    const otherId = action?.metadata?.opposingActionId;
-    if (!otherId) return;
+    const otherId = action?.metadata?.opposingActionId; if (!otherId) return;
     const other = runtime.actionMap[otherId];
     if (other?.metadata?.opposingActionId === action.id) delete other.metadata.opposingActionId;
     if (other?.metadata?.clashedByActionId === action.id) delete other.metadata.clashedByActionId;
@@ -253,13 +229,10 @@
   }
 
   function linkClash(runtime, interceptorActionId, targetActionId) {
-    const interceptor = runtime.actionMap[String(interceptorActionId)];
-    const target = runtime.actionMap[String(targetActionId)];
+    const interceptor = runtime.actionMap[String(interceptorActionId)], target = runtime.actionMap[String(targetActionId)];
     if (!interceptor || !target) return { linked: false, reason: "action_missing" };
     if (interceptor.resolution.type !== "clash" || target.resolution.type !== "clash") return { linked: false, reason: "clash_action_required" };
-    const preview = previewQueue(runtime);
-    const interceptorEntry = preview.getEntry(interceptor.id);
-    const targetEntry = preview.getEntry(target.id);
+    const preview = previewQueue(runtime), interceptorEntry = preview.getEntry(interceptor.id), targetEntry = preview.getEntry(target.id);
     if (!interceptorEntry || !targetEntry) return { linked: false, reason: "queue_entry_missing" };
     if (interceptorEntry.side === targetEntry.side) return { linked: false, reason: "opposing_side_required" };
     if (!queueApi.canForceClash({ interceptorEntry, targetEntry })) return { linked: false, reason: "insufficient_speed_to_force_clash", interceptorSpeed: interceptorEntry.speed, targetSpeed: targetEntry.speed };
@@ -273,11 +246,9 @@
   function beginCombatPhase(runtime, context = {}) {
     if (!runtime.playerReady || !runtime.aiReady) return { started: false, reason: "planning_not_ready" };
     if (runtime.phase !== schema.PHASES.COMBAT_START) return { started: false, reason: "combat_start_required", phase: runtime.phase };
-    runtime.queue = previewQueue(runtime);
-    record(runtime, "combat_start", { queue: runtime.queue.entries.map((entry) => entry.actionId) });
+    runtime.queue = previewQueue(runtime); record(runtime, "combat_start", { queue: runtime.queue.entries.map((entry) => entry.actionId) });
     if (typeof context.onCombatStart === "function") context.onCombatStart({ runtime, queue: runtime.queue });
-    setPhase(runtime, schema.PHASES.COMBAT_PHASE);
-    record(runtime, "combat_phase_started", { queue: runtime.queue.entries.map((entry) => entry.actionId) });
+    setPhase(runtime, schema.PHASES.COMBAT_PHASE); record(runtime, "combat_phase_started", { queue: runtime.queue.entries.map((entry) => entry.actionId) });
     return { started: true, phase: runtime.phase, queue: runtime.queue };
   }
 
@@ -286,10 +257,8 @@
     for (const action of asArray(result.actions).concat(result.action ? [result.action] : [])) {
       if (!action?.id) continue;
       runtime.actionMap[action.id] = action;
-      const index = runtime.actions.findIndex((entry) => entry.id === action.id);
-      if (index >= 0) runtime.actions[index] = action;
-      const reactionIndex = runtime.preparedReactions.findIndex((entry) => entry.id === action.id);
-      if (reactionIndex >= 0) runtime.preparedReactions[reactionIndex] = action;
+      const index = runtime.actions.findIndex((entry) => entry.id === action.id); if (index >= 0) runtime.actions[index] = action;
+      const reactionIndex = runtime.preparedReactions.findIndex((entry) => entry.id === action.id); if (reactionIndex >= 0) runtime.preparedReactions[reactionIndex] = action;
       if (runtime.queue) { const entry = runtime.queue.getEntry(action.id); if (entry) entry.action = action; }
       updates.push(action.id);
     }
@@ -309,8 +278,7 @@
     const cancelled = [];
     for (const unit of activeUnits(runtime)) {
       const blocked = isStaggered(unit) || (typeof context.isActionBlocked === "function" && context.isActionBlocked({ unit, runtime }) === true);
-      if (!blocked) continue;
-      cancelled.push(...cancelActorPending(runtime, entityId(unit), isStaggered(unit) ? { type: "stagger" } : { type: "action_blocked" }));
+      if (blocked) cancelled.push(...cancelActorPending(runtime, entityId(unit), isStaggered(unit) ? { type: "stagger" } : { type: "action_blocked" }));
     }
     return cancelled;
   }
@@ -318,48 +286,37 @@
   function applyRetarget(runtime, action, context = {}) {
     const status = queueApi.retargetStatus(action, activeUnits(runtime), { isAvailable: (target) => runtimeTargetAvailable(runtime, target, context) });
     if (status.executable) return { ready: true, action };
-    if (!status.requiresRetarget) {
-      action.state = "cancelled"; action.cancelReason = { type: status.reason || "target_unavailable" }; runtime.resolvedActionIds.add(action.id);
-      return { ready: false, cancelled: true, reason: status.reason || "target_unavailable", action };
-    }
+    if (!status.requiresRetarget) { action.state = "cancelled"; action.cancelReason = { type: status.reason || "target_unavailable" }; runtime.resolvedActionIds.add(action.id); return { ready: false, cancelled: true, reason: status.reason || "target_unavailable", action }; }
     if (typeof context.chooseRetarget !== "function") return { ready: false, pending: true, reason: "retarget_required", candidates: status.candidates, action };
     const targetId = context.chooseRetarget({ action, candidates: status.candidates, runtime });
     if (!targetId || !status.candidates.includes(String(targetId))) return { ready: false, pending: true, reason: "retarget_required", candidates: status.candidates, action };
     const previous = asArray(action.targeting.targetIds).map(String).filter((id) => id !== String(action.targeting.mainTargetId || ""));
-    action.targeting.mainTargetId = String(targetId);
-    action.targeting.targetIds = [String(targetId), ...previous.filter((id) => id !== String(targetId))].slice(0, Math.max(1, Number(action.targeting.attackWeight || 1)));
+    action.targeting.mainTargetId = String(targetId); action.targeting.targetIds = [String(targetId), ...previous.filter((id) => id !== String(targetId))].slice(0, Math.max(1, Number(action.targeting.attackWeight || 1)));
     record(runtime, "action_retargeted", { actionId: action.id, targetId: String(targetId) });
     return { ready: true, retargeted: true, action };
   }
 
   function defaultTriggerMatch(trigger, event) {
     if (!trigger || !event) return false;
-    const triggerType = normalizeId(trigger.type || trigger.event || trigger.trigger);
-    const eventType = normalizeId(event.type || event.event);
+    const triggerType = normalizeId(trigger.type || trigger.event || trigger.trigger), eventType = normalizeId(event.type || event.event);
     return Boolean(triggerType && eventType && triggerType === eventType);
   }
 
   function triggerReactions(runtime, event = {}, context = {}) {
     if (runtime.phase !== schema.PHASES.COMBAT_PHASE) return [];
-    const results = [];
-    const matcher = typeof context.reactionTriggerMatcher === "function" ? context.reactionTriggerMatcher : defaultTriggerMatch;
+    const results = [], matcher = typeof context.reactionTriggerMatcher === "function" ? context.reactionTriggerMatcher : defaultTriggerMatch;
     for (const stored of runtime.preparedReactions) {
       const reaction = runtime.actionMap[stored.id] || stored;
       if (terminal(reaction) || !matcher(reaction.reaction?.trigger, event, reaction, runtime)) continue;
-      const result = resolver.resolveCombatAction(reaction, resolverContext(runtime, context, schema.PHASES.COMBAT_PHASE));
-      syncResultActions(runtime, result);
+      const result = resolver.resolveCombatAction(reaction, resolverContext(runtime, context, schema.PHASES.COMBAT_PHASE)); syncResultActions(runtime, result);
       results.push({ mode: "prepared", actionId: reaction.id, result });
     }
     if (typeof context.getAdaptiveReactions === "function") {
       for (const raw of asArray(context.getAdaptiveReactions({ event, runtime }))) {
         const reaction = schema.normalizeCombatAction(raw);
-        reaction.economy.cost = schema.ECONOMY_COSTS.REACTION;
-        reaction.phase.selectedAt = schema.PHASES.COMBAT_PHASE;
-        reaction.phase.executesAt = schema.PHASES.COMBAT_PHASE;
-        reaction.reaction = { ...(reaction.reaction || {}), mode: "adaptive" };
+        reaction.economy.cost = schema.ECONOMY_COSTS.REACTION; reaction.phase.selectedAt = schema.PHASES.COMBAT_PHASE; reaction.phase.executesAt = schema.PHASES.COMBAT_PHASE; reaction.reaction = { ...(reaction.reaction || {}), mode: "adaptive" };
         runtime.actionMap[reaction.id] = reaction;
-        const result = resolver.resolveCombatAction(reaction, resolverContext(runtime, context, schema.PHASES.COMBAT_PHASE));
-        syncResultActions(runtime, result);
+        const result = resolver.resolveCombatAction(reaction, resolverContext(runtime, context, schema.PHASES.COMBAT_PHASE)); syncResultActions(runtime, result);
         results.push({ mode: "adaptive", actionId: reaction.id, result });
       }
     }
@@ -376,14 +333,9 @@
 
   function applyGrappleOutcome(runtime, action, result = {}) {
     if (!grappleSucceeded(action, result)) return null;
-    const targetId = String(action.targeting?.mainTargetId || action.targeting?.targetIds?.[0] || "");
-    if (!targetId) return null;
-    const cancelledActionIds = cancelActorPending(runtime, targetId, { type: "grapple" });
-    const locks = [];
-    if (runtime.encounter && teamEconomy?.lockUnitSlots) {
-      locks.push(teamEconomy.lockUnitSlots(runtime.encounter, action.actorId, 1, "grapple"));
-      locks.push(teamEconomy.lockUnitSlots(runtime.encounter, targetId, 1, "grapple"));
-    }
+    const targetId = String(action.targeting?.mainTargetId || action.targeting?.targetIds?.[0] || ""); if (!targetId) return null;
+    const cancelledActionIds = cancelActorPending(runtime, targetId, { type: "grapple" }), locks = [];
+    if (runtime.encounter && teamEconomy?.lockUnitSlots) { locks.push(teamEconomy.lockUnitSlots(runtime.encounter, action.actorId, 1, "grapple")); locks.push(teamEconomy.lockUnitSlots(runtime.encounter, targetId, 1, "grapple")); }
     record(runtime, "grapple_applied", { actorId: action.actorId, targetId, cancelledActionIds });
     return { targetId, cancelledActionIds, locks };
   }
@@ -391,18 +343,13 @@
   function resolveQueueEntry(runtime, entry, context = {}) {
     let action = runtime.actionMap[entry.actionId] || entry.action;
     if (!action || terminal(action) || runtime.resolvedActionIds.has(action.id)) return { skipped: true, reason: "already_terminal", action };
-    applyBlockingStates(runtime, context);
-    action = runtime.actionMap[entry.actionId] || entry.action;
+    applyBlockingStates(runtime, context); action = runtime.actionMap[entry.actionId] || entry.action;
     if (terminal(action) || runtime.resolvedActionIds.has(action.id)) return { skipped: true, reason: "cancelled_before_resolution", action };
-    const retarget = applyRetarget(runtime, action, context);
-    if (!retarget.ready) return retarget;
-    const opposingId = action.metadata?.opposingActionId;
-    const opposingAction = opposingId ? runtime.actionMap[opposingId] || null : null;
+    const retarget = applyRetarget(runtime, action, context); if (!retarget.ready) return retarget;
+    const opposingId = action.metadata?.opposingActionId, opposingAction = opposingId ? runtime.actionMap[opposingId] || null : null;
     triggerReactions(runtime, { type: "before_action", actionId: action.id, actorId: action.actorId }, context);
-    const result = resolver.resolveCombatAction(action, resolverContext(runtime, context, schema.PHASES.COMBAT_PHASE, { opposingAction }));
-    syncResultActions(runtime, result);
-    const grapple = applyGrappleOutcome(runtime, result.action || action, result);
-    applyBlockingStates(runtime, context);
+    const result = resolver.resolveCombatAction(action, resolverContext(runtime, context, schema.PHASES.COMBAT_PHASE, { opposingAction })); syncResultActions(runtime, result);
+    const grapple = applyGrappleOutcome(runtime, result.action || action, result); applyBlockingStates(runtime, context);
     triggerReactions(runtime, { type: "after_action", actionId: action.id, actorId: action.actorId, result }, context);
     record(runtime, "action_resolved", { actionId: action.id, resolved: result.resolved, reason: result.reason || null, type: result.type || result.resolution?.type || action.resolution.type });
     return grapple ? { ...result, grapple } : result;
@@ -412,12 +359,10 @@
     if (runtime.phase !== schema.PHASES.COMBAT_PHASE || !runtime.queue) return { completed: false, reason: "combat_phase_required" };
     const results = [];
     for (const entry of runtime.queue.entries) {
-      const result = resolveQueueEntry(runtime, entry, context);
-      results.push({ actionId: entry.actionId, result });
+      const result = resolveQueueEntry(runtime, entry, context); results.push({ actionId: entry.actionId, result });
       if (result?.pending && result.reason === "retarget_required") return { completed: false, pending: true, reason: "retarget_required", actionId: entry.actionId, candidates: result.candidates, results };
     }
-    setPhase(runtime, schema.PHASES.COMBAT_END);
-    record(runtime, "combat_end", { resolvedActionIds: [...runtime.resolvedActionIds] });
+    setPhase(runtime, schema.PHASES.COMBAT_END); record(runtime, "combat_end", { resolvedActionIds: [...runtime.resolvedActionIds] });
     if (typeof context.onCombatEnd === "function") context.onCombatEnd({ runtime, results });
     return { completed: true, phase: runtime.phase, results };
   }
@@ -425,24 +370,43 @@
   function teamForUnit(runtime, unit) { return !runtime.encounter || !teamEconomy?.teamForSide ? null : teamEconomy.teamForSide(runtime.encounter, queueApi.sideOf(unit)); }
   function replaceRuntimeUnit(runtime, outgoing, incoming) { const index = runtime.units.indexOf(outgoing); if (index >= 0) runtime.units.splice(index, 1, incoming); else runtime.units.push(incoming); }
 
+  function reserveRetreatProfile(runtime, team, profile, actor) {
+    const index = team.active.indexOf(profile); if (index >= 0) team.active.splice(index, 1);
+    runtime.retreatReserve.push({ unitId: entityId(actor), side: team.side, profile, returnRound: runtime.round + 2 });
+    actor.combatAbsentThroughRound = runtime.round + 1;
+    teamEconomy?.syncEncounter?.(runtime.encounter);
+  }
+
+  function restoreRetreatReserve(runtime, targetRound) {
+    if (!runtime.encounter || !teamEconomy?.teamForSide || !runtime.retreatReserve.length) return [];
+    const restored = [], pending = [];
+    for (const entry of runtime.retreatReserve) {
+      if (entry.returnRound > targetRound) { pending.push(entry); continue; }
+      const team = teamEconomy.teamForSide(runtime.encounter, entry.side);
+      if (!team.active.some((profile) => profile.id === entry.profile.id)) team.active.push(entry.profile);
+      const unit = unitById(runtime, entry.unitId); if (unit) delete unit.combatAbsentThroughRound;
+      restored.push(entry.unitId);
+    }
+    runtime.retreatReserve = pending;
+    if (restored.length) teamEconomy.syncEncounter?.(runtime.encounter);
+    return restored;
+  }
+
   function defaultRetreat(runtime, actor, effect = {}) {
-    const side = queueApi.sideOf(actor);
-    const team = teamForUnit(runtime, actor);
+    const side = queueApi.sideOf(actor), team = teamForUnit(runtime, actor);
     if (team && teamEconomy?.profileForUnit) {
       const found = teamEconomy.profileForUnit(runtime.encounter, actor);
-      if (team.backups?.length) {
-        const backupProfile = team.backups.shift();
-        const incomingUnit = backupProfile.unit;
+      if (found?.profile && team.backups?.length) {
+        const backupProfile = team.backups.shift(), incomingUnit = backupProfile.unit;
         const incoming = teamEconomy.inheritReplacementSlots ? teamEconomy.inheritReplacementSlots(runtime.encounter, side, actor, incomingUnit, { cap: effect.inheritActionSlotsCap || 2 }) : backupProfile;
-        const activeIndex = team.active.indexOf(found.profile);
-        if (activeIndex >= 0) team.active.splice(activeIndex, 1, incoming);
+        const activeIndex = team.active.indexOf(found.profile); if (activeIndex >= 0) team.active.splice(activeIndex, 1, incoming);
         found.profile.statusLockedSlots = 0; found.profile.usableActionSlots = 0; team.backups.push(found.profile);
-        replaceRuntimeUnit(runtime, actor, incomingUnit);
-        teamEconomy.syncEncounter?.(runtime.encounter);
+        replaceRuntimeUnit(runtime, actor, incomingUnit); teamEconomy.syncEncounter?.(runtime.encounter);
         return { retreated: true, replaced: true, outgoingUnitId: entityId(actor), incomingUnitId: entityId(incomingUnit), inheritedSlots: incoming.currentActionSlots };
       }
-    }
-    actor.combatAbsentThroughRound = runtime.round + 1;
+      if (found?.profile) reserveRetreatProfile(runtime, team, found.profile, actor);
+      else actor.combatAbsentThroughRound = runtime.round + 1;
+    } else actor.combatAbsentThroughRound = runtime.round + 1;
     return { retreated: true, replaced: false, absentThroughRound: actor.combatAbsentThroughRound };
   }
 
@@ -453,25 +417,20 @@
       const found = teamEconomy.profileForUnit(runtime.encounter, actor);
       if (found?.profile) {
         const index = team.active.indexOf(found.profile); if (index >= 0) team.active.splice(index, 1);
-        teamEconomy.registerVacatedSlots?.(runtime.encounter, team.side, found.profile.currentActionSlots || 1, { hasBackup: team.backups?.length > 0 });
-        teamEconomy.syncEncounter?.(runtime.encounter);
+        teamEconomy.registerVacatedSlots?.(runtime.encounter, team.side, found.profile.currentActionSlots || 1, { hasBackup: team.backups?.length > 0 }); teamEconomy.syncEncounter?.(runtime.encounter);
       }
     }
     return { escaped: true, unitId: entityId(actor), eligibleForXp: false };
   }
 
-  function turnEndEffectHandlers(runtime, context = {}) {
-    return { ...(context.effectHandlers || {}), retreat: context.effectHandlers?.retreat || (({ actor, effect }) => defaultRetreat(runtime, actor, effect)), escape: context.effectHandlers?.escape || (({ actor }) => defaultEscape(runtime, actor)) };
-  }
+  function turnEndEffectHandlers(runtime, context = {}) { return { ...(context.effectHandlers || {}), retreat: context.effectHandlers?.retreat || (({ actor, effect }) => defaultRetreat(runtime, actor, effect)), escape: context.effectHandlers?.escape || (({ actor }) => defaultEscape(runtime, actor)) }; }
 
   function resolveTurnEnd(runtime, context = {}) {
     if (runtime.phase !== schema.PHASES.COMBAT_END && runtime.phase !== schema.PHASES.ON_TURN_END) return { completed: false, reason: "combat_end_required" };
     setPhase(runtime, schema.PHASES.ON_TURN_END);
-    const results = [];
-    const turnEndActions = runtime.actions.filter((action) => action.phase.executesAt === schema.PHASES.ON_TURN_END && !terminal(action));
+    const results = [], turnEndActions = runtime.actions.filter((action) => action.phase.executesAt === schema.PHASES.ON_TURN_END && !terminal(action));
     const ordered = [...turnEndActions].sort((a, b) => {
-      const aSource = runtime.speedSnapshot?.[queueApi.speedSourceKey(a.actorId, queueApi.partIdOf(a))];
-      const bSource = runtime.speedSnapshot?.[queueApi.speedSourceKey(b.actorId, queueApi.partIdOf(b))];
+      const aSource = runtime.speedSnapshot?.[queueApi.speedSourceKey(a.actorId, queueApi.partIdOf(a))], bSource = runtime.speedSnapshot?.[queueApi.speedSourceKey(b.actorId, queueApi.partIdOf(b))];
       return (Number(bSource?.speed || 0) - Number(aSource?.speed || 0)) || (Number(aSource?.tieRoll || 0) - Number(bSource?.tieRoll || 0));
     });
     const effectHandlers = turnEndEffectHandlers(runtime, context);
@@ -479,13 +438,10 @@
       const unit = unitById(runtime, action.actorId);
       const blocked = !unit || !isUnitActive(runtime, unit) || isStaggered(unit) || (typeof context.isTurnEndBlocked === "function" && context.isTurnEndBlocked({ action, unit, runtime }) === true);
       if (blocked) {
-        action.state = "cancelled"; action.cancelReason = { type: !unit ? "actor_missing" : (isStaggered(unit) ? "stagger" : "turn_end_blocked") };
-        runtime.actionMap[action.id] = action; runtime.resolvedActionIds.add(action.id);
-        results.push({ actionId: action.id, resolved: false, cancelled: true, reason: action.cancelReason.type });
-        continue;
+        action.state = "cancelled"; action.cancelReason = { type: !unit ? "actor_missing" : (isStaggered(unit) ? "stagger" : "turn_end_blocked") }; runtime.actionMap[action.id] = action; runtime.resolvedActionIds.add(action.id);
+        results.push({ actionId: action.id, resolved: false, cancelled: true, reason: action.cancelReason.type }); continue;
       }
-      const result = resolver.resolveCombatAction(action, resolverContext(runtime, { ...context, effectHandlers }, schema.PHASES.ON_TURN_END));
-      syncResultActions(runtime, result); results.push({ actionId: action.id, ...result });
+      const result = resolver.resolveCombatAction(action, resolverContext(runtime, { ...context, effectHandlers }, schema.PHASES.ON_TURN_END)); syncResultActions(runtime, result); results.push({ actionId: action.id, ...result });
     }
     record(runtime, "turn_end_complete", { actionIds: results.map((entry) => entry.actionId) });
     return { completed: true, phase: runtime.phase, results };
@@ -493,17 +449,19 @@
 
   function nextRound(runtime, options = {}) {
     if (runtime.phase !== schema.PHASES.ON_TURN_END) return { started: false, reason: "turn_end_required" };
+    const targetRound = (runtime.encounter?.round || runtime.round) + 1;
+    const restored = restoreRetreatReserve(runtime, targetRound);
     runtime.round += 1;
     if (runtime.encounter && teamEconomy?.beginNextRound) { teamEconomy.beginNextRound(runtime.encounter); runtime.round = runtime.encounter.round; }
     beginTurn(runtime, options);
-    return { started: true, round: runtime.round, phase: runtime.phase, speedSnapshot: runtime.speedSnapshot };
+    return { started: true, round: runtime.round, phase: runtime.phase, speedSnapshot: runtime.speedSnapshot, restoredUnitIds: restored };
   }
 
   const api = Object.freeze({
     createRuntime, activeUnits, isUnitActive, beginTurn, availableSlotCount, validateActionSlot, registerAction,
     playerPlanningReady, aiPlanningReady, previewQueue, linkClash, beginCombatPhase, cancelActorPending,
     triggerReactions, applyGrappleOutcome, resolveQueueEntry, resolveCombatPhase, defaultRetreat, defaultEscape,
-    resolveTurnEnd, nextRound,
+    restoreRetreatReserve, resolveTurnEnd, nextRound,
   });
 
   global.LuminousCombatRuntimeIntegration = api;

--- a/tests/combat-action-queue-smoke.mjs
+++ b/tests/combat-action-queue-smoke.mjs
@@ -22,7 +22,11 @@ const actions = [
 ];
 const rolls = [0.8,0.2,0.5,0.7,0.1,0.9,0.4];
 let ri = 0;
-const round = queue.buildRoundOrder({actions,units,random:()=>rolls[ri++] ?? 0.5});
+const speedSnapshot = queue.snapshotSpeedSources(units,{random:()=>rolls[ri++] ?? 0.5});
+
+// Speed/tie placement is frozen at ON_TURN_START, before planning/combat.
+p1.speed = 1;
+const round = queue.buildRoundOrder({actions,units,speedSnapshot,random:()=>0.99});
 assert.equal(round.entries[0].actionId,'head1');
 assert.equal(round.getSpeed('p1'),8);
 assert.equal(round.getSpeed('abno','head'),9);
@@ -32,9 +36,6 @@ assert.deepEqual(round.entries.filter(x=>x.actorId==='p1').map(x=>x.actionId),['
 assert.deepEqual(round.layout.allies.map(x=>x.actorId),['p2','p1','p3']);
 assert.equal(round.layout.enemies.at(-1).actorId,'abno');
 assert.equal(round.layout.enemies.at(-1).partId,'head');
-
-p1.speed = 1;
-assert.equal(round.getSpeed('p1'),8);
 
 const p1Entry = round.getEntry('p1s1');
 const e1Entry = round.getEntry('e1s1');

--- a/tests/combat-action-queue-smoke.mjs
+++ b/tests/combat-action-queue-smoke.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const queue = require('../js/combat-action-queue.js');
+
+const p1 = { id:'p1', faction:'allies', speed:8, hp:20 };
+const p2 = { id:'p2', faction:'allies', speed:8, hp:20 };
+const p3 = { id:'p3', faction:'allies', speed:5, hp:20 };
+const e1 = { id:'e1', faction:'enemies', speed:7, hp:20 };
+const e2 = { id:'e2', faction:'enemies', speed:7, hp:20 };
+const abnormality = { id:'abno', faction:'enemies', speed:2, hp:100, parts:[{id:'head',speed:9},{id:'arm',speed:4}] };
+const units = [p1,p2,p3,e1,e2,abnormality];
+const actions = [
+  {id:'p1s1',actorId:'p1',actionSlotId:'p1_slot_0',state:'planned',phase:{executesAt:'combat_phase'},targeting:{mainTargetId:'e1',targetIds:['e1']}},
+  {id:'p1s2',actorId:'p1',actionSlotId:'p1_slot_1',state:'planned',phase:{executesAt:'combat_phase'},targeting:{mainTargetId:'e1',targetIds:['e1']}},
+  {id:'p2s1',actorId:'p2',actionSlotId:'p2_slot_0',state:'planned',phase:{executesAt:'combat_phase'},targeting:{mainTargetId:'e1',targetIds:['e1']}},
+  {id:'p3s1',actorId:'p3',state:'planned',phase:{executesAt:'combat_phase'},targeting:{mainTargetId:'e1',targetIds:['e1']}},
+  {id:'e1s1',actorId:'e1',state:'planned',phase:{executesAt:'combat_phase'},targeting:{mainTargetId:'p3',targetIds:['p3']}},
+  {id:'e2s1',actorId:'e2',state:'planned',phase:{executesAt:'combat_phase'},targeting:{mainTargetId:'p1',targetIds:['p1']}},
+  {id:'head1',actorId:'abno',metadata:{partId:'head'},state:'planned',phase:{executesAt:'combat_phase'},targeting:{mainTargetId:'p1',targetIds:['p1']}},
+  {id:'arm1',actorId:'abno',metadata:{partId:'arm'},state:'planned',phase:{executesAt:'combat_phase'},targeting:{mainTargetId:'p1',targetIds:['p1']}},
+];
+const rolls = [0.8,0.2,0.5,0.7,0.1,0.9,0.4];
+let ri = 0;
+const round = queue.buildRoundOrder({actions,units,random:()=>rolls[ri++] ?? 0.5});
+assert.equal(round.entries[0].actionId,'head1');
+assert.equal(round.getSpeed('p1'),8);
+assert.equal(round.getSpeed('abno','head'),9);
+assert.equal(round.getSpeed('abno','arm'),4);
+assert.deepEqual(round.entries.filter(x=>x.actorId==='p1').map(x=>x.speed),[8,8]);
+assert.deepEqual(round.entries.filter(x=>x.actorId==='p1').map(x=>x.actionId),['p1s1','p1s2']);
+assert.deepEqual(round.layout.allies.map(x=>x.actorId),['p2','p1','p3']);
+assert.equal(round.layout.enemies.at(-1).actorId,'abno');
+assert.equal(round.layout.enemies.at(-1).partId,'head');
+
+p1.speed = 1;
+assert.equal(round.getSpeed('p1'),8);
+
+const p1Entry = round.getEntry('p1s1');
+const e1Entry = round.getEntry('e1s1');
+const e2Entry = round.getEntry('e2s1');
+assert.equal(queue.canForceClash({interceptorEntry:p1Entry,targetEntry:e1Entry}),true);
+assert.equal(queue.canForceClash({interceptorEntry:e1Entry,targetEntry:p1Entry}),true);
+const neutralTarget = {...p1Entry, action:{...p1Entry.action,targeting:{mainTargetId:'e2',targetIds:['e2']}}};
+assert.equal(queue.canForceClash({interceptorEntry:e1Entry,targetEntry:neutralTarget}),false);
+assert.equal(queue.canForceClash({interceptorEntry:e2Entry,targetEntry:p1Entry}),false);
+assert.equal(queue.canForceClash({interceptorEntry:p1Entry,targetEntry:e2Entry}),true);
+
+const sameA = {actorId:'p1',speed:7,action:{targeting:{targetIds:['x']}}};
+const sameB = {actorId:'e1',speed:7,action:{targeting:{targetIds:['p3']}}};
+assert.equal(queue.canForceClash({interceptorEntry:sameA,targetEntry:sameB}),false);
+
+actions[0].state = 'resolving';
+actions[1].state = 'planned';
+const resolved = {id:'done',actorId:'p1',state:'resolved',phase:{executesAt:'combat_phase'},targeting:{}};
+round.entries.push({action:resolved,actionId:'done',actorId:'p1',partId:null,speed:8});
+const cancelled = queue.cancelActorActions(round,'p1',{type:'stagger'});
+assert.ok(cancelled.includes('p1s1'));
+assert.ok(cancelled.includes('p1s2'));
+assert.equal(resolved.state,'resolved');
+assert.equal(round.getSpeed('p1'),8);
+
+const actor = {id:'a',faction:'allies',hp:20};
+const A = {id:'A',faction:'enemies',hp:10};
+const B = {id:'B',faction:'enemies',hp:10};
+const C = {id:'C',faction:'enemies',hp:10};
+const ally = {id:'ally',faction:'allies',hp:10};
+let skill = {actorId:'a',targeting:{mainTargetId:'A',targetIds:['A'],attackWeight:1,allegiance:'enemy'},metadata:{sourceDefinition:{targetingType:'Focused Attack'}}};
+let coin = queue.selectCoinTarget(skill,[actor,A,B,C]);
+assert.equal(coin.targetId,'A');
+A.hp = 0;
+coin = queue.selectCoinTarget(skill,[actor,A,B,C],coin.state);
+assert.equal(coin.cancelled,true);
+
+A.hp = 10;
+skill = {actorId:'a',targeting:{mainTargetId:'A',targetIds:['A'],attackWeight:1,allegiance:'enemy'},metadata:{sourceDefinition:{targetingType:'Unfocused Volley'}}};
+let state = {};
+coin = queue.selectCoinTarget(skill,[actor,A,B,C],state,{random:()=>0});
+assert.equal(coin.targetId,'A'); state=coin.state;
+coin = queue.selectCoinTarget(skill,[actor,A,B,C],state,{random:()=>0});
+assert.equal(coin.targetId,'B'); state=coin.state;
+coin = queue.selectCoinTarget(skill,[actor,A,B,C],state,{random:()=>0});
+assert.equal(coin.targetId,'A');
+B.hp=0; C.hp=0;
+coin = queue.selectCoinTarget(skill,[actor,A,B,C],coin.state,{random:()=>0.9});
+assert.equal(coin.targetId,'A');
+
+B.hp=10; C.hp=10;
+const indis = {actorId:'a',targeting:{mainTargetId:'A',targetIds:['A'],attackWeight:1,mode:'indiscriminate',indiscriminate:true},metadata:{sourceDefinition:{targetingType:'Unfocused Volley'}}};
+const poolIds = queue.targetPool(indis,[actor,ally,A,B]).map(queue.entityId);
+assert.ok(poolIds.includes('ally'));
+assert.ok(poolIds.includes('A'));
+assert.ok(!poolIds.includes('a'));
+
+const weighted = {actorId:'a',targeting:{mainTargetId:'A',targetIds:['A','B'],attackWeight:2,allegiance:'enemy'},metadata:{sourceDefinition:{targetingType:'Unfocused Volley'}}};
+assert.deepEqual(queue.targetPool(weighted,[actor,A,B,C]).map(queue.entityId),['A','B']);
+A.hp=0; B.hp=0;
+assert.equal(queue.selectCoinTarget(weighted,[actor,A,B,C],{}, {random:()=>0}).cancelled,true);
+
+console.log('combat-action-queue smoke: ok');

--- a/tests/combat-action-queue-smoke.mjs
+++ b/tests/combat-action-queue-smoke.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
-import { createRequire } from 'node:module';
-const require = createRequire(import.meta.url);
-const queue = require('../js/combat-action-queue.js');
+await import('../js/combat-action-queue.js');
+const queue = globalThis.LuminousCombatActionQueue;
+if (!queue) throw new Error('LuminousCombatActionQueue was not initialized.');
 
 const p1 = { id:'p1', faction:'allies', speed:8, hp:20 };
 const p2 = { id:'p2', faction:'allies', speed:8, hp:20 };
@@ -23,8 +23,6 @@ const actions = [
 const rolls = [0.8,0.2,0.5,0.7,0.1,0.9,0.4];
 let ri = 0;
 const speedSnapshot = queue.snapshotSpeedSources(units,{random:()=>rolls[ri++] ?? 0.5});
-
-// Speed/tie placement is frozen at ON_TURN_START, before planning/combat.
 p1.speed = 1;
 const round = queue.buildRoundOrder({actions,units,speedSnapshot,random:()=>0.99});
 assert.equal(round.entries[0].actionId,'head1');

--- a/tests/combat-action-resolver-smoke.mjs
+++ b/tests/combat-action-resolver-smoke.mjs
@@ -100,4 +100,31 @@ const checkResult = resolver.resolveCombatAction(checkAction, { ...common, check
 assert.equal(checkResult.resolved, true);
 assert.equal(checkResult.resolution.result.pass, true);
 
+// A clash that degrades to unopposed must still validate and consume the active action's resources.
+attackCalls = 0;
+let allowFallbackResource = false;
+let fallbackConsumes = 0;
+const guardedHandlers = {
+  trait_use: {
+    validate: () => ({ available: allowFallbackResource, reason: allowFallbackResource ? null : 'no_resource' }),
+    consume: () => { fallbackConsumes++; return { consumed:true }; },
+  },
+};
+const fallbackA = adapters.compileSkillToCombatAction(a, { id:'fallback_a', basePower:4, coinAmount:1, resourceCosts:[{type:'trait_use',id:'fallback_cost',amount:1}] }, { targetId:'b' });
+const fallbackB = adapters.compileSkillToCombatAction(b, { id:'fallback_b', basePower:3, coinAmount:1 }, { targetId:'a', isAi:true });
+fallbackB.state = 'cancelled';
+const blockedFallback = resolver.resolveCombatAction(fallbackA, { ...common, resourceHandlers:guardedHandlers, opposingAction:fallbackB });
+assert.equal(blockedFallback.resolved, false);
+assert.equal(blockedFallback.reason, 'no_resource');
+assert.equal(attackCalls, 0);
+assert.equal(fallbackConsumes, 0);
+
+allowFallbackResource = true;
+const fallbackA2 = adapters.compileSkillToCombatAction(a, { id:'fallback_a2', basePower:4, coinAmount:1, resourceCosts:[{type:'trait_use',id:'fallback_cost_2',amount:1}] }, { targetId:'b' });
+const allowedFallback = resolver.resolveCombatAction(fallbackA2, { ...common, resourceHandlers:guardedHandlers, opposingAction:fallbackB });
+assert.equal(allowedFallback.resolved, true);
+assert.equal(allowedFallback.type, 'unopposed');
+assert.equal(fallbackConsumes, 1);
+assert.equal(attackCalls, 1);
+
 console.log('combat-action-resolver smoke: ok');

--- a/tests/combat-action-resolver-smoke.mjs
+++ b/tests/combat-action-resolver-smoke.mjs
@@ -1,21 +1,26 @@
 import assert from 'node:assert/strict';
-import { createRequire } from 'node:module';
-const require = createRequire(import.meta.url);
-const schema = require('../js/combat-action-schema.js');
-globalThis.LuminousCombatAction = schema;
-const adapters = require('../js/combat-action-adapters.js');
-globalThis.LuminousCombatActionAdapters = adapters;
-const bridge = require('../js/combat-action-engine-bridge.js');
-globalThis.LuminousCombatActionEngineBridge = bridge;
-const resolver = require('../js/combat-action-resolver.js');
+
+await import('../js/combat-action-schema.js');
+const schema = globalThis.LuminousCombatAction;
+await import('../js/combat-action-adapters.js');
+const adapters = globalThis.LuminousCombatActionAdapters;
+await import('../js/combat-action-engine-bridge.js');
+const bridge = globalThis.LuminousCombatActionEngineBridge;
+await import('../js/combat-action-queue.js');
+const queue = globalThis.LuminousCombatActionQueue;
+await import('../js/combat-action-resolver.js');
+const resolver = globalThis.LuminousCombatActionResolver;
+if (!schema || !adapters || !bridge || !queue || !resolver) throw new Error('Combat resolver modules were not initialized.');
 
 let clashCalls = 0;
 let attackCalls = 0;
+const attackTargetLog = [];
 const engine = {
   calculateFinalPower(skill, heads) { return Number(skill.basePower || 0) + Number(heads || 0); },
   resolveStandardClash() { clashCalls++; return { winner: 'A', clashLogs: [{}, {}], mitigationPenalty: 0 }; },
   resolveUnilateralWithCounter(attacker, skill, defender, counter, options) {
     attackCalls++;
+    attackTargetLog.push(defender.id);
     defender.hp = (defender.hp ?? 20) - 3;
     return { damageTaken: 3, attackLogs: [{ target: defender.id }], options, bonus: skill.__combatActionFinalPowerBonus || 0 };
   },
@@ -34,7 +39,7 @@ const resourceHandlers = {
     consume: ({resource}) => { resourceLog.push(resource.id); return { consumed:true }; },
   }
 };
-const common = { phase:'combat_phase', units, engine, resourceHandlers, random: () => 0 };
+const common = { phase:'combat_phase', units, engine, resourceHandlers, random: () => 0, combatActionQueue:queue };
 
 bridge.installCombatActionPowerBridge(engine);
 assert.equal(engine.calculateFinalPower({basePower:4,__combatActionFinalPowerBonus:1}, 2), 7);
@@ -50,7 +55,7 @@ assert.equal(clashCalls, 1);
 assert.equal(attackCalls, 2);
 assert.deepEqual(clash.resolvedActionIds.sort(), [actionA.id, actionB.id].sort());
 
-clashCalls = 0; attackCalls = 0;
+clashCalls = 0; attackCalls = 0; attackTargetLog.length = 0;
 b.isStaggered = true;
 const staggerA = adapters.compileSkillToCombatAction(a, { id:'s2', basePower:4, coinAmount:1, attackWeight:1, isClashable:true }, { targetId:'b' });
 const staggerB = adapters.compileSkillToCombatAction(b, { id:'s3', basePower:4, coinAmount:1, isClashable:true }, { targetId:'a', isAi:true });
@@ -101,7 +106,7 @@ assert.equal(checkResult.resolved, true);
 assert.equal(checkResult.resolution.result.pass, true);
 
 // A clash that degrades to unopposed must still validate and consume the active action's resources.
-attackCalls = 0;
+attackCalls = 0; attackTargetLog.length = 0;
 let allowFallbackResource = false;
 let fallbackConsumes = 0;
 const guardedHandlers = {
@@ -126,5 +131,32 @@ assert.equal(allowedFallback.resolved, true);
 assert.equal(allowedFallback.type, 'unopposed');
 assert.equal(fallbackConsumes, 1);
 assert.equal(attackCalls, 1);
+
+// Unfocused Volley resolves every Coin independently and avoids the previous target when another marked/valid target exists.
+attackCalls = 0; attackTargetLog.length = 0;
+b.hp = 20; e2.hp = 20;
+const unfocused = adapters.compileSkillToCombatAction(a, {
+  id:'unfocused_three', basePower:3, coinPower:1, coinAmount:3, attackWeight:1,
+  targetingType:'Unfocused Volley', coins:[{},{},{}], isClashable:false,
+}, { targetId:'b' });
+const unfocusedResult = resolver.resolveCombatAction(unfocused, { ...common, coinwiseResolution:true, random:()=>0 });
+assert.equal(unfocusedResult.resolved, true);
+assert.equal(unfocusedResult.resolution.coinwise, true);
+assert.deepEqual(attackTargetLog, ['b','e2','b']);
+assert.equal(attackCalls, 3);
+
+// Focused Volley stops remaining Coins if its focused target dies.
+attackCalls = 0; attackTargetLog.length = 0;
+b.hp = 2; e2.hp = 20;
+const focused = adapters.compileSkillToCombatAction(a, {
+  id:'focused_three', basePower:3, coinPower:1, coinAmount:3, attackWeight:1,
+  targetingType:'Focused Volley', coins:[{},{},{}], isClashable:false,
+}, { targetId:'b' });
+const focusedResult = resolver.resolveCombatAction(focused, { ...common, coinwiseResolution:true });
+assert.equal(focusedResult.cancelled, true);
+assert.equal(focusedResult.action.state, 'cancelled');
+assert.equal(focusedResult.resolution.partial, true);
+assert.equal(attackCalls, 1);
+assert.deepEqual(attackTargetLog, ['b']);
 
 console.log('combat-action-resolver smoke: ok');

--- a/tests/combat-action-smoke.mjs
+++ b/tests/combat-action-smoke.mjs
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
-import { createRequire } from 'node:module';
-const require = createRequire(import.meta.url);
-const schema = require('../js/combat-action-schema.js');
-const adapters = require('../js/combat-action-adapters.js');
+
+await import('../js/combat-action-schema.js');
+const schema = globalThis.LuminousCombatAction;
+await import('../js/combat-action-adapters.js');
+const adapters = globalThis.LuminousCombatActionAdapters;
+if (!schema || !adapters) throw new Error('CombatAction modules were not initialized.');
 
 const actor = { id: 'a1' };
 const skill = {

--- a/tests/combat-runtime-integration-smoke.mjs
+++ b/tests/combat-runtime-integration-smoke.mjs
@@ -1,18 +1,18 @@
 import assert from 'node:assert/strict';
-import { createRequire } from 'node:module';
-const require = createRequire(import.meta.url);
 
-const schema = require('../js/combat-action-schema.js');
-globalThis.LuminousCombatAction = schema;
-const adapters = require('../js/combat-action-adapters.js');
-globalThis.LuminousCombatActionAdapters = adapters;
-const bridge = require('../js/combat-action-engine-bridge.js');
-globalThis.LuminousCombatActionEngineBridge = bridge;
-const queue = require('../js/combat-action-queue.js');
-globalThis.LuminousCombatActionQueue = queue;
-const resolver = require('../js/combat-action-resolver.js');
-globalThis.LuminousCombatActionResolver = resolver;
-const runtimeApi = require('../js/combat-runtime-integration.js');
+await import('../js/combat-action-schema.js');
+const schema = globalThis.LuminousCombatAction;
+await import('../js/combat-action-adapters.js');
+const adapters = globalThis.LuminousCombatActionAdapters;
+await import('../js/combat-action-engine-bridge.js');
+const bridge = globalThis.LuminousCombatActionEngineBridge;
+await import('../js/combat-action-queue.js');
+const queue = globalThis.LuminousCombatActionQueue;
+await import('../js/combat-action-resolver.js');
+const resolver = globalThis.LuminousCombatActionResolver;
+await import('../js/combat-runtime-integration.js');
+const runtimeApi = globalThis.LuminousCombatRuntimeIntegration;
+if (!schema || !adapters || !bridge || !queue || !resolver || !runtimeApi) throw new Error('Combat runtime modules were not initialized.');
 
 let clashCalls = 0;
 let attackCalls = 0;
@@ -96,12 +96,9 @@ assert.equal(runtimeApi.registerAction(runtime,e1a1).registered,true);
 assert.equal(runtimeApi.registerAction(runtime,e1a2).registered,true);
 assert.equal(runtimeApi.registerAction(runtime,e2a1).registered,true);
 
-// p2 is not e1a1's target and is slower (5 < 7), so it cannot steal the clash.
 const denied = runtimeApi.linkClash(runtime,p2a1.id,e1a1.id);
 assert.equal(denied.linked,false);
 assert.equal(denied.reason,'insufficient_speed_to_force_clash');
-
-// p1 is the declared target, so it can clash regardless of speed; its frozen speed remains 8 anyway.
 const linked = runtimeApi.linkClash(runtime,p1a1.id,e1a1.id);
 assert.equal(linked.linked,true);
 

--- a/tests/combat-runtime-integration-smoke.mjs
+++ b/tests/combat-runtime-integration-smoke.mjs
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+
+const schema = require('../js/combat-action-schema.js');
+globalThis.LuminousCombatAction = schema;
+const adapters = require('../js/combat-action-adapters.js');
+globalThis.LuminousCombatActionAdapters = adapters;
+const bridge = require('../js/combat-action-engine-bridge.js');
+globalThis.LuminousCombatActionEngineBridge = bridge;
+const queue = require('../js/combat-action-queue.js');
+globalThis.LuminousCombatActionQueue = queue;
+const resolver = require('../js/combat-action-resolver.js');
+globalThis.LuminousCombatActionResolver = resolver;
+const runtimeApi = require('../js/combat-runtime-integration.js');
+
+let clashCalls = 0;
+let attackCalls = 0;
+const engine = {
+  calculateFinalPower(skill, heads) { return Number(skill.basePower || 0) + Number(heads || 0); },
+  resolveStandardClash() {
+    clashCalls++;
+    return { winner:'A', clashLogs:[{}], mitigationPenalty:0 };
+  },
+  resolveUnilateralWithCounter(attacker, skill, defender, counter, options) {
+    attackCalls++;
+    defender.hp = Math.max(0, Number(defender.hp ?? 20) - 4);
+    if (defender.id === 'e1') defender.isStaggered = true;
+    return { damageTaken:4, options };
+  },
+  resolveSpell() { return { isSuccess:false }; },
+  getCoinProbability() { return 50; },
+};
+
+const p1 = { id:'p1', faction:'allies', speed:8, hp:20, sp:0 };
+const p2 = { id:'p2', faction:'allies', speed:5, hp:20, sp:0 };
+const e1 = { id:'e1', faction:'enemies', speed:7, hp:20, sp:0 };
+const e2 = { id:'e2', faction:'enemies', speed:4, hp:20, sp:0 };
+const units = [p1,p2,e1,e2];
+let randomIndex = 0;
+const randomValues = [0.3,0.8,0.2,0.6,0.4,0.7,0.1,0.9];
+const runtime = runtimeApi.createRuntime({ units, random:()=>randomValues[randomIndex++ % randomValues.length] });
+
+runtimeApi.beginTurn(runtime);
+assert.equal(runtime.phase, schema.PHASES.PLANNING_PHASE_PLAYER);
+assert.equal(runtime.speedSnapshot[queue.speedSourceKey('p1',null)].speed, 8);
+
+// Speed is frozen at ON_TURN_START; later mutation cannot change this round's order.
+p1.speed = 1;
+
+let quickUses = 0;
+const quick = schema.createCombatAction({
+  actorId:'p2', source:{type:'trait',id:'quick_ping'},
+  economy:{cost:'quick_action'},
+  phase:{selectedAt:'planning_phase_player',executesAt:'planning_phase_player'},
+  targeting:{mode:'single',allegiance:'enemy',mainTargetId:'e2',targetIds:['e2']},
+  resolution:{type:'unopposed'},
+  metadata:{sourceDefinition:{id:'quick_ping',basePower:2,coinAmount:1,coins:[{}]}},
+});
+const quickResult = runtimeApi.registerAction(runtime, quick, { context:{ engine, consumeQuickAction:()=>{ quickUses++; return {consumed:true}; } } });
+assert.equal(quickResult.immediate, true);
+assert.equal(quickResult.result.resolved, true);
+assert.equal(quickUses, 1);
+
+const p1a1 = adapters.compileSkillToCombatAction(p1, {
+  id:'p1_slash', basePower:4, coinPower:2, coinAmount:1, isClashable:true,
+  resourceCosts:[{type:'trait_use',id:'p1_cost',amount:1}],
+}, { actionSlotId:'p1_slot_0', targetId:'e1' });
+const p1a2 = adapters.compileSkillToCombatAction(p1, {
+  id:'p1_follow', basePower:3, coinPower:1, coinAmount:1, isClashable:true,
+}, { actionSlotId:'p1_slot_1', targetId:'e2' });
+const p2a1 = adapters.compileSkillToCombatAction(p2, {
+  id:'p2_intercept', basePower:3, coinPower:1, coinAmount:1, isClashable:true,
+}, { actionSlotId:'p2_slot_0', targetId:'e1' });
+const retreat = adapters.compileUniversalAction(p2, 'retreat', { actionSlotId:'p2_slot_1' });
+
+assert.equal(runtimeApi.registerAction(runtime,p1a1).registered,true);
+assert.equal(runtimeApi.registerAction(runtime,p1a2).registered,true);
+assert.equal(runtimeApi.registerAction(runtime,p2a1).registered,true);
+assert.equal(runtimeApi.registerAction(runtime,retreat).registered,true);
+
+runtimeApi.playerPlanningReady(runtime);
+assert.equal(runtime.phase, schema.PHASES.PLANNING_PHASE_AI);
+
+const e1a1 = adapters.compileSkillToCombatAction(e1, {
+  id:'e1_hit', basePower:3, coinPower:1, coinAmount:1, isClashable:true,
+  resourceCosts:[{type:'trait_use',id:'e1_cost',amount:1}],
+}, { actionSlotId:'e1_slot_0', targetId:'p1', isAi:true });
+const e1a2 = adapters.compileSkillToCombatAction(e1, {
+  id:'e1_second', basePower:3, coinPower:1, coinAmount:1, isClashable:true,
+}, { actionSlotId:'e1_slot_1', targetId:'p2', isAi:true });
+const e2a1 = adapters.compileSkillToCombatAction(e2, {
+  id:'e2_hit', basePower:2, coinPower:1, coinAmount:1, isClashable:true,
+}, { actionSlotId:'e2_slot_0', targetId:'p2', isAi:true });
+assert.equal(runtimeApi.registerAction(runtime,e1a1).registered,true);
+assert.equal(runtimeApi.registerAction(runtime,e1a2).registered,true);
+assert.equal(runtimeApi.registerAction(runtime,e2a1).registered,true);
+
+// p2 is not e1a1's target and is slower (5 < 7), so it cannot steal the clash.
+const denied = runtimeApi.linkClash(runtime,p2a1.id,e1a1.id);
+assert.equal(denied.linked,false);
+assert.equal(denied.reason,'insufficient_speed_to_force_clash');
+
+// p1 is the declared target, so it can clash regardless of speed; its frozen speed remains 8 anyway.
+const linked = runtimeApi.linkClash(runtime,p1a1.id,e1a1.id);
+assert.equal(linked.linked,true);
+
+runtimeApi.aiPlanningReady(runtime);
+assert.equal(runtime.phase, schema.PHASES.COMBAT_START);
+const started = runtimeApi.beginCombatPhase(runtime);
+assert.equal(started.started,true);
+assert.equal(runtime.phase,schema.PHASES.COMBAT_PHASE);
+assert.equal(runtime.queue.getSpeed('p1'),8);
+assert.equal(runtime.queue.entries[0].actorId,'p1');
+
+const resourceLog = [];
+const resourceHandlers = {
+  trait_use:{
+    validate:()=>({available:true}),
+    consume:({resource})=>{resourceLog.push(resource.id);return {consumed:true};},
+  },
+};
+const combat = runtimeApi.resolveCombatPhase(runtime,{ engine, resourceHandlers });
+assert.equal(combat.completed,true);
+assert.equal(runtime.phase,schema.PHASES.COMBAT_END);
+assert.equal(clashCalls,1);
+assert.ok(resourceLog.includes('p1_cost'));
+assert.ok(resourceLog.includes('e1_cost'));
+assert.equal(runtime.actionMap[e1a2.id].state,'cancelled');
+assert.equal(runtime.actionMap[e1a2.id].cancelReason.type,'stagger');
+assert.ok(runtime.resolvedActionIds.has(e1a2.id));
+
+let retreated = false;
+const end = runtimeApi.resolveTurnEnd(runtime,{
+  engine,
+  effectHandlers:{ retreat:()=>{retreated=true;return {swapped:true};} },
+});
+assert.equal(end.completed,true);
+assert.equal(runtime.phase,schema.PHASES.ON_TURN_END);
+assert.equal(retreated,true);
+
+const next = runtimeApi.nextRound(runtime);
+assert.equal(next.started,true);
+assert.equal(runtime.round,2);
+assert.equal(runtime.phase,schema.PHASES.PLANNING_PHASE_PLAYER);
+assert.equal(runtime.speedSnapshot[queue.speedSourceKey('p1',null)].speed,1);
+
+console.log('combat-runtime-integration smoke: ok');

--- a/tests/combat-runtime-integration-smoke.mjs
+++ b/tests/combat-runtime-integration-smoke.mjs
@@ -8,14 +8,17 @@ await import('../js/combat-action-engine-bridge.js');
 const bridge = globalThis.LuminousCombatActionEngineBridge;
 await import('../js/combat-action-queue.js');
 const queue = globalThis.LuminousCombatActionQueue;
+await import('../js/team-action-economy.js');
+const economy = globalThis.LuminousTeamActionEconomy;
 await import('../js/combat-action-resolver.js');
 const resolver = globalThis.LuminousCombatActionResolver;
 await import('../js/combat-runtime-integration.js');
 const runtimeApi = globalThis.LuminousCombatRuntimeIntegration;
-if (!schema || !adapters || !bridge || !queue || !resolver || !runtimeApi) throw new Error('Combat runtime modules were not initialized.');
+if (!schema || !adapters || !bridge || !queue || !economy || !resolver || !runtimeApi) throw new Error('Combat runtime modules were not initialized.');
 
 let clashCalls = 0;
 let attackCalls = 0;
+const attackTargets = [];
 const engine = {
   calculateFinalPower(skill, heads) { return Number(skill.basePower || 0) + Number(heads || 0); },
   resolveStandardClash() {
@@ -24,6 +27,7 @@ const engine = {
   },
   resolveUnilateralWithCounter(attacker, skill, defender, counter, options) {
     attackCalls++;
+    attackTargets.push(defender.id);
     defender.hp = Math.max(0, Number(defender.hp ?? 20) - 4);
     if (defender.id === 'e1') defender.isStaggered = true;
     return { damageTaken:4, options };
@@ -32,6 +36,8 @@ const engine = {
   getCoinProbability() { return 50; },
 };
 
+// Full round: turn-start Speed snapshot, Quick Action, Planning, Clash, Stagger cancellation,
+// Prepared Reaction, Combat hooks, Turn End and next-round Speed refresh.
 const p1 = { id:'p1', faction:'allies', speed:8, hp:20, sp:0 };
 const p2 = { id:'p2', faction:'allies', speed:5, hp:20, sp:0 };
 const e1 = { id:'e1', faction:'enemies', speed:7, hp:20, sp:0 };
@@ -44,8 +50,6 @@ const runtime = runtimeApi.createRuntime({ units, random:()=>randomValues[random
 runtimeApi.beginTurn(runtime);
 assert.equal(runtime.phase, schema.PHASES.PLANNING_PHASE_PLAYER);
 assert.equal(runtime.speedSnapshot[queue.speedSourceKey('p1',null)].speed, 8);
-
-// Speed is frozen at ON_TURN_START; later mutation cannot change this round's order.
 p1.speed = 1;
 
 let quickUses = 0;
@@ -73,11 +77,13 @@ const p2a1 = adapters.compileSkillToCombatAction(p2, {
   id:'p2_intercept', basePower:3, coinPower:1, coinAmount:1, isClashable:true,
 }, { actionSlotId:'p2_slot_0', targetId:'e1' });
 const retreat = adapters.compileUniversalAction(p2, 'retreat', { actionSlotId:'p2_slot_1' });
+const prepared = adapters.compileReactionToCombatAction(p2, { id:'prepared_watch', sourceType:'trait' }, { mode:'prepared', trigger:{type:'before_action'} });
 
 assert.equal(runtimeApi.registerAction(runtime,p1a1).registered,true);
 assert.equal(runtimeApi.registerAction(runtime,p1a2).registered,true);
 assert.equal(runtimeApi.registerAction(runtime,p2a1).registered,true);
 assert.equal(runtimeApi.registerAction(runtime,retreat).registered,true);
+assert.equal(runtimeApi.registerAction(runtime,prepared).preparedReaction,true);
 
 runtimeApi.playerPlanningReady(runtime);
 assert.equal(runtime.phase, schema.PHASES.PLANNING_PHASE_AI);
@@ -104,8 +110,11 @@ assert.equal(linked.linked,true);
 
 runtimeApi.aiPlanningReady(runtime);
 assert.equal(runtime.phase, schema.PHASES.COMBAT_START);
-const started = runtimeApi.beginCombatPhase(runtime);
+let combatStartHooks = 0;
+let combatEndHooks = 0;
+const started = runtimeApi.beginCombatPhase(runtime,{onCombatStart:()=>combatStartHooks++});
 assert.equal(started.started,true);
+assert.equal(combatStartHooks,1);
 assert.equal(runtime.phase,schema.PHASES.COMBAT_PHASE);
 assert.equal(runtime.queue.getSpeed('p1'),8);
 assert.equal(runtime.queue.entries[0].actorId,'p1');
@@ -117,9 +126,18 @@ const resourceHandlers = {
     consume:({resource})=>{resourceLog.push(resource.id);return {consumed:true};},
   },
 };
-const combat = runtimeApi.resolveCombatPhase(runtime,{ engine, resourceHandlers });
+let reactionUses = 0;
+const combat = runtimeApi.resolveCombatPhase(runtime,{
+  engine,
+  resourceHandlers,
+  consumeReaction:()=>{reactionUses++;return {consumed:true};},
+  onCombatEnd:()=>combatEndHooks++,
+});
 assert.equal(combat.completed,true);
 assert.equal(runtime.phase,schema.PHASES.COMBAT_END);
+assert.equal(combatEndHooks,1);
+assert.equal(reactionUses,1);
+assert.equal(runtime.actionMap[prepared.id].state,'resolved');
 assert.equal(clashCalls,1);
 assert.ok(resourceLog.includes('p1_cost'));
 assert.ok(resourceLog.includes('e1_cost'));
@@ -141,5 +159,101 @@ assert.equal(next.started,true);
 assert.equal(runtime.round,2);
 assert.equal(runtime.phase,schema.PHASES.PLANNING_PHASE_PLAYER);
 assert.equal(runtime.speedSnapshot[queue.speedSourceKey('p1',null)].speed,1);
+
+// Action Slot ownership: an Action requires a slot; the same slot cannot hold two Actions,
+// and a Unit cannot plan more Actions than its usable slot count.
+const slotUser = {id:'slot_user',faction:'allies',speed:5,hp:10,activeSlots:1};
+const slotEnemy = {id:'slot_enemy',faction:'enemies',speed:4,hp:10};
+const slotRuntime = runtimeApi.createRuntime({units:[slotUser,slotEnemy],random:()=>0.5});
+runtimeApi.beginTurn(slotRuntime);
+const noSlot = adapters.compileSkillToCombatAction(slotUser,{id:'no_slot',isClashable:false},{targetId:'slot_enemy'});
+assert.equal(runtimeApi.registerAction(slotRuntime,noSlot).reason,'action_slot_required');
+const slotOne = adapters.compileSkillToCombatAction(slotUser,{id:'slot_one',isClashable:false},{actionSlotId:'slot_user_slot_0',targetId:'slot_enemy'});
+assert.equal(runtimeApi.registerAction(slotRuntime,slotOne).registered,true);
+const duplicateSlot = adapters.compileSkillToCombatAction(slotUser,{id:'duplicate_slot',isClashable:false},{actionSlotId:'slot_user_slot_0',targetId:'slot_enemy'});
+assert.equal(runtimeApi.registerAction(slotRuntime,duplicateSlot).reason,'action_slot_already_used');
+const overCap = adapters.compileSkillToCombatAction(slotUser,{id:'over_cap',isClashable:false},{actionSlotId:'slot_user_slot_1',targetId:'slot_enemy'});
+assert.equal(runtimeApi.registerAction(slotRuntime,overCap).reason,'no_usable_action_slots');
+
+// Runtime automatically enables Coin-by-Coin Unfocused Volley resolution.
+const volleyUser = {id:'volley_user',faction:'allies',speed:9,hp:20,activeSlots:1};
+const volleyA = {id:'volley_a',faction:'enemies',speed:4,hp:20};
+const volleyB = {id:'volley_b',faction:'enemies',speed:3,hp:20};
+const volleyRuntime = runtimeApi.createRuntime({units:[volleyUser,volleyA,volleyB],random:()=>0});
+runtimeApi.beginTurn(volleyRuntime);
+const volleyAction = adapters.compileSkillToCombatAction(volleyUser,{
+  id:'runtime_unfocused',basePower:2,coinPower:1,coinAmount:3,coins:[{},{},{}],targetingType:'Unfocused Volley',isClashable:false,
+},{actionSlotId:'volley_user_slot_0',targetId:'volley_a'});
+assert.equal(runtimeApi.registerAction(volleyRuntime,volleyAction).registered,true);
+runtimeApi.playerPlanningReady(volleyRuntime);
+runtimeApi.aiPlanningReady(volleyRuntime);
+runtimeApi.beginCombatPhase(volleyRuntime);
+const beforeVolleyLog = attackTargets.length;
+const volleyResult = runtimeApi.resolveCombatPhase(volleyRuntime,{engine});
+assert.equal(volleyResult.completed,true);
+assert.deepEqual(attackTargets.slice(beforeVolleyLog),['volley_a','volley_b','volley_a']);
+
+// Grapple success cancels all unresolved target Actions and locks exactly one slot on each participant.
+const grappler = {id:'grappler',faction:'allies',speed:9,hp:20,initialActionSlots:1,maxActionSlots:2};
+const victim = {id:'victim',faction:'enemies',speed:5,hp:20,initialActionSlots:2,maxActionSlots:2};
+const grappleEncounter = economy.createEncounter({allies:[grappler],enemies:[victim],enemiesOptions:{roundGrowthEnabled:false}});
+const grappleRuntime = runtimeApi.createRuntime({units:[grappler,victim],encounter:grappleEncounter,random:()=>0.5});
+runtimeApi.beginTurn(grappleRuntime);
+const grappleAction = adapters.compileUniversalAction(grappler,'grapple',{actionSlotId:'grappler_slot_0',targetId:'victim'});
+assert.equal(runtimeApi.registerAction(grappleRuntime,grappleAction).registered,true);
+runtimeApi.playerPlanningReady(grappleRuntime);
+const victimAction1 = adapters.compileSkillToCombatAction(victim,{id:'victim_one',isClashable:false},{actionSlotId:'victim_slot_0',targetId:'grappler',isAi:true});
+const victimAction2 = adapters.compileSkillToCombatAction(victim,{id:'victim_two',isClashable:false},{actionSlotId:'victim_slot_1',targetId:'grappler',isAi:true});
+assert.equal(runtimeApi.registerAction(grappleRuntime,victimAction1).registered,true);
+assert.equal(runtimeApi.registerAction(grappleRuntime,victimAction2).registered,true);
+runtimeApi.aiPlanningReady(grappleRuntime);
+runtimeApi.beginCombatPhase(grappleRuntime);
+const grappleCombat = runtimeApi.resolveCombatPhase(grappleRuntime,{engine,contestResolver:()=>({success:true})});
+assert.equal(grappleCombat.completed,true);
+assert.equal(grappleRuntime.actionMap[victimAction1.id].state,'cancelled');
+assert.equal(grappleRuntime.actionMap[victimAction2.id].state,'cancelled');
+const grappleSnapshot = economy.snapshot(grappleEncounter);
+assert.equal(grappleSnapshot.allies.active.find(x=>x.id==='grappler').statusLocked,1);
+assert.equal(grappleSnapshot.enemies.active.find(x=>x.id==='victim').statusLocked,1);
+
+// Retreat with a Backup swaps the active Unit at Turn End and inherits at most two slots.
+const outgoing = {id:'outgoing',faction:'allies',speed:8,hp:20,initialActionSlots:2,currentActionSlots:2,maxActionSlots:3};
+const backup = {id:'backup',faction:'allies',speed:6,hp:20,initialActionSlots:1,maxActionSlots:3};
+const retreatEnemy = {id:'retreat_enemy',faction:'enemies',speed:3,hp:20,initialActionSlots:1,maxActionSlots:1};
+const retreatEncounter = economy.createEncounter({allies:[outgoing],allyBackups:[backup],enemies:[retreatEnemy],enemiesOptions:{roundGrowthEnabled:false}});
+const retreatRuntime = runtimeApi.createRuntime({units:[outgoing,retreatEnemy],encounter:retreatEncounter,random:()=>0.5});
+runtimeApi.beginTurn(retreatRuntime);
+const realRetreat = adapters.compileUniversalAction(outgoing,'retreat',{actionSlotId:'outgoing_slot_0'});
+assert.equal(runtimeApi.registerAction(retreatRuntime,realRetreat).registered,true);
+runtimeApi.playerPlanningReady(retreatRuntime);
+runtimeApi.aiPlanningReady(retreatRuntime);
+runtimeApi.beginCombatPhase(retreatRuntime);
+assert.equal(runtimeApi.resolveCombatPhase(retreatRuntime,{engine}).completed,true);
+const retreatEnd = runtimeApi.resolveTurnEnd(retreatRuntime,{engine});
+assert.equal(retreatEnd.completed,true);
+assert.ok(retreatRuntime.units.some(unit=>unit.id==='backup'));
+assert.ok(!retreatRuntime.units.some(unit=>unit.id==='outgoing'));
+assert.equal(retreatEncounter.allies.active[0].id,'backup');
+assert.ok(retreatEncounter.allies.active[0].currentActionSlots<=2);
+assert.ok(retreatEncounter.allies.backups.some(profile=>profile.id==='outgoing'));
+
+// Escape permanently removes the Unit from active encounter play and makes it XP-ineligible.
+const escaper = {id:'escaper',faction:'allies',speed:7,hp:20,initialActionSlots:1,maxActionSlots:1};
+const escapeEnemy = {id:'escape_enemy',faction:'enemies',speed:2,hp:20,initialActionSlots:1,maxActionSlots:1};
+const escapeEncounter = economy.createEncounter({allies:[escaper],enemies:[escapeEnemy],enemiesOptions:{roundGrowthEnabled:false}});
+const escapeRuntime = runtimeApi.createRuntime({units:[escaper,escapeEnemy],encounter:escapeEncounter,random:()=>0.5});
+runtimeApi.beginTurn(escapeRuntime);
+const escapeAction = adapters.compileUniversalAction(escaper,'escape',{actionSlotId:'escaper_slot_0'});
+assert.equal(runtimeApi.registerAction(escapeRuntime,escapeAction).registered,true);
+runtimeApi.playerPlanningReady(escapeRuntime);
+runtimeApi.aiPlanningReady(escapeRuntime);
+runtimeApi.beginCombatPhase(escapeRuntime);
+assert.equal(runtimeApi.resolveCombatPhase(escapeRuntime,{engine}).completed,true);
+const escapeEnd = runtimeApi.resolveTurnEnd(escapeRuntime,{engine});
+assert.equal(escapeEnd.completed,true);
+assert.equal(escaper.escaped,true);
+assert.equal(escaper.eligibleForXp,false);
+assert.ok(!escapeEncounter.allies.active.some(profile=>profile.id==='escaper'));
+assert.equal(runtimeApi.isUnitActive(escapeRuntime,escaper),false);
 
 console.log('combat-runtime-integration smoke: ok');

--- a/tests/combat-runtime-rules-smoke.mjs
+++ b/tests/combat-runtime-rules-smoke.mjs
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+
+await import('../js/combat-action-schema.js');
+const schema = globalThis.LuminousCombatAction;
+await import('../js/combat-action-adapters.js');
+const adapters = globalThis.LuminousCombatActionAdapters;
+await import('../js/combat-action-engine-bridge.js');
+await import('../js/combat-action-queue.js');
+const queue = globalThis.LuminousCombatActionQueue;
+await import('../js/team-action-economy.js');
+const economy = globalThis.LuminousTeamActionEconomy;
+await import('../js/combat-action-resolver.js');
+await import('../js/combat-runtime-integration.js');
+const runtimeApi = globalThis.LuminousCombatRuntimeIntegration;
+
+const engine = {
+  calculateFinalPower(skill, heads) { return Number(skill.basePower || 0) + Number(heads || 0); },
+  resolveUnilateralWithCounter(attacker, skill, defender) {
+    defender.hp = Math.max(0, Number(defender.hp ?? 20) - 1);
+    return { damageTaken:1 };
+  },
+  resolveStandardClash() { return { winner:'A', clashLogs:[], mitigationPenalty:0 }; },
+  resolveSpell() { return { isSuccess:false }; },
+  getCoinProbability() { return 50; },
+};
+
+// Runtime owns the default one-Quick-per-side budget when no TeamActionEconomy encounter exists.
+const quickUser = {id:'quick_user',faction:'allies',speed:8,hp:20};
+const quickEnemy = {id:'quick_enemy',faction:'enemies',speed:4,hp:20};
+const quickRuntime = runtimeApi.createRuntime({units:[quickUser,quickEnemy],random:()=>0.5});
+runtimeApi.beginTurn(quickRuntime);
+const makeQuick = (id) => schema.createCombatAction({
+  actorId:'quick_user',source:{type:'trait',id},economy:{cost:'quick_action'},
+  phase:{selectedAt:'planning_phase_player',executesAt:'planning_phase_player'},
+  targeting:{mode:'single',allegiance:'enemy',mainTargetId:'quick_enemy',targetIds:['quick_enemy']},
+  resolution:{type:'unopposed'},metadata:{sourceDefinition:{id,basePower:1,coinAmount:1,coins:[{}]}},
+});
+const q1 = runtimeApi.registerAction(quickRuntime,makeQuick('q1'),{context:{engine}});
+const q2 = runtimeApi.registerAction(quickRuntime,makeQuick('q2'),{context:{engine}});
+assert.equal(q1.result.resolved,true);
+assert.equal(q2.result.resolved,false);
+assert.equal(q2.result.reason,'team_quick_action_spent');
+assert.equal(quickRuntime.teamResources.allies.quickActionRemaining,0);
+
+// Prepared Reactions use the runtime's one-Reaction-per-Unit budget and resolve only once.
+const reactor = {id:'reactor',faction:'allies',speed:7,hp:20,activeSlots:1};
+const reactionEnemy = {id:'reaction_enemy',faction:'enemies',speed:3,hp:20};
+const reactionRuntime = runtimeApi.createRuntime({units:[reactor,reactionEnemy],random:()=>0.5});
+runtimeApi.beginTurn(reactionRuntime);
+const prepared = adapters.compileReactionToCombatAction(reactor,{id:'watch',sourceType:'trait'},{mode:'prepared',trigger:{type:'before_action'}});
+assert.equal(runtimeApi.registerAction(reactionRuntime,prepared).registered,true);
+const hit = adapters.compileSkillToCombatAction(reactor,{id:'hit',isClashable:false,coinAmount:1,coins:[{}]},{actionSlotId:'reactor_slot_0',targetId:'reaction_enemy'});
+assert.equal(runtimeApi.registerAction(reactionRuntime,hit).registered,true);
+runtimeApi.playerPlanningReady(reactionRuntime);
+runtimeApi.aiPlanningReady(reactionRuntime);
+runtimeApi.beginCombatPhase(reactionRuntime);
+assert.equal(runtimeApi.resolveCombatPhase(reactionRuntime,{engine}).completed,true);
+assert.equal(reactionRuntime.actionMap[prepared.id].state,'resolved');
+assert.equal(reactionRuntime.reactionRemaining.reactor,0);
+assert.equal(reactionRuntime.history.filter(entry=>entry.type==='reactions_resolved').length,1);
+
+// Retreat without Backup removes the Unit from encounter.active for exactly the following round,
+// does not redistribute it as a Backup swap, and restores the same profile for the next round after that.
+const runner = {id:'runner',faction:'allies',speed:9,hp:20,initialActionSlots:1,maxActionSlots:2};
+const guard = {id:'guard',faction:'enemies',speed:3,hp:20,initialActionSlots:1,maxActionSlots:1};
+const encounter = economy.createEncounter({allies:[runner],enemies:[guard],enemiesOptions:{roundGrowthEnabled:false}});
+const retreatRuntime = runtimeApi.createRuntime({units:[runner,guard],encounter,random:()=>0.5});
+runtimeApi.beginTurn(retreatRuntime);
+const retreat = adapters.compileUniversalAction(runner,'retreat',{actionSlotId:'runner_slot_0'});
+assert.equal(runtimeApi.registerAction(retreatRuntime,retreat).registered,true);
+runtimeApi.playerPlanningReady(retreatRuntime);
+runtimeApi.aiPlanningReady(retreatRuntime);
+runtimeApi.beginCombatPhase(retreatRuntime);
+assert.equal(runtimeApi.resolveCombatPhase(retreatRuntime,{engine}).completed,true);
+assert.equal(runtimeApi.resolveTurnEnd(retreatRuntime,{engine}).completed,true);
+assert.equal(runner.combatAbsentThroughRound,2);
+assert.ok(!encounter.allies.active.some(profile=>profile.id==='runner'));
+assert.equal(retreatRuntime.retreatReserve.length,1);
+
+const round2 = runtimeApi.nextRound(retreatRuntime);
+assert.equal(round2.round,2);
+assert.equal(runtimeApi.isUnitActive(retreatRuntime,runner),false);
+assert.ok(!encounter.allies.active.some(profile=>profile.id==='runner'));
+assert.equal(retreatRuntime.speedSnapshot[queue.speedSourceKey('runner',null)],undefined);
+
+runtimeApi.playerPlanningReady(retreatRuntime);
+runtimeApi.aiPlanningReady(retreatRuntime);
+runtimeApi.beginCombatPhase(retreatRuntime);
+assert.equal(runtimeApi.resolveCombatPhase(retreatRuntime,{engine}).completed,true);
+assert.equal(runtimeApi.resolveTurnEnd(retreatRuntime,{engine}).completed,true);
+const round3 = runtimeApi.nextRound(retreatRuntime);
+assert.equal(round3.round,3);
+assert.equal(runtimeApi.isUnitActive(retreatRuntime,runner),true);
+assert.ok(encounter.allies.active.some(profile=>profile.id==='runner'));
+assert.ok(retreatRuntime.speedSnapshot[queue.speedSourceKey('runner',null)]);
+assert.equal(retreatRuntime.retreatReserve.length,0);
+
+console.log('combat-runtime-rules smoke: ok');

--- a/tests/team-action-economy-smoke.mjs
+++ b/tests/team-action-economy-smoke.mjs
@@ -1,16 +1,16 @@
 import assert from 'node:assert/strict';
-import { createRequire } from 'node:module';
 
-const require = createRequire(import.meta.url);
-const economy = require('../js/team-action-economy.js');
+await import('../js/team-action-economy.js');
+const economy = globalThis.LuminousTeamActionEconomy;
+if (!economy?.createEncounter) throw new Error('LuminousTeamActionEconomy was not initialized.');
 
-globalThis.LuminousTeamActionEconomy = economy;
 globalThis.LuminousActionEconomy = {
   beginPlanning(unit) { unit.__planningCount = (unit.__planningCount || 0) + 1; },
   beginCombat(unit) { unit.__combatCount = (unit.__combatCount || 0) + 1; },
 };
 
-const bridge = require('../js/combat-team-economy-bridge.js');
+await import('../js/combat-team-economy-bridge.js');
+const bridge = globalThis.LuminousCombatTeamEconomyBridge;
 
 // Allied side: 12 total Actions, distributed by Speed; only the two fastest may reach 3.
 const allies = Array.from({ length: 8 }, (_, index) => ({


### PR DESCRIPTION
## Summary

Integrates the canonical CombatAction layer into a complete combat round runtime instead of adding another isolated helper.

### Runtime lifecycle
- ON_TURN_START Speed snapshot and equal-Speed random placement
- Player Planning → Ready → AI Planning → Ready
- COMBAT_START → COMBAT_PHASE → COMBAT_END
- ON_TURN_END → next round

### Speed / Queue
- One Speed per normal Unit, inherited by all its Action Slots
- Speed per Abnormality Part where applicable
- Side A visual order fast left→right; Side B fast right→left
- Equal Speed uses random placement generated at turn start; no hidden stat/ID tie-breaker in combat order
- Speed remains frozen for the round

### Clash
- A non-target may force a Clash only with strictly greater Speed
- The declared target may Clash regardless of relative Speed
- Clash pairs resolve once through `resolvedActionIds`
- If the opposing Action is cancelled/unavailable/Staggered, unilateral fallback still validates and consumes the active Action's economy/resources before damage

### Targeting / Volley
- Focused targeting cancels remaining Coins when its focused target becomes unavailable
- Unfocused Volley resolves Coin-by-Coin and randomly changes target each Coin, avoiding consecutive repeats while alternatives exist
- One remaining valid target can receive all remaining Coins
- Attack Weight restricts Unfocused Volley to the originally marked group
- Indiscriminate never includes the Skill user

### Cancellation / status
- Stagger/action-blocked Units lose unresolved Actions
- Mid-execution Stagger cuts remaining Coin-by-Coin resolution without reverting completed Coins
- Successful Grapple cancels the target's unresolved Actions and locks one slot on both participants when TeamActionEconomy is present

### Economy
- Normal Actions require an Action Slot and duplicate/over-cap planning is rejected
- Quick Action executes immediately during Planning
- One Quick + one Help per Side and one Reaction per Unit are enforced locally when no encounter economy is supplied
- Existing TeamActionEconomy remains authoritative when an encounter is present

### Turn End
- Retreat with backup swaps to the next backup and caps inherited slots at 2
- Retreat without backup removes the Unit from encounter.active for the full following round and restores it the round after
- Escape removes the Unit from active encounter play and makes it XP-ineligible

### Verification
Adds `Combat Runtime Smoke` CI plus focused smoke coverage for schema, team economy, CombatAction, resolver, queue, lifecycle, Volley, Reaction, Grapple, Retreat and Escape.

See `docs/combat-runtime-integration.md` for the integrated contract.