### PR TITLE
Hotfix: stop DM Viewer progressive UI mutation loop

### DIFF
--- a/js/battle-viewer-progressive-ui-074.js
+++ b/js/battle-viewer-progressive-ui-074.js
@@ -12,6 +12,7 @@
     installed: false,
     observer: null,
     timer: null,
+    syncQueued: false,
     dmExpanded: false,
   };
 
@@ -31,7 +32,8 @@
     const panel = global.document?.getElementById?.(SKILL_PANEL_ID);
     if (!panel) return false;
     const shouldShow = shouldShowSkillPlanner();
-    if (panel.hidden === shouldShow) panel.hidden = !shouldShow;
+    const shouldHide = !shouldShow;
+    if (Boolean(panel.hidden) !== shouldHide) panel.hidden = shouldHide;
     if (!shouldShow) {
       const planner = playerSkillPlanner();
       if (planner?.state) planner.state.selectedSkillId = null;
@@ -46,9 +48,15 @@
     const toggle = doc?.getElementById?.(DM_TOGGLE_ID);
     if (!panel || !body || !toggle) return false;
 
-    body.hidden = !state.dmExpanded;
-    panel.classList?.toggle?.("dm074-compact", !state.dmExpanded);
-    toggle.textContent = state.dmExpanded ? "—" : "+";
+    const shouldHide = !state.dmExpanded;
+    const toggleText = state.dmExpanded ? "—" : "+";
+
+    // Important: do not rewrite reflected DOM attributes/text when they already
+    // match. The progressive UI is driven by a MutationObserver, so redundant
+    // writes can create an observer feedback loop in a real browser.
+    if (Boolean(body.hidden) !== shouldHide) body.hidden = shouldHide;
+    panel.classList?.toggle?.("dm074-compact", shouldHide);
+    if (toggle.textContent !== toggleText) toggle.textContent = toggleText;
 
     if (toggle.dataset?.progressiveUi074Bound !== "1") {
       if (toggle.dataset) toggle.dataset.progressiveUi074Bound = "1";
@@ -57,7 +65,8 @@
         if (original) original.call(this, event);
         state.dmExpanded = !body.hidden;
         panel.classList?.toggle?.("dm074-compact", !state.dmExpanded);
-        toggle.textContent = state.dmExpanded ? "—" : "+";
+        const nextText = state.dmExpanded ? "—" : "+";
+        if (toggle.textContent !== nextText) toggle.textContent = nextText;
       };
     }
     return true;
@@ -84,21 +93,34 @@
     return true;
   }
 
+  function scheduleSync() {
+    if (state.syncQueued) return false;
+    state.syncQueued = true;
+    const run = () => {
+      state.syncQueued = false;
+      sync();
+    };
+    if (typeof global.queueMicrotask === "function") global.queueMicrotask(run);
+    else if (typeof global.setTimeout === "function") global.setTimeout(run, 0);
+    else run();
+    return true;
+  }
+
   function install() {
     if (!global.document?.body) return false;
     if (!state.installed) {
       state.installed = true;
       if (typeof global.MutationObserver === "function") {
-        state.observer = new global.MutationObserver(() => sync());
+        state.observer = new global.MutationObserver(() => scheduleSync());
+        // We only need to notice console/planner mounts and remounts. Observing
+        // `hidden` was unsafe because syncDmPanel itself owns that attribute.
         state.observer.observe(global.document.body, {
           childList: true,
           subtree: true,
-          attributes: true,
-          attributeFilter: ["hidden"],
         });
       }
       if (typeof global.setInterval === "function") {
-        state.timer = global.setInterval(sync, 250);
+        state.timer = global.setInterval(sync, 500);
         state.timer?.unref?.();
       }
     }
@@ -111,6 +133,7 @@
     state.observer = null;
     if (state.timer && typeof global.clearInterval === "function") global.clearInterval(state.timer);
     state.timer = null;
+    state.syncQueued = false;
     state.installed = false;
   }
 
@@ -128,6 +151,7 @@
     syncDmPanel,
     setDmExpanded,
     sync,
+    scheduleSync,
     install,
     stop,
   });

--- a/tests/combat-v074-progressive-ui-smoke.mjs
+++ b/tests/combat-v074-progressive-ui-smoke.mjs
@@ -30,16 +30,34 @@ function classList() {
   };
 }
 
+function trackedBody(initialHidden = false) {
+  let hidden = Boolean(initialHidden);
+  let writes = 0;
+  return {
+    get hidden() { return hidden; },
+    set hidden(value) { hidden = Boolean(value); writes += 1; },
+    get hiddenWrites() { return writes; },
+  };
+}
+
+function trackedToggle(bodyRef, initialText = '—') {
+  let text = initialText;
+  let writes = 0;
+  return {
+    dataset: {},
+    get textContent() { return text; },
+    set textContent(value) { text = String(value); writes += 1; },
+    get textWrites() { return writes; },
+    onclick() {
+      bodyRef.hidden = !bodyRef.hidden;
+      this.textContent = bodyRef.hidden ? '+' : '—';
+    },
+  };
+}
+
 const panel = { classList: classList() };
-let body = { hidden: false };
-let toggle = {
-  textContent: '—',
-  dataset: {},
-  onclick() {
-    body.hidden = !body.hidden;
-    this.textContent = body.hidden ? '+' : '—';
-  },
-};
+let body = trackedBody(false);
+let toggle = trackedToggle(body);
 const nodes = {
   'dm-dashboard': panel,
   'dm074-body': body,
@@ -53,6 +71,14 @@ assert.equal(ui.syncDmPanel(), true);
 assert.equal(body.hidden, true);
 assert.equal(panel.classList.contains('dm074-compact'), true);
 assert.equal(toggle.textContent, '+');
+assert.equal(body.hiddenWrites, 1);
+assert.equal(toggle.textWrites, 1);
+
+// Regression: repeated synchronization must be idempotent. Redundant writes to
+// `hidden` or textContent can feed the browser MutationObserver back into sync.
+ui.syncDmPanel();
+assert.equal(body.hiddenWrites, 1, 'sync must not rewrite hidden when state already matches');
+assert.equal(toggle.textWrites, 1, 'sync must not rewrite toggle text when state already matches');
 
 toggle.onclick({ type: 'click' });
 assert.equal(ui.state.dmExpanded, true, 'manual DM expansion should be remembered');
@@ -60,20 +86,15 @@ assert.equal(body.hidden, false);
 assert.equal(panel.classList.contains('dm074-compact'), false);
 
 // Simulate the legacy DM console remounting its innerHTML after Firebase refresh.
-body = { hidden: false };
-toggle = {
-  textContent: '—',
-  dataset: {},
-  onclick() {
-    body.hidden = !body.hidden;
-    this.textContent = body.hidden ? '+' : '—';
-  },
-};
+body = trackedBody(false);
+toggle = trackedToggle(body);
 nodes['dm074-body'] = body;
 nodes['dm074-collapse'] = toggle;
 ui.syncDmPanel();
 assert.equal(body.hidden, false, 'DM expansion preference survives console remounts');
 assert.equal(toggle.textContent, '—');
+assert.equal(body.hiddenWrites, 0, 'matching expanded state must not rewrite hidden after remount');
+assert.equal(toggle.textWrites, 0, 'matching expanded label must not rewrite text after remount');
 
 skills = [];
 ui.syncSkillPlanner();
@@ -85,7 +106,10 @@ assert.equal(nodes['bv074-player-skill-planner'].hidden, false);
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const runtimeSource = fs.readFileSync(path.join(here, '..', 'js', 'battle-viewer-runtime-074.js'), 'utf8');
+const progressiveSource = fs.readFileSync(path.join(here, '..', 'js', 'battle-viewer-progressive-ui-074.js'), 'utf8');
 assert.match(runtimeSource, /battle-viewer-progressive-ui-074\.js/);
 assert.match(runtimeSource, /LuminousBattleViewerProgressiveUi074/);
+assert.doesNotMatch(progressiveSource, /attributeFilter\s*:\s*\[\s*["']hidden["']\s*\]/, 'progressive UI must not observe the hidden attribute it owns');
+assert.match(progressiveSource, /childList\s*:\s*true/);
 
 console.log('combat-v074-progressive-ui-smoke: ok');


### PR DESCRIPTION
Fixes the DM Battle Viewer crash introduced by the progressive UI controller.

Root cause:
- The progressive UI observed the `hidden` attribute while also writing `body.hidden` during every sync.
- It also rewrote the collapse button text during every sync.
- In a real browser this can feed MutationObserver callbacks back into the same sync path and hang/crash the Viewer.

Fix:
- Observe DOM child mounts/remounts only; do not observe `hidden`.
- Make DM panel synchronization idempotent: write `hidden` and toggle text only when values actually change.
- Coalesce observer callbacks through `scheduleSync()`.
- Keep a slower interval fallback for environments where remounts are missed.
- Add regression coverage proving repeated syncs do not rewrite the owned DOM state.

No changes to combat mechanics, Firebase writes, ownership, Action Economy, Skills or Spells.