### PR TITLE
feat: canonical universal spell library and combat runtime

### DIFF
--- a/js/battle-viewer-spell-adapter-074.js
+++ b/js/battle-viewer-spell-adapter-074.js
@@ -19,18 +19,16 @@
     if (typeof require === "function") { try { return require("./battle-viewer-action-adapter-073.js"); } catch (_) {} }
     return null;
   }
-
   function spellLoadoutRuntime() {
     if (global?.LuminousCombatSpellLoadout074) return global.LuminousCombatSpellLoadout074;
     if (typeof require === "function") { try { return require("./combat-spell-loadout-074.js"); } catch (_) {} }
     return null;
   }
-
   function spellcastingRuntime() {
     if (global?.LuminousSpellcastingRuntime) return global.LuminousSpellcastingRuntime;
     if (typeof require === "function") {
-      try { return require("./spellcasting-basic-rules-runtime.js"); } catch (_) {}
       try { return require("./spellcasting-runtime.js"); } catch (_) {}
+      try { return require("./spellcasting-basic-rules-runtime.js"); } catch (_) {}
     }
     return null;
   }
@@ -38,12 +36,7 @@
   function combatData(base) { return base?.combatData?.() || global.combatData || {}; }
   function unitIdFromSlot(base, slotId) { return base?.unitIdFromSlot?.(slotId) || clean(slotId).split("_slot_")[0]; }
   function planForSlot(base, slotId) { return base?.planForSlot?.(slotId) || null; }
-
-  function spellIdForPlan(plan = {}, data = {}) { return clean(plan.spellId || plan.sourceId || data.libraryKey || data.spellId || data.id); }
-  function isPlayerActor(actor = {}, plan = {}) {
-    const category = normalizeId(actor.actorCategory || actor.category || actor.type);
-    return plan.__ownerPlayerId != null || actor.isPlayer === true || category === "player" || normalizeId(actor.canonicalScope) === "player";
-  }
+  function spellIdForPlan(plan = {}, data = {}) { return normalizeId(plan.spellId || plan.sourceId || data.libraryKey || data.spellId || data.id); }
   function planKind(plan = {}, data = {}) { return normalizeId(plan.type || plan.kind || data.kind || data.type); }
   function isSpellPlan(plan = {}, data = {}) {
     const kind = planKind(plan, data);
@@ -57,7 +50,7 @@
     if (!runtime?.resolveSpellForCombatant) return { ok: false, reason: "spell_loadout_runtime_required", spellId, spell: null };
     const result = runtime.resolveSpellForCombatant(actor, spellId, { classId: plan.classId });
     return result.ok
-      ? { ok: true, reason: null, spellId, spell: result.spell, classId: result.classId, entry: result.entry || null }
+      ? { ok: true, reason: null, spellId: result.spellId || spellId, spell: result.spell, classId: result.classId, entry: result.entry || null }
       : { ok: false, reason: String(result.reason || "spell_unavailable").toLowerCase(), spellId, spell: null, classId: null };
   }
 
@@ -70,64 +63,196 @@
 
   function canonicalCastResource(classId, slotLevel, overcast) {
     return {
-      owner: "source",
-      type: "spell_slot",
+      owner: "source", type: "spell_slot",
       id: overcast === true ? `${OVERCAST_PREFIX}${clean(classId)}` : clean(classId),
       amount: 1,
-      metadata: { classId: clean(classId), slotLevel: Math.max(0, Number(slotLevel) || 0), overcast: overcast === true },
+      metadata: { classId: clean(classId), slotLevel: Math.max(0, Number(slotLevel) || 0), overcast: overcast === true }
     };
+  }
+
+  function actorLevel(actor = {}) {
+    const direct = actor.Level ?? actor.level ?? actor.characterBuild?.calculatedAtLevel;
+    if (Number.isFinite(Number(direct))) return Math.max(0, Math.trunc(Number(direct)));
+    const classes = Array.isArray(actor.classes) ? actor.classes : (Array.isArray(actor.characterBuild?.classes) ? actor.characterBuild.classes : []);
+    return classes.reduce((sum, row) => sum + Math.max(0, Math.trunc(Number(row?.levels ?? row?.level ?? 0) || 0)), 0);
+  }
+
+  function spellcastingValues(actor, classId) {
+    const runtime = spellcastingRuntime();
+    try {
+      if (typeof runtime?.resolveSpellcasting === "function") return runtime.resolveSpellcasting(actor, classId) || null;
+    } catch (_) {}
+    return null;
+  }
+
+  function resolvedStatusEffect(status, potency = 0, count = 0, trigger = "on_hit", target = "target", extra = {}) {
+    return {
+      trigger, target, type: "status", status: normalizeId(status),
+      potency: Math.max(0, Math.trunc(Number(potency) || 0)),
+      count: Math.max(0, Math.trunc(Number(count) || 0)),
+      timing: "immediate", ...clone(extra)
+    };
+  }
+
+  function materializeSpell(actor, classId, spell, slotLevel, plan = {}) {
+    const definition = clone(spell) || {};
+    const mechanics = definition.mechanics || {};
+    const baseLevel = Math.max(0, Math.trunc(Number(definition.level ?? definition.spellLevel ?? 0) || 0));
+    const extraLevels = Math.max(0, slotLevel - baseLevel);
+    const casting = spellcastingValues(actor, classId) || {};
+    const spellMod = Number(casting.spellMod) || 0;
+    const level = actorLevel(actor);
+
+    if (mechanics.levelCoinPower?.every) {
+      const every = Math.max(1, Number(mechanics.levelCoinPower.every) || 20);
+      const amount = Number(mechanics.levelCoinPower.amount) || 0;
+      definition.coinPower = Number(definition.coinPower || 0) + Math.floor(level / every) * amount;
+    }
+    if (definition.upcast?.coinPowerPerLevel) {
+      definition.coinPower = Number(definition.coinPower || 0) + extraLevels * Number(definition.upcast.coinPowerPerLevel || 0);
+    }
+    if (definition.upcast?.atkWeightPerLevel) {
+      definition.attackWeight = Math.max(1, Number(definition.attackWeight || definition.atkWeight || 1) + extraLevels * Number(definition.upcast.atkWeightPerLevel || 0));
+      definition.atkWeight = definition.attackWeight;
+    }
+    if (definition.upcast?.coinsPerLevel) {
+      definition.coinAmount = Math.max(1, Number(definition.coinAmount || definition.coins || 1) + extraLevels * Number(definition.upcast.coinsPerLevel || 0));
+      definition.coins = definition.coinAmount;
+    }
+
+    const effects = [];
+    const modStatus = mechanics.onHitStatusFromSpellMod;
+    if (modStatus?.status) {
+      const divisor = Math.max(1, Number(modStatus.potencyDivisor) || 1);
+      const minimum = Math.max(0, Number(modStatus.minimum) || 0);
+      const potency = Math.max(minimum, Math.floor(spellMod / divisor));
+      effects.push(resolvedStatusEffect(modStatus.status, potency, 0, "on_hit", "target", {
+        doubleIfTargetHasStatus: modStatus.doubleIfTargetHasStatus ? normalizeId(modStatus.doubleIfTargetHasStatus) : undefined
+      }));
+    }
+    if (mechanics.onHitStatus?.status) {
+      effects.push(resolvedStatusEffect(mechanics.onHitStatus.status, mechanics.onHitStatus.potency, mechanics.onHitStatus.count, "on_hit", "target", {
+        perCoin: mechanics.onHitStatus.perCoin === true
+      }));
+    }
+    if (mechanics.onFailedSave?.status) {
+      effects.push(resolvedStatusEffect(
+        mechanics.onFailedSave.status,
+        mechanics.onFailedSave.potency,
+        mechanics.onFailedSave.count,
+        "on_failed_save",
+        mechanics.onFailedSave.target || "target",
+        { breakOnDamageFromCasterOrAlly: mechanics.breakCharmOnDamageFromCasterOrAlly === true }
+      ));
+    }
+    if (mechanics.onUse?.status) {
+      effects.push(resolvedStatusEffect(mechanics.onUse.status, mechanics.onUse.potency, mechanics.onUse.count, "on_use", mechanics.onUse.target || "self"));
+    }
+    if (mechanics.whileConcentratingTurnStart?.status) {
+      effects.push(resolvedStatusEffect(
+        mechanics.whileConcentratingTurnStart.status,
+        mechanics.whileConcentratingTurnStart.potency,
+        mechanics.whileConcentratingTurnStart.count,
+        "turn_start",
+        mechanics.whileConcentratingTurnStart.target || "self",
+        { requiresConcentration: true, spellId: definition.id }
+      ));
+    }
+
+    if (mechanics.requiresChoice?.key === "element") {
+      const element = normalizeId(plan.element || plan.elementId || plan.choice?.element);
+      const allowed = mechanics.requiresChoice.values || [];
+      if (!element || !allowed.includes(element)) {
+        return { ok: false, reason: "spell_choice_required", choiceKey: "element", choices: clone(allowed) };
+      }
+      const elementEffect = mechanics.elementalStatus?.[element];
+      if (elementEffect?.status) effects.push(resolvedStatusEffect(elementEffect.status, elementEffect.potency, elementEffect.count, "on_hit", "target", { element }));
+      definition.selectedElement = element;
+    }
+
+    definition.effects = [...(Array.isArray(definition.effects) ? definition.effects : []), ...effects];
+    definition.spellMod = spellMod;
+    definition.spellDC = Number(casting.spellDC) || 0;
+    definition.materializedAtLevel = level;
+    definition.slotLevel = slotLevel;
+    definition.luminousMechanics = clone(mechanics);
+
+    return { ok: true, definition, spellMod, spellDC: definition.spellDC, extraLevels };
   }
 
   function applyCanonicalSave(action, actor, classId, spell) {
     if (action?.resolution?.type !== "save") return action;
-    const resolved = spellcastingRuntime()?.resolveSpellSave?.(actor, classId, spell);
+    const runtime = spellcastingRuntime();
+    let resolved = null;
+    try {
+      if (typeof runtime?.resolveSpellSave === "function") resolved = runtime.resolveSpellSave(actor, classId, spell);
+      if (!resolved && typeof runtime?.resolveSpellcasting === "function") {
+        const casting = runtime.resolveSpellcasting(actor, classId);
+        if (casting) resolved = { dc: casting.spellDC };
+      }
+    } catch (_) {}
     if (resolved && Number.isFinite(Number(resolved.dc))) action.resolution.save.dc = Number(resolved.dc);
     return action;
   }
 
-  function applyUpcast(action, spell, slotLevel) {
-    const upcast = spellcastingRuntime()?.resolveUpcast?.(spell, slotLevel) || null;
-    if (!upcast || !action) return upcast;
-    if (Number(upcast.finalPower)) action.modifiers = [...(action.modifiers || []), { source: "spell_upcast", type: "final_power", amount: Number(upcast.finalPower) }];
-    if (Number(upcast.coinPower) && action.metadata?.sourceDefinition) {
-      const definition = action.metadata.sourceDefinition;
-      definition.coinPower = Number(definition.coinPower || definition.coin_power || 0) + Number(upcast.coinPower);
-      definition.coin_power = definition.coinPower;
-    }
-    if (Number(upcast.atkWeight)) action.targeting.attackWeight = Math.max(1, Number(action.targeting.attackWeight || 1) + Number(upcast.atkWeight));
-    action.metadata = { ...(action.metadata || {}), upcast: clone(upcast) };
-    return upcast;
+  function applyCanonicalMetadata(action, definition, slotLevel, plan) {
+    if (!action) return action;
+    action.metadata = {
+      ...(action.metadata || {}),
+      basePower: Number(definition.basePower ?? definition.base_power ?? 0),
+      coinPower: Number(definition.coinPower ?? definition.coin_power ?? 0),
+      coinAmount: Math.max(0, Math.trunc(Number(definition.coinAmount ?? definition.coins ?? definition.coin_count ?? 0) || 0)),
+      damageType: definition.damageType || definition.dmgType || null,
+      sinAffinity: definition.sinAffinity || definition.affinity || null,
+      slotLevel,
+      sourceDefinition: clone(definition),
+      spellChoice: clone(plan.choice || (definition.selectedElement ? { element: definition.selectedElement } : null))
+    };
+    if (action.targeting) action.targeting.attackWeight = Math.max(1, Number(definition.attackWeight || definition.atkWeight || action.targeting.attackWeight || 1));
+    if (normalizeId(definition.castingTime) === "quick_action" && action.economy) action.economy.cost = "quick_action";
+    return action;
   }
 
-  function compileTrustedPlayerSpell(base, slotId, explicitTargetSlotId, plan, actor, data) {
+  function compileCanonicalSpell(base, slotId, explicitTargetSlotId, plan, actor, data) {
     const embedded = plan.combatAction || (plan.schemaVersion && plan.source && plan.resolution ? plan : null);
-    if (embedded) return { action: null, plan, reason: "player_embedded_spell_action_forbidden" };
+    if (embedded) return { action: null, plan, reason: "embedded_spell_action_forbidden" };
 
     const trusted = trustedSpell(actor, plan, data);
     if (!trusted.ok) return { action: null, plan, reason: trusted.reason, kind: "spell", spellId: trusted.spellId };
     const slotLevel = requestedSlotLevel(plan, trusted.spell);
     if (slotLevel > 9) return { action: null, plan, reason: "spell_slot_level_invalid", kind: "spell", spellId: trusted.spellId };
 
+    const materialized = materializeSpell(actor, trusted.classId, trusted.spell, slotLevel, plan);
+    if (!materialized.ok) return { action: null, plan, reason: materialized.reason, kind: "spell", spellId: trusted.spellId, choices: materialized.choices || [] };
+
     const trustedPlan = {
       ...clone(plan), type: "spell", kind: "spell", spellId: trusted.spellId,
-      classId: trusted.classId, slotLevel, data: clone(trusted.spell),
-      spell: undefined, definition: undefined, sourceDefinition: undefined, combatAction: undefined,
+      classId: trusted.classId, slotLevel, data: clone(materialized.definition),
+      spell: undefined, definition: undefined, sourceDefinition: undefined, combatAction: undefined
     };
     const compiled = base.compilePlan(slotId, explicitTargetSlotId, trustedPlan);
     if (!compiled?.action) return compiled;
+
     compiled.action.source = { type: "spell", id: trusted.spellId };
     compiled.action.resources = trusted.spell.cantrip === true || slotLevel === 0 ? [] : [canonicalCastResource(trusted.classId, slotLevel, plan.overcast === true)];
     compiled.action.effects = [
       { type: "viewer_spell_cast", spellId: trusted.spellId, classId: trusted.classId, slotLevel, concentration: trusted.spell.concentration === true },
-      ...(compiled.action.effects || []),
+      ...(compiled.action.effects || [])
     ];
     compiled.action.metadata = {
-      ...(compiled.action.metadata || {}), loadoutSpellId: trusted.spellId, canonicalSpell: true,
-      sourceClassId: trusted.classId, slotLevel, overcast: plan.overcast === true,
-      sourceDefinition: clone(trusted.spell), viewerPlan: clone(plan),
+      ...(compiled.action.metadata || {}),
+      loadoutSpellId: trusted.spellId,
+      canonicalSpell: true,
+      sourceClassId: trusted.classId,
+      slotLevel,
+      overcast: plan.overcast === true,
+      viewerPlan: clone(plan),
+      spellMod: materialized.spellMod,
+      spellDC: materialized.spellDC,
+      luminousSpellMechanics: clone(materialized.definition.luminousMechanics)
     };
-    applyCanonicalSave(compiled.action, actor, trusted.classId, trusted.spell);
-    applyUpcast(compiled.action, trusted.spell, slotLevel);
+    applyCanonicalMetadata(compiled.action, materialized.definition, slotLevel, plan);
+    applyCanonicalSave(compiled.action, actor, trusted.classId, materialized.definition);
     return { ...compiled, source: "spell", spellId: trusted.spellId, canonicalSpell: true };
   }
 
@@ -137,22 +262,28 @@
     if (global.LuminousBattleViewerActionAdapter073?.__spellAdapter074) return true;
     installedBase = base;
     const wrapped = Object.freeze({
-      ...base, __spellAdapter074: true, spellIdForPlan, isSpellPlan, trustedSpell, requestedSlotLevel, canonicalCastResource,
+      ...base,
+      __spellAdapter074: true,
+      spellIdForPlan, isSpellPlan, trustedSpell, requestedSlotLevel, canonicalCastResource, materializeSpell,
       compilePlan(slotId, explicitTargetSlotId = null, providedPlan = null) {
         const plan = providedPlan || planForSlot(base, slotId);
         if (!plan) return base.compilePlan(slotId, explicitTargetSlotId, providedPlan);
         const actor = combatData(base)[unitIdFromSlot(base, slotId)] || null;
         if (!actor) return base.compilePlan(slotId, explicitTargetSlotId, providedPlan);
         const data = plan.data || plan.sourceDefinition || plan.definition || plan.spell || plan;
-        if (isPlayerActor(actor, plan) && isSpellPlan(plan, data)) return compileTrustedPlayerSpell(base, slotId, explicitTargetSlotId, plan, actor, data);
+        if (isSpellPlan(plan, data)) return compileCanonicalSpell(base, slotId, explicitTargetSlotId, plan, actor, data);
         return base.compilePlan(slotId, explicitTargetSlotId, providedPlan);
-      },
+      }
     });
     global.LuminousBattleViewerActionAdapter073 = wrapped;
     return true;
   }
 
-  const api = Object.freeze({ version: VERSION, OVERCAST_PREFIX, spellIdForPlan, isSpellPlan, trustedSpell, requestedSlotLevel, canonicalCastResource, applyUpcast, compileTrustedPlayerSpell, install });
+  const api = Object.freeze({
+    version: VERSION, OVERCAST_PREFIX, spellIdForPlan, isSpellPlan, trustedSpell, requestedSlotLevel,
+    canonicalCastResource, actorLevel, spellcastingValues, materializeSpell, applyCanonicalSave,
+    applyCanonicalMetadata, compileCanonicalSpell, install
+  });
   install();
   return api;
 });

--- a/js/combat-spell-loadout-074.js
+++ b/js/combat-spell-loadout-074.js
@@ -9,60 +9,87 @@
   const VERSION = "0.7.4";
   const clean = (value) => String(value ?? "").trim();
   const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
-  const normalizeId = (value) => clean(value).toLowerCase().replace(/\s+/g, "_");
+  const normalizeId = (value) => clean(value).toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
 
   function contentRegistry() {
     if (global?.LuminousContentRegistry) return global.LuminousContentRegistry;
-    if (typeof require === "function") {
-      try { return require("./content-registry.js"); } catch (_) {}
-    }
+    if (typeof require === "function") { try { return require("./content-registry.js"); } catch (_) {} }
     return null;
   }
-
   function contentBootstrap() {
     if (global?.LuminousContentRegistryBootstrap) return global.LuminousContentRegistryBootstrap;
+    if (typeof require === "function") { try { return require("./content-registry-bootstrap.js"); } catch (_) {} }
+    return null;
+  }
+  function ensureSpellCatalog() {
+    if (global?.LuminousSpellCatalog) return global.LuminousSpellCatalog;
     if (typeof require === "function") {
-      try { return require("./content-registry-bootstrap.js"); } catch (_) {}
+      try {
+        const catalog = require("./spell-catalog-core.js");
+        if (global && catalog) global.LuminousSpellCatalog = catalog;
+        return catalog;
+      } catch (_) {}
     }
     return null;
   }
-
   function spellcastingRuntime() {
     if (global?.LuminousSpellcastingRuntime) return global.LuminousSpellcastingRuntime;
     if (typeof require === "function") {
-      try { return require("./spellcasting-basic-rules-runtime.js"); } catch (_) {}
       try { return require("./spellcasting-runtime.js"); } catch (_) {}
+      try { return require("./spellcasting-basic-rules-runtime.js"); } catch (_) {}
     }
     return null;
   }
 
   function selectionSource(source = {}) {
     if (Array.isArray(source.spellIds)) return source.spellIds;
+    if (Array.isArray(source.spells)) return source.spells;
+    if (Array.isArray(source.spell_ids)) return source.spell_ids;
     if (Array.isArray(source.spellSelections)) return source.spellSelections;
+    if (Array.isArray(source.characterBuild?.spellIds)) return source.characterBuild.spellIds;
     if (Array.isArray(source.characterBuild?.spellSelections)) return source.characterBuild.spellSelections;
     if (source.spellSelectionIndex && typeof source.spellSelectionIndex === "object") {
       return Object.entries(source.spellSelectionIndex).filter(([, enabled]) => enabled === true).map(([id]) => id);
     }
+    if (source.characterBuild?.spellSelectionIndex && typeof source.characterBuild.spellSelectionIndex === "object") {
+      return Object.entries(source.characterBuild.spellSelectionIndex).filter(([, enabled]) => enabled === true).map(([id]) => id);
+    }
     return [];
   }
 
-  function spellIdsFor(source = {}) {
+  function rawSpellIdsFor(source = {}) {
     return [...new Set(selectionSource(source).map((entry) => clean(entry?.spellId || entry?.id || entry)).filter(Boolean))];
   }
 
-  function buildSpellSelectionIndex(sourceOrIds = {}) {
-    const ids = Array.isArray(sourceOrIds) ? sourceOrIds.map(clean).filter(Boolean) : spellIdsFor(sourceOrIds);
-    return Object.fromEntries([...new Set(ids)].map((id) => [id, true]));
+  function classIdsFor(source = {}) {
+    const ids = [];
+    const add = (value) => { const id = normalizeId(value); if (id && !ids.includes(id)) ids.push(id); };
+    add(source.classId || source.class_id || source.class);
+    add(source.characterBuild?.classId || source.characterBuild?.class_id);
+    const lists = [source.classIds, source.classes, source.multiclass, source.characterBuild?.classIds, source.characterBuild?.classes];
+    lists.forEach((list) => (Array.isArray(list) ? list : []).forEach((entry) => add(entry?.classId || entry?.class_id || entry?.id || entry)));
+    if (source.classLevels && typeof source.classLevels === "object") Object.keys(source.classLevels).forEach(add);
+    return ids;
   }
 
-  function ownsSpell(source = {}, spellId) {
-    const id = clean(spellId);
+  function isCastingClass(classId) {
+    const id = normalizeId(classId);
     if (!id) return false;
-    if (source.spellSelectionIndex && typeof source.spellSelectionIndex === "object") return source.spellSelectionIndex[id] === true;
-    return spellIdsFor(source).includes(id);
+    const runtime = spellcastingRuntime();
+    if (typeof runtime?.getClassSpellcastingAbility === "function") {
+      try { return Boolean(runtime.getClassSpellcastingAbility(id)); } catch (_) { return false; }
+    }
+    if (typeof runtime?.classSpellcastingAbility === "function") {
+      try { return Boolean(runtime.classSpellcastingAbility({}, id)); } catch (_) { return false; }
+    }
+    return false;
   }
+
+  function castingClassIdsFor(source = {}) { return classIdsFor(source).filter(isCastingClass); }
+  function canCastSpells(source = {}) { return castingClassIdsFor(source).length > 0; }
 
   function registerAvailableSpellCatalog() {
+    ensureSpellCatalog();
     const bootstrap = contentBootstrap();
     try { bootstrap?.registerAvailableCore?.(); } catch (_) {}
     return contentRegistry();
@@ -73,32 +100,19 @@
     if (!id) return null;
     const registry = registerAvailableSpellCatalog();
     if (!registry) return null;
-    try {
-      return registry.get?.("spell", id) || registry.get?.(`spell:${id}`) || null;
-    } catch (_) {
-      return null;
-    }
+    try { return registry.get?.("spell", id) || registry.get?.(`spell:${id}`) || null; } catch (_) { return null; }
   }
 
   function normalizeSpellDefinition(spellId, definition = {}) {
-    const id = clean(spellId);
+    const id = normalizeId(spellId);
     const spell = clone(definition || {}) || {};
     const levelRaw = spell.level ?? spell.spellLevel ?? spell.slotLevel ?? 0;
     const level = Number.isFinite(Number(levelRaw)) ? Math.max(0, Math.trunc(Number(levelRaw))) : 0;
-    return {
-      ...spell,
-      id,
-      spellId: id,
-      name: clean(spell.name || spell.nombre) || id,
-      level,
-      spellLevel: level,
-      cantrip: spell.cantrip === true || level === 0,
-      canonicalContentId: `spell:${id}`,
-    };
+    return { ...spell, id, spellId: id, name: clean(spell.name || spell.nombre) || id, level, spellLevel: level, cantrip: spell.cantrip === true || level === 0, canonicalContentId: `spell:${id}` };
   }
 
   function resolveSpellDefinition(spellId) {
-    const id = clean(spellId);
+    const id = normalizeId(spellId);
     if (!id) return { ok: false, reason: "SPELL_ID_REQUIRED", spellId: id, spell: null, entry: null };
     const registry = registerAvailableSpellCatalog();
     if (!registry) return { ok: false, reason: "CONTENT_REGISTRY_REQUIRED", spellId: id, spell: null, entry: null };
@@ -107,46 +121,22 @@
     return { ok: true, reason: null, spellId: id, spell: normalizeSpellDefinition(id, entry.definition), entry };
   }
 
-  function classIdsFor(source = {}) {
-    const classes = Array.isArray(source.characterBuild?.classes) ? source.characterBuild.classes : Array.isArray(source.classes) ? source.classes : [];
-    return [...new Set(classes.map((entry) => normalizeId(entry?.classId || entry?.id || entry)).filter(Boolean))];
-  }
-
   function spellAllowedClassIds(spell = {}) {
     const values = [];
     const add = (value) => { const id = normalizeId(value); if (id && !values.includes(id)) values.push(id); };
     add(spell.sourceClassId || spell.classId || spell.class_id);
-    const lists = [spell.classIds, spell.classes, spell.allowedClasses, spell.allowedClassIds];
-    lists.forEach((list) => (Array.isArray(list) ? list : []).forEach((entry) => add(entry?.classId || entry?.id || entry)));
+    [spell.classIds, spell.classes, spell.allowedClasses, spell.allowedClassIds].forEach((list) => (Array.isArray(list) ? list : []).forEach((entry) => add(entry?.classId || entry?.id || entry)));
     return values;
   }
 
-  function isCastingClass(classId) {
-    const id = normalizeId(classId);
-    if (!id) return false;
-    const runtime = spellcastingRuntime();
-    if (typeof runtime?.getClassSpellcastingAbility === "function") {
-      try { return Boolean(runtime.getClassSpellcastingAbility(id)); } catch (_) {}
-    }
-    if (typeof runtime?.classSpellcastingAbility === "function") {
-      try { return Boolean(runtime.classSpellcastingAbility({}, id)); } catch (_) {}
-    }
-    return true;
-  }
-
   function resolveCastClass(source = {}, spell = {}, requestedClassId = null) {
-    const owned = classIdsFor(source);
+    const owned = castingClassIdsFor(source);
     const allowed = spellAllowedClassIds(spell);
     const requested = normalizeId(requestedClassId);
-    const legal = (id) => Boolean(id && owned.includes(id) && isCastingClass(id) && (!allowed.length || allowed.includes(id)));
-
-    if (requested) return legal(requested)
-      ? { ok: true, reason: null, classId: requested }
-      : { ok: false, reason: "SPELL_CLASS_NOT_AVAILABLE", classId: null };
-
+    const legal = (id) => Boolean(id && owned.includes(id) && (!allowed.length || allowed.includes(id)));
+    if (requested) return legal(requested) ? { ok: true, reason: null, classId: requested } : { ok: false, reason: "SPELL_CLASS_NOT_AVAILABLE", classId: null };
     const sourceClass = normalizeId(spell.sourceClassId || spell.classId || spell.class_id);
     if (legal(sourceClass)) return { ok: true, reason: null, classId: sourceClass };
-
     const candidates = owned.filter(legal);
     if (candidates.length === 1) return { ok: true, reason: null, classId: candidates[0] };
     if (!candidates.length) return { ok: false, reason: "SPELL_CASTING_CLASS_NOT_FOUND", classId: null };
@@ -154,9 +144,10 @@
   }
 
   function resolveSpellForCombatant(combatant = {}, spellId, options = {}) {
-    const id = clean(spellId);
+    const id = normalizeId(spellId);
     if (!id) return { ok: false, reason: "SPELL_ID_REQUIRED", spellId: id, spell: null };
-    if (!ownsSpell(combatant, id)) return { ok: false, reason: "SPELL_NOT_SELECTED", spellId: id, spell: null };
+    if (!canCastSpells(combatant)) return { ok: false, reason: "SPELLCASTING_ABILITY_REQUIRED", spellId: id, spell: null };
+    if (!rawSpellIdsFor(combatant).map(normalizeId).includes(id)) return { ok: false, reason: "SPELL_NOT_SELECTED", spellId: id, spell: null };
     const definition = resolveSpellDefinition(id);
     if (!definition.ok) return definition;
     const castClass = resolveCastClass(combatant, definition.spell, options.classId);
@@ -164,36 +155,54 @@
     return { ...definition, ok: true, reason: null, classId: castClass.classId };
   }
 
+  function spellIdsFor(source = {}) {
+    if (!canCastSpells(source)) return [];
+    return rawSpellIdsFor(source)
+      .map(normalizeId)
+      .filter((id) => {
+        const definition = resolveSpellDefinition(id);
+        return definition.ok && resolveCastClass(source, definition.spell).ok;
+      });
+  }
+
+  function buildSpellSelectionIndex(sourceOrIds = {}) {
+    const ids = Array.isArray(sourceOrIds) ? sourceOrIds.map(normalizeId).filter(Boolean) : spellIdsFor(sourceOrIds);
+    return Object.fromEntries([...new Set(ids)].map((id) => [id, true]));
+  }
+
+  function ownsSpell(source = {}, spellId) {
+    const id = normalizeId(spellId);
+    return Boolean(id && spellIdsFor(source).includes(id));
+  }
+
   function hydrateSpellSelections(source = {}) {
     const ids = spellIdsFor(source);
     const spellsById = {};
-    const missingIds = [];
-    const invalidIds = [];
-    const entries = ids.map((id) => {
+    const entries = [];
+    ids.forEach((id) => {
       const definition = resolveSpellDefinition(id);
-      if (!definition.ok) {
-        if (definition.reason === "SPELL_DEFINITION_NOT_FOUND") missingIds.push(id);
-        else invalidIds.push(id);
-        return { spellId: id, status: "invalid", reason: definition.reason, spell: null };
-      }
+      if (!definition.ok) return;
       spellsById[id] = definition.spell;
-      return { spellId: id, status: "ready", reason: null, spell: definition.spell };
+      entries.push({ spellId: id, status: "ready", reason: null, spell: definition.spell });
     });
     return {
+      canCastSpells: canCastSpells(source),
+      castingClassIds: castingClassIdsFor(source),
       spellIds: ids,
       spellSelectionIndex: buildSpellSelectionIndex(ids),
       spellsById,
       spells: ids.map((id) => spellsById[id]).filter(Boolean),
       entries,
-      missingIds,
-      invalidIds,
-      ready: missingIds.length === 0 && invalidIds.length === 0,
-      hasErrors: missingIds.length > 0 || invalidIds.length > 0,
+      missingIds: [],
+      invalidIds: [],
+      ready: true,
+      hasErrors: false
     };
   }
 
   return Object.freeze({
     version: VERSION,
+    rawSpellIdsFor,
     spellIdsFor,
     buildSpellSelectionIndex,
     ownsSpell,
@@ -203,8 +212,10 @@
     classIdsFor,
     spellAllowedClassIds,
     isCastingClass,
+    castingClassIdsFor,
+    canCastSpells,
     resolveCastClass,
     resolveSpellForCombatant,
-    hydrateSpellSelections,
+    hydrateSpellSelections
   });
 });

--- a/js/spell-catalog-core.js
+++ b/js/spell-catalog-core.js
@@ -1,0 +1,113 @@
+(function (global, factory) {
+  "use strict";
+  const catalog = factory();
+  if (typeof module !== "undefined" && module.exports) module.exports = catalog;
+  if (global) global.LuminousSpellCatalog = catalog;
+})(typeof window !== "undefined" ? window : globalThis, function () {
+  "use strict";
+
+  const status = (trigger, id, potency = 0, count = 0, target = "target") => ({
+    trigger, target, type: "status", status: id, potency, count, timing: "immediate"
+  });
+
+  return Object.freeze({
+    fire_bolt: Object.freeze({
+      id: "fire_bolt", name: "Fire Bolt", nombre: "Descarga de Fuego",
+      level: 0, spellLevel: 0, cantrip: true,
+      classIds: ["artificer", "sorcerer", "wizard"],
+      sinAffinity: "wrath", damageType: "perforante",
+      targetingType: "focused_attack", attackWeight: 1, atkWeight: 1,
+      basePower: 5, coinPower: 8, coinAmount: 1, coins: 1,
+      mechanics: {
+        levelCoinPower: { every: 20, amount: 1 },
+        onHitStatusFromSpellMod: { status: "burn", potencyDivisor: 2, minimum: 1 }
+      },
+      effects: []
+    }),
+
+    poison_spray: Object.freeze({
+      id: "poison_spray", name: "Poison Spray", nombre: "Rociada Venenosa",
+      level: 0, spellLevel: 0, cantrip: true,
+      classIds: ["artificer", "druid", "sorcerer", "warlock", "wizard"],
+      sinAffinity: "gluttony", damageType: "perforante",
+      targetingType: "focused_attack", attackWeight: 1, atkWeight: 1,
+      basePower: 4, coinPower: 10, coinAmount: 1, coins: 1,
+      mechanics: {
+        levelCoinPower: { every: 20, amount: 1 },
+        onHitStatusFromSpellMod: { status: "poison", potencyDivisor: 2, minimum: 1, doubleIfTargetHasStatus: "poison" }
+      },
+      effects: []
+    }),
+
+    charm_person: Object.freeze({
+      id: "charm_person", name: "Charm Person", nombre: "Hechizar Persona",
+      level: 1, spellLevel: 1, cantrip: false,
+      classIds: ["bard", "druid", "sorcerer", "warlock", "wizard"],
+      sinAffinity: "lust", damageType: null,
+      targetingType: "multi", targetType: "multi", attackWeight: 1, atkWeight: 1,
+      isUnclashable: true,
+      save: { abilityId: "wis", onSuccess: "negates" },
+      concentration: false,
+      mechanics: {
+        onFailedSave: status("on_failed_save", "charmed", 0, 10),
+        breakCharmOnDamageFromCasterOrAlly: true
+      },
+      upcast: { atkWeightPerLevel: 1 },
+      effects: []
+    }),
+
+    chromatic_orb: Object.freeze({
+      id: "chromatic_orb", name: "Chromatic Orb", nombre: "Orbe Cromático",
+      level: 1, spellLevel: 1, cantrip: false,
+      classIds: ["sorcerer", "wizard"],
+      sinAffinity: "sinless", damageType: "perforante",
+      targetingType: "focused_attack", attackWeight: 1, atkWeight: 1,
+      basePower: 5, coinPower: 10, coinAmount: 1, coins: 1,
+      mechanics: {
+        requiresChoice: {
+          key: "element",
+          values: ["acid", "cold", "fire", "lightning", "poison", "thunder"]
+        },
+        elementalStatus: {
+          acid: { status: "corrosion", count: 1 },
+          cold: { status: "chill", count: 1 },
+          fire: { status: "burn", potency: 1 },
+          lightning: { status: "shock", count: 1 },
+          poison: { status: "poison", potency: 1 },
+          thunder: { status: "tremor", potency: 1 }
+        },
+        onCritJump: { differentTarget: true, noRepeatTarget: true, maxJumpsFromSlotLevel: true }
+      },
+      upcast: { coinPowerPerLevel: 1 },
+      effects: []
+    }),
+
+    expeditious_retreat: Object.freeze({
+      id: "expeditious_retreat", name: "Expeditious Retreat", nombre: "Retirada Expeditiva",
+      level: 1, spellLevel: 1, cantrip: false,
+      classIds: ["artificer", "sorcerer", "warlock", "wizard"],
+      sinAffinity: "gloom", damageType: null,
+      targetType: "self", targetingType: "self", attackWeight: 1, atkWeight: 1,
+      isUnclashable: true, concentration: true, castingTime: "quick_action",
+      mechanics: {
+        onUse: status("on_use", "haste", 0, 3, "self"),
+        whileConcentratingTurnStart: status("turn_start", "haste", 0, 3, "self")
+      },
+      effects: []
+    }),
+
+    scorching_ray: Object.freeze({
+      id: "scorching_ray", name: "Scorching Ray", nombre: "Rayo Abrasador",
+      level: 2, spellLevel: 2, cantrip: false,
+      classIds: ["sorcerer", "wizard"],
+      sinAffinity: "wrath", damageType: "perforante",
+      targetingType: "focused_volley", attackWeight: 1, atkWeight: 1,
+      basePower: 4, coinPower: 4, coinAmount: 3, coins: 3,
+      mechanics: {
+        onHitStatus: { status: "burn", potency: 1, perCoin: true }
+      },
+      upcast: { coinsPerLevel: 1 },
+      effects: []
+    })
+  });
+});

--- a/tests/canonical-spell-runtime-smoke.mjs
+++ b/tests/canonical-spell-runtime-smoke.mjs
@@ -1,0 +1,87 @@
+import { createRequire } from "node:module";
+import assert from "node:assert/strict";
+
+const require = createRequire(import.meta.url);
+
+globalThis.LuminousContentRegistry = {
+  entries: new Map(),
+  registerSource(type, store, collection) {
+    for (const [id, definition] of Object.entries(collection || {})) {
+      this.entries.set(`${type}:${id}`, { definition: JSON.parse(JSON.stringify(definition)) });
+    }
+  },
+  get(type, id) {
+    if (id === undefined) return this.entries.get(type) || null;
+    return this.entries.get(`${type}:${id}`) || null;
+  }
+};
+
+globalThis.LuminousContentRegistryBootstrap = {
+  registerAvailableCore() {
+    if (globalThis.LuminousSpellCatalog) {
+      globalThis.LuminousContentRegistry.registerSource("spell", "spell-catalog", globalThis.LuminousSpellCatalog);
+    }
+  }
+};
+
+globalThis.LuminousSpellcastingRuntime = {
+  getClassSpellcastingAbility(id) {
+    return {
+      artificer: "int", bard: "cha", druid: "wis",
+      sorcerer: "cha", warlock: "cha", wizard: "int"
+    }[id] || null;
+  },
+  resolveSpellcasting(actor, classId) {
+    const spellMod = classId === "wizard" ? 3 : 2;
+    return { classId, spellMod, proficiency: 2, spellDC: 8 + spellMod + 2 };
+  }
+};
+
+globalThis.LuminousSpellCatalog = require("../js/spell-catalog-core.js");
+const loadout = require("../js/combat-spell-loadout-074.js");
+
+const wizard = {
+  id: "wizard_unit",
+  classId: "wizard",
+  level: 40,
+  spellIds: ["fire_bolt", "scorching_ray", "old_test_spell"]
+};
+const barbarian = {
+  id: "barbarian_unit",
+  classId: "barbarian",
+  level: 40,
+  spellIds: ["fire_bolt"]
+};
+
+assert.equal(loadout.canCastSpells(wizard), true);
+assert.deepEqual(loadout.spellIdsFor(wizard), ["fire_bolt", "scorching_ray"]);
+assert.equal(loadout.canCastSpells(barbarian), false);
+assert.deepEqual(loadout.spellIdsFor(barbarian), []);
+assert.equal(loadout.resolveSpellForCombatant(barbarian, "fire_bolt").reason, "SPELLCASTING_ABILITY_REQUIRED");
+assert.equal(loadout.resolveSpellForCombatant(wizard, "old_test_spell").reason, "SPELL_DEFINITION_NOT_FOUND");
+
+globalThis.LuminousBattleViewerActionAdapter073 = {
+  compilePlan() {
+    return { action: { targeting: { attackWeight: 1 }, economy: { cost: "action" }, metadata: {}, effects: [] } };
+  }
+};
+
+const adapter = require("../js/battle-viewer-spell-adapter-074.js");
+
+const fire = loadout.resolveSpellDefinition("fire_bolt").spell;
+const fire40 = adapter.materializeSpell(wizard, "wizard", fire, 0, {});
+assert.equal(fire40.ok, true);
+assert.equal(fire40.definition.coinPower, 10);
+assert.equal(fire40.definition.effects[0].status, "burn");
+
+const ray = loadout.resolveSpellDefinition("scorching_ray").spell;
+const rayAt4 = adapter.materializeSpell(wizard, "wizard", ray, 4, {});
+assert.equal(rayAt4.definition.coinAmount, 5);
+
+const orb = loadout.resolveSpellDefinition("chromatic_orb").spell;
+assert.equal(adapter.materializeSpell(wizard, "wizard", orb, 1, {}).reason, "spell_choice_required");
+const fireOrb = adapter.materializeSpell(wizard, "wizard", orb, 2, { element: "fire" });
+assert.equal(fireOrb.definition.coinPower, 11);
+assert.equal(fireOrb.definition.effects[0].status, "burn");
+
+console.log("canonical spell runtime smoke: ok");

--- a/tests/canonical-spell-runtime-smoke.mjs
+++ b/tests/canonical-spell-runtime-smoke.mjs
@@ -1,7 +1,4 @@
-import { createRequire } from "node:module";
 import assert from "node:assert/strict";
-
-const require = createRequire(import.meta.url);
 
 globalThis.LuminousContentRegistry = {
   entries: new Map(),
@@ -37,8 +34,9 @@ globalThis.LuminousSpellcastingRuntime = {
   }
 };
 
-globalThis.LuminousSpellCatalog = require("../js/spell-catalog-core.js");
-const loadout = require("../js/combat-spell-loadout-074.js");
+await import("../js/spell-catalog-core.js");
+await import("../js/combat-spell-loadout-074.js");
+const loadout = globalThis.LuminousCombatSpellLoadout074;
 
 const wizard = {
   id: "wizard_unit",
@@ -66,7 +64,8 @@ globalThis.LuminousBattleViewerActionAdapter073 = {
   }
 };
 
-const adapter = require("../js/battle-viewer-spell-adapter-074.js");
+await import("../js/battle-viewer-spell-adapter-074.js");
+const adapter = globalThis.LuminousBattleViewerSpellAdapter074;
 
 const fire = loadout.resolveSpellDefinition("fire_bolt").spell;
 const fire40 = adapter.materializeSpell(wizard, "wizard", fire, 0, {});


### PR DESCRIPTION
## Summary
- Add the canonical universal `LuminousSpellCatalog` with Fire Bolt, Poison Spray, Charm Person, Chromatic Orb, Expeditious Retreat, and Scorching Ray.
- Make spell loadouts fail closed when an actor has no valid Spellcasting Ability.
- Filter legacy/test/non-canonical spell IDs out of combat spell menus/loadouts.
- Resolve every combat Spell (Player or Unit) from the trusted canonical catalog instead of accepting embedded spell definitions.
- Materialize Level/Spell Mod/Spell DC and Upcast mechanics at cast time.
- Support Scorching Ray coin-count Upcast and Chromatic Orb elemental choice metadata/effects.
- Add smoke coverage for caster gating, canonical filtering, cantrip scaling, Upcast, and required spell choices.

## Validation
- `node --check` passed for the new/modified runtime modules locally.
- `node tests/canonical-spell-runtime-smoke.mjs` passed locally under the repository's `type: module` setup.

## Gameplay rule enforced
No valid Spellcasting Ability -> no castable canonical spells -> no Spell menu entries. Actors only cast spell IDs they actually have equipped/selected and which their caster class is allowed to use.