### PR TITLE
Feature: make Captain and Leader universal command ranks

### DIFF
--- a/.github/workflows/combat-runtime-smoke.yml
+++ b/.github/workflows/combat-runtime-smoke.yml
@@ -33,6 +33,8 @@ jobs:
         run: node tests/starter-status-skill-catalog-smoke.mjs
       - name: Kobold Unit Library smoke
         run: node tests/kobold-unit-library-smoke.mjs
+      - name: Universal Unit rank command smoke
+        run: node tests/unit-rank-command-smoke.mjs
       - name: G1-G2 Skill Forge smoke
         run: node tests/skill-forge-g2-smoke.mjs
       - name: G1-G2 Skill Forge runtime smoke
@@ -89,7 +91,10 @@ jobs:
           node --check js/status-rupture-runtime.js
           node --check js/skill-catalog-starter-status-tier1.js
           node --check js/skill-catalog-kobold-tier1.js
+          node --check js/unit-rank-runtime.js
           node --check js/unit-catalog-kobold-tier1.js
+          node --check js/combat-team-economy-bridge.js
+          node --check js/universal-action-economy.js
           node --check js/skill-forge-g2.js
           node --check js/skill-forge-runtime-g2.js
       - name: Battle Viewer 0.7.4 Firebase contract smoke

--- a/dm-unit-kobold-seeder.html
+++ b/dm-unit-kobold-seeder.html
@@ -10,17 +10,18 @@
 <body>
 <div class="wrap"><div class="panel">
 <h1>Kobold · Unit Library</h1>
-<p>Primer catálogo canónico de Units enemigas: Dagger y Sling. Las definiciones usan Base Level 1–3, rangos Normal/Captain/Leader, HP por coeficiente, tres Stagger Thresholds, Scores/Proficiencies y Skills Tier 1 especializadas en Count.</p>
+<p>Primer catálogo canónico de Units enemigas: Dagger y Sling. Las definiciones usan Base Level 1–3, rangos universales Normal/Captain/Leader, HP por coeficiente, tres Stagger Thresholds, Scores/Proficiencies y Skills Tier 1 especializadas en Count.</p>
 <div class="toolbar"><button class="btn primary" id="sync" disabled>SINCRONIZAR KOBOLDS</button><button class="btn" id="refresh">REVISAR CATÁLOGO</button><span>Units: <code>campaña/base_datos_unidades</code> · Skills: <code>campaña/base_datos_skills</code></span></div>
 <div id="status" class="status">Cargando catálogo y verificando sesión DM…</div>
 <div id="units" class="units"></div>
-<p>La sincronización usa <code>update()</code> con IDs determinísticos. No borra otras Units ni otras Skills. Pack Tactics y los Stagger Thresholds quedan guardados como contrato canónico; sólo las mecánicas que ya consume el runtime se ejecutan automáticamente.</p>
+<p>La sincronización usa <code>update()</code> con IDs determinísticos. No borra otras Units ni otras Skills. Pack Tactics y los Stagger Thresholds quedan guardados como contrato canónico.</p>
 </div></div>
 <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
 <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
 <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-database.js"></script>
 <script src="js/combat-skill-schema.js"></script>
 <script src="js/skill-catalog-kobold-tier1.js"></script>
+<script src="js/unit-rank-runtime.js"></script>
 <script src="js/unit-catalog-kobold-tier1.js"></script>
 <script src="js/battle-viewer-firebase-session-074.js"></script>
 <script>
@@ -33,22 +34,23 @@ const UNIT_PATH='campaña/base_datos_unidades';
 const SKILL_PATH='campaña/base_datos_skills';
 const catalog=window.LuminousKoboldUnitCatalog;
 const skills=window.LuminousKoboldTier1SkillCatalog;
+const ranks=window.LuminousUnitRankRuntime;
 const schema=window.CombatSkillSchema;
 const session=window.LuminousBattleViewerFirebaseSession074;
 const $=id=>document.getElementById(id);
 let dmReady=false;
 function setStatus(text,kind){$('status').textContent=text;$('status').className='status'+(kind?' '+kind:'')}
-function rankRows(unitId){return ['normal','captain','leader'].map(rank=>{const a=catalog.resolve(unitId,{baseLevel:1,rank}),b=catalog.resolve(unitId,{baseLevel:3,rank});return `<tr><td>${rank.toUpperCase()}</td><td>${a.mechanics.speed}</td><td>${a.mechanics.hp}</td><td>${b.mechanics.hp}</td><td>+${a.mechanics.statusApplyBonus}</td><td>+${a.mechanics.basePowerBonus}</td></tr>`}).join('')}
+function rankRows(unitId){return ['normal','captain','leader'].map(rank=>{const a=catalog.resolve(unitId,{baseLevel:1,rank}),b=catalog.resolve(unitId,{baseLevel:3,rank});return `<tr><td>${rank.toUpperCase()}</td><td>${a.mechanics.speed}</td><td>${a.mechanics.hp}</td><td>${b.mechanics.hp}</td><td>+${a.mechanics.statusApplyBonus}</td><td>+${a.mechanics.basePowerBonus}</td><td>+${a.mechanics.turnEndSpRecovery} SP</td></tr>`}).join('')}
 function render(){
- if(!catalog||!skills||!schema){setStatus('Falta CombatSkillSchema o uno de los catálogos Kobold.','bad');return false}
+ if(!catalog||!skills||!ranks||!schema){setStatus('Falta CombatSkillSchema o uno de los catálogos/runtimes de Unit.','bad');return false}
  const definitions=catalog.list();
  const skillList=skills.list();
  const invalid=skillList.map(s=>[s,schema.validateCombatSkill(s)]).filter(([,v])=>!v.valid);
  if(invalid.length){setStatus(`Skill inválida: ${invalid[0][0].id} · ${invalid[0][1].errors.join(' · ')}`,'bad');return false}
  const outOfTier=skillList.filter(s=>{const p=skills.finalPower(s);return p<10||p>12});
  if(outOfTier.length){setStatus(`Tier 1 fuera de 10–12: ${outOfTier[0].id}.`,'bad');return false}
- $('units').innerHTML=definitions.map(unit=>`<section class="unit"><img src="${unit.visual.spriteUrl}" alt="${unit.name}"><h2>${unit.name}</h2><div class="skills">${unit.action_slots.join(' · ')}</div><table class="ranks"><thead><tr><th>Rank</th><th>Speed Lv1</th><th>HP Lv1</th><th>HP Lv3</th><th>Apply</th><th>Base</th></tr></thead><tbody>${rankRows(unit.id)}</tbody></table></section>`).join('');
- setStatus(`Catálogo válido: ${definitions.length} Units · ${skillList.length} Skills · versión ${catalog.version}.`,'ok');return true;
+ $('units').innerHTML=definitions.map(unit=>`<section class="unit"><img src="${unit.visual.spriteUrl}" alt="${unit.name}"><h2>${unit.name}</h2><div class="skills">${unit.action_slots.join(' · ')}</div><table class="ranks"><thead><tr><th>Rank</th><th>Speed Lv1</th><th>HP Lv1</th><th>HP Lv3</th><th>Apply</th><th>Base</th><th>Turn End</th></tr></thead><tbody>${rankRows(unit.id)}</tbody></table></section>`).join('');
+ setStatus(`Catálogo válido: ${definitions.length} Units · ${skillList.length} Skills · Unit Rank ${ranks.version} · Kobold ${catalog.version}.`,'ok');return true;
 }
 async function authorize(){
  $('sync').disabled=true;dmReady=false;

--- a/js/combat-team-economy-bridge.js
+++ b/js/combat-team-economy-bridge.js
@@ -14,6 +14,14 @@
     return null;
   }
 
+  function rankDirector() {
+    if (global.LuminousUnitRankRuntime) return global.LuminousUnitRankRuntime;
+    if (typeof require === "function") {
+      try { return require("./unit-rank-runtime.js"); } catch (_) {}
+    }
+    return null;
+  }
+
   function allActiveUnits(encounter) {
     if (!encounter) return [];
     return [
@@ -44,6 +52,11 @@
     engine.getTeamEconomySnapshot = function getTeamEconomySnapshot() {
       const api = director();
       return api && this.teamActionEncounter ? api.snapshot(this.teamActionEncounter) : null;
+    };
+
+    engine.getTeamCommandContext = function getTeamCommandContext() {
+      const ranks = rankDirector();
+      return ranks?.encounterCommandContext?.(this.teamActionEncounter) || null;
     };
 
     engine.consumeTeamQuickAction = function consumeTeamQuickAction(side) {
@@ -85,7 +98,11 @@
     engine.markPlayerPlanningReady = function markPlayerPlanningReady(options = {}) {
       const api = director();
       if (!api || !this.teamActionEncounter) return { ready: false, reason: "team_economy_unavailable" };
-      const result = api.playerReady(this.teamActionEncounter, { aiPlanner: options.aiPlanner });
+      const ranks = rankDirector();
+      const planner = typeof options.aiPlanner === "function"
+        ? (encounter) => options.aiPlanner(encounter, ranks?.encounterCommandContext?.(encounter) || null)
+        : options.aiPlanner;
+      const result = api.playerReady(this.teamActionEncounter, { aiPlanner: planner });
       if (!result.ready) return result;
 
       const finishAi = (aiResult) => {
@@ -125,19 +142,22 @@
       const api = director();
       if (!api || !this.teamActionEncounter) return { ended: false, reason: "team_economy_unavailable" };
       const result = api.endRound(this.teamActionEncounter, handlers);
+      let commandRecovery = null;
       if (result.ended) {
+        const ranks = rankDirector();
+        commandRecovery = ranks?.applyEncounterTurnEndSpRecovery?.(this.teamActionEncounter) || null;
         this.currentState = "PRE_COMBAT_PLANNING";
         const unitEconomy = global.LuminousActionEconomy;
         if (unitEconomy) allActiveUnits(this.teamActionEncounter).forEach((unit) => unitEconomy.beginPlanning?.(unit));
       }
-      return result;
+      return commandRecovery ? { ...result, commandRecovery } : result;
     };
 
     Object.defineProperty(engine, "__luminousTeamEconomyInstalled", { value: true, configurable: true, enumerable: false });
     return { installed: true, engine };
   }
 
-  const api = Object.freeze({ director, allActiveUnits, install });
+  const api = Object.freeze({ director, rankDirector, allActiveUnits, install });
   global.LuminousCombatTeamEconomyBridge = api;
   if (global.CombatEngine) install(global.CombatEngine);
   if (typeof module !== "undefined" && module.exports) module.exports = api;

--- a/js/unit-catalog-kobold-tier1.js
+++ b/js/unit-catalog-kobold-tier1.js
@@ -4,6 +4,8 @@
   const clone = (value) => JSON.parse(JSON.stringify(value));
   const skillCatalog = global.LuminousKoboldTier1SkillCatalog
     || (typeof require !== 'undefined' ? (() => { try { return require('./skill-catalog-kobold-tier1.js'); } catch (_) { return null; } })() : null);
+  const rankRuntime = global.LuminousUnitRankRuntime
+    || (typeof require !== 'undefined' ? (() => { try { return require('./unit-rank-runtime.js'); } catch (_) { return null; } })() : null);
 
   const BASE_LEVEL = Object.freeze({ min: 1, max: 3 });
   const STAGGER_THRESHOLDS = Object.freeze([75, 50, 25]);
@@ -22,11 +24,23 @@
     description: 'When this Kobold attacks a target that is also being attacked by another Kobold ally during the round, gain +1 Clash Power.',
   });
 
-  const RANKS = Object.freeze({
-    normal: Object.freeze({ id: 'normal', levelMultiplier: 1, hpBase: 24, hpCoefficient: 1.00, defLvlMod: 0, minSpeedBonus: 0, maxSpeedBonus: 0, applyBonus: 0, basePowerBonus: 0 }),
-    captain: Object.freeze({ id: 'captain', levelMultiplier: 2, hpBase: 30, hpCoefficient: 1.25, defLvlMod: 0, minSpeedBonus: 0, maxSpeedBonus: 1, applyBonus: 1, basePowerBonus: 0 }),
-    leader: Object.freeze({ id: 'leader', levelMultiplier: 3, hpBase: 36, hpCoefficient: 1.50, defLvlMod: 0, minSpeedBonus: 1, maxSpeedBonus: 2, applyBonus: 2, basePowerBonus: 1 }),
+  const FALLBACK_UNIVERSAL_RANKS = Object.freeze({
+    normal: Object.freeze({ id: 'normal', levelMultiplier: 1, minSpeedBonus: 0, maxSpeedBonus: 0, applyBonus: 0, basePowerBonus: 0, commandLevel: 0, aiCoordination: 'independent', targetPriority: 'random', turnEndSpRecovery: 0 }),
+    captain: Object.freeze({ id: 'captain', levelMultiplier: 2, minSpeedBonus: 0, maxSpeedBonus: 1, applyBonus: 1, basePowerBonus: 0, commandLevel: 1, aiCoordination: 'focus_fire', targetPriority: 'lowest_hp_ratio', turnEndSpRecovery: 5 }),
+    leader: Object.freeze({ id: 'leader', levelMultiplier: 3, minSpeedBonus: 1, maxSpeedBonus: 2, applyBonus: 2, basePowerBonus: 1, commandLevel: 2, aiCoordination: 'directed_focus', targetPriority: 'lowest_hp_ratio_then_highest_threat', turnEndSpRecovery: 10 }),
   });
+  const UNIVERSAL_RANKS = rankRuntime?.RANKS || FALLBACK_UNIVERSAL_RANKS;
+
+  // Durability belongs to the Kobold chassis. Command/speed/apply/power behavior belongs to the universal rank runtime.
+  const HP_RANKS = Object.freeze({
+    normal: Object.freeze({ hpBase: 24, hpCoefficient: 1.00, defLvlMod: 0 }),
+    captain: Object.freeze({ hpBase: 30, hpCoefficient: 1.25, defLvlMod: 0 }),
+    leader: Object.freeze({ hpBase: 36, hpCoefficient: 1.50, defLvlMod: 0 }),
+  });
+
+  const RANKS = Object.freeze(Object.fromEntries(
+    Object.keys(HP_RANKS).map((rankId) => [rankId, Object.freeze({ ...UNIVERSAL_RANKS[rankId], ...HP_RANKS[rankId] })])
+  ));
 
   function baseUnit({ id, name, variant, sprite, speed, skills }) {
     return {
@@ -81,7 +95,7 @@
       metadata: {
         canonicalUnit: true,
         catalog: 'kobold-tier1',
-        rankModel: 'normal_captain_leader',
+        rankModel: 'universal_normal_captain_leader',
         hpModel: 'rank_coefficient',
       },
     };
@@ -107,7 +121,7 @@
   });
 
   function normalizeRank(rank) {
-    const id = String(rank || 'normal').trim().toLowerCase();
+    const id = rankRuntime?.normalizeRank ? rankRuntime.normalizeRank(rank, '') : String(rank || 'normal').trim().toLowerCase();
     if (!RANKS[id]) throw new Error(`UNKNOWN_UNIT_RANK:${id}`);
     return id;
   }
@@ -150,7 +164,7 @@
     const baseLevel = normalizeBaseLevel(opts.baseLevel ?? 1);
     const rank = normalizeRank(opts.rank ?? 'normal');
     const profile = RANKS[rank];
-    const effectiveLevel = baseLevel * profile.levelMultiplier;
+    const effectiveLevel = rankRuntime?.effectiveLevel ? rankRuntime.effectiveLevel(baseLevel, rank) : baseLevel * profile.levelMultiplier;
     const maxHp = Math.floor(profile.hpBase + (effectiveLevel + profile.defLvlMod) * profile.hpCoefficient);
     const baseSpeed = parseSpeed(unit.mechanics.speed);
     const minSpeed = baseSpeed.min + profile.minSpeedBonus;
@@ -161,6 +175,12 @@
     unit.baseLevelSelected = baseLevel;
     unit.effectiveLevel = effectiveLevel;
     unit.rankBonuses = clone(profile);
+    unit.commandProfile = {
+      commandLevel: profile.commandLevel,
+      aiCoordination: profile.aiCoordination,
+      targetPriority: profile.targetPriority,
+      turnEndSpRecovery: profile.turnEndSpRecovery,
+    };
     unit.resolvedSkills = resolvedSkills;
     unit.mechanics = {
       ...unit.mechanics,
@@ -177,6 +197,9 @@
       maxSpeed,
       statusApplyBonus: profile.applyBonus,
       basePowerBonus: profile.basePowerBonus,
+      commandLevel: profile.commandLevel,
+      aiCoordination: profile.aiCoordination,
+      turnEndSpRecovery: profile.turnEndSpRecovery,
     };
     return unit;
   }
@@ -193,7 +216,8 @@
   }
 
   const api = Object.freeze({
-    version: '1.0.0', BASE_LEVEL, STAGGER_THRESHOLDS, SCORES, PROFICIENCIES, PACK_TACTICS, RANKS, DEFINITIONS,
+    version: '1.1.0', BASE_LEVEL, STAGGER_THRESHOLDS, SCORES, PROFICIENCIES, PACK_TACTICS,
+    UNIVERSAL_RANKS, HP_RANKS, RANKS, DEFINITIONS,
     list, get, resolve, resolveSkill, firebasePayload, firebaseSkillPayload,
   });
   global.LuminousKoboldUnitCatalog = api;

--- a/js/unit-rank-runtime.js
+++ b/js/unit-rank-runtime.js
@@ -1,0 +1,385 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousUnitRankRuntime) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousUnitRankRuntime;
+    return;
+  }
+
+  const RANKS = Object.freeze({
+    normal: Object.freeze({
+      id: "normal",
+      levelMultiplier: 1,
+      minSpeedBonus: 0,
+      maxSpeedBonus: 0,
+      applyBonus: 0,
+      basePowerBonus: 0,
+      commandLevel: 0,
+      aiCoordination: "independent",
+      targetPriority: "random",
+      turnEndSpRecovery: 0,
+    }),
+    captain: Object.freeze({
+      id: "captain",
+      levelMultiplier: 2,
+      minSpeedBonus: 0,
+      maxSpeedBonus: 1,
+      applyBonus: 1,
+      basePowerBonus: 0,
+      commandLevel: 1,
+      aiCoordination: "focus_fire",
+      targetPriority: "lowest_hp_ratio",
+      turnEndSpRecovery: 5,
+    }),
+    leader: Object.freeze({
+      id: "leader",
+      levelMultiplier: 3,
+      minSpeedBonus: 1,
+      maxSpeedBonus: 2,
+      applyBonus: 2,
+      basePowerBonus: 1,
+      commandLevel: 2,
+      aiCoordination: "directed_focus",
+      targetPriority: "lowest_hp_ratio_then_highest_threat",
+      turnEndSpRecovery: 10,
+    }),
+  });
+
+  const clone = (value) => JSON.parse(JSON.stringify(value));
+  const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const clean = (value) => String(value ?? "").trim();
+  const normalizeFaction = (value) => clean(value).toLowerCase();
+
+  function normalizeRank(value, fallback = "normal") {
+    const raw = clean(value || fallback).toLowerCase();
+    return RANKS[raw] ? raw : fallback;
+  }
+
+  function rankForUnit(unit = {}) {
+    return normalizeRank(
+      unit.rank
+      ?? unit.unitRank
+      ?? unit.rankId
+      ?? unit.mechanics?.rank
+      ?? unit.metadata?.unitRank
+      ?? unit.metadata?.rank,
+      "normal"
+    );
+  }
+
+  function profileForRank(rank) {
+    return RANKS[normalizeRank(rank)];
+  }
+
+  function profileForUnit(unit = {}) {
+    return profileForRank(rankForUnit(unit));
+  }
+
+  function effectiveLevel(baseLevel, rank) {
+    const level = Math.max(1, Math.floor(finite(baseLevel, 1)));
+    return level * profileForRank(rank).levelMultiplier;
+  }
+
+  function factionForUnit(unit = {}) {
+    return normalizeFaction(unit.faction ?? unit.faccion ?? unit.side ?? unit.team ?? "");
+  }
+
+  function currentHp(unit = {}) {
+    const candidates = [unit.hp, unit.currentHp, unit.currentHP, unit.mechanics?.hp];
+    const found = candidates.map(Number).find(Number.isFinite);
+    return found == null ? null : found;
+  }
+
+  function maxHp(unit = {}) {
+    const candidates = [unit.maxHp, unit.maxHP, unit.hpMax, unit.hp_max, unit.mechanics?.maxHp, unit.mechanics?.hp];
+    const found = candidates.map(Number).find((value) => Number.isFinite(value) && value > 0);
+    return found == null ? null : found;
+  }
+
+  function isActiveUnit(unit = {}) {
+    if (!unit || typeof unit !== "object") return false;
+    if (unit.dead === true || unit.defeated === true || unit.isDead === true || unit.removed === true) return false;
+    const hp = currentHp(unit);
+    return hp == null || hp > 0;
+  }
+
+  function commandProfile(units = []) {
+    const active = (Array.isArray(units) ? units : []).filter(isActiveUnit);
+    let best = RANKS.normal;
+    let commander = null;
+    active.forEach((unit) => {
+      const profile = profileForUnit(unit);
+      if (profile.commandLevel > best.commandLevel) {
+        best = profile;
+        commander = unit;
+      }
+    });
+    return {
+      rank: best.id,
+      commandLevel: best.commandLevel,
+      aiCoordination: best.aiCoordination,
+      targetPriority: best.targetPriority,
+      turnEndSpRecovery: best.turnEndSpRecovery,
+      commanderId: commander ? clean(commander.id || commander.unitId || commander.actorId || commander.name) : null,
+      commander: commander || null,
+    };
+  }
+
+  function commandProfilesByFaction(units = []) {
+    const groups = new Map();
+    (Array.isArray(units) ? units : []).filter(isActiveUnit).forEach((unit) => {
+      const faction = factionForUnit(unit);
+      if (!faction) return;
+      if (!groups.has(faction)) groups.set(faction, []);
+      groups.get(faction).push(unit);
+    });
+    const result = {};
+    groups.forEach((members, faction) => { result[faction] = commandProfile(members); });
+    return result;
+  }
+
+  function readSp(unit = {}) {
+    const candidates = [unit.sp, unit.currentSp, unit.currentSP, unit.mechanics?.sp];
+    const found = candidates.map(Number).find(Number.isFinite);
+    return found == null ? 0 : found;
+  }
+
+  function readMaxSp(unit = {}) {
+    const candidates = [unit.maxSp, unit.maxSP, unit.spMax, unit.sp_max, unit.mechanics?.maxSp, unit.mechanics?.spMax];
+    const found = candidates.map(Number).find(Number.isFinite);
+    return found == null ? null : found;
+  }
+
+  function writeSp(unit, value) {
+    const next = finite(value, 0);
+    if (Object.prototype.hasOwnProperty.call(unit, "sp") || !unit.mechanics) unit.sp = next;
+    if (Object.prototype.hasOwnProperty.call(unit, "currentSp")) unit.currentSp = next;
+    if (Object.prototype.hasOwnProperty.call(unit, "currentSP")) unit.currentSP = next;
+    if (unit.mechanics && typeof unit.mechanics === "object") unit.mechanics.sp = next;
+    return next;
+  }
+
+  function recoverSp(unit, amount) {
+    if (!isActiveUnit(unit)) return { unit, before: readSp(unit), after: readSp(unit), recovered: 0 };
+    const before = readSp(unit);
+    const max = readMaxSp(unit);
+    const requested = Math.max(0, finite(amount, 0));
+    const after = max == null ? before + requested : Math.min(max, before + requested);
+    writeSp(unit, after);
+    return { unit, before, after, recovered: Math.max(0, after - before) };
+  }
+
+  function applyTurnEndSpRecovery(units = []) {
+    const active = (Array.isArray(units) ? units : []).filter(isActiveUnit);
+    const byFaction = new Map();
+    active.forEach((unit) => {
+      const faction = factionForUnit(unit);
+      if (!faction) return;
+      if (!byFaction.has(faction)) byFaction.set(faction, []);
+      byFaction.get(faction).push(unit);
+    });
+
+    const factions = {};
+    const recoveries = [];
+    byFaction.forEach((members, faction) => {
+      const command = commandProfile(members);
+      factions[faction] = { ...command, commander: undefined };
+      if (command.turnEndSpRecovery <= 0) return;
+      members.forEach((unit) => {
+        const result = recoverSp(unit, command.turnEndSpRecovery);
+        recoveries.push({
+          faction,
+          unitId: clean(unit.id || unit.unitId || unit.actorId || unit.name),
+          rank: command.rank,
+          amount: command.turnEndSpRecovery,
+          before: result.before,
+          after: result.after,
+          recovered: result.recovered,
+        });
+      });
+    });
+    return { factions, recoveries };
+  }
+
+  function encounterCommandContext(encounter = {}) {
+    const teamUnits = (team) => (team?.active || []).map((entry) => entry?.unit || entry).filter(Boolean);
+    return {
+      allies: commandProfile(teamUnits(encounter.allies)),
+      enemies: commandProfile(teamUnits(encounter.enemies)),
+    };
+  }
+
+  function applyEncounterTurnEndSpRecovery(encounter = {}) {
+    const active = [
+      ...(encounter.allies?.active || []).map((entry) => entry?.unit || entry),
+      ...(encounter.enemies?.active || []).map((entry) => entry?.unit || entry),
+    ].filter(Boolean);
+    return applyTurnEndSpRecovery(active);
+  }
+
+  function slotBaseId(slotOrId) {
+    const id = typeof slotOrId === "string" ? slotOrId : clean(slotOrId?.id);
+    return id.split("_slot_")[0];
+  }
+
+  function hpRatio(unit = {}) {
+    const hp = currentHp(unit);
+    const max = maxHp(unit);
+    if (hp == null || max == null || max <= 0) return 1;
+    return Math.max(0, hp / max);
+  }
+
+  function threatScore(unit = {}) {
+    const speed = finite(unit.resolvedSpeed ?? unit.currentSpeed ?? unit.speedRoll ?? unit.speedValue ?? unit.speed, 0);
+    const slots = finite(unit.activeSlots ?? unit.currentActionSlots ?? unit.actionSlots ?? 1, 1);
+    return (slots * 10) + speed;
+  }
+
+  function orderedTargetIds(targetSlots = [], combatData = {}, command = RANKS.normal) {
+    const slots = Array.from(targetSlots || []);
+    const ids = [...new Set(slots.map(slotBaseId).filter(Boolean))];
+    if (command.commandLevel <= 0) return ids;
+
+    return ids.sort((a, b) => {
+      const unitA = combatData[a] || {};
+      const unitB = combatData[b] || {};
+      const ratioDiff = hpRatio(unitA) - hpRatio(unitB);
+      if (Math.abs(ratioDiff) > 0.000001) return ratioDiff;
+      if (command.commandLevel >= 2) {
+        const threatDiff = threatScore(unitB) - threatScore(unitA);
+        if (threatDiff) return threatDiff;
+      }
+      return String(a).localeCompare(String(b));
+    });
+  }
+
+  function assignTargetSlots({ attackSlots = [], targetSlots = [], combatData = {}, slotTargets = {}, random = Math.random } = {}) {
+    const attackers = Array.from(attackSlots || []).filter((slot) => {
+      const unit = combatData[slotBaseId(slot)];
+      return !unit?.isImmobilized && isActiveUnit(unit || {});
+    });
+    const targets = Array.from(targetSlots || []).filter((slot) => isActiveUnit(combatData[slotBaseId(slot)] || {}));
+    if (!attackers.length || !targets.length) return { command: commandProfile([]), assignments: [] };
+
+    const attackerUnits = [...new Set(attackers.map((slot) => combatData[slotBaseId(slot)]).filter(Boolean))];
+    const command = commandProfile(attackerUnits);
+    const assignments = [];
+
+    if (command.commandLevel <= 0) {
+      attackers.forEach((slot) => {
+        const index = Math.max(0, Math.min(targets.length - 1, Math.floor(finite(random(), 0) * targets.length)));
+        const target = targets[index];
+        slotTargets[slot.id] = target.id;
+        assignments.push({ attackerSlotId: slot.id, targetSlotId: target.id, targetUnitId: slotBaseId(target) });
+      });
+      return { command: { ...command, commander: undefined }, assignments };
+    }
+
+    const orderedIds = orderedTargetIds(targets, combatData, command);
+    const focusId = orderedIds[0];
+    const focusSlots = targets.filter((slot) => slotBaseId(slot) === focusId);
+    const pool = focusSlots.length ? focusSlots : targets;
+
+    attackers.forEach((slot, index) => {
+      const target = pool[index % pool.length];
+      slotTargets[slot.id] = target.id;
+      assignments.push({ attackerSlotId: slot.id, targetSlotId: target.id, targetUnitId: slotBaseId(target) });
+    });
+    return { command: { ...command, commander: undefined }, assignments };
+  }
+
+  function viewerValue(expression) {
+    try {
+      if (typeof global.eval === "function") return global.eval(expression);
+    } catch (_) {}
+    return null;
+  }
+
+  function viewerCombatData() {
+    return global.combatData || viewerValue("typeof combatData !== 'undefined' ? combatData : null") || {};
+  }
+
+  function viewerSlotTargets() {
+    return global.slotTargets || viewerValue("typeof slotTargets !== 'undefined' ? slotTargets : null") || null;
+  }
+
+  function installBattleViewerTargeting() {
+    if (!global.document || typeof global.rollEnemyTargets !== "function") return false;
+    if (global.rollEnemyTargets.__luminousUnitRankCommandWrapped) return true;
+    const legacy = global.rollEnemyTargets;
+    const wrapped = function rollEnemyTargetsWithCommand() {
+      const combatData = viewerCombatData();
+      const slotTargets = viewerSlotTargets();
+      if (!slotTargets) return legacy.apply(this, arguments);
+      const attackSlots = global.document.querySelectorAll('.action-slot-wrapper[data-faction="enemy"]');
+      const targetSlots = global.document.querySelectorAll('.action-slot-wrapper[data-faction="ally"]');
+      return assignTargetSlots({ attackSlots, targetSlots, combatData, slotTargets });
+    };
+    Object.defineProperty(wrapped, "__luminousUnitRankCommandWrapped", { value: true });
+    Object.defineProperty(wrapped, "__legacy", { value: legacy });
+    global.rollEnemyTargets = wrapped;
+    return true;
+  }
+
+  function installCombatEngineRoundEnd() {
+    const engine = global.CombatEngine;
+    if (!engine || typeof engine.triggerPhase !== "function") return false;
+    if (engine.triggerPhase.__luminousUnitRankCommandWrapped) return true;
+    const original = engine.triggerPhase;
+    const wrapped = function triggerPhaseWithCommand(phaseTag, allUnits, ...rest) {
+      const result = original.call(this, phaseTag, allUnits, ...rest);
+      if (String(phaseTag || "").trim().toLowerCase() === "[round end]") {
+        this.lastUnitRankCommandRecovery = applyTurnEndSpRecovery(Array.isArray(allUnits) ? allUnits : []);
+      }
+      return result;
+    };
+    Object.defineProperty(wrapped, "__luminousUnitRankCommandWrapped", { value: true });
+    engine.triggerPhase = wrapped;
+    return true;
+  }
+
+  function installBrowserBridges() {
+    if (!global.document) return false;
+    let attempts = 0;
+    const timer = global.setInterval?.(() => {
+      attempts += 1;
+      const targetReady = installBattleViewerTargeting();
+      const engineReady = installCombatEngineRoundEnd();
+      if ((targetReady && engineReady) || attempts >= 200) global.clearInterval?.(timer);
+    }, 25);
+    return Boolean(timer);
+  }
+
+  const api = Object.freeze({
+    version: "1.0.0",
+    RANKS,
+    normalizeRank,
+    rankForUnit,
+    profileForRank,
+    profileForUnit,
+    effectiveLevel,
+    factionForUnit,
+    isActiveUnit,
+    commandProfile,
+    commandProfilesByFaction,
+    readSp,
+    readMaxSp,
+    writeSp,
+    recoverSp,
+    applyTurnEndSpRecovery,
+    encounterCommandContext,
+    applyEncounterTurnEndSpRecovery,
+    slotBaseId,
+    hpRatio,
+    threatScore,
+    orderedTargetIds,
+    assignTargetSlots,
+    installBattleViewerTargeting,
+    installCombatEngineRoundEnd,
+    installBrowserBridges,
+  });
+
+  global.LuminousUnitRankRuntime = api;
+  installBrowserBridges();
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/universal-action-economy.js
+++ b/js/universal-action-economy.js
@@ -31,6 +31,16 @@
     global.document.head?.appendChild(script);
   }
 
+  function ensureUnitRankRuntime() {
+    if (!global.document || global.LuminousUnitRankRuntime) return;
+    if (global.document.getElementById("luminous-unit-rank-runtime-bootstrap")) return;
+    const script = global.document.createElement("script");
+    script.id = "luminous-unit-rank-runtime-bootstrap";
+    script.src = "js/unit-rank-runtime.js";
+    script.async = false;
+    global.document.head?.appendChild(script);
+  }
+
   function normalizePhase(value) {
     const id = normalizeId(value);
     if (["pre_combat_planning", "planning", "planning_phase", "before_combat", "before_combat_phase"].includes(id)) return PHASES.PLANNING;
@@ -324,5 +334,6 @@
 
   global.LuminousActionEconomy = api;
   ensureEnvironmentRuntime();
+  ensureUnitRankRuntime();
   if (typeof module !== "undefined" && module.exports) module.exports = api;
 })(typeof window !== "undefined" ? window : globalThis);

--- a/tests/unit-rank-command-smoke.mjs
+++ b/tests/unit-rank-command-smoke.mjs
@@ -37,6 +37,7 @@ assert.equal(field[3].sp, 7);
 assert.equal(recovery.recoveries.filter(entry => entry.faction === 'enemy').length, 3);
 assert.equal(recovery.factions.enemy.turnEndSpRecovery, 10);
 
+// A dead Leader stops commanding; the living Captain takes over.
 field[2].hp = 0;
 field[0].sp = field[1].sp = 0;
 const captainRecovery = rank.applyTurnEndSpRecovery(field);
@@ -45,6 +46,7 @@ assert.equal(field[0].sp, 5);
 assert.equal(field[1].sp, 5);
 assert.equal(field[2].sp, 10);
 
+// Respect a combatant's explicit SP cap when it exists.
 const capped = [
   { id: 'captain', faction: 'enemy', rank: 'captain', hp: 10, maxHp: 10, sp: 8, maxSp: 10 },
   { id: 'trooper', faction: 'enemy', hp: 10, maxHp: 10, sp: 9, maxSp: 10 },
@@ -53,6 +55,7 @@ rank.applyTurnEndSpRecovery(capped);
 assert.equal(capped[0].sp, 10);
 assert.equal(capped[1].sp, 10);
 
+// Normal Units preserve the legacy random enemy targeting behavior.
 const combatDataNormal = {
   e1: { id: 'e1', faction: 'enemy', rank: 'normal', hp: 10, maxHp: 10 },
   e2: { id: 'e2', faction: 'enemy', rank: 'normal', hp: 10, maxHp: 10 },
@@ -75,6 +78,7 @@ assert.equal(normalPlan.command.rank, 'normal');
 assert.equal(normalTargets.e1_slot_0, 'a1_slot_0');
 assert.equal(normalTargets.e2_slot_0, 'a2_slot_1');
 
+// Captain coordinates focus fire onto the most vulnerable target.
 const combatDataCaptain = JSON.parse(JSON.stringify(combatDataNormal));
 combatDataCaptain.e1.rank = 'captain';
 const captainTargets = {};
@@ -82,6 +86,7 @@ const captainPlan = rank.assignTargetSlots({ attackSlots, targetSlots, combatDat
 assert.equal(captainPlan.command.rank, 'captain');
 assert.deepEqual(new Set(Object.values(captainTargets).map(id => id.split('_slot_')[0])), new Set(['a2']));
 
+// Leader keeps vulnerability first and resolves equal vulnerability by highest threat.
 const leaderData = {
   e1: { id: 'e1', faction: 'enemy', rank: 'leader', hp: 10, maxHp: 10 },
   e2: { id: 'e2', faction: 'enemy', rank: 'normal', hp: 10, maxHp: 10 },
@@ -94,6 +99,7 @@ const leaderPlan = rank.assignTargetSlots({ attackSlots, targetSlots: leaderTarg
 assert.equal(leaderPlan.command.rank, 'leader');
 assert.deepEqual(new Set(Object.values(leaderTargets).map(id => id.split('_slot_')[0])), new Set(['a2']));
 
+// Encounter helpers only read FIELD/active profiles. Backups do not command.
 const encounter = {
   allies: { active: [{ unit: { id: 'ally', faction: 'ally', rank: 'normal', hp: 10, sp: 0 } }], backups: [{ unit: { id: 'ally_leader_backup', faction: 'ally', rank: 'leader', hp: 10, sp: 0 } }] },
   enemies: { active: [{ unit: { id: 'enemy', faction: 'enemy', rank: 'captain', hp: 10, sp: 0 } }], backups: [{ unit: { id: 'enemy_leader_backup', faction: 'enemy', rank: 'leader', hp: 10, sp: 0 } }] },
@@ -101,5 +107,40 @@ const encounter = {
 const encounterCommand = rank.encounterCommandContext(encounter);
 assert.equal(encounterCommand.allies.rank, 'normal');
 assert.equal(encounterCommand.enemies.rank, 'captain');
+
+// Team Economy passes the command context to the AI planner and resolves the SP aura at Turn End.
+await import('../js/team-action-economy.js');
+globalThis.LuminousActionEconomy = {
+  beginPlanning() {},
+  beginCombat() {},
+};
+await import('../js/combat-team-economy-bridge.js');
+const bridge = globalThis.LuminousCombatTeamEconomyBridge;
+const engine = { currentState: 'COMBAT_ACTIVE' };
+assert.equal(bridge.install(engine).installed, true);
+const activeCaptain = { id: 'bridge_captain', faction: 'enemy', rank: 'captain', hp: 20, maxHp: 20, sp: 0, initialActionSlots: 1, maxActionSlots: 1 };
+const activeTrooper = { id: 'bridge_trooper', faction: 'enemy', rank: 'normal', hp: 20, maxHp: 20, sp: 0, initialActionSlots: 1, maxActionSlots: 1 };
+const backupLeader = { id: 'bridge_leader_backup', faction: 'enemy', rank: 'leader', hp: 20, maxHp: 20, sp: 0, initialActionSlots: 1, maxActionSlots: 1 };
+const activeAlly = { id: 'bridge_ally', faction: 'ally', rank: 'normal', hp: 20, maxHp: 20, sp: 0, initialActionSlots: 1, maxActionSlots: 1 };
+engine.createTeamEconomyEncounter({ allies: [activeAlly], enemies: [activeCaptain, activeTrooper], enemyBackups: [backupLeader] });
+let plannerCommand = null;
+const ready = engine.markPlayerPlanningReady({
+  aiPlanner: (_encounter, commandContext) => {
+    plannerCommand = commandContext;
+    return { planned: true };
+  },
+});
+assert.equal(ready.aiResult.planned, true);
+assert.equal(plannerCommand.enemies.rank, 'captain');
+assert.equal(plannerCommand.enemies.aiCoordination, 'focus_fire');
+assert.equal(engine.getTeamCommandContext().enemies.rank, 'captain');
+assert.equal(engine.beginTeamTurnEnd().started, true);
+const ended = engine.endTeamRound();
+assert.equal(ended.ended, true);
+assert.equal(ended.commandRecovery.factions.enemy.rank, 'captain');
+assert.equal(activeCaptain.sp, 5);
+assert.equal(activeTrooper.sp, 5);
+assert.equal(backupLeader.sp, 0);
+assert.equal(activeAlly.sp, 0);
 
 console.log('universal unit rank command smoke: OK');

--- a/tests/unit-rank-command-smoke.mjs
+++ b/tests/unit-rank-command-smoke.mjs
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+
+await import('../js/unit-rank-runtime.js');
+const rank = globalThis.LuminousUnitRankRuntime;
+if (!rank) throw new Error('LuminousUnitRankRuntime was not initialized.');
+
+assert.equal(rank.RANKS.normal.levelMultiplier, 1);
+assert.equal(rank.RANKS.captain.levelMultiplier, 2);
+assert.equal(rank.RANKS.leader.levelMultiplier, 3);
+assert.equal(rank.RANKS.captain.turnEndSpRecovery, 5);
+assert.equal(rank.RANKS.leader.turnEndSpRecovery, 10);
+assert.equal(rank.RANKS.captain.maxSpeedBonus, 1);
+assert.equal(rank.RANKS.leader.minSpeedBonus, 1);
+assert.equal(rank.RANKS.leader.maxSpeedBonus, 2);
+assert.equal(rank.RANKS.leader.applyBonus, 2);
+assert.equal(rank.RANKS.leader.basePowerBonus, 1);
+
+assert.equal(rank.effectiveLevel(3, 'captain'), 6);
+assert.equal(rank.effectiveLevel(3, 'leader'), 9);
+
+const field = [
+  { id: 'enemy_normal', faction: 'enemy', rank: 'normal', hp: 10, maxHp: 10, sp: 0 },
+  { id: 'enemy_captain', faction: 'enemy', rank: 'captain', hp: 10, maxHp: 10, sp: 0 },
+  { id: 'enemy_leader', faction: 'enemy', rank: 'leader', hp: 10, maxHp: 10, sp: 0 },
+  { id: 'ally_player', faction: 'ally', hp: 10, maxHp: 10, sp: 7 },
+];
+const command = rank.commandProfile(field.filter(unit => unit.faction === 'enemy'));
+assert.equal(command.rank, 'leader');
+assert.equal(command.commandLevel, 2);
+assert.equal(command.turnEndSpRecovery, 10);
+
+const recovery = rank.applyTurnEndSpRecovery(field);
+assert.equal(field[0].sp, 10);
+assert.equal(field[1].sp, 10);
+assert.equal(field[2].sp, 10);
+assert.equal(field[3].sp, 7);
+assert.equal(recovery.recoveries.filter(entry => entry.faction === 'enemy').length, 3);
+assert.equal(recovery.factions.enemy.turnEndSpRecovery, 10);
+
+field[2].hp = 0;
+field[0].sp = field[1].sp = 0;
+const captainRecovery = rank.applyTurnEndSpRecovery(field);
+assert.equal(captainRecovery.factions.enemy.rank, 'captain');
+assert.equal(field[0].sp, 5);
+assert.equal(field[1].sp, 5);
+assert.equal(field[2].sp, 10);
+
+const capped = [
+  { id: 'captain', faction: 'enemy', rank: 'captain', hp: 10, maxHp: 10, sp: 8, maxSp: 10 },
+  { id: 'trooper', faction: 'enemy', hp: 10, maxHp: 10, sp: 9, maxSp: 10 },
+];
+rank.applyTurnEndSpRecovery(capped);
+assert.equal(capped[0].sp, 10);
+assert.equal(capped[1].sp, 10);
+
+const combatDataNormal = {
+  e1: { id: 'e1', faction: 'enemy', rank: 'normal', hp: 10, maxHp: 10 },
+  e2: { id: 'e2', faction: 'enemy', rank: 'normal', hp: 10, maxHp: 10 },
+  a1: { id: 'a1', faction: 'ally', hp: 100, maxHp: 100, speed: 3, actionSlots: 1 },
+  a2: { id: 'a2', faction: 'ally', hp: 20, maxHp: 100, speed: 8, actionSlots: 2 },
+};
+const attackSlots = [{ id: 'e1_slot_0' }, { id: 'e2_slot_0' }];
+const targetSlots = [{ id: 'a1_slot_0' }, { id: 'a2_slot_0' }, { id: 'a2_slot_1' }];
+const normalTargets = {};
+const rolls = [0, 0.99];
+let rollIndex = 0;
+const normalPlan = rank.assignTargetSlots({
+  attackSlots,
+  targetSlots,
+  combatData: combatDataNormal,
+  slotTargets: normalTargets,
+  random: () => rolls[rollIndex++],
+});
+assert.equal(normalPlan.command.rank, 'normal');
+assert.equal(normalTargets.e1_slot_0, 'a1_slot_0');
+assert.equal(normalTargets.e2_slot_0, 'a2_slot_1');
+
+const combatDataCaptain = JSON.parse(JSON.stringify(combatDataNormal));
+combatDataCaptain.e1.rank = 'captain';
+const captainTargets = {};
+const captainPlan = rank.assignTargetSlots({ attackSlots, targetSlots, combatData: combatDataCaptain, slotTargets: captainTargets });
+assert.equal(captainPlan.command.rank, 'captain');
+assert.deepEqual(new Set(Object.values(captainTargets).map(id => id.split('_slot_')[0])), new Set(['a2']));
+
+const leaderData = {
+  e1: { id: 'e1', faction: 'enemy', rank: 'leader', hp: 10, maxHp: 10 },
+  e2: { id: 'e2', faction: 'enemy', rank: 'normal', hp: 10, maxHp: 10 },
+  a1: { id: 'a1', faction: 'ally', hp: 50, maxHp: 100, speed: 2, actionSlots: 1 },
+  a2: { id: 'a2', faction: 'ally', hp: 50, maxHp: 100, speed: 9, actionSlots: 2 },
+};
+const leaderTargetSlots = [{ id: 'a1_slot_0' }, { id: 'a2_slot_0' }, { id: 'a2_slot_1' }];
+const leaderTargets = {};
+const leaderPlan = rank.assignTargetSlots({ attackSlots, targetSlots: leaderTargetSlots, combatData: leaderData, slotTargets: leaderTargets });
+assert.equal(leaderPlan.command.rank, 'leader');
+assert.deepEqual(new Set(Object.values(leaderTargets).map(id => id.split('_slot_')[0])), new Set(['a2']));
+
+const encounter = {
+  allies: { active: [{ unit: { id: 'ally', faction: 'ally', rank: 'normal', hp: 10, sp: 0 } }], backups: [{ unit: { id: 'ally_leader_backup', faction: 'ally', rank: 'leader', hp: 10, sp: 0 } }] },
+  enemies: { active: [{ unit: { id: 'enemy', faction: 'enemy', rank: 'captain', hp: 10, sp: 0 } }], backups: [{ unit: { id: 'enemy_leader_backup', faction: 'enemy', rank: 'leader', hp: 10, sp: 0 } }] },
+};
+const encounterCommand = rank.encounterCommandContext(encounter);
+assert.equal(encounterCommand.allies.rank, 'normal');
+assert.equal(encounterCommand.enemies.rank, 'captain');
+
+console.log('universal unit rank command smoke: OK');


### PR DESCRIPTION
## Summary
- introduce a universal Unit Rank runtime for Normal / Captain / Leader
- move shared level, Speed, Apply and Base Power rank rules out of the Kobold-only contract
- make Captain and Leader improve same-side AI organization
- grant same-side FIELD Units SP recovery at Turn End while an active commander is present
- connect command context to the Team Action Economy AI planner
- keep Kobold durability as chassis-specific HP data

## Universal Rank contract
### Normal
- Level ×1
- existing Speed / Apply / Base Power baseline
- independent/random targeting
- no command SP recovery

### Captain
- Level ×2
- Max Speed +1
- Apply +1
- Command Level 1: coordinated focus fire against the most vulnerable target
- same-side active FIELD Units recover +5 SP at Turn End

### Leader
- Level ×3
- Min Speed +1
- Max Speed +2
- Apply +2
- Base Power +1
- Command Level 2: directed focus fire; vulnerability first, then threat for ties
- same-side active FIELD Units recover +10 SP at Turn End

## Command rules
- highest active rank wins; Captain and Leader do not stack to +15 SP
- a dead/defeated commander stops providing command
- BACKUP / reserve Units do not provide command until they are in FIELD
- SP respects an explicit combatant max-SP cap when present
- command is same-side/faction based and applies to any future Unit using `rank: captain|leader`

## Runtime integration
- legacy Battle Viewer enemy targeting keeps its random behavior with no commander
- Captain/Leader targeting is supplied by the universal Unit Rank runtime
- Team Action Economy planners receive a second `commandContext` argument without breaking existing one-argument planners
- Team Turn End resolves the command SP recovery for active Units
- Kobold catalog now consumes universal rank behavior while keeping its own HP Base / HP Coefficient profiles

## Tests
- universal Unit Rank command smoke
- existing Kobold Unit Library smoke remains enabled
- existing Team Action Economy and full Combat Runtime regression suite remain enabled
- syntax checks added for the new runtime and touched bridges

## Safety
- no production Firebase writes
- no Firebase Rules deployment
- no reserve/encounter roster mutations