### PR TITLE
Hotfix: separate class resources and action effects from Status UI

### DIFF
--- a/.github/workflows/combat-runtime-smoke.yml
+++ b/.github/workflows/combat-runtime-smoke.yml
@@ -27,6 +27,8 @@ jobs:
         run: node tests/unbreakable-red-coin-smoke.mjs
       - name: Unified canonical Status Library smoke
         run: node tests/combat-v074-unified-status-library-smoke.mjs
+      - name: Class Status semantics smoke
+        run: node tests/class-status-semantics-smoke.mjs
       - name: Starter Tier 1 status skill catalog smoke
         run: node tests/starter-status-skill-catalog-smoke.mjs
       - name: G1-G2 Skill Forge smoke
@@ -61,6 +63,7 @@ jobs:
         run: |
           node --check js/status-library.js
           node --check js/statusManager.js
+          node --check js/class-status-semantics.js
           node --check js/battle-viewer-action-adapter-073.js
           node --check js/battle-viewer-firebase-session-074.js
           node --check js/combat-skill-loadout-074.js

--- a/js/class-status-semantics.js
+++ b/js/class-status-semantics.js
@@ -1,0 +1,167 @@
+(function (global) {
+  "use strict";
+
+  const VERSION = "0.7.4-class-status-semantics";
+  const RAGE_ICON = "https://imgur.com/j3C7GzS.png";
+  const INTERNAL_EFFECT_IDS = Object.freeze(new Set([
+    "reckless_attack_armed",
+    "countercharm",
+  ]));
+  const RESOURCE_ONLY_IDS = Object.freeze(new Set([
+    "sorcery_points",
+  ]));
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+  function isInternalEffectId(value) {
+    return INTERNAL_EFFECT_IDS.has(normalizeId(value));
+  }
+
+  function isResourceOnlyId(value) {
+    return RESOURCE_ONLY_IDS.has(normalizeId(value));
+  }
+
+  function registerClassStatuses() {
+    const library = global.LuminousStatusLibrary;
+    if (!library?.registerExtension) return false;
+
+    library.registerExtension("rage", {
+      name: "Rage",
+      type: "positive",
+      mode: "zero",
+      icon: RAGE_ICON,
+      description: "Barbarian Rage. A visible combat Status created by the Rage Quick Action and consumed by Barbarian/Archetype mechanics.",
+      classId: "barbarian",
+      visible: true,
+    });
+
+    return library.get?.("rage")?.icon === RAGE_ICON;
+  }
+
+  function patchRecklessAttack(definition) {
+    if (!definition) return null;
+    const next = clone(definition);
+
+    next.effects = (next.effects || []).map((effect) => {
+      const patched = clone(effect);
+      if (normalizeId(patched.id) === "reckless_attack_arm") {
+        patched.operations = [{ type: "set_flag", flagId: "reckless_attack_armed", value: true }];
+      }
+      return patched;
+    });
+
+    if (!next.effects.some((effect) => normalizeId(effect.id) === "reckless_attack_disarm")) {
+      next.effects.push({
+        id: "reckless_attack_disarm",
+        contexts: ["combat"],
+        trigger: "attack_end",
+        conditions: [{ flagId: "reckless_attack_armed", operator: "truthy" }],
+        operations: [{ type: "clear_flag", flagId: "reckless_attack_armed" }],
+      });
+    }
+
+    next.rules = (next.rules || [])
+      .filter((rule) => !(normalizeId(rule.type) === "status" && normalizeId(rule.statusId) === "reckless_attack_armed"))
+      .map((rule) => {
+        const patched = clone(rule);
+        if (normalizeId(patched.whileStatus) === "reckless_attack_armed") {
+          delete patched.whileStatus;
+          patched.conditions = [
+            ...(Array.isArray(patched.conditions) ? patched.conditions : []),
+            { flagId: "reckless_attack_armed", operator: "truthy" },
+          ];
+        }
+        return patched;
+      });
+
+    return next;
+  }
+
+  function patchTraitCatalog() {
+    const source = global.LuminousTraitCatalogCore;
+    if (!source) return false;
+    if (source.__classStatusSemantics074) return true;
+
+    const baseGet = typeof source.getDefinition === "function"
+      ? source.getDefinition.bind(source)
+      : (id) => clone(source.DEFINITIONS?.[normalizeId(id)] || null);
+    const baseAll = typeof source.allDefinitions === "function"
+      ? source.allDefinitions.bind(source)
+      : () => clone(source.DEFINITIONS || {});
+
+    const reckless = patchRecklessAttack(baseGet("reckless_attack"));
+    if (!reckless) return false;
+
+    const definitions = Object.freeze({
+      ...(source.DEFINITIONS || baseAll()),
+      reckless_attack: Object.freeze(clone(reckless)),
+    });
+
+    const getDefinition = (id) => normalizeId(id) === "reckless_attack"
+      ? clone(reckless)
+      : baseGet(id);
+    const allDefinitions = () => ({ ...baseAll(), reckless_attack: clone(reckless) });
+
+    global.LuminousTraitCatalogCore = Object.freeze({
+      ...source,
+      __classStatusSemantics074: true,
+      DEFINITIONS: definitions,
+      getDefinition,
+      allDefinitions,
+    });
+    return true;
+  }
+
+  function patchStatusEngine() {
+    const source = global.LuminousStatusEngine;
+    if (!source) return false;
+    if (source.__classStatusSemantics074) return true;
+
+    const wrapped = Object.freeze({
+      ...source,
+      __classStatusSemantics074: true,
+      listStatuses(unit) {
+        const rows = typeof source.listStatuses === "function" ? source.listStatuses(unit) : [];
+        return (rows || []).filter((entry) => !isInternalEffectId(entry?.id || entry?.instance?.id));
+      },
+    });
+
+    global.LuminousStatusEngine = wrapped;
+    return true;
+  }
+
+  function install() {
+    const status = registerClassStatuses();
+    const catalog = patchTraitCatalog();
+    const engine = patchStatusEngine();
+    return { status, catalog, engine };
+  }
+
+  const api = Object.freeze({
+    version: VERSION,
+    RAGE_ICON,
+    INTERNAL_EFFECT_IDS,
+    RESOURCE_ONLY_IDS,
+    isInternalEffectId,
+    isResourceOnlyId,
+    registerClassStatuses,
+    patchTraitCatalog,
+    patchStatusEngine,
+    patchRecklessAttack,
+    install,
+  });
+
+  global.LuminousClassStatusSemantics = api;
+  install();
+
+  if (typeof global.setInterval === "function") {
+    const timer = global.setInterval(() => {
+      const result = install();
+      if (result.status && result.catalog && result.engine) global.clearInterval?.(timer);
+    }, 250);
+    timer?.unref?.();
+  }
+
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/statusManager.js
+++ b/js/statusManager.js
@@ -29,6 +29,26 @@
     return library.registry || global.STATUS_REGISTRY || null;
   }
 
+  function ensureClassStatusSemantics() {
+    if (global.LuminousClassStatusSemantics) {
+      global.LuminousClassStatusSemantics.install?.();
+      return Promise.resolve(global.LuminousClassStatusSemantics);
+    }
+    if (typeof require === "function") {
+      try {
+        const runtime = require("./class-status-semantics.js");
+        runtime?.install?.();
+        if (runtime) return Promise.resolve(runtime);
+      } catch (_) {}
+    }
+    if (!global.document) return Promise.resolve(null);
+    return loadOnce("class-status-semantics-script", "js/class-status-semantics.js", () => global.LuminousClassStatusSemantics)
+      .then((runtime) => {
+        runtime?.install?.();
+        return runtime;
+      });
+  }
+
   function ensureElementalRuntime() {
     if (global.LuminousElementalStatusRuntime) {
       global.LuminousElementalStatusRuntime.install?.();
@@ -46,11 +66,13 @@
 
   if (library) {
     installLibrary(library);
+    ensureClassStatusSemantics();
     ensureElementalRuntime();
   } else if (global.document) {
     loadOnce("status-library-script", "js/status-library.js", () => global.LuminousStatusLibrary)
       .then((loaded) => {
         installLibrary(loaded);
+        ensureClassStatusSemantics();
         ensureElementalRuntime();
       });
   }
@@ -62,6 +84,7 @@
     get registry() { return global.LuminousStatusLibrary?.registry || global.STATUS_REGISTRY || null; },
     install() {
       const active = installLibrary(global.LuminousStatusLibrary);
+      ensureClassStatusSemantics();
       ensureElementalRuntime();
       return active;
     }

--- a/tests/class-status-semantics-smoke.mjs
+++ b/tests/class-status-semantics-smoke.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+for (const key of [
+  'LuminousStatusEngine',
+  'LuminousStatusLibrary',
+  'LuminousTraitEngine',
+  'LuminousTraitCatalogCore',
+  'LuminousClassStatusSemantics',
+  'STATUS_REGISTRY',
+]) delete globalThis[key];
+
+await import('../js/status-engine.js');
+await import('../js/status-library.js');
+await import('../js/trait-engine.js');
+await import('../js/trait-catalog-core.js');
+await import('../js/class-status-semantics.js');
+
+const library = globalThis.LuminousStatusLibrary;
+const semantics = globalThis.LuminousClassStatusSemantics;
+assert.ok(library, 'Status Library must load');
+assert.equal(semantics?.version, '0.7.4-class-status-semantics');
+semantics.install();
+
+// Rage is a real visible combat Status and owns the supplied canonical icon.
+assert.equal(library.has('rage'), true);
+assert.equal(library.get('rage')?.name, 'Rage');
+assert.equal(library.get('rage')?.mode, 'zero');
+assert.equal(library.get('rage')?.icon, 'https://imgur.com/j3C7GzS.png');
+
+// Class resources and Action/Passive implementation markers are not Status Effects.
+assert.equal(library.has('sorcery_points'), false, 'Sorcery Points are a Sorcerer class resource, not a Status');
+assert.equal(library.has('reckless_attack_armed'), false, 'Reckless Attack arming is internal Trait state');
+assert.equal(library.has('countercharm'), false, 'Countercharm is an Action effect, not a canonical Status');
+assert.equal(library.has('wild_instincts'), false, 'Wild Instincts is a Trait, not a Status');
+assert.equal(library.has('haste'), true, 'Wild Instincts may still apply the canonical Haste Status');
+
+// Reckless Attack must use Trait flags rather than polluting statusEffects.
+const reckless = globalThis.LuminousTraitCatalogCore.getDefinition('reckless_attack');
+assert.ok(reckless, 'Reckless Attack must remain in the Trait catalog');
+const arm = reckless.effects.find((effect) => effect.id === 'reckless_attack_arm');
+assert.deepEqual(arm?.operations, [{ type: 'set_flag', flagId: 'reckless_attack_armed', value: true }]);
+const disarm = reckless.effects.find((effect) => effect.id === 'reckless_attack_disarm');
+assert.deepEqual(disarm?.operations, [{ type: 'clear_flag', flagId: 'reckless_attack_armed' }]);
+assert.equal(reckless.effects.some((effect) => (effect.operations || []).some((op) => op.type === 'apply_status' && op.statusId === 'reckless_attack_armed')), false);
+assert.equal(reckless.rules.some((rule) => rule.statusId === 'reckless_attack_armed'), false);
+for (const rule of reckless.rules.filter((rule) => ['coin', 'status'].includes(rule.type))) {
+  if (rule.type === 'coin' || rule.statusId === 'fragile') {
+    assert.equal(rule.whileStatus, undefined);
+    assert.ok((rule.conditions || []).some((condition) => condition.flagId === 'reckless_attack_armed' && condition.operator === 'truthy'));
+  }
+}
+
+// Legacy/runtime Action markers can still exist mechanically, but the canonical Status UI must hide them.
+const unit = {
+  statusEffects: {
+    rage: { id: 'rage', count: 1, potency: 0 },
+    haste: { id: 'haste', count: 2, potency: 0 },
+    countercharm: { id: 'countercharm', count: 2, potency: 0 },
+    reckless_attack_armed: { id: 'reckless_attack_armed', count: 1, potency: 0 },
+  },
+};
+const visible = globalThis.LuminousStatusEngine.listStatuses(unit).map((entry) => entry.id).sort();
+assert.deepEqual(visible, ['haste', 'rage']);
+
+// Sorcerer keeps Sorcery Points in classResources; it must not regress into the Status Library.
+const sorcererSource = fs.readFileSync(path.join(root, 'js/sorcerer-class-runtime.js'), 'utf8');
+assert.match(sorcererSource, /classResources/);
+assert.match(sorcererSource, /sorceryPoints/);
+assert.doesNotMatch(sorcererSource, /statusId\s*:\s*["']sorcery_points["']/);
+
+const managerSource = fs.readFileSync(path.join(root, 'js/statusManager.js'), 'utf8');
+assert.match(managerSource, /class-status-semantics\.js/);
+
+console.log('Class Status semantics smoke passed: Rage visible; Reckless/Countercharm internal; Sorcery Points remain a resource.');


### PR DESCRIPTION
Classify class mechanics cleanly around the unified Status Library.

- Register visible Barbarian Rage in LuminousStatusLibrary with the canonical icon https://imgur.com/j3C7GzS.png
- Keep Sorcery Points as a Sorcerer class resource, not a Status
- Convert Reckless Attack arming from a fake Status into Trait flag state
- Treat Countercharm as an internal Action effect for Status UI purposes
- Keep Wild Instincts as a Trait while preserving its real Haste application
- Add smoke coverage and module syntax checks