### PR TITLE
Combat: rebuild Skill Deck as independent Action Slot cycles

### DIFF
--- a/.github/workflows/combat-runtime-smoke.yml
+++ b/.github/workflows/combat-runtime-smoke.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - feature/combat-runtime-integration
+      - feature/combat-deck-engine
   pull_request:
     branches:
       - main
@@ -32,3 +33,5 @@ jobs:
         run: node tests/combat-runtime-integration-smoke.mjs
       - name: Combat Runtime Rules smoke
         run: node tests/combat-runtime-rules-smoke.mjs
+      - name: Combat Deck Engine smoke
+        run: node tests/combat-deck-engine-smoke.mjs

--- a/js/deckEngine.js
+++ b/js/deckEngine.js
@@ -1,87 +1,389 @@
-const DeckEngine = {
-    /**
-     * Initializes a unit's deck and drawing logic.
-     * @param {Object} unit - The unit whose deck is to be initialized.
-     * @param {Array} equippedSkills - Array of skill objects equipped by the unit.
-     */
-    initDeck: function(unit, equippedSkills) {
-        // Initialize deck based on equipped skills
-        unit.deck = [];
-        equippedSkills.forEach(skill => {
-            // Default amount is 1 if not specified
-            let amount = skill.skillAmount || 1;
-            for (let i = 0; i < amount; i++) {
-                unit.deck.push(Object.assign({}, skill));
+(function (global) {
+    "use strict";
+
+    const DECK_VERSION = 2;
+    const DEFAULT_CAPACITY = 12;
+    const DEFAULT_MAX_UNIQUE_SKILLS = 8;
+    const HAND_SIZE = 2;
+    const TIER_COPIES = Object.freeze({ 1: 3, 2: 2, 3: 1 });
+
+    const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+    const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+
+    function skillId(skill = {}) {
+        return String(skill.id ?? skill.skillId ?? skill.skill_id ?? skill.name ?? skill.nombre ?? "").trim();
+    }
+
+    function normalizeTier(value) {
+        if (typeof value === "string") {
+            const raw = value.trim().toUpperCase();
+            if (raw === "I") return 1;
+            if (raw === "II") return 2;
+            if (raw === "III") return 3;
+        }
+        const tier = Math.trunc(Number(value));
+        return [1, 2, 3].includes(tier) ? tier : null;
+    }
+
+    function tierOf(skill = {}) {
+        return normalizeTier(skill.tier ?? skill.skillTier ?? skill.skill_tier ?? skill.skillLevel ?? skill.skill_level);
+    }
+
+    function copiesForTier(tier) {
+        return TIER_COPIES[normalizeTier(tier)] || 0;
+    }
+
+    function availabilityType(skill = {}) {
+        return normalizeId(skill.availability?.type ?? skill.availabilityType ?? skill.skillAvailability ?? skill.skill_availability ?? "deck");
+    }
+
+    function isDeckEligible(skill = {}) {
+        if (skill.deck?.enabled === false || skill.inDeck === false || skill.in_deck === false) return false;
+        return !["granted", "free", "off_deck", "offdeck", "defensive", "defense"].includes(availabilityType(skill));
+    }
+
+    function copiesForSkill(skill = {}) {
+        const tier = tierOf(skill);
+        if (tier) return copiesForTier(tier);
+
+        // Legacy-readable only. Canonical combat Skills should author Tier I/II/III.
+        const legacy = Math.trunc(Number(skill.deckCopies ?? skill.skillAmount ?? skill.skill_amount));
+        return [1, 2, 3].includes(legacy) ? legacy : 0;
+    }
+
+    function buildDeckDefinition(equippedSkills = [], options = {}) {
+        const capacity = Math.max(1, Math.trunc(Number(options.capacity ?? DEFAULT_CAPACITY)) || DEFAULT_CAPACITY);
+        const maxUniqueSkills = Math.max(1, Math.trunc(Number(options.maxUniqueSkills ?? DEFAULT_MAX_UNIQUE_SKILLS)) || DEFAULT_MAX_UNIQUE_SKILLS);
+        const requireFull = options.requireFull !== false;
+        const cards = [];
+        const excludedSkillIds = [];
+        const uniqueIds = new Set();
+
+        for (const rawSkill of Array.isArray(equippedSkills) ? equippedSkills : []) {
+            if (!rawSkill || typeof rawSkill !== "object") continue;
+            const id = skillId(rawSkill);
+            if (!id) throw new Error("deck_skill_id_required");
+            if (!isDeckEligible(rawSkill)) {
+                excludedSkillIds.push(id);
+                continue;
             }
-        });
 
-        // Shuffle the deck initially
-        this.shuffleDeck(unit.deck);
-    },
+            const tier = tierOf(rawSkill);
+            const copies = copiesForSkill(rawSkill);
+            if (!copies) throw new Error(`deck_skill_tier_required:${id}`);
+            uniqueIds.add(id);
 
-    /**
-     * Shuffles a deck array in place using the Fisher-Yates algorithm.
-     * @param {Array} deck - The deck array to shuffle.
-     */
-    shuffleDeck: function(deck) {
+            for (let copyIndex = 0; copyIndex < copies; copyIndex++) {
+                cards.push({
+                    cardTemplateId: `${id}::copy::${copyIndex + 1}`,
+                    skillId: id,
+                    tier,
+                    copyIndex,
+                    skill: clone(rawSkill),
+                });
+            }
+        }
+
+        if (uniqueIds.size > maxUniqueSkills) throw new Error(`deck_unique_skill_limit_exceeded:${uniqueIds.size}/${maxUniqueSkills}`);
+        if (cards.length > capacity) throw new Error(`deck_capacity_exceeded:${cards.length}/${capacity}`);
+        if (requireFull && cards.length !== capacity) throw new Error(`deck_must_equal_capacity:${cards.length}/${capacity}`);
+
+        return {
+            version: DECK_VERSION,
+            capacity,
+            maxUniqueSkills,
+            cardCount: cards.length,
+            uniqueSkillCount: uniqueIds.size,
+            cards,
+            excludedSkillIds,
+            combatReady: cards.length === capacity,
+        };
+    }
+
+    function shuffleDeck(deck = [], random = Math.random) {
+        const rng = typeof random === "function" ? random : Math.random;
         for (let i = deck.length - 1; i > 0; i--) {
-            const j = Math.floor(Math.random() * (i + 1));
+            const roll = Math.max(0, Math.min(0.999999999999, Number(rng()) || 0));
+            const j = Math.floor(roll * (i + 1));
             [deck[i], deck[j]] = [deck[j], deck[i]];
         }
-    },
-
-    /**
-     * Draws the hand for a given action slot.
-     * Returns 2 active skills and 1 preview skill.
-     * If the deck runs out, it needs to be reshuffled from a discard pile (to be implemented as needed).
-     * @param {Array} deck - The unit's current deck of skills.
-     * @returns {Object} An object containing the drawn skills.
-     */
-    drawHandForSlot: function(deck) {
-        // We need at least 3 skills for a full hand (2 active, 1 preview)
-        // If there are fewer than 3 skills, we will just return what we have.
-        // In a full implementation, you would move a discard pile back to the deck and reshuffle.
-
-        let hand = {
-            activeOptions: [],
-            previewOption: null
-        };
-
-        if (deck.length >= 1) {
-            hand.activeOptions.push(deck.shift());
-        }
-        if (deck.length >= 1) {
-            hand.activeOptions.push(deck.shift());
-        }
-        if (deck.length >= 1) {
-            hand.previewOption = deck.shift();
-        }
-
-        return hand;
-    },
-
-    /**
-     * Injects a defensive skill into the hand, replacing a specified active option.
-     * This bypasses the random deck draw and is triggered by a long-press in the UI.
-     * @param {Object} currentHand - The current hand object (returned by drawHandForSlot).
-     * @param {Object} defensiveSkill - The static defensive skill to inject.
-     * @param {number} indexToReplace - The index of the active option to replace (0 or 1).
-     * @returns {Object} The updated hand.
-     */
-    injectDefensiveSkill: function(currentHand, defensiveSkill, indexToReplace) {
-        if (!currentHand || !currentHand.activeOptions) return currentHand;
-
-        if (indexToReplace >= 0 && indexToReplace < currentHand.activeOptions.length) {
-            // Replace the selected slot with the defensive skill
-            currentHand.activeOptions[indexToReplace] = Object.assign({}, defensiveSkill);
-        }
-
-        return currentHand;
+        return deck;
     }
-};
 
-if (typeof module !== 'undefined' && module.exports) {
-    module.exports = DeckEngine;
-} else if (typeof window !== 'undefined') {
-    window.DeckEngine = DeckEngine;
-}
+    function createRuntimeState(definition) {
+        return {
+            version: DECK_VERSION,
+            definition: clone(definition),
+            slots: {},
+            drawSerial: 0,
+            lastTurnStartRound: null,
+        };
+    }
+
+    function initDeck(unit, equippedSkills, options = {}) {
+        if (!unit || typeof unit !== "object") throw new Error("deck_unit_required");
+        const definition = buildDeckDefinition(equippedSkills, options);
+        unit.skillDeck = createRuntimeState(definition);
+
+        // Legacy-readable mirror. Canonical slot draws never consume this array.
+        unit.deck = definition.cards.map((card) => clone(card.skill));
+        return unit.skillDeck;
+    }
+
+    function hasDeck(unit = {}) {
+        return Boolean(unit.skillDeck?.definition?.cards?.length);
+    }
+
+    function ensureDrawPile(state, slot, random) {
+        if (slot.drawPile.length) return;
+        slot.cycle += 1;
+        slot.drawPile = state.definition.cards.map((card) => clone(card));
+        shuffleDeck(slot.drawPile, random);
+    }
+
+    function drawCard(state, slot, random) {
+        ensureDrawPile(state, slot, random);
+        const template = slot.drawPile.shift();
+        if (!template) throw new Error("deck_draw_failed");
+        state.drawSerial += 1;
+        return {
+            drawId: `${slot.id}::draw::${state.drawSerial}`,
+            cardTemplateId: template.cardTemplateId,
+            skillId: template.skillId,
+            tier: template.tier,
+            copyIndex: template.copyIndex,
+            cycle: slot.cycle,
+            skill: clone(template.skill),
+        };
+    }
+
+    function fillHand(state, slot, random) {
+        while (slot.hand.length < HAND_SIZE) slot.hand.push(drawCard(state, slot, random));
+        if (slot.hand.length > HAND_SIZE) slot.hand = slot.hand.slice(-HAND_SIZE);
+        return slot.hand;
+    }
+
+    function createSlotState(state, slotId, options = {}) {
+        const slot = {
+            id: String(slotId),
+            hand: [],
+            drawPile: [],
+            cycle: 0,
+            usedDrawId: null,
+            createdRound: options.round ?? null,
+            lastTurnStartRound: options.round ?? null,
+        };
+        fillHand(state, slot, options.random);
+        return slot;
+    }
+
+    function rotateSlotAtTurnStart(state, slot, options = {}) {
+        const oldest = slot.hand[0] || null;
+        const newest = slot.hand[1] || null;
+        const usedDrawId = slot.usedDrawId ? String(slot.usedDrawId) : null;
+        const usedNewest = Boolean(newest && usedDrawId === newest.drawId);
+
+        // Every surviving Slot ages one card per Turn Start. If the newest card was
+        // actually executed last round, it also leaves, accelerating the build by 2.
+        slot.hand = usedNewest ? [] : (newest ? [newest] : []);
+        slot.usedDrawId = null;
+        fillHand(state, slot, options.random);
+        slot.lastTurnStartRound = options.round ?? null;
+
+        return {
+            slotId: slot.id,
+            removedOldestDrawId: oldest?.drawId || null,
+            removedUsedNewestDrawId: usedNewest ? newest?.drawId || null : null,
+            hand: clone(slot.hand),
+        };
+    }
+
+    function slotIdsForCount(unit, count) {
+        const actorId = String(unit?.id ?? unit?.unitId ?? unit?.characterId ?? "unit");
+        const total = Math.max(0, Math.trunc(Number(count) || 0));
+        return Array.from({ length: total }, (_, index) => `${actorId}_slot_${index}`);
+    }
+
+    function onTurnStart(unit, options = {}) {
+        if (!hasDeck(unit)) return { synced: false, reason: "deck_not_initialized", slots: {} };
+        const state = unit.skillDeck;
+        const round = options.round ?? ((Number(state.lastTurnStartRound) || 0) + 1);
+        const random = typeof options.random === "function" ? options.random : Math.random;
+        const desiredSlotIds = Array.isArray(options.slotIds)
+            ? options.slotIds.map(String)
+            : slotIdsForCount(unit, options.slotCount ?? Object.keys(state.slots).length);
+        const desired = new Set(desiredSlotIds);
+        const removedSlotIds = [];
+        const createdSlotIds = [];
+        const rotated = [];
+
+        for (const slotId of Object.keys(state.slots)) {
+            if (desired.has(slotId)) continue;
+            removedSlotIds.push(slotId);
+            delete state.slots[slotId];
+        }
+
+        for (const slotId of desiredSlotIds) {
+            let slot = state.slots[slotId];
+            if (!slot) {
+                slot = createSlotState(state, slotId, { random, round });
+                state.slots[slotId] = slot;
+                createdSlotIds.push(slotId);
+                continue;
+            }
+            if (slot.lastTurnStartRound === round) continue;
+            rotated.push(rotateSlotAtTurnStart(state, slot, { random, round }));
+        }
+
+        state.lastTurnStartRound = round;
+        return {
+            synced: true,
+            round,
+            createdSlotIds,
+            removedSlotIds,
+            rotated,
+            slots: snapshot(unit).slots,
+        };
+    }
+
+    function getSlot(unit, slotId) {
+        return unit?.skillDeck?.slots?.[String(slotId)] || null;
+    }
+
+    function getSlotHand(unit, slotId) {
+        const slot = getSlot(unit, slotId);
+        return slot ? clone(slot.hand) : [];
+    }
+
+    function getHandOptions(unit, slotId) {
+        return getSlotHand(unit, slotId).map((card, handIndex) => ({
+            ...clone(card.skill),
+            __deckCard: {
+                slotId: String(slotId),
+                drawId: card.drawId,
+                skillId: card.skillId,
+                handIndex,
+                tier: card.tier,
+            },
+        }));
+    }
+
+    function markCardUsed(unit, slotId, drawId) {
+        const slot = getSlot(unit, slotId);
+        if (!slot) return { used: false, reason: "deck_slot_missing" };
+        const card = slot.hand.find((entry) => entry.drawId === String(drawId));
+        if (!card) return { used: false, reason: "deck_card_not_in_hand" };
+        slot.usedDrawId = card.drawId;
+        return { used: true, slotId: slot.id, drawId: card.drawId, skillId: card.skillId };
+    }
+
+    function bindActionToCard(action, unit, slotId, cardRef) {
+        if (!action || typeof action !== "object") throw new Error("deck_action_required");
+        const slot = getSlot(unit, slotId);
+        if (!slot) throw new Error("deck_slot_missing");
+
+        let card = null;
+        if (typeof cardRef === "number") card = slot.hand[cardRef] || null;
+        else if (typeof cardRef === "string") card = slot.hand.find((entry) => entry.drawId === cardRef) || null;
+        else if (cardRef?.drawId) card = slot.hand.find((entry) => entry.drawId === String(cardRef.drawId)) || null;
+        if (!card) throw new Error("deck_card_not_in_hand");
+
+        action.actionSlotId = String(slotId);
+        action.metadata = {
+            ...(action.metadata || {}),
+            deckCard: {
+                slotId: String(slotId),
+                drawId: card.drawId,
+                skillId: card.skillId,
+            },
+        };
+        return action;
+    }
+
+    function markActionUsed(unit, action = {}) {
+        const ref = action.metadata?.deckCard || action.metadata?.deckSelection || null;
+        if (!ref?.drawId) return { used: false, reason: "action_has_no_deck_card" };
+        const slotId = String(ref.slotId || action.actionSlotId || "");
+        if (!slotId) return { used: false, reason: "action_has_no_deck_slot" };
+        return markCardUsed(unit, slotId, ref.drawId);
+    }
+
+    function snapshot(unit = {}) {
+        if (!hasDeck(unit)) return { initialized: false };
+        const state = unit.skillDeck;
+        const slots = {};
+        for (const [slotId, slot] of Object.entries(state.slots)) {
+            slots[slotId] = {
+                id: slot.id,
+                hand: clone(slot.hand),
+                drawPileRemaining: slot.drawPile.length,
+                cycle: slot.cycle,
+                usedDrawId: slot.usedDrawId,
+                createdRound: slot.createdRound,
+                lastTurnStartRound: slot.lastTurnStartRound,
+            };
+        }
+        return {
+            initialized: true,
+            version: state.version,
+            capacity: state.definition.capacity,
+            cardCount: state.definition.cardCount,
+            combatReady: state.definition.combatReady,
+            lastTurnStartRound: state.lastTurnStartRound,
+            slots,
+        };
+    }
+
+    // Legacy helper retained for old prototype callers. Canonical combat uses
+    // onTurnStart() and independent per-Slot state; there is no preview card.
+    function drawHandForSlot(deck) {
+        const source = Array.isArray(deck) ? deck : [];
+        return {
+            activeOptions: source.splice(0, HAND_SIZE),
+            previewOption: null,
+        };
+    }
+
+    // Defensive Skills are permanent options outside the Deck. This helper no
+    // longer replaces a drawn card; it exposes the option separately.
+    function injectDefensiveSkill(currentHand, defensiveSkill) {
+        const hand = currentHand && typeof currentHand === "object" ? clone(currentHand) : { activeOptions: [], previewOption: null };
+        hand.defensiveOptions = Array.isArray(hand.defensiveOptions) ? hand.defensiveOptions : [];
+        hand.defensiveOptions.push(clone(defensiveSkill));
+        return hand;
+    }
+
+    const DeckEngine = Object.freeze({
+        DECK_VERSION,
+        DEFAULT_CAPACITY,
+        DEFAULT_MAX_UNIQUE_SKILLS,
+        HAND_SIZE,
+        TIER_COPIES,
+        skillId,
+        tierOf,
+        copiesForTier,
+        copiesForSkill,
+        isDeckEligible,
+        buildDeckDefinition,
+        initDeck,
+        hasDeck,
+        shuffleDeck,
+        createSlotState,
+        rotateSlotAtTurnStart,
+        slotIdsForCount,
+        onTurnStart,
+        getSlot,
+        getSlotHand,
+        getHandOptions,
+        markCardUsed,
+        bindActionToCard,
+        markActionUsed,
+        snapshot,
+        drawHandForSlot,
+        injectDefensiveSkill,
+    });
+
+    global.LuminousDeckEngine = DeckEngine;
+    global.DeckEngine = DeckEngine;
+    if (typeof module !== "undefined" && module.exports) module.exports = DeckEngine;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/tests/combat-deck-engine-smoke.mjs
+++ b/tests/combat-deck-engine-smoke.mjs
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+
+await import('../js/deckEngine.js');
+const deck = globalThis.LuminousDeckEngine;
+if (!deck) throw new Error('LuminousDeckEngine was not initialized.');
+
+const skills = [
+  { id:'skill_a', name:'Skill A', tier:1 },
+  { id:'skill_b', name:'Skill B', tier:'I' },
+  { id:'skill_c', name:'Skill C', tier:2 },
+  { id:'skill_d', name:'Skill D', tier:'II' },
+  { id:'skill_e', name:'Skill E', tier:3 },
+  { id:'skill_f', name:'Skill F', tier:'III' },
+];
+
+// Canonical 12-card build: Tier I = 3 copies, Tier II = 2, Tier III = 1.
+const definition = deck.buildDeckDefinition(skills);
+assert.equal(definition.capacity, 12);
+assert.equal(definition.cardCount, 12);
+assert.equal(definition.uniqueSkillCount, 6);
+assert.equal(definition.combatReady, true);
+const counts = Object.fromEntries(skills.map((skill) => [skill.id, definition.cards.filter((card) => card.skillId === skill.id).length]));
+assert.deepEqual(counts, {
+  skill_a:3,
+  skill_b:3,
+  skill_c:2,
+  skill_d:2,
+  skill_e:1,
+  skill_f:1,
+});
+
+// Granted / Off-Deck / Defensive Skills never enter the canonical Deck.
+const nonDeck = [
+  { id:'granted', tier:1, availability:{type:'granted'} },
+  { id:'off_deck', tier:1, availability:{type:'off_deck'} },
+  { id:'guard', tier:1, availability:{type:'defensive'} },
+];
+const preview = deck.buildDeckDefinition([...skills, ...nonDeck], { requireFull:false, capacity:20 });
+assert.deepEqual(preview.excludedSkillIds, ['granted','off_deck','guard']);
+assert.equal(preview.cardCount, 12);
+
+// Each Action Slot owns an independent real deck and always starts with two cards.
+// random=0 makes Fisher-Yates rotate the source list, yielding duplicate Skill A
+// in the opening hand; duplicates are intentionally legal.
+const unit = { id:'u1' };
+deck.initDeck(unit, skills);
+const first = deck.onTurnStart(unit, { round:1, slotCount:2, random:()=>0 });
+assert.equal(first.createdSlotIds.length, 2);
+assert.equal(deck.getSlotHand(unit,'u1_slot_0').length, 2);
+assert.equal(deck.getSlotHand(unit,'u1_slot_1').length, 2);
+assert.deepEqual(deck.getSlotHand(unit,'u1_slot_0').map((card)=>card.skillId), ['skill_a','skill_a']);
+assert.deepEqual(deck.getSlotHand(unit,'u1_slot_1').map((card)=>card.skillId), ['skill_a','skill_a']);
+assert.equal(deck.snapshot(unit).slots.u1_slot_0.drawPileRemaining, 10);
+assert.equal(deck.snapshot(unit).slots.u1_slot_1.drawPileRemaining, 10);
+
+// Slot 1 consuming cards never consumes Slot 2's independent draw pile.
+const slot0Round1 = deck.getSlotHand(unit,'u1_slot_0');
+const slot1Round1 = deck.getSlotHand(unit,'u1_slot_1');
+assert.equal(deck.markCardUsed(unit,'u1_slot_0',slot0Round1[1].drawId).used, true);
+const second = deck.onTurnStart(unit, { round:2, slotCount:2, random:()=>0 });
+assert.equal(second.rotated.length, 2);
+const slot0Round2 = deck.getSlotHand(unit,'u1_slot_0');
+const slot1Round2 = deck.getSlotHand(unit,'u1_slot_1');
+
+// Using the newest card accelerates that Slot by two cards.
+assert.ok(!slot0Round2.some((card)=>card.drawId === slot0Round1[0].drawId));
+assert.ok(!slot0Round2.some((card)=>card.drawId === slot0Round1[1].drawId));
+assert.equal(deck.snapshot(unit).slots.u1_slot_0.drawPileRemaining, 8);
+
+// A Slot with no used Deck Skill ages exactly one card; its newest survives.
+assert.equal(slot1Round2[0].drawId, slot1Round1[1].drawId);
+assert.ok(!slot1Round2.some((card)=>card.drawId === slot1Round1[0].drawId));
+assert.equal(deck.snapshot(unit).slots.u1_slot_1.drawPileRemaining, 9);
+
+// Planning a card does not make it used. If the CombatAction is cancelled before
+// execution, the selected newest card survives the normal Turn Start cycle.
+const plannedCard = slot1Round2[1];
+const plannedAction = { id:'planned', actionSlotId:null, metadata:{} };
+deck.bindActionToCard(plannedAction, unit, 'u1_slot_1', plannedCard.drawId);
+assert.equal(plannedAction.metadata.deckCard.drawId, plannedCard.drawId);
+deck.onTurnStart(unit, { round:3, slotCount:2, random:()=>0 });
+const slot1Round3 = deck.getSlotHand(unit,'u1_slot_1');
+assert.equal(slot1Round3[0].drawId, plannedCard.drawId);
+
+// Once execution starts, markActionUsed makes the card used even if the Skill is
+// later interrupted. A used newest card plus normal ageing rotates two cards.
+const executingAction = { id:'executing', actionSlotId:null, metadata:{} };
+deck.bindActionToCard(executingAction, unit, 'u1_slot_1', slot1Round3[1].drawId);
+assert.equal(deck.markActionUsed(unit, executingAction).used, true);
+const usedNewestId = slot1Round3[1].drawId;
+deck.onTurnStart(unit, { round:4, slotCount:2, random:()=>0 });
+assert.ok(!deck.getSlotHand(unit,'u1_slot_1').some((card)=>card.drawId === usedNewestId));
+
+// Losing a Slot destroys its hand. A regained Slot is new and immediately has two cards.
+const lostHandIds = deck.getSlotHand(unit,'u1_slot_1').map((card)=>card.drawId);
+const loss = deck.onTurnStart(unit, { round:5, slotCount:1, random:()=>0 });
+assert.deepEqual(loss.removedSlotIds, ['u1_slot_1']);
+assert.equal(deck.getSlot(unit,'u1_slot_1'), null);
+const gain = deck.onTurnStart(unit, { round:6, slotCount:2, random:()=>0 });
+assert.deepEqual(gain.createdSlotIds, ['u1_slot_1']);
+const gainedHand = deck.getSlotHand(unit,'u1_slot_1');
+assert.equal(gainedHand.length, 2);
+assert.ok(gainedHand.every((card)=>!lostHandIds.includes(card.drawId)));
+
+// When a Slot reaches the end of its private 12-card deck, it reshuffles a fresh
+// 12-card sequence. Hands never become empty.
+for (let round = 7; round <= 22; round++) {
+  deck.onTurnStart(unit, { round, slotCount:2, random:()=>0 });
+  assert.equal(deck.getSlotHand(unit,'u1_slot_0').length, 2);
+  assert.equal(deck.getSlotHand(unit,'u1_slot_1').length, 2);
+}
+assert.ok(deck.getSlot(unit,'u1_slot_0').cycle >= 2);
+assert.ok(deck.getSlot(unit,'u1_slot_1').cycle >= 2);
+
+// Re-running ON_TURN_START for the same round is idempotent.
+const beforeRepeat = deck.getSlotHand(unit,'u1_slot_0').map((card)=>card.drawId);
+deck.onTurnStart(unit, { round:22, slotCount:2, random:()=>0 });
+assert.deepEqual(deck.getSlotHand(unit,'u1_slot_0').map((card)=>card.drawId), beforeRepeat);
+
+console.log('combat deck engine smoke passed');


### PR DESCRIPTION
## Summary
- Replaces the legacy shared draw/preview prototype with the canonical 12-card combat Deck.
- Tier I / II / III expand to 3 / 2 / 1 copies.
- Each Action Slot owns an independent shuffled 12-card sequence and a FIFO hand of exactly 2 cards.
- Duplicate Skills in the same hand are legal.
- `ON_TURN_START` performs rotation: oldest always leaves; using the newest card accelerates the Slot by two cards.
- Planning/cancellation alone does not consume a card; `markActionUsed()` is called only when execution actually begins.
- Losing a Slot destroys its hand; a newly gained Slot immediately spawns with 2 cards.
- When a Slot exhausts its private sequence, it reshuffles a fresh copy of the 12-card Deck.
- Granted, Off-Deck and Defensive Skills are excluded from the Deck.
- Defensive Skill legacy injection no longer replaces a drawn card; it is exposed as a permanent external option.

## Tests
Adds `tests/combat-deck-engine-smoke.mjs` covering:
- Tier copy counts and 12-card validation
- legal duplicate draws
- independent Slot state
- FIFO rotation and accelerated rotation
- cancelled-before-execution preservation
- execution-start consumption
- Slot loss/regain behavior
- reshuffle cycles
- same-round `ON_TURN_START` idempotence

CI now runs the Deck smoke suite with the existing combat runtime smoke workflow.