### PR TITLE
Feature: add canonical Kobold Unit Library

### DIFF
--- a/.github/workflows/combat-runtime-smoke.yml
+++ b/.github/workflows/combat-runtime-smoke.yml
@@ -31,6 +31,8 @@ jobs:
         run: node tests/class-status-semantics-smoke.mjs
       - name: Starter Tier 1 status skill catalog smoke
         run: node tests/starter-status-skill-catalog-smoke.mjs
+      - name: Kobold Unit Library smoke
+        run: node tests/kobold-unit-library-smoke.mjs
       - name: G1-G2 Skill Forge smoke
         run: node tests/skill-forge-g2-smoke.mjs
       - name: G1-G2 Skill Forge runtime smoke
@@ -86,6 +88,8 @@ jobs:
           node --check js/elemental-status-compat.js
           node --check js/status-rupture-runtime.js
           node --check js/skill-catalog-starter-status-tier1.js
+          node --check js/skill-catalog-kobold-tier1.js
+          node --check js/unit-catalog-kobold-tier1.js
           node --check js/skill-forge-g2.js
           node --check js/skill-forge-runtime-g2.js
       - name: Battle Viewer 0.7.4 Firebase contract smoke

--- a/dm-unit-kobold-seeder.html
+++ b/dm-unit-kobold-seeder.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Luminous · Kobold Unit Library Seeder</title>
+<style>
+:root{color-scheme:dark;--bg:#080808;--panel:#12110e;--line:#453b2b;--gold:#d5ad5d;--text:#eee6d7;--muted:#8c8477;--ok:#85b97a;--bad:#df7669}*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--text);font:14px Arial,sans-serif}.wrap{max-width:1100px;margin:0 auto;padding:28px}.panel{border:1px solid var(--line);background:var(--panel);padding:22px}h1{margin:0 0 4px;color:var(--gold)}p{color:var(--muted);line-height:1.5}.toolbar{display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin:18px 0}.btn{border:1px solid var(--gold);background:#211a0e;color:var(--gold);padding:10px 16px;font-weight:700;cursor:pointer}.btn.primary{background:var(--gold);color:#151006}.btn:disabled{opacity:.5;cursor:wait}.status{padding:10px;border:1px solid #333;background:#090909;color:var(--muted)}.status.ok{border-color:#375a32;color:var(--ok)}.status.bad{border-color:#71372f;color:var(--bad)}.units{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px;margin-top:16px}.unit{border:1px solid #302b23;padding:14px;background:#0c0c0b}.unit img{width:100%;height:190px;object-fit:contain;background:#050505}.unit h2{color:var(--gold);margin:10px 0 4px}.ranks{width:100%;border-collapse:collapse;font-size:12px}.ranks td,.ranks th{border:1px solid #302b23;padding:5px;text-align:center}.skills{color:#cdb98b;font-size:12px;line-height:1.6}code{color:#d7c49d}@media(max-width:760px){.units{grid-template-columns:1fr}}</style>
+</head>
+<body>
+<div class="wrap"><div class="panel">
+<h1>Kobold · Unit Library</h1>
+<p>Primer catálogo canónico de Units enemigas: Dagger y Sling. Las definiciones usan Base Level 1–3, rangos Normal/Captain/Leader, HP por coeficiente, tres Stagger Thresholds, Scores/Proficiencies y Skills Tier 1 especializadas en Count.</p>
+<div class="toolbar"><button class="btn primary" id="sync" disabled>SINCRONIZAR KOBOLDS</button><button class="btn" id="refresh">REVISAR CATÁLOGO</button><span>Units: <code>campaña/base_datos_unidades</code> · Skills: <code>campaña/base_datos_skills</code></span></div>
+<div id="status" class="status">Cargando catálogo y verificando sesión DM…</div>
+<div id="units" class="units"></div>
+<p>La sincronización usa <code>update()</code> con IDs determinísticos. No borra otras Units ni otras Skills. Pack Tactics y los Stagger Thresholds quedan guardados como contrato canónico; sólo las mecánicas que ya consume el runtime se ejecutan automáticamente.</p>
+</div></div>
+<script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
+<script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
+<script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-database.js"></script>
+<script src="js/combat-skill-schema.js"></script>
+<script src="js/skill-catalog-kobold-tier1.js"></script>
+<script src="js/unit-catalog-kobold-tier1.js"></script>
+<script src="js/battle-viewer-firebase-session-074.js"></script>
+<script>
+(function(){
+'use strict';
+const firebaseConfig={apiKey:"AIzaSyAIVIuKgXUsdrb9Mmss9PH7R3FpWAMG2hU",authDomain:"luminous-system.firebaseapp.com",databaseURL:"https://luminous-system-default-rtdb.firebaseio.com",projectId:"luminous-system",storageBucket:"luminous-system.firebasestorage.app",messagingSenderId:"330473029689",appId:"1:330473029689:web:44a05e870d493a3b294de8",measurementId:"G-X775P4YS7W"};
+if(!firebase.apps.length)firebase.initializeApp(firebaseConfig);
+const db=firebase.database();
+const UNIT_PATH='campaña/base_datos_unidades';
+const SKILL_PATH='campaña/base_datos_skills';
+const catalog=window.LuminousKoboldUnitCatalog;
+const skills=window.LuminousKoboldTier1SkillCatalog;
+const schema=window.CombatSkillSchema;
+const session=window.LuminousBattleViewerFirebaseSession074;
+const $=id=>document.getElementById(id);
+let dmReady=false;
+function setStatus(text,kind){$('status').textContent=text;$('status').className='status'+(kind?' '+kind:'')}
+function rankRows(unitId){return ['normal','captain','leader'].map(rank=>{const a=catalog.resolve(unitId,{baseLevel:1,rank}),b=catalog.resolve(unitId,{baseLevel:3,rank});return `<tr><td>${rank.toUpperCase()}</td><td>${a.mechanics.speed}</td><td>${a.mechanics.hp}</td><td>${b.mechanics.hp}</td><td>+${a.mechanics.statusApplyBonus}</td><td>+${a.mechanics.basePowerBonus}</td></tr>`}).join('')}
+function render(){
+ if(!catalog||!skills||!schema){setStatus('Falta CombatSkillSchema o uno de los catálogos Kobold.','bad');return false}
+ const definitions=catalog.list();
+ const skillList=skills.list();
+ const invalid=skillList.map(s=>[s,schema.validateCombatSkill(s)]).filter(([,v])=>!v.valid);
+ if(invalid.length){setStatus(`Skill inválida: ${invalid[0][0].id} · ${invalid[0][1].errors.join(' · ')}`,'bad');return false}
+ const outOfTier=skillList.filter(s=>{const p=skills.finalPower(s);return p<10||p>12});
+ if(outOfTier.length){setStatus(`Tier 1 fuera de 10–12: ${outOfTier[0].id}.`,'bad');return false}
+ $('units').innerHTML=definitions.map(unit=>`<section class="unit"><img src="${unit.visual.spriteUrl}" alt="${unit.name}"><h2>${unit.name}</h2><div class="skills">${unit.action_slots.join(' · ')}</div><table class="ranks"><thead><tr><th>Rank</th><th>Speed Lv1</th><th>HP Lv1</th><th>HP Lv3</th><th>Apply</th><th>Base</th></tr></thead><tbody>${rankRows(unit.id)}</tbody></table></section>`).join('');
+ setStatus(`Catálogo válido: ${definitions.length} Units · ${skillList.length} Skills · versión ${catalog.version}.`,'ok');return true;
+}
+async function authorize(){
+ $('sync').disabled=true;dmReady=false;
+ if(!session?.preflight){setStatus('Falta el preflight Firebase 0.7.4.','bad');return false}
+ try{const result=await session.preflight({firebase});if(!result?.ok){setStatus(`Firebase bloqueado: ${result?.reason||'FIREBASE_SESSION_FAILED'}.`,'bad');return false}if(result.role!=='dm'){setStatus(`Sesión válida pero sin autoridad DM (${result.role||'unknown'}).`,'bad');return false}dmReady=true;$('sync').disabled=false;setStatus(`DM autorizado · catálogo ${catalog.version} listo para sincronizar.`,'ok');return true}catch(error){console.error(error);setStatus(`No se pudo validar la sesión DM: ${error.message||error}`,'bad');return false}
+}
+async function sync(){
+ if(!dmReady){setStatus('Sincronización bloqueada: se requiere sesión DM.','bad');return}
+ if(!render())return;
+ const button=$('sync');button.disabled=true;
+ try{const unitPayload=catalog.firebasePayload();const skillPayload=catalog.firebaseSkillPayload(schema);await db.ref(UNIT_PATH).update(unitPayload);await db.ref(SKILL_PATH).update(skillPayload);setStatus(`Sincronización completa: ${Object.keys(unitPayload).length} Units y ${Object.keys(skillPayload).length} Skills actualizadas.`,'ok')}catch(error){console.error(error);setStatus(`No se pudo sincronizar: ${error.message||error}`,'bad')}finally{button.disabled=!dmReady}
+}
+$('sync').addEventListener('click',sync);$('refresh').addEventListener('click',()=>{render();authorize()});render();authorize();
+})();
+</script>
+</body>
+</html>

--- a/js/skill-catalog-kobold-tier1.js
+++ b/js/skill-catalog-kobold-tier1.js
@@ -1,0 +1,173 @@
+(function (global) {
+  'use strict';
+
+  const clone = (value) => JSON.parse(JSON.stringify(value));
+
+  function statusEffect(status, potency, count) {
+    return {
+      trigger: '[On Hit]',
+      target: 'target',
+      type: 'status',
+      status,
+      potency,
+      count,
+      maxCap: 0,
+      scaleTarget: null,
+      scaleCondition: null,
+      is_reuse: false,
+      target_ally: false,
+      timing: 'immediate',
+      condition: null,
+    };
+  }
+
+  function coin(index, effects) {
+    return { index, type: 'normal', status: 'active', effects: effects || [] };
+  }
+
+  function attack({ id, name, variant, basePower, coinPower, coinAmount, damageType, skillRange, statusFamily, statusCoin, potency, count }) {
+    const coins = Array.from({ length: coinAmount }, (_, index) => coin(index, []));
+    if (statusFamily) coins[statusCoin].effects.push(statusEffect(statusFamily, potency, count));
+    return {
+      id,
+      name,
+      type: 'Attack',
+      tier: 1,
+      basePower,
+      coinPower,
+      coinAmount,
+      coinType: 'positive',
+      attackWeight: 1,
+      skillRange,
+      damageType,
+      sinAffinity: 'sinless',
+      scalingStat: 'Destreza',
+      statUsed: '',
+      skillUsed: '',
+      targetingType: 'Focused Attack',
+      aoePattern: 'Self',
+      skillAmount: 1,
+      sourceType: 'skill',
+      sourceId: id,
+      isItemSkill: false,
+      isDefense: false,
+      defenseSubtype: '',
+      isClashable: true,
+      isUnclashable: false,
+      isIndiscriminate: false,
+      isTargetFixed: false,
+      requiresUnlock: false,
+      effects: [],
+      coins,
+      evolutionChain: null,
+      schemaVersion: 2,
+      metadata: {
+        canonicalUnitSkill: true,
+        species: 'kobold',
+        unitVariant: variant,
+        tier: 1,
+        statusFamily,
+        rulesPolicy: 'enemy_count_specialist',
+        combatRange: skillRange > 1 ? 'ranged' : 'melee',
+      },
+    };
+  }
+
+  function evade({ id, name, variant }) {
+    return {
+      id,
+      name,
+      type: 'Defense',
+      tier: 1,
+      basePower: 5,
+      coinPower: 5,
+      coinAmount: 1,
+      coinType: 'positive',
+      attackWeight: 1,
+      skillRange: 1,
+      damageType: 'contundente',
+      sinAffinity: 'sinless',
+      scalingStat: 'Destreza',
+      statUsed: '',
+      skillUsed: '',
+      targetingType: 'Focused Attack',
+      aoePattern: 'Self',
+      skillAmount: 1,
+      sourceType: 'skill',
+      sourceId: id,
+      isItemSkill: false,
+      isDefense: true,
+      defenseSubtype: 'Evade',
+      isClashable: true,
+      isUnclashable: false,
+      isIndiscriminate: false,
+      isTargetFixed: false,
+      requiresUnlock: false,
+      effects: [],
+      coins: [coin(0, [])],
+      evolutionChain: null,
+      schemaVersion: 2,
+      metadata: {
+        canonicalUnitSkill: true,
+        species: 'kobold',
+        unitVariant: variant,
+        tier: 1,
+        statusFamily: null,
+        rulesPolicy: 'defense_only',
+        combatRange: 'self',
+      },
+    };
+  }
+
+  const DEFINITIONS = Object.freeze({
+    kobold_dagger_jab: Object.freeze(attack({
+      id: 'kobold_dagger_jab', name: 'Dagger Jab', variant: 'dagger',
+      basePower: 6, coinPower: 5, coinAmount: 1,
+      damageType: 'perforante', skillRange: 1,
+      statusFamily: 'bleed', statusCoin: 0, potency: 1, count: 2,
+    })),
+    kobold_desperate_stab: Object.freeze(attack({
+      id: 'kobold_desperate_stab', name: 'Desperate Stab', variant: 'dagger',
+      basePower: 4, coinPower: 3, coinAmount: 2,
+      damageType: 'perforante', skillRange: 1,
+      statusFamily: 'bleed', statusCoin: 1, potency: 1, count: 3,
+    })),
+    kobold_scurry: Object.freeze(evade({ id: 'kobold_scurry', name: 'Scurry', variant: 'dagger' })),
+    kobold_sling_shot: Object.freeze(attack({
+      id: 'kobold_sling_shot', name: 'Sling Shot', variant: 'sling',
+      basePower: 6, coinPower: 4, coinAmount: 1,
+      damageType: 'contundente', skillRange: 6,
+      statusFamily: 'tremor', statusCoin: 0, potency: 1, count: 2,
+    })),
+    kobold_rapid_pebble: Object.freeze(attack({
+      id: 'kobold_rapid_pebble', name: 'Rapid Pebble', variant: 'sling',
+      basePower: 4, coinPower: 3, coinAmount: 2,
+      damageType: 'contundente', skillRange: 6,
+      statusFamily: 'tremor', statusCoin: 1, potency: 1, count: 3,
+    })),
+    kobold_duck_away: Object.freeze(evade({ id: 'kobold_duck_away', name: 'Duck Away', variant: 'sling' })),
+  });
+
+  function list() { return Object.values(DEFINITIONS).map(clone); }
+  function get(id) { return DEFINITIONS[String(id || '')] ? clone(DEFINITIONS[String(id || '')]) : null; }
+  function finalPower(skillOrId) {
+    const skill = typeof skillOrId === 'string' ? get(skillOrId) : skillOrId;
+    if (!skill) return null;
+    return Number(skill.basePower || 0) + Number(skill.coinPower || 0) * Number(skill.coinAmount || 0);
+  }
+  function firebasePayload(schema = global.CombatSkillSchema) {
+    const payload = {};
+    list().forEach((skill) => {
+      if (schema?.validateCombatSkill && schema?.serializeCombatSkill) {
+        const validation = schema.validateCombatSkill(skill);
+        if (!validation.valid) throw new Error(`${skill.id}: ${validation.errors.join(' · ')}`);
+        payload[skill.id] = schema.serializeCombatSkill({ ...validation.skill, id: skill.id }, { includeLegacyAliases: true });
+      } else payload[skill.id] = skill;
+    });
+    return payload;
+  }
+
+  const api = Object.freeze({ version: '1.0.0', DEFINITIONS, list, get, finalPower, firebasePayload });
+  global.LuminousKoboldTier1SkillCatalog = api;
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/unit-catalog-kobold-tier1.js
+++ b/js/unit-catalog-kobold-tier1.js
@@ -1,0 +1,201 @@
+(function (global) {
+  'use strict';
+
+  const clone = (value) => JSON.parse(JSON.stringify(value));
+  const skillCatalog = global.LuminousKoboldTier1SkillCatalog
+    || (typeof require !== 'undefined' ? (() => { try { return require('./skill-catalog-kobold-tier1.js'); } catch (_) { return null; } })() : null);
+
+  const BASE_LEVEL = Object.freeze({ min: 1, max: 3 });
+  const STAGGER_THRESHOLDS = Object.freeze([75, 50, 25]);
+  const SCORES = Object.freeze({ str: 7, dex: 15, con: 9, int: 8, wis: 7, cha: 8 });
+  const PROFICIENCIES = Object.freeze({
+    savingThrows: Object.freeze({ dex: 'proficient' }),
+    skills: Object.freeze({ stealth: 'proficient' }),
+  });
+  const PACK_TACTICS = Object.freeze({
+    id: 'kobold_pack_tactics',
+    name: 'Pack Tactics',
+    type: 'passive',
+    clashPower: 1,
+    condition: 'target_also_attacked_by_kobold_ally_this_round',
+    runtimeHook: 'metadata_only',
+    description: 'When this Kobold attacks a target that is also being attacked by another Kobold ally during the round, gain +1 Clash Power.',
+  });
+
+  const RANKS = Object.freeze({
+    normal: Object.freeze({ id: 'normal', levelMultiplier: 1, hpBase: 24, hpCoefficient: 1.00, defLvlMod: 0, minSpeedBonus: 0, maxSpeedBonus: 0, applyBonus: 0, basePowerBonus: 0 }),
+    captain: Object.freeze({ id: 'captain', levelMultiplier: 2, hpBase: 30, hpCoefficient: 1.25, defLvlMod: 0, minSpeedBonus: 0, maxSpeedBonus: 1, applyBonus: 1, basePowerBonus: 0 }),
+    leader: Object.freeze({ id: 'leader', levelMultiplier: 3, hpBase: 36, hpCoefficient: 1.50, defLvlMod: 0, minSpeedBonus: 1, maxSpeedBonus: 2, applyBonus: 2, basePowerBonus: 1 }),
+  });
+
+  function baseUnit({ id, name, variant, sprite, speed, skills }) {
+    return {
+      id,
+      name,
+      species: 'kobold',
+      variant,
+      unitType: 'enemy',
+      faction: 'enemy',
+      actorCategory: 'enemy',
+      isPlayer: false,
+      linkedPlayerUID: '',
+      tags: ['canonical', 'kobold', 'enemy', 'tier1'],
+      icono: sprite,
+      visual: {
+        spriteUrl: sprite,
+        idle_sprite: sprite,
+        moving_sprite: '',
+        guard_sprite: '',
+        evade_sprite: '',
+        hurt_sprite: '',
+        dead_sprite: '',
+        scale: 1,
+        spriteX: 0,
+        spriteY: 0,
+        uiX: 0,
+        uiY: 0,
+        isFocused: false,
+      },
+      baseLevel: clone(BASE_LEVEL),
+      scores: clone(SCORES),
+      proficiencies: clone(PROFICIENCIES),
+      traitIds: [PACK_TACTICS.id],
+      traits: [clone(PACK_TACTICS)],
+      staggerThresholds: clone(STAGGER_THRESHOLDS),
+      rankProfiles: clone(RANKS),
+      action_slots: skills.slice(),
+      attack_tier_1_sequence: skills.filter((skillId) => !skillId.includes('scurry') && !skillId.includes('duck_away')),
+      attack_tier_2_sequence: [],
+      attack_tier_3_sequence: [],
+      mechanics: {
+        hpModel: 'coefficient',
+        sp: 0,
+        speed,
+        actionSlots: 1,
+        maxSlotsLimit: 1,
+        skills: skills.slice(),
+        staggerThresholds: clone(STAGGER_THRESHOLDS),
+        stagger: '75%,50%,25%',
+      },
+      schemaVersion: 1,
+      metadata: {
+        canonicalUnit: true,
+        catalog: 'kobold-tier1',
+        rankModel: 'normal_captain_leader',
+        hpModel: 'rank_coefficient',
+      },
+    };
+  }
+
+  const DEFINITIONS = Object.freeze({
+    kobold_dagger: Object.freeze(baseUnit({
+      id: 'kobold_dagger',
+      name: 'Kobold · Dagger',
+      variant: 'dagger',
+      sprite: 'https://imgur.com/2BBvM2s.png',
+      speed: '3-5',
+      skills: ['kobold_dagger_jab', 'kobold_desperate_stab', 'kobold_scurry'],
+    })),
+    kobold_sling: Object.freeze(baseUnit({
+      id: 'kobold_sling',
+      name: 'Kobold · Sling',
+      variant: 'sling',
+      sprite: 'https://imgur.com/ndB257N.png',
+      speed: '2-4',
+      skills: ['kobold_sling_shot', 'kobold_rapid_pebble', 'kobold_duck_away'],
+    })),
+  });
+
+  function normalizeRank(rank) {
+    const id = String(rank || 'normal').trim().toLowerCase();
+    if (!RANKS[id]) throw new Error(`UNKNOWN_UNIT_RANK:${id}`);
+    return id;
+  }
+
+  function normalizeBaseLevel(level) {
+    const value = Math.floor(Number(level));
+    if (!Number.isFinite(value) || value < BASE_LEVEL.min || value > BASE_LEVEL.max) throw new Error(`BASE_LEVEL_OUT_OF_RANGE:${level}`);
+    return value;
+  }
+
+  function parseSpeed(speed) {
+    const match = String(speed || '').match(/^\s*(\d+)\s*-\s*(\d+)\s*$/);
+    if (!match) throw new Error(`INVALID_SPEED:${speed}`);
+    return { min: Number(match[1]), max: Number(match[2]) };
+  }
+
+  function get(id) { return DEFINITIONS[String(id || '')] ? clone(DEFINITIONS[String(id || '')]) : null; }
+  function list() { return Object.values(DEFINITIONS).map(clone); }
+
+  function resolveSkill(skillId, rank) {
+    if (!skillCatalog?.get) throw new Error('KOBOLD_SKILL_CATALOG_REQUIRED');
+    const skill = skillCatalog.get(skillId);
+    if (!skill) throw new Error(`UNKNOWN_KOBOLD_SKILL:${skillId}`);
+    const rankId = normalizeRank(rank);
+    const profile = RANKS[rankId];
+    skill.basePower += profile.basePowerBonus;
+    const applyCountBonus = (effects) => (effects || []).forEach((effect) => {
+      if (effect?.type === 'status' && Number(effect.count) > 0) effect.count = Number(effect.count) + profile.applyBonus;
+    });
+    applyCountBonus(skill.effects);
+    (skill.coins || []).forEach((coinData) => applyCountBonus(coinData.effects));
+    skill.metadata = { ...(skill.metadata || {}), unitRank: rankId, rankBasePowerBonus: profile.basePowerBonus, rankApplyBonus: profile.applyBonus };
+    return skill;
+  }
+
+  function resolve(id, options) {
+    const unit = get(id);
+    if (!unit) throw new Error(`UNKNOWN_KOBOLD_UNIT:${id}`);
+    const opts = options || {};
+    const baseLevel = normalizeBaseLevel(opts.baseLevel ?? 1);
+    const rank = normalizeRank(opts.rank ?? 'normal');
+    const profile = RANKS[rank];
+    const effectiveLevel = baseLevel * profile.levelMultiplier;
+    const maxHp = Math.floor(profile.hpBase + (effectiveLevel + profile.defLvlMod) * profile.hpCoefficient);
+    const baseSpeed = parseSpeed(unit.mechanics.speed);
+    const minSpeed = baseSpeed.min + profile.minSpeedBonus;
+    const maxSpeed = baseSpeed.max + profile.maxSpeedBonus;
+    const resolvedSkills = unit.action_slots.map((skillId) => resolveSkill(skillId, rank));
+
+    unit.rank = rank;
+    unit.baseLevelSelected = baseLevel;
+    unit.effectiveLevel = effectiveLevel;
+    unit.rankBonuses = clone(profile);
+    unit.resolvedSkills = resolvedSkills;
+    unit.mechanics = {
+      ...unit.mechanics,
+      hp: maxHp,
+      maxHp,
+      level: effectiveLevel,
+      baseLevel,
+      rank,
+      hpBase: profile.hpBase,
+      hpCoefficient: profile.hpCoefficient,
+      defLvlMod: profile.defLvlMod,
+      speed: `${minSpeed}-${maxSpeed}`,
+      minSpeed,
+      maxSpeed,
+      statusApplyBonus: profile.applyBonus,
+      basePowerBonus: profile.basePowerBonus,
+    };
+    return unit;
+  }
+
+  function firebasePayload() {
+    const payload = {};
+    list().forEach((unit) => { payload[unit.id] = unit; });
+    return payload;
+  }
+
+  function firebaseSkillPayload(schema) {
+    if (!skillCatalog?.firebasePayload) throw new Error('KOBOLD_SKILL_CATALOG_REQUIRED');
+    return skillCatalog.firebasePayload(schema);
+  }
+
+  const api = Object.freeze({
+    version: '1.0.0', BASE_LEVEL, STAGGER_THRESHOLDS, SCORES, PROFICIENCIES, PACK_TACTICS, RANKS, DEFINITIONS,
+    list, get, resolve, resolveSkill, firebasePayload, firebaseSkillPayload,
+  });
+  global.LuminousKoboldUnitCatalog = api;
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/tests/kobold-unit-library-smoke.mjs
+++ b/tests/kobold-unit-library-smoke.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+
+await import('../js/skill-catalog-kobold-tier1.js');
+await import('../js/unit-catalog-kobold-tier1.js');
+
+const skills = globalThis.LuminousKoboldTier1SkillCatalog;
+const units = globalThis.LuminousKoboldUnitCatalog;
+if (!skills || !units) throw new Error('Kobold catalogs did not initialize.');
+
+assert.equal(units.list().length, 2);
+assert.equal(skills.list().length, 6);
+
+const dagger = units.get('kobold_dagger');
+const sling = units.get('kobold_sling');
+assert.equal(dagger.visual.spriteUrl, 'https://imgur.com/2BBvM2s.png');
+assert.equal(sling.visual.spriteUrl, 'https://imgur.com/ndB257N.png');
+assert.deepEqual(dagger.scores, { str: 7, dex: 15, con: 9, int: 8, wis: 7, cha: 8 });
+assert.equal(dagger.proficiencies.savingThrows.dex, 'proficient');
+assert.equal(dagger.proficiencies.skills.stealth, 'proficient');
+assert.deepEqual(dagger.staggerThresholds, [75, 50, 25]);
+assert.equal(dagger.traits[0].id, 'kobold_pack_tactics');
+assert.equal(dagger.traits[0].clashPower, 1);
+assert.equal(dagger.mechanics.actionSlots, 1);
+assert.equal(dagger.mechanics.maxSlotsLimit, 1);
+assert.equal(dagger.mechanics.sp, 0);
+
+for (const skill of skills.list()) {
+  const power = skills.finalPower(skill);
+  assert.ok(power >= 10 && power <= 12, `${skill.id} Tier 1 final power must be 10-12, got ${power}`);
+}
+assert.equal(skills.finalPower('kobold_dagger_jab'), 11);
+assert.equal(skills.finalPower('kobold_desperate_stab'), 10);
+assert.equal(skills.finalPower('kobold_sling_shot'), 10);
+assert.equal(skills.finalPower('kobold_rapid_pebble'), 10);
+
+const normalDagger1 = units.resolve('kobold_dagger', { baseLevel: 1, rank: 'normal' });
+const normalDagger3 = units.resolve('kobold_dagger', { baseLevel: 3, rank: 'normal' });
+const captainDagger2 = units.resolve('kobold_dagger', { baseLevel: 2, rank: 'captain' });
+const leaderDagger3 = units.resolve('kobold_dagger', { baseLevel: 3, rank: 'leader' });
+assert.equal(normalDagger1.mechanics.hp, 25);
+assert.equal(normalDagger3.mechanics.hp, 27);
+assert.equal(captainDagger2.effectiveLevel, 4);
+assert.equal(captainDagger2.mechanics.hp, 35);
+assert.equal(captainDagger2.mechanics.speed, '3-6');
+assert.equal(leaderDagger3.effectiveLevel, 9);
+assert.equal(leaderDagger3.mechanics.hp, 49);
+assert.equal(leaderDagger3.mechanics.speed, '4-7');
+
+const captainSling = units.resolve('kobold_sling', { baseLevel: 1, rank: 'captain' });
+const leaderSling = units.resolve('kobold_sling', { baseLevel: 1, rank: 'leader' });
+assert.equal(captainSling.mechanics.speed, '2-5');
+assert.equal(leaderSling.mechanics.speed, '3-6');
+
+const normalJab = units.resolveSkill('kobold_dagger_jab', 'normal');
+const captainJab = units.resolveSkill('kobold_dagger_jab', 'captain');
+const leaderJab = units.resolveSkill('kobold_dagger_jab', 'leader');
+assert.equal(normalJab.coins[0].effects[0].status, 'bleed');
+assert.equal(normalJab.coins[0].effects[0].count, 2);
+assert.equal(captainJab.coins[0].effects[0].count, 3);
+assert.equal(leaderJab.coins[0].effects[0].count, 4);
+assert.equal(skills.finalPower(leaderJab), 12);
+
+const normalRapid = units.resolveSkill('kobold_rapid_pebble', 'normal');
+const captainRapid = units.resolveSkill('kobold_rapid_pebble', 'captain');
+const leaderRapid = units.resolveSkill('kobold_rapid_pebble', 'leader');
+assert.equal(normalRapid.coins[1].effects[0].status, 'tremor');
+assert.equal(normalRapid.coins[1].effects[0].count, 3);
+assert.equal(captainRapid.coins[1].effects[0].count, 4);
+assert.equal(leaderRapid.coins[1].effects[0].count, 5);
+assert.equal(skills.finalPower(leaderRapid), 11);
+
+assert.deepEqual(Object.keys(units.firebasePayload()).sort(), ['kobold_dagger', 'kobold_sling']);
+assert.equal(Object.keys(units.firebaseSkillPayload()).length, 6);
+assert.throws(() => units.resolve('kobold_dagger', { baseLevel: 4, rank: 'normal' }), /BASE_LEVEL_OUT_OF_RANGE/);
+assert.throws(() => units.resolve('kobold_dagger', { baseLevel: 1, rank: 'elite' }), /UNKNOWN_UNIT_RANK/);
+
+console.log('kobold unit library smoke: ok');


### PR DESCRIPTION
## Summary
- add canonical Kobold Dagger and Kobold Sling Unit definitions
- add Tier 1 Kobold Skill catalog with Bleed/Tremor Count specialization
- add Normal/Captain/Leader resolver for HP, Speed, Apply and Leader Base Power
- add DM-gated deterministic Unit/Skill seeder
- add Unit Library smoke coverage

## Contracts
- Base Level 1–3
- Normal ×1, Captain ×2, Leader ×3 effective level
- Captain: Max Speed +1, Apply +1
- Leader: Min Speed +1, Max Speed +2, Apply +2, Base Power +1
- 3 Stagger Thresholds: 75/50/25
- DEX save + Stealth proficiency
- Pack Tactics remains Trait metadata; its combat runtime hook is not implemented in this PR

## Content
- `kobold_dagger` · sprite `https://imgur.com/2BBvM2s.png` · Bleed
- `kobold_sling` · sprite `https://imgur.com/ndB257N.png` · Tremor
- six canonical Tier 1 Skills, all base final power 10–12

## Safety
- no production Firebase writes or deploys
- seeder requires an explicit authenticated DM session and button click
- seeder uses deterministic IDs and `update()` so it does not delete unrelated Units or Skills