### PR TITLE
Hotfix: Unbreakable Red Coin UI assets + runtime support

### DIFF
--- a/.github/workflows/combat-runtime-smoke.yml
+++ b/.github/workflows/combat-runtime-smoke.yml
@@ -22,6 +22,8 @@ jobs:
           node-version: '20'
       - name: Combat Skill schema smoke
         run: node tests/combat-skill-schema-smoke.mjs
+      - name: Unbreakable Red Coin smoke
+        run: node tests/unbreakable-red-coin-smoke.mjs
       - name: Starter Tier 1 status skill catalog smoke
         run: node tests/starter-status-skill-catalog-smoke.mjs
       - name: G1-G2 Skill Forge smoke

--- a/js/coin-engine-core.js
+++ b/js/coin-engine-core.js
@@ -3,6 +3,14 @@
 
   const HEAD_SRC = "https://imgur.com/yshLPnQ.png";
   const TAIL_SRC = "https://imgur.com/XDx0ICt.png";
+
+  // Unbreakable / Red Coin canonical UI assets.
+  // `active` = intact Red Coin; `latent` = cracked Red Coin after losing a Clash.
+  const UNBREAKABLE_HEAD_SRC = "https://imgur.com/yCxmI84.png";
+  const UNBREAKABLE_TAIL_SRC = "https://imgur.com/12jXebG.png";
+  const UNBREAKABLE_CRACKED_HEAD_SRC = "https://imgur.com/3wKu1xC.png";
+  const UNBREAKABLE_CRACKED_TAIL_SRC = "https://imgur.com/lFKCm2b.png";
+
   const HEAD_SFX = "Assets/Audio/SFX/UI/Coin%20SFX/Coin_Heads.wav";
   const TAIL_SFX = "Assets/Audio/SFX/UI/Coin%20SFX/Coin_Tails.wav";
   const DEFAULT_COIN_COUNT = 5;
@@ -18,30 +26,78 @@
     return Math.max(5, Math.min(95, numberOr(value, 50)));
   }
 
+  function normalizeSide(side) {
+    return String(side || "tail").toLowerCase() === "head" ? "head" : "tail";
+  }
+
+  function normalizeCoinType(value) {
+    const raw = String(value || "normal").trim().toLowerCase();
+    if (raw === "unbreakable" || raw === "red" || raw === "red_coin" || raw === "unbreakable_coin") {
+      return "unbreakable";
+    }
+    return "normal";
+  }
+
+  function normalizeCoinStatus(value) {
+    const raw = String(value || "active").trim().toLowerCase();
+    if (raw === "latent" || raw === "cracked") return "latent";
+    return "active";
+  }
+
+  function coinVisualState(coin = {}) {
+    const type = normalizeCoinType(coin.type ?? coin.coinType);
+    const status = type === "unbreakable"
+      ? normalizeCoinStatus(coin.status ?? coin.coinStatus)
+      : "active";
+    return Object.freeze({
+      type,
+      status,
+      unbreakable: type === "unbreakable",
+      cracked: type === "unbreakable" && status === "latent",
+    });
+  }
+
   function rollSide(headsChance, rng) {
     const random = typeof rng === "function" ? rng : global.Math.random;
     return (random() * 100) < clampHeadsChance(headsChance) ? "head" : "tail";
   }
 
-  function coinSrc(side) {
-    return side === "head" ? HEAD_SRC : TAIL_SRC;
+  function coinSrc(side, coin = {}) {
+    const normalizedSide = normalizeSide(side);
+    const state = coinVisualState(coin);
+
+    if (state.unbreakable) {
+      if (state.cracked) {
+        return normalizedSide === "head"
+          ? UNBREAKABLE_CRACKED_HEAD_SRC
+          : UNBREAKABLE_CRACKED_TAIL_SRC;
+      }
+      return normalizedSide === "head"
+        ? UNBREAKABLE_HEAD_SRC
+        : UNBREAKABLE_TAIL_SRC;
+    }
+
+    return normalizedSide === "head" ? HEAD_SRC : TAIL_SRC;
   }
 
   function playSideSfx(side, options = {}) {
     if (options.silent || typeof global.Audio !== "function") return;
     try {
-      const audio = new global.Audio(side === "head" ? HEAD_SFX : TAIL_SFX);
+      const audio = new global.Audio(normalizeSide(side) === "head" ? HEAD_SFX : TAIL_SFX);
       audio.volume = Math.max(0, Math.min(1, numberOr(options.volume, 0.3)));
       const result = audio.play();
       if (result?.catch) result.catch(() => {});
     } catch (_) {}
   }
 
-  function createCoinNode(doc, index) {
+  function createCoinNode(doc, index, coinDefinition = {}) {
+    const state = coinVisualState(coinDefinition);
     const wrapper = doc.createElement("div");
     wrapper.className = "coin-toss-item luminous-core-coin";
     wrapper.dataset.coinIndex = String(index);
     wrapper.dataset.state = "spinning";
+    wrapper.dataset.coinType = state.type;
+    wrapper.dataset.coinStatus = state.status;
     Object.assign(wrapper.style, {
       width: "60px",
       height: "60px",
@@ -50,8 +106,10 @@
     });
 
     const image = doc.createElement("img");
-    image.src = TAIL_SRC;
-    image.alt = `Coin ${index + 1}`;
+    image.src = coinSrc("tail", coinDefinition);
+    image.alt = state.unbreakable
+      ? (state.cracked ? `Cracked Red Coin ${index + 1}` : `Red Coin ${index + 1}`)
+      : `Coin ${index + 1}`;
     Object.assign(image.style, {
       width: "100%",
       height: "100%",
@@ -70,7 +128,7 @@
       image.classList.add("luminous-core-coin-spinning");
     }
 
-    return { wrapper, image, animation };
+    return { wrapper, image, animation, definition: coinDefinition, visualState: state };
   }
 
   function runAnimatedRoll(options = {}) {
@@ -78,7 +136,11 @@
     const container = options.container;
     if (!doc || !container) return Promise.reject(new Error("Coin Engine requiere un contenedor DOM."));
 
-    const coinCount = Math.max(1, Math.trunc(numberOr(options.coinCount, DEFAULT_COIN_COUNT)));
+    const providedCoins = Array.isArray(options.coins)
+      ? options.coins
+      : (Array.isArray(options.coinDefinitions) ? options.coinDefinitions : []);
+    const fallbackCount = providedCoins.length || DEFAULT_COIN_COUNT;
+    const coinCount = Math.max(1, Math.trunc(numberOr(options.coinCount, fallbackCount)));
     const base = Math.trunc(numberOr(options.base, 0));
     const headsChance = clampHeadsChance(options.headsChance);
     const intervalMs = Math.max(80, Math.trunc(numberOr(options.intervalMs, DEFAULT_INTERVAL_MS)));
@@ -94,7 +156,8 @@
 
     const fragment = doc.createDocumentFragment();
     for (let index = 0; index < coinCount; index += 1) {
-      const node = createCoinNode(doc, index);
+      const definition = providedCoins[index] || {};
+      const node = createCoinNode(doc, index, definition);
       nodes.push(node);
       fragment.appendChild(node.wrapper);
     }
@@ -124,22 +187,41 @@
         node.animation?.cancel?.();
         node.image.classList.remove("luminous-core-coin-spinning");
 
-        const side = rollSide(headsChance, options.rng);
+        const definition = node.definition || {};
+        const visualState = node.visualState || coinVisualState(definition);
+        const forcedSide = String(definition.side || "").toLowerCase();
+        const side = forcedSide === "head" || forcedSide === "tail"
+          ? forcedSide
+          : rollSide(headsChance, options.rng);
+        const src = coinSrc(side, definition);
+
         node.wrapper.dataset.side = side;
         node.image.dataset.side = side;
-        node.image.alt = side === "head" ? "Head" : "Tail";
-        node.image.src = coinSrc(side);
-        if (side === "head") currentTotal += HEAD_BONUS;
+        node.image.alt = `${visualState.cracked ? "Cracked " : ""}${visualState.unbreakable ? "Red Coin " : ""}${side === "head" ? "Head" : "Tail"}`;
+        node.image.src = src;
+
+        // A latent Unbreakable Coin has already lost its Clash. CombatEngine resolves
+        // that doctrine at fixed Power 1, so the generic UI toss must not grant its
+        // normal Heads bonus a second time.
+        const contributesHeadBonus = side === "head" && !visualState.cracked;
+        if (contributesHeadBonus) currentTotal += HEAD_BONUS;
         if (options.totalNode) options.totalNode.textContent = String(currentTotal);
         playSideSfx(side, options);
 
-        const coin = { index, side, src: coinSrc(side) };
+        const coin = {
+          index,
+          side,
+          src,
+          type: visualState.type,
+          status: visualState.status,
+          unbreakable: visualState.unbreakable,
+          cracked: visualState.cracked,
+          contributesHeadBonus,
+        };
         coins[index] = coin;
         resolved += 1;
         options.onCoinResolved?.({
-          index,
-          side,
-          src: coin.src,
+          ...coin,
           currentTotal,
           resolved,
           coinCount,
@@ -162,13 +244,20 @@
   global.LuminousCoinEngine = Object.freeze({
     HEAD_SRC,
     TAIL_SRC,
+    UNBREAKABLE_HEAD_SRC,
+    UNBREAKABLE_TAIL_SRC,
+    UNBREAKABLE_CRACKED_HEAD_SRC,
+    UNBREAKABLE_CRACKED_TAIL_SRC,
     HEAD_SFX,
     TAIL_SFX,
     DEFAULT_COIN_COUNT,
     HEAD_BONUS,
     clampHeadsChance,
+    normalizeCoinType,
+    normalizeCoinStatus,
+    coinVisualState,
     rollSide,
     coinSrc,
     runAnimatedRoll,
   });
-})(window);
+})(typeof window !== "undefined" ? window : globalThis);

--- a/tests/unbreakable-red-coin-smoke.mjs
+++ b/tests/unbreakable-red-coin-smoke.mjs
@@ -1,0 +1,91 @@
+globalThis.window = globalThis;
+
+await import('../js/combat-skill-schema.js');
+await import('../js/coin-engine-core.js');
+
+const schema = globalThis.CombatSkillSchema;
+const engine = globalThis.LuminousCoinEngine;
+
+if (!schema) throw new Error('CombatSkillSchema was not initialized.');
+if (!engine) throw new Error('LuminousCoinEngine was not initialized.');
+
+const EXPECTED = Object.freeze({
+  activeHead: 'https://imgur.com/yCxmI84.png',
+  activeTail: 'https://imgur.com/12jXebG.png',
+  crackedHead: 'https://imgur.com/3wKu1xC.png',
+  crackedTail: 'https://imgur.com/lFKCm2b.png',
+});
+
+const assetChecks = [
+  ['active head', engine.coinSrc('head', { type: 'unbreakable', status: 'active' }), EXPECTED.activeHead],
+  ['active tail', engine.coinSrc('tail', { type: 'unbreakable', status: 'active' }), EXPECTED.activeTail],
+  ['latent head', engine.coinSrc('head', { type: 'unbreakable', status: 'latent' }), EXPECTED.crackedHead],
+  ['latent tail', engine.coinSrc('tail', { type: 'unbreakable', status: 'latent' }), EXPECTED.crackedTail],
+];
+
+for (const [label, actual, expected] of assetChecks) {
+  if (actual !== expected) throw new Error(`Unexpected Red Coin asset for ${label}: ${actual}`);
+}
+
+if (engine.coinSrc('head', { type: 'normal' }) !== engine.HEAD_SRC) {
+  throw new Error('Normal Heads asset regressed.');
+}
+if (engine.coinSrc('tail', { type: 'normal' }) !== engine.TAIL_SRC) {
+  throw new Error('Normal Tails asset regressed.');
+}
+
+const activeState = engine.coinVisualState({ type: 'unbreakable', status: 'active' });
+if (!activeState.unbreakable || activeState.cracked || activeState.status !== 'active') {
+  throw new Error(`Unexpected active Red Coin state: ${JSON.stringify(activeState)}`);
+}
+
+const latentState = engine.coinVisualState({ type: 'unbreakable', status: 'latent' });
+if (!latentState.unbreakable || !latentState.cracked || latentState.status !== 'latent') {
+  throw new Error(`Unexpected latent Red Coin state: ${JSON.stringify(latentState)}`);
+}
+
+// The Skill Creator uses the same CombatSkillSchema for Attack and Spell authoring.
+// This verifies an authored Spell can mix Normal and Unbreakable Coins without
+// losing the per-Coin mechanic during normalization / Firebase serialization.
+const authoredSpell = schema.normalizeCombatSkill({
+  id: 'red_coin_spell_smoke',
+  name: 'Red Coin Spell Smoke',
+  type: 'Spell',
+  coinAmount: 4,
+  basePower: 5,
+  coinPower: 3,
+  coins: [
+    { type: 'normal', status: 'active', effects: [] },
+    { type: 'unbreakable', status: 'active', effects: [] },
+    { type: 'unbreakable', status: 'latent', effects: [] },
+    { coinType: 'unbreakable', coinStatus: 'active', effects: [] },
+  ],
+});
+
+if (authoredSpell.type !== 'Spell') throw new Error('Spell authoring type was not preserved.');
+if (authoredSpell.coins[0].type !== 'normal') throw new Error('Normal Coin type was not preserved.');
+if (authoredSpell.coins[1].type !== 'unbreakable') throw new Error('Active Red Coin type was not preserved.');
+if (authoredSpell.coins[2].type !== 'unbreakable' || authoredSpell.coins[2].status !== 'latent') {
+  throw new Error('Latent Red Coin state was not preserved.');
+}
+if (authoredSpell.coins[3].type !== 'unbreakable') {
+  throw new Error('Legacy coinType alias did not normalize to an Unbreakable Coin.');
+}
+
+const serialized = schema.serializeCombatSkill(authoredSpell, { includeLegacyAliases: true });
+const roundTrip = schema.normalizeCombatSkill(JSON.parse(JSON.stringify(serialized)));
+
+for (const index of [1, 2, 3]) {
+  if (roundTrip.coins[index].type !== 'unbreakable') {
+    throw new Error(`Red Coin ${index + 1} was lost during serialization round-trip.`);
+  }
+}
+if (roundTrip.coins[2].status !== 'latent') {
+  throw new Error('Cracked/latent Red Coin status was lost during serialization round-trip.');
+}
+
+console.log('[UnbreakableRedCoin] Smoke test passed.');
+console.log({
+  assets: EXPECTED,
+  spellCoinTypes: roundTrip.coins.map((coin) => `${coin.type}:${coin.status}`),
+});


### PR DESCRIPTION
## Summary
- Adds canonical Unbreakable / Red Coin UI assets for Heads, Tails, Cracked Heads, and Cracked Tails.
- Extends `LuminousCoinEngine.coinSrc(side, coin)` to resolve visuals from per-Coin `type/status` while preserving normal Coin behavior.
- Supports `active` and `latent` Red Coin states; `latent` maps to the cracked assets and does not grant a generic Heads bonus a second time.
- Keeps the existing canonical Skill Creator representation (`coin.type = "unbreakable"`) and verifies that Attack/Spell authoring survives schema normalization and Firebase serialization.
- Adds `tests/unbreakable-red-coin-smoke.mjs` and wires it into Combat Runtime CI.

## Canonical assets
- Active Heads: https://imgur.com/yCxmI84.png
- Active Tails: https://imgur.com/12jXebG.png
- Cracked Heads: https://imgur.com/3wKu1xC.png
- Cracked Tails: https://imgur.com/lFKCm2b.png

## Compatibility
No Firebase schema migration is required. Existing Skills/Spells authored with per-Coin `type: "unbreakable"` remain compatible.