### PR TITLE
Integrate Rogue Mastermind archetype

### DIFF
--- a/.github/workflows/combat-runtime-smoke.yml
+++ b/.github/workflows/combat-runtime-smoke.yml
@@ -51,6 +51,10 @@ jobs:
         run: node tests/orosh-lineage-runtime-smoke.mjs
       - name: Rogue Theatre and Combat smoke
         run: node tests/rogue-class-runtime-smoke.mjs
+      - name: Mastermind archetype Theatre and Combat smoke
+        run: node tests/mastermind-archetype-runtime-smoke.mjs
+      - name: Mastermind Trait bridge smoke
+        run: node tests/mastermind-trait-bridge-smoke.mjs
       - name: Battle Viewer 0.7.3 rules smoke
         run: node tests/combat-v073-rules-smoke.mjs
       - name: Battle Viewer 0.7.3 runtime authority smoke

--- a/js/archetype-combat-event-runtime.js
+++ b/js/archetype-combat-event-runtime.js
@@ -51,5 +51,10 @@
       "js/rogue-combat-runtime.js",
       () => Boolean(global.LuminousRogueCombatRuntime),
     ))
+    .then(() => ensureScript(
+      "mastermind-archetype-runtime-script",
+      "js/mastermind-archetype-runtime.js",
+      () => Boolean(global.LuminousMastermindArchetypeRuntime),
+    ))
     .catch((error) => console.error("Archetype Combat Event Bootstrap:", error));
 })(typeof window !== "undefined" ? window : globalThis);

--- a/js/mastermind-archetype-runtime.js
+++ b/js/mastermind-archetype-runtime.js
@@ -1,0 +1,663 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousMastermindArchetypeRuntime) return;
+
+  const ARCHETYPE_ID = "mastermind";
+  const ARCHETYPE_NAME = "Mastermind";
+  const CLASS_ID = "rogue";
+  const CLASS_NAME = "Rogue";
+  const PATCH_INTERVAL_MS = 500;
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const intOr = (value, fallback = 0) => Number.isFinite(Number.parseInt(value, 10)) ? Number.parseInt(value, 10) : fallback;
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const asArray = (value) => value == null ? [] : (Array.isArray(value) ? value : [value]);
+
+  const ARCHETYPE = Object.freeze({
+    id: ARCHETYPE_ID,
+    name: ARCHETYPE_NAME,
+    classId: CLASS_ID,
+    className: CLASS_NAME,
+    unlockLevel: 15,
+    traitLevels: [15, 45, 65, 85],
+  });
+
+  const SOURCE = Object.freeze({
+    type: "archetype",
+    id: ARCHETYPE_ID,
+    archetypeId: ARCHETYPE_ID,
+    archetypeName: ARCHETYPE_NAME,
+    classId: CLASS_ID,
+    className: CLASS_NAME,
+  });
+
+  const DEFINITIONS = Object.freeze({
+    master_of_intrigue: Object.freeze({
+      schemaVersion: 1,
+      id: "master_of_intrigue",
+      name: "Master of Intrigue",
+      description: "You gain proficiency with the Disguise Kit, Forgery Kit, and one Gaming Set of your choice. You learn two additional languages. After listening to a creature speak for at least 1 minute, you can mimic its speech patterns, accent, and mannerisms well enough to pass yourself off as a native speaker of the same region or background.",
+      source: SOURCE,
+      contexts: ["theatre", "any"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [], rules: [],
+      mechanics: { narrative: true, languageChoices: 2, toolProficiencies: ["disguise_kit", "forgery_kit"], gamingSetChoices: 1, mimicSpeechAfterMinutes: 1 },
+    }),
+    master_of_tactics: Object.freeze({
+      schemaVersion: 1,
+      id: "master_of_tactics",
+      name: "Master of Tactics",
+      description: "You use Help as a Quick Action. Your Help gives +1 additional Final Power; if used on a slower ally, +2 instead; if used on the slowest ally, +3 instead.",
+      source: SOURCE,
+      contexts: ["combat"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [], rules: [],
+      mechanics: { helpActionCost: "quick_action", additionalHelpFinalPower: 1, slowerAllyAdditionalHelpFinalPower: 2, slowestAllyAdditionalHelpFinalPower: 3 },
+    }),
+    insightful_manipulator: Object.freeze({
+      schemaVersion: 1,
+      id: "insightful_manipulator",
+      name: "Insightful Manipulator",
+      description: "After observing or interacting with a creature for at least 1 minute outside of combat, you can assess its behavior and capabilities. You may determine whether selected mental or social attributes, or its overall experience, appear superior, equal, or inferior to your own. The DM may also reveal additional details about the creature's personality, habits, or background.",
+      source: SOURCE,
+      contexts: ["theatre", "any"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [], rules: [],
+      mechanics: { narrative: true, observationMinutes: 1 },
+    }),
+    misdirection: Object.freeze({
+      schemaVersion: 1,
+      id: "misdirection",
+      name: "Misdirection",
+      description: "When you use Help on an ally, that ally applies 1 Assist Guard. Assist Guard - [Unit Name]: when [Unit Name] is targeted by an Unopposed Attack, redirect the attack and force a Clash using an available Skill you haven't used or selected. Consume 1 Count.",
+      source: SOURCE,
+      contexts: ["combat"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [], rules: [],
+      mechanics: { onHelpApplyStatus: "assist_guard_[unit_name]", count: 1, intercepts: "unopposed_attack", consumesCount: 1, iconPending: true },
+    }),
+    soul_of_deceit: Object.freeze({
+      schemaVersion: 1,
+      id: "soul_of_deceit",
+      name: "Soul of Deceit",
+      description: "Your thoughts cannot be read unless you allow it. When a creature attempts to read your mind, you may present false thoughts instead. Effects that attempt to determine whether you are speaking truthfully treat you as truthful if you choose.",
+      source: SOURCE,
+      contexts: ["theatre", "any"],
+      activation: { type: "passive", actionCost: "none" },
+      effects: [], rules: [],
+      mechanics: { narrative: true, mindReadingRequiresConsent: true, canPresentFalseThoughts: true, mayAppearTruthful: true },
+    }),
+  });
+
+  const grant = (level, traitId) => Object.freeze({
+    sourceType: "archetype",
+    sourceId: ARCHETYPE_ID,
+    archetypeId: ARCHETYPE_ID,
+    classId: CLASS_ID,
+    atLevel: level,
+    traitId,
+    source: { ...SOURCE, atLevel: level, requiredClassLevel: level },
+  });
+
+  const GRANTS = Object.freeze([
+    grant(15, "master_of_intrigue"),
+    grant(15, "master_of_tactics"),
+    grant(45, "insightful_manipulator"),
+    grant(65, "misdirection"),
+    grant(85, "soul_of_deceit"),
+  ]);
+
+  function identityValues(entity = {}) {
+    return [
+      entity.combatId, entity.combat_id, entity.unitId, entity.unit_id,
+      entity.id, entity.playerId, entity.player_id, entity.characterId, entity.character_id,
+      entity.actorId, entity.actor_id, entity.uid, entity.vinculo_jugador,
+    ].filter((value) => value != null && String(value).trim() !== "").map((value) => String(value).trim());
+  }
+
+  function entityId(entity = {}) { return identityValues(entity)[0] || ""; }
+  function entityName(entity = {}) { return String(entity.characterName || entity.character_name || entity.nombre || entity.name || "Unknown").trim() || "Unknown"; }
+  function sameEntity(a, b) {
+    if (!a || !b) return false;
+    if (a === b) return true;
+    const ids = new Set(identityValues(a));
+    if (identityValues(b).some((id) => ids.has(id))) return true;
+    return normalizeId(entityName(a)) === normalizeId(entityName(b));
+  }
+
+  function unitList(context = {}) {
+    if (Array.isArray(context.units)) return context.units.filter(Boolean);
+    return Object.values(context.combatData || {}).filter(Boolean);
+  }
+
+  function unitById(context = {}, id) {
+    const wanted = String(id ?? "").trim();
+    if (!wanted) return null;
+    if (typeof context.getUnit === "function") {
+      const direct = context.getUnit(wanted);
+      if (direct) return direct;
+    }
+    return unitList(context).find((unit) => identityValues(unit).includes(wanted)) || null;
+  }
+
+  function normalizedCharacter(character = {}) {
+    if (Array.isArray(character.classes)) return character;
+    if (Array.isArray(character.characterBuild?.classes)) return { ...character, classes: character.characterBuild.classes };
+    return character;
+  }
+
+  function rogueLevel(character = {}) {
+    if (global.LuminousRogueClassRuntime?.rogueLevel) return Math.max(0, intOr(global.LuminousRogueClassRuntime.rogueLevel(character), 0));
+    const engine = global.LuminousArchetypeEngine;
+    if (engine?.getClassLevel) return Math.max(0, intOr(engine.getClassLevel(normalizedCharacter(character), CLASS_ID), 0));
+    const classes = Array.isArray(character.classes) ? character.classes : Array.isArray(character.characterBuild?.classes) ? character.characterBuild.classes : [];
+    const found = classes.find((entry) => normalizeId(entry?.classId || entry?.id || entry?.name) === CLASS_ID);
+    return Math.max(0, intOr(found?.levels ?? found?.level, 0));
+  }
+
+  function selectedMastermind(character = {}) {
+    const engine = global.LuminousArchetypeEngine;
+    if (engine?.isSelected) return Boolean(engine.isSelected(character, ARCHETYPE_ID, CLASS_ID));
+    const raw = character.characterBuild?.archetypes ?? character.archetypes ?? [];
+    const list = Array.isArray(raw) ? raw : Object.entries(raw || {}).map(([classId, value]) => typeof value === "string" ? { classId, archetypeId: value } : { classId, ...(value || {}) });
+    return list.some((entry) => normalizeId(entry?.classId || entry?.parentClassId) === CLASS_ID && normalizeId(entry?.archetypeId || entry?.subclassId || entry?.id) === ARCHETYPE_ID);
+  }
+
+  function hasMastermindLevel(character, level) { return selectedMastermind(character) && rogueLevel(character) >= Number(level || 0); }
+
+  function sameSide(a = {}, b = {}) {
+    const sideA = normalizeId(a.side || a.team || a.faction || a.faccion);
+    const sideB = normalizeId(b.side || b.team || b.faction || b.faccion);
+    if (sideA && sideB) return sideA === sideB;
+    return false;
+  }
+
+  function combatSpeed(unit = {}) {
+    const runtime = global.LuminousUniversalSpeedRuntime;
+    if (runtime?.effectiveSpeed) {
+      const resolved = Number(runtime.effectiveSpeed(unit));
+      if (Number.isFinite(resolved)) return resolved;
+    }
+    for (const value of [unit.speed, unit.effectiveSpeed, unit.currentSpeed, unit.maxSpeed, unit.max_speed, unit.combatStats?.maxSpeed, unit.combatStats?.max_speed]) {
+      if (Number.isFinite(Number(value))) return Number(value);
+    }
+    return 0;
+  }
+
+  function helpAdditionalBonus(mastermind, ally, context = {}) {
+    if (!mastermind || !ally) return 1;
+    const allies = unitList(context).filter((unit) => !sameEntity(unit, mastermind) && sameSide(unit, mastermind));
+    const allySpeed = combatSpeed(ally);
+    if (allies.length) {
+      const slowest = Math.min(...allies.map(combatSpeed));
+      if (allySpeed <= slowest) return 3;
+    }
+    if (allySpeed < combatSpeed(mastermind)) return 2;
+    return 1;
+  }
+
+  function actionById(context = {}, id) {
+    if (!id) return null;
+    if (typeof context.getActionById === "function") {
+      const found = context.getActionById(id);
+      if (found) return found;
+    }
+    if (context.actionMap instanceof Map) return context.actionMap.get(id) || null;
+    return context.actionMap?.[id] || null;
+  }
+
+  function helpTarget(action = {}, context = {}) {
+    for (const effect of asArray(action.effects)) {
+      if (normalizeId(effect?.type) !== "modify_combat_action") continue;
+      const targetAction = actionById(context, effect.targetActionId);
+      const unit = targetAction ? unitById(context, targetAction.actorId) : null;
+      if (unit) return { ally: unit, targetAction, effect };
+    }
+    for (const id of [action.targeting?.mainTargetId, ...asArray(action.targeting?.targetIds)]) {
+      const unit = unitById(context, id);
+      if (unit) return { ally: unit, targetAction: null, effect: null };
+    }
+    return { ally: null, targetAction: null, effect: null };
+  }
+
+  function isHelpAction(action = {}) {
+    return normalizeId(action.source?.type || action.source?.kind) === "universal" && normalizeId(action.source?.id) === "help";
+  }
+
+  function prepareMastermindHelp(actionInput, mastermind, context = {}) {
+    const action = clone(actionInput || {});
+    if (!hasMastermindLevel(mastermind, 15) || !isHelpAction(action)) return action;
+    if (!action.economy || typeof action.economy !== "object") action.economy = {};
+    action.economy.cost = "quick_action";
+    const { ally } = helpTarget(action, context);
+    const additional = ally ? helpAdditionalBonus(mastermind, ally, context) : 1;
+    action.effects = asArray(action.effects).map((effect) => {
+      if (normalizeId(effect?.type) !== "modify_combat_action") return clone(effect);
+      const next = clone(effect);
+      if (!next.modifier || typeof next.modifier !== "object") next.modifier = {};
+      next.modifier.amount = numberOr(next.modifier.amount, 1) + additional;
+      next.modifier.mastermindAdditional = additional;
+      return next;
+    });
+    action.metadata = { ...(action.metadata || {}), mastermindMasterOfTactics: true, mastermindHelpAdditional: additional };
+    return action;
+  }
+
+  function assistGuardStatusId(protectedUnit = {}) {
+    const key = normalizeId(entityId(protectedUnit) || entityName(protectedUnit) || "unit") || "unit";
+    return `assist_guard_${key}`;
+  }
+
+  function statusStore(unit = {}) {
+    if (global.LuminousStatusEngine?.ensureStore) return global.LuminousStatusEngine.ensureStore(unit);
+    if (!unit.statusEffects || typeof unit.statusEffects !== "object" || Array.isArray(unit.statusEffects)) unit.statusEffects = {};
+    return unit.statusEffects;
+  }
+
+  function applyAssistGuard(guard, protectedUnit, count = 1) {
+    if (!guard || !protectedUnit) return null;
+    const id = assistGuardStatusId(protectedUnit);
+    const input = {
+      mode: "gain",
+      name: `Assist Guard - ${entityName(protectedUnit)}`,
+      count: Math.max(1, intOr(count, 1)),
+      potency: 0,
+      duration: "until_removed",
+      sourceTraitId: "misdirection",
+      sourceUnitId: entityId(protectedUnit) || null,
+      data: {
+        protectedUnitId: entityId(protectedUnit) || null,
+        protectedUnitName: entityName(protectedUnit),
+        archetypeId: ARCHETYPE_ID,
+        dynamicStatus: true,
+        iconPending: true,
+      },
+    };
+    if (global.LuminousStatusEngine?.applyStatus) return global.LuminousStatusEngine.applyStatus(guard, id, input);
+    const store = statusStore(guard);
+    const existing = store[id] || null;
+    store[id] = { ...input, id, count: numberOr(existing?.count, 0) + input.count, data: { ...(existing?.data || {}), ...input.data } };
+    delete store[id].mode;
+    return clone(store[id]);
+  }
+
+  function assistGuardEntries(unit = {}) {
+    const store = statusStore(unit) || {};
+    return Object.entries(store).map(([id, value]) => ({ id: normalizeId(id), status: value })).filter(({ id, status }) =>
+      id.startsWith("assist_guard_") && normalizeId(status?.sourceTraitId) === "misdirection" && numberOr(status?.count, 0) > 0,
+    );
+  }
+
+  function statusProtects(status, protectedUnit) {
+    const wantedIds = new Set(identityValues(protectedUnit));
+    const storedId = String(status?.data?.protectedUnitId || status?.sourceUnitId || "").trim();
+    if (storedId && wantedIds.has(storedId)) return true;
+    return normalizeId(status?.data?.protectedUnitName) === normalizeId(entityName(protectedUnit));
+  }
+
+  function consumeAssistGuard(guard, statusId) {
+    const store = statusStore(guard);
+    const current = store?.[normalizeId(statusId)];
+    if (!current) return { consumed: false, countAfter: 0 };
+    const next = Math.max(0, numberOr(current.count, 0) - 1);
+    if (next <= 0) {
+      if (global.LuminousStatusEngine?.removeStatus) global.LuminousStatusEngine.removeStatus(guard, statusId, { from: "self", ignoreProtection: true });
+      else delete store[normalizeId(statusId)];
+    } else if (global.LuminousStatusEngine?.applyStatus) {
+      global.LuminousStatusEngine.applyStatus(guard, statusId, { ...current, mode: "set", count: next });
+    } else current.count = next;
+    return { consumed: true, countAfter: next };
+  }
+
+  function actionMapValues(context = {}) {
+    if (context.actionMap instanceof Map) return [...context.actionMap.values()];
+    return Object.values(context.actionMap || {});
+  }
+
+  function skillId(skill = {}) { return String(skill.id || skill.skillId || skill.skill_id || skill.name || "").trim(); }
+
+  function skillsForUnit(unit = {}, context = {}) {
+    if (typeof context.getAvailableAssistGuardSkills === "function") {
+      const direct = context.getAvailableAssistGuardSkills(unit);
+      if (Array.isArray(direct)) return direct.filter(Boolean);
+    }
+    if (typeof context.getSkillsForUnit === "function") {
+      const direct = context.getSkillsForUnit(unit);
+      if (Array.isArray(direct)) return direct.filter(Boolean);
+    }
+    const source = unit.availableSkills || unit.skills || unit.skillDeck || unit.skill_deck || unit.deck || [];
+    return Array.isArray(source) ? source.filter(Boolean) : Object.values(source || {}).filter(Boolean);
+  }
+
+  function selectedOrUsedSkillIds(unit, context = {}) {
+    const id = entityId(unit);
+    const ids = new Set();
+    actionMapValues(context).forEach((action) => {
+      if (String(action?.actorId || "") !== id) return;
+      if (normalizeId(action?.source?.type) !== "skill") return;
+      if (normalizeId(action?.state) === "cancelled") return;
+      const value = skillId(action.source);
+      if (value) ids.add(normalizeId(value));
+    });
+    return ids;
+  }
+
+  function assistGuardSkillAvailable(skill, guard, context = {}) {
+    if (!skill) return false;
+    const id = normalizeId(skillId(skill));
+    if (!id) return false;
+    if (skill.used === true || skill.isUsed === true || skill.selected === true || skill.isSelected === true || skill.disabled === true || skill.available === false || skill.__mastermindAssistGuardUsed === true) return false;
+    if (Number.isFinite(Number(skill.usesRemaining)) && Number(skill.usesRemaining) <= 0) return false;
+    if (Number.isFinite(Number(skill.cooldown)) && Number(skill.cooldown) > 0) return false;
+    if (selectedOrUsedSkillIds(guard, context).has(id)) return false;
+    if (typeof context.isAssistGuardSkillAvailable === "function" && context.isAssistGuardSkillAvailable({ skill, guard, context }) === false) return false;
+    return true;
+  }
+
+  function chooseAssistGuardSkill(guard, protectedUnit, attacker, incomingAction, context = {}) {
+    const candidates = skillsForUnit(guard, context).filter((skill) => assistGuardSkillAvailable(skill, guard, context));
+    if (!candidates.length) return null;
+    if (typeof context.selectAssistGuardSkill === "function") {
+      const selected = context.selectAssistGuardSkill({ guard, protectedUnit, attacker, incomingAction, candidates, context });
+      if (selected && typeof selected === "object") return selected;
+      const wanted = normalizeId(selected);
+      const found = candidates.find((skill) => normalizeId(skillId(skill)) === wanted);
+      if (found) return found;
+    }
+    return candidates[0];
+  }
+
+  function findAssistGuard(protectedUnit, attacker, incomingAction, context = {}) {
+    const candidates = [];
+    for (const guard of unitList(context)) {
+      if (sameEntity(guard, protectedUnit) || !sameSide(guard, protectedUnit)) continue;
+      for (const entry of assistGuardEntries(guard)) {
+        if (!statusProtects(entry.status, protectedUnit)) continue;
+        const skill = chooseAssistGuardSkill(guard, protectedUnit, attacker, incomingAction, context);
+        if (skill) candidates.push({ guard, statusId: entry.id, status: entry.status, skill });
+      }
+    }
+    if (!candidates.length) return null;
+    if (typeof context.selectAssistGuard === "function") {
+      const selected = context.selectAssistGuard({ protectedUnit, attacker, incomingAction, candidates, context });
+      if (selected && candidates.includes(selected)) return selected;
+      const selectedId = String(selected?.guardId || selected || "");
+      const found = candidates.find((entry) => entityId(entry.guard) === selectedId);
+      if (found) return found;
+    }
+    return candidates[0];
+  }
+
+  function buildAssistGuardAction(guard, attacker, skill, incomingAction = {}) {
+    const guardId = entityId(guard);
+    const attackerId = entityId(attacker);
+    const id = skillId(skill);
+    return {
+      id: `assist_guard_${guardId}_${normalizeId(id)}_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+      actorId: guardId,
+      source: { type: "skill", id },
+      economy: { cost: "action" },
+      phase: { selectedAt: incomingAction.phase?.selectedAt || "planning_phase_player", executesAt: incomingAction.phase?.executesAt || "combat_phase" },
+      targeting: { allegiance: "enemy", mode: "single", mainTargetId: attackerId, targetIds: [attackerId], attackWeight: Math.max(1, intOr(skill.attackWeight ?? skill.atkWeight ?? skill.attack_weight, 1)) },
+      resolution: { type: "clash" },
+      resources: clone(skill.resources || []),
+      modifiers: clone(skill.modifiers || []),
+      effects: [],
+      metadata: { sourceDefinition: clone(skill), assistGuard: true, protectedByMisdirection: true },
+      state: "planned",
+    };
+  }
+
+  function redirectedIncomingAction(actionInput, protectedUnit, guard) {
+    const action = clone(actionInput || {});
+    const protectedId = entityId(protectedUnit);
+    const guardId = entityId(guard);
+    if (!action.targeting || typeof action.targeting !== "object") action.targeting = {};
+    const ids = asArray(action.targeting.targetIds).map(String);
+    action.targeting.targetIds = ids.length ? ids.map((id) => id === protectedId ? guardId : id) : [guardId];
+    if (!action.targeting.targetIds.includes(guardId)) action.targeting.targetIds.unshift(guardId);
+    if (!action.targeting.mainTargetId || String(action.targeting.mainTargetId) === protectedId) action.targeting.mainTargetId = guardId;
+    action.resolution = { ...(action.resolution || {}), type: "clash" };
+    action.metadata = { ...(action.metadata || {}), assistGuardRedirectedFrom: protectedId, assistGuardRedirectedTo: guardId };
+    return action;
+  }
+
+  function protectedTargetForAction(action = {}, context = {}) {
+    const ids = [action.targeting?.mainTargetId, ...asArray(action.targeting?.targetIds)].filter(Boolean).map(String);
+    for (const id of ids) {
+      const target = unitById(context, id);
+      if (target) return target;
+    }
+    return null;
+  }
+
+  function markAssistGuardSkillUsed(guard, skill, context = {}, action = null) {
+    if (typeof context.markAssistGuardSkillUsed === "function") {
+      context.markAssistGuardSkillUsed({ guard, skill, action, context });
+      return;
+    }
+    try { skill.__mastermindAssistGuardUsed = true; } catch (_) {}
+  }
+
+  function tryAssistGuard(actionInput, context, resolverSource) {
+    if (!resolverSource?.resolveClashPair || context?.__mastermindAssistGuardActive) return null;
+    const action = clone(actionInput || {});
+    const attacker = unitById(context, action.actorId);
+    const protectedUnit = protectedTargetForAction(action, context);
+    if (!attacker || !protectedUnit || sameSide(attacker, protectedUnit)) return null;
+    const found = findAssistGuard(protectedUnit, attacker, action, context);
+    if (!found) return null;
+    const redirected = redirectedIncomingAction(action, protectedUnit, found.guard);
+    const guardAction = buildAssistGuardAction(found.guard, attacker, found.skill, action);
+    const clash = resolverSource.resolveClashPair(redirected, guardAction, { ...context, __mastermindAssistGuardActive: true });
+    if (!clash?.resolved) return null;
+    const consumption = consumeAssistGuard(found.guard, found.statusId);
+    markAssistGuardSkillUsed(found.guard, found.skill, context, guardAction);
+    return {
+      ...clash,
+      assistGuard: {
+        triggered: true,
+        statusId: found.statusId,
+        statusName: found.status?.name || `Assist Guard - ${entityName(protectedUnit)}`,
+        protectedUnitId: entityId(protectedUnit),
+        guardUnitId: entityId(found.guard),
+        skillId: skillId(found.skill),
+        countAfter: consumption.countAfter,
+      },
+    };
+  }
+
+  function helpApplied(result = {}) {
+    const entries = result.resolution?.effects || result.effects || [];
+    return asArray(entries).some((entry) => entry?.applied === true && normalizeId(entry?.effect?.type) === "modify_combat_action");
+  }
+
+  function maybeApplyMisdirection(mastermind, helpAction, result, context = {}) {
+    if (!hasMastermindLevel(mastermind, 65) || !result?.resolved || !helpApplied(result)) return null;
+    const { ally } = helpTarget(helpAction, context);
+    if (!ally || !sameSide(mastermind, ally)) return null;
+    return applyAssistGuard(ally, mastermind, 1);
+  }
+
+  function patchArchetypeCatalog() {
+    const source = global.LuminousArchetypeTraitCatalog;
+    if (!source?.allDefinitions || !source?.allGrants || !source?.allArchetypes) return false;
+    if (source.__mastermindArchetypeIntegrated) return true;
+    const originalDefinitions = source.allDefinitions.bind(source);
+    const originalGrants = source.allGrants.bind(source);
+    const originalArchetypes = source.allArchetypes.bind(source);
+    const originalGet = typeof source.getDefinition === "function" ? source.getDefinition.bind(source) : null;
+    const originalResolve = typeof source.resolveTraitGrants === "function" ? source.resolveTraitGrants.bind(source) : null;
+    const wrapped = Object.freeze({
+      ...source,
+      __mastermindArchetypeIntegrated: true,
+      MASTERMIND_ID: ARCHETYPE_ID,
+      MASTERMIND_CLASS_ID: CLASS_ID,
+      ARCHETYPES: Object.freeze({ ...(source.ARCHETYPES || {}), [ARCHETYPE_ID]: ARCHETYPE }),
+      DEFINITIONS: Object.freeze({ ...(source.DEFINITIONS || {}), ...DEFINITIONS }),
+      GRANTS: Object.freeze([...(source.GRANTS || []), ...GRANTS]),
+      allDefinitions() { return { ...originalDefinitions(), ...DEFINITIONS }; },
+      allGrants() { return [...originalGrants(), ...GRANTS.map((entry) => ({ ...entry, source: { ...(entry.source || {}) } }))]; },
+      allArchetypes() { return { ...originalArchetypes(), [ARCHETYPE_ID]: { ...ARCHETYPE } }; },
+      getDefinition(id) { return DEFINITIONS[normalizeId(id)] || originalGet?.(id) || null; },
+      resolveTraitGrants(character = {}, definitions) {
+        const base = originalResolve ? originalResolve(character, definitions) || [] : [];
+        const engine = global.LuminousArchetypeEngine;
+        const extra = engine?.resolveTraitGrants
+          ? engine.resolveTraitGrants(character, GRANTS, definitions ? { ...definitions, ...DEFINITIONS } : DEFINITIONS, { [ARCHETYPE_ID]: ARCHETYPE }, global.LuminousTraitEngine) || []
+          : [];
+        const byId = new Map();
+        [...base, ...extra].forEach((trait) => { const id = normalizeId(trait?.id || trait?.name); if (id && !byId.has(id)) byId.set(id, trait); });
+        return [...byId.values()];
+      },
+    });
+    global.LuminousArchetypeTraitCatalog = wrapped;
+    return true;
+  }
+
+  function patchCoreCatalog() {
+    const source = global.LuminousTraitCatalogCore;
+    if (!source?.allDefinitions || !source?.allGrants || source.__mastermindArchetypeIntegrated) return Boolean(source?.__mastermindArchetypeIntegrated);
+    const originalDefinitions = source.allDefinitions.bind(source);
+    const originalGrants = source.allGrants.bind(source);
+    const originalGet = typeof source.getDefinition === "function" ? source.getDefinition.bind(source) : null;
+    global.LuminousTraitCatalogCore = Object.freeze({
+      ...source,
+      __mastermindArchetypeIntegrated: true,
+      allDefinitions() { return { ...originalDefinitions(), ...DEFINITIONS }; },
+      allGrants() { return [...originalGrants(), ...GRANTS]; },
+      getDefinition(id) { return DEFINITIONS[normalizeId(id)] || originalGet?.(id) || null; },
+    });
+    return true;
+  }
+
+  function patchTraitEngine() {
+    const source = global.LuminousTraitEngine;
+    if (!source?.resolveTraitGrants || source.__mastermindArchetypeIntegrated) return Boolean(source?.__mastermindArchetypeIntegrated);
+    const originalResolve = source.resolveTraitGrants.bind(source);
+    global.LuminousTraitEngine = Object.freeze({
+      ...source,
+      __mastermindArchetypeIntegrated: true,
+      resolveTraitGrants(character = {}, grants = [], definitions = {}) {
+        const base = originalResolve(character, grants, definitions) || [];
+        const engine = global.LuminousArchetypeEngine;
+        const extra = engine?.resolveTraitGrants
+          ? engine.resolveTraitGrants(character, GRANTS, { ...definitions, ...DEFINITIONS }, { [ARCHETYPE_ID]: ARCHETYPE }, source) || []
+          : [];
+        const byId = new Map();
+        [...base, ...extra].forEach((trait) => { const id = normalizeId(trait?.id || trait?.name); if (id && !byId.has(id)) byId.set(id, trait); });
+        return [...byId.values()];
+      },
+    });
+    return true;
+  }
+
+  function isMastermindTrait(trait = {}) {
+    const source = trait.source || {};
+    return ["archetype", "subclass", "class_archetype"].includes(normalizeId(source.type || trait.sourceType)) && normalizeId(source.archetypeId || source.id) === ARCHETYPE_ID;
+  }
+
+  function patchArchetypeRuntime() {
+    const source = global.LuminousArchetypeRuntime;
+    if (!source?.syncArchetypeTraitsForUnit || source.__mastermindArchetypeIntegrated) return Boolean(source?.__mastermindArchetypeIntegrated);
+    const originalSync = source.syncArchetypeTraitsForUnit.bind(source);
+    global.LuminousArchetypeRuntime = Object.freeze({
+      ...source,
+      __mastermindArchetypeIntegrated: true,
+      syncArchetypeTraitsForUnit(unit = {}) {
+        const base = originalSync(unit) || [];
+        const engine = global.LuminousArchetypeEngine;
+        const granted = engine?.resolveTraitGrants
+          ? engine.resolveTraitGrants(unit, GRANTS, DEFINITIONS, { [ARCHETYPE_ID]: ARCHETYPE }, global.LuminousTraitEngine) || []
+          : [];
+        const existing = Array.isArray(unit.traitDefinitions) ? unit.traitDefinitions : [];
+        const byId = new Map();
+        [...existing.filter((trait) => !isMastermindTrait(trait)), ...granted].forEach((trait) => {
+          const id = normalizeId(trait?.id || trait?.name);
+          if (id && !byId.has(id)) byId.set(id, trait);
+        });
+        unit.traitDefinitions = [...byId.values()];
+        return [...base, ...granted];
+      },
+    });
+    return true;
+  }
+
+  function patchCombatActionResolver() {
+    const source = global.LuminousCombatActionResolver;
+    if (!source?.resolveCombatAction || source.__mastermindArchetypeIntegrated) return Boolean(source?.__mastermindArchetypeIntegrated);
+    const originalResolve = source.resolveCombatAction.bind(source);
+    const originalPrepared = typeof source.resolvePreparedUnopposed === "function" ? source.resolvePreparedUnopposed.bind(source) : null;
+    const originalClash = typeof source.resolveClashPair === "function" ? source.resolveClashPair.bind(source) : null;
+    const wrapped = Object.freeze({
+      ...source,
+      __mastermindArchetypeIntegrated: true,
+      resolveCombatAction(input = {}, context = {}) {
+        const actor = unitById(context, input.actorId);
+        let action = actor ? prepareMastermindHelp(input, actor, context) : clone(input);
+        const type = normalizeId(action.resolution?.type);
+        if (!context.__mastermindAssistGuardActive && (type === "unopposed" || (type === "clash" && !context.opposingAction))) {
+          const intercepted = tryAssistGuard(action, context, source);
+          if (intercepted) return intercepted;
+        }
+        const result = originalResolve(action, context);
+        if (actor && isHelpAction(action)) {
+          const status = maybeApplyMisdirection(actor, action, result, context);
+          if (status) result.mastermindMisdirection = { applied: true, status: clone(status), target: helpTarget(action, context).ally ? entityId(helpTarget(action, context).ally) : null };
+          result.mastermindMasterOfTactics = { applied: hasMastermindLevel(actor, 15), additionalHelpFinalPower: action.metadata?.mastermindHelpAdditional || 0, economyCost: action.economy?.cost };
+        }
+        return result;
+      },
+      resolvePreparedUnopposed(action, actor, targets, context = {}, options = {}) {
+        if (!context.__mastermindAssistGuardActive) {
+          const target = asArray(targets)[0];
+          const preparedAction = clone(action || {});
+          if (target) {
+            if (!preparedAction.targeting || typeof preparedAction.targeting !== "object") preparedAction.targeting = {};
+            preparedAction.targeting.mainTargetId = entityId(target);
+            preparedAction.targeting.targetIds = [entityId(target)];
+          }
+          const intercepted = tryAssistGuard(preparedAction, context, source);
+          if (intercepted) return intercepted;
+        }
+        return originalPrepared ? originalPrepared(action, actor, targets, context, options) : { resolved: false, reason: "prepared_unopposed_resolver_unavailable" };
+      },
+      resolveClashPair(action, opposingAction, context = {}) {
+        const opposingUnit = unitById(context, opposingAction?.actorId);
+        const opposingUnavailable = !opposingAction || ["resolved", "cancelled"].includes(normalizeId(opposingAction?.state)) || opposingUnit?.staggered === true || opposingUnit?.isStaggered === true;
+        if (!context.__mastermindAssistGuardActive && opposingUnavailable) {
+          const intercepted = tryAssistGuard(action, context, source);
+          if (intercepted) return intercepted;
+        }
+        return originalClash ? originalClash(action, opposingAction, context) : { resolved: false, reason: "clash_resolver_unavailable" };
+      },
+    });
+    global.LuminousCombatActionResolver = wrapped;
+    return true;
+  }
+
+  function install() {
+    patchArchetypeCatalog();
+    patchCoreCatalog();
+    patchTraitEngine();
+    patchArchetypeRuntime();
+    patchCombatActionResolver();
+    return true;
+  }
+
+  const api = Object.freeze({
+    ARCHETYPE_ID, ARCHETYPE_NAME, CLASS_ID, CLASS_NAME, ARCHETYPE, SOURCE, DEFINITIONS, GRANTS,
+    rogueLevel, selectedMastermind, hasMastermindLevel,
+    combatSpeed, helpAdditionalBonus, prepareMastermindHelp,
+    assistGuardStatusId, applyAssistGuard, assistGuardEntries, consumeAssistGuard,
+    skillsForUnit, assistGuardSkillAvailable, chooseAssistGuardSkill, findAssistGuard,
+    buildAssistGuardAction, redirectedIncomingAction, tryAssistGuard,
+    patchArchetypeCatalog, patchCoreCatalog, patchTraitEngine, patchArchetypeRuntime, patchCombatActionResolver, install,
+  });
+
+  global.LuminousMastermindArchetypeRuntime = api;
+  install();
+  if (global.document && global.setInterval) global.setInterval(install, PATCH_INTERVAL_MS);
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/mastermind-theatre-runtime.js
+++ b/js/mastermind-theatre-runtime.js
@@ -1,0 +1,306 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousMastermindTheatreRuntime) return;
+
+  const ARCHETYPE_ID = "mastermind";
+  const CLASS_ID = "rogue";
+  const PATCH_INTERVAL_MS = 700;
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+  let traitEngineSource = null;
+  let playerTraitSource = null;
+
+  function currentCharacter() {
+    return global.LuminousPlayerTraitRuntime?.getCharacter?.() || global.datosJugador || null;
+  }
+
+  function grantedMastermindTraits(character = {}) {
+    const catalog = global.LuminousArchetypeTraitCatalog;
+    const granted = catalog?.resolveTraitGrants?.(character) || [];
+    return granted.filter((trait) => {
+      const source = trait?.source || {};
+      return normalizeId(source.archetypeId || source.id) === ARCHETYPE_ID && normalizeId(source.classId) === CLASS_ID;
+    });
+  }
+
+  function hasTrait(character = {}, traitId) {
+    const wanted = normalizeId(traitId);
+    const granted = grantedMastermindTraits(character);
+    if (granted.some((trait) => normalizeId(trait?.id || trait?.name) === wanted)) return true;
+    const runtime = global.LuminousMastermindArchetypeRuntime;
+    const levelByTrait = {
+      master_of_intrigue: 15,
+      master_of_tactics: 15,
+      insightful_manipulator: 45,
+      misdirection: 65,
+      soul_of_deceit: 85,
+    };
+    return Boolean(runtime?.hasMastermindLevel?.(character, levelByTrait[wanted] || Number.POSITIVE_INFINITY));
+  }
+
+  function ensureObject(root, key) {
+    if (!root[key] || typeof root[key] !== "object" || Array.isArray(root[key])) root[key] = {};
+    return root[key];
+  }
+
+  function masterOfIntrigueChoices(character = {}) {
+    const stored = character.traitChoices?.master_of_intrigue || {};
+    const languages = [...new Set((stored.languages || []).map(normalizeId).filter(Boolean))].slice(0, 2);
+    const gamingSet = normalizeId(stored.gamingSet || stored.gamingSetId || "") || null;
+    return { languages, gamingSet };
+  }
+
+  function syncMasterOfIntrigue(character = {}) {
+    if (!hasTrait(character, "master_of_intrigue")) return { active: false, character };
+    const tools = ensureObject(character, "toolProficiencies");
+    tools.disguise_kit = "proficient";
+    tools.forgery_kit = "proficient";
+
+    const choices = masterOfIntrigueChoices(character);
+    if (choices.gamingSet) tools[choices.gamingSet] = "proficient";
+    const languages = ensureObject(character, "languages");
+    choices.languages.forEach((languageId) => {
+      const existing = languages[languageId];
+      languages[languageId] = typeof existing === "number"
+        ? Math.max(100, existing)
+        : { ...(existing && typeof existing === "object" ? existing : {}), habla: true, entiende: true, porcentaje: 100, traitGranted: true, sourceTraitId: "master_of_intrigue" };
+    });
+
+    character.mastermindTheatre = {
+      ...(character.mastermindTheatre || {}),
+      masterOfIntrigue: {
+        fixedToolProficiencies: ["disguise_kit", "forgery_kit"],
+        gamingSetChoices: 1,
+        languageChoices: 2,
+        selectedGamingSet: choices.gamingSet,
+        selectedLanguages: [...choices.languages],
+        mimicSpeechAfterMinutes: 1,
+      },
+    };
+    return { active: true, choices, tools: clone(tools), languages: clone(languages) };
+  }
+
+  function applyMasterOfIntrigueChoices(character = {}, input = {}) {
+    if (!hasTrait(character, "master_of_intrigue")) return { applied: false, reason: "master_of_intrigue_unavailable" };
+    const languages = [...new Set((input.languages || []).map(normalizeId).filter(Boolean))];
+    const gamingSet = normalizeId(input.gamingSet || input.gamingSetId || "") || null;
+    if (languages.length > 2) return { applied: false, reason: "master_of_intrigue_language_limit", maximum: 2 };
+    if (Array.isArray(input.gamingSets) && input.gamingSets.filter(Boolean).length > 1) return { applied: false, reason: "master_of_intrigue_gaming_set_limit", maximum: 1 };
+    ensureObject(character, "traitChoices").master_of_intrigue = { languages, gamingSet };
+    const synced = syncMasterOfIntrigue(character);
+    return { applied: true, ...synced };
+  }
+
+  function canMimicSpeech(character = {}, observedMinutes = 0) {
+    return hasTrait(character, "master_of_intrigue") && numberOr(observedMinutes, 0) >= 1;
+  }
+
+  function statScore(character = {}, abilityId) {
+    const id = normalizeId(abilityId);
+    const aliases = {
+      int: ["int", "intelligence", "inteligencia"],
+      wis: ["wis", "wisdom", "sabiduria"],
+      cha: ["cha", "charisma", "carisma"],
+    }[id] || [id];
+    const stats = character.stats || {};
+    for (const key of aliases) {
+      const value = stats[key] ?? character[key];
+      if (Number.isFinite(Number(value))) return Number(value);
+    }
+    return 10;
+  }
+
+  function totalLevel(character = {}) {
+    if (Number.isFinite(Number(character.level))) return Number(character.level);
+    const classes = Array.isArray(character.classes) ? character.classes : Array.isArray(character.characterBuild?.classes) ? character.characterBuild.classes : [];
+    return classes.reduce((sum, entry) => sum + Math.max(0, numberOr(entry?.levels ?? entry?.level, 0)), 0);
+  }
+
+  function comparison(targetValue, selfValue) {
+    if (targetValue > selfValue) return "superior";
+    if (targetValue < selfValue) return "inferior";
+    return "equal";
+  }
+
+  function assessCreature(character = {}, target = {}, options = {}) {
+    if (!hasTrait(character, "insightful_manipulator")) return { available: false, reason: "insightful_manipulator_unavailable" };
+    if (!target || typeof target !== "object") return { available: false, reason: "target_required" };
+    if (options.inCombat === true || normalizeId(options.context) === "combat") return { available: false, reason: "outside_combat_only" };
+    if (numberOr(options.observedMinutes ?? options.minutes, 0) < 1) return { available: false, reason: "observation_time_required", requiredMinutes: 1 };
+
+    const requested = [...new Set((options.fields || ["int", "wis", "cha", "experience"]).map(normalizeId))]
+      .filter((id) => ["int", "wis", "cha", "experience"].includes(id));
+    const results = {};
+    requested.forEach((id) => {
+      const selfValue = id === "experience" ? totalLevel(character) : statScore(character, id);
+      const targetValue = id === "experience" ? totalLevel(target) : statScore(target, id);
+      results[id] = { relation: comparison(targetValue, selfValue), selfValue, targetValue };
+    });
+    return {
+      available: true,
+      traitId: "insightful_manipulator",
+      observedMinutes: numberOr(options.observedMinutes ?? options.minutes, 0),
+      results,
+      dmMayRevealAdditionalDetails: true,
+    };
+  }
+
+  function soulPreferences(character = {}) {
+    const stored = character.traitChoices?.soul_of_deceit || character.soulOfDeceit || {};
+    return {
+      allowMindReading: stored.allowMindReading === true,
+      presentFalseThoughts: stored.presentFalseThoughts === true,
+      appearTruthful: stored.appearTruthful !== false,
+    };
+  }
+
+  function setSoulOfDeceitPreferences(character = {}, input = {}) {
+    if (!hasTrait(character, "soul_of_deceit")) return { applied: false, reason: "soul_of_deceit_unavailable" };
+    const prefs = {
+      allowMindReading: input.allowMindReading === true,
+      presentFalseThoughts: input.presentFalseThoughts === true,
+      appearTruthful: input.appearTruthful !== false,
+    };
+    ensureObject(character, "traitChoices").soul_of_deceit = prefs;
+    return { applied: true, preferences: clone(prefs) };
+  }
+
+  function resolveSoulOfDeceit(character = {}, effect = {}) {
+    if (!hasTrait(character, "soul_of_deceit")) return { active: false };
+    const prefs = { ...soulPreferences(character), ...(effect.preferences || {}) };
+    const kind = normalizeId(effect.kind || effect.type || effect.effectType || effect.intent);
+    if (["mind_reading", "read_mind", "detect_thoughts", "thought_reading"].includes(kind)) {
+      if (!prefs.allowMindReading) return { active: true, traitId: "soul_of_deceit", kind: "mind_reading", blocked: true, requiresConsent: true };
+      return { active: true, traitId: "soul_of_deceit", kind: "mind_reading", blocked: false, requiresConsent: true, presentFalseThoughts: prefs.presentFalseThoughts };
+    }
+    if (["truth_detection", "detect_truth", "truthfulness", "lie_detection"].includes(kind)) {
+      return { active: true, traitId: "soul_of_deceit", kind: "truth_detection", appearsTruthful: prefs.appearTruthful };
+    }
+    return { active: true, traitId: "soul_of_deceit", kind, handled: false };
+  }
+
+  function tagsForCheck(check = {}) {
+    const values = [check.intent, check.effectType, check.actionId, check.kind, check.purpose, ...(Array.isArray(check.tags) ? check.tags : [])];
+    return new Set(values.map(normalizeId).filter(Boolean));
+  }
+
+  function hasAny(tags, values) {
+    return values.some((value) => tags.has(normalizeId(value)));
+  }
+
+  function applyMastermindTheatreResult(input = {}, result = {}) {
+    const character = input.character || input.self || {};
+    const check = { ...(result.check || input.check || {}) };
+    const outcomes = [...(result.outcomes || [])];
+    const tags = tagsForCheck(check);
+
+    if (hasTrait(character, "master_of_intrigue") && hasAny(tags, ["mimic_speech", "speech_mimicry", "mimic_accent"])) {
+      const minutes = numberOr(check.observedMinutes ?? check.minutesListened, 0);
+      const available = canMimicSpeech(character, minutes);
+      check.mastermindMimicSpeech = { available, observedMinutes: minutes, requiredMinutes: 1 };
+      outcomes.push({ type: "mastermind_master_of_intrigue", traitId: "master_of_intrigue", mimicSpeech: available, observedMinutes: minutes });
+    }
+
+    if (hasTrait(character, "insightful_manipulator") && hasAny(tags, ["insightful_manipulator", "assess_creature", "observe_creature"])) {
+      const target = check.target || check.targetCharacter || input.target || null;
+      const assessment = assessCreature(character, target, {
+        observedMinutes: check.observedMinutes ?? check.minutesObserved,
+        context: check.context || input.context || "theatre",
+        inCombat: check.inCombat === true,
+        fields: check.assessmentFields,
+      });
+      check.mastermindAssessment = assessment;
+      outcomes.push({ type: "mastermind_insightful_manipulator", traitId: "insightful_manipulator", assessment: clone(assessment) });
+    }
+
+    const target = check.target || check.targetCharacter || input.target || null;
+    if (target && hasTrait(target, "soul_of_deceit")) {
+      if (hasAny(tags, ["mind_reading", "read_mind", "detect_thoughts", "thought_reading"])) {
+        const resolution = resolveSoulOfDeceit(target, { kind: "mind_reading", preferences: check.soulOfDeceitPreferences });
+        check.soulOfDeceit = resolution;
+        if (resolution.blocked) {
+          check.blocked = true;
+          check.blockedByTrait = "soul_of_deceit";
+        }
+        outcomes.push({ type: "mastermind_soul_of_deceit", traitId: "soul_of_deceit", ...clone(resolution) });
+      } else if (hasAny(tags, ["truth_detection", "detect_truth", "truthfulness", "lie_detection"])) {
+        const resolution = resolveSoulOfDeceit(target, { kind: "truth_detection", preferences: check.soulOfDeceitPreferences });
+        check.soulOfDeceit = resolution;
+        if (resolution.appearsTruthful) check.truthDetectionResult = "truthful";
+        outcomes.push({ type: "mastermind_soul_of_deceit", traitId: "soul_of_deceit", ...clone(resolution) });
+      }
+    }
+
+    return { ...result, check, outcomes };
+  }
+
+  function patchTraitEngine() {
+    const source = global.LuminousTraitEngine;
+    if (!source?.resolveTheatreCheck) return false;
+    if (source.__mastermindTheatreRuntimeIntegrated) {
+      traitEngineSource = source;
+      return true;
+    }
+    if (traitEngineSource === source) return true;
+    const original = source.resolveTheatreCheck.bind(source);
+    const wrapped = Object.freeze({
+      ...source,
+      __mastermindTheatreRuntimeIntegrated: true,
+      resolveTheatreCheck(input = {}) {
+        return applyMastermindTheatreResult(input, original(input) || {});
+      },
+    });
+    global.LuminousTraitEngine = wrapped;
+    traitEngineSource = wrapped;
+    return true;
+  }
+
+  function patchPlayerTraitRuntime() {
+    const source = global.LuminousPlayerTraitRuntime;
+    if (!source?.resolveTheatreCheck) return false;
+    if (source.__mastermindTheatreRuntimeIntegrated) {
+      playerTraitSource = source;
+      return true;
+    }
+    if (playerTraitSource === source) return true;
+    const original = source.resolveTheatreCheck.bind(source);
+    const wrapped = Object.freeze({
+      ...source,
+      __mastermindTheatreRuntimeIntegrated: true,
+      resolveTheatreCheck(check = {}, runtimeInput = {}) {
+        const target = runtimeInput?.target || check?.target || null;
+        const enriched = target ? { ...(check || {}), target } : { ...(check || {}) };
+        return original(enriched, runtimeInput);
+      },
+    });
+    global.LuminousPlayerTraitRuntime = wrapped;
+    playerTraitSource = wrapped;
+    return true;
+  }
+
+  function install() {
+    const character = currentCharacter();
+    if (character) syncMasterOfIntrigue(character);
+    patchTraitEngine();
+    patchPlayerTraitRuntime();
+    return true;
+  }
+
+  const api = Object.freeze({
+    ARCHETYPE_ID, CLASS_ID,
+    grantedMastermindTraits, hasTrait,
+    masterOfIntrigueChoices, syncMasterOfIntrigue, applyMasterOfIntrigueChoices, canMimicSpeech,
+    statScore, totalLevel, assessCreature,
+    soulPreferences, setSoulOfDeceitPreferences, resolveSoulOfDeceit,
+    applyMastermindTheatreResult,
+    patchTraitEngine, patchPlayerTraitRuntime, install,
+  });
+
+  global.LuminousMastermindTheatreRuntime = api;
+  install();
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+  if (global.document && global.setInterval) global.setInterval(install, PATCH_INTERVAL_MS);
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/player-archetype-runtime.js
+++ b/js/player-archetype-runtime.js
@@ -51,5 +51,15 @@
       "js/rogue-theatre-runtime.js",
       () => Boolean(global.LuminousRogueTheatreRuntime),
     ))
+    .then(() => ensureScript(
+      "mastermind-archetype-runtime-script",
+      "js/mastermind-archetype-runtime.js",
+      () => Boolean(global.LuminousMastermindArchetypeRuntime),
+    ))
+    .then(() => ensureScript(
+      "mastermind-theatre-runtime-script",
+      "js/mastermind-theatre-runtime.js",
+      () => Boolean(global.LuminousMastermindTheatreRuntime),
+    ))
     .catch((error) => console.error("Player Archetype Bootstrap:", error));
 })(window);

--- a/tests/mastermind-archetype-runtime-smoke.mjs
+++ b/tests/mastermind-archetype-runtime-smoke.mjs
@@ -1,0 +1,215 @@
+import assert from "node:assert/strict";
+
+const g = globalThis;
+
+const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+const unitId = (unit = {}) => String(unit.id || unit.unitId || unit.characterId || "");
+
+function rogueLevel(character = {}) {
+  const classes = Array.isArray(character.classes) ? character.classes : character.characterBuild?.classes || [];
+  const found = classes.find((entry) => normalizeId(entry.id || entry.classId || entry.name) === "rogue");
+  return Number(found?.level ?? found?.levels ?? 0);
+}
+
+function isMastermind(character = {}) {
+  const raw = character.characterBuild?.archetypes || character.archetypes || [];
+  return raw.some((entry) => normalizeId(entry.classId) === "rogue" && normalizeId(entry.archetypeId || entry.id) === "mastermind");
+}
+
+g.LuminousArchetypeEngine = {
+  getClassLevel(character, classId) { return normalizeId(classId) === "rogue" ? rogueLevel(character) : 0; },
+  isSelected(character, archetypeId, classId) {
+    return normalizeId(archetypeId) === "mastermind" && normalizeId(classId) === "rogue" && isMastermind(character);
+  },
+  resolveTraitGrants(character, grants = [], definitions = {}, archetypes = {}) {
+    if (!isMastermind(character)) return [];
+    const level = rogueLevel(character);
+    return grants.filter((grant) => level >= Number(grant.atLevel || 0)).map((grant) => ({
+      ...clone(definitions[grant.traitId]),
+      source: { ...(definitions[grant.traitId]?.source || {}), ...(grant.source || {}) },
+    })).filter((trait) => trait.id);
+  },
+};
+
+g.LuminousRogueClassRuntime = { rogueLevel };
+
+g.LuminousUniversalSpeedRuntime = { effectiveSpeed(unit) { return Number(unit.speed || 0); } };
+
+g.LuminousStatusEngine = {
+  ensureStore(unit) {
+    if (!unit.statusEffects || typeof unit.statusEffects !== "object" || Array.isArray(unit.statusEffects)) unit.statusEffects = {};
+    return unit.statusEffects;
+  },
+  applyStatus(unit, statusId, input = {}) {
+    const store = this.ensureStore(unit);
+    const id = normalizeId(statusId);
+    const existing = store[id];
+    const mode = normalizeId(input.mode || "gain");
+    const count = mode === "set" ? Number(input.count || 0) : Number(existing?.count || 0) + Number(input.count ?? 1);
+    store[id] = {
+      id,
+      name: input.name || existing?.name || id,
+      count,
+      potency: Number(input.potency || 0),
+      duration: input.duration || "until_removed",
+      sourceTraitId: input.sourceTraitId || existing?.sourceTraitId || null,
+      sourceUnitId: input.sourceUnitId || existing?.sourceUnitId || null,
+      data: { ...(existing?.data || {}), ...(input.data || {}) },
+    };
+    return clone(store[id]);
+  },
+  removeStatus(unit, statusId) {
+    const store = this.ensureStore(unit);
+    const id = normalizeId(statusId);
+    const removed = Boolean(store[id]);
+    delete store[id];
+    return { removed };
+  },
+};
+
+g.LuminousArchetypeTraitCatalog = {
+  ARCHETYPES: {}, DEFINITIONS: {}, GRANTS: [],
+  allArchetypes() { return {}; },
+  allDefinitions() { return {}; },
+  allGrants() { return []; },
+  getDefinition() { return null; },
+  resolveTraitGrants() { return []; },
+};
+
+g.LuminousTraitCatalogCore = {
+  allDefinitions() { return {}; },
+  allGrants() { return []; },
+  getDefinition() { return null; },
+};
+
+g.LuminousTraitEngine = {
+  resolveTraitGrants() { return []; },
+  normalizeTrait(trait) { return clone(trait); },
+};
+
+g.LuminousArchetypeRuntime = { syncArchetypeTraitsForUnit() { return []; } };
+
+const baseResolverCalls = [];
+const baseClashes = [];
+g.LuminousCombatActionResolver = {
+  resolveCombatAction(action, context = {}) {
+    baseResolverCalls.push(clone(action));
+    const effects = (action.effects || []).map((effect) => {
+      if (normalizeId(effect.type) !== "modify_combat_action") return { effect, applied: false };
+      const targetAction = context.actionMap?.[effect.targetActionId];
+      if (!targetAction) return { effect, applied: false, reason: "target_action_missing" };
+      targetAction.modifiers ||= [];
+      targetAction.modifiers.push({ type: "final_power", source: "help_final_power", amount: Number(effect.modifier?.amount ?? 1), fromActorId: action.actorId });
+      return { effect, applied: true };
+    });
+    return { resolved: true, action: clone(action), resolution: { resolved: true, type: "automatic", effects } };
+  },
+  resolvePreparedUnopposed(action) { return { resolved: true, type: "unopposed", action: clone(action), basePrepared: true }; },
+  resolveClashPair(action, opposingAction) {
+    baseClashes.push([clone(action), clone(opposingAction)]);
+    return { resolved: true, type: "clash", winner: "B", actions: [clone(action), clone(opposingAction)], resolvedActionIds: [action.id, opposingAction.id] };
+  },
+};
+
+await import("../js/mastermind-archetype-runtime.js");
+const runtime = g.LuminousMastermindArchetypeRuntime;
+assert.ok(runtime, "Mastermind archetype runtime should install");
+
+assert.equal(runtime.ARCHETYPE_ID, "mastermind");
+assert.equal(runtime.CLASS_ID, "rogue");
+assert.equal(g.LuminousArchetypeTraitCatalog.allArchetypes().mastermind.name, "Mastermind");
+assert.equal(g.LuminousArchetypeTraitCatalog.getDefinition("master_of_tactics").name, "Master of Tactics");
+assert.match(g.LuminousArchetypeTraitCatalog.getDefinition("soul_of_deceit").description, /thoughts cannot be read/i);
+
+const mastermind = {
+  id: "mastermind_unit", name: "Moriarty", side: "allies", speed: 6,
+  classes: [{ id: "rogue", level: 65 }],
+  characterBuild: { archetypes: [{ classId: "rogue", archetypeId: "mastermind" }] },
+};
+const slowAlly = { id: "slow_ally", name: "Slow Ally", side: "allies", speed: 2, skills: [{ id: "guard_skill", name: "Guard Skill", coinAmount: 1, basePower: 5 }] };
+const middleAlly = { id: "middle_ally", name: "Middle Ally", side: "allies", speed: 4, skills: [{ id: "middle_skill", coinAmount: 1 }] };
+const fastAlly = { id: "fast_ally", name: "Fast Ally", side: "allies", speed: 8, skills: [{ id: "fast_skill", coinAmount: 1 }] };
+const enemy = { id: "enemy_unit", name: "Enemy", side: "enemies", speed: 5, skills: [{ id: "enemy_skill", coinAmount: 1 }] };
+const units = [mastermind, slowAlly, middleAlly, fastAlly, enemy];
+
+assert.equal(runtime.helpAdditionalBonus(mastermind, slowAlly, { units }), 3, "slowest ally gets +3 additional");
+assert.equal(runtime.helpAdditionalBonus(mastermind, middleAlly, { units }), 2, "slower non-slowest ally gets +2 additional");
+assert.equal(runtime.helpAdditionalBonus(mastermind, fastAlly, { units }), 1, "other ally gets +1 additional");
+
+const helpedAction = { id: "slow_action", actorId: slowAlly.id, state: "planned", resolution: { type: "clash" }, modifiers: [] };
+const help = {
+  id: "help_action",
+  actorId: mastermind.id,
+  source: { type: "universal", id: "help" },
+  economy: { cost: "action" },
+  phase: { selectedAt: "planning_phase_player", executesAt: "planning_phase_player" },
+  targeting: { allegiance: "ally", mode: "single", mainTargetId: slowAlly.id, targetIds: [slowAlly.id], attackWeight: 1 },
+  resolution: { type: "automatic" },
+  effects: [{ type: "modify_combat_action", targetActionId: helpedAction.id, modifier: { amount: 1 } }],
+  state: "planned",
+};
+const helpContext = { units, actionMap: { [helpedAction.id]: helpedAction } };
+const helpResult = g.LuminousCombatActionResolver.resolveCombatAction(help, helpContext);
+assert.equal(helpResult.resolved, true);
+assert.equal(helpResult.action.economy.cost, "quick_action", "Master of Tactics turns Help into Quick Action");
+assert.equal(helpedAction.modifiers.at(-1).amount, 4, "normal Help +1 plus slowest Mastermind +3");
+assert.equal(helpResult.mastermindMasterOfTactics.additionalHelpFinalPower, 3);
+assert.equal(helpResult.mastermindMisdirection.applied, true);
+
+const assistId = runtime.assistGuardStatusId(mastermind);
+assert.equal(slowAlly.statusEffects[assistId].count, 1, "Misdirection applies 1 Assist Guard Count");
+assert.equal(slowAlly.statusEffects[assistId].name, "Assist Guard - Moriarty");
+assert.equal(slowAlly.statusEffects[assistId].data.iconPending, true, "status explicitly remains icon-pending");
+
+const incoming = {
+  id: "incoming_unopposed",
+  actorId: enemy.id,
+  source: { type: "skill", id: "enemy_skill" },
+  economy: { cost: "action" },
+  phase: { selectedAt: "planning_phase_ai", executesAt: "combat_phase" },
+  targeting: { allegiance: "enemy", mode: "single", mainTargetId: mastermind.id, targetIds: [mastermind.id], attackWeight: 1 },
+  resolution: { type: "unopposed" },
+  resources: [], modifiers: [], effects: [],
+  metadata: { sourceDefinition: { id: "enemy_skill", coinAmount: 1, basePower: 5 } },
+  state: "planned",
+};
+const intercept = g.LuminousCombatActionResolver.resolveCombatAction(incoming, { units, actionMap: {} });
+assert.equal(intercept.resolved, true);
+assert.equal(intercept.type, "clash");
+assert.equal(intercept.assistGuard.triggered, true);
+assert.equal(intercept.assistGuard.protectedUnitId, mastermind.id);
+assert.equal(intercept.assistGuard.guardUnitId, slowAlly.id);
+assert.equal(intercept.assistGuard.skillId, "guard_skill");
+assert.equal(intercept.assistGuard.countAfter, 0);
+assert.equal(slowAlly.statusEffects[assistId], undefined, "Assist Guard consumes 1 Count after interception");
+assert.equal(baseClashes.length, 1, "Assist Guard forces a Clash");
+assert.equal(baseClashes[0][0].targeting.mainTargetId, slowAlly.id, "incoming attack is redirected to guard");
+assert.equal(baseClashes[0][1].actorId, slowAlly.id, "guard provides the opposing Skill");
+assert.equal(slowAlly.skills[0].__mastermindAssistGuardUsed, true, "fallback marks intercepted Skill used");
+
+const noGuardDirect = g.LuminousCombatActionResolver.resolveCombatAction({ ...incoming, id: "incoming_no_guard", targeting: { ...incoming.targeting, mainTargetId: middleAlly.id, targetIds: [middleAlly.id] } }, { units, actionMap: {} });
+assert.equal(noGuardDirect.resolved, true);
+assert.equal(noGuardDirect.assistGuard, undefined, "without matching Assist Guard the attack follows normal resolver");
+assert.ok(baseResolverCalls.some((entry) => entry.id === "incoming_no_guard"));
+
+const level15 = {
+  id: "level15", name: "Junior", side: "allies", speed: 5,
+  classes: [{ id: "rogue", level: 15 }],
+  characterBuild: { archetypes: [{ classId: "rogue", archetypeId: "mastermind" }] },
+};
+const juniorTarget = { id: "junior_target", side: "allies", speed: 3, skills: [] };
+const juniorAction = { id: "junior_action", actorId: juniorTarget.id, state: "planned", resolution: { type: "clash" }, modifiers: [] };
+const juniorHelp = { ...clone(help), id: "junior_help", actorId: level15.id, effects: [{ type: "modify_combat_action", targetActionId: juniorAction.id, modifier: { amount: 1 } }] };
+const juniorResult = g.LuminousCombatActionResolver.resolveCombatAction(juniorHelp, { units: [level15, juniorTarget], actionMap: { [juniorAction.id]: juniorAction } });
+assert.equal(juniorResult.action.economy.cost, "quick_action");
+assert.equal(juniorResult.mastermindMisdirection, undefined, "Misdirection is not active before Rogue 65");
+
+const traits85 = g.LuminousArchetypeTraitCatalog.resolveTraitGrants({
+  id: "level85",
+  classes: [{ id: "rogue", level: 85 }],
+  characterBuild: { archetypes: [{ classId: "rogue", archetypeId: "mastermind" }] },
+});
+assert.deepEqual(traits85.map((trait) => trait.id).sort(), ["insightful_manipulator", "master_of_intrigue", "master_of_tactics", "misdirection", "soul_of_deceit"].sort());
+
+console.log("Mastermind archetype Theatre/Combat smoke passed.");

--- a/tests/mastermind-trait-bridge-smoke.mjs
+++ b/tests/mastermind-trait-bridge-smoke.mjs
@@ -1,0 +1,301 @@
+import assert from "node:assert/strict";
+
+const g = globalThis;
+const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+const unitId = (unit = {}) => String(unit.id || unit.unitId || unit.characterId || "");
+
+function rogueLevel(character = {}) {
+  const classes = Array.isArray(character.classes) ? character.classes : character.characterBuild?.classes || [];
+  const found = classes.find((entry) => normalizeId(entry.id || entry.classId || entry.name) === "rogue");
+  return Number(found?.level ?? found?.levels ?? 0);
+}
+
+function isMastermind(character = {}) {
+  const raw = character.characterBuild?.archetypes || character.archetypes || [];
+  return raw.some((entry) => normalizeId(entry.classId) === "rogue" && normalizeId(entry.archetypeId || entry.id) === "mastermind");
+}
+
+function mastermind(level, extra = {}) {
+  return {
+    id: `mastermind_${level}`,
+    name: `Mastermind ${level}`,
+    side: "allies",
+    speed: 6,
+    level,
+    stats: { inteligencia: 14, sabiduria: 12, carisma: 16 },
+    classes: [{ id: "rogue", level }],
+    characterBuild: { archetypes: [{ classId: "rogue", archetypeId: "mastermind" }] },
+    statusEffects: {},
+    ...extra,
+  };
+}
+
+g.LuminousArchetypeEngine = {
+  getClassLevel(character, classId) { return normalizeId(classId) === "rogue" ? rogueLevel(character) : 0; },
+  isSelected(character, archetypeId, classId) {
+    return normalizeId(archetypeId) === "mastermind" && normalizeId(classId) === "rogue" && isMastermind(character);
+  },
+  resolveTraitGrants(character, grants = [], definitions = {}) {
+    if (!isMastermind(character)) return [];
+    const level = rogueLevel(character);
+    return grants.filter((grant) => level >= Number(grant.atLevel || 0)).map((grant) => {
+      const definition = clone(definitions[grant.traitId]);
+      if (!definition) return null;
+      definition.source = { ...(definition.source || {}), ...(grant.source || {}) };
+      return definition;
+    }).filter(Boolean);
+  },
+};
+
+g.LuminousRogueClassRuntime = { rogueLevel };
+g.LuminousUniversalSpeedRuntime = { effectiveSpeed(unit) { return Number(unit.speed || 0); } };
+
+g.LuminousStatusEngine = {
+  ensureStore(unit) {
+    if (!unit.statusEffects || typeof unit.statusEffects !== "object" || Array.isArray(unit.statusEffects)) unit.statusEffects = {};
+    return unit.statusEffects;
+  },
+  applyStatus(unit, statusId, input = {}) {
+    const store = this.ensureStore(unit);
+    const id = normalizeId(statusId);
+    const existing = store[id];
+    const mode = normalizeId(input.mode || "gain");
+    const count = mode === "set" ? Number(input.count || 0) : Number(existing?.count || 0) + Number(input.count ?? 1);
+    store[id] = {
+      id,
+      name: input.name || existing?.name || id,
+      count,
+      potency: Number(input.potency || 0),
+      duration: input.duration || "until_removed",
+      sourceTraitId: input.sourceTraitId || existing?.sourceTraitId || null,
+      sourceUnitId: input.sourceUnitId || existing?.sourceUnitId || null,
+      data: { ...(existing?.data || {}), ...(input.data || {}) },
+    };
+    return clone(store[id]);
+  },
+  removeStatus(unit, statusId) {
+    const store = this.ensureStore(unit);
+    const id = normalizeId(statusId);
+    const removed = Boolean(store[id]);
+    delete store[id];
+    return { removed };
+  },
+};
+
+g.LuminousArchetypeTraitCatalog = {
+  ARCHETYPES: {}, DEFINITIONS: {}, GRANTS: [],
+  allArchetypes() { return {}; },
+  allDefinitions() { return {}; },
+  allGrants() { return []; },
+  getDefinition() { return null; },
+  resolveTraitGrants() { return []; },
+};
+
+g.LuminousTraitCatalogCore = {
+  allDefinitions() { return {}; },
+  allGrants() { return []; },
+  getDefinition() { return null; },
+};
+
+g.LuminousTraitEngine = {
+  resolveTraitGrants() { return []; },
+  normalizeTrait(trait) { return clone(trait); },
+  resolveTheatreCheck(input = {}) { return { check: { ...(input.check || {}) }, state: input.state || {}, outcomes: [] }; },
+};
+
+g.LuminousArchetypeRuntime = { syncArchetypeTraitsForUnit() { return []; } };
+
+const baseClashes = [];
+const baseResolverCalls = [];
+g.LuminousCombatActionResolver = {
+  resolveCombatAction(action, context = {}) {
+    baseResolverCalls.push(clone(action));
+    const effects = (action.effects || []).map((effect) => {
+      if (normalizeId(effect.type) !== "modify_combat_action") return { effect, applied: false };
+      const targetAction = context.actionMap?.[effect.targetActionId];
+      if (!targetAction) return { effect, applied: false, reason: "target_action_missing" };
+      targetAction.modifiers ||= [];
+      targetAction.modifiers.push({ type: "final_power", source: "help_final_power", amount: Number(effect.modifier?.amount ?? 1), fromActorId: action.actorId });
+      return { effect, applied: true };
+    });
+    return { resolved: true, action: clone(action), resolution: { resolved: true, type: "automatic", effects } };
+  },
+  resolvePreparedUnopposed(action) { return { resolved: true, type: "unopposed", action: clone(action) }; },
+  resolveClashPair(action, opposingAction) {
+    baseClashes.push([clone(action), clone(opposingAction)]);
+    return { resolved: true, type: "clash", winner: "B", actions: [clone(action), clone(opposingAction)], resolvedActionIds: [action.id, opposingAction.id] };
+  },
+};
+
+g.datosJugador = mastermind(85);
+g.LuminousPlayerTraitRuntime = {
+  getCharacter() { return g.datosJugador; },
+  getTraits() { return g.LuminousArchetypeTraitCatalog.resolveTraitGrants(g.datosJugador); },
+  resolveTheatreCheck(check = {}, runtimeInput = {}) {
+    return g.LuminousTraitEngine.resolveTheatreCheck({
+      character: g.datosJugador,
+      traits: this.getTraits(),
+      check: { ...(check || {}) },
+      state: {},
+      target: runtimeInput.target || null,
+      context: "theatre",
+    });
+  },
+};
+
+await import("../js/mastermind-archetype-runtime.js");
+await import("../js/mastermind-theatre-runtime.js");
+
+const runtime = g.LuminousMastermindArchetypeRuntime;
+const theatre = g.LuminousMastermindTheatreRuntime;
+assert.ok(runtime, "Mastermind base runtime should install");
+assert.ok(theatre, "Mastermind Theatre runtime should install");
+
+// Trait grant progression is the source of truth for both surfaces.
+const expectedByLevel = new Map([
+  [14, []],
+  [15, ["master_of_intrigue", "master_of_tactics"]],
+  [45, ["master_of_intrigue", "master_of_tactics", "insightful_manipulator"]],
+  [65, ["master_of_intrigue", "master_of_tactics", "insightful_manipulator", "misdirection"]],
+  [85, ["master_of_intrigue", "master_of_tactics", "insightful_manipulator", "misdirection", "soul_of_deceit"]],
+]);
+for (const [level, expected] of expectedByLevel) {
+  const character = mastermind(level);
+  const granted = g.LuminousArchetypeTraitCatalog.resolveTraitGrants(character).map((trait) => trait.id).sort();
+  assert.deepEqual(granted, [...expected].sort(), `Mastermind level ${level} grant progression`);
+}
+
+// Archetype runtime sync places the same granted Traits on the live unit used by Theatre/Combat.
+const synced = mastermind(85);
+g.LuminousArchetypeRuntime.syncArchetypeTraitsForUnit(synced);
+assert.deepEqual(
+  synced.traitDefinitions.map((trait) => trait.id).sort(),
+  [...expectedByLevel.get(85)].sort(),
+  "live unit traitDefinitions should contain all granted Mastermind Traits",
+);
+
+// Master of Intrigue: fixed proficiencies, stored choices, languages, and 1-minute mimic capability.
+const intrigue = mastermind(15);
+const choiceResult = theatre.applyMasterOfIntrigueChoices(intrigue, { gamingSet: "dragon_chess", languages: ["elvish", "infernal"] });
+assert.equal(choiceResult.applied, true);
+assert.equal(intrigue.toolProficiencies.disguise_kit, "proficient");
+assert.equal(intrigue.toolProficiencies.forgery_kit, "proficient");
+assert.equal(intrigue.toolProficiencies.dragon_chess, "proficient");
+assert.equal(intrigue.languages.elvish.porcentaje, 100);
+assert.equal(intrigue.languages.infernal.porcentaje, 100);
+assert.equal(theatre.canMimicSpeech(intrigue, 0.99), false);
+assert.equal(theatre.canMimicSpeech(intrigue, 1), true);
+const mimicCheck = g.LuminousTraitEngine.resolveTheatreCheck({
+  character: intrigue,
+  traits: g.LuminousArchetypeTraitCatalog.resolveTraitGrants(intrigue),
+  check: { tags: ["mimic_speech"], observedMinutes: 1 },
+  state: {},
+});
+assert.equal(mimicCheck.check.mastermindMimicSpeech.available, true);
+assert.ok(mimicCheck.outcomes.some((entry) => entry.traitId === "master_of_intrigue"));
+
+// Insightful Manipulator: Theatre observation resolves concrete superior/equal/inferior comparisons.
+const observer = mastermind(45, { stats: { inteligencia: 14, sabiduria: 12, carisma: 16 } });
+const observed = {
+  id: "observed_target",
+  level: 60,
+  stats: { inteligencia: 18, sabiduria: 12, carisma: 10 },
+  classes: [{ id: "fighter", level: 60 }],
+};
+const assessment = theatre.assessCreature(observer, observed, { observedMinutes: 1, fields: ["int", "wis", "cha", "experience"], context: "theatre" });
+assert.equal(assessment.available, true);
+assert.equal(assessment.results.int.relation, "superior");
+assert.equal(assessment.results.wis.relation, "equal");
+assert.equal(assessment.results.cha.relation, "inferior");
+assert.equal(assessment.results.experience.relation, "superior");
+assert.equal(theatre.assessCreature(observer, observed, { observedMinutes: 1, context: "combat" }).available, false);
+const assessmentCheck = g.LuminousTraitEngine.resolveTheatreCheck({
+  character: observer,
+  traits: g.LuminousArchetypeTraitCatalog.resolveTraitGrants(observer),
+  check: { tags: ["assess_creature"], observedMinutes: 1, target: observed, assessmentFields: ["int", "cha"] },
+  state: {},
+});
+assert.equal(assessmentCheck.check.mastermindAssessment.available, true);
+assert.equal(assessmentCheck.check.mastermindAssessment.results.int.relation, "superior");
+
+// Soul of Deceit: incoming Theatre effects are altered through the live Player Trait bridge.
+const soul = mastermind(85);
+g.datosJugador = { id: "reader", name: "Reader", level: 20, classes: [{ id: "wizard", level: 20 }] };
+const blockedRead = g.LuminousPlayerTraitRuntime.resolveTheatreCheck(
+  { tags: ["mind_reading"] },
+  { target: soul },
+);
+assert.equal(blockedRead.check.blocked, true);
+assert.equal(blockedRead.check.blockedByTrait, "soul_of_deceit");
+assert.ok(blockedRead.outcomes.some((entry) => entry.traitId === "soul_of_deceit" && entry.blocked === true));
+theatre.setSoulOfDeceitPreferences(soul, { allowMindReading: true, presentFalseThoughts: true, appearTruthful: true });
+const allowedRead = g.LuminousPlayerTraitRuntime.resolveTheatreCheck(
+  { tags: ["mind_reading"] },
+  { target: soul },
+);
+assert.equal(allowedRead.check.blocked, undefined);
+assert.equal(allowedRead.check.soulOfDeceit.blocked, false);
+assert.equal(allowedRead.check.soulOfDeceit.presentFalseThoughts, true);
+const truthCheck = g.LuminousPlayerTraitRuntime.resolveTheatreCheck(
+  { tags: ["truth_detection"] },
+  { target: soul },
+);
+assert.equal(truthCheck.check.truthDetectionResult, "truthful");
+
+// Combat: Master of Tactics modifies real Help, then Misdirection produces Assist Guard.
+g.datosJugador = mastermind(85);
+const mastermindUnit = mastermind(65, { id: "mastermind_unit", name: "Moriarty", speed: 6 });
+const guard = { id: "guard", name: "Guard", side: "allies", speed: 2, statusEffects: {}, skills: [{ id: "guard_skill", name: "Guard Skill", coinAmount: 1, basePower: 5 }] };
+const middle = { id: "middle", name: "Middle", side: "allies", speed: 4, statusEffects: {}, skills: [{ id: "middle_skill", coinAmount: 1 }] };
+const enemy = { id: "enemy", name: "Enemy", side: "enemies", speed: 5, statusEffects: {}, skills: [{ id: "enemy_skill", coinAmount: 1 }] };
+const units = [mastermindUnit, guard, middle, enemy];
+const helpedAction = { id: "guard_action", actorId: guard.id, state: "planned", resolution: { type: "clash" }, modifiers: [] };
+const helpAction = {
+  id: "mastermind_help",
+  actorId: mastermindUnit.id,
+  source: { type: "universal", id: "help" },
+  economy: { cost: "action" },
+  phase: { selectedAt: "planning_phase_player", executesAt: "planning_phase_player" },
+  targeting: { allegiance: "ally", mode: "single", mainTargetId: guard.id, targetIds: [guard.id], attackWeight: 1 },
+  resolution: { type: "automatic" },
+  effects: [{ type: "modify_combat_action", targetActionId: helpedAction.id, modifier: { amount: 1 } }],
+  state: "planned",
+};
+const helpResult = g.LuminousCombatActionResolver.resolveCombatAction(helpAction, { units, actionMap: { [helpedAction.id]: helpedAction } });
+assert.equal(helpResult.resolved, true);
+assert.equal(helpResult.action.economy.cost, "quick_action", "Master of Tactics must use Quick Action");
+assert.equal(helpedAction.modifiers.at(-1).amount, 4, "slowest ally receives base Help + Mastermind +3");
+assert.equal(helpResult.mastermindMisdirection.applied, true);
+const assistId = runtime.assistGuardStatusId(mastermindUnit);
+assert.equal(guard.statusEffects[assistId].count, 1, "Misdirection grants Assist Guard after Help");
+
+// Combat: that status must cross the unopposed resolver and become a forced Clash.
+const incoming = {
+  id: "incoming_unopposed",
+  actorId: enemy.id,
+  source: { type: "skill", id: "enemy_skill" },
+  economy: { cost: "action" },
+  phase: { selectedAt: "planning_phase_ai", executesAt: "combat_phase" },
+  targeting: { allegiance: "enemy", mode: "single", mainTargetId: mastermindUnit.id, targetIds: [mastermindUnit.id], attackWeight: 1 },
+  resolution: { type: "unopposed" },
+  resources: [], modifiers: [], effects: [],
+  metadata: { sourceDefinition: { id: "enemy_skill", coinAmount: 1, basePower: 5 } },
+  state: "planned",
+};
+const intercepted = g.LuminousCombatActionResolver.resolveCombatAction(incoming, { units, actionMap: {} });
+assert.equal(intercepted.resolved, true);
+assert.equal(intercepted.type, "clash");
+assert.equal(intercepted.assistGuard.triggered, true);
+assert.equal(intercepted.assistGuard.protectedUnitId, mastermindUnit.id);
+assert.equal(intercepted.assistGuard.guardUnitId, guard.id);
+assert.equal(intercepted.assistGuard.countAfter, 0);
+assert.equal(guard.statusEffects[assistId], undefined);
+assert.equal(baseClashes.length, 1);
+
+// A non-Mastermind must not receive the subclass grants or effects.
+const plainRogue = { id: "plain", side: "allies", speed: 5, classes: [{ id: "rogue", level: 85 }], characterBuild: { archetypes: [] }, statusEffects: {} };
+assert.deepEqual(g.LuminousArchetypeTraitCatalog.resolveTraitGrants(plainRogue), []);
+assert.equal(theatre.canMimicSpeech(plainRogue, 10), false);
+
+console.log("Mastermind Trait -> Theatre/Combat bridge smoke passed.");


### PR DESCRIPTION
## Summary
Adds the Rogue **Mastermind** archetype as a separate runtime integration for Luminous Theatre and Combat, with functional Trait bridges and end-to-end smoke coverage.

## Progression
- Lv15 — **Master of Intrigue**: Theatre runtime grants Disguise Kit and Forgery Kit proficiency, stores one Gaming Set choice and two language choices, and enables speech/accent mimicry after at least 1 minute of listening.
- Lv15 — **Master of Tactics**: Help becomes a Quick Action. Help gains +1 additional Final Power, +2 instead for a slower ally, or +3 instead for the slowest ally.
- Lv45 — **Insightful Manipulator**: Theatre runtime allows a 1-minute outside-combat assessment of selected INT/WIS/CHA or overall experience as superior/equal/inferior relative to the Mastermind.
- Lv65 — **Misdirection**: successful Help on an ally applies 1 dynamic `Assist Guard - [Unit Name]` Count.
- Lv85 — **Soul of Deceit**: Theatre runtime blocks mind-reading unless allowed, can expose false-thought presentation when mind-reading is allowed, and can make truth-detection resolve the Mastermind as truthful.

## Trait -> Theatre / Combat bridge
The new integration test verifies the complete path rather than catalog presence alone:
1. Archetype selection + Rogue class level resolves the correct Trait grants.
2. Granted Traits synchronize into the live unit `traitDefinitions`.
3. Theatre Traits execute through `LuminousTraitEngine.resolveTheatreCheck` / `LuminousPlayerTraitRuntime.resolveTheatreCheck` and produce observable results.
4. Combat Traits execute through `LuminousCombatActionResolver` and modify Help / Misdirection / Assist Guard behavior.
5. A Rogue without the Mastermind archetype receives none of these grants or effects.

## Assist Guard runtime
`Assist Guard - [Unit Name]` stores the protected Mastermind in status metadata. When that Mastermind is targeted by an Unopposed Attack, an allied holder with an available Skill that has not been used/selected can intercept, redirect the incoming target, and force a Clash. A successful interception consumes 1 Count.

Assist Guard remains intentionally pending in the presentation layer. Its mechanic is functional, but its final Status registration/presentation and icon are still open for review before merge.

## Integration
- Adds `js/mastermind-archetype-runtime.js` for catalog, grants, Combat Help/Misdirection/Assist Guard behavior.
- Adds `js/mastermind-theatre-runtime.js` for Master of Intrigue, Insightful Manipulator, and Soul of Deceit Theatre behavior.
- Hooks player/Theatre and combat bootstraps.
- Adds `tests/mastermind-archetype-runtime-smoke.mjs`.
- Adds `tests/mastermind-trait-bridge-smoke.mjs`.
- Runs both Mastermind tests inside the current `Combat Runtime Smoke` workflow without dropping the newer Status Library / Battle Viewer checks from `main`.

## Validation
Current branch is rebased onto the current `main` and is 1 commit ahead / 0 behind.

GitHub Actions `Combat Runtime Smoke` run #215 completed successfully on head `d71b8fc726c621ba76680c76fde191a5d447a5d9`, including:
- Rogue Theatre and Combat smoke
- Mastermind archetype Theatre and Combat smoke
- Mastermind Trait bridge smoke
- Unified canonical Status Library smoke
- Battle Viewer 0.7.3 / 0.7.4 runtime, ownership, loadout, planner and DM console smokes

## Follow-up before merge
- Review Assist Guard behavior against the live Combat UI.
- Register/finalize Assist Guard in the canonical Status presentation layer if needed.
- Add/finalize the Assist Guard icon.

PR intentionally remains open until the Assist Guard Status presentation/icon pass is complete.