### PR TITLE
Hotfix: classify class Status effects and add Rage icon

### DIFF
--- a/.github/workflows/combat-runtime-smoke.yml
+++ b/.github/workflows/combat-runtime-smoke.yml
@@ -7,6 +7,7 @@ on:
       - feature/combat-deck-engine
       - feature/battle-viewer-0.7.3-engine-migration
       - hotfix/unified-status-library
+      - hotfix/class-status-classification-rage
   pull_request:
     branches:
       - main
@@ -27,6 +28,8 @@ jobs:
         run: node tests/unbreakable-red-coin-smoke.mjs
       - name: Unified canonical Status Library smoke
         run: node tests/combat-v074-unified-status-library-smoke.mjs
+      - name: Class Status classification smoke
+        run: node tests/combat-v074-class-status-classification-smoke.mjs
       - name: Starter Tier 1 status skill catalog smoke
         run: node tests/starter-status-skill-catalog-smoke.mjs
       - name: G1-G2 Skill Forge smoke
@@ -61,6 +64,7 @@ jobs:
         run: |
           node --check js/status-library.js
           node --check js/statusManager.js
+          node --check js/class-status-classification.js
           node --check js/battle-viewer-action-adapter-073.js
           node --check js/battle-viewer-firebase-session-074.js
           node --check js/combat-skill-loadout-074.js

--- a/js/class-status-classification.js
+++ b/js/class-status-classification.js
@@ -1,0 +1,127 @@
+(function (global) {
+  "use strict";
+
+  const VERSION = "0.7.4-class-status-classification";
+  if (global.LuminousClassStatusClassification?.version === VERSION) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousClassStatusClassification;
+    return;
+  }
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+  // These are mechanical markers/resources used by Traits and Classes. They are
+  // deliberately NOT Status Library entries and must never render in the Status HUD.
+  const INTERNAL_TRAIT_EFFECT_IDS = Object.freeze([
+    "reckless_attack_armed",
+    "countercharm",
+  ]);
+  const RESOURCE_ONLY_IDS = Object.freeze([
+    "sorcery_points",
+    "sorcerypoints",
+  ]);
+  const internalIds = new Set(INTERNAL_TRAIT_EFFECT_IDS);
+  const resourceIds = new Set(RESOURCE_ONLY_IDS);
+
+  const RAGE_DEFINITION = Object.freeze({
+    name: "Rage",
+    type: "positive",
+    mode: "zero",
+    icon: "https://imgur.com/j3C7GzS.png",
+    category: "class_status",
+    sourceClassId: "barbarian",
+    description: "Barbarian Rage. Its mechanics, duration, restrictions and scaling are supplied by the Barbarian Trait runtime.",
+  });
+
+  function library() {
+    return global.LuminousStatusLibrary || null;
+  }
+
+  function isInternalTraitEffect(statusId) {
+    return internalIds.has(normalizeId(statusId));
+  }
+
+  function isResourceOnly(statusId) {
+    return resourceIds.has(normalizeId(statusId));
+  }
+
+  function isVisibleStatus(statusId) {
+    const id = normalizeId(statusId);
+    return Boolean(id && !internalIds.has(id) && !resourceIds.has(id));
+  }
+
+  function installRage() {
+    const statusLibrary = library();
+    if (!statusLibrary?.registerExtension) return false;
+    if (!statusLibrary.has?.("rage")) statusLibrary.registerExtension("rage", RAGE_DEFINITION);
+    return Boolean(statusLibrary.get?.("rage"));
+  }
+
+  function installStatusEngineBridge() {
+    const source = global.LuminousStatusEngine;
+    if (!source) return false;
+    if (source.__classStatusClassification074) return true;
+
+    const wrapped = Object.freeze({
+      ...source,
+      __classStatusClassification074: true,
+      isInternalTraitEffect,
+      isResourceOnly,
+      isVisibleStatus,
+      getDefinition(statusId) {
+        const id = normalizeId(statusId);
+        if (isInternalTraitEffect(id)) {
+          return {
+            id,
+            name: id,
+            type: "internal",
+            mode: "zero",
+            icon: null,
+            rules: [],
+            hidden: true,
+            internalEffect: true,
+            description: "Internal Trait effect marker; not a Status Effect.",
+          };
+        }
+        return source.getDefinition(statusId);
+      },
+      listStatuses(unit) {
+        const entries = source.listStatuses?.(unit) || [];
+        return entries.filter((entry) => isVisibleStatus(entry?.id || entry?.instance?.id));
+      },
+    });
+
+    global.LuminousStatusEngine = wrapped;
+    return true;
+  }
+
+  function install() {
+    const rage = installRage();
+    const statusEngine = installStatusEngineBridge();
+    return { rage, statusEngine };
+  }
+
+  const api = Object.freeze({
+    version: VERSION,
+    rageDefinition: clone(RAGE_DEFINITION),
+    internalTraitEffectIds: INTERNAL_TRAIT_EFFECT_IDS,
+    resourceOnlyIds: RESOURCE_ONLY_IDS,
+    isInternalTraitEffect,
+    isResourceOnly,
+    isVisibleStatus,
+    installRage,
+    installStatusEngineBridge,
+    install,
+  });
+
+  global.LuminousClassStatusClassification = api;
+  install();
+
+  const timer = typeof global.setInterval === "function" ? global.setInterval(() => {
+    installRage();
+    installStatusEngineBridge();
+  }, 250) : null;
+  timer?.unref?.();
+
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/statusManager.js
+++ b/js/statusManager.js
@@ -29,6 +29,29 @@
     return library.registry || global.STATUS_REGISTRY || null;
   }
 
+  function installClassStatusClassification() {
+    if (global.LuminousClassStatusClassification) {
+      global.LuminousClassStatusClassification.install?.();
+      return Promise.resolve(global.LuminousClassStatusClassification);
+    }
+    if (typeof require === "function") {
+      try {
+        const classification = require("./class-status-classification.js");
+        classification?.install?.();
+        return Promise.resolve(classification || null);
+      } catch (_) {}
+    }
+    if (!global.document) return Promise.resolve(null);
+    return loadOnce(
+      "class-status-classification-script",
+      "js/class-status-classification.js",
+      () => global.LuminousClassStatusClassification,
+    ).then((classification) => {
+      classification?.install?.();
+      return classification || null;
+    });
+  }
+
   function ensureElementalRuntime() {
     if (global.LuminousElementalStatusRuntime) {
       global.LuminousElementalStatusRuntime.install?.();
@@ -39,20 +62,22 @@
       .then((runtime) => runtime?.install?.());
   }
 
+  function finishInstall(library) {
+    const registry = installLibrary(library);
+    installClassStatusClassification().then(() => ensureElementalRuntime());
+    return registry;
+  }
+
   let library = global.LuminousStatusLibrary || null;
   if (!library && typeof require === "function") {
     try { library = require("./status-library.js"); } catch (_) {}
   }
 
   if (library) {
-    installLibrary(library);
-    ensureElementalRuntime();
+    finishInstall(library);
   } else if (global.document) {
     loadOnce("status-library-script", "js/status-library.js", () => global.LuminousStatusLibrary)
-      .then((loaded) => {
-        installLibrary(loaded);
-        ensureElementalRuntime();
-      });
+      .then((loaded) => finishInstall(loaded));
   }
 
   // Compatibility export only.  statusManager no longer owns a registry.
@@ -62,7 +87,7 @@
     get registry() { return global.LuminousStatusLibrary?.registry || global.STATUS_REGISTRY || null; },
     install() {
       const active = installLibrary(global.LuminousStatusLibrary);
-      ensureElementalRuntime();
+      installClassStatusClassification().then(() => ensureElementalRuntime());
       return active;
     }
   });

--- a/tests/combat-v074-class-status-classification-smoke.mjs
+++ b/tests/combat-v074-class-status-classification-smoke.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+for (const key of [
+  'LuminousStatusLibrary',
+  'LuminousStatusEngine',
+  'LuminousClassStatusClassification',
+  'STATUS_REGISTRY',
+]) delete globalThis[key];
+
+await import('../js/status-library.js');
+await import('../js/status-engine.js');
+await import('../js/class-status-classification.js');
+
+const library = globalThis.LuminousStatusLibrary;
+const engine = globalThis.LuminousStatusEngine;
+const classification = globalThis.LuminousClassStatusClassification;
+
+assert.ok(library, 'canonical Status Library must load');
+assert.ok(engine, 'Status Engine must load');
+assert.ok(classification, 'class Status classification bridge must load');
+
+const rage = library.get('rage');
+assert.ok(rage, 'Rage must be registered in the canonical Status Library');
+assert.equal(rage.name, 'Rage');
+assert.equal(rage.type, 'positive');
+assert.equal(rage.mode, 'zero');
+assert.equal(rage.icon, 'https://imgur.com/j3C7GzS.png');
+assert.equal(rage.category, 'class_status');
+
+for (const id of ['reckless_attack_armed', 'countercharm']) {
+  assert.equal(library.get(id), null, `${id} is an internal Trait effect, not a Status definition`);
+  assert.equal(classification.isInternalTraitEffect(id), true);
+}
+
+for (const id of ['sorcery_points', 'sorcerypoints']) {
+  assert.equal(library.get(id), null, `${id} is a Class resource, not a Status definition`);
+  assert.equal(classification.isResourceOnly(id), true);
+}
+
+const unit = {};
+engine.applyStatus(unit, 'rage', { mode: 'set', duration: 'until_removed' });
+engine.applyStatus(unit, 'reckless_attack_armed', { mode: 'set', duration: 'next_skill' });
+engine.applyStatus(unit, 'countercharm', { mode: 'set', count: 2 });
+
+assert.equal(engine.hasStatus(unit, 'rage'), true, 'Rage remains a real Status');
+assert.equal(engine.hasStatus(unit, 'reckless_attack_armed'), true, 'Reckless may keep an internal transient marker for mechanics');
+assert.equal(engine.hasStatus(unit, 'countercharm'), true, 'Countercharm may keep an internal action-effect marker for mechanics');
+
+const visible = engine.listStatuses(unit).map((entry) => entry.id).sort();
+assert.deepEqual(visible, ['rage'], 'only real Status Effects may render in the Status HUD');
+assert.equal(engine.getDefinition('reckless_attack_armed').hidden, true);
+assert.equal(engine.getDefinition('countercharm').hidden, true);
+
+const sorcererSource = fs.readFileSync(path.join(root, 'js/sorcerer-class-runtime.js'), 'utf8');
+assert.match(sorcererSource, /const STATE_ROOT = "classResources"/);
+assert.match(sorcererSource, /sorceryPoints/);
+assert.doesNotMatch(sorcererSource, /applyStatus\([^\n]*sorcery[_ ]?points/i);
+
+const barbarianSource = fs.readFileSync(path.join(root, 'js/trait-catalog-core.js'), 'utf8');
+assert.match(barbarianSource, /statusId: "rage"/);
+assert.match(barbarianSource, /statusId: "haste"/);
+
+console.log('Class Status classification smoke passed: Rage is visible; Reckless/Countercharm are internal; Sorcery Points are a Class resource.');


### PR DESCRIPTION
Classify class mechanics so only true Status Effects appear in the canonical Status HUD.

- Register Rage in the existing LuminousStatusLibrary with mode `zero` and the provided icon.
- Keep Reckless Attack armed state and Countercharm as internal Trait/Action effect markers, not Status Library definitions.
- Keep Sorcery Points as a Sorcerer class resource, never a Status.
- Load the classification bridge through statusManager.
- Add a dedicated smoke test and CI step.