### PR TITLE
Hotfix: add DM encounter roster monitor

### DIFF
--- a/.github/workflows/combat-runtime-smoke.yml
+++ b/.github/workflows/combat-runtime-smoke.yml
@@ -61,6 +61,8 @@ jobs:
         run: node tests/vtt-actor-library-units-smoke.mjs
       - name: Battle Viewer 0.7.4 progressive UI smoke
         run: node tests/combat-v074-progressive-ui-smoke.mjs
+      - name: Battle Viewer 0.7.4 DM encounter roster smoke
+        run: node tests/combat-v074-dm-encounter-roster-smoke.mjs
       - name: Battle Viewer 0.7.4 module syntax
         run: |
           node --check js/status-library.js
@@ -78,6 +80,7 @@ jobs:
           node --check js/battle-viewer-player-entry-074.js
           node --check js/battle-viewer-ownership-074.js
           node --check js/battle-viewer-dm-console-074-magic.js
+          node --check js/battle-viewer-dm-encounter-roster-074.js
           node --check js/battle-viewer-progressive-ui-074.js
           node --check js/battle-viewer-runtime-074.js
           node --check js/elemental-status-compat.js

--- a/js/battle-viewer-dm-encounter-roster-074.js
+++ b/js/battle-viewer-dm-encounter-roster-074.js
@@ -1,0 +1,257 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousBattleViewerDmEncounterRoster074?.version === "0.7.4") {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousBattleViewerDmEncounterRoster074;
+    return;
+  }
+
+  const VERSION = "0.7.4";
+  const CARD_ID = "dm074-encounter-roster";
+  const STYLE_ID = "dm074-encounter-roster-style";
+  const ROOTS = Object.freeze({
+    combatants: "campaña/combate/combatants",
+    reserves: "campaña/combate/reserves",
+  });
+
+  const state = {
+    db: null,
+    combatants: {},
+    reserves: {},
+    started: false,
+    listeners: [],
+    mountTimer: null,
+  };
+
+  const clean = (value) => String(value ?? "").trim();
+  const normalized = (value) => clean(value).toLowerCase().replace(/[\s-]+/g, "_");
+  const escapeHtml = (value) => clean(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+
+  function consoleApi() {
+    return global.LuminousBattleViewerDmConsole074 || null;
+  }
+
+  function labelFor(key, unit = {}) {
+    return clean(unit.characterName || unit.character_name || unit.nombre || unit.name || unit.displayName || key || "UNIT") || "UNIT";
+  }
+
+  function sideFor(unit = {}) {
+    const category = normalized(unit.actorCategory || unit.category || unit.type || unit.kind);
+    const faction = normalized(unit.faction || unit.faccion || unit.team || unit.side);
+    if (unit.isPlayer === true || category === "player") return "ally";
+    if (["ally", "allied", "friendly", "player", "players", "aliado", "aliados"].includes(faction)) return "ally";
+    if (["ally", "allied", "friendly", "aliado"].includes(category)) return "ally";
+    if (["enemy", "enemies", "hostile", "enemigo", "enemigos", "boss"].includes(faction)) return "enemy";
+    if (["enemy", "hostile", "enemigo", "boss", "monster", "monstruo"].includes(category)) return "enemy";
+    if (unit.hostile === true || unit.enemy === true || unit.isEnemy === true) return "enemy";
+    return "neutral";
+  }
+
+  function roleFor(unit = {}) {
+    const category = normalized(unit.actorCategory || unit.category || unit.type || unit.kind);
+    const faction = normalized(unit.faction || unit.faccion || unit.team || unit.side);
+    if (unit.isPlayer === true || category === "player") return "player";
+    if (category === "boss" || faction === "boss" || unit.isBoss === true) return "boss";
+    return sideFor(unit) === "ally" ? "ally" : sideFor(unit) === "enemy" ? "enemy" : "neutral";
+  }
+
+  function entriesFor(collection = {}, deployment = "field") {
+    return Object.entries(collection || {})
+      .filter(([, unit]) => unit && typeof unit === "object")
+      .map(([key, unit]) => ({
+        key,
+        unit,
+        name: labelFor(key, unit),
+        side: sideFor(unit),
+        role: roleFor(unit),
+        deployment,
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  function sectionSummary(entries = []) {
+    return {
+      total: entries.length,
+      players: entries.filter((entry) => entry.role === "player").length,
+      allies: entries.filter((entry) => entry.role === "ally").length,
+      enemies: entries.filter((entry) => entry.role === "enemy").length,
+      bosses: entries.filter((entry) => entry.role === "boss").length,
+      neutral: entries.filter((entry) => entry.role === "neutral").length,
+    };
+  }
+
+  function summarizeRoster(combatants = state.combatants, reserves = state.reserves) {
+    const fieldEntries = entriesFor(combatants, "field");
+    const backupEntries = entriesFor(reserves, "backup");
+    const split = (entries, side) => entries.filter((entry) => entry.side === side);
+    const fieldAlly = split(fieldEntries, "ally");
+    const fieldEnemy = split(fieldEntries, "enemy");
+    const fieldNeutral = split(fieldEntries, "neutral");
+    const backupAlly = split(backupEntries, "ally");
+    const backupEnemy = split(backupEntries, "enemy");
+    const backupNeutral = split(backupEntries, "neutral");
+    return {
+      field: {
+        entries: fieldEntries,
+        allies: fieldAlly,
+        enemies: fieldEnemy,
+        neutral: fieldNeutral,
+        counts: sectionSummary(fieldEntries),
+      },
+      backup: {
+        entries: backupEntries,
+        allies: backupAlly,
+        enemies: backupEnemy,
+        neutral: backupNeutral,
+        counts: sectionSummary(backupEntries),
+      },
+      allied: {
+        field: sectionSummary(fieldAlly),
+        backup: sectionSummary(backupAlly),
+      },
+      enemy: {
+        field: sectionSummary(fieldEnemy),
+        backup: sectionSummary(backupEnemy),
+      },
+    };
+  }
+
+  function ensureStyle() {
+    const doc = global.document;
+    if (!doc?.head || doc.getElementById(STYLE_ID)) return false;
+    const style = doc.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = `
+      #${CARD_ID} .dm074-roster-score{display:grid;grid-template-columns:1fr 1fr;gap:5px;margin-bottom:6px}
+      #${CARD_ID} .dm074-roster-side{border:1px solid #2d281f;padding:5px;background:rgba(255,255,255,.02)}
+      #${CARD_ID} .dm074-roster-side b{display:block;color:#f0d17f;font-size:12px}
+      #${CARD_ID} .dm074-roster-side small{color:#8f8778}
+      #${CARD_ID} .dm074-roster-columns{display:grid;grid-template-columns:1fr 1fr;gap:6px}
+      #${CARD_ID} .dm074-roster-column{min-width:0}
+      #${CARD_ID} .dm074-roster-subtitle{color:#a8997d;font-size:9px;font-weight:700;letter-spacing:.5px;margin:4px 0 2px}
+      #${CARD_ID} .dm074-roster-list{display:grid;gap:2px;max-height:100px;overflow:auto}
+      #${CARD_ID} .dm074-roster-entry{font-size:10px;border-bottom:1px solid #211e18;padding:2px 0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+      #${CARD_ID} .dm074-roster-entry span{color:#7f7565;margin-right:4px}
+      #${CARD_ID} .dm074-roster-empty{font-size:9px;color:#6f685d;font-style:italic}
+    `;
+    doc.head.appendChild(style);
+    return true;
+  }
+
+  function badge(entry) {
+    if (entry.role === "player") return "P";
+    if (entry.role === "boss") return "BOSS";
+    if (entry.side === "ally") return "A";
+    if (entry.side === "enemy") return "E";
+    return "N";
+  }
+
+  function listHtml(entries, emptyText) {
+    if (!entries.length) return `<div class="dm074-roster-empty">${escapeHtml(emptyText)}</div>`;
+    return entries.map((entry) => `<div class="dm074-roster-entry" title="${escapeHtml(entry.key)}"><span>[${badge(entry)}]</span>${escapeHtml(entry.name)}</div>`).join("");
+  }
+
+  function mount() {
+    const doc = global.document;
+    const dashboard = doc?.getElementById?.("dm-dashboard");
+    const body = doc?.getElementById?.("dm074-body") || dashboard?.querySelector?.(".dm074-body");
+    if (!dashboard?.classList?.contains("dm074") || !body) return false;
+    ensureStyle();
+    let card = doc.getElementById(CARD_ID);
+    if (!card) {
+      card = doc.createElement("section");
+      card.id = CARD_ID;
+      card.className = "dm074-card";
+      const firstCard = body.querySelector?.(".dm074-card");
+      if (firstCard) body.insertBefore(card, firstCard);
+      else body.appendChild(card);
+    }
+    const roster = summarizeRoster();
+    const af = roster.allied.field;
+    const ab = roster.allied.backup;
+    const ef = roster.enemy.field;
+    const eb = roster.enemy.backup;
+    card.innerHTML = `
+      <div class="dm074-title">Encounter Roster</div>
+      <div class="dm074-roster-score">
+        <div class="dm074-roster-side"><b>ALLIED · FIELD ${af.total} / BACKUP ${ab.total}</b><small>${af.players} Players · ${af.allies} Allied Units</small></div>
+        <div class="dm074-roster-side"><b>ENEMY · FIELD ${ef.total} / BACKUP ${eb.total}</b><small>${ef.enemies} Enemies · ${ef.bosses} Bosses</small></div>
+      </div>
+      <div class="dm074-roster-columns">
+        <div class="dm074-roster-column">
+          <div class="dm074-roster-subtitle">ALLIED FIELD</div><div class="dm074-roster-list">${listHtml(roster.field.allies, "No allied units deployed.")}</div>
+          <div class="dm074-roster-subtitle">ALLIED BACKUP</div><div class="dm074-roster-list">${listHtml(roster.backup.allies, "No allied backups.")}</div>
+        </div>
+        <div class="dm074-roster-column">
+          <div class="dm074-roster-subtitle">ENEMY FIELD</div><div class="dm074-roster-list">${listHtml(roster.field.enemies, "No enemies deployed.")}</div>
+          <div class="dm074-roster-subtitle">ENEMY BACKUP</div><div class="dm074-roster-list">${listHtml(roster.backup.enemies, "No enemy backups.")}</div>
+        </div>
+      </div>
+      ${(roster.field.neutral.length || roster.backup.neutral.length) ? `<div class="dm074-roster-subtitle">UNASSIGNED / NEUTRAL · FIELD ${roster.field.neutral.length} / BACKUP ${roster.backup.neutral.length}</div>` : ""}`;
+    return true;
+  }
+
+  function stop() {
+    for (const listener of state.listeners) {
+      try { listener.ref.off("value", listener.handler); } catch (_) {}
+    }
+    state.listeners = [];
+    if (state.mountTimer && typeof global.clearInterval === "function") global.clearInterval(state.mountTimer);
+    state.mountTimer = null;
+    state.started = false;
+  }
+
+  function subscribe(path, assign) {
+    const ref = state.db.ref(path);
+    const handler = (snapshot) => {
+      assign(snapshot?.val?.() || {});
+      mount();
+    };
+    ref.on("value", handler);
+    state.listeners.push({ ref, handler });
+  }
+
+  function init(options = {}) {
+    const db = options.db || consoleApi()?._state?.db || (() => {
+      try { return global.firebase?.database?.() || null; } catch (_) { return null; }
+    })();
+    if (!db?.ref) return false;
+    if (state.started && state.db === db) {
+      mount();
+      return true;
+    }
+    if (state.started) stop();
+    state.db = db;
+    state.started = true;
+    subscribe(ROOTS.combatants, (value) => { state.combatants = value; });
+    subscribe(ROOTS.reserves, (value) => { state.reserves = value; });
+    if (typeof global.setInterval === "function") {
+      state.mountTimer = global.setInterval(mount, 750);
+      state.mountTimer?.unref?.();
+    }
+    mount();
+    return true;
+  }
+
+  const api = Object.freeze({
+    version: VERSION,
+    ROOTS,
+    state,
+    labelFor,
+    sideFor,
+    roleFor,
+    entriesFor,
+    summarizeRoster,
+    mount,
+    init,
+    stop,
+  });
+
+  global.LuminousBattleViewerDmEncounterRoster074 = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/battle-viewer-progressive-ui-074.js
+++ b/js/battle-viewer-progressive-ui-074.js
@@ -7,6 +7,8 @@
   const DM_BODY_ID = "dm074-body";
   const DM_TOGGLE_ID = "dm074-collapse";
   const SKILL_PANEL_ID = "bv074-player-skill-planner";
+  const ROSTER_SCRIPT_ID = "battle-viewer-dm-encounter-roster-074-script";
+  const ROSTER_SCRIPT_SRC = "js/battle-viewer-dm-encounter-roster-074.js";
 
   const state = {
     installed: false,
@@ -72,6 +74,25 @@
     return true;
   }
 
+  function syncEncounterRoster() {
+    const dmConsole = global.LuminousBattleViewerDmConsole074 || null;
+    const db = dmConsole?._state?.db || null;
+    if (!db?.ref) return false;
+    const roster = global.LuminousBattleViewerDmEncounterRoster074 || null;
+    if (roster?.init) return roster.init({ db });
+    const doc = global.document;
+    if (!doc?.head) return false;
+    let script = doc.getElementById(ROSTER_SCRIPT_ID);
+    if (!script) {
+      script = doc.createElement("script");
+      script.id = ROSTER_SCRIPT_ID;
+      script.src = ROSTER_SCRIPT_SRC;
+      script.async = false;
+      doc.head.appendChild(script);
+    }
+    return false;
+  }
+
   function ensureStyle() {
     const doc = global.document;
     if (!doc?.head || doc.getElementById(STYLE_ID)) return false;
@@ -90,6 +111,7 @@
     ensureStyle();
     syncDmPanel();
     syncSkillPlanner();
+    syncEncounterRoster();
     return true;
   }
 
@@ -149,6 +171,7 @@
     shouldShowSkillPlanner,
     syncSkillPlanner,
     syncDmPanel,
+    syncEncounterRoster,
     setDmExpanded,
     sync,
     scheduleSync,

--- a/tests/combat-v074-dm-encounter-roster-smoke.mjs
+++ b/tests/combat-v074-dm-encounter-roster-smoke.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+for (const key of ['LuminousBattleViewerDmEncounterRoster074']) delete globalThis[key];
+await import('../js/battle-viewer-dm-encounter-roster-074.js');
+const roster = globalThis.LuminousBattleViewerDmEncounterRoster074;
+
+assert.equal(roster?.version, '0.7.4');
+assert.equal(roster.ROOTS.combatants, 'campaña/combate/combatants');
+assert.equal(roster.ROOTS.reserves, 'campaña/combate/reserves');
+
+const combatants = {
+  'player:alice': { id: 'player:alice', name: 'Alice', isPlayer: true, category: 'player' },
+  ally_guard: { id: 'ally_guard', name: 'Guard', faction: 'ally', category: 'ally' },
+  enemy_a: { id: 'enemy_a', name: 'Raider', faction: 'enemy', category: 'enemy' },
+  boss_a: { id: 'boss_a', name: 'Warden', faction: 'enemy', category: 'boss', isBoss: true },
+};
+const reserves = {
+  ally_backup: { id: 'ally_backup', name: 'Medic', faction: 'ally', category: 'ally' },
+  enemy_backup: { id: 'enemy_backup', name: 'Raider Reinforcement', faction: 'enemy', category: 'enemy' },
+  boss_backup: { id: 'boss_backup', name: 'Second Warden', faction: 'enemy', category: 'boss' },
+};
+
+const summary = roster.summarizeRoster(combatants, reserves);
+assert.equal(summary.allied.field.total, 2, 'Player + allied Unit should count as allied FIELD');
+assert.equal(summary.allied.field.players, 1);
+assert.equal(summary.allied.field.allies, 1);
+assert.equal(summary.allied.backup.total, 1);
+assert.equal(summary.enemy.field.total, 2);
+assert.equal(summary.enemy.field.enemies, 1);
+assert.equal(summary.enemy.field.bosses, 1);
+assert.equal(summary.enemy.backup.total, 2);
+assert.equal(summary.enemy.backup.enemies, 1);
+assert.equal(summary.enemy.backup.bosses, 1);
+
+assert.equal(roster.sideFor({ isPlayer: true }), 'ally', 'Players are allied even without a legacy faction field');
+assert.equal(roster.roleFor({ faction: 'enemy', category: 'boss' }), 'boss');
+assert.equal(roster.sideFor({ faction: 'enemy', category: 'boss' }), 'enemy');
+assert.equal(roster.sideFor({ category: 'npc' }), 'neutral');
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const progressiveSource = fs.readFileSync(path.join(here, '..', 'js', 'battle-viewer-progressive-ui-074.js'), 'utf8');
+assert.match(progressiveSource, /battle-viewer-dm-encounter-roster-074\.js/);
+assert.match(progressiveSource, /syncEncounterRoster/);
+
+console.log('combat-v074-dm-encounter-roster-smoke: ok');


### PR DESCRIPTION
Add a compact DM-facing Encounter Roster monitor without changing combat resolution.

Contract:
- `campaña/combate/combatants` remains the authoritative FIELD roster. Anything there is deployed and the Viewer may spawn it.
- `campaña/combate/reserves` is the BACKUP roster. Reserves are not combatants and therefore are not spawned by the current Viewer.

DM UI:
- Shows Allied FIELD / BACKUP counts.
- Shows Enemy FIELD / BACKUP counts.
- Breaks allied counts into Players and allied Units.
- Breaks enemy counts into Enemies and Bosses.
- Lists the actual names on each side and deployment group.
- Surfaces neutral/unassigned entries instead of silently classifying them.
- Treats canonical Players as allied even when legacy `faction` is absent.

Implementation is intentionally read-only in this pass. It does not move combatants, mutate planned actions, or change targeting. A later Encounter Setup pass can add Deploy / Send to Backup on top of the same roster contract.

Adds focused smoke coverage and syntax coverage.