### PR TITLE
Hotfix: make Battle Viewer UI progressive and compact

### DIFF
--- a/.github/workflows/combat-runtime-smoke.yml
+++ b/.github/workflows/combat-runtime-smoke.yml
@@ -59,6 +59,8 @@ jobs:
         run: node tests/combat-v073-runtime-authority-smoke.mjs
       - name: VTT combat unit actor library smoke
         run: node tests/vtt-actor-library-units-smoke.mjs
+      - name: Battle Viewer 0.7.4 progressive UI smoke
+        run: node tests/combat-v074-progressive-ui-smoke.mjs
       - name: Battle Viewer 0.7.4 module syntax
         run: |
           node --check js/status-library.js
@@ -76,6 +78,7 @@ jobs:
           node --check js/battle-viewer-player-entry-074.js
           node --check js/battle-viewer-ownership-074.js
           node --check js/battle-viewer-dm-console-074-magic.js
+          node --check js/battle-viewer-progressive-ui-074.js
           node --check js/battle-viewer-runtime-074.js
           node --check js/elemental-status-compat.js
           node --check js/status-rupture-runtime.js

--- a/js/battle-viewer-progressive-ui-074.js
+++ b/js/battle-viewer-progressive-ui-074.js
@@ -1,0 +1,138 @@
+(function (global) {
+  "use strict";
+
+  const VERSION = "0.7.4";
+  const STYLE_ID = "battle-viewer-progressive-ui-074-style";
+  const DM_PANEL_ID = "dm-dashboard";
+  const DM_BODY_ID = "dm074-body";
+  const DM_TOGGLE_ID = "dm074-collapse";
+  const SKILL_PANEL_ID = "bv074-player-skill-planner";
+
+  const state = {
+    installed: false,
+    observer: null,
+    timer: null,
+    dmExpanded: false,
+  };
+
+  function playerSkillPlanner() {
+    return global.LuminousBattleViewerPlayerSkillPlanner074 || null;
+  }
+
+  function shouldShowSkillPlanner() {
+    const planner = playerSkillPlanner();
+    if (!planner?.currentOwnerContext || !planner?.equippedSkillsFor) return false;
+    const context = planner.currentOwnerContext();
+    if (!context?.ok || !context?.combatant?.ok) return false;
+    return planner.equippedSkillsFor(context.playerId).length > 0;
+  }
+
+  function syncSkillPlanner() {
+    const panel = global.document?.getElementById?.(SKILL_PANEL_ID);
+    if (!panel) return false;
+    const shouldShow = shouldShowSkillPlanner();
+    if (panel.hidden === shouldShow) panel.hidden = !shouldShow;
+    if (!shouldShow) {
+      const planner = playerSkillPlanner();
+      if (planner?.state) planner.state.selectedSkillId = null;
+    }
+    return shouldShow;
+  }
+
+  function syncDmPanel() {
+    const doc = global.document;
+    const panel = doc?.getElementById?.(DM_PANEL_ID);
+    const body = doc?.getElementById?.(DM_BODY_ID);
+    const toggle = doc?.getElementById?.(DM_TOGGLE_ID);
+    if (!panel || !body || !toggle) return false;
+
+    body.hidden = !state.dmExpanded;
+    panel.classList?.toggle?.("dm074-compact", !state.dmExpanded);
+    toggle.textContent = state.dmExpanded ? "—" : "+";
+
+    if (toggle.dataset?.progressiveUi074Bound !== "1") {
+      if (toggle.dataset) toggle.dataset.progressiveUi074Bound = "1";
+      const original = typeof toggle.onclick === "function" ? toggle.onclick : null;
+      toggle.onclick = function (event) {
+        if (original) original.call(this, event);
+        state.dmExpanded = !body.hidden;
+        panel.classList?.toggle?.("dm074-compact", !state.dmExpanded);
+        toggle.textContent = state.dmExpanded ? "—" : "+";
+      };
+    }
+    return true;
+  }
+
+  function ensureStyle() {
+    const doc = global.document;
+    if (!doc?.head || doc.getElementById(STYLE_ID)) return false;
+    const style = doc.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = `
+      #${DM_PANEL_ID}.dm074.dm074-compact{width:230px;max-height:none}
+      #${DM_PANEL_ID}.dm074.dm074-compact .dm074-head{border-bottom:0}
+      #${SKILL_PANEL_ID}[hidden]{display:none!important}
+    `;
+    doc.head.appendChild(style);
+    return true;
+  }
+
+  function sync() {
+    ensureStyle();
+    syncDmPanel();
+    syncSkillPlanner();
+    return true;
+  }
+
+  function install() {
+    if (!global.document?.body) return false;
+    if (!state.installed) {
+      state.installed = true;
+      if (typeof global.MutationObserver === "function") {
+        state.observer = new global.MutationObserver(() => sync());
+        state.observer.observe(global.document.body, {
+          childList: true,
+          subtree: true,
+          attributes: true,
+          attributeFilter: ["hidden"],
+        });
+      }
+      if (typeof global.setInterval === "function") {
+        state.timer = global.setInterval(sync, 250);
+        state.timer?.unref?.();
+      }
+    }
+    sync();
+    return true;
+  }
+
+  function stop() {
+    state.observer?.disconnect?.();
+    state.observer = null;
+    if (state.timer && typeof global.clearInterval === "function") global.clearInterval(state.timer);
+    state.timer = null;
+    state.installed = false;
+  }
+
+  function setDmExpanded(expanded) {
+    state.dmExpanded = expanded === true;
+    syncDmPanel();
+    return state.dmExpanded;
+  }
+
+  const api = Object.freeze({
+    version: VERSION,
+    state,
+    shouldShowSkillPlanner,
+    syncSkillPlanner,
+    syncDmPanel,
+    setDmExpanded,
+    sync,
+    install,
+    stop,
+  });
+
+  global.LuminousBattleViewerProgressiveUi074 = api;
+  if (global.document?.body) install();
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/battle-viewer-runtime-074.js
+++ b/js/battle-viewer-runtime-074.js
@@ -36,6 +36,7 @@
     ["battle-viewer-dm-console-074-script", "js/battle-viewer-dm-console-074.js", "LuminousBattleViewerDmConsole074"],
     ["battle-viewer-player-entry-074-script", "js/battle-viewer-player-entry-074.js", "LuminousBattleViewerPlayerEntry074"],
     ["battle-viewer-dm-console-074-magic-script", "js/battle-viewer-dm-console-074-magic.js", "LuminousBattleViewerDmMagic074"],
+    ["battle-viewer-progressive-ui-074-script", "js/battle-viewer-progressive-ui-074.js", "LuminousBattleViewerProgressiveUi074"],
   ];
 
   function waitForReady(isReady, valueGetter = null, timeoutMs = WAIT_TIMEOUT_MS) {
@@ -114,6 +115,7 @@
     parts.spellAdapter?.install?.();
     parts.spellRuntime?.install?.();
     parts.ownership?.install?.();
+    parts.progressiveUi?.install?.();
   }
 
   function initializeConfiguredDmConsole(dmConsole, result = {}) {
@@ -204,11 +206,12 @@
     const dmConsole = global.LuminousBattleViewerDmConsole074 || null;
     const playerEntry = global.LuminousBattleViewerPlayerEntry074 || null;
     const dmMagic = global.LuminousBattleViewerDmMagic074 || null;
+    const progressiveUi = global.LuminousBattleViewerProgressiveUi074 || null;
     const ruptureStatus = global.LuminousRuptureStatusRuntime || null;
     const skillForge = global.LuminousSkillForgeG2 || null;
     const parts = {
       firebaseSession, skillLoadout, spellLoadout, spellAdapter, spellRuntime, ownership,
-      playerSkillPlanner, playerSpellPlanner, dmConsole, playerEntry, dmMagic, ruptureStatus, skillForge,
+      playerSkillPlanner, playerSpellPlanner, dmConsole, playerEntry, dmMagic, progressiveUi, ruptureStatus, skillForge,
     };
     initializeSharedRuntime(parts);
     const sessionReady = initializeRoleRuntime(parts);
@@ -228,6 +231,7 @@
       dmConsole,
       playerEntry,
       dmMagic,
+      progressiveUi,
       ruptureStatus,
       skillForge,
       initializeConfiguredDmConsole,
@@ -258,6 +262,7 @@
       && global.LuminousBattleViewerDmConsole074
       && global.LuminousBattleViewerPlayerEntry074
       && global.LuminousBattleViewerDmMagic074
+      && global.LuminousBattleViewerProgressiveUi074
     );
   }
 
@@ -287,6 +292,7 @@
     try { if (!global.LuminousBattleViewerDmConsole074) require("./battle-viewer-dm-console-074.js"); } catch (_) {}
     try { if (!global.LuminousBattleViewerPlayerEntry074) require("./battle-viewer-player-entry-074.js"); } catch (_) {}
     try { if (!global.LuminousBattleViewerDmMagic074) require("./battle-viewer-dm-console-074-magic.js"); } catch (_) {}
+    try { if (!global.LuminousBattleViewerProgressiveUi074) require("./battle-viewer-progressive-ui-074.js"); } catch (_) {}
     const api = buildApi();
     module.exports = api;
   } else if (!HAS_DOCUMENT) {

--- a/tests/combat-v074-progressive-ui-smoke.mjs
+++ b/tests/combat-v074-progressive-ui-smoke.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+for (const key of ['document', 'MutationObserver', 'LuminousBattleViewerProgressiveUi074', 'LuminousBattleViewerPlayerSkillPlanner074']) delete globalThis[key];
+
+await import('../js/battle-viewer-progressive-ui-074.js');
+const ui = globalThis.LuminousBattleViewerProgressiveUi074;
+assert.equal(ui?.version, '0.7.4');
+assert.equal(ui.state.dmExpanded, false, 'DM tools should default to compact mode');
+
+let skills = [];
+globalThis.LuminousBattleViewerPlayerSkillPlanner074 = {
+  state: { selectedSkillId: 'stale_skill' },
+  currentOwnerContext() {
+    return { ok: true, playerId: 'player_a', combatant: { ok: true }, unit: { id: 'player:player_a' } };
+  },
+  equippedSkillsFor() { return skills; },
+};
+assert.equal(ui.shouldShowSkillPlanner(), false, '0 equipped Skills must not reserve Player Skill UI space');
+skills = [{ id: 'skill_a', name: 'Skill A' }];
+assert.equal(ui.shouldShowSkillPlanner(), true, 'equipped Skills should make the Player Skill UI actionable');
+
+function classList() {
+  const values = new Set();
+  return {
+    toggle(name, enabled) { enabled ? values.add(name) : values.delete(name); },
+    contains(name) { return values.has(name); },
+  };
+}
+
+const panel = { classList: classList() };
+let body = { hidden: false };
+let toggle = {
+  textContent: '—',
+  dataset: {},
+  onclick() {
+    body.hidden = !body.hidden;
+    this.textContent = body.hidden ? '+' : '—';
+  },
+};
+const nodes = {
+  'dm-dashboard': panel,
+  'dm074-body': body,
+  'dm074-collapse': toggle,
+  'bv074-player-skill-planner': { hidden: false },
+};
+globalThis.document = { getElementById(id) { return nodes[id] || null; } };
+
+ui.state.dmExpanded = false;
+assert.equal(ui.syncDmPanel(), true);
+assert.equal(body.hidden, true);
+assert.equal(panel.classList.contains('dm074-compact'), true);
+assert.equal(toggle.textContent, '+');
+
+toggle.onclick({ type: 'click' });
+assert.equal(ui.state.dmExpanded, true, 'manual DM expansion should be remembered');
+assert.equal(body.hidden, false);
+assert.equal(panel.classList.contains('dm074-compact'), false);
+
+// Simulate the legacy DM console remounting its innerHTML after Firebase refresh.
+body = { hidden: false };
+toggle = {
+  textContent: '—',
+  dataset: {},
+  onclick() {
+    body.hidden = !body.hidden;
+    this.textContent = body.hidden ? '+' : '—';
+  },
+};
+nodes['dm074-body'] = body;
+nodes['dm074-collapse'] = toggle;
+ui.syncDmPanel();
+assert.equal(body.hidden, false, 'DM expansion preference survives console remounts');
+assert.equal(toggle.textContent, '—');
+
+skills = [];
+ui.syncSkillPlanner();
+assert.equal(nodes['bv074-player-skill-planner'].hidden, true);
+assert.equal(globalThis.LuminousBattleViewerPlayerSkillPlanner074.state.selectedSkillId, null);
+skills = [{ id: 'skill_a', name: 'Skill A' }];
+ui.syncSkillPlanner();
+assert.equal(nodes['bv074-player-skill-planner'].hidden, false);
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const runtimeSource = fs.readFileSync(path.join(here, '..', 'js', 'battle-viewer-runtime-074.js'), 'utf8');
+assert.match(runtimeSource, /battle-viewer-progressive-ui-074\.js/);
+assert.match(runtimeSource, /LuminousBattleViewerProgressiveUi074/);
+
+console.log('combat-v074-progressive-ui-smoke: ok');


### PR DESCRIPTION
Polish Battle Viewer screen occupancy without changing combat mechanics.

- Add a progressive UI controller for Battle Viewer 0.7.4.
- DM Test Console starts compact/collapsed instead of reserving the full 390px panel.
- Preserve the DM's manual expanded/collapsed preference when the legacy console remounts after Firebase refreshes.
- Hide the Player Skill Planner when the authenticated combatant has 0 equipped Skills instead of reserving the 560px planner surface with `No equipped Skills`.
- Keep the existing Spell Planner behavior: it already hides when there are no selected Spells.
- Do not change Action Slot counts, Action Economy, ownership, planning writes, or combat resolution.
- Add a focused progressive UI smoke plus module syntax coverage.