### PR TITLE
Integrate Rogue class with Theatre and Combat runtimes

### DIFF
--- a/.github/workflows/combat-runtime-smoke.yml
+++ b/.github/workflows/combat-runtime-smoke.yml
@@ -37,3 +37,5 @@ jobs:
         run: node tests/combat-deck-engine-smoke.mjs
       - name: Orosh complete Theatre and Combat smoke
         run: node tests/orosh-lineage-runtime-smoke.mjs
+      - name: Rogue Theatre and Combat smoke
+        run: node tests/rogue-class-runtime-smoke.mjs

--- a/js/archetype-combat-event-runtime.js
+++ b/js/archetype-combat-event-runtime.js
@@ -41,5 +41,15 @@
       "js/orosh-lineage-complete-runtime.js",
       () => Boolean(global.LuminousOroshLineageCompleteRuntime),
     ))
+    .then(() => ensureScript(
+      "rogue-class-runtime-script",
+      "js/rogue-class-runtime.js",
+      () => Boolean(global.LuminousRogueClassRuntime),
+    ))
+    .then(() => ensureScript(
+      "rogue-combat-runtime-script",
+      "js/rogue-combat-runtime.js",
+      () => Boolean(global.LuminousRogueCombatRuntime),
+    ))
     .catch((error) => console.error("Archetype Combat Event Bootstrap:", error));
 })(typeof window !== "undefined" ? window : globalThis);

--- a/js/player-archetype-runtime.js
+++ b/js/player-archetype-runtime.js
@@ -41,5 +41,15 @@
       "js/orosh-lineage-complete-runtime.js",
       () => Boolean(global.LuminousOroshLineageCompleteRuntime),
     ))
+    .then(() => ensureScript(
+      "rogue-class-runtime-script",
+      "js/rogue-class-runtime.js",
+      () => Boolean(global.LuminousRogueClassRuntime),
+    ))
+    .then(() => ensureScript(
+      "rogue-theatre-runtime-script",
+      "js/rogue-theatre-runtime.js",
+      () => Boolean(global.LuminousRogueTheatreRuntime),
+    ))
     .catch((error) => console.error("Player Archetype Bootstrap:", error));
 })(window);

--- a/js/rogue-class-runtime.js
+++ b/js/rogue-class-runtime.js
@@ -1,0 +1,418 @@
+(function (global) {
+  "use strict";
+
+  const CLASS_ID = "rogue";
+  const CLASS_NAME = "Rogue";
+  const CATALOG_VERSION = 5;
+  const ABILITY_IDS = Object.freeze(["str", "dex", "con", "int", "wis", "cha"]);
+  const LANGUAGE_ID = "thieves_cant";
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const intOr = (value, fallback = 0) => Number.isFinite(Number.parseInt(value, 10)) ? Number.parseInt(value, 10) : fallback;
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+  const ROGUE_SOURCE = Object.freeze({ type: "class", id: CLASS_ID, classId: CLASS_ID, className: CLASS_NAME });
+  const THIEVES_CANT_DEFINITION = Object.freeze({
+    nombre: "Thieves' Cant",
+    sistema: "dnd",
+    tipo: "class_language",
+    classRestricted: true,
+    requiredClassId: CLASS_ID,
+    requiredClassLevel: 1,
+    estilo_ofuscacion: "ellipsis",
+  });
+
+  function deepFreeze(value, seen = new WeakSet()) {
+    if (!value || typeof value !== "object" || seen.has(value)) return value;
+    seen.add(value);
+    Reflect.ownKeys(value).forEach((key) => deepFreeze(value[key], seen));
+    return Object.freeze(value);
+  }
+
+  const ROGUE_DEFINITIONS = deepFreeze({
+    rogue_expertise: {
+      schemaVersion: 1,
+      id: "rogue_expertise",
+      name: "Expertise",
+      description: "Choose 2 proficient Abilities/Skills to gain Expertise. At Rogue level 30 choose 2 additional proficiencies.",
+      source: ROGUE_SOURCE,
+      contexts: ["theatre", "any"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [], rules: [],
+      mechanics: { instancePerSource: true, expertise: { abilityChoices: 2, additionalAtSourceClassLevel: { level: 30, abilityChoices: 2 } } },
+    },
+    sneak_attack: {
+      schemaVersion: 1, id: "sneak_attack", name: "Sneak Attack",
+      description: "Deal +max(1, floor(Rogue Class Level / 2))% Damage with Melee and Range Unopposed Attacks. Does not apply to Spells.",
+      source: ROGUE_SOURCE, contexts: ["combat"], activation: { type: "passive", actionCost: "none" }, effects: [], rules: [],
+      mechanics: { unopposedDamagePercentFormula: "max(1, floor(ClassLevel / 2))", attackKinds: ["melee", "range"], excludesSpells: true },
+    },
+    thieves_cant: {
+      schemaVersion: 1, id: "thieves_cant", name: "Thieves' Cant",
+      description: "Unlock Thieves' Cant as a Rogue-only language.", source: ROGUE_SOURCE, contexts: ["theatre", "any"],
+      activation: { type: "passive", actionCost: "none" }, effects: [], rules: [], mechanics: { languageGrant: LANGUAGE_ID, classRestricted: true },
+    },
+    cunning_action: {
+      schemaVersion: 1, id: "cunning_action", name: "Cunning Action",
+      description: "Gain +max(1, floor(Rogue Class Level / 20)) Max Speed, +max(1, floor(Rogue Class Level / 10)) Defense Power, and use a Quick Action to Retreat.",
+      source: ROGUE_SOURCE, contexts: ["combat"], activation: { type: "passive", actionCost: "none" }, effects: [], rules: [], mechanics: { quickRetreat: true },
+    },
+    uncanny_dodge: {
+      schemaVersion: 1, id: "uncanny_dodge", name: "Uncanny Dodge",
+      description: "Reaction [Before Getting]: take 50% less damage from the next Skill.", source: ROGUE_SOURCE, contexts: ["combat"],
+      activation: { type: "manual", actionCost: "reaction", trigger: "before_getting" }, effects: [], rules: [], mechanics: { nextSkillDamageMultiplier: 0.5 },
+    },
+    nimble_reflexes: {
+      schemaVersion: 1, id: "nimble_reflexes", name: "Nimble Reflexes",
+      description: "[On Evaded] recover 2 SP. Take 25% less damage when you are a secondary target of a Skill/Spell with 2+ ATK Weight.",
+      source: ROGUE_SOURCE, contexts: ["combat"], activation: { type: "passive", actionCost: "none" }, effects: [], rules: [],
+      mechanics: { recoverSpOnEvaded: 2, secondaryTargetDamageMultiplier: 0.75, minimumAttackWeight: 2 },
+    },
+    reliable_talent: {
+      schemaVersion: 1, id: "reliable_talent", name: "Reliable Talent",
+      description: "When making a Check with a Proficient Skill gain +3 Final Power.", source: ROGUE_SOURCE, contexts: ["theatre"],
+      activation: { type: "passive", actionCost: "none" }, effects: [], rules: [], mechanics: { proficientCheckFinalPower: 3 },
+    },
+    blindsense: {
+      schemaVersion: 1, id: "blindsense", name: "Blindsense",
+      description: "Invisible targets do not gain Invisible-derived buffs against you.", source: ROGUE_SOURCE, contexts: ["combat"],
+      activation: { type: "passive", actionCost: "none" }, effects: [], rules: [], mechanics: { suppressInvisibleBuffsAgainstSelf: true },
+    },
+    slippery_mind: {
+      schemaVersion: 1, id: "slippery_mind", name: "Slippery Mind",
+      description: "Gain +6 Final Save Power against Frightened/Charmed-inducing Skills, Spells and Traits; take 30% less Sinking damage; reduce SP loss by 3.",
+      source: ROGUE_SOURCE, contexts: ["combat", "theatre"], activation: { type: "passive", actionCost: "none" }, effects: [], rules: [],
+      mechanics: { finalSavePower: 6, saveAgainst: ["frightened", "charmed"], sinkingDamageMultiplier: 0.7, spLossReduction: 3 },
+    },
+    elusive: {
+      schemaVersion: 1, id: "elusive", name: "Elusive",
+      description: "Gain +15 Evade Power against Units with Positive Status effects. Gain Clash Power equal to the enemy's Power Buff.",
+      source: ROGUE_SOURCE, contexts: ["combat"], activation: { type: "passive", actionCost: "none" }, effects: [], rules: [],
+      mechanics: { evadePowerVsPositiveStatus: 15, mirrorEnemyPowerBuffAsClashPower: true },
+    },
+    stroke_of_luck: {
+      schemaVersion: 1, id: "stroke_of_luck", name: "Stroke of Luck",
+      description: "Repeat a Failed Check once. Gain +5% Heads Probability.", source: ROGUE_SOURCE, contexts: ["combat", "theatre"],
+      activation: { type: "passive", actionCost: "none" }, effects: [], rules: [], mechanics: { repeatFailedCheckOnce: true, headsProbabilityBonus: 0.05 },
+    },
+  });
+
+  const rogueGrant = (level, traitId) => ({
+    id: `core_class_rogue_l${level}_${traitId}`,
+    sourceType: "class", sourceId: CLASS_ID,
+    source: { className: CLASS_NAME, atLevel: level, requiredClassLevel: level },
+    atLevel: level, traitId, grantType: "trait", multiclassPolicy: "allowed",
+  });
+
+  const ROGUE_GRANTS = deepFreeze([
+    rogueGrant(1, "rogue_expertise"), rogueGrant(1, "sneak_attack"), rogueGrant(1, "thieves_cant"),
+    rogueGrant(10, "cunning_action"), rogueGrant(25, "uncanny_dodge"), rogueGrant(35, "nimble_reflexes"),
+    rogueGrant(55, "reliable_talent"), rogueGrant(70, "blindsense"), rogueGrant(75, "slippery_mind"),
+    rogueGrant(90, "elusive"), rogueGrant(100, "stroke_of_luck"),
+  ]);
+
+  function classEntries(character = {}) {
+    const candidates = [character.classes, character.characterBuild?.classes, character.dnd?.classes, character.classLevels];
+    for (const value of candidates) {
+      if (Array.isArray(value)) return value;
+      if (value && typeof value === "object") return Object.entries(value).map(([id, entry]) => typeof entry === "object" ? { id, ...entry } : { id, level: entry });
+    }
+    return [];
+  }
+
+  function getClassLevel(character = {}, classId = CLASS_ID, engine = global.LuminousTraitEngine) {
+    if (engine?.getClassLevel) {
+      const viaEngine = Number(engine.getClassLevel(character, classId));
+      if (Number.isFinite(viaEngine)) return Math.max(0, Math.trunc(viaEngine));
+    }
+    const id = normalizeId(classId);
+    const found = classEntries(character).find((entry) => normalizeId(entry?.classId || entry?.id || entry?.name) === id);
+    if (found) return Math.max(0, intOr(found.levels ?? found.level ?? found.classLevel, 0));
+    const direct = character?.[`${id}Level`] ?? character?.classLevel?.[id];
+    return Math.max(0, intOr(direct, 0));
+  }
+
+  function rogueLevel(character = {}, engine) { return getClassLevel(character, CLASS_ID, engine); }
+  function activeAt(character, level, engine) { return rogueLevel(character, engine) >= level; }
+
+  function proficiencyState(character = {}, check = {}) {
+    const explicit = normalizeId(check.proficiencyState || check.profState || check.proficiency || "");
+    if (["none", "half", "proficient", "expertise"].includes(explicit)) return explicit;
+    const skillId = normalizeId(check.skillId || check.skill || "");
+    const abilityId = normalizeId(check.abilityId || check.statId || check.ability || "");
+    if (skillId) {
+      const map = character.skillProficiency || character.skillProficiencies || character.dndSkillProficiency || {};
+      const nested = character.dndSkills?.[skillId];
+      const value = normalizeId(map?.[skillId] ?? nested?.proficiency ?? nested?.proficiencyState ?? "none");
+      if (value) return value;
+    }
+    if (abilityId) {
+      const value = normalizeId(character.abilityProficiency?.[abilityId] ?? character.abilityProficiencies?.[abilityId] ?? "none");
+      if (value) return value;
+    }
+    return "none";
+  }
+
+  function expertiseChoiceCount(character = {}, engine) { return activeAt(character, 30, engine) ? 4 : activeAt(character, 1, engine) ? 2 : 0; }
+
+  function applyExpertiseChoices(character = {}, abilityIds = [], engine) {
+    const allowedCount = expertiseChoiceCount(character, engine);
+    const choices = [...new Set((abilityIds || []).map(normalizeId).filter(Boolean))];
+    if (choices.length > allowedCount) return { success: false, reason: `Expertise allows ${allowedCount} choices.`, allowedCount, choices };
+    if (!character.abilityProficiency || typeof character.abilityProficiency !== "object" || Array.isArray(character.abilityProficiency)) character.abilityProficiency = {};
+    if (!character.skillProficiency || typeof character.skillProficiency !== "object" || Array.isArray(character.skillProficiency)) character.skillProficiency = {};
+    choices.forEach((id) => {
+      if (ABILITY_IDS.includes(id)) character.abilityProficiency[id] = "expertise";
+      else character.skillProficiency[id] = "expertise";
+    });
+    if (!character.traitChoices || typeof character.traitChoices !== "object" || Array.isArray(character.traitChoices)) character.traitChoices = {};
+    character.traitChoices.rogue_expertise = { abilities: choices, sourceClassId: CLASS_ID };
+    return { success: true, allowedCount, choices, remainingChoices: Math.max(0, allowedCount - choices.length) };
+  }
+
+  function attackKind(skill = {}) {
+    const values = [skill.attackKind, skill.attack_kind, skill.rangeType, skill.range_type, skill.type, skill.skillType, skill.skill_type].map(normalizeId);
+    if (values.some((id) => ["melee", "close", "close_range", "melee_attack"].includes(id))) return "melee";
+    if (values.some((id) => ["range", "ranged", "ranged_attack", "long_range"].includes(id))) return "range";
+    return "";
+  }
+
+  function isSpellSkill(skill = {}) {
+    if (skill.isSpell === true || skill.spell === true) return true;
+    return [skill.type, skill.skillType, skill.skill_type, skill.sourceType, skill.source_type, skill.category].map(normalizeId).some((id) => id === "spell" || id.includes("spell"));
+  }
+
+  function sneakAttackPercent(character = {}, engine) {
+    const level = rogueLevel(character, engine);
+    return level >= 1 ? Math.max(1, Math.floor(level / 2)) : 0;
+  }
+
+  function applySneakAttackDamage(baseDamage, input = {}) {
+    const amount = Math.max(0, numberOr(baseDamage, 0));
+    const character = input.character || input.attacker || {};
+    const skill = input.skill || input.attackSkill || {};
+    const unopposed = input.unopposed === true || input.clashMetadata?.unopposed === true || input.context?.unopposed === true;
+    const kind = attackKind(skill);
+    if (!activeAt(character, 1, input.engine) || !unopposed || isSpellSkill(skill) || !["melee", "range"].includes(kind)) return amount;
+    return amount * (1 + sneakAttackPercent(character, input.engine) / 100);
+  }
+
+  function cunningActionBonuses(character = {}, engine) {
+    const level = rogueLevel(character, engine);
+    if (level < 10) return { maxSpeed: 0, defensePower: 0 };
+    return { maxSpeed: Math.max(1, Math.floor(level / 20)), defensePower: Math.max(1, Math.floor(level / 10)) };
+  }
+
+  function useQuickRetreat(character = {}, options = {}) {
+    if (!activeAt(character, 10, options.engine)) return { success: false, reason: "cunning_action_locked" };
+    const economy = options.actionEconomy || global.LuminousActionEconomy;
+    const phaseOptions = { ...(options.actionOptions || {}), phase: options.phase || "planning" };
+    if (economy?.consume && !economy.consume(character, "quick_action", phaseOptions)) return { success: false, reason: "quick_action_unavailable" };
+    if (typeof options.retreat === "function") options.retreat(character, options);
+    if (typeof global.CustomEvent === "function" && global.document?.dispatchEvent) global.document.dispatchEvent(new global.CustomEvent("luminous:rogue-retreat", { detail: { character, sourceTraitId: "cunning_action" } }));
+    return { success: true, actionCost: "quick_action", action: "retreat" };
+  }
+
+  const UNCANNY_KEY = "__luminousRogueUncannyDodge";
+  function armUncannyDodge(character = {}, options = {}) {
+    if (!activeAt(character, 25, options.engine)) return { success: false, reason: "uncanny_dodge_locked" };
+    const economy = options.actionEconomy || global.LuminousActionEconomy;
+    const phaseOptions = { ...(options.actionOptions || {}), phase: options.phase || "combat" };
+    if (options.consumeReaction !== false && economy?.consume && !economy.consume(character, "reaction", phaseOptions)) return { success: false, reason: "reaction_unavailable" };
+    character[UNCANNY_KEY] = true;
+    return { success: true, armed: true };
+  }
+
+  function consumeUncannyDodge(character = {}) {
+    if (!character?.[UNCANNY_KEY]) return false;
+    character[UNCANNY_KEY] = false;
+    return true;
+  }
+
+  function incomingSkillMultiplier(character = {}, context = {}) {
+    let multiplier = 1;
+    const consumedUncanny = activeAt(character, 25, context.engine) && consumeUncannyDodge(character);
+    if (consumedUncanny) multiplier *= 0.5;
+    if (activeAt(character, 35, context.engine) && context.isSecondaryTarget === true && numberOr(context.attackWeight, 1) >= 2) multiplier *= 0.75;
+    if (activeAt(character, 75, context.engine) && normalizeId(context.damageType || context.statusId || context.damageSource) === "sinking") multiplier *= 0.7;
+    return { multiplier, consumedUncanny };
+  }
+
+  function applyIncomingSkillDamage(character = {}, damage, context = {}) {
+    const result = incomingSkillMultiplier(character, context);
+    return { damage: Math.max(0, numberOr(damage, 0)) * result.multiplier, ...result };
+  }
+
+  function readSp(character = {}) {
+    const keys = ["sp", "sanity", "currentSp", "currentSP"];
+    for (const key of keys) if (Number.isFinite(Number(character?.[key]))) return { owner: character, key, value: Number(character[key]) };
+    if (character.combatStats) for (const key of keys) if (Number.isFinite(Number(character.combatStats[key]))) return { owner: character.combatStats, key, value: Number(character.combatStats[key]) };
+    return { owner: character, key: "sp", value: 0 };
+  }
+
+  function onEvaded(character = {}, options = {}) {
+    if (!activeAt(character, 35, options.engine)) return { recovered: 0 };
+    const rec = readSp(character);
+    const maxSp = Number.isFinite(Number(character.maxSp ?? character.maxSP ?? character.combatStats?.maxSp ?? character.combatStats?.maxSP)) ? Number(character.maxSp ?? character.maxSP ?? character.combatStats?.maxSp ?? character.combatStats?.maxSP) : 45;
+    const before = rec.value;
+    rec.owner[rec.key] = Math.min(maxSp, before + 2);
+    return { recovered: rec.owner[rec.key] - before, before, after: rec.owner[rec.key] };
+  }
+
+  function reduceSpLoss(character = {}, loss, engine) {
+    const amount = Math.max(0, numberOr(loss, 0));
+    return activeAt(character, 75, engine) ? Math.max(0, amount - 3) : amount;
+  }
+
+  function reliableTalentFinalPower(character = {}, check = {}, engine) {
+    if (!activeAt(character, 55, engine)) return 0;
+    const state = proficiencyState(character, check);
+    return ["proficient", "expertise"].includes(state) ? 3 : 0;
+  }
+
+  function finalSavePowerBonus(character = {}, effect = {}, engine) {
+    if (!activeAt(character, 75, engine)) return 0;
+    const values = [effect.statusId, effect.conditionId, effect.effectId, effect.inflicts, effect.status, ...(Array.isArray(effect.statuses) ? effect.statuses : [])].map(normalizeId);
+    return values.some((id) => id.includes("fright") || id.includes("charm")) ? 6 : 0;
+  }
+
+  function hasPositiveStatus(unit = {}) {
+    if (unit.hasPositiveStatus === true) return true;
+    const stores = [unit.positiveStatuses, unit.positiveStatusEffects, unit.buffs, unit.statusEffects, unit.statuses];
+    return stores.some((store) => {
+      if (Array.isArray(store)) return store.some((entry) => entry?.positive === true || normalizeId(entry?.polarity || entry?.type) === "positive");
+      if (store && typeof store === "object") return Object.values(store).some((entry) => entry?.positive === true || normalizeId(entry?.polarity || entry?.type) === "positive");
+      return false;
+    });
+  }
+
+  function enemyPowerBuff(unit = {}) {
+    const explicit = [unit.powerBuff, unit.power_buff, unit.bonusPower, unit.bonus_power, unit.combatStats?.powerBuff].map(Number).find(Number.isFinite);
+    if (Number.isFinite(explicit)) return Math.max(0, explicit);
+    const stores = [unit.buffs, unit.statusEffects, unit.statuses];
+    let total = 0;
+    stores.forEach((store) => {
+      const entries = Array.isArray(store) ? store : Object.values(store || {});
+      entries.forEach((entry) => {
+        if (!entry || normalizeId(entry.stat || entry.statId || entry.effect) !== "power") return;
+        total += Math.max(0, numberOr(entry.amount ?? entry.value ?? entry.potency, 0));
+      });
+    });
+    return total;
+  }
+
+  function blindsenseSuppressesInvisibleBuffs(character = {}, source = {}, engine) {
+    if (!activeAt(character, 70, engine)) return false;
+    return source.invisible === true || source.isInvisible === true || Boolean(source.statusEffects?.invisible || source.statuses?.invisible);
+  }
+
+  function elusiveEvadePower(character = {}, enemy = {}, engine) { return activeAt(character, 90, engine) && hasPositiveStatus(enemy) ? 15 : 0; }
+  function elusiveClashPower(character = {}, enemy = {}, engine) { return activeAt(character, 90, engine) ? enemyPowerBuff(enemy) : 0; }
+  function headsProbabilityBonus(character = {}, engine) { return activeAt(character, 100, engine) ? 0.05 : 0; }
+  function hasThievesCant(character = {}, engine) { return activeAt(character, 1, engine); }
+
+  function isFailedCheck(result) {
+    if (!result) return false;
+    if (result.success === false || result.passed === false || result.failed === true) return true;
+    const value = normalizeId(result.outcome || result.result || result.status);
+    return ["fail", "failed", "failure"].includes(value);
+  }
+
+  function resolveTheatreCheck(character = {}, check = {}, attempt, options = {}) {
+    if (typeof attempt !== "function") throw new TypeError("attempt must be a function");
+    const finalPowerBonus = reliableTalentFinalPower(character, check, options.engine);
+    const headsBonus = headsProbabilityBonus(character, options.engine);
+    const context = { ...check, finalPowerBonus: numberOr(check.finalPowerBonus, 0) + finalPowerBonus, headsProbabilityBonus: numberOr(check.headsProbabilityBonus, 0) + headsBonus };
+    const first = attempt(context, { attempt: 1, strokeOfLuck: false });
+    const retry = (result) => {
+      if (!activeAt(character, 100, options.engine) || !isFailedCheck(result)) return { result, attempts: 1, retried: false, context };
+      const second = attempt({ ...context, strokeOfLuckRetry: true }, { attempt: 2, strokeOfLuck: true });
+      if (second && typeof second.then === "function") return second.then((value) => ({ result: value, attempts: 2, retried: true, context }));
+      return { result: second, attempts: 2, retried: true, context };
+    };
+    if (first && typeof first.then === "function") return first.then(retry);
+    return retry(first);
+  }
+
+  function ensureThievesCantOnCharacter(character = {}, engine) {
+    if (!hasThievesCant(character, engine)) return false;
+    if (!character.languages || typeof character.languages !== "object") character.languages = {};
+    const current = character.languages[LANGUAGE_ID];
+    if (typeof current === "number") character.languages[LANGUAGE_ID] = Math.max(100, current);
+    else character.languages[LANGUAGE_ID] = { ...(current && typeof current === "object" ? current : {}), habla: true, entiende: true, porcentaje: 100, classGranted: true };
+    return true;
+  }
+
+  function wrapCatalog() {
+    const source = global.LuminousTraitCatalogCore || (typeof require === "function" ? require("./trait-catalog-core.js") : null);
+    if (!source || source.__rogueClassCatalogExtended) return Boolean(source);
+    const baseDefinitions = source.allDefinitions?.bind(source) || (() => clone(source.DEFINITIONS || {}));
+    const baseGrants = source.allGrants?.bind(source) || (() => clone(source.GRANTS || []));
+    const baseGet = source.getDefinition?.bind(source) || (() => null);
+    const allDefinitions = () => ({ ...baseDefinitions(), ...clone(ROGUE_DEFINITIONS) });
+    const allGrants = () => [...baseGrants(), ...clone(ROGUE_GRANTS)];
+    global.LuminousTraitCatalogCore = Object.freeze({
+      ...source, __rogueClassCatalogExtended: true,
+      CATALOG_VERSION: Math.max(CATALOG_VERSION, Number(source.CATALOG_VERSION || 0)),
+      DEFINITIONS: deepFreeze({ ...(source.DEFINITIONS || baseDefinitions()), ...clone(ROGUE_DEFINITIONS) }),
+      GRANTS: deepFreeze([...(source.GRANTS || baseGrants()), ...clone(ROGUE_GRANTS)]),
+      allDefinitions, allGrants,
+      getDefinition(id) { return clone(ROGUE_DEFINITIONS[normalizeId(id)] || baseGet(id)); },
+    });
+    return true;
+  }
+
+  function wrapTraitEngine() {
+    const source = global.LuminousTraitEngine || (typeof require === "function" ? require("./trait-engine.js") : null);
+    if (!source || source.__rogueClassRuntimeWrapped) return Boolean(source);
+    const originalResolveTheatreCheck = source.resolveTheatreCheck?.bind(source);
+    const originalActivateTrait = source.activateTrait?.bind(source);
+    const wrapped = Object.freeze({
+      ...source,
+      __rogueClassRuntimeWrapped: true,
+      resolveTheatreCheck(input = {}) {
+        const result = originalResolveTheatreCheck ? originalResolveTheatreCheck(input) : { check: { ...(input.check || {}) }, state: input.state, outcomes: [] };
+        const character = input.character || input.self || {};
+        const bonus = reliableTalentFinalPower(character, result.check || input.check || {}, source);
+        result.check = { ...(result.check || input.check || {}), finalPowerBonus: numberOr(result.check?.finalPowerBonus, 0) + bonus };
+        if (bonus) result.outcomes = [...(result.outcomes || []), { type: "rogue_reliable_talent", traitId: "reliable_talent", finalPowerBonus: bonus }];
+        return result;
+      },
+      activateTrait(trait, runtime = {}, state) {
+        const result = originalActivateTrait ? originalActivateTrait(trait, runtime, state) : { available: true, trait, runtime, outcomes: [] };
+        const id = normalizeId(result?.trait?.id || trait?.id || trait?.name);
+        if (id === "uncanny_dodge" && result?.available !== false) {
+          const character = result.runtime?.self || result.runtime?.character || runtime.self || runtime.character || {};
+          const armed = armUncannyDodge(character, { engine: source, consumeReaction: false });
+          result.outcomes = [...(result.outcomes || []), { type: "rogue_uncanny_dodge_armed", traitId: "uncanny_dodge", ...armed }];
+        }
+        return result;
+      },
+    });
+    global.LuminousTraitEngine = wrapped;
+    return true;
+  }
+
+  function install() {
+    const catalogReady = wrapCatalog();
+    const engineReady = wrapTraitEngine();
+    const character = global.datosJugador || global.currentCharacter || null;
+    if (character) ensureThievesCantOnCharacter(character);
+    return catalogReady && engineReady;
+  }
+
+  const api = Object.freeze({
+    CLASS_ID, CLASS_NAME, CATALOG_VERSION, LANGUAGE_ID, THIEVES_CANT_DEFINITION, ROGUE_DEFINITIONS, ROGUE_GRANTS,
+    install, wrapCatalog, wrapTraitEngine, getClassLevel, rogueLevel, proficiencyState, expertiseChoiceCount, applyExpertiseChoices,
+    attackKind, isSpellSkill, sneakAttackPercent, applySneakAttackDamage, cunningActionBonuses, useQuickRetreat,
+    armUncannyDodge, consumeUncannyDodge, incomingSkillMultiplier, applyIncomingSkillDamage, onEvaded, reduceSpLoss,
+    reliableTalentFinalPower, finalSavePowerBonus, blindsenseSuppressesInvisibleBuffs, hasPositiveStatus, enemyPowerBuff,
+    elusiveEvadePower, elusiveClashPower, headsProbabilityBonus, hasThievesCant, ensureThievesCantOnCharacter,
+    isFailedCheck, resolveTheatreCheck,
+  });
+
+  global.LuminousRogueClassRuntime = api;
+  install();
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+  if (global.document && global.setInterval) global.setInterval(install, 800);
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/rogue-combat-runtime.js
+++ b/js/rogue-combat-runtime.js
@@ -1,0 +1,272 @@
+(function (global) {
+  "use strict";
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const BRIDGE_KEY = "__luminousRogueCombatBridgeState";
+  const SPEED_KEY = "__luminousRogueCunningSpeedBase";
+
+  function runtime() { return global.LuminousRogueClassRuntime || (typeof require === "function" ? require("./rogue-class-runtime.js") : null); }
+  function bridgeState() {
+    if (!global[BRIDGE_KEY]) global[BRIDGE_KEY] = { actionSession: null, opponent: new WeakMap(), resolutionStack: [] };
+    return global[BRIDGE_KEY];
+  }
+
+  function isInvisible(unit = {}) {
+    return unit.invisible === true || unit.isInvisible === true || Boolean(unit.statusEffects?.invisible || unit.statuses?.invisible);
+  }
+
+  function withHiddenInvisibleStatus(unit, hidden, callback) {
+    if (!hidden || !unit || typeof callback !== "function") return callback();
+    const stores = [unit.statusEffects, unit.statuses].filter((store) => store && typeof store === "object" && !Array.isArray(store));
+    const saved = stores.map((store) => ({ store, had: Object.prototype.hasOwnProperty.call(store, "invisible"), value: store.invisible }));
+    saved.forEach((entry) => { if (entry.had) delete entry.store.invisible; });
+    const direct = { invisible: unit.invisible, isInvisible: unit.isInvisible };
+    unit.invisible = false;
+    unit.isInvisible = false;
+    try { return callback(); }
+    finally {
+      unit.invisible = direct.invisible;
+      unit.isInvisible = direct.isInvisible;
+      saved.forEach((entry) => { if (entry.had) entry.store.invisible = entry.value; });
+    }
+  }
+
+  function currentOpponent(unit) { return bridgeState().opponent.get(unit) || null; }
+  function setOpponents(a, b) {
+    const state = bridgeState();
+    if (a && typeof a === "object") state.opponent.set(a, b || null);
+    if (b && typeof b === "object") state.opponent.set(b, a || null);
+  }
+  function clearOpponents(a, b) {
+    const state = bridgeState();
+    if (a && typeof a === "object") state.opponent.delete(a);
+    if (b && typeof b === "object") state.opponent.delete(b);
+  }
+
+  function currentSessionTargetInfo(skill = {}, options = {}) {
+    const session = bridgeState().actionSession;
+    const index = Number.isFinite(Number(options.rogueTargetIndex)) ? Math.max(0, Math.trunc(Number(options.rogueTargetIndex)))
+      : session ? Math.max(0, session.nextTargetIndex++) : 0;
+    const attackWeight = Math.max(1, numberOr(options.attackWeight ?? session?.attackWeight ?? skill.attackWeight ?? skill.attack_weight, 1));
+    return { targetIndex: index, isSecondaryTarget: options.isSecondaryTarget === true || index > 0, attackWeight };
+  }
+
+  function skillDamageType(skill = {}) {
+    return normalizeId(skill.damageType || skill.damage_type || skill.statusDamageType || skill.status_damage_type || skill.statusId || "");
+  }
+
+  function applyCunningSpeed(unit = {}) {
+    const rogue = runtime();
+    if (!rogue) return 0;
+    const bonus = rogue.cunningActionBonuses(unit).maxSpeed;
+    if (!bonus) return 0;
+    if (!unit[SPEED_KEY]) {
+      const key = Object.prototype.hasOwnProperty.call(unit, "maxSpeed") ? "maxSpeed"
+        : Object.prototype.hasOwnProperty.call(unit, "max_speed") ? "max_speed"
+          : unit.combatStats && Object.prototype.hasOwnProperty.call(unit.combatStats, "max_speed") ? "combatStats.max_speed" : "maxSpeed";
+      const base = key === "combatStats.max_speed" ? numberOr(unit.combatStats.max_speed, 0) : numberOr(unit[key], 0);
+      try { Object.defineProperty(unit, SPEED_KEY, { value: { key, base }, writable: true, configurable: true, enumerable: false }); }
+      catch (_) { unit[SPEED_KEY] = { key, base }; }
+    }
+    const record = unit[SPEED_KEY];
+    if (record.key === "combatStats.max_speed") {
+      if (!unit.combatStats) unit.combatStats = {};
+      unit.combatStats.max_speed = record.base + bonus;
+    } else unit[record.key] = record.base + bonus;
+    return bonus;
+  }
+
+  function adjustSpLoss(unit, before) {
+    const rogue = runtime();
+    if (!rogue || !unit || !Number.isFinite(Number(before)) || !Number.isFinite(Number(unit.sp))) return;
+    const after = Number(unit.sp);
+    if (after >= before) return;
+    const rawLoss = before - after;
+    const reduced = rogue.reduceSpLoss(unit, rawLoss);
+    unit.sp = before - reduced;
+  }
+
+  function withSpLossProtection(units, callback) {
+    const unique = [...new Set((units || []).filter((unit) => unit && typeof unit === "object"))];
+    const before = new Map(unique.map((unit) => [unit, Number.isFinite(Number(unit.sp)) ? Number(unit.sp) : null]));
+    const result = callback();
+    unique.forEach((unit) => adjustSpLoss(unit, before.get(unit)));
+    return result;
+  }
+
+  function withProbabilityUnits(engine, units, callback) {
+    const rogue = runtime();
+    if (!rogue || !engine?.getCoinProbability || !units?.length) return callback();
+    const originalProbability = engine.getCoinProbability;
+    let callIndex = 0;
+    engine.getCoinProbability = function (sp) {
+      const base = originalProbability.call(engine, sp);
+      const unit = units[callIndex % units.length];
+      callIndex += 1;
+      const bonus = rogue.headsProbabilityBonus(unit);
+      return Math.max(0, Math.min(100, base + bonus * 100));
+    };
+    try { return callback(); }
+    finally { engine.getCoinProbability = originalProbability; }
+  }
+
+  function wrapResolver() {
+    const source = global.LuminousCombatActionResolver;
+    if (!source || source.__rogueCombatResolverWrapped) return Boolean(source);
+    const originalResolve = source.resolveCombatAction?.bind(source);
+    const originalPrepared = source.resolvePreparedUnopposed?.bind(source);
+    const wrapped = Object.freeze({
+      ...source,
+      __rogueCombatResolverWrapped: true,
+      resolveCombatAction(input = {}, context = {}) {
+        if (!originalResolve) return { resolved: false, reason: "resolver_unavailable" };
+        const previous = bridgeState().actionSession;
+        bridgeState().actionSession = {
+          resolutionType: normalizeId(input?.resolution?.type),
+          attackWeight: Math.max(1, numberOr(input?.targeting?.attackWeight, 1)),
+          nextTargetIndex: 0,
+        };
+        try { return originalResolve(input, context); }
+        finally { bridgeState().actionSession = previous; }
+      },
+      resolvePreparedUnopposed(action, actor, targets, context = {}, options = {}) {
+        if (!originalPrepared) return { resolved: false, reason: "resolver_unavailable" };
+        const previous = bridgeState().actionSession;
+        bridgeState().actionSession = {
+          resolutionType: "unopposed",
+          attackWeight: Math.max(1, numberOr(action?.targeting?.attackWeight, 1)),
+          nextTargetIndex: 0,
+        };
+        try { return originalPrepared(action, actor, targets, context, options); }
+        finally { bridgeState().actionSession = previous; }
+      },
+    });
+    global.LuminousCombatActionResolver = wrapped;
+    return true;
+  }
+
+  function installEngine(engine = global.CombatEngine) {
+    const rogue = runtime();
+    if (!engine || !rogue) return false;
+    if (engine.__rogueClassCombatWrapped) return true;
+
+    const originalInitialize = engine.initializeUnitData?.bind(engine);
+    const originalPassive = engine.applyPassiveModifiers?.bind(engine);
+    const originalFinalPower = engine.calculateFinalPower?.bind(engine);
+    const originalCoinDamage = engine.calculateCoinDamage?.bind(engine);
+    const originalUnilateral = engine.resolveUnilateralWithCounter?.bind(engine);
+    const originalClash = engine.resolveStandardClash?.bind(engine);
+    const originalEvade = engine.resolveEvade?.bind(engine);
+    const originalGuard = engine.resolveGuard?.bind(engine);
+    const originalSpell = engine.resolveSpell?.bind(engine);
+    const originalProcessStatus = engine.processStatusEffects?.bind(engine);
+    const originalTrigger = engine.triggerEvent?.bind(engine);
+
+    if (originalInitialize) engine.initializeUnitData = function (unit) {
+      const result = originalInitialize(unit);
+      applyCunningSpeed(unit);
+      return result;
+    };
+
+    if (originalPassive) engine.applyPassiveModifiers = function (unit, contextOptions = null) {
+      const opponent = currentOpponent(unit);
+      const suppressInvisible = opponent && rogue.blindsenseSuppressesInvisibleBuffs(opponent, unit) && isInvisible(unit);
+      const modifiers = withHiddenInvisibleStatus(unit, suppressInvisible, () => originalPassive(unit, contextOptions)) || {};
+      const cunning = rogue.cunningActionBonuses(unit);
+      if (cunning.defensePower) modifiers.defense_power = numberOr(modifiers.defense_power, 0) + cunning.defensePower;
+      if (opponent) modifiers.clash_power = numberOr(modifiers.clash_power, 0) + rogue.elusiveClashPower(unit, opponent);
+      return modifiers;
+    };
+
+    if (originalFinalPower) engine.calculateFinalPower = function (skill, headsFlipped, unit) {
+      let power = originalFinalPower(skill, headsFlipped, unit);
+      const opponent = currentOpponent(unit);
+      const type = normalizeId(skill?.defenseSubtype || skill?.type);
+      if (unit && opponent && type === "evade") power += rogue.elusiveEvadePower(unit, opponent);
+      return power;
+    };
+
+    if (originalCoinDamage) engine.calculateCoinDamage = function (attacker, defender, skill, coinPower, isCritical, clashCount, context) {
+      let damage = originalCoinDamage(attacker, defender, skill, coinPower, isCritical, clashCount, context);
+      const info = skill?.__luminousRogueResolutionContext || {};
+      damage = rogue.applySneakAttackDamage(damage, { character: attacker, skill, unopposed: info.unopposed === true });
+      if (Number.isFinite(Number(info.incomingMultiplier)) && info.incomingMultiplier !== 1 && rogue.rogueLevel(defender) > 0) damage *= info.incomingMultiplier;
+      return damage;
+    };
+
+    if (originalUnilateral) engine.resolveUnilateralWithCounter = function (attacker, skill, defender, counterSkill, options = {}) {
+      const targetInfo = currentSessionTargetInfo(skill, options);
+      const unopposed = options.unopposed === true || options.clashMetadata?.unopposed === true || options.clashResult == null;
+      const incoming = rogue.incomingSkillMultiplier(defender, {
+        attackWeight: targetInfo.attackWeight,
+        isSecondaryTarget: targetInfo.isSecondaryTarget,
+        damageType: skillDamageType(skill),
+      });
+      const previous = skill.__luminousRogueResolutionContext;
+      skill.__luminousRogueResolutionContext = { ...targetInfo, unopposed, incomingMultiplier: incoming.multiplier, consumedUncanny: incoming.consumedUncanny };
+      setOpponents(attacker, defender);
+      try { return withProbabilityUnits(engine, [attacker], () => originalUnilateral(attacker, skill, defender, counterSkill, options)); }
+      finally {
+        if (previous === undefined) delete skill.__luminousRogueResolutionContext;
+        else skill.__luminousRogueResolutionContext = previous;
+        clearOpponents(attacker, defender);
+      }
+    };
+
+    if (originalClash) engine.resolveStandardClash = function (unitA, skillA, unitB, skillB) {
+      setOpponents(unitA, unitB);
+      try { return withProbabilityUnits(engine, [unitA, unitB], () => originalClash(unitA, skillA, unitB, skillB)); }
+      finally { clearOpponents(unitA, unitB); }
+    };
+
+    if (originalEvade) engine.resolveEvade = function (defender, evadeSkill, attacker, attackSkill) {
+      setOpponents(defender, attacker);
+      try { return withProbabilityUnits(engine, [defender, attacker], () => originalEvade(defender, evadeSkill, attacker, attackSkill)); }
+      finally { clearOpponents(defender, attacker); }
+    };
+
+    if (originalGuard) engine.resolveGuard = function (defender, guardSkill) {
+      return withProbabilityUnits(engine, [defender], () => originalGuard(defender, guardSkill));
+    };
+
+    if (originalSpell) engine.resolveSpell = function (spellSkill, target, targetHeadsFlipped) {
+      const result = originalSpell(spellSkill, target, targetHeadsFlipped) || {};
+      const bonus = rogue.finalSavePowerBonus(target, spellSkill);
+      if (bonus) {
+        result.savePower = numberOr(result.savePower, 0) + bonus;
+        result.isSuccess = result.savePower >= numberOr(result.dc ?? spellSkill?.saveDC, 0);
+        result.winner = result.isSuccess ? "Target" : "Caster";
+        result.rogueFinalSavePowerBonus = bonus;
+      }
+      return result;
+    };
+
+    if (originalProcessStatus) engine.processStatusEffects = function (unit, triggerKey, context = {}) {
+      return withSpLossProtection([unit], () => originalProcessStatus(unit, triggerKey, context));
+    };
+
+    if (originalTrigger) engine.triggerEvent = function (triggerKey, context = {}, targets = []) {
+      const units = [context?.attacker, context?.defender, context?.self, ...(Array.isArray(targets) ? targets : [])];
+      const result = withSpLossProtection(units, () => originalTrigger(triggerKey, context, targets));
+      if (normalizeId(triggerKey) === "on_evade") rogue.onEvaded(context?.defender || context?.self || targets?.[0] || {});
+      return result;
+    };
+
+    try { Object.defineProperty(engine, "__rogueClassCombatWrapped", { value: true, configurable: true, enumerable: false }); }
+    catch (_) { engine.__rogueClassCombatWrapped = true; }
+    return true;
+  }
+
+  function install() {
+    const engineReady = installEngine(global.CombatEngine);
+    const resolverReady = wrapResolver();
+    return engineReady || resolverReady;
+  }
+
+  const api = Object.freeze({ install, installEngine, wrapResolver, applyCunningSpeed, currentSessionTargetInfo });
+  global.LuminousRogueCombatRuntime = api;
+  install();
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+  if (global.setInterval) global.setInterval(install, 800);
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/rogue-theatre-runtime.js
+++ b/js/rogue-theatre-runtime.js
@@ -1,0 +1,123 @@
+(function (global) {
+  "use strict";
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  const RETRY_KEY = "__luminousRogueStrokeOfLuckRetry";
+
+  function runtime() { return global.LuminousRogueClassRuntime || (typeof require === "function" ? require("./rogue-class-runtime.js") : null); }
+  function playerCharacter() { return global.datosJugador || global.currentCharacter || global.characterData || {}; }
+
+  function effectiveCheckForRogue(character = {}, check = {}) {
+    const rogue = runtime();
+    if (!rogue) return { ...check };
+    const finalPowerBonus = rogue.reliableTalentFinalPower(character, check);
+    const headsProbabilityBonus = rogue.headsProbabilityBonus(character);
+    const next = { ...check, rogueFinalPowerBonus: finalPowerBonus, rogueHeadsProbabilityBonus: headsProbabilityBonus };
+    if (finalPowerBonus && Number.isFinite(Number(next.thresholdRaw ?? next.threshold))) {
+      if (next.thresholdRaw != null) next.thresholdRaw = Math.max(0, Number(next.thresholdRaw) - finalPowerBonus);
+      else next.threshold = Math.max(0, Number(next.threshold) - finalPowerBonus);
+    }
+    return next;
+  }
+
+  function wrapTheatreRolls() {
+    const source = global.LuminousTheatreRolls;
+    const rogue = runtime();
+    if (!source || !rogue || source.__rogueTheatreWrapped) return Boolean(source && rogue);
+    const originalArm = source.armCheck?.bind(source);
+    const originalPublish = source.publishRoll?.bind(source);
+    const wrapped = Object.freeze({
+      ...source,
+      __rogueTheatreWrapped: true,
+      armCheck(options = {}) {
+        const character = playerCharacter();
+        rogue.ensureThievesCantOnCharacter(character);
+        const check = effectiveCheckForRogue(character, options);
+        return originalArm ? originalArm(check) : check;
+      },
+      async publishRoll(payload = {}) {
+        const result = originalPublish ? await originalPublish(payload) : { published: false, payload };
+        const character = playerCharacter();
+        const outcome = normalizeId(payload.outcome || result?.outcome || payload.checkOutcome || result?.checkOutcome);
+        const failed = ["failed", "fail", "failure"].includes(outcome);
+        if (!failed || rogue.rogueLevel(character) < 100 || payload[RETRY_KEY] === true) return result;
+        const detail = { character, sourceTraitId: "stroke_of_luck", originalPayload: payload, retryOnce: true, retryKey: RETRY_KEY };
+        if (typeof global.LuminousTheatreRogueRetryHandler === "function") {
+          const retryResult = await global.LuminousTheatreRogueRetryHandler(detail);
+          return { ...result, rogueStrokeOfLuck: { requested: true, retried: true, retryResult } };
+        }
+        if (typeof global.CustomEvent === "function" && global.document?.dispatchEvent) global.document.dispatchEvent(new global.CustomEvent("luminous:rogue-stroke-of-luck-retry", { detail }));
+        return { ...result, rogueStrokeOfLuck: { requested: true, retried: false, reason: "theatre_retry_handler_required" } };
+      },
+    });
+    global.LuminousTheatreRolls = wrapped;
+    return true;
+  }
+
+  function wrapLanguageCatalog() {
+    const source = global.LuminousLanguageCatalog;
+    const rogue = runtime();
+    if (!source || !rogue || source.__rogueLanguageCatalogWrapped) return Boolean(source && rogue);
+    const originalList = source.list?.bind(source) || (() => []);
+    const originalGet = source.get?.bind(source) || (() => null);
+    const definition = rogue.THIEVES_CANT_DEFINITION;
+    const wrapped = Object.freeze({
+      ...source,
+      __rogueLanguageCatalogWrapped: true,
+      list() {
+        const values = originalList();
+        if (!values.some((entry) => normalizeId(entry?.languageId) === rogue.LANGUAGE_ID)) values.push({ languageId: rogue.LANGUAGE_ID, definition: { ...definition } });
+        return values;
+      },
+      get(languageId) {
+        if (normalizeId(languageId) === rogue.LANGUAGE_ID) return { ...definition };
+        return originalGet(languageId);
+      },
+    });
+    global.LuminousLanguageCatalog = wrapped;
+    return true;
+  }
+
+  function enforceThievesCant(character = playerCharacter()) {
+    const rogue = runtime();
+    if (!rogue) return false;
+    if (rogue.hasThievesCant(character)) return rogue.ensureThievesCantOnCharacter(character);
+    const languages = character?.languages;
+    if (languages && typeof languages === "object" && Object.prototype.hasOwnProperty.call(languages, rogue.LANGUAGE_ID)) delete languages[rogue.LANGUAGE_ID];
+    return false;
+  }
+
+  function wrapCharacterManager() {
+    const source = global.LuminousCharacterManager;
+    const rogue = runtime();
+    if (!source || !rogue || source.__rogueLanguageAccessWrapped) return Boolean(source && rogue);
+    const originalListLanguages = source.listLanguages?.bind(source);
+    if (!originalListLanguages) return false;
+    global.LuminousCharacterManager = Object.freeze({
+      ...source,
+      __rogueLanguageAccessWrapped: true,
+      listLanguages() {
+        const values = originalListLanguages();
+        if (!values.some((entry) => normalizeId(entry?.languageId) === rogue.LANGUAGE_ID)) values.push({ languageId: rogue.LANGUAGE_ID, language: { ...rogue.THIEVES_CANT_DEFINITION } });
+        return values;
+      },
+    });
+    return true;
+  }
+
+  function install() {
+    const rogue = runtime();
+    if (!rogue) return false;
+    enforceThievesCant();
+    const rolls = wrapTheatreRolls();
+    const languages = wrapLanguageCatalog();
+    const manager = wrapCharacterManager();
+    return rolls || languages || manager;
+  }
+
+  const api = Object.freeze({ install, effectiveCheckForRogue, wrapTheatreRolls, wrapLanguageCatalog, wrapCharacterManager, enforceThievesCant });
+  global.LuminousRogueTheatreRuntime = api;
+  install();
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+  if (global.setInterval) global.setInterval(install, 800);
+})(typeof window !== "undefined" ? window : globalThis);

--- a/tests/rogue-class-runtime-smoke.mjs
+++ b/tests/rogue-class-runtime-smoke.mjs
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+
+const realSetInterval = globalThis.setInterval;
+globalThis.setInterval = () => 0;
+
+globalThis.LuminousTraitCatalogCore = {
+  CATALOG_VERSION: 4,
+  DEFINITIONS: {},
+  GRANTS: [],
+  allDefinitions() { return {}; },
+  allGrants() { return []; },
+  getDefinition() { return null; },
+};
+
+globalThis.LuminousTraitEngine = {
+  getClassLevel(character, classId) {
+    return Number((character.classes || []).find((entry) => (entry.classId || entry.id) === classId)?.levels ?? (character.classes || []).find((entry) => (entry.classId || entry.id) === classId)?.level ?? 0);
+  },
+  resolveTheatreCheck(input = {}) { return { check: { ...(input.check || {}) }, state: input.state || {}, outcomes: [] }; },
+  activateTrait(trait, runtime = {}) { return { available: true, trait, runtime, outcomes: [] }; },
+};
+
+globalThis.LuminousActionEconomy = {
+  consume(unit, cost) {
+    if (cost === "reaction") {
+      if (unit.reactionSpent) return false;
+      unit.reactionSpent = true;
+      return true;
+    }
+    if (cost === "quick_action") {
+      if (unit.quickSpent) return false;
+      unit.quickSpent = true;
+      return true;
+    }
+    return true;
+  },
+};
+
+globalThis.LuminousLanguageCatalog = {
+  list() { return [{ languageId: "common", definition: { nombre: "Común", universal: true } }]; },
+  get(id) { return id === "common" ? { nombre: "Común", universal: true } : null; },
+};
+
+globalThis.LuminousCharacterManager = {
+  listLanguages() { return [{ languageId: "common", language: { nombre: "Común", universal: true } }]; },
+};
+
+let armedCheck = null;
+globalThis.LuminousTheatreRolls = {
+  armCheck(check) { armedCheck = { ...check }; return armedCheck; },
+  async publishRoll(payload) { return { published: true, outcome: payload.outcome }; },
+};
+
+function rogue(level, extra = {}) {
+  return { id: `rogue-${level}`, classes: [{ classId: "rogue", levels: level }], hp: 500, maxHp: 500, sp: 0, maxSp: 45, statusEffects: {}, abilityProficiency: { dex: "proficient" }, ...extra };
+}
+
+globalThis.datosJugador = rogue(100);
+
+globalThis.CombatEngine = {
+  currentState: "COMBAT_ACTIVE",
+  initializeUnitData() {},
+  getCoinProbability(sp) { return Math.max(5, Math.min(95, 50 + Number(sp || 0))); },
+  applyPassiveModifiers(unit) {
+    const result = { damage_dealt_multiplier: 0, damage_taken_multiplier: 0, defense_power: 0, clash_power: 0 };
+    if (unit.statusEffects?.invisible) result.clash_power += 9;
+    return result;
+  },
+  calculateFinalPower(skill) { return Number(skill.basePower || 0); },
+  calculateCoinDamage(attacker, defender, skill, coinPower) { return Number(coinPower || 0); },
+  resolveUnilateralWithCounter(attacker, skill, defender, counter, options = {}) {
+    const damage = this.calculateCoinDamage(attacker, defender, skill, 100, false, 0, { attacker, defender, skill });
+    defender.hp -= damage;
+    return { damageTaken: damage, options };
+  },
+  resolveStandardClash(a, sa, b, sb) {
+    const ma = this.applyPassiveModifiers(a, { skill: sa });
+    const mb = this.applyPassiveModifiers(b, { skill: sb });
+    return { powerA: this.calculateFinalPower(sa, [], a) + ma.clash_power, powerB: this.calculateFinalPower(sb, [], b) + mb.clash_power };
+  },
+  resolveEvade(defender, evadeSkill, attacker, attackSkill) {
+    return { evadePower: this.calculateFinalPower(evadeSkill, [], defender), attackPower: this.calculateFinalPower(attackSkill, [], attacker) };
+  },
+  resolveGuard(defender) { return { probability: this.getCoinProbability(defender.sp || 0) }; },
+  resolveSpell(spellSkill) { return { dc: spellSkill.saveDC || 10, savePower: 5, isSuccess: false, winner: "Caster" }; },
+  processStatusEffects(unit, trigger) { if (trigger === "lose_sp") unit.sp -= 8; return unit; },
+  triggerEvent() {},
+};
+
+globalThis.LuminousCombatActionResolver = {
+  resolveCombatAction(input, context = {}) {
+    const actor = context.actor;
+    const targets = context.targets || [];
+    const skill = { type: "Normal", attackKind: "melee", attackWeight: input.targeting?.attackWeight || 1 };
+    return { resolved: true, results: targets.map((target) => globalThis.CombatEngine.resolveUnilateralWithCounter(actor, { ...skill }, target, null, { clashResult: null })) };
+  },
+  resolvePreparedUnopposed(action, actor, targets) {
+    return { resolved: true, results: targets.map((target) => globalThis.CombatEngine.resolveUnilateralWithCounter(actor, { type: "Normal", attackKind: "melee", attackWeight: action.targeting?.attackWeight || 1 }, target, null, { clashResult: null })) };
+  },
+};
+
+await import("../js/rogue-class-runtime.js");
+const rogueRuntime = globalThis.LuminousRogueClassRuntime;
+assert.ok(rogueRuntime, "Rogue class runtime should install");
+assert.equal(rogueRuntime.expertiseChoiceCount(rogue(1)), 2);
+assert.equal(rogueRuntime.expertiseChoiceCount(rogue(30)), 4);
+const expertiseCharacter = rogue(30);
+assert.equal(rogueRuntime.applyExpertiseChoices(expertiseCharacter, ["dex", "stealth", "perception", "int"]).success, true);
+assert.equal(expertiseCharacter.skillProficiency.stealth, "expertise");
+assert.equal(rogueRuntime.sneakAttackPercent(rogue(1)), 1);
+assert.equal(rogueRuntime.sneakAttackPercent(rogue(100)), 50);
+assert.equal(rogueRuntime.applySneakAttackDamage(100, { character: rogue(100), skill: { type: "Normal", attackKind: "range" }, unopposed: true }), 150);
+assert.equal(rogueRuntime.applySneakAttackDamage(100, { character: rogue(100), skill: { type: "Spell", attackKind: "range" }, unopposed: true }), 100);
+assert.equal(rogueRuntime.cunningActionBonuses(rogue(40)).maxSpeed, 2);
+assert.equal(rogueRuntime.cunningActionBonuses(rogue(40)).defensePower, 4);
+const retreater = rogue(10);
+assert.equal(rogueRuntime.useQuickRetreat(retreater).success, true);
+assert.equal(retreater.quickSpent, true);
+const uncanny = rogue(25);
+assert.equal(rogueRuntime.armUncannyDodge(uncanny).success, true);
+assert.equal(rogueRuntime.applyIncomingSkillDamage(uncanny, 100).damage, 50);
+assert.equal(rogueRuntime.applyIncomingSkillDamage(uncanny, 100).damage, 100, "Uncanny Dodge must only affect the next Skill");
+const nimble = rogue(35);
+assert.equal(rogueRuntime.applyIncomingSkillDamage(nimble, 100, { attackWeight: 2, isSecondaryTarget: true }).damage, 75);
+assert.equal(rogueRuntime.applyIncomingSkillDamage(nimble, 100, { attackWeight: 2, isSecondaryTarget: false }).damage, 100);
+nimble.sp = 10;
+assert.equal(rogueRuntime.onEvaded(nimble).after, 12);
+assert.equal(rogueRuntime.reliableTalentFinalPower(rogue(55), { abilityId: "dex" }), 3);
+assert.equal(rogueRuntime.blindsenseSuppressesInvisibleBuffs(rogue(70), { statusEffects: { invisible: {} } }), true);
+assert.equal(rogueRuntime.finalSavePowerBonus(rogue(75), { statuses: ["frightened"] }), 6);
+assert.equal(rogueRuntime.applyIncomingSkillDamage(rogue(75), 100, { damageType: "sinking" }).damage, 70);
+assert.equal(rogueRuntime.reduceSpLoss(rogue(75), 8), 5);
+assert.equal(rogueRuntime.elusiveEvadePower(rogue(90), { hasPositiveStatus: true }), 15);
+assert.equal(rogueRuntime.elusiveClashPower(rogue(90), { powerBuff: 4 }), 4);
+assert.equal(rogueRuntime.headsProbabilityBonus(rogue(100)), 0.05);
+let attempts = 0;
+const retried = rogueRuntime.resolveTheatreCheck(rogue(100), { abilityId: "dex" }, () => ({ success: ++attempts > 1 }));
+assert.equal(retried.attempts, 2);
+assert.equal(retried.retried, true);
+assert.equal(rogueRuntime.hasThievesCant(rogue(1)), true);
+assert.equal(rogueRuntime.hasThievesCant({ classes: [] }), false);
+
+await import("../js/rogue-combat-runtime.js");
+const combatRuntime = globalThis.LuminousRogueCombatRuntime;
+assert.ok(combatRuntime, "Rogue combat runtime should install");
+const attacker = rogue(100);
+const targetA = { hp: 500, sp: 0, statusEffects: {} };
+const targetB = rogue(35);
+targetB.__luminousRogueUncannyDodge = true;
+const multi = globalThis.LuminousCombatActionResolver.resolveCombatAction(
+  { resolution: { type: "unopposed" }, targeting: { attackWeight: 2 } },
+  { actor: attacker, targets: [targetA, targetB] },
+);
+assert.equal(multi.results[0].damageTaken, 150, "Sneak Attack should apply through CombatEngine");
+assert.equal(multi.results[1].damageTaken, 56.25, "Secondary target should combine Uncanny Dodge and Nimble Reflexes");
+const cunning = rogue(40, { maxSpeed: 5 });
+globalThis.CombatEngine.initializeUnitData(cunning);
+assert.equal(cunning.maxSpeed, 7, "Cunning Action should increase Max Speed");
+assert.equal(globalThis.CombatEngine.applyPassiveModifiers(cunning).defense_power, 4, "Cunning Action should increase Defense Power");
+const mental = rogue(75, { sp: 0 });
+globalThis.CombatEngine.processStatusEffects(mental, "lose_sp");
+assert.equal(mental.sp, -5, "Slippery Mind should reduce SP loss by 3");
+const save = globalThis.CombatEngine.resolveSpell({ saveDC: 10, statuses: ["charmed"] }, rogue(75), []);
+assert.equal(save.savePower, 11);
+assert.equal(save.isSuccess, true);
+const lucky = rogue(100, { sp: 45 });
+assert.equal(globalThis.CombatEngine.resolveGuard(lucky, { type: "Guard" }).probability, 100, "Stroke of Luck should add 5 percentage points Heads Probability");
+const elusive = rogue(90);
+const buffedEnemy = { hp: 100, sp: 0, powerBuff: 6, hasPositiveStatus: true, statusEffects: {} };
+const evade = globalThis.CombatEngine.resolveEvade(elusive, { type: "Evade", basePower: 10 }, buffedEnemy, { type: "Normal", basePower: 10 });
+assert.equal(evade.evadePower, 25, "Elusive should add +15 Evade Power against a buffed unit");
+const invisibleEnemy = { hp: 100, sp: 0, statusEffects: { invisible: { count: 1 } } };
+const blindRogue = rogue(70);
+const clash = globalThis.CombatEngine.resolveStandardClash(invisibleEnemy, { basePower: 10 }, blindRogue, { basePower: 10 });
+assert.equal(clash.powerA, 10, "Blindsense should suppress Invisible-derived clash buffs against the Rogue");
+
+await import("../js/rogue-theatre-runtime.js");
+const theatreRuntime = globalThis.LuminousRogueTheatreRuntime;
+assert.ok(theatreRuntime, "Rogue Theatre runtime should install");
+globalThis.datosJugador = rogue(55);
+globalThis.LuminousTheatreRolls.armCheck({ thresholdRaw: 20, abilityId: "dex" });
+assert.equal(armedCheck.thresholdRaw, 17, "Reliable Talent +3 Final Power should apply to Theatre checks");
+const languages = globalThis.LuminousLanguageCatalog.list();
+assert.ok(languages.some((entry) => entry.languageId === "thieves_cant"), "Thieves' Cant should be registered in the language catalog");
+globalThis.datosJugador = rogue(1);
+theatreRuntime.enforceThievesCant(globalThis.datosJugador);
+assert.equal(globalThis.datosJugador.languages.thieves_cant.porcentaje, 100, "Rogues should automatically unlock Thieves' Cant");
+const nonRogue = { classes: [], languages: { thieves_cant: { porcentaje: 100 } } };
+theatreRuntime.enforceThievesCant(nonRogue);
+assert.equal(nonRogue.languages.thieves_cant, undefined, "Non-Rogues should not retain Thieves' Cant");
+
+globalThis.setInterval = realSetInterval;
+console.log("Rogue class Theatre/Combat smoke passed.");


### PR DESCRIPTION
## Summary
Adds the custom Rogue/Pícaro base class runtime through level 100 and wires its effects into both Luminous Theatre and Combat.

## Rogue progression implemented
- Lv1 Expertise: reuses the existing proficiency/expertise model; 2 choices, +2 more at Lv30
- Lv1 Sneak Attack: +max(1, floor(Rogue level / 2))% damage on Melee/Range Unopposed attacks; Spells excluded
- Lv1 Thieves' Cant: Rogue-only language grant
- Lv10 Cunning Action: scaling Max Speed and Defense Power; Quick Action Retreat
- Lv25 Uncanny Dodge: Reaction, next incoming Skill damage x0.5
- Lv35 Nimble Reflexes: On Evaded +2 SP; secondary targets of 2+ ATK Weight Skills/Spells take 25% less damage
- Lv55 Reliable Talent: +3 Final Power on proficient Checks
- Lv70 Blindsense: suppresses Invisible-derived buffs against the Rogue
- Lv75 Slippery Mind: +6 Final Save Power vs Frightened/Charmed-inducing effects, 30% less Sinking damage, SP loss reduced by 3
- Lv90 Elusive: +15 Evade Power vs units with Positive Status; Clash Power mirrors enemy Power Buff
- Lv100 Stroke of Luck: failed Check retry hook +5 percentage points Heads Probability

## Integration
- Adds Rogue trait definitions/grants to the trait catalog runtime
- Adds CombatEngine bridge for damage, SP, Evade/Clash/Save, Heads probability and targeting context
- Adds Theatre bridge for Reliable Talent, Stroke of Luck retry handoff and Thieves' Cant access
- Loads Rogue runtime from existing player/Theatre and combat runtime bootstraps

## Tests
Adds `tests/rogue-class-runtime-smoke.mjs` and runs it in `Combat Runtime Smoke`, covering both core helpers and mocked live engine bridges.