### PR TITLE
Fix: give backup commanders half SP support

### DIFF
--- a/js/unit-rank-runtime.js
+++ b/js/unit-rank-runtime.js
@@ -6,6 +6,7 @@
     return;
   }
 
+  const BACKUP_COMMAND_SP_MULTIPLIER = 0.5;
   const RANKS = Object.freeze({
     normal: Object.freeze({
       id: "normal",
@@ -183,7 +184,7 @@
     const recoveries = [];
     byFaction.forEach((members, faction) => {
       const command = commandProfile(members);
-      factions[faction] = { ...command, commander: undefined };
+      factions[faction] = { ...command, commander: undefined, sourceDeployment: "field" };
       if (command.turnEndSpRecovery <= 0) return;
       members.forEach((unit) => {
         const result = recoverSp(unit, command.turnEndSpRecovery);
@@ -191,6 +192,7 @@
           faction,
           unitId: clean(unit.id || unit.unitId || unit.actorId || unit.name),
           rank: command.rank,
+          sourceDeployment: "field",
           amount: command.turnEndSpRecovery,
           before: result.before,
           after: result.after,
@@ -201,20 +203,61 @@
     return { factions, recoveries };
   }
 
-  function encounterCommandContext(encounter = {}) {
-    const teamUnits = (team) => (team?.active || []).map((entry) => entry?.unit || entry).filter(Boolean);
+  function entriesToUnits(entries = []) {
+    return (Array.isArray(entries) ? entries : []).map((entry) => entry?.unit || entry).filter(Boolean);
+  }
+
+  function commandSpRecoveryProfile(activeUnits = [], backupUnits = []) {
+    const field = commandProfile(activeUnits);
+    const backup = commandProfile(backupUnits);
+    const backupRecovery = backup.turnEndSpRecovery * BACKUP_COMMAND_SP_MULTIPLIER;
+    if (field.turnEndSpRecovery >= backupRecovery) {
+      return { ...field, sourceDeployment: "field", recoveryMultiplier: 1 };
+    }
     return {
-      allies: commandProfile(teamUnits(encounter.allies)),
-      enemies: commandProfile(teamUnits(encounter.enemies)),
+      ...backup,
+      turnEndSpRecovery: backupRecovery,
+      sourceDeployment: "backup",
+      recoveryMultiplier: BACKUP_COMMAND_SP_MULTIPLIER,
+    };
+  }
+
+  function encounterCommandContext(encounter = {}) {
+    return {
+      allies: commandProfile(entriesToUnits(encounter.allies?.active)),
+      enemies: commandProfile(entriesToUnits(encounter.enemies?.active)),
     };
   }
 
   function applyEncounterTurnEndSpRecovery(encounter = {}) {
-    const active = [
-      ...(encounter.allies?.active || []).map((entry) => entry?.unit || entry),
-      ...(encounter.enemies?.active || []).map((entry) => entry?.unit || entry),
-    ].filter(Boolean);
-    return applyTurnEndSpRecovery(active);
+    const factions = {};
+    const recoveries = [];
+
+    [encounter.allies, encounter.enemies].forEach((team) => {
+      const active = entriesToUnits(team?.active).filter(isActiveUnit);
+      const backups = entriesToUnits(team?.backups).filter(isActiveUnit);
+      if (!active.length) return;
+      const command = commandSpRecoveryProfile(active, backups);
+      const faction = active.map(factionForUnit).find(Boolean) || factionForUnit(command.commander || {});
+      if (!faction) return;
+      factions[faction] = { ...command, commander: undefined };
+      if (command.turnEndSpRecovery <= 0) return;
+      active.forEach((unit) => {
+        const result = recoverSp(unit, command.turnEndSpRecovery);
+        recoveries.push({
+          faction,
+          unitId: clean(unit.id || unit.unitId || unit.actorId || unit.name),
+          rank: command.rank,
+          sourceDeployment: command.sourceDeployment,
+          amount: command.turnEndSpRecovery,
+          before: result.before,
+          after: result.after,
+          recovered: result.recovered,
+        });
+      });
+    });
+
+    return { factions, recoveries };
   }
 
   function slotBaseId(slotOrId) {
@@ -351,7 +394,8 @@
   }
 
   const api = Object.freeze({
-    version: "1.0.0",
+    version: "1.1.0",
+    BACKUP_COMMAND_SP_MULTIPLIER,
     RANKS,
     normalizeRank,
     rankForUnit,
@@ -367,6 +411,7 @@
     writeSp,
     recoverSp,
     applyTurnEndSpRecovery,
+    commandSpRecoveryProfile,
     encounterCommandContext,
     applyEncounterTurnEndSpRecovery,
     slotBaseId,

--- a/tests/unit-rank-command-smoke.mjs
+++ b/tests/unit-rank-command-smoke.mjs
@@ -4,6 +4,8 @@ await import('../js/unit-rank-runtime.js');
 const rank = globalThis.LuminousUnitRankRuntime;
 if (!rank) throw new Error('LuminousUnitRankRuntime was not initialized.');
 
+assert.equal(rank.version, '1.1.0');
+assert.equal(rank.BACKUP_COMMAND_SP_MULTIPLIER, 0.5);
 assert.equal(rank.RANKS.normal.levelMultiplier, 1);
 assert.equal(rank.RANKS.captain.levelMultiplier, 2);
 assert.equal(rank.RANKS.leader.levelMultiplier, 3);
@@ -99,7 +101,7 @@ const leaderPlan = rank.assignTargetSlots({ attackSlots, targetSlots: leaderTarg
 assert.equal(leaderPlan.command.rank, 'leader');
 assert.deepEqual(new Set(Object.values(leaderTargets).map(id => id.split('_slot_')[0])), new Set(['a2']));
 
-// Encounter helpers only read FIELD/active profiles. Backups do not command.
+// AI command comes only from FIELD. Backup commanders instead provide half SP support.
 const encounter = {
   allies: { active: [{ unit: { id: 'ally', faction: 'ally', rank: 'normal', hp: 10, sp: 0 } }], backups: [{ unit: { id: 'ally_leader_backup', faction: 'ally', rank: 'leader', hp: 10, sp: 0 } }] },
   enemies: { active: [{ unit: { id: 'enemy', faction: 'enemy', rank: 'captain', hp: 10, sp: 0 } }], backups: [{ unit: { id: 'enemy_leader_backup', faction: 'enemy', rank: 'leader', hp: 10, sp: 0 } }] },
@@ -108,7 +110,29 @@ const encounterCommand = rank.encounterCommandContext(encounter);
 assert.equal(encounterCommand.allies.rank, 'normal');
 assert.equal(encounterCommand.enemies.rank, 'captain');
 
-// Team Economy passes the command context to the AI planner and resolves the SP aura at Turn End.
+const encounterRecovery = rank.applyEncounterTurnEndSpRecovery(encounter);
+assert.equal(encounter.allies.active[0].unit.sp, 5, 'backup Leader grants half of +10 SP');
+assert.equal(encounter.allies.backups[0].unit.sp, 0, 'backup Units do not receive the recovery');
+assert.equal(encounterRecovery.factions.ally.rank, 'leader');
+assert.equal(encounterRecovery.factions.ally.sourceDeployment, 'backup');
+assert.equal(encounterRecovery.factions.ally.turnEndSpRecovery, 5);
+assert.equal(encounter.enemies.active[0].unit.sp, 5, 'FIELD Captain ties backup Leader at 5 and wins by deployment priority');
+assert.equal(encounterRecovery.factions.enemy.rank, 'captain');
+assert.equal(encounterRecovery.factions.enemy.sourceDeployment, 'field');
+
+const backupCaptainEncounter = {
+  enemies: {
+    active: [{ unit: { id: 'trooper', faction: 'enemy', rank: 'normal', hp: 10, sp: 0 } }],
+    backups: [{ unit: { id: 'captain_backup', faction: 'enemy', rank: 'captain', hp: 10, sp: 0 } }],
+  },
+};
+const backupCaptainRecovery = rank.applyEncounterTurnEndSpRecovery(backupCaptainEncounter);
+assert.equal(backupCaptainEncounter.enemies.active[0].unit.sp, 2.5, 'backup Captain grants half of +5 SP');
+assert.equal(backupCaptainEncounter.enemies.backups[0].unit.sp, 0);
+assert.equal(backupCaptainRecovery.factions.enemy.turnEndSpRecovery, 2.5);
+assert.equal(backupCaptainRecovery.factions.enemy.sourceDeployment, 'backup');
+
+// Team Economy passes FIELD command context to the AI planner and resolves the best SP aura at Turn End.
 await import('../js/team-action-economy.js');
 globalThis.LuminousActionEconomy = {
   beginPlanning() {},
@@ -138,6 +162,7 @@ assert.equal(engine.beginTeamTurnEnd().started, true);
 const ended = engine.endTeamRound();
 assert.equal(ended.ended, true);
 assert.equal(ended.commandRecovery.factions.enemy.rank, 'captain');
+assert.equal(ended.commandRecovery.factions.enemy.sourceDeployment, 'field');
 assert.equal(activeCaptain.sp, 5);
 assert.equal(activeTrooper.sp, 5);
 assert.equal(backupLeader.sp, 0);


### PR DESCRIPTION
## Summary
- keep Captain / Leader AI command restricted to FIELD
- let backup commanders provide half of their Turn End SP support to allied FIELD Units
- keep command auras non-stacking by choosing the best effective support
- prefer FIELD on ties

## Universal command support
- Captain FIELD: +5 SP On Turn End
- Captain BACKUP: +2.5 SP On Turn End
- Leader FIELD: +10 SP On Turn End
- Leader BACKUP: +5 SP On Turn End

## Rules
- only FIELD Units receive the SP recovery
- backup Units can provide support but do not recover SP themselves
- FIELD command remains authoritative for AI organization
- dead/defeated commanders provide no support
- highest effective SP support wins; auras do not stack
- explicit max-SP caps are still respected

## Tests
- expands the universal Unit Rank command smoke with backup Captain / Leader recovery cases
- preserves Team Action Economy command-context coverage

## Safety
- no production Firebase writes
- no Firebase Rules changes
- no encounter roster mutations