### PR TITLE
feat: merge Kobold and Goblin Unit Library batch

### DIFF
--- a/dm-unit-library-seeder.html
+++ b/dm-unit-library-seeder.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Luminous · Unit Library Seeder</title>
+<style>
+:root{color-scheme:dark;--bg:#080808;--panel:#12110e;--line:#453b2b;--gold:#d5ad5d;--text:#eee6d7;--muted:#8c8477;--ok:#85b97a;--bad:#df7669;--pending:#d5ad5d}*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--text);font:14px Arial,sans-serif}.wrap{max-width:1240px;margin:0 auto;padding:28px}.panel{border:1px solid var(--line);background:var(--panel);padding:22px}h1{margin:0 0 4px;color:var(--gold)}p{color:var(--muted);line-height:1.5}.toolbar{display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin:18px 0}.btn{border:1px solid var(--gold);background:#211a0e;color:var(--gold);padding:10px 16px;font-weight:700;cursor:pointer}.btn.primary{background:var(--gold);color:#151006}.btn:disabled{opacity:.5;cursor:wait}.status{padding:10px;border:1px solid #333;background:#090909;color:var(--muted)}.status.ok{border-color:#375a32;color:var(--ok)}.status.bad{border-color:#71372f;color:var(--bad)}.families{display:grid;gap:22px;margin-top:20px}.family>h2{margin:0 0 10px;color:var(--gold);font-size:18px}.units{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}.unit{border:1px solid #302b23;padding:14px;background:#0c0c0b;min-width:0}.portrait{width:100%;height:190px;display:flex;align-items:center;justify-content:center;background:#050505;border:1px solid #1d1b17;color:var(--muted);font-size:12px;text-align:center;padding:12px}.portrait img{width:100%;height:100%;object-fit:contain}.unit h3{color:var(--gold);margin:10px 0 4px}.meta,.refs,.traits{color:#cdb98b;font-size:12px;line-height:1.6;overflow-wrap:anywhere}.pending{color:var(--pending)}.ranks{width:100%;border-collapse:collapse;font-size:12px;margin-top:10px}.ranks td,.ranks th{border:1px solid #302b23;padding:5px;text-align:center}.ranks th{color:#b9aa8c}.label{color:var(--muted)}code{color:#d7c49d}@media(max-width:820px){.units{grid-template-columns:1fr}.wrap{padding:14px}}
+</style>
+</head>
+<body>
+<div class="wrap"><div class="panel">
+<h1>Luminous · Unit Library</h1>
+<p>Seeder canónico conjunto para las Units Kobold y Goblin. La sincronización conserva IDs determinísticos y actualiza únicamente las entradas incluidas en estos catálogos.</p>
+<div class="toolbar"><button class="btn primary" id="sync" disabled>SINCRONIZAR UNIT LIBRARY</button><button class="btn" id="refresh">REVISAR CATÁLOGOS</button><span>Units: <code>campaña/base_datos_unidades</code> · Skills canónicas disponibles: <code>campaña/base_datos_skills</code></span></div>
+<div id="status" class="status">Cargando catálogos y verificando sesión DM…</div>
+<div id="families" class="families"></div>
+<p>El sync usa <code>update()</code>: no elimina otras Units ni otras Skills. Las Skills Kobold se validan y sincronizan desde su catálogo canónico. Los Goblins se sincronizan como Units con sus Traits, Ammo y weapon loadouts declarados; este seeder no inventa un catálogo de Skills Goblin donde el catálogo de Unit todavía marca referencias pendientes.</p>
+</div></div>
+<script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
+<script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
+<script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-database.js"></script>
+<script src="js/combat-skill-schema.js"></script>
+<script src="js/skill-catalog-kobold-tier1.js"></script>
+<script src="js/unit-rank-runtime.js"></script>
+<script src="js/universal-ranged-ammo-runtime.js"></script>
+<script src="js/goblin-unit-runtime.js"></script>
+<script src="js/unit-catalog-kobold-tier1.js"></script>
+<script src="js/unit-catalog-goblin.js"></script>
+<script src="js/battle-viewer-firebase-session-074.js"></script>
+<script>
+(function(){
+'use strict';
+const firebaseConfig={apiKey:"AIzaSyAIVIuKgXUsdrb9Mmss9PH7R3FpWAMG2hU",authDomain:"luminous-system.firebaseapp.com",databaseURL:"https://luminous-system-default-rtdb.firebaseio.com",projectId:"luminous-system",storageBucket:"luminous-system.firebasestorage.app",messagingSenderId:"330473029689",appId:"1:330473029689:web:44a05e870d493a3b294de8",measurementId:"G-X775P4YS7W"};
+if(!firebase.apps.length)firebase.initializeApp(firebaseConfig);
+const db=firebase.database();
+const UNIT_PATH='campaña/base_datos_unidades';
+const SKILL_PATH='campaña/base_datos_skills';
+const kobolds=window.LuminousKoboldUnitCatalog;
+const goblins=window.LuminousGoblinUnitCatalog;
+const koboldSkills=window.LuminousKoboldTier1SkillCatalog;
+const ranks=window.LuminousUnitRankRuntime;
+const schema=window.CombatSkillSchema;
+const session=window.LuminousBattleViewerFirebaseSession074;
+const $=id=>document.getElementById(id);
+let dmReady=false;
+
+function esc(value){return String(value??'').replace(/[&<>"']/g,ch=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]))}
+function setStatus(text,kind){$('status').textContent=text;$('status').className='status'+(kind?' '+kind:'')}
+function pending(value,fallback='Pendiente'){return value==null||value===''?`<span class="pending">${esc(fallback)}</span>`:esc(value)}
+function mergePayloads(...payloads){
+ const merged={};
+ for(const payload of payloads){for(const [id,value] of Object.entries(payload||{})){if(Object.prototype.hasOwnProperty.call(merged,id))throw new Error(`DUPLICATE_UNIT_ID:${id}`);merged[id]=value}}
+ return merged;
+}
+function familyEntries(){return [
+ {id:'kobold',label:'Kobolds',catalog:kobolds},
+ {id:'goblin',label:'Goblins',catalog:goblins},
+]}
+function levelRange(unit){const range=unit.naturalWorldLevel||unit.baseLevel||{};const min=Number(range.min||1);const max=Number(range.max||min);return {min,max}}
+function rankRows(entry,unit){
+ const levels=levelRange(unit);
+ return (unit.allowedRanks||['normal']).map(rank=>{
+  try{
+   const low=entry.catalog.resolve(unit.id,{baseLevel:levels.min,rank});
+   const high=entry.catalog.resolve(unit.id,{baseLevel:levels.max,rank});
+   const speed=low?.mechanics?.speed||unit?.mechanics?.speed||null;
+   const apply=low?.mechanics?.statusApplyBonus;
+   const base=low?.mechanics?.basePowerBonus;
+   const sp=low?.mechanics?.turnEndSpRecovery??low?.commandProfile?.turnEndSpRecovery;
+   return `<tr><td>${esc(String(rank).toUpperCase())}</td><td>${pending(speed)}</td><td>${esc(low?.mechanics?.hp??low?.hp??'—')}</td><td>${esc(high?.mechanics?.hp??high?.hp??'—')}</td><td>${apply==null?'—':`+${esc(apply)}`}</td><td>${base==null?'—':`+${esc(base)}`}</td><td>${sp==null?'—':`${esc(sp)} SP`}</td></tr>`;
+  }catch(error){return `<tr><td>${esc(String(rank).toUpperCase())}</td><td colspan="6" class="pending">${esc(error.message||error)}</td></tr>`}
+ }).join('');
+}
+function unitReferences(unit){
+ const slots=Array.isArray(unit.action_slots)?unit.action_slots:[];
+ if(slots.length)return slots.map(esc).join(' · ');
+ const weapons=Array.isArray(unit?.mechanics?.weaponLoadout)?unit.mechanics.weaponLoadout:[];
+ if(weapons.length)return weapons.map(w=>{const ammo=w.ammoType?` · Ammo ${w.ammoType}`:'';const pierced=w.onHitStatusId?` · On Hit ${w.onHitStatusId}`:'';return `${esc(w.weaponId)} (${esc(w.range)})${esc(ammo)}${esc(pierced)}`}).join('<br>');
+ return '<span class="pending">Skills pendientes en catálogo</span>';
+}
+function traitReferences(unit){const traits=Array.isArray(unit.traits)?unit.traits:[];return traits.length?traits.map(t=>esc(t.name||t.id||t)).join(' · '):'—'}
+function defense(unit){const d=unit.damageTypeDefense||unit?.mechanics?.damageTypeDefense;if(!d)return '<span class="pending">Perfil físico pendiente</span>';return `Resist ${esc(d.resist||'—')} · Weak ${esc(d.weak||'—')}`}
+function portrait(unit){const src=unit?.visual?.spriteUrl||unit?.icono||'';return src?`<div class="portrait"><img src="${esc(src)}" alt="${esc(unit.name)}"></div>`:`<div class="portrait pending">Sprite pendiente en catálogo</div>`}
+function unitCard(entry,unit){
+ const levels=levelRange(unit);
+ const ammo=(unit?.mechanics?.ammoLoadout||[]).map(a=>`${a.amount} ${a.id}`).join(' · ')||'—';
+ return `<section class="unit">${portrait(unit)}<h3>${esc(unit.name)}</h3><div class="meta"><span class="label">ID:</span> ${esc(unit.id)} · <span class="label">Nivel natural:</span> ${levels.min}${levels.max!==levels.min?`–${levels.max}`:''} · <span class="label">Ranks:</span> ${(unit.allowedRanks||[]).map(esc).join(', ')}</div><div class="traits"><span class="label">Traits:</span> ${traitReferences(unit)}</div><div class="refs"><span class="label">Skills / Weapons:</span><br>${unitReferences(unit)}</div><div class="meta"><span class="label">Ammo:</span> ${esc(ammo)} · <span class="label">Defense:</span> ${defense(unit)}</div><table class="ranks"><thead><tr><th>Rank</th><th>Speed</th><th>HP Min</th><th>HP Max</th><th>Apply</th><th>Base</th><th>Turn End</th></tr></thead><tbody>${rankRows(entry,unit)}</tbody></table></section>`;
+}
+function validateKoboldSkills(){
+ if(!koboldSkills||!schema)return {ok:false,error:'Falta CombatSkillSchema o LuminousKoboldTier1SkillCatalog.'};
+ const list=koboldSkills.list();
+ const invalid=list.map(skill=>[skill,schema.validateCombatSkill(skill)]).filter(([,result])=>!result.valid);
+ if(invalid.length)return {ok:false,error:`Skill inválida: ${invalid[0][0].id} · ${invalid[0][1].errors.join(' · ')}`};
+ return {ok:true,count:list.length};
+}
+function render(){
+ if(!kobolds||!goblins||!ranks){setStatus('Falta uno de los catálogos/runtimes requeridos por Unit Library.','bad');return false}
+ const skillValidation=validateKoboldSkills();
+ if(!skillValidation.ok){setStatus(skillValidation.error,'bad');return false}
+ const entries=familyEntries();
+ const unitPayload=mergePayloads(...entries.map(entry=>entry.catalog.firebasePayload()));
+ $('families').innerHTML=entries.map(entry=>{const definitions=entry.catalog.list();return `<section class="family"><h2>${esc(entry.label)} · ${definitions.length}</h2><div class="units">${definitions.map(unit=>unitCard(entry,unit)).join('')}</div></section>`}).join('');
+ setStatus(`Unit Library válido: ${Object.keys(unitPayload).length} Units (${kobolds.list().length} Kobold + ${goblins.list().length} Goblin) · ${skillValidation.count} Skills Kobold validadas · Unit Rank ${ranks.version}.`,'ok');
+ return true;
+}
+async function authorize(){
+ $('sync').disabled=true;dmReady=false;
+ if(!session?.preflight){setStatus('Falta el preflight Firebase 0.7.4.','bad');return false}
+ try{
+  const result=await session.preflight({firebase});
+  if(!result?.ok){setStatus(`Firebase bloqueado: ${result?.reason||'FIREBASE_SESSION_FAILED'}.`,'bad');return false}
+  if(result.role!=='dm'){setStatus(`Sesión válida pero sin autoridad DM (${result.role||'unknown'}).`,'bad');return false}
+  dmReady=true;$('sync').disabled=false;
+  setStatus(`DM autorizado · Kobold ${kobolds.version} + Goblin ${goblins.version} listos para sincronizar.`,'ok');return true;
+ }catch(error){console.error(error);setStatus(`No se pudo validar la sesión DM: ${error.message||error}`,'bad');return false}
+}
+async function sync(){
+ if(!dmReady){setStatus('Sincronización bloqueada: se requiere sesión DM.','bad');return}
+ if(!render())return;
+ const button=$('sync');button.disabled=true;
+ try{
+  const unitPayload=mergePayloads(kobolds.firebasePayload(),goblins.firebasePayload());
+  const skillPayload=kobolds.firebaseSkillPayload(schema);
+  await db.ref(UNIT_PATH).update(unitPayload);
+  await db.ref(SKILL_PATH).update(skillPayload);
+  setStatus(`Sincronización completa: ${Object.keys(unitPayload).length} Units y ${Object.keys(skillPayload).length} Skills canónicas actualizadas.`,'ok');
+ }catch(error){console.error(error);setStatus(`No se pudo sincronizar: ${error.message||error}`,'bad')}
+ finally{button.disabled=!dmReady}
+}
+$('sync').addEventListener('click',sync);
+$('refresh').addEventListener('click',()=>{render();authorize()});
+render();authorize();
+})();
+</script>
+</body>
+</html>

--- a/js/goblin-unit-runtime.js
+++ b/js/goblin-unit-runtime.js
@@ -112,9 +112,28 @@
     };
   }
 
+  function installTurnResetBridge(engine) {
+    if (!engine || engine.__goblinRedirectTurnResetInstalled || typeof engine.triggerEvent !== 'function') return Boolean(engine?.__goblinRedirectTurnResetInstalled);
+    const originalTriggerEvent = engine.triggerEvent;
+    engine.triggerEvent = function (eventName, context = {}, targetUnits = []) {
+      const event = normalizeId(eventName);
+      if (event === 'turn_start' || event === 'round_start') {
+        const units = asArray(targetUnits).length
+          ? asArray(targetUnits)
+          : (asArray(context.units).length ? asArray(context.units) : asArray(this.getAllAliveUnits?.()));
+        units.forEach(resetRedirect);
+      }
+      return originalTriggerEvent.call(this, eventName, context, targetUnits);
+    };
+    Object.defineProperty(engine, '__goblinRedirectTurnResetInstalled', { value: true, configurable: true });
+    return true;
+  }
+
   function installCombatBridge() {
     const engine = global.CombatEngine;
-    if (!engine || engine.__goblinUnitRuntimeInstalled || typeof engine.resolveUnilateralWithCounter !== 'function') return Boolean(engine?.__goblinUnitRuntimeInstalled);
+    if (!engine || typeof engine.resolveUnilateralWithCounter !== 'function') return false;
+    installTurnResetBridge(engine);
+    if (engine.__goblinUnitRuntimeInstalled) return true;
     const originalResolve = engine.resolveUnilateralWithCounter;
 
     engine.resolveUnilateralWithCounter = function (attacker, skill, defender, counterSkill, options = {}) {
@@ -161,9 +180,9 @@
   function install() { return installCombatBridge(); }
 
   const api = Object.freeze({
-    version: '1.0.0', MULTI_ATTACK, REDIRECT_ATTACK, hasTrait, effectiveLevel, skillCoinCount, isMeleeSkill, reuseTimes,
+    version: '1.1.0', MULTI_ATTACK, REDIRECT_ATTACK, hasTrait, effectiveLevel, skillCoinCount, isMeleeSkill, reuseTimes,
     prepareMultiAttackSkill, isGoblin, isFieldUnit, selectRedirectTarget, resetRedirect, onTurnStart, lastCoinReuseSkill,
-    installCombatBridge, install,
+    installTurnResetBridge, installCombatBridge, install,
   });
 
   global.LuminousGoblinUnitRuntime = api;

--- a/js/goblin-unit-runtime.js
+++ b/js/goblin-unit-runtime.js
@@ -1,0 +1,176 @@
+(function (global) {
+  'use strict';
+
+  const normalizeId = (value) => String(value ?? '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const asArray = (value) => value == null ? [] : (Array.isArray(value) ? value : [value]);
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+  const MULTI_ATTACK = Object.freeze({
+    id: 'goblin_multi_attack',
+    name: 'Multi Attack',
+    type: 'passive',
+    description: 'Melee Skills with 2+ Coins reuse the last Coin 1 + floor(Level / 30) times. Melee Skills with 5+ Coins deal +5% Damage.',
+    mechanics: Object.freeze({ meleeOnly: true, reuseMinimumCoins: 2, reuseFormula: '1 + floor(Level / 30)', damageMinimumCoins: 5, damageMultiplierBonus: 0.05 }),
+  });
+
+  const REDIRECT_ATTACK = Object.freeze({
+    id: 'goblin_redirect_attack',
+    name: 'Redirect Attack',
+    type: 'passive',
+    description: '[Before Getting Hit] If another allied Goblin is on the Field, redirect the attack to that Ally Goblin. Once per Turn.',
+    mechanics: Object.freeze({ trigger: '[Before Getting Hit]', species: 'goblin', oncePerTurn: true }),
+  });
+
+  function unitId(unit = {}) { return String(unit.id ?? unit.unitId ?? unit.characterId ?? ''); }
+  function traitIds(unit = {}) {
+    const ids = [...asArray(unit.traitIds), ...asArray(unit.traits).map((trait) => trait?.id || trait)];
+    return ids.filter(Boolean).map(normalizeId);
+  }
+  function hasTrait(unit, traitId) { return traitIds(unit).includes(normalizeId(traitId)); }
+  function effectiveLevel(unit = {}) {
+    return Math.max(0, Math.floor(numberOr(unit.effectiveLevel ?? unit.mechanics?.level ?? unit.level ?? unit.runtimeLevel, 0)));
+  }
+  function skillCoinCount(skill = {}) { return Math.max(0, Math.floor(numberOr(skill.coinAmount ?? skill.coins?.length, 0))); }
+  function isMeleeSkill(skill = {}) {
+    const range = Number(skill.skillRange ?? skill.range ?? skill.metadata?.skillRange);
+    return !Number.isFinite(range) || range <= 1;
+  }
+  function reuseTimes(unit) { return 1 + Math.floor(effectiveLevel(unit) / 30); }
+
+  function prepareMultiAttackSkill(unit, skill = {}) {
+    const prepared = clone(skill);
+    if (!hasTrait(unit, MULTI_ATTACK.id) || !isMeleeSkill(prepared) || skillCoinCount(prepared) < 5) return prepared;
+    prepared.coins = asArray(prepared.coins).map((coin, index) => {
+      const effects = asArray(coin?.effects).map(clone);
+      effects.push({
+        id: `goblin_multi_attack_damage_${index}`,
+        type: 'percentage_damage',
+        potency: 5,
+        sourceTraitId: MULTI_ATTACK.id,
+        trigger: 'damage',
+      });
+      return { ...(coin || {}), effects };
+    });
+    prepared.metadata = { ...(prepared.metadata || {}), goblinMultiAttackDamageBonus: 0.05 };
+    return prepared;
+  }
+
+  function isGoblin(unit = {}) {
+    if (normalizeId(unit.species) === 'goblin' || normalizeId(unit.raceId) === 'goblin') return true;
+    return asArray(unit.tags).map(normalizeId).includes('goblin');
+  }
+  function isFieldUnit(unit = {}) {
+    if (!unit || numberOr(unit.hp ?? unit.mechanics?.hp, 0) <= 0) return false;
+    if (unit.isBackup === true || unit.retreated === true || unit.escaped === true || unit.removed === true) return false;
+    const state = normalizeId(unit.deploymentState || unit.deployment || unit.positionState || unit.zone || 'field');
+    return !['backup', 'retreated', 'escaped', 'removed', 'dead'].includes(state);
+  }
+  function sameSide(a = {}, b = {}) {
+    const af = normalizeId(a.faction ?? a.faccion ?? a.side);
+    const bf = normalizeId(b.faction ?? b.faccion ?? b.side);
+    return Boolean(af && bf && af === bf);
+  }
+  function selectRedirectTarget(defender, combatants = []) {
+    if (!hasTrait(defender, REDIRECT_ATTACK.id) || defender.__goblinRedirectUsedThisTurn === true) return null;
+    return asArray(combatants).find((candidate) => candidate && unitId(candidate) !== unitId(defender) && isGoblin(candidate) && isFieldUnit(candidate) && sameSide(defender, candidate)) || null;
+  }
+  function markRedirectUsed(unit) {
+    if (!unit || typeof unit !== 'object') return;
+    unit.__goblinRedirectUsedThisTurn = true;
+  }
+  function resetRedirect(unit) {
+    if (unit && typeof unit === 'object') unit.__goblinRedirectUsedThisTurn = false;
+  }
+  function onTurnStart(unit) { resetRedirect(unit); return unit; }
+
+  function lastCoinReuseSkill(originalSkill, preparedSkill, baseResult) {
+    const coins = asArray(preparedSkill.coins);
+    const lastCoin = clone(coins[coins.length - 1] || { index: 0, type: 'normal', status: 'active', effects: [] });
+    lastCoin.index = 0;
+    lastCoin.status = 'active';
+    lastCoin.isReused = true;
+
+    const logs = asArray(baseResult?.attackLogs);
+    const lastLog = logs[logs.length - 1] || {};
+    const coinPower = numberOr(preparedSkill.coinPower, 0);
+    const tosses = asArray(lastLog.attackTosses);
+    const lastToss = tosses.length ? Boolean(tosses[tosses.length - 1]) : false;
+    const loggedPower = Number(lastLog.attackPower);
+    const baseline = Number.isFinite(loggedPower) ? Math.max(0, loggedPower - (lastToss ? coinPower : 0)) : numberOr(preparedSkill.basePower, 0);
+
+    return {
+      ...clone(preparedSkill),
+      id: `${originalSkill.id || preparedSkill.id || 'skill'}__goblin_last_coin_reuse`,
+      name: `${originalSkill.name || preparedSkill.name || 'Skill'} · Reused Last Coin`,
+      basePower: baseline,
+      coinPower,
+      coinAmount: 1,
+      coins: [lastCoin],
+      resourceCosts: [],
+      metadata: { ...(preparedSkill.metadata || {}), goblinMultiAttackReuse: true, originalSkillId: originalSkill.id || preparedSkill.id || null },
+    };
+  }
+
+  function installCombatBridge() {
+    const engine = global.CombatEngine;
+    if (!engine || engine.__goblinUnitRuntimeInstalled || typeof engine.resolveUnilateralWithCounter !== 'function') return Boolean(engine?.__goblinUnitRuntimeInstalled);
+    const originalResolve = engine.resolveUnilateralWithCounter;
+
+    engine.resolveUnilateralWithCounter = function (attacker, skill, defender, counterSkill, options = {}) {
+      const combatants = asArray(options.combatants).length ? asArray(options.combatants) : asArray(this.getAllAliveUnits?.());
+      let actualDefender = defender;
+      let redirect = null;
+      if (options.__goblinRedirectApplied !== true) {
+        const ally = selectRedirectTarget(defender, combatants);
+        if (ally) {
+          markRedirectUsed(defender);
+          redirect = { traitId: REDIRECT_ATTACK.id, fromId: unitId(defender), toId: unitId(ally) };
+          actualDefender = ally;
+        }
+      }
+
+      const preparedSkill = prepareMultiAttackSkill(attacker, skill);
+      const base = originalResolve.call(this, attacker, preparedSkill, actualDefender, counterSkill, { ...options, __goblinRedirectApplied: true });
+      if (redirect && base && typeof base === 'object') base.redirectAttack = redirect;
+
+      const eligibleReuse = options.__goblinMultiReuse !== true && hasTrait(attacker, MULTI_ATTACK.id) && isMeleeSkill(skill) && skillCoinCount(skill) >= 2;
+      if (!eligibleReuse || !base || typeof base !== 'object') return base;
+
+      const requested = reuseTimes(attacker);
+      const attacks = [];
+      const reuseSkill = lastCoinReuseSkill(skill, preparedSkill, base);
+      for (let index = 0; index < requested; index += 1) {
+        if (!actualDefender || numberOr(actualDefender.hp ?? actualDefender.mechanics?.hp, 0) <= 0) break;
+        const reuseResult = originalResolve.call(this, attacker, clone(reuseSkill), actualDefender, null, {
+          ...options,
+          skipUseHooks: true,
+          __goblinRedirectApplied: true,
+          __goblinMultiReuse: true,
+        });
+        attacks.push(reuseResult);
+      }
+      base.multiAttackReuse = { traitId: MULTI_ATTACK.id, timesRequested: requested, timesResolved: attacks.length, attacks };
+      return base;
+    };
+
+    Object.defineProperty(engine, '__goblinUnitRuntimeInstalled', { value: true, configurable: true });
+    return true;
+  }
+
+  function install() { return installCombatBridge(); }
+
+  const api = Object.freeze({
+    version: '1.0.0', MULTI_ATTACK, REDIRECT_ATTACK, hasTrait, effectiveLevel, skillCoinCount, isMeleeSkill, reuseTimes,
+    prepareMultiAttackSkill, isGoblin, isFieldUnit, selectRedirectTarget, resetRedirect, onTurnStart, lastCoinReuseSkill,
+    installCombatBridge, install,
+  });
+
+  global.LuminousGoblinUnitRuntime = api;
+  install();
+  if (global.document) {
+    global.setTimeout?.(install, 0);
+    global.setTimeout?.(install, 800);
+  }
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/kobold-combat-action-extension.js
+++ b/js/kobold-combat-action-extension.js
@@ -1,0 +1,86 @@
+(function (global) {
+  'use strict';
+
+  const normalizeId = (value) => String(value ?? '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  const mechanics = global.LuminousUnitCombatMechanics || (typeof require === 'function' ? (() => { try { return require('./unit-combat-mechanics-runtime.js'); } catch (_) { return null; } })() : null);
+
+  function entityId(entity = {}) { return String(entity.id ?? entity.unitId ?? entity.characterId ?? '').trim(); }
+  function unitById(context = {}, id) {
+    const wanted = String(id ?? '');
+    const units = Array.isArray(context.units) ? context.units : Object.values(context.combatData || {});
+    return units.find((unit) => entityId(unit) === wanted) || null;
+  }
+
+  function ammunitionHandler() {
+    return {
+      validate({ actor, resource }) {
+        const current = mechanics?.ammunitionCount ? mechanics.ammunitionCount(actor, resource.id) : 0;
+        const required = Math.max(1, Number(resource.amount || 1));
+        return { available: current >= required, current, required, reason: current >= required ? null : 'ammunition_unavailable' };
+      },
+      consume({ actor, resource }) {
+        const result = mechanics?.consumeAmmunition ? mechanics.consumeAmmunition(actor, resource.id, resource.amount) : { ok: false, reason: 'ammunition_runtime_unavailable' };
+        return { ...result, consumed: result.ok === true, success: result.ok === true, reason: result.ok === true ? null : (result.reason || 'ammunition_unavailable') };
+      },
+    };
+  }
+
+  function withUnitResourceHandlers(context = {}) {
+    return {
+      ...context,
+      resourceHandlers: {
+        ...(context.resourceHandlers || {}),
+        ammunition: context.resourceHandlers?.ammunition || ammunitionHandler(),
+      },
+    };
+  }
+
+  function failedSaveTargets(result = {}, context = {}) {
+    const rows = result?.resolution?.results || [];
+    return rows.filter((row) => row?.result?.isSuccess === false).map((row) => unitById(context, row.targetId)).filter(Boolean);
+  }
+
+  function install() {
+    const base = global.LuminousCombatActionResolver;
+    if (!base || base.__koboldUnitMechanicsInstalled === true || !mechanics) return false;
+
+    const wrappedResolveCombatAction = function (input = {}, rawContext = {}) {
+      const context = withUnitResourceHandlers(rawContext);
+      const normalized = global.LuminousCombatAction?.normalizeCombatAction ? global.LuminousCombatAction.normalizeCombatAction(input) : input;
+      const actor = unitById(context, normalized.actorId);
+      const source = normalized?.metadata?.sourceDefinition || {};
+
+      if (normalized?.resolution?.type === 'unopposed' && actor && normalized?.targeting?.mainTargetId) {
+        const target = unitById(context, normalized.targeting.mainTargetId);
+        const rule = mechanics.flyingTargetRule?.({ attacker: actor, target, skill: source, resolutionType: 'unopposed' });
+        if (rule?.allowed === false) return { resolved: false, reason: rule.reason, flyingRule: rule, action: normalized };
+      }
+
+      const result = base.resolveCombatAction(input, context);
+      if (!result?.resolved || result?.resolution?.type !== 'save') return result;
+
+      const failurePolicy = normalizeId(source?.save?.onFailure || source?.save?.on_failure || source?.saveOnFailure);
+      if (failurePolicy !== 'unopposed_attack') return result;
+
+      const failedTargets = failedSaveTargets(result, context);
+      if (!failedTargets.length) return { ...result, failedSaveFollowup: { resolved: true, attacks: [] } };
+      if (!actor || typeof base.resolveDirectAttack !== 'function') return { ...result, failedSaveFollowup: { resolved: false, reason: 'direct_attack_resolver_unavailable' } };
+
+      const attack = base.resolveDirectAttack(result.action || normalized, actor, failedTargets, context, { skill: source, skipUseHooks: true });
+      return { ...result, failedSaveFollowup: { resolved: Boolean(attack?.resolved), attacks: attack?.results || [], attack } };
+    };
+
+    global.LuminousCombatActionResolver = Object.freeze({
+      ...base,
+      __koboldUnitMechanicsInstalled: true,
+      withUnitResourceHandlers,
+      resolveCombatAction: wrappedResolveCombatAction,
+    });
+    return true;
+  }
+
+  const api = Object.freeze({ version: '1.0.0', ammunitionHandler, withUnitResourceHandlers, install });
+  global.LuminousKoboldCombatActionExtension = api;
+  install();
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/kobold-combat-action-extension.js
+++ b/js/kobold-combat-action-extension.js
@@ -10,6 +10,8 @@
     const units = Array.isArray(context.units) ? context.units : Object.values(context.combatData || {});
     return units.find((unit) => entityId(unit) === wanted) || null;
   }
+  function normalizeAction(input) { return global.LuminousCombatAction?.normalizeCombatAction ? global.LuminousCombatAction.normalizeCombatAction(input) : input; }
+  function sourceOf(action = {}) { return action?.metadata?.sourceDefinition || {}; }
 
   function ammunitionHandler() {
     return {
@@ -28,16 +30,57 @@
   function withUnitResourceHandlers(context = {}) {
     return {
       ...context,
-      resourceHandlers: {
-        ...(context.resourceHandlers || {}),
-        ammunition: context.resourceHandlers?.ammunition || ammunitionHandler(),
-      },
+      resourceHandlers: { ...(context.resourceHandlers || {}), ammunition: context.resourceHandlers?.ammunition || ammunitionHandler() },
     };
   }
 
+  function applyDeclaredEconomy(action) {
+    const source = sourceOf(action);
+    const declared = normalizeId(source?.economy);
+    if (declared === 'quick_action' && action?.economy) action.economy.cost = 'quick_action';
+    if (declared === 'reaction' && action?.economy) action.economy.cost = 'reaction';
+    return action;
+  }
+
+  function flyingUnopposedGate(action, actor, context) {
+    if (action?.resolution?.type !== 'unopposed' || !actor) return null;
+    const ids = [action?.targeting?.mainTargetId, ...(action?.targeting?.targetIds || [])].filter(Boolean);
+    for (const id of ids) {
+      const target = unitById(context, id);
+      const rule = mechanics.flyingTargetRule?.({ attacker: actor, target, skill: sourceOf(action), resolutionType: 'unopposed' });
+      if (rule?.allowed === false) return rule;
+    }
+    return null;
+  }
+
+  function runWithFlyingClashGuard(action, context, run) {
+    if (action?.resolution?.type !== 'clash' || !context.opposingAction) return run();
+    const engine = context.engine || global.CombatEngine;
+    if (!engine || typeof engine.resolveUnilateralWithCounter !== 'function') return run();
+
+    const opposing = normalizeAction(context.opposingAction);
+    const original = engine.resolveUnilateralWithCounter;
+    const sourceA = sourceOf(action);
+    const sourceB = sourceOf(opposing);
+    const actorA = unitById(context, action.actorId);
+    const actorB = unitById(context, opposing.actorId);
+
+    engine.resolveUnilateralWithCounter = function (attacker, attackSkill, defender, counterSkill, options) {
+      const attackerIsA = entityId(attacker) === entityId(actorA);
+      const defenderSkill = attackerIsA ? sourceB : sourceA;
+      const rule = mechanics.flyingClashDamageRule?.({ attacker, defender, attackerSkill: attackSkill, defenderSkill });
+      if (rule?.canDamage === false && normalizeId(options?.clashResult) === 'win') {
+        return { resolved: true, damageNegated: true, damage: 0, flyingRule: rule, attackLogs: [], message: 'Clash won; melee damage cannot reach the Flying Unit.' };
+      }
+      return original.call(engine, attacker, attackSkill, defender, counterSkill, options);
+    };
+
+    try { return run(); }
+    finally { engine.resolveUnilateralWithCounter = original; }
+  }
+
   function failedSaveTargets(result = {}, context = {}) {
-    const rows = result?.resolution?.results || [];
-    return rows.filter((row) => row?.result?.isSuccess === false).map((row) => unitById(context, row.targetId)).filter(Boolean);
+    return (result?.resolution?.results || []).filter((row) => row?.result?.isSuccess === false).map((row) => unitById(context, row.targetId)).filter(Boolean);
   }
 
   function install() {
@@ -46,40 +89,30 @@
 
     const wrappedResolveCombatAction = function (input = {}, rawContext = {}) {
       const context = withUnitResourceHandlers(rawContext);
-      const normalized = global.LuminousCombatAction?.normalizeCombatAction ? global.LuminousCombatAction.normalizeCombatAction(input) : input;
-      const actor = unitById(context, normalized.actorId);
-      const source = normalized?.metadata?.sourceDefinition || {};
+      const action = applyDeclaredEconomy(normalizeAction(input));
+      const actor = unitById(context, action.actorId);
+      const source = sourceOf(action);
+      const flyingGate = flyingUnopposedGate(action, actor, context);
+      if (flyingGate) return { resolved: false, reason: flyingGate.reason, flyingRule: flyingGate, action };
 
-      if (normalized?.resolution?.type === 'unopposed' && actor && normalized?.targeting?.mainTargetId) {
-        const target = unitById(context, normalized.targeting.mainTargetId);
-        const rule = mechanics.flyingTargetRule?.({ attacker: actor, target, skill: source, resolutionType: 'unopposed' });
-        if (rule?.allowed === false) return { resolved: false, reason: rule.reason, flyingRule: rule, action: normalized };
-      }
-
-      const result = base.resolveCombatAction(input, context);
+      const result = runWithFlyingClashGuard(action, context, () => base.resolveCombatAction(action, context));
       if (!result?.resolved || result?.resolution?.type !== 'save') return result;
 
       const failurePolicy = normalizeId(source?.save?.onFailure || source?.save?.on_failure || source?.saveOnFailure);
       if (failurePolicy !== 'unopposed_attack') return result;
-
       const failedTargets = failedSaveTargets(result, context);
       if (!failedTargets.length) return { ...result, failedSaveFollowup: { resolved: true, attacks: [] } };
       if (!actor || typeof base.resolveDirectAttack !== 'function') return { ...result, failedSaveFollowup: { resolved: false, reason: 'direct_attack_resolver_unavailable' } };
 
-      const attack = base.resolveDirectAttack(result.action || normalized, actor, failedTargets, context, { skill: source, skipUseHooks: true });
+      const attack = base.resolveDirectAttack(result.action || action, actor, failedTargets, context, { skill: source, skipUseHooks: true });
       return { ...result, failedSaveFollowup: { resolved: Boolean(attack?.resolved), attacks: attack?.results || [], attack } };
     };
 
-    global.LuminousCombatActionResolver = Object.freeze({
-      ...base,
-      __koboldUnitMechanicsInstalled: true,
-      withUnitResourceHandlers,
-      resolveCombatAction: wrappedResolveCombatAction,
-    });
+    global.LuminousCombatActionResolver = Object.freeze({ ...base, __koboldUnitMechanicsInstalled: true, withUnitResourceHandlers, resolveCombatAction: wrappedResolveCombatAction });
     return true;
   }
 
-  const api = Object.freeze({ version: '1.0.0', ammunitionHandler, withUnitResourceHandlers, install });
+  const api = Object.freeze({ version: '1.1.0', ammunitionHandler, withUnitResourceHandlers, applyDeclaredEconomy, runWithFlyingClashGuard, install });
   global.LuminousKoboldCombatActionExtension = api;
   install();
   if (typeof module !== 'undefined' && module.exports) module.exports = api;

--- a/js/kobold-thrown-projectile-profiles.js
+++ b/js/kobold-thrown-projectile-profiles.js
@@ -1,0 +1,70 @@
+(function (global) {
+  'use strict';
+
+  const ROCK_ASSET = 'https://imgur.com/P4J48yc.png';
+  const HOLDING_ROCK = 'https://imgur.com/529fa4E.png';
+  const WITHOUT_ROCK = 'https://imgur.com/zmA1FPz.png';
+  const DAGGER = 'https://imgur.com/evsrs1B.png';
+
+  function runtime() {
+    return global.LuminousThrownProjectileSequenceRuntime
+      || (typeof require === 'function' ? (() => { try { return require('./thrown-projectile-sequence-runtime.js'); } catch (_) { return null; } })() : null);
+  }
+
+  function install() {
+    const api = runtime();
+    if (!api?.registerProfile) return false;
+    api.registerProfile('winged_kobold_falling_rock', {
+      type: 'thrown_projectile',
+      projectileAsset: ROCK_ASSET,
+      projectileSize: 54,
+      originAnchor: { x: 0.58, y: 0.58 },
+      targetAnchor: { x: 0.50, y: 0.52 },
+      groundAnchor: { x: 0.56, y: 0.86 },
+      groundOffsetOnHit: { x: 22, y: 0 },
+      approach: { enabled: true, actorLeft: '45%', actorTop: '92px' },
+      holdingSprite: HOLDING_ROCK,
+      releaseSprite: WITHOUT_ROCK,
+      postActionSprite: DAGGER,
+      returnToOrigin: true,
+      resumeHover: true,
+      hover: { distance: 7, duration: 1300 },
+      arc: 74,
+      hitArc: 58,
+      spin: 300,
+      hitSpin: 270,
+      rollDistance: 150,
+      rollRotation: 520,
+      timings: {
+        approach: 650,
+        aim: 350,
+        releaseHold: 250,
+        projectile: 560,
+        hitProjectile: 470,
+        bounce: 300,
+        impactPause: 100,
+        roll: 940,
+        equip: 260,
+        return: 620,
+      },
+      metadata: {
+        approvedSequence: true,
+        saveSuccess: 'miss_ground_roll_vanish',
+        saveFailure: 'hit_bounce_ground_roll_vanish',
+        postAction: 'equip_dagger_return_hover',
+      },
+    });
+    return true;
+  }
+
+  const api = Object.freeze({
+    version: '1.0.0',
+    FALLING_ROCK_SKILL_ID: 'winged_kobold_falling_rock',
+    assets: Object.freeze({ rock: ROCK_ASSET, holdingRock: HOLDING_ROCK, withoutRock: WITHOUT_ROCK, dagger: DAGGER }),
+    install,
+  });
+
+  global.LuminousKoboldThrownProjectileProfiles = api;
+  install();
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/skill-catalog-kobold-tier1.js
+++ b/js/skill-catalog-kobold-tier1.js
@@ -13,9 +13,10 @@
 
   function coin(index, effects) { return { index, type: 'normal', status: 'active', effects: effects || [] }; }
 
-  function attack({ id, name, variant, tier = 1, maxCopies, basePower, coinPower, coinAmount, damageType, skillRange, statusFamily, statusCoin = 0, potency, count, effects = [], metadata = {} }) {
+  function attack({ id, name, variant, tier = 1, maxCopies, basePower, coinPower, coinAmount, damageType, skillRange, statusFamily, statusCoin = 0, potency, count, effects = [], ammoType = null, metadata = {} }) {
     const coins = Array.from({ length: coinAmount }, (_, index) => coin(index, []));
     if (statusFamily && coins[statusCoin]) coins[statusCoin].effects.push(statusEffect(statusFamily, potency, count));
+    const resourceCosts = ammoType ? [{ owner: 'source', type: 'ammunition', id: ammoType, amount: 1, timing: 'on_user' }] : [];
     return {
       id, name, type: 'Attack', tier, maxCopies: maxCopies ?? (tier === 1 ? 3 : tier === 2 ? 2 : 1),
       basePower, coinPower, coinAmount, coinType: 'positive', attackWeight: 1, skillRange,
@@ -23,10 +24,12 @@
       targetingType: 'Focused Attack', aoePattern: 'Self', skillAmount: 1, sourceType: 'skill', sourceId: id,
       isItemSkill: false, isDefense: false, defenseSubtype: '', isClashable: true, isUnclashable: false,
       isIndiscriminate: false, isTargetFixed: false, requiresUnlock: false,
+      resourceCosts,
       effects: clone(effects), coins, evolutionChain: null, schemaVersion: 2,
       metadata: {
         canonicalUnitSkill: true, species: 'kobold', unitVariant: variant, tier,
-        statusFamily: statusFamily || null, combatRange: skillRange > 1 ? 'ranged' : 'melee', ...metadata,
+        statusFamily: statusFamily || null, combatRange: skillRange > 1 ? 'ranged' : 'melee', weaponSkill: true,
+        ...(ammoType ? { ammoType } : {}), ...metadata,
       },
     };
   }
@@ -39,8 +42,8 @@
       statUsed: '', skillUsed: '', targetingType: 'Focused Attack', aoePattern: 'Self', skillAmount: 1,
       sourceType: 'skill', sourceId: id, isItemSkill: false, isDefense: true, defenseSubtype: 'Evade',
       isClashable: true, isUnclashable: false, isIndiscriminate: false, isTargetFixed: false,
-      requiresUnlock: false, effects: [], coins: [coin(0, [])], evolutionChain: null, schemaVersion: 2,
-      metadata: { canonicalUnitSkill: true, species: 'kobold', unitVariant: variant, tier: 1, statusFamily: null, rulesPolicy: 'defense_only', combatRange: 'self' },
+      requiresUnlock: false, resourceCosts: [], effects: [], coins: [coin(0, [])], evolutionChain: null, schemaVersion: 2,
+      metadata: { canonicalUnitSkill: true, species: 'kobold', unitVariant: variant, tier: 1, statusFamily: null, rulesPolicy: 'defense_only', combatRange: 'self', weaponSkill: false },
     };
   }
 
@@ -89,6 +92,9 @@
         tier: 1,
         tierPowerException: 'save_harassment_skill',
         combatRange: 'ranged',
+        ammoType: 'rock',
+        weaponSkill: false,
+        thrownProjectile: true,
         damageTypeLabel: 'Blunt',
         economyLabel: 'Quick Action',
         resolutionPolicy: 'save_then_unopposed_attack_on_failure',
@@ -100,8 +106,8 @@
     kobold_dagger_jab: Object.freeze(attack({ id: 'kobold_dagger_jab', name: 'Dagger Jab', variant: 'dagger', basePower: 6, coinPower: 5, coinAmount: 1, damageType: 'perforante', skillRange: 1, statusFamily: 'bleed', statusCoin: 0, potency: 1, count: 2 })),
     kobold_desperate_stab: Object.freeze(attack({ id: 'kobold_desperate_stab', name: 'Desperate Stab', variant: 'dagger', basePower: 4, coinPower: 3, coinAmount: 2, damageType: 'perforante', skillRange: 1, statusFamily: 'bleed', statusCoin: 1, potency: 1, count: 3 })),
     kobold_scurry: Object.freeze(evade({ id: 'kobold_scurry', name: 'Scurry', variant: 'dagger' })),
-    kobold_sling_shot: Object.freeze(attack({ id: 'kobold_sling_shot', name: 'Sling Shot', variant: 'sling', basePower: 6, coinPower: 4, coinAmount: 1, damageType: 'contundente', skillRange: 6, statusFamily: 'tremor', statusCoin: 0, potency: 1, count: 2 })),
-    kobold_rapid_pebble: Object.freeze(attack({ id: 'kobold_rapid_pebble', name: 'Rapid Pebble', variant: 'sling', basePower: 4, coinPower: 3, coinAmount: 2, damageType: 'contundente', skillRange: 6, statusFamily: 'tremor', statusCoin: 1, potency: 1, count: 3 })),
+    kobold_sling_shot: Object.freeze(attack({ id: 'kobold_sling_shot', name: 'Sling Shot', variant: 'sling', basePower: 6, coinPower: 4, coinAmount: 1, damageType: 'contundente', skillRange: 6, statusFamily: 'tremor', statusCoin: 0, potency: 1, count: 2, ammoType: 'pebbles' })),
+    kobold_rapid_pebble: Object.freeze(attack({ id: 'kobold_rapid_pebble', name: 'Rapid Pebble', variant: 'sling', basePower: 4, coinPower: 3, coinAmount: 2, damageType: 'contundente', skillRange: 6, statusFamily: 'tremor', statusCoin: 1, potency: 1, count: 3, ammoType: 'pebbles' })),
     kobold_duck_away: Object.freeze(evade({ id: 'kobold_duck_away', name: 'Duck Away', variant: 'sling' })),
 
     winged_kobold_dagger: Object.freeze(attack({ id: 'winged_kobold_dagger', name: 'Airborne Dagger', variant: 'winged', tier: 1, basePower: 5, coinPower: 5, coinAmount: 1, damageType: 'perforante', skillRange: 1, metadata: { rulesPolicy: 'flying_melee' } })),
@@ -132,7 +138,7 @@
     return payload;
   }
 
-  const api = Object.freeze({ version: '1.1.0', DEFINITIONS, list, get, finalPower, firebasePayload });
+  const api = Object.freeze({ version: '1.2.0', DEFINITIONS, list, get, finalPower, firebasePayload });
   global.LuminousKoboldTier1SkillCatalog = api;
   if (typeof module !== 'undefined' && module.exports) module.exports = api;
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/js/skill-catalog-kobold-tier1.js
+++ b/js/skill-catalog-kobold-tier1.js
@@ -5,104 +5,79 @@
 
   function statusEffect(status, potency, count) {
     return {
-      trigger: '[On Hit]',
-      target: 'target',
-      type: 'status',
-      status,
-      potency,
-      count,
-      maxCap: 0,
-      scaleTarget: null,
-      scaleCondition: null,
-      is_reuse: false,
-      target_ally: false,
-      timing: 'immediate',
-      condition: null,
+      trigger: '[On Hit]', target: 'target', type: 'status', status, potency, count,
+      maxCap: 0, scaleTarget: null, scaleCondition: null, is_reuse: false,
+      target_ally: false, timing: 'immediate', condition: null,
     };
   }
 
-  function coin(index, effects) {
-    return { index, type: 'normal', status: 'active', effects: effects || [] };
-  }
+  function coin(index, effects) { return { index, type: 'normal', status: 'active', effects: effects || [] }; }
 
-  function attack({ id, name, variant, basePower, coinPower, coinAmount, damageType, skillRange, statusFamily, statusCoin, potency, count }) {
+  function attack({ id, name, variant, tier = 1, maxCopies, basePower, coinPower, coinAmount, damageType, skillRange, statusFamily, statusCoin = 0, potency, count, effects = [], metadata = {} }) {
     const coins = Array.from({ length: coinAmount }, (_, index) => coin(index, []));
-    if (statusFamily) coins[statusCoin].effects.push(statusEffect(statusFamily, potency, count));
+    if (statusFamily && coins[statusCoin]) coins[statusCoin].effects.push(statusEffect(statusFamily, potency, count));
     return {
-      id,
-      name,
-      type: 'Attack',
-      tier: 1,
-      basePower,
-      coinPower,
-      coinAmount,
-      coinType: 'positive',
-      attackWeight: 1,
-      skillRange,
-      damageType,
-      sinAffinity: 'sinless',
-      scalingStat: 'Destreza',
-      statUsed: '',
-      skillUsed: '',
-      targetingType: 'Focused Attack',
-      aoePattern: 'Self',
-      skillAmount: 1,
-      sourceType: 'skill',
-      sourceId: id,
-      isItemSkill: false,
-      isDefense: false,
-      defenseSubtype: '',
-      isClashable: true,
-      isUnclashable: false,
-      isIndiscriminate: false,
-      isTargetFixed: false,
-      requiresUnlock: false,
-      effects: [],
-      coins,
-      evolutionChain: null,
-      schemaVersion: 2,
+      id, name, type: 'Attack', tier, maxCopies: maxCopies ?? (tier === 1 ? 3 : tier === 2 ? 2 : 1),
+      basePower, coinPower, coinAmount, coinType: 'positive', attackWeight: 1, skillRange,
+      damageType, sinAffinity: 'sinless', scalingStat: 'Destreza', statUsed: '', skillUsed: '',
+      targetingType: 'Focused Attack', aoePattern: 'Self', skillAmount: 1, sourceType: 'skill', sourceId: id,
+      isItemSkill: false, isDefense: false, defenseSubtype: '', isClashable: true, isUnclashable: false,
+      isIndiscriminate: false, isTargetFixed: false, requiresUnlock: false,
+      effects: clone(effects), coins, evolutionChain: null, schemaVersion: 2,
       metadata: {
-        canonicalUnitSkill: true,
-        species: 'kobold',
-        unitVariant: variant,
-        tier: 1,
-        statusFamily,
-        rulesPolicy: 'enemy_count_specialist',
-        combatRange: skillRange > 1 ? 'ranged' : 'melee',
+        canonicalUnitSkill: true, species: 'kobold', unitVariant: variant, tier,
+        statusFamily: statusFamily || null, combatRange: skillRange > 1 ? 'ranged' : 'melee', ...metadata,
       },
     };
   }
 
   function evade({ id, name, variant }) {
     return {
-      id,
-      name,
-      type: 'Defense',
+      id, name, type: 'Defense', tier: 1, maxCopies: 3,
+      basePower: 5, coinPower: 5, coinAmount: 1, coinType: 'positive', attackWeight: 1,
+      skillRange: 1, damageType: 'contundente', sinAffinity: 'sinless', scalingStat: 'Destreza',
+      statUsed: '', skillUsed: '', targetingType: 'Focused Attack', aoePattern: 'Self', skillAmount: 1,
+      sourceType: 'skill', sourceId: id, isItemSkill: false, isDefense: true, defenseSubtype: 'Evade',
+      isClashable: true, isUnclashable: false, isIndiscriminate: false, isTargetFixed: false,
+      requiresUnlock: false, effects: [], coins: [coin(0, [])], evolutionChain: null, schemaVersion: 2,
+      metadata: { canonicalUnitSkill: true, species: 'kobold', unitVariant: variant, tier: 1, statusFamily: null, rulesPolicy: 'defense_only', combatRange: 'self' },
+    };
+  }
+
+  function fallingRock() {
+    return {
+      id: 'winged_kobold_falling_rock',
+      name: 'Falling Rock',
+      type: 'Attack',
       tier: 1,
-      basePower: 5,
-      coinPower: 5,
+      maxCopies: 3,
+      basePower: 3,
+      coinPower: 3,
       coinAmount: 1,
       coinType: 'positive',
       attackWeight: 1,
-      skillRange: 1,
+      skillRange: 6,
       damageType: 'contundente',
       sinAffinity: 'sinless',
       scalingStat: 'Destreza',
       statUsed: '',
       skillUsed: '',
+      economy: 'quick_action',
       targetingType: 'Focused Attack',
       aoePattern: 'Self',
       skillAmount: 1,
       sourceType: 'skill',
-      sourceId: id,
+      sourceId: 'winged_kobold_falling_rock',
       isItemSkill: false,
-      isDefense: true,
-      defenseSubtype: 'Evade',
-      isClashable: true,
-      isUnclashable: false,
+      isDefense: false,
+      defenseSubtype: '',
+      isClashable: false,
+      isUnclashable: true,
       isIndiscriminate: false,
       isTargetFixed: false,
       requiresUnlock: false,
+      save: { ability: 'dexterity', dc: 9, onSuccess: 'negates', onFailure: 'unopposed_attack' },
+      resourceCosts: [{ owner: 'source', type: 'ammunition', id: 'rock', amount: 1, timing: 'on_user' }],
       effects: [],
       coins: [coin(0, [])],
       evolutionChain: null,
@@ -110,42 +85,32 @@
       metadata: {
         canonicalUnitSkill: true,
         species: 'kobold',
-        unitVariant: variant,
+        unitVariant: 'winged',
         tier: 1,
-        statusFamily: null,
-        rulesPolicy: 'defense_only',
-        combatRange: 'self',
+        tierPowerException: 'save_harassment_skill',
+        combatRange: 'ranged',
+        damageTypeLabel: 'Blunt',
+        economyLabel: 'Quick Action',
+        resolutionPolicy: 'save_then_unopposed_attack_on_failure',
       },
     };
   }
 
   const DEFINITIONS = Object.freeze({
-    kobold_dagger_jab: Object.freeze(attack({
-      id: 'kobold_dagger_jab', name: 'Dagger Jab', variant: 'dagger',
-      basePower: 6, coinPower: 5, coinAmount: 1,
-      damageType: 'perforante', skillRange: 1,
-      statusFamily: 'bleed', statusCoin: 0, potency: 1, count: 2,
-    })),
-    kobold_desperate_stab: Object.freeze(attack({
-      id: 'kobold_desperate_stab', name: 'Desperate Stab', variant: 'dagger',
-      basePower: 4, coinPower: 3, coinAmount: 2,
-      damageType: 'perforante', skillRange: 1,
-      statusFamily: 'bleed', statusCoin: 1, potency: 1, count: 3,
-    })),
+    kobold_dagger_jab: Object.freeze(attack({ id: 'kobold_dagger_jab', name: 'Dagger Jab', variant: 'dagger', basePower: 6, coinPower: 5, coinAmount: 1, damageType: 'perforante', skillRange: 1, statusFamily: 'bleed', statusCoin: 0, potency: 1, count: 2 })),
+    kobold_desperate_stab: Object.freeze(attack({ id: 'kobold_desperate_stab', name: 'Desperate Stab', variant: 'dagger', basePower: 4, coinPower: 3, coinAmount: 2, damageType: 'perforante', skillRange: 1, statusFamily: 'bleed', statusCoin: 1, potency: 1, count: 3 })),
     kobold_scurry: Object.freeze(evade({ id: 'kobold_scurry', name: 'Scurry', variant: 'dagger' })),
-    kobold_sling_shot: Object.freeze(attack({
-      id: 'kobold_sling_shot', name: 'Sling Shot', variant: 'sling',
-      basePower: 6, coinPower: 4, coinAmount: 1,
-      damageType: 'contundente', skillRange: 6,
-      statusFamily: 'tremor', statusCoin: 0, potency: 1, count: 2,
-    })),
-    kobold_rapid_pebble: Object.freeze(attack({
-      id: 'kobold_rapid_pebble', name: 'Rapid Pebble', variant: 'sling',
-      basePower: 4, coinPower: 3, coinAmount: 2,
-      damageType: 'contundente', skillRange: 6,
-      statusFamily: 'tremor', statusCoin: 1, potency: 1, count: 3,
-    })),
+    kobold_sling_shot: Object.freeze(attack({ id: 'kobold_sling_shot', name: 'Sling Shot', variant: 'sling', basePower: 6, coinPower: 4, coinAmount: 1, damageType: 'contundente', skillRange: 6, statusFamily: 'tremor', statusCoin: 0, potency: 1, count: 2 })),
+    kobold_rapid_pebble: Object.freeze(attack({ id: 'kobold_rapid_pebble', name: 'Rapid Pebble', variant: 'sling', basePower: 4, coinPower: 3, coinAmount: 2, damageType: 'contundente', skillRange: 6, statusFamily: 'tremor', statusCoin: 1, potency: 1, count: 3 })),
     kobold_duck_away: Object.freeze(evade({ id: 'kobold_duck_away', name: 'Duck Away', variant: 'sling' })),
+
+    winged_kobold_dagger: Object.freeze(attack({ id: 'winged_kobold_dagger', name: 'Airborne Dagger', variant: 'winged', tier: 1, basePower: 5, coinPower: 5, coinAmount: 1, damageType: 'perforante', skillRange: 1, metadata: { rulesPolicy: 'flying_melee' } })),
+    winged_kobold_falling_rock: Object.freeze(fallingRock()),
+    winged_kobold_dive_stab: Object.freeze(attack({ id: 'winged_kobold_dive_stab', name: 'Dive Stab', variant: 'winged', tier: 2, maxCopies: 2, basePower: 7, coinPower: 5, coinAmount: 2, damageType: 'perforante', skillRange: 1, metadata: { rulesPolicy: 'flying_melee_commit' } })),
+
+    dragonheart_spear_thrust: Object.freeze(attack({ id: 'dragonheart_spear_thrust', name: 'Spear Thrust', variant: 'dragonheart', tier: 1, basePower: 6, coinPower: 6, coinAmount: 1, damageType: 'perforante', skillRange: 1 })),
+    dragonheart_guarding_skewer: Object.freeze(attack({ id: 'dragonheart_guarding_skewer', name: 'Guarding Skewer', variant: 'dragonheart', tier: 2, maxCopies: 2, basePower: 7, coinPower: 5, coinAmount: 2, damageType: 'perforante', skillRange: 1, metadata: { condition: 'while_command_rank_active', conditionBonus: '+1 Clash Power' } })),
+    dragonheart_dragon_spear: Object.freeze(attack({ id: 'dragonheart_dragon_spear', name: 'Dragon Spear', variant: 'dragonheart', tier: 3, maxCopies: 1, basePower: 9, coinPower: 5, coinAmount: 3, damageType: 'perforante', skillRange: 1, metadata: { condition: 'target_has_negative_status', conditionBonus: '+1 Final Power' } })),
   });
 
   function list() { return Object.values(DEFINITIONS).map(clone); }
@@ -167,7 +132,7 @@
     return payload;
   }
 
-  const api = Object.freeze({ version: '1.0.0', DEFINITIONS, list, get, finalPower, firebasePayload });
+  const api = Object.freeze({ version: '1.1.0', DEFINITIONS, list, get, finalPower, firebasePayload });
   global.LuminousKoboldTier1SkillCatalog = api;
   if (typeof module !== 'undefined' && module.exports) module.exports = api;
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/js/status-engine.js
+++ b/js/status-engine.js
@@ -174,6 +174,8 @@
     try { if (!global.LuminousConditionRuntime) require("./core-condition-runtime.js"); } catch (_) {}
     try { if (!global.LuminousConditionCombatBridge) require("./core-condition-combat-bridge.js"); } catch (_) {}
     try { if (!global.LuminousConditionTheatreBridge) require("./core-condition-theatre-bridge.js"); } catch (_) {}
+    try { if (!global.LuminousUniversalRangedAmmoRuntime) require("./universal-ranged-ammo-runtime.js"); } catch (_) {}
+    try { if (!global.LuminousGoblinUnitRuntime) require("./goblin-unit-runtime.js"); } catch (_) {}
   }
 
   function loadScript(id, src) {
@@ -205,6 +207,8 @@
   if (global.document && !global.LuminousRestEngine) loadScript("rest-engine-script", "js/rest-engine.js");
   if (global.document && !global.LuminousRestRuntime) loadScript("rest-runtime-integration-script", "js/rest-runtime-integration.js");
   if (global.document && !global.LuminousUniversalSpeedRuntime) loadScript("universal-speed-runtime-script", "js/universal-speed-runtime.js");
+  if (global.document && !global.LuminousUniversalRangedAmmoRuntime) loadScript("universal-ranged-ammo-runtime-script", "js/universal-ranged-ammo-runtime.js");
+  if (global.document && !global.LuminousGoblinUnitRuntime) loadScript("goblin-unit-runtime-script", "js/goblin-unit-runtime.js");
   if (global.document && !global.LuminousFixedDamageRuntime) loadScript("fixed-damage-runtime-script", "js/fixed-damage-runtime.js");
   if (global.document && !global.LuminousElementalStatusRuntime) loadScript("elemental-status-runtime-script", "js/elemental-status-runtime.js");
   if (global.document && !global.LuminousElementalStatusCompatibility) loadScript("elemental-status-compat-script", "js/elemental-status-compat.js");

--- a/js/status-engine.js
+++ b/js/status-engine.js
@@ -198,6 +198,7 @@
 
   ensureCoreConditionRuntime();
   if (global.document && !global.LuminousThrownProjectileSequenceRuntime) loadScript("thrown-projectile-sequence-runtime-script", "js/thrown-projectile-sequence-runtime.js");
+  if (global.document && !global.LuminousThrownProjectileSequenceProfiles) loadScript("thrown-projectile-sequence-profiles-script", "js/thrown-projectile-sequence-profiles.js");
   if (global.document && !global.LuminousConditionCombatBridge) loadScript("core-condition-combat-bridge-script", "js/core-condition-combat-bridge.js");
   if (global.document && !global.LuminousConditionTheatreBridge) loadScript("core-condition-theatre-bridge-script", "js/core-condition-theatre-bridge.js");
   if (global.document && !global.LuminousCharacterBuildRules) loadScript("character-build-rules-script", "js/character-build-rules.js");

--- a/js/status-engine.js
+++ b/js/status-engine.js
@@ -197,6 +197,7 @@
   }
 
   ensureCoreConditionRuntime();
+  if (global.document && !global.LuminousThrownProjectileSequenceRuntime) loadScript("thrown-projectile-sequence-runtime-script", "js/thrown-projectile-sequence-runtime.js");
   if (global.document && !global.LuminousConditionCombatBridge) loadScript("core-condition-combat-bridge-script", "js/core-condition-combat-bridge.js");
   if (global.document && !global.LuminousConditionTheatreBridge) loadScript("core-condition-theatre-bridge-script", "js/core-condition-theatre-bridge.js");
   if (global.document && !global.LuminousCharacterBuildRules) loadScript("character-build-rules-script", "js/character-build-rules.js");

--- a/js/thrown-projectile-sequence-profiles.js
+++ b/js/thrown-projectile-sequence-profiles.js
@@ -1,0 +1,63 @@
+(function (global) {
+  'use strict';
+
+  const profiles = Object.freeze({
+    winged_kobold_falling_rock: Object.freeze({
+      type: 'thrown_projectile',
+      projectileAsset: 'https://imgur.com/P4J48yc.png',
+      projectileSize: 54,
+      originAnchor: { x: 0.58, y: 0.58 },
+      targetAnchor: { x: 0.50, y: 0.52 },
+      groundAnchor: { x: 0.56, y: 0.86 },
+      groundOffsetOnHit: { x: 22, y: 0 },
+      approach: { enabled: true, actorLeft: '45%', actorTop: '92px' },
+      holdingSprite: 'https://imgur.com/529fa4E.png',
+      releaseSprite: 'https://imgur.com/zmA1FPz.png',
+      postActionSprite: 'https://imgur.com/evsrs1B.png',
+      returnToOrigin: true,
+      resumeHover: true,
+      hover: { distance: 7, duration: 1300 },
+      arc: 74,
+      hitArc: 58,
+      spin: 300,
+      hitSpin: 270,
+      rollDistance: 150,
+      rollRotation: 520,
+      timings: {
+        approach: 650,
+        aim: 350,
+        releaseHold: 250,
+        projectile: 560,
+        hitProjectile: 470,
+        bounce: 300,
+        impactPause: 100,
+        roll: 940,
+        equip: 260,
+        return: 620,
+      },
+      metadata: {
+        approvedSequence: true,
+        saveSuccess: 'miss_ground_roll_vanish',
+        saveFailure: 'hit_bounce_ground_roll_vanish',
+        postAction: 'equip_dagger_return_hover',
+      },
+    }),
+  });
+
+  function runtime() {
+    return global.LuminousThrownProjectileSequenceRuntime
+      || (typeof require === 'function' ? (() => { try { return require('./thrown-projectile-sequence-runtime.js'); } catch (_) { return null; } })() : null);
+  }
+
+  function install() {
+    const api = runtime();
+    if (!api?.registerProfile) return false;
+    Object.entries(profiles).forEach(([skillId, profile]) => api.registerProfile(skillId, profile));
+    return true;
+  }
+
+  const api = Object.freeze({ version: '1.0.0', profiles, install });
+  global.LuminousThrownProjectileSequenceProfiles = api;
+  install();
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/thrown-projectile-sequence-runtime.js
+++ b/js/thrown-projectile-sequence-runtime.js
@@ -1,0 +1,335 @@
+(function (global) {
+  'use strict';
+
+  const VERSION = '1.0.0';
+  const profiles = Object.create(null);
+  const normalizeId = (value) => String(value ?? '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const numberOr = (value, fallback) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const sleep = (ms) => new Promise((resolve) => global.setTimeout(resolve, Math.max(0, Number(ms) || 0)));
+
+  const DEFAULT_TIMING = Object.freeze({
+    approach: 650,
+    aim: 350,
+    releaseHold: 250,
+    projectile: 560,
+    hitProjectile: 470,
+    bounce: 300,
+    impactPause: 100,
+    roll: 940,
+    equip: 260,
+    return: 620,
+  });
+
+  function normalizeProfile(input = {}) {
+    const timings = { ...DEFAULT_TIMING, ...(input.timings || {}) };
+    return {
+      id: normalizeId(input.id || input.skillId || input.sourceId),
+      type: normalizeId(input.type || 'thrown_projectile'),
+      projectileAsset: String(input.projectileAsset || ''),
+      projectileSize: Math.max(8, numberOr(input.projectileSize, 54)),
+      originAnchor: { x: numberOr(input.originAnchor?.x, 0.58), y: numberOr(input.originAnchor?.y, 0.58) },
+      targetAnchor: { x: numberOr(input.targetAnchor?.x, 0.5), y: numberOr(input.targetAnchor?.y, 0.52) },
+      groundAnchor: { x: numberOr(input.groundAnchor?.x, 0.56), y: numberOr(input.groundAnchor?.y, 0.86) },
+      groundOffsetOnHit: { x: numberOr(input.groundOffsetOnHit?.x, 22), y: numberOr(input.groundOffsetOnHit?.y, 0) },
+      approach: {
+        enabled: input.approach?.enabled !== false,
+        actorLeft: input.approach?.actorLeft ?? '45%',
+        actorTop: input.approach?.actorTop ?? '92px',
+      },
+      releaseSprite: input.releaseSprite || null,
+      postActionSprite: input.postActionSprite || null,
+      holdingSprite: input.holdingSprite || null,
+      returnToOrigin: input.returnToOrigin !== false,
+      resumeHover: input.resumeHover !== false,
+      hover: {
+        distance: numberOr(input.hover?.distance, 7),
+        duration: Math.max(200, numberOr(input.hover?.duration, 1300)),
+      },
+      arc: numberOr(input.arc, 74),
+      hitArc: numberOr(input.hitArc, 58),
+      spin: numberOr(input.spin, 300),
+      hitSpin: numberOr(input.hitSpin, 270),
+      rollDistance: numberOr(input.rollDistance, 150),
+      rollRotation: numberOr(input.rollRotation, 520),
+      timings,
+      metadata: clone(input.metadata || {}),
+    };
+  }
+
+  function registerProfile(skillId, profile = {}) {
+    const id = normalizeId(skillId || profile.id || profile.skillId);
+    if (!id) throw new Error('THROWN_PROJECTILE_PROFILE_ID_REQUIRED');
+    const normalized = normalizeProfile({ ...profile, id });
+    profiles[id] = Object.freeze(normalized);
+    return clone(profiles[id]);
+  }
+
+  function getProfile(skillId) {
+    const profile = profiles[normalizeId(skillId)];
+    return profile ? clone(profile) : null;
+  }
+
+  function listProfiles() { return Object.values(profiles).map(clone); }
+
+  function buildSequencePlan(outcome, profileInput = {}) {
+    const profile = normalizeProfile(profileInput);
+    const success = outcome === true || normalizeId(outcome) === 'success' || normalizeId(outcome) === 'save_success';
+    const phases = ['capture_origin'];
+    if (profile.approach.enabled) phases.push('approach');
+    phases.push('release', 'projectile_from_actor');
+    if (success) phases.push('miss_to_ground');
+    else phases.push('hit_target', 'bounce_to_ground');
+    phases.push('roll', 'vanish');
+    if (profile.postActionSprite) phases.push('equip_post_action');
+    if (profile.returnToOrigin) phases.push('return_to_origin');
+    if (profile.resumeHover) phases.push('resume_hover');
+    return { outcome: success ? 'save_success' : 'save_failure', phases, profile };
+  }
+
+  function ensureStyle(doc = global.document) {
+    if (!doc?.head || doc.getElementById('luminous-thrown-projectile-sequence-style')) return false;
+    const style = doc.createElement('style');
+    style.id = 'luminous-thrown-projectile-sequence-style';
+    style.textContent = [
+      '.luminous-flying-hover{animation:luminousFlyingHover var(--luminous-hover-duration,1300ms) ease-in-out infinite alternate;}',
+      '@keyframes luminousFlyingHover{from{transform:translateY(calc(var(--luminous-hover-distance,7px) * -0.55));}to{transform:translateY(var(--luminous-hover-distance,7px));}}',
+      '.luminous-thrown-projectile{position:absolute;z-index:1800;pointer-events:none;object-fit:contain;transform-origin:center;}',
+      '.luminous-thrown-impact{position:absolute;z-index:1799;pointer-events:none;border-radius:50%;background:radial-gradient(ellipse,rgba(215,184,108,.65),rgba(215,184,108,.08) 55%,transparent 70%);opacity:0;}',
+      '.luminous-thrown-impact.active{animation:luminousThrownImpact .42s ease-out;}',
+      '@keyframes luminousThrownImpact{0%{opacity:0;transform:scale(.2)}25%{opacity:1}100%{opacity:0;transform:scale(1.7)}}'
+    ].join('');
+    doc.head.appendChild(style);
+    return true;
+  }
+
+  function elementPoint(stage, element, anchor = {}) {
+    const sr = stage.getBoundingClientRect();
+    const er = element.getBoundingClientRect();
+    return {
+      x: er.left - sr.left + er.width * numberOr(anchor.x, 0.5),
+      y: er.top - sr.top + er.height * numberOr(anchor.y, 0.5),
+    };
+  }
+
+  function resolveStage(options = {}) {
+    const doc = options.document || global.document;
+    return options.stage || doc?.getElementById?.('battlefield') || doc?.getElementById?.('game-container') || null;
+  }
+
+  function resolveActorElement(actorId, options = {}) {
+    const doc = options.document || global.document;
+    return options.actorElement || doc?.getElementById?.(`anchor-${actorId}`)?.closest?.('.sprite-container') || doc?.getElementById?.(`anchor-${actorId}`) || null;
+  }
+
+  function resolveActorSprite(actorId, actorElement, options = {}) {
+    const doc = options.document || global.document;
+    return options.actorSprite || doc?.getElementById?.(`anchor-${actorId}`)?.querySelector?.('.sprite-img') || actorElement?.querySelector?.('.sprite-img') || null;
+  }
+
+  function resolveTargetElement(targetId, options = {}) {
+    const doc = options.document || global.document;
+    return options.targetElement || doc?.getElementById?.(`anchor-${targetId}`)?.closest?.('.sprite-container') || doc?.getElementById?.(`anchor-${targetId}`) || null;
+  }
+
+  function setHover(element, enabled, profileInput = {}) {
+    if (!element?.classList) return false;
+    const profile = normalizeProfile(profileInput);
+    element.style?.setProperty?.('--luminous-hover-distance', `${profile.hover.distance}px`);
+    element.style?.setProperty?.('--luminous-hover-duration', `${profile.hover.duration}ms`);
+    element.classList.toggle('luminous-flying-hover', Boolean(enabled));
+    return true;
+  }
+
+  function createProjectile(stage, profile, doc) {
+    const img = doc.createElement('img');
+    img.className = 'luminous-thrown-projectile';
+    img.src = profile.projectileAsset;
+    img.alt = '';
+    img.style.width = `${profile.projectileSize}px`;
+    img.style.height = `${profile.projectileSize}px`;
+    stage.appendChild(img);
+    return img;
+  }
+
+  function createImpact(stage, doc) {
+    const impact = doc.createElement('div');
+    impact.className = 'luminous-thrown-impact';
+    impact.style.width = '110px';
+    impact.style.height = '42px';
+    stage.appendChild(impact);
+    return impact;
+  }
+
+  function place(element, point, width = 0, height = 0) {
+    element.style.left = `${point.x - width / 2}px`;
+    element.style.top = `${point.y - height / 2}px`;
+  }
+
+  async function animateFlight(projectile, from, to, options = {}) {
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+    const arc = numberOr(options.arc, 70);
+    const spin = numberOr(options.spin, 240);
+    const animation = projectile.animate([
+      { transform: 'translate(0px,0px) rotate(0deg) scale(.9)', offset: 0 },
+      { transform: `translate(${dx * .48}px,${dy * .42 - arc}px) rotate(${spin * .45}deg) scale(1)`, offset: .48 },
+      { transform: `translate(${dx}px,${dy}px) rotate(${spin}deg) scale(1.06)`, offset: 1 },
+    ], { duration: Math.max(1, Number(options.duration) || 1), easing: 'cubic-bezier(.32,.03,.68,.98)', fill: 'forwards' });
+    await animation.finished;
+  }
+
+  async function animateBounce(projectile, from, to, duration) {
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+    const animation = projectile.animate([
+      { transform: 'translate(0,0) rotate(0deg)', offset: 0 },
+      { transform: `translate(${dx * .5}px,${dy * .15 - 36}px) rotate(120deg)`, offset: .45 },
+      { transform: `translate(${dx}px,${dy}px) rotate(240deg)`, offset: 1 },
+    ], { duration: Math.max(1, Number(duration) || 1), easing: 'cubic-bezier(.25,.7,.45,1)', fill: 'forwards' });
+    await animation.finished;
+  }
+
+  async function animateRoll(projectile, profile) {
+    const animation = projectile.animate([
+      { transform: 'translate(0,0) rotate(0deg) scale(1)', opacity: 1 },
+      { transform: `translate(${profile.rollDistance * .72}px,4px) rotate(${profile.rollRotation * .72}deg) scale(.88)`, opacity: 1, offset: .72 },
+      { transform: `translate(${profile.rollDistance}px,6px) rotate(${profile.rollRotation}deg) scale(.78)`, opacity: 0 },
+    ], { duration: profile.timings.roll, easing: 'ease-out', fill: 'forwards' });
+    await animation.finished;
+  }
+
+  function flashImpact(impact, point) {
+    place(impact, point, 110, 42);
+    impact.classList.remove('active');
+    void impact.offsetWidth;
+    impact.classList.add('active');
+  }
+
+  function spriteFor(profile, key, options = {}) {
+    const override = options.sprites?.[key];
+    if (override) return override;
+    return profile[key] || null;
+  }
+
+  async function play(input = {}) {
+    const profile = normalizeProfile(input.profile || getProfile(input.skillId) || {});
+    if (!profile.projectileAsset) return { played: false, reason: 'projectile_asset_required' };
+    const doc = input.document || global.document;
+    const stage = resolveStage(input);
+    const actorId = String(input.actorId || input.actor?.id || input.actor?.unitId || '');
+    const targetId = String(input.targetId || input.target?.id || input.target?.unitId || '');
+    const actorElement = resolveActorElement(actorId, input);
+    const actorSprite = resolveActorSprite(actorId, actorElement, input);
+    const targetElement = resolveTargetElement(targetId, input);
+    if (!doc || !stage || !actorElement || !targetElement) return { played: false, reason: 'sequence_elements_missing' };
+    ensureStyle(doc);
+
+    const success = input.saveSuccess === true || normalizeId(input.outcome) === 'save_success' || normalizeId(input.outcome) === 'success';
+    const plan = buildSequencePlan(success, profile);
+    const projectile = createProjectile(stage, profile, doc);
+    const impact = createImpact(stage, doc);
+    const original = {
+      left: actorElement.style.left,
+      top: actorElement.style.top,
+      bottom: actorElement.style.bottom,
+      transform: actorElement.style.transform,
+      sprite: actorSprite?.getAttribute?.('src') || null,
+    };
+
+    try {
+      setHover(actorElement, false, profile);
+      if (profile.approach.enabled) {
+        actorElement.style.left = profile.approach.actorLeft;
+        actorElement.style.top = profile.approach.actorTop;
+        await sleep(profile.timings.approach);
+      }
+      await sleep(profile.timings.aim);
+
+      const from = elementPoint(stage, actorElement, profile.originAnchor);
+      place(projectile, from, profile.projectileSize, profile.projectileSize);
+      const releaseSprite = spriteFor(profile, 'releaseSprite', input);
+      if (actorSprite && releaseSprite) actorSprite.src = releaseSprite;
+      input.onRelease?.({ profile, actorElement, actorSprite, projectile });
+      await sleep(profile.timings.releaseHold);
+
+      const targetPoint = elementPoint(stage, targetElement, profile.targetAnchor);
+      const ground = elementPoint(stage, targetElement, profile.groundAnchor);
+      let rollOrigin = ground;
+
+      if (success) {
+        await animateFlight(projectile, from, ground, { duration: profile.timings.projectile, arc: profile.arc, spin: profile.spin });
+        flashImpact(impact, ground);
+      } else {
+        await animateFlight(projectile, from, targetPoint, { duration: profile.timings.hitProjectile, arc: profile.hitArc, spin: profile.hitSpin });
+        flashImpact(impact, targetPoint);
+        input.onHit?.({ profile, targetElement, targetPoint });
+        await sleep(profile.timings.impactPause);
+        rollOrigin = { x: ground.x + profile.groundOffsetOnHit.x, y: ground.y + profile.groundOffsetOnHit.y };
+        place(projectile, targetPoint, profile.projectileSize, profile.projectileSize);
+        await animateBounce(projectile, targetPoint, rollOrigin, profile.timings.bounce);
+        flashImpact(impact, rollOrigin);
+      }
+
+      input.onGround?.({ profile, point: rollOrigin });
+      await sleep(profile.timings.impactPause);
+      place(projectile, rollOrigin, profile.projectileSize, profile.projectileSize);
+      await animateRoll(projectile, profile);
+      projectile.remove();
+
+      const postSprite = spriteFor(profile, 'postActionSprite', input);
+      if (actorSprite && postSprite) actorSprite.src = postSprite;
+      await sleep(profile.timings.equip);
+
+      if (profile.returnToOrigin) {
+        actorElement.style.left = original.left;
+        actorElement.style.top = original.top;
+        actorElement.style.bottom = original.bottom;
+        actorElement.style.transform = original.transform;
+        await sleep(profile.timings.return);
+      }
+      if (profile.resumeHover) setHover(actorElement, true, profile);
+      input.onEnd?.({ profile, plan, actorElement, actorSprite });
+      return { played: true, outcome: plan.outcome, phases: plan.phases };
+    } finally {
+      projectile.remove?.();
+      impact.remove?.();
+    }
+  }
+
+  function saveOutcomeFromResult(result = {}, targetId) {
+    const rows = result?.resolution?.results || result?.results || [];
+    const row = rows.find((entry) => !targetId || String(entry?.targetId || '') === String(targetId)) || rows[0];
+    if (!row) return null;
+    return row?.result?.isSuccess === true;
+  }
+
+  function playForCombatResult(input = {}) {
+    const action = input.action || input.result?.action || {};
+    const skillId = input.skillId || action.source?.id || action.metadata?.sourceDefinition?.id;
+    const profile = input.profile || getProfile(skillId);
+    if (!profile) return Promise.resolve({ played: false, reason: 'sequence_profile_missing' });
+    const targetId = input.targetId || action.targeting?.mainTargetId || action.targeting?.targetIds?.[0];
+    const saveSuccess = input.saveSuccess ?? saveOutcomeFromResult(input.result || {}, targetId);
+    return play({ ...input, profile, skillId, actorId: input.actorId || action.actorId, targetId, saveSuccess });
+  }
+
+  const api = Object.freeze({
+    version: VERSION,
+    DEFAULT_TIMING,
+    normalizeProfile,
+    registerProfile,
+    getProfile,
+    listProfiles,
+    buildSequencePlan,
+    ensureStyle,
+    elementPoint,
+    setHover,
+    play,
+    playForCombatResult,
+    saveOutcomeFromResult,
+  });
+
+  global.LuminousThrownProjectileSequenceRuntime = api;
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/unit-catalog-goblin.js
+++ b/js/unit-catalog-goblin.js
@@ -1,0 +1,157 @@
+(function (global) {
+  'use strict';
+
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const safeRequire = (path) => {
+    if (typeof require !== 'function') return null;
+    try { return require(path); } catch (_) { return null; }
+  };
+
+  const rankRuntime = global.LuminousUnitRankRuntime || safeRequire('./unit-rank-runtime.js');
+  const rangedAmmo = global.LuminousUniversalRangedAmmoRuntime || safeRequire('./universal-ranged-ammo-runtime.js');
+  const goblinRuntime = global.LuminousGoblinUnitRuntime || safeRequire('./goblin-unit-runtime.js');
+
+  const STAGGER_THRESHOLDS = Object.freeze([75, 50, 25]);
+  const RACIAL_TRAIT_IDS = Object.freeze(['goblin_fury_of_small', 'goblin_nimble_escape']);
+  const GOBLIN_SCORES = Object.freeze({ str: 8, dex: 15, con: 10, int: 10, wis: 9, cha: 8 });
+  const GOBLIN_BOSS_SCORES = Object.freeze({ str: 10, dex: 16, con: 12, int: 11, wis: 10, cha: 12 });
+
+  const FALLBACK_RANKS = Object.freeze({
+    normal: Object.freeze({ id: 'normal', levelMultiplier: 1, minSpeedBonus: 0, maxSpeedBonus: 0, applyBonus: 0, basePowerBonus: 0, commandLevel: 0, aiCoordination: 'independent', targetPriority: 'random', turnEndSpRecovery: 0 }),
+    captain: Object.freeze({ id: 'captain', levelMultiplier: 2, minSpeedBonus: 0, maxSpeedBonus: 1, applyBonus: 1, basePowerBonus: 0, commandLevel: 1, aiCoordination: 'focus_fire', targetPriority: 'lowest_hp_ratio', turnEndSpRecovery: 5 }),
+    leader: Object.freeze({ id: 'leader', levelMultiplier: 3, minSpeedBonus: 1, maxSpeedBonus: 2, applyBonus: 2, basePowerBonus: 1, commandLevel: 2, aiCoordination: 'directed_focus', targetPriority: 'lowest_hp_ratio_then_highest_threat', turnEndSpRecovery: 10 }),
+  });
+  const UNIVERSAL_RANKS = rankRuntime?.RANKS || FALLBACK_RANKS;
+
+  function ammoTrait(ammoId, amount) {
+    if (rangedAmmo?.createAmmoTrait) return rangedAmmo.createAmmoTrait(ammoId, amount);
+    return { id: `ammo_${ammoId}`, name: `Ammo — ${ammoId}`, type: 'passive', description: `[On Encounter Start] Gain ${amount} ${ammoId}.`, mechanics: { ammoId, encounterStart: amount, statusMode: 'single', rangedSkillsOnly: true } };
+  }
+
+  const AMMO_ARROWS = Object.freeze(ammoTrait('arrows', 10));
+  const AMMO_JAVELIN = Object.freeze(ammoTrait('javelin', 6));
+  const MULTI_ATTACK = Object.freeze(clone(goblinRuntime?.MULTI_ATTACK || {
+    id: 'goblin_multi_attack', name: 'Multi Attack', type: 'passive',
+    description: 'Melee Skills with 2+ Coins reuse the last Coin 1 + floor(Level / 30) times. Melee Skills with 5+ Coins deal +5% Damage.',
+  }));
+  const REDIRECT_ATTACK = Object.freeze(clone(goblinRuntime?.REDIRECT_ATTACK || {
+    id: 'goblin_redirect_attack', name: 'Redirect Attack', type: 'passive',
+    description: '[Before Getting Hit] If another allied Goblin is on the Field, redirect the attack to that Ally Goblin. Once per Turn.',
+  }));
+
+  function racialTraits() { return RACIAL_TRAIT_IDS.map((id) => ({ id, source: 'racial_trait_catalog' })); }
+  function weaponRef(id, range, options = {}) {
+    return {
+      weaponId: id,
+      range,
+      skillRange: range === 'ranged' ? null : 1,
+      canonicalWeaponSkillPending: true,
+      ...(options.ammoType ? { ammoType: options.ammoType, ammoPerSkill: 1 } : {}),
+      ...(options.pierced ? { onHitStatusId: 'pierced', onHitStatusCount: null, onHitStatusCountPending: true } : {}),
+    };
+  }
+
+  const DEFINITIONS = Object.freeze({
+    goblin: Object.freeze({
+      id: 'goblin', name: 'Goblin', species: 'goblin', variant: 'standard', unitType: 'enemy', actorCategory: 'enemy', faction: 'enemy', isPlayer: false,
+      naturalWorldLevel: Object.freeze({ min: 2, max: 4 }), baseLevel: Object.freeze({ min: 2, max: 4 }),
+      scores: GOBLIN_SCORES,
+      hpBase: 7, hpCoefficient: 0.21,
+      size: 'goblin',
+      traitIds: Object.freeze([...RACIAL_TRAIT_IDS, AMMO_ARROWS.id]),
+      traits: Object.freeze([...racialTraits(), AMMO_ARROWS]),
+      allowedRanks: Object.freeze(['normal', 'captain', 'leader']),
+      rankProfiles: UNIVERSAL_RANKS,
+      staggerThresholds: STAGGER_THRESHOLDS,
+      visual: Object.freeze({ spriteUrl: '', spritePending: true }),
+      mechanics: Object.freeze({
+        hpModel: 'chassis_coefficient', hpBase: 7, hpCoefficient: 0.21,
+        ammoLoadout: Object.freeze([{ id: 'arrows', amount: 10 }]),
+        ammunition: Object.freeze({ arrows: Object.freeze({ type: 'single', icon: 'https://imgur.com/ivdNbBA.png' }) }),
+        weaponLoadout: Object.freeze([
+          Object.freeze(weaponRef('scimitar', 'melee')),
+          Object.freeze(weaponRef('shortbow', 'ranged', { ammoType: 'arrows', pierced: true })),
+        ]),
+        staggerThresholds: STAGGER_THRESHOLDS,
+      }),
+      metadata: Object.freeze({ canonicalUnit: true, catalog: 'goblin-batch', spritePending: true, weaponSkillsPendingCanonicalCatalog: true, physicalProfilePending: true, speedPending: true }),
+      schemaVersion: 2,
+    }),
+
+    goblin_boss: Object.freeze({
+      id: 'goblin_boss', name: 'Goblin Boss', species: 'goblin', variant: 'boss', unitType: 'enemy', actorCategory: 'enemy', faction: 'enemy', isPlayer: false,
+      naturalWorldLevel: Object.freeze({ min: 5, max: 5 }), baseLevel: Object.freeze({ min: 5, max: 5 }),
+      scores: GOBLIN_BOSS_SCORES,
+      hpBase: 21, hpCoefficient: 0.24,
+      size: 'goblin',
+      traitIds: Object.freeze([...RACIAL_TRAIT_IDS, AMMO_JAVELIN.id, MULTI_ATTACK.id, REDIRECT_ATTACK.id]),
+      traits: Object.freeze([...racialTraits(), AMMO_JAVELIN, MULTI_ATTACK, REDIRECT_ATTACK]),
+      allowedRanks: Object.freeze(['captain']),
+      rankProfiles: UNIVERSAL_RANKS,
+      staggerThresholds: STAGGER_THRESHOLDS,
+      visual: Object.freeze({ spriteUrl: '', spritePending: true }),
+      mechanics: Object.freeze({
+        hpModel: 'chassis_coefficient', hpBase: 21, hpCoefficient: 0.24,
+        ammoLoadout: Object.freeze([{ id: 'javelin', amount: 6 }]),
+        ammunition: Object.freeze({ javelin: Object.freeze({ type: 'single', icon: 'https://imgur.com/3wBN5qk.png' }) }),
+        weaponLoadout: Object.freeze([
+          Object.freeze(weaponRef('scimitar', 'melee')),
+          Object.freeze(weaponRef('javelin', 'ranged', { ammoType: 'javelin', pierced: true })),
+        ]),
+        multiAttack: MULTI_ATTACK.mechanics || null,
+        redirectAttack: REDIRECT_ATTACK.mechanics || null,
+        staggerThresholds: STAGGER_THRESHOLDS,
+      }),
+      metadata: Object.freeze({ canonicalUnit: true, catalog: 'goblin-batch', alwaysCaptain: true, spritePending: true, weaponSkillsPendingCanonicalCatalog: true, physicalProfilePending: true, speedPending: true }),
+      schemaVersion: 2,
+    }),
+  });
+
+  function get(id) { return DEFINITIONS[String(id || '')] ? clone(DEFINITIONS[String(id || '')]) : null; }
+  function list() { return Object.values(DEFINITIONS).map(clone); }
+  function normalizeRank(rank) {
+    const id = rankRuntime?.normalizeRank ? rankRuntime.normalizeRank(rank, '') : String(rank || 'normal').trim().toLowerCase();
+    if (!UNIVERSAL_RANKS[id]) throw new Error(`UNKNOWN_UNIT_RANK:${id}`);
+    return id;
+  }
+  function normalizeLevel(level) {
+    const value = Math.floor(Number(level));
+    if (!Number.isFinite(value) || value < 1) throw new Error(`UNIT_LEVEL_OUT_OF_RANGE:${level}`);
+    return value;
+  }
+  function resolve(id, options = {}) {
+    const unit = get(id);
+    if (!unit) throw new Error(`UNKNOWN_GOBLIN_UNIT:${id}`);
+    const level = normalizeLevel(options.level ?? options.baseLevel ?? unit.naturalWorldLevel.min);
+    const rank = normalizeRank(options.rank ?? unit.allowedRanks[0]);
+    if (!unit.allowedRanks.includes(rank)) throw new Error(`UNIT_RANK_NOT_ALLOWED:${id}:${rank}`);
+    const profile = UNIVERSAL_RANKS[rank];
+    const effectiveLevel = rankRuntime?.effectiveLevel ? rankRuntime.effectiveLevel(level, rank) : level * Number(profile.levelMultiplier || 1);
+    const maxHp = Math.floor(Number(unit.hpBase) + effectiveLevel * Number(unit.hpCoefficient));
+    unit.rank = rank;
+    unit.runtimeLevel = level;
+    unit.baseLevelSelected = level;
+    unit.effectiveLevel = effectiveLevel;
+    unit.rankBonuses = clone(profile);
+    unit.commandProfile = { commandLevel: profile.commandLevel, aiCoordination: profile.aiCoordination, targetPriority: profile.targetPriority, turnEndSpRecovery: profile.turnEndSpRecovery };
+    unit.hp = maxHp;
+    unit.maxHp = maxHp;
+    unit.mechanics = { ...unit.mechanics, hp: maxHp, maxHp, level: effectiveLevel, runtimeLevel: level, rank, commandLevel: profile.commandLevel, basePowerBonus: profile.basePowerBonus, statusApplyBonus: profile.applyBonus };
+    if (options.initializeEncounter === true) rangedAmmo?.onEncounterStart?.(unit);
+    return unit;
+  }
+
+  function firebasePayload() {
+    const payload = {};
+    list().forEach((unit) => { payload[unit.id] = unit; });
+    return payload;
+  }
+
+  const api = Object.freeze({
+    version: '1.0.0', STAGGER_THRESHOLDS, RACIAL_TRAIT_IDS, GOBLIN_SCORES, GOBLIN_BOSS_SCORES, UNIVERSAL_RANKS,
+    AMMO_ARROWS, AMMO_JAVELIN, MULTI_ATTACK, REDIRECT_ATTACK, DEFINITIONS, get, list, resolve, firebasePayload,
+  });
+
+  global.LuminousGoblinUnitCatalog = api;
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/unit-catalog-kobold-tier1.js
+++ b/js/unit-catalog-kobold-tier1.js
@@ -5,6 +5,7 @@
   const skillCatalog = global.LuminousKoboldTier1SkillCatalog || (typeof require !== 'undefined' ? (() => { try { return require('./skill-catalog-kobold-tier1.js'); } catch (_) { return null; } })() : null);
   const rankRuntime = global.LuminousUnitRankRuntime || (typeof require !== 'undefined' ? (() => { try { return require('./unit-rank-runtime.js'); } catch (_) { return null; } })() : null);
   const combatMechanics = global.LuminousUnitCombatMechanics || (typeof require !== 'undefined' ? (() => { try { return require('./unit-combat-mechanics-runtime.js'); } catch (_) { return null; } })() : null);
+  const rangedAmmo = global.LuminousUniversalRangedAmmoRuntime || (typeof require !== 'undefined' ? (() => { try { return require('./universal-ranged-ammo-runtime.js'); } catch (_) { return null; } })() : null);
 
   const STAGGER_THRESHOLDS = Object.freeze([75, 50, 25]);
   const SCORES = Object.freeze({ str: 7, dex: 15, con: 9, int: 8, wis: 7, cha: 8 });
@@ -17,6 +18,15 @@
     leader: Object.freeze({ id: 'leader', levelMultiplier: 3, minSpeedBonus: 1, maxSpeedBonus: 2, applyBonus: 2, basePowerBonus: 1, commandLevel: 2, aiCoordination: 'directed_focus', targetPriority: 'lowest_hp_ratio_then_highest_threat', turnEndSpRecovery: 10 }),
   });
   const UNIVERSAL_RANKS = rankRuntime?.RANKS || FALLBACK_RANKS;
+
+  function ammoTrait(ammoId, amount) {
+    if (rangedAmmo?.createAmmoTrait) return Object.freeze(rangedAmmo.createAmmoTrait(ammoId, amount));
+    const name = String(ammoId || '').replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+    return Object.freeze({ id: `ammo_${ammoId}`, name: `Ammo — ${name}`, type: 'passive', description: `[On Encounter Start] Gain ${amount} ${name}.`, mechanics: { ammoId, encounterStart: amount, statusMode: 'single', rangedSkillsOnly: true } });
+  }
+
+  const AMMO_PEBBLES = ammoTrait('pebbles', 6);
+  const AMMO_ROCK = ammoTrait('rock', 1);
 
   const AERIAL_HARRIER = Object.freeze({
     id: 'aerial_harrier', name: 'Aerial Harrier', type: 'passive',
@@ -66,16 +76,20 @@
 
   const DEFINITIONS = Object.freeze({
     kobold_dagger: Object.freeze(makeUnit({ id: 'kobold_dagger', name: 'Kobold · Dagger', variant: 'dagger', sprite: 'https://imgur.com/2BBvM2s.png', naturalWorldLevel: { min: 1, max: 3 }, hpBase: 5, hpCoefficient: 0.19, speed: '3-5', resist: 'perforante', weak: 'contundente', tags: ['tier1'], tier1: ['kobold_dagger_jab', 'kobold_desperate_stab', 'kobold_scurry'] })),
-    kobold_sling: Object.freeze(makeUnit({ id: 'kobold_sling', name: 'Kobold · Sling', variant: 'sling', sprite: 'https://imgur.com/ndB257N.png', naturalWorldLevel: { min: 1, max: 3 }, hpBase: 5, hpCoefficient: 0.19, speed: '2-4', resist: 'perforante', weak: 'contundente', tags: ['tier1'], tier1: ['kobold_sling_shot', 'kobold_rapid_pebble', 'kobold_duck_away'] })),
+    kobold_sling: Object.freeze(makeUnit({
+      id: 'kobold_sling', name: 'Kobold · Sling', variant: 'sling', sprite: 'https://imgur.com/ndB257N.png', naturalWorldLevel: { min: 1, max: 3 }, hpBase: 5, hpCoefficient: 0.19, speed: '2-4', resist: 'perforante', weak: 'contundente', tags: ['tier1', 'ranged'], traits: [AMMO_PEBBLES], tier1: ['kobold_sling_shot', 'kobold_rapid_pebble', 'kobold_duck_away'],
+      mechanics: { ammoLoadout: [{ id: 'pebbles', amount: 6 }], ammunition: { pebbles: { type: 'single', icon: 'https://imgur.com/hhYbwsi.png' } } },
+    })),
     winged_kobold: Object.freeze(makeUnit({
       id: 'winged_kobold', name: 'Winged Kobold', variant: 'winged', sprite: 'https://imgur.com/529fa4E.png',
       spriteVariants: { dagger: 'https://imgur.com/evsrs1B.png', holdingRock: 'https://imgur.com/529fa4E.png', withoutRock: 'https://imgur.com/zmA1FPz.png', rockAsset: 'https://imgur.com/P4J48yc.png' },
       naturalWorldLevel: { min: 2, max: 4 }, hpBase: 7, hpCoefficient: 0.22, speed: '3-5', speedBonus: { min: 0, max: 2 }, resist: 'cortante', weak: 'perforante',
-      tags: ['tier1', 'tier2', 'flying'], traits: [AERIAL_HARRIER], tier1: ['winged_kobold_falling_rock', 'winged_kobold_dagger'], tier2: ['winged_kobold_dive_stab'],
+      tags: ['tier1', 'tier2', 'flying'], traits: [AERIAL_HARRIER, AMMO_ROCK], tier1: ['winged_kobold_falling_rock', 'winged_kobold_dagger'], tier2: ['winged_kobold_dive_stab'],
       mechanics: {
         flying: true,
+        ammoLoadout: [{ id: 'rock', amount: 1 }],
         ammunition: { rock: { type: 'single', max: 1, icon: 'https://imgur.com/7rOv1S0.png', asset: 'https://imgur.com/P4J48yc.png' } },
-        unitLifecycle: { onEncounterStart: { grantAmmunition: [{ id: 'rock', amount: 1, max: 1 }] }, onComeback: { grantAmmunition: [{ id: 'rock', amount: 1, max: 1 }] } },
+        unitLifecycle: { onComeback: { grantAmmunition: [{ id: 'rock', amount: 1, max: 1 }] } },
         ai: { prefersRetreat: true, retreatAfter: 'harassment', fallingRockRequiresAmmo: 'rock' },
       },
     })),
@@ -146,7 +160,7 @@
   function firebasePayload() { const payload = {}; list().forEach((u) => { payload[u.id] = u; }); return payload; }
   function firebaseSkillPayload(schema) { if (!skillCatalog?.firebasePayload) throw new Error('KOBOLD_SKILL_CATALOG_REQUIRED'); return skillCatalog.firebasePayload(schema); }
 
-  const api = Object.freeze({ version: '2.0.1', STAGGER_THRESHOLDS, SCORES, PROFICIENCIES, PACK_TACTICS_ID, UNIVERSAL_RANKS, AERIAL_HARRIER, DRAGONHEART, DRAGON_RESISTANCE, SPELL_CASTER_CHARISMA, DEFINITIONS, list, get, resolve, resolveSkill, firebasePayload, firebaseSkillPayload });
+  const api = Object.freeze({ version: '2.1.0', STAGGER_THRESHOLDS, SCORES, PROFICIENCIES, PACK_TACTICS_ID, UNIVERSAL_RANKS, AMMO_PEBBLES, AMMO_ROCK, AERIAL_HARRIER, DRAGONHEART, DRAGON_RESISTANCE, SPELL_CASTER_CHARISMA, DEFINITIONS, list, get, resolve, resolveSkill, firebasePayload, firebaseSkillPayload });
   global.LuminousKoboldUnitCatalog = api;
   if (typeof module !== 'undefined' && module.exports) module.exports = api;
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/js/unit-catalog-kobold-tier1.js
+++ b/js/unit-catalog-kobold-tier1.js
@@ -6,23 +6,13 @@
     || (typeof require !== 'undefined' ? (() => { try { return require('./skill-catalog-kobold-tier1.js'); } catch (_) { return null; } })() : null);
   const rankRuntime = global.LuminousUnitRankRuntime
     || (typeof require !== 'undefined' ? (() => { try { return require('./unit-rank-runtime.js'); } catch (_) { return null; } })() : null);
+  const combatMechanics = global.LuminousUnitCombatMechanics
+    || (typeof require !== 'undefined' ? (() => { try { return require('./unit-combat-mechanics-runtime.js'); } catch (_) { return null; } })() : null);
 
-  const BASE_LEVEL = Object.freeze({ min: 1, max: 3 });
   const STAGGER_THRESHOLDS = Object.freeze([75, 50, 25]);
   const SCORES = Object.freeze({ str: 7, dex: 15, con: 9, int: 8, wis: 7, cha: 8 });
-  const PROFICIENCIES = Object.freeze({
-    savingThrows: Object.freeze({ dex: 'proficient' }),
-    skills: Object.freeze({ stealth: 'proficient' }),
-  });
-  const PACK_TACTICS = Object.freeze({
-    id: 'kobold_pack_tactics',
-    name: 'Pack Tactics',
-    type: 'passive',
-    clashPower: 1,
-    condition: 'target_also_attacked_by_kobold_ally_this_round',
-    runtimeHook: 'metadata_only',
-    description: 'When this Kobold attacks a target that is also being attacked by another Kobold ally during the round, gain +1 Clash Power.',
-  });
+  const PROFICIENCIES = Object.freeze({ savingThrows: Object.freeze({ dex: 'proficient' }), skills: Object.freeze({ stealth: 'proficient' }) });
+  const PACK_TACTICS_ID = 'pack_tactics';
 
   const FALLBACK_UNIVERSAL_RANKS = Object.freeze({
     normal: Object.freeze({ id: 'normal', levelMultiplier: 1, minSpeedBonus: 0, maxSpeedBonus: 0, applyBonus: 0, basePowerBonus: 0, commandLevel: 0, aiCoordination: 'independent', targetPriority: 'random', turnEndSpRecovery: 0 }),
@@ -31,104 +21,127 @@
   });
   const UNIVERSAL_RANKS = rankRuntime?.RANKS || FALLBACK_UNIVERSAL_RANKS;
 
-  // Durability belongs to the Kobold chassis. Command/speed/apply/power behavior belongs to the universal rank runtime.
-  const HP_RANKS = Object.freeze({
-    normal: Object.freeze({ hpBase: 24, hpCoefficient: 1.00, defLvlMod: 0 }),
-    captain: Object.freeze({ hpBase: 30, hpCoefficient: 1.25, defLvlMod: 0 }),
-    leader: Object.freeze({ hpBase: 36, hpCoefficient: 1.50, defLvlMod: 0 }),
+  const AERIAL_HARRIER = Object.freeze({
+    id: 'aerial_harrier',
+    name: 'Aerial Harrier',
+    type: 'passive',
+    description: 'This unit is a Flying Unit. [On Encounter Start] Gain 1 Rock. [On Comeback] Gain 1 Rock. If this unit has Rock, it may use Falling Rock. This unit prefers Retreat after harassment patterns.',
+    mechanics: Object.freeze({ flying: true, ammunition: 'rock', preferredRetreatPattern: 'after_harassment' }),
   });
 
-  const RANKS = Object.freeze(Object.fromEntries(
-    Object.keys(HP_RANKS).map((rankId) => [rankId, Object.freeze({ ...UNIVERSAL_RANKS[rankId], ...HP_RANKS[rankId] })])
-  ));
+  const DRAGONHEART = Object.freeze({
+    id: 'dragonheart',
+    name: 'Draggonheart',
+    type: 'passive',
+    description: 'Gain +5 Final Power on Saves against Frightened and Paralyzed. While deployed, on Turn Start all Kobold allies gain +1 Clash Power Up.',
+    mechanics: Object.freeze({ saveFinalPowerBonus: 5, saveConditions: ['frightened', 'paralyzed'], turnStartKoboldAllyClashPowerUp: 1 }),
+  });
 
-  function baseUnit({ id, name, variant, sprite, speed, skills }) {
+  const DRAGON_RESISTANCE = Object.freeze({
+    id: 'dragon_resistance',
+    name: 'Dragon Resistance',
+    type: 'passive',
+    description: 'On Encounter Start gain Resist on a random Sin Type and the Status Effect associated with the selected element.',
+    mechanics: Object.freeze({ trigger: 'on_encounter_start', randomSinResistance: true, linkedElementStatusResistance: true }),
+  });
+
+  const SPELL_CASTER_CHARISMA = Object.freeze({
+    id: 'spell_caster_charisma',
+    name: 'Spell Caster — Charisma',
+    type: 'passive',
+    description: 'Uses Charisma as Spell Casting Mod. Spell Save Threshold = 10 + CHA Mod.',
+    mechanics: Object.freeze({ spellcastingAbility: 'charisma', spellSaveBase: 10 }),
+  });
+
+  function visual(sprite, variants) {
     return {
-      id,
-      name,
-      species: 'kobold',
-      variant,
-      unitType: 'enemy',
-      faction: 'enemy',
-      actorCategory: 'enemy',
-      isPlayer: false,
-      linkedPlayerUID: '',
-      tags: ['canonical', 'kobold', 'enemy', 'tier1'],
-      icono: sprite,
-      visual: {
-        spriteUrl: sprite,
-        idle_sprite: sprite,
-        moving_sprite: '',
-        guard_sprite: '',
-        evade_sprite: '',
-        hurt_sprite: '',
-        dead_sprite: '',
-        scale: 1,
-        spriteX: 0,
-        spriteY: 0,
-        uiX: 0,
-        uiY: 0,
-        isFocused: false,
-      },
-      baseLevel: clone(BASE_LEVEL),
-      scores: clone(SCORES),
-      proficiencies: clone(PROFICIENCIES),
-      traitIds: [PACK_TACTICS.id],
-      traits: [clone(PACK_TACTICS)],
-      staggerThresholds: clone(STAGGER_THRESHOLDS),
-      rankProfiles: clone(RANKS),
-      action_slots: skills.slice(),
-      attack_tier_1_sequence: skills.filter((skillId) => !skillId.includes('scurry') && !skillId.includes('duck_away')),
-      attack_tier_2_sequence: [],
-      attack_tier_3_sequence: [],
+      spriteUrl: sprite, idle_sprite: sprite, moving_sprite: '', guard_sprite: '', evade_sprite: '', hurt_sprite: '', dead_sprite: '',
+      scale: 1, spriteX: 0, spriteY: 0, uiX: 0, uiY: 0, isFocused: false,
+      variants: clone(variants || {}),
+    };
+  }
+
+  function baseUnit({ id, name, variant, sprite, spriteVariants, level, hpBase, hpCoefficient, speed, speedBonus, defLvlMod = 0, skills, tier2 = [], tier3 = [], traits = [], allowedRanks = ['normal', 'captain', 'leader'], resist, weak, tags = [], mechanics = {} }) {
+    const traitIds = [PACK_TACTICS_ID, ...traits.map((trait) => trait.id)];
+    return {
+      id, name, species: 'kobold', variant, unitType: 'enemy', faction: 'enemy', actorCategory: 'enemy', isPlayer: false, linkedPlayerUID: '',
+      tags: ['canonical', 'kobold', 'enemy', ...tags], icono: sprite, visual: visual(sprite, spriteVariants),
+      baseLevel: clone(level), scores: clone(SCORES), proficiencies: clone(PROFICIENCIES), size: 'kobold',
+      traitIds, traits: [{ id: PACK_TACTICS_ID, source: 'racial_trait_catalog' }, ...traits.map(clone)],
+      staggerThresholds: clone(STAGGER_THRESHOLDS), rankProfiles: clone(UNIVERSAL_RANKS), allowedRanks: allowedRanks.slice(),
+      action_slots: skills.slice(), attack_tier_1_sequence: skills.filter((id) => !id.startsWith('spell:')),
+      attack_tier_2_sequence: tier2.slice(), attack_tier_3_sequence: tier3.slice(),
+      damageTypeDefense: { resist, weak },
       mechanics: {
-        hpModel: 'coefficient',
-        sp: 0,
-        speed,
-        actionSlots: 1,
-        maxSlotsLimit: 1,
-        skills: skills.slice(),
-        staggerThresholds: clone(STAGGER_THRESHOLDS),
-        stagger: '75%,50%,25%',
+        hpModel: 'chassis_coefficient', hpBase, hpCoefficient, defLvlMod, sp: 0, speed,
+        speedBonus: clone(speedBonus || { min: 0, max: 0 }), actionSlots: 1, maxSlotsLimit: 1,
+        skills: [...skills, ...tier2, ...tier3], staggerThresholds: clone(STAGGER_THRESHOLDS), stagger: '75%,50%,25%',
+        damageTypeDefense: { resist, weak }, ...clone(mechanics),
       },
-      schemaVersion: 1,
-      metadata: {
-        canonicalUnit: true,
-        catalog: 'kobold-tier1',
-        rankModel: 'universal_normal_captain_leader',
-        hpModel: 'rank_coefficient',
-      },
+      schemaVersion: 2,
+      metadata: { canonicalUnit: true, catalog: 'kobold-batch', rankModel: 'universal_normal_captain_leader', hpModel: 'chassis_coefficient' },
     };
   }
 
   const DEFINITIONS = Object.freeze({
     kobold_dagger: Object.freeze(baseUnit({
-      id: 'kobold_dagger',
-      name: 'Kobold · Dagger',
-      variant: 'dagger',
-      sprite: 'https://imgur.com/2BBvM2s.png',
-      speed: '3-5',
+      id: 'kobold_dagger', name: 'Kobold · Dagger', variant: 'dagger', sprite: 'https://imgur.com/2BBvM2s.png',
+      level: { min: 1, max: 3 }, hpBase: 5, hpCoefficient: 0.19, speed: '3-5', resist: 'perforante', weak: 'contundente', tags: ['tier1'],
       skills: ['kobold_dagger_jab', 'kobold_desperate_stab', 'kobold_scurry'],
     })),
     kobold_sling: Object.freeze(baseUnit({
-      id: 'kobold_sling',
-      name: 'Kobold · Sling',
-      variant: 'sling',
-      sprite: 'https://imgur.com/ndB257N.png',
-      speed: '2-4',
+      id: 'kobold_sling', name: 'Kobold · Sling', variant: 'sling', sprite: 'https://imgur.com/ndB257N.png',
+      level: { min: 1, max: 3 }, hpBase: 5, hpCoefficient: 0.19, speed: '2-4', resist: 'perforante', weak: 'contundente', tags: ['tier1'],
       skills: ['kobold_sling_shot', 'kobold_rapid_pebble', 'kobold_duck_away'],
+    })),
+    winged_kobold: Object.freeze(baseUnit({
+      id: 'winged_kobold', name: 'Winged Kobold', variant: 'winged', sprite: 'https://imgur.com/529fa4E.png',
+      spriteVariants: { dagger: 'https://imgur.com/evsrs1B.png', holdingRock: 'https://imgur.com/529fa4E.png', withoutRock: 'https://imgur.com/zmA1FPz.png', rockAsset: 'https://imgur.com/P4J48yc.png' },
+      level: { min: 2, max: 4 }, hpBase: 7, hpCoefficient: 0.22, speed: '3-5', speedBonus: { min: 0, max: 2 },
+      resist: 'cortante', weak: 'perforante', tags: ['tier1', 'tier2', 'flying'], traits: [AERIAL_HARRIER],
+      skills: ['winged_kobold_falling_rock', 'winged_kobold_dagger'], tier2: ['winged_kobold_dive_stab'],
+      mechanics: {
+        flying: true,
+        ammunition: { rock: { type: 'single', max: 1, icon: 'https://imgur.com/7rOv1S0.png', asset: 'https://imgur.com/P4J48yc.png' } },
+        unitLifecycle: {
+          onEncounterStart: { grantAmmunition: [{ id: 'rock', amount: 1, max: 1 }] },
+          onComeback: { grantAmmunition: [{ id: 'rock', amount: 1, max: 1 }] },
+        },
+        ai: { prefersRetreat: true, retreatAfter: 'harassment', fallingRockRequiresAmmo: 'rock' },
+      },
+    })),
+    dragonheart_kobold: Object.freeze(baseUnit({
+      id: 'dragonheart_kobold', name: 'Dragonheart Kobold', variant: 'dragonheart', sprite: 'https://imgur.com/4EYu3us.png',
+      level: { min: 5, max: 9 }, hpBase: 44, hpCoefficient: 0.30, speed: '2-4', defLvlMod: 3,
+      resist: 'cortante', weak: 'contundente', tags: ['tier1', 'tier2', 'tier3', 'commander'], traits: [DRAGONHEART, DRAGON_RESISTANCE],
+      allowedRanks: ['captain', 'leader'], skills: ['dragonheart_spear_thrust'], tier2: ['dragonheart_guarding_skewer'], tier3: ['dragonheart_dragon_spear'],
+    })),
+    scale_sorcerer_kobold: Object.freeze(baseUnit({
+      id: 'scale_sorcerer_kobold', name: 'Scale Sorcerer Kobold', variant: 'scale_sorcerer', sprite: 'https://imgur.com/TOHr6Dk.png',
+      level: { min: 5, max: 9 }, hpBase: 27, hpCoefficient: 0.25, speed: '2-4', defLvlMod: 3,
+      resist: 'perforante', weak: 'cortante', tags: ['spellcaster', 'commander'], traits: [SPELL_CASTER_CHARISMA], allowedRanks: ['captain', 'leader'],
+      skills: ['kobold_dagger_jab', 'spell:fire_bolt', 'spell:poison_spray', 'spell:charm_person', 'spell:chromatic_orb', 'spell:expeditious_retreat', 'spell:scorching_ray'],
+      mechanics: {
+        spellcasting: { ability: 'charisma', saveThresholdFormula: '10 + CHA_MOD', spellSlots: { 1: 4, 2: 2 } },
+        sorceryPoints: { encounterStart: 3, runtime: 'sorcerer_class_runtime', metamagic: ['subtle_spell', 'heightened_spell'] },
+        spellReferencesPendingCanonicalCatalog: true,
+      },
     })),
   });
 
+  function get(id) { return DEFINITIONS[String(id || '')] ? clone(DEFINITIONS[String(id || '')]) : null; }
+  function list() { return Object.values(DEFINITIONS).map(clone); }
+
   function normalizeRank(rank) {
     const id = rankRuntime?.normalizeRank ? rankRuntime.normalizeRank(rank, '') : String(rank || 'normal').trim().toLowerCase();
-    if (!RANKS[id]) throw new Error(`UNKNOWN_UNIT_RANK:${id}`);
+    if (!UNIVERSAL_RANKS[id]) throw new Error(`UNKNOWN_UNIT_RANK:${id}`);
     return id;
   }
 
-  function normalizeBaseLevel(level) {
+  function normalizeBaseLevel(unit, level) {
     const value = Math.floor(Number(level));
-    if (!Number.isFinite(value) || value < BASE_LEVEL.min || value > BASE_LEVEL.max) throw new Error(`BASE_LEVEL_OUT_OF_RANGE:${level}`);
+    const range = unit.baseLevel || { min: 1, max: 1 };
+    if (!Number.isFinite(value) || value < range.min || value > range.max) throw new Error(`BASE_LEVEL_OUT_OF_RANGE:${level}`);
     return value;
   }
 
@@ -138,18 +151,17 @@
     return { min: Number(match[1]), max: Number(match[2]) };
   }
 
-  function get(id) { return DEFINITIONS[String(id || '')] ? clone(DEFINITIONS[String(id || '')]) : null; }
-  function list() { return Object.values(DEFINITIONS).map(clone); }
-
   function resolveSkill(skillId, rank) {
+    const id = String(skillId || '');
+    if (id.startsWith('spell:')) return { id: id.slice(6), sourceType: 'spell', canonicalReference: true, pendingSpellCatalogResolution: true };
     if (!skillCatalog?.get) throw new Error('KOBOLD_SKILL_CATALOG_REQUIRED');
-    const skill = skillCatalog.get(skillId);
-    if (!skill) throw new Error(`UNKNOWN_KOBOLD_SKILL:${skillId}`);
+    const skill = skillCatalog.get(id);
+    if (!skill) throw new Error(`UNKNOWN_KOBOLD_SKILL:${id}`);
     const rankId = normalizeRank(rank);
-    const profile = RANKS[rankId];
-    skill.basePower += profile.basePowerBonus;
+    const profile = UNIVERSAL_RANKS[rankId];
+    skill.basePower += Number(profile.basePowerBonus || 0);
     const applyCountBonus = (effects) => (effects || []).forEach((effect) => {
-      if (effect?.type === 'status' && Number(effect.count) > 0) effect.count = Number(effect.count) + profile.applyBonus;
+      if (effect?.type === 'status' && Number(effect.count) > 0) effect.count = Number(effect.count) + Number(profile.applyBonus || 0);
     });
     applyCountBonus(skill.effects);
     (skill.coins || []).forEach((coinData) => applyCountBonus(coinData.effects));
@@ -161,63 +173,43 @@
     const unit = get(id);
     if (!unit) throw new Error(`UNKNOWN_KOBOLD_UNIT:${id}`);
     const opts = options || {};
-    const baseLevel = normalizeBaseLevel(opts.baseLevel ?? 1);
-    const rank = normalizeRank(opts.rank ?? 'normal');
-    const profile = RANKS[rank];
-    const effectiveLevel = rankRuntime?.effectiveLevel ? rankRuntime.effectiveLevel(baseLevel, rank) : baseLevel * profile.levelMultiplier;
-    const maxHp = Math.floor(profile.hpBase + (effectiveLevel + profile.defLvlMod) * profile.hpCoefficient);
-    const baseSpeed = parseSpeed(unit.mechanics.speed);
-    const minSpeed = baseSpeed.min + profile.minSpeedBonus;
-    const maxSpeed = baseSpeed.max + profile.maxSpeedBonus;
-    const resolvedSkills = unit.action_slots.map((skillId) => resolveSkill(skillId, rank));
+    const baseLevel = normalizeBaseLevel(unit, opts.baseLevel ?? unit.baseLevel.min);
+    const rank = normalizeRank(opts.rank ?? unit.allowedRanks[0] ?? 'normal');
+    if (!unit.allowedRanks.includes(rank)) throw new Error(`UNIT_RANK_NOT_ALLOWED:${id}:${rank}`);
+    const profile = UNIVERSAL_RANKS[rank];
+    const effectiveLevel = rankRuntime?.effectiveLevel ? rankRuntime.effectiveLevel(baseLevel, rank) : baseLevel * Number(profile.levelMultiplier || 1);
+    const chassis = unit.mechanics;
+    const maxHp = Math.floor(Number(chassis.hpBase || 0) + effectiveLevel * Number(chassis.hpCoefficient || 0));
+    const defensiveLevel = effectiveLevel + Number(chassis.defLvlMod || 0);
+    const baseSpeed = parseSpeed(chassis.speed);
+    const chassisSpeedBonus = chassis.speedBonus || { min: 0, max: 0 };
+    const minSpeed = baseSpeed.min + Number(chassisSpeedBonus.min || 0) + Number(profile.minSpeedBonus || 0);
+    const maxSpeed = baseSpeed.max + Number(chassisSpeedBonus.max || 0) + Number(profile.maxSpeedBonus || 0);
+    const resolvedSkills = chassis.skills.map((skillId) => resolveSkill(skillId, rank));
 
     unit.rank = rank;
     unit.baseLevelSelected = baseLevel;
     unit.effectiveLevel = effectiveLevel;
+    unit.defensiveLevel = defensiveLevel;
     unit.rankBonuses = clone(profile);
-    unit.commandProfile = {
-      commandLevel: profile.commandLevel,
-      aiCoordination: profile.aiCoordination,
-      targetPriority: profile.targetPriority,
-      turnEndSpRecovery: profile.turnEndSpRecovery,
-    };
+    unit.commandProfile = { commandLevel: profile.commandLevel, aiCoordination: profile.aiCoordination, targetPriority: profile.targetPriority, turnEndSpRecovery: profile.turnEndSpRecovery };
     unit.resolvedSkills = resolvedSkills;
     unit.mechanics = {
-      ...unit.mechanics,
-      hp: maxHp,
-      maxHp,
-      level: effectiveLevel,
-      baseLevel,
-      rank,
-      hpBase: profile.hpBase,
-      hpCoefficient: profile.hpCoefficient,
-      defLvlMod: profile.defLvlMod,
-      speed: `${minSpeed}-${maxSpeed}`,
-      minSpeed,
-      maxSpeed,
-      statusApplyBonus: profile.applyBonus,
-      basePowerBonus: profile.basePowerBonus,
-      commandLevel: profile.commandLevel,
-      aiCoordination: profile.aiCoordination,
+      ...unit.mechanics, hp: maxHp, maxHp, level: effectiveLevel, defensiveLevel, baseLevel, rank,
+      minSpeed, maxSpeed, speed: `${minSpeed}-${maxSpeed}`, statusApplyBonus: profile.applyBonus,
+      basePowerBonus: profile.basePowerBonus, commandLevel: profile.commandLevel, aiCoordination: profile.aiCoordination,
       turnEndSpRecovery: profile.turnEndSpRecovery,
     };
+    if (combatMechanics?.onEncounterStart && opts.initializeEncounter === true) combatMechanics.onEncounterStart(unit);
     return unit;
   }
 
-  function firebasePayload() {
-    const payload = {};
-    list().forEach((unit) => { payload[unit.id] = unit; });
-    return payload;
-  }
-
-  function firebaseSkillPayload(schema) {
-    if (!skillCatalog?.firebasePayload) throw new Error('KOBOLD_SKILL_CATALOG_REQUIRED');
-    return skillCatalog.firebasePayload(schema);
-  }
+  function firebasePayload() { const payload = {}; list().forEach((unit) => { payload[unit.id] = unit; }); return payload; }
+  function firebaseSkillPayload(schema) { if (!skillCatalog?.firebasePayload) throw new Error('KOBOLD_SKILL_CATALOG_REQUIRED'); return skillCatalog.firebasePayload(schema); }
 
   const api = Object.freeze({
-    version: '1.1.0', BASE_LEVEL, STAGGER_THRESHOLDS, SCORES, PROFICIENCIES, PACK_TACTICS,
-    UNIVERSAL_RANKS, HP_RANKS, RANKS, DEFINITIONS,
+    version: '2.0.0', STAGGER_THRESHOLDS, SCORES, PROFICIENCIES, PACK_TACTICS_ID, UNIVERSAL_RANKS,
+    AERIAL_HARRIER, DRAGONHEART, DRAGON_RESISTANCE, SPELL_CASTER_CHARISMA, DEFINITIONS,
     list, get, resolve, resolveSkill, firebasePayload, firebaseSkillPayload,
   });
   global.LuminousKoboldUnitCatalog = api;

--- a/js/unit-catalog-kobold-tier1.js
+++ b/js/unit-catalog-kobold-tier1.js
@@ -1,217 +1,152 @@
 (function (global) {
   'use strict';
 
-  const clone = (value) => JSON.parse(JSON.stringify(value));
-  const skillCatalog = global.LuminousKoboldTier1SkillCatalog
-    || (typeof require !== 'undefined' ? (() => { try { return require('./skill-catalog-kobold-tier1.js'); } catch (_) { return null; } })() : null);
-  const rankRuntime = global.LuminousUnitRankRuntime
-    || (typeof require !== 'undefined' ? (() => { try { return require('./unit-rank-runtime.js'); } catch (_) { return null; } })() : null);
-  const combatMechanics = global.LuminousUnitCombatMechanics
-    || (typeof require !== 'undefined' ? (() => { try { return require('./unit-combat-mechanics-runtime.js'); } catch (_) { return null; } })() : null);
+  const clone = (v) => JSON.parse(JSON.stringify(v));
+  const skillCatalog = global.LuminousKoboldTier1SkillCatalog || (typeof require !== 'undefined' ? (() => { try { return require('./skill-catalog-kobold-tier1.js'); } catch (_) { return null; } })() : null);
+  const rankRuntime = global.LuminousUnitRankRuntime || (typeof require !== 'undefined' ? (() => { try { return require('./unit-rank-runtime.js'); } catch (_) { return null; } })() : null);
+  const combatMechanics = global.LuminousUnitCombatMechanics || (typeof require !== 'undefined' ? (() => { try { return require('./unit-combat-mechanics-runtime.js'); } catch (_) { return null; } })() : null);
 
   const STAGGER_THRESHOLDS = Object.freeze([75, 50, 25]);
   const SCORES = Object.freeze({ str: 7, dex: 15, con: 9, int: 8, wis: 7, cha: 8 });
   const PROFICIENCIES = Object.freeze({ savingThrows: Object.freeze({ dex: 'proficient' }), skills: Object.freeze({ stealth: 'proficient' }) });
   const PACK_TACTICS_ID = 'pack_tactics';
 
-  const FALLBACK_UNIVERSAL_RANKS = Object.freeze({
+  const FALLBACK_RANKS = Object.freeze({
     normal: Object.freeze({ id: 'normal', levelMultiplier: 1, minSpeedBonus: 0, maxSpeedBonus: 0, applyBonus: 0, basePowerBonus: 0, commandLevel: 0, aiCoordination: 'independent', targetPriority: 'random', turnEndSpRecovery: 0 }),
     captain: Object.freeze({ id: 'captain', levelMultiplier: 2, minSpeedBonus: 0, maxSpeedBonus: 1, applyBonus: 1, basePowerBonus: 0, commandLevel: 1, aiCoordination: 'focus_fire', targetPriority: 'lowest_hp_ratio', turnEndSpRecovery: 5 }),
     leader: Object.freeze({ id: 'leader', levelMultiplier: 3, minSpeedBonus: 1, maxSpeedBonus: 2, applyBonus: 2, basePowerBonus: 1, commandLevel: 2, aiCoordination: 'directed_focus', targetPriority: 'lowest_hp_ratio_then_highest_threat', turnEndSpRecovery: 10 }),
   });
-  const UNIVERSAL_RANKS = rankRuntime?.RANKS || FALLBACK_UNIVERSAL_RANKS;
+  const UNIVERSAL_RANKS = rankRuntime?.RANKS || FALLBACK_RANKS;
 
   const AERIAL_HARRIER = Object.freeze({
-    id: 'aerial_harrier',
-    name: 'Aerial Harrier',
-    type: 'passive',
+    id: 'aerial_harrier', name: 'Aerial Harrier', type: 'passive',
     description: 'This unit is a Flying Unit. [On Encounter Start] Gain 1 Rock. [On Comeback] Gain 1 Rock. If this unit has Rock, it may use Falling Rock. This unit prefers Retreat after harassment patterns.',
     mechanics: Object.freeze({ flying: true, ammunition: 'rock', preferredRetreatPattern: 'after_harassment' }),
   });
-
   const DRAGONHEART = Object.freeze({
-    id: 'dragonheart',
-    name: 'Draggonheart',
-    type: 'passive',
+    id: 'dragonheart', name: 'Draggonheart', type: 'passive',
     description: 'Gain +5 Final Power on Saves against Frightened and Paralyzed. While deployed, on Turn Start all Kobold allies gain +1 Clash Power Up.',
     mechanics: Object.freeze({ saveFinalPowerBonus: 5, saveConditions: ['frightened', 'paralyzed'], turnStartKoboldAllyClashPowerUp: 1 }),
   });
-
   const DRAGON_RESISTANCE = Object.freeze({
-    id: 'dragon_resistance',
-    name: 'Dragon Resistance',
-    type: 'passive',
+    id: 'dragon_resistance', name: 'Dragon Resistance', type: 'passive',
     description: 'On Encounter Start gain Resist on a random Sin Type and the Status Effect associated with the selected element.',
     mechanics: Object.freeze({ trigger: 'on_encounter_start', randomSinResistance: true, linkedElementStatusResistance: true }),
   });
-
   const SPELL_CASTER_CHARISMA = Object.freeze({
-    id: 'spell_caster_charisma',
-    name: 'Spell Caster — Charisma',
-    type: 'passive',
+    id: 'spell_caster_charisma', name: 'Spell Caster — Charisma', type: 'passive',
     description: 'Uses Charisma as Spell Casting Mod. Spell Save Threshold = 10 + CHA Mod.',
     mechanics: Object.freeze({ spellcastingAbility: 'charisma', spellSaveBase: 10 }),
   });
 
   function visual(sprite, variants) {
-    return {
-      spriteUrl: sprite, idle_sprite: sprite, moving_sprite: '', guard_sprite: '', evade_sprite: '', hurt_sprite: '', dead_sprite: '',
-      scale: 1, spriteX: 0, spriteY: 0, uiX: 0, uiY: 0, isFocused: false,
-      variants: clone(variants || {}),
-    };
+    return { spriteUrl: sprite, idle_sprite: sprite, moving_sprite: '', guard_sprite: '', evade_sprite: '', hurt_sprite: '', dead_sprite: '', scale: 1, spriteX: 0, spriteY: 0, uiX: 0, uiY: 0, isFocused: false, variants: clone(variants || {}) };
   }
 
-  function baseUnit({ id, name, variant, sprite, spriteVariants, level, hpBase, hpCoefficient, speed, speedBonus, defLvlMod = 0, skills, tier2 = [], tier3 = [], traits = [], allowedRanks = ['normal', 'captain', 'leader'], resist, weak, tags = [], mechanics = {} }) {
-    const traitIds = [PACK_TACTICS_ID, ...traits.map((trait) => trait.id)];
+  function makeUnit(cfg) {
+    const traitIds = [PACK_TACTICS_ID, ...(cfg.traits || []).map((t) => t.id)];
+    const allSkills = [...cfg.tier1, ...(cfg.tier2 || []), ...(cfg.tier3 || [])];
     return {
-      id, name, species: 'kobold', variant, unitType: 'enemy', faction: 'enemy', actorCategory: 'enemy', isPlayer: false, linkedPlayerUID: '',
-      tags: ['canonical', 'kobold', 'enemy', ...tags], icono: sprite, visual: visual(sprite, spriteVariants),
-      baseLevel: clone(level), scores: clone(SCORES), proficiencies: clone(PROFICIENCIES), size: 'kobold',
-      traitIds, traits: [{ id: PACK_TACTICS_ID, source: 'racial_trait_catalog' }, ...traits.map(clone)],
-      staggerThresholds: clone(STAGGER_THRESHOLDS), rankProfiles: clone(UNIVERSAL_RANKS), allowedRanks: allowedRanks.slice(),
-      action_slots: skills.slice(), attack_tier_1_sequence: skills.filter((id) => !id.startsWith('spell:')),
-      attack_tier_2_sequence: tier2.slice(), attack_tier_3_sequence: tier3.slice(),
-      damageTypeDefense: { resist, weak },
+      id: cfg.id, name: cfg.name, species: 'kobold', variant: cfg.variant, unitType: 'enemy', faction: 'enemy', actorCategory: 'enemy', isPlayer: false, linkedPlayerUID: '',
+      tags: ['canonical', 'kobold', 'enemy', ...(cfg.tags || [])], icono: cfg.sprite, visual: visual(cfg.sprite, cfg.spriteVariants),
+      naturalWorldLevel: clone(cfg.naturalWorldLevel), baseLevel: clone(cfg.naturalWorldLevel), scores: clone(SCORES), proficiencies: clone(PROFICIENCIES), size: 'kobold',
+      traitIds, traits: [{ id: PACK_TACTICS_ID, source: 'racial_trait_catalog' }, ...(cfg.traits || []).map(clone)],
+      staggerThresholds: clone(STAGGER_THRESHOLDS), rankProfiles: clone(UNIVERSAL_RANKS), allowedRanks: (cfg.allowedRanks || ['normal', 'captain', 'leader']).slice(),
+      action_slots: allSkills.slice(), attack_tier_1_sequence: cfg.tier1.filter((id) => !id.startsWith('spell:')), attack_tier_2_sequence: (cfg.tier2 || []).slice(), attack_tier_3_sequence: (cfg.tier3 || []).slice(),
+      damageTypeDefense: { resist: cfg.resist, weak: cfg.weak },
       mechanics: {
-        hpModel: 'chassis_coefficient', hpBase, hpCoefficient, defLvlMod, sp: 0, speed,
-        speedBonus: clone(speedBonus || { min: 0, max: 0 }), actionSlots: 1, maxSlotsLimit: 1,
-        skills: [...skills, ...tier2, ...tier3], staggerThresholds: clone(STAGGER_THRESHOLDS), stagger: '75%,50%,25%',
-        damageTypeDefense: { resist, weak }, ...clone(mechanics),
+        hpModel: 'chassis_coefficient', hpBase: cfg.hpBase, hpCoefficient: cfg.hpCoefficient, defLvlMod: cfg.defLvlMod || 0, sp: 0,
+        speed: cfg.speed, speedBonus: clone(cfg.speedBonus || { min: 0, max: 0 }), actionSlots: 1, maxSlotsLimit: 1, skills: allSkills.slice(),
+        staggerThresholds: clone(STAGGER_THRESHOLDS), stagger: '75%,50%,25%', damageTypeDefense: { resist: cfg.resist, weak: cfg.weak }, ...(clone(cfg.mechanics || {})),
       },
       schemaVersion: 2,
-      metadata: { canonicalUnit: true, catalog: 'kobold-batch', rankModel: 'universal_normal_captain_leader', hpModel: 'chassis_coefficient' },
+      metadata: { canonicalUnit: true, catalog: 'kobold-batch', rankModel: 'universal_normal_captain_leader', hpModel: 'chassis_coefficient', naturalWorldLevelIsReferenceOnly: true },
     };
   }
 
   const DEFINITIONS = Object.freeze({
-    kobold_dagger: Object.freeze(baseUnit({
-      id: 'kobold_dagger', name: 'Kobold · Dagger', variant: 'dagger', sprite: 'https://imgur.com/2BBvM2s.png',
-      level: { min: 1, max: 3 }, hpBase: 5, hpCoefficient: 0.19, speed: '3-5', resist: 'perforante', weak: 'contundente', tags: ['tier1'],
-      skills: ['kobold_dagger_jab', 'kobold_desperate_stab', 'kobold_scurry'],
-    })),
-    kobold_sling: Object.freeze(baseUnit({
-      id: 'kobold_sling', name: 'Kobold · Sling', variant: 'sling', sprite: 'https://imgur.com/ndB257N.png',
-      level: { min: 1, max: 3 }, hpBase: 5, hpCoefficient: 0.19, speed: '2-4', resist: 'perforante', weak: 'contundente', tags: ['tier1'],
-      skills: ['kobold_sling_shot', 'kobold_rapid_pebble', 'kobold_duck_away'],
-    })),
-    winged_kobold: Object.freeze(baseUnit({
+    kobold_dagger: Object.freeze(makeUnit({ id: 'kobold_dagger', name: 'Kobold · Dagger', variant: 'dagger', sprite: 'https://imgur.com/2BBvM2s.png', naturalWorldLevel: { min: 1, max: 3 }, hpBase: 5, hpCoefficient: 0.19, speed: '3-5', resist: 'perforante', weak: 'contundente', tags: ['tier1'], tier1: ['kobold_dagger_jab', 'kobold_desperate_stab', 'kobold_scurry'] })),
+    kobold_sling: Object.freeze(makeUnit({ id: 'kobold_sling', name: 'Kobold · Sling', variant: 'sling', sprite: 'https://imgur.com/ndB257N.png', naturalWorldLevel: { min: 1, max: 3 }, hpBase: 5, hpCoefficient: 0.19, speed: '2-4', resist: 'perforante', weak: 'contundente', tags: ['tier1'], tier1: ['kobold_sling_shot', 'kobold_rapid_pebble', 'kobold_duck_away'] })),
+    winged_kobold: Object.freeze(makeUnit({
       id: 'winged_kobold', name: 'Winged Kobold', variant: 'winged', sprite: 'https://imgur.com/529fa4E.png',
       spriteVariants: { dagger: 'https://imgur.com/evsrs1B.png', holdingRock: 'https://imgur.com/529fa4E.png', withoutRock: 'https://imgur.com/zmA1FPz.png', rockAsset: 'https://imgur.com/P4J48yc.png' },
-      level: { min: 2, max: 4 }, hpBase: 7, hpCoefficient: 0.22, speed: '3-5', speedBonus: { min: 0, max: 2 },
-      resist: 'cortante', weak: 'perforante', tags: ['tier1', 'tier2', 'flying'], traits: [AERIAL_HARRIER],
-      skills: ['winged_kobold_falling_rock', 'winged_kobold_dagger'], tier2: ['winged_kobold_dive_stab'],
+      naturalWorldLevel: { min: 2, max: 4 }, hpBase: 7, hpCoefficient: 0.22, speed: '3-5', speedBonus: { min: 0, max: 2 }, resist: 'cortante', weak: 'perforante',
+      tags: ['tier1', 'tier2', 'flying'], traits: [AERIAL_HARRIER], tier1: ['winged_kobold_falling_rock', 'winged_kobold_dagger'], tier2: ['winged_kobold_dive_stab'],
       mechanics: {
         flying: true,
         ammunition: { rock: { type: 'single', max: 1, icon: 'https://imgur.com/7rOv1S0.png', asset: 'https://imgur.com/P4J48yc.png' } },
-        unitLifecycle: {
-          onEncounterStart: { grantAmmunition: [{ id: 'rock', amount: 1, max: 1 }] },
-          onComeback: { grantAmmunition: [{ id: 'rock', amount: 1, max: 1 }] },
-        },
+        unitLifecycle: { onEncounterStart: { grantAmmunition: [{ id: 'rock', amount: 1, max: 1 }] }, onComeback: { grantAmmunition: [{ id: 'rock', amount: 1, max: 1 }] } },
         ai: { prefersRetreat: true, retreatAfter: 'harassment', fallingRockRequiresAmmo: 'rock' },
       },
     })),
-    dragonheart_kobold: Object.freeze(baseUnit({
-      id: 'dragonheart_kobold', name: 'Dragonheart Kobold', variant: 'dragonheart', sprite: 'https://imgur.com/4EYu3us.png',
-      level: { min: 5, max: 9 }, hpBase: 44, hpCoefficient: 0.30, speed: '2-4', defLvlMod: 3,
-      resist: 'cortante', weak: 'contundente', tags: ['tier1', 'tier2', 'tier3', 'commander'], traits: [DRAGONHEART, DRAGON_RESISTANCE],
-      allowedRanks: ['captain', 'leader'], skills: ['dragonheart_spear_thrust'], tier2: ['dragonheart_guarding_skewer'], tier3: ['dragonheart_dragon_spear'],
+    dragonheart_kobold: Object.freeze(makeUnit({
+      id: 'dragonheart_kobold', name: 'Dragonheart Kobold', variant: 'dragonheart', sprite: 'https://imgur.com/4EYu3us.png', naturalWorldLevel: { min: 5, max: 9 },
+      hpBase: 44, hpCoefficient: 0.30, speed: '2-4', defLvlMod: 3, resist: 'cortante', weak: 'contundente', tags: ['tier1', 'tier2', 'tier3', 'commander'],
+      traits: [DRAGONHEART, DRAGON_RESISTANCE], allowedRanks: ['captain', 'leader'], tier1: ['dragonheart_spear_thrust'], tier2: ['dragonheart_guarding_skewer'], tier3: ['dragonheart_dragon_spear'],
     })),
-    scale_sorcerer_kobold: Object.freeze(baseUnit({
-      id: 'scale_sorcerer_kobold', name: 'Scale Sorcerer Kobold', variant: 'scale_sorcerer', sprite: 'https://imgur.com/TOHr6Dk.png',
-      level: { min: 5, max: 9 }, hpBase: 27, hpCoefficient: 0.25, speed: '2-4', defLvlMod: 3,
-      resist: 'perforante', weak: 'cortante', tags: ['spellcaster', 'commander'], traits: [SPELL_CASTER_CHARISMA], allowedRanks: ['captain', 'leader'],
-      skills: ['kobold_dagger_jab', 'spell:fire_bolt', 'spell:poison_spray', 'spell:charm_person', 'spell:chromatic_orb', 'spell:expeditious_retreat', 'spell:scorching_ray'],
-      mechanics: {
-        spellcasting: { ability: 'charisma', saveThresholdFormula: '10 + CHA_MOD', spellSlots: { 1: 4, 2: 2 } },
-        sorceryPoints: { encounterStart: 3, runtime: 'sorcerer_class_runtime', metamagic: ['subtle_spell', 'heightened_spell'] },
-        spellReferencesPendingCanonicalCatalog: true,
-      },
+    scale_sorcerer_kobold: Object.freeze(makeUnit({
+      id: 'scale_sorcerer_kobold', name: 'Scale Sorcerer Kobold', variant: 'scale_sorcerer', sprite: 'https://imgur.com/TOHr6Dk.png', naturalWorldLevel: { min: 5, max: 9 },
+      hpBase: 27, hpCoefficient: 0.25, speed: '2-4', defLvlMod: 3, resist: 'perforante', weak: 'cortante', tags: ['spellcaster', 'commander'], traits: [SPELL_CASTER_CHARISMA], allowedRanks: ['captain', 'leader'],
+      tier1: ['kobold_dagger_jab', 'spell:fire_bolt', 'spell:poison_spray', 'spell:charm_person', 'spell:chromatic_orb', 'spell:expeditious_retreat', 'spell:scorching_ray'],
+      mechanics: { spellcasting: { ability: 'charisma', saveThresholdFormula: '10 + CHA_MOD', spellSlots: { 1: 4, 2: 2 } }, sorceryPoints: { encounterStart: 3, runtime: 'sorcerer_class_runtime', metamagic: ['subtle_spell', 'heightened_spell'] }, spellReferencesPendingCanonicalCatalog: true },
     })),
   });
 
   function get(id) { return DEFINITIONS[String(id || '')] ? clone(DEFINITIONS[String(id || '')]) : null; }
   function list() { return Object.values(DEFINITIONS).map(clone); }
-
   function normalizeRank(rank) {
     const id = rankRuntime?.normalizeRank ? rankRuntime.normalizeRank(rank, '') : String(rank || 'normal').trim().toLowerCase();
     if (!UNIVERSAL_RANKS[id]) throw new Error(`UNKNOWN_UNIT_RANK:${id}`);
     return id;
   }
-
-  function normalizeBaseLevel(unit, level) {
+  function normalizeRuntimeLevel(level) {
     const value = Math.floor(Number(level));
-    const range = unit.baseLevel || { min: 1, max: 1 };
-    if (!Number.isFinite(value) || value < range.min || value > range.max) throw new Error(`BASE_LEVEL_OUT_OF_RANGE:${level}`);
+    if (!Number.isFinite(value) || value < 1) throw new Error(`UNIT_LEVEL_OUT_OF_RANGE:${level}`);
     return value;
   }
-
   function parseSpeed(speed) {
-    const match = String(speed || '').match(/^\s*(\d+)\s*-\s*(\d+)\s*$/);
-    if (!match) throw new Error(`INVALID_SPEED:${speed}`);
-    return { min: Number(match[1]), max: Number(match[2]) };
+    const m = String(speed || '').match(/^\s*(\d+)\s*-\s*(\d+)\s*$/);
+    if (!m) throw new Error(`INVALID_SPEED:${speed}`);
+    return { min: Number(m[1]), max: Number(m[2]) };
   }
-
   function resolveSkill(skillId, rank) {
     const id = String(skillId || '');
     if (id.startsWith('spell:')) return { id: id.slice(6), sourceType: 'spell', canonicalReference: true, pendingSpellCatalogResolution: true };
     if (!skillCatalog?.get) throw new Error('KOBOLD_SKILL_CATALOG_REQUIRED');
     const skill = skillCatalog.get(id);
     if (!skill) throw new Error(`UNKNOWN_KOBOLD_SKILL:${id}`);
-    const rankId = normalizeRank(rank);
-    const profile = UNIVERSAL_RANKS[rankId];
+    const profile = UNIVERSAL_RANKS[normalizeRank(rank)];
     skill.basePower += Number(profile.basePowerBonus || 0);
-    const applyCountBonus = (effects) => (effects || []).forEach((effect) => {
-      if (effect?.type === 'status' && Number(effect.count) > 0) effect.count = Number(effect.count) + Number(profile.applyBonus || 0);
-    });
-    applyCountBonus(skill.effects);
-    (skill.coins || []).forEach((coinData) => applyCountBonus(coinData.effects));
-    skill.metadata = { ...(skill.metadata || {}), unitRank: rankId, rankBasePowerBonus: profile.basePowerBonus, rankApplyBonus: profile.applyBonus };
+    const boost = (effects) => (effects || []).forEach((e) => { if (e?.type === 'status' && Number(e.count) > 0) e.count = Number(e.count) + Number(profile.applyBonus || 0); });
+    boost(skill.effects); (skill.coins || []).forEach((c) => boost(c.effects));
+    skill.metadata = { ...(skill.metadata || {}), unitRank: profile.id, rankBasePowerBonus: profile.basePowerBonus, rankApplyBonus: profile.applyBonus };
     return skill;
   }
-
   function resolve(id, options) {
-    const unit = get(id);
-    if (!unit) throw new Error(`UNKNOWN_KOBOLD_UNIT:${id}`);
+    const unit = get(id); if (!unit) throw new Error(`UNKNOWN_KOBOLD_UNIT:${id}`);
     const opts = options || {};
-    const baseLevel = normalizeBaseLevel(unit, opts.baseLevel ?? unit.baseLevel.min);
+    const level = normalizeRuntimeLevel(opts.level ?? opts.baseLevel ?? unit.naturalWorldLevel.min);
     const rank = normalizeRank(opts.rank ?? unit.allowedRanks[0] ?? 'normal');
     if (!unit.allowedRanks.includes(rank)) throw new Error(`UNIT_RANK_NOT_ALLOWED:${id}:${rank}`);
     const profile = UNIVERSAL_RANKS[rank];
-    const effectiveLevel = rankRuntime?.effectiveLevel ? rankRuntime.effectiveLevel(baseLevel, rank) : baseLevel * Number(profile.levelMultiplier || 1);
-    const chassis = unit.mechanics;
-    const maxHp = Math.floor(Number(chassis.hpBase || 0) + effectiveLevel * Number(chassis.hpCoefficient || 0));
-    const defensiveLevel = effectiveLevel + Number(chassis.defLvlMod || 0);
-    const baseSpeed = parseSpeed(chassis.speed);
-    const chassisSpeedBonus = chassis.speedBonus || { min: 0, max: 0 };
-    const minSpeed = baseSpeed.min + Number(chassisSpeedBonus.min || 0) + Number(profile.minSpeedBonus || 0);
-    const maxSpeed = baseSpeed.max + Number(chassisSpeedBonus.max || 0) + Number(profile.maxSpeedBonus || 0);
-    const resolvedSkills = chassis.skills.map((skillId) => resolveSkill(skillId, rank));
-
-    unit.rank = rank;
-    unit.baseLevelSelected = baseLevel;
-    unit.effectiveLevel = effectiveLevel;
-    unit.defensiveLevel = defensiveLevel;
-    unit.rankBonuses = clone(profile);
+    const effectiveLevel = rankRuntime?.effectiveLevel ? rankRuntime.effectiveLevel(level, rank) : level * Number(profile.levelMultiplier || 1);
+    const maxHp = Math.floor(Number(unit.mechanics.hpBase || 0) + effectiveLevel * Number(unit.mechanics.hpCoefficient || 0));
+    const defensiveLevel = effectiveLevel + Number(unit.mechanics.defLvlMod || 0);
+    const baseSpeed = parseSpeed(unit.mechanics.speed); const sb = unit.mechanics.speedBonus || {};
+    const minSpeed = baseSpeed.min + Number(sb.min || 0) + Number(profile.minSpeedBonus || 0);
+    const maxSpeed = baseSpeed.max + Number(sb.max || 0) + Number(profile.maxSpeedBonus || 0);
+    unit.rank = rank; unit.baseLevelSelected = level; unit.runtimeLevel = level; unit.effectiveLevel = effectiveLevel; unit.defensiveLevel = defensiveLevel; unit.rankBonuses = clone(profile);
     unit.commandProfile = { commandLevel: profile.commandLevel, aiCoordination: profile.aiCoordination, targetPriority: profile.targetPriority, turnEndSpRecovery: profile.turnEndSpRecovery };
-    unit.resolvedSkills = resolvedSkills;
-    unit.mechanics = {
-      ...unit.mechanics, hp: maxHp, maxHp, level: effectiveLevel, defensiveLevel, baseLevel, rank,
-      minSpeed, maxSpeed, speed: `${minSpeed}-${maxSpeed}`, statusApplyBonus: profile.applyBonus,
-      basePowerBonus: profile.basePowerBonus, commandLevel: profile.commandLevel, aiCoordination: profile.aiCoordination,
-      turnEndSpRecovery: profile.turnEndSpRecovery,
-    };
+    unit.resolvedSkills = unit.mechanics.skills.map((skillId) => resolveSkill(skillId, rank));
+    unit.mechanics = { ...unit.mechanics, hp: maxHp, maxHp, level: effectiveLevel, runtimeLevel: level, defensiveLevel, rank, minSpeed, maxSpeed, speed: `${minSpeed}-${maxSpeed}`, statusApplyBonus: profile.applyBonus, basePowerBonus: profile.basePowerBonus, commandLevel: profile.commandLevel, aiCoordination: profile.aiCoordination, turnEndSpRecovery: profile.turnEndSpRecovery };
     if (combatMechanics?.onEncounterStart && opts.initializeEncounter === true) combatMechanics.onEncounterStart(unit);
     return unit;
   }
 
-  function firebasePayload() { const payload = {}; list().forEach((unit) => { payload[unit.id] = unit; }); return payload; }
+  function firebasePayload() { const payload = {}; list().forEach((u) => { payload[u.id] = u; }); return payload; }
   function firebaseSkillPayload(schema) { if (!skillCatalog?.firebasePayload) throw new Error('KOBOLD_SKILL_CATALOG_REQUIRED'); return skillCatalog.firebasePayload(schema); }
 
-  const api = Object.freeze({
-    version: '2.0.0', STAGGER_THRESHOLDS, SCORES, PROFICIENCIES, PACK_TACTICS_ID, UNIVERSAL_RANKS,
-    AERIAL_HARRIER, DRAGONHEART, DRAGON_RESISTANCE, SPELL_CASTER_CHARISMA, DEFINITIONS,
-    list, get, resolve, resolveSkill, firebasePayload, firebaseSkillPayload,
-  });
+  const api = Object.freeze({ version: '2.0.1', STAGGER_THRESHOLDS, SCORES, PROFICIENCIES, PACK_TACTICS_ID, UNIVERSAL_RANKS, AERIAL_HARRIER, DRAGONHEART, DRAGON_RESISTANCE, SPELL_CASTER_CHARISMA, DEFINITIONS, list, get, resolve, resolveSkill, firebasePayload, firebaseSkillPayload });
   global.LuminousKoboldUnitCatalog = api;
   if (typeof module !== 'undefined' && module.exports) module.exports = api;
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/js/unit-combat-mechanics-runtime.js
+++ b/js/unit-combat-mechanics-runtime.js
@@ -1,0 +1,168 @@
+(function (global) {
+  'use strict';
+
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const normalizeId = (value) => String(value ?? '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+
+  const ROCK_STATUS = Object.freeze({
+    id: 'rock',
+    name: 'Rock',
+    icon: 'https://imgur.com/7rOv1S0.png',
+    type: 'ammunition',
+    stackType: 'single',
+    maxCount: 1,
+    maxPotency: 1,
+    description: 'Ammunition for skills.',
+    metadata: Object.freeze({ asset: 'https://imgur.com/P4J48yc.png', category: 'ammunition' }),
+  });
+
+  function statusEngine() {
+    return global.LuminousStatusEngine || global.StatusEngine || null;
+  }
+
+  function statusLibrary() {
+    return global.LuminousStatusLibrary || global.StatusLibrary || null;
+  }
+
+  function registerRockStatus() {
+    const library = statusLibrary();
+    if (!library?.registerExtension) return false;
+    try {
+      library.registerExtension(ROCK_STATUS.id, clone(ROCK_STATUS));
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function statusRows(unit) {
+    if (!unit) return [];
+    if (!Array.isArray(unit.statusEffects)) unit.statusEffects = [];
+    return unit.statusEffects;
+  }
+
+  function findStatus(unit, statusId) {
+    const id = normalizeId(statusId);
+    return statusRows(unit).find((row) => normalizeId(row?.id || row?.status || row?.statusId) === id) || null;
+  }
+
+  function ammunitionCount(unit, ammoId) {
+    const row = findStatus(unit, ammoId);
+    return Math.max(0, Number(row?.count ?? row?.potency ?? 0) || 0);
+  }
+
+  function setAmmunition(unit, ammoId, amount, maxAmount = 1) {
+    const id = normalizeId(ammoId);
+    const next = Math.max(0, Math.min(Number(maxAmount) || 1, Math.floor(Number(amount) || 0)));
+    const engine = statusEngine();
+    if (engine?.applyStatus) {
+      engine.applyStatus(unit, id, { count: next, potency: next }, { mode: 'set' });
+      return ammunitionCount(unit, id);
+    }
+    const rows = statusRows(unit);
+    let row = findStatus(unit, id);
+    if (!row) {
+      row = { id, status: id, count: 0, potency: 0 };
+      rows.push(row);
+    }
+    row.count = next;
+    row.potency = next;
+    return next;
+  }
+
+  function gainAmmunition(unit, ammoId, amount = 1, maxAmount = 1) {
+    return setAmmunition(unit, ammoId, ammunitionCount(unit, ammoId) + amount, maxAmount);
+  }
+
+  function consumeAmmunition(unit, ammoId, amount = 1) {
+    const required = Math.max(1, Math.floor(Number(amount) || 1));
+    const current = ammunitionCount(unit, ammoId);
+    if (current < required) return { ok: false, current, required };
+    const remaining = setAmmunition(unit, ammoId, current - required, Math.max(1, current));
+    return { ok: true, current, required, remaining };
+  }
+
+  function lifecycleRules(unit) {
+    return unit?.mechanics?.unitLifecycle || unit?.unitLifecycle || {};
+  }
+
+  function applyLifecycle(unit, trigger) {
+    const rules = lifecycleRules(unit);
+    const grants = Array.isArray(rules?.[trigger]?.grantAmmunition) ? rules[trigger].grantAmmunition : [];
+    const applied = [];
+    grants.forEach((grant) => {
+      const id = normalizeId(grant?.id);
+      if (!id) return;
+      const amount = Math.max(1, Math.floor(Number(grant?.amount) || 1));
+      const max = Math.max(amount, Math.floor(Number(grant?.max) || 1));
+      applied.push({ id, amount, total: gainAmmunition(unit, id, amount, max) });
+    });
+    return applied;
+  }
+
+  function onEncounterStart(unit) { return applyLifecycle(unit, 'onEncounterStart'); }
+  function onComeback(unit) { return applyLifecycle(unit, 'onComeback'); }
+
+  function isFlyingUnit(unit) {
+    if (!unit) return false;
+    if (unit?.mechanics?.flying === true || unit?.flying === true) return true;
+    const ids = Array.isArray(unit.traitIds) ? unit.traitIds.map(normalizeId) : [];
+    return ids.includes('aerial_harrier') || ids.includes('flying');
+  }
+
+  function deliveryType(skill) {
+    const explicit = normalizeId(skill?.deliveryType || skill?.metadata?.combatRange || skill?.combatRange);
+    if (explicit === 'melee' || explicit === 'ranged') return explicit;
+    const range = Number(skill?.skillRange ?? skill?.range ?? skill?.metadata?.skillRange);
+    return Number.isFinite(range) && range > 1 ? 'ranged' : 'melee';
+  }
+
+  function flyingTargetRule({ attacker, target, skill, resolutionType }) {
+    if (!isFlyingUnit(target)) return { allowed: true, canDamage: true, reason: 'target_not_flying' };
+    const delivery = deliveryType(skill);
+    const resolution = normalizeId(resolutionType || 'unopposed');
+    if (delivery === 'ranged') return { allowed: true, canDamage: true, reason: 'ranged_vs_flying' };
+    if (resolution === 'unopposed') return { allowed: false, canDamage: false, reason: 'ground_melee_unopposed_cannot_target_flying' };
+    return { allowed: true, canDamage: true, reason: 'melee_clash_vs_flying' };
+  }
+
+  function flyingClashDamageRule({ attacker, defender, attackerSkill, defenderSkill }) {
+    if (!isFlyingUnit(defender)) return { canDamage: true, reason: 'defender_not_flying' };
+    if (deliveryType(attackerSkill) === 'ranged') return { canDamage: true, reason: 'ranged_vs_flying' };
+    if (deliveryType(defenderSkill) === 'melee') return { canDamage: true, reason: 'flying_melee_exposed' };
+    return { canDamage: false, reason: 'ground_melee_only_negates_flying_ranged_clash' };
+  }
+
+  function resourceCostForSkill(skill) {
+    const rows = Array.isArray(skill?.resourceCosts) ? skill.resourceCosts : [];
+    return rows.map(clone);
+  }
+
+  function consumeSkillAmmunition(unit, skill) {
+    const costs = resourceCostForSkill(skill).filter((cost) => normalizeId(cost?.type) === 'ammunition');
+    const results = costs.map((cost) => consumeAmmunition(unit, cost.id, cost.amount));
+    return { ok: results.every((result) => result.ok), results };
+  }
+
+  registerRockStatus();
+
+  const api = Object.freeze({
+    version: '1.0.0',
+    ROCK_STATUS,
+    registerRockStatus,
+    ammunitionCount,
+    setAmmunition,
+    gainAmmunition,
+    consumeAmmunition,
+    consumeSkillAmmunition,
+    onEncounterStart,
+    onComeback,
+    isFlyingUnit,
+    deliveryType,
+    flyingTargetRule,
+    flyingClashDamageRule,
+  });
+
+  global.LuminousUnitCombatMechanics = api;
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/unit-combat-mechanics-runtime.js
+++ b/js/unit-combat-mechanics-runtime.js
@@ -4,104 +4,25 @@
   const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
   const normalizeId = (value) => String(value ?? '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
 
-  const ROCK_STATUS = Object.freeze({
-    id: 'rock',
-    name: 'Rock',
-    icon: 'https://imgur.com/7rOv1S0.png',
-    type: 'ammunition',
-    stackType: 'single',
-    maxCount: 1,
-    maxPotency: 1,
-    description: 'Ammunition for skills.',
-    metadata: Object.freeze({ asset: 'https://imgur.com/P4J48yc.png', category: 'ammunition' }),
-  });
-
-  function statusEngine() {
-    return global.LuminousStatusEngine || global.StatusEngine || null;
+  function safeRequire(path) {
+    if (typeof require !== 'function') return null;
+    try { return require(path); } catch (_) { return null; }
   }
 
-  function statusLibrary() {
-    return global.LuminousStatusLibrary || global.StatusLibrary || null;
-  }
+  const rangedAmmo = global.LuminousUniversalRangedAmmoRuntime || safeRequire('./universal-ranged-ammo-runtime.js');
+  const ROCK_STATUS = Object.freeze(clone(rangedAmmo?.AMMO?.rock || {
+    id: 'rock', name: 'Rock', icon: 'https://imgur.com/7rOv1S0.png', type: 'neutral', mode: 'single', maxCount: 1,
+    description: 'Ammunition for ranged Skills.', metadata: { projectileAsset: 'https://imgur.com/P4J48yc.png' },
+  }));
 
-  function registerRockStatus() {
-    const library = statusLibrary();
-    if (!library?.registerExtension) return false;
-    try {
-      library.registerExtension(ROCK_STATUS.id, clone(ROCK_STATUS));
-      return true;
-    } catch (_) {
-      return false;
-    }
-  }
+  function registerRockStatus() { return rangedAmmo?.registerStatuses?.() === true; }
+  function ammunitionCount(unit, ammoId) { return rangedAmmo?.ammoCount?.(unit, ammoId) ?? 0; }
+  function setAmmunition(unit, ammoId, amount) { return rangedAmmo?.setAmmo?.(unit, ammoId, amount) ?? 0; }
+  function gainAmmunition(unit, ammoId, amount = 1) { return rangedAmmo?.gainAmmo?.(unit, ammoId, amount) ?? 0; }
+  function consumeAmmunition(unit, ammoId, amount = 1) { return rangedAmmo?.consumeAmmo?.(unit, ammoId, amount) || { ok: false, reason: 'universal_ammo_runtime_unavailable' }; }
 
-  function statusRows(unit) {
-    if (!unit) return [];
-    if (!Array.isArray(unit.statusEffects)) unit.statusEffects = [];
-    return unit.statusEffects;
-  }
-
-  function findStatus(unit, statusId) {
-    const id = normalizeId(statusId);
-    return statusRows(unit).find((row) => normalizeId(row?.id || row?.status || row?.statusId) === id) || null;
-  }
-
-  function ammunitionCount(unit, ammoId) {
-    const row = findStatus(unit, ammoId);
-    return Math.max(0, Number(row?.count ?? row?.potency ?? 0) || 0);
-  }
-
-  function setAmmunition(unit, ammoId, amount, maxAmount = 1) {
-    const id = normalizeId(ammoId);
-    const next = Math.max(0, Math.min(Number(maxAmount) || 1, Math.floor(Number(amount) || 0)));
-    const engine = statusEngine();
-    if (engine?.applyStatus) {
-      engine.applyStatus(unit, id, { count: next, potency: next }, { mode: 'set' });
-      return ammunitionCount(unit, id);
-    }
-    const rows = statusRows(unit);
-    let row = findStatus(unit, id);
-    if (!row) {
-      row = { id, status: id, count: 0, potency: 0 };
-      rows.push(row);
-    }
-    row.count = next;
-    row.potency = next;
-    return next;
-  }
-
-  function gainAmmunition(unit, ammoId, amount = 1, maxAmount = 1) {
-    return setAmmunition(unit, ammoId, ammunitionCount(unit, ammoId) + amount, maxAmount);
-  }
-
-  function consumeAmmunition(unit, ammoId, amount = 1) {
-    const required = Math.max(1, Math.floor(Number(amount) || 1));
-    const current = ammunitionCount(unit, ammoId);
-    if (current < required) return { ok: false, current, required };
-    const remaining = setAmmunition(unit, ammoId, current - required, Math.max(1, current));
-    return { ok: true, current, required, remaining };
-  }
-
-  function lifecycleRules(unit) {
-    return unit?.mechanics?.unitLifecycle || unit?.unitLifecycle || {};
-  }
-
-  function applyLifecycle(unit, trigger) {
-    const rules = lifecycleRules(unit);
-    const grants = Array.isArray(rules?.[trigger]?.grantAmmunition) ? rules[trigger].grantAmmunition : [];
-    const applied = [];
-    grants.forEach((grant) => {
-      const id = normalizeId(grant?.id);
-      if (!id) return;
-      const amount = Math.max(1, Math.floor(Number(grant?.amount) || 1));
-      const max = Math.max(amount, Math.floor(Number(grant?.max) || 1));
-      applied.push({ id, amount, total: gainAmmunition(unit, id, amount, max) });
-    });
-    return applied;
-  }
-
-  function onEncounterStart(unit) { return applyLifecycle(unit, 'onEncounterStart'); }
-  function onComeback(unit) { return applyLifecycle(unit, 'onComeback'); }
+  function onEncounterStart(unit) { return rangedAmmo?.onEncounterStart?.(unit) || []; }
+  function onComeback(unit) { return rangedAmmo?.onComeback?.(unit) || []; }
 
   function isFlyingUnit(unit) {
     if (!unit) return false;
@@ -111,8 +32,6 @@
   }
 
   function deliveryType(skill) {
-    const explicit = normalizeId(skill?.deliveryType || skill?.metadata?.combatRange || skill?.combatRange);
-    if (explicit === 'melee' || explicit === 'ranged') return explicit;
     const range = Number(skill?.skillRange ?? skill?.range ?? skill?.metadata?.skillRange);
     return Number.isFinite(range) && range > 1 ? 'ranged' : 'melee';
   }
@@ -133,34 +52,20 @@
     return { canDamage: false, reason: 'ground_melee_only_negates_flying_ranged_clash' };
   }
 
-  function resourceCostForSkill(skill) {
-    const rows = Array.isArray(skill?.resourceCosts) ? skill.resourceCosts : [];
-    return rows.map(clone);
-  }
-
+  function resourceCostForSkill(skill) { return (Array.isArray(skill?.resourceCosts) ? skill.resourceCosts : []).map(clone); }
   function consumeSkillAmmunition(unit, skill) {
     const costs = resourceCostForSkill(skill).filter((cost) => normalizeId(cost?.type) === 'ammunition');
-    const results = costs.map((cost) => consumeAmmunition(unit, cost.id, cost.amount));
-    return { ok: results.every((result) => result.ok), results };
+    const results = costs.map((cost) => rangedAmmo?.isAmmoConsumingSkill?.(skill, cost.id)
+      ? consumeAmmunition(unit, cost.id, cost.amount)
+      : { ok: false, reason: 'ammunition_requires_ranged_skill' });
+    return { ok: results.length > 0 && results.every((result) => result.ok), results };
   }
 
   registerRockStatus();
 
   const api = Object.freeze({
-    version: '1.0.0',
-    ROCK_STATUS,
-    registerRockStatus,
-    ammunitionCount,
-    setAmmunition,
-    gainAmmunition,
-    consumeAmmunition,
-    consumeSkillAmmunition,
-    onEncounterStart,
-    onComeback,
-    isFlyingUnit,
-    deliveryType,
-    flyingTargetRule,
-    flyingClashDamageRule,
+    version: '2.0.0', ROCK_STATUS, registerRockStatus, ammunitionCount, setAmmunition, gainAmmunition, consumeAmmunition,
+    consumeSkillAmmunition, onEncounterStart, onComeback, isFlyingUnit, deliveryType, flyingTargetRule, flyingClashDamageRule,
   });
 
   global.LuminousUnitCombatMechanics = api;

--- a/js/universal-ranged-ammo-runtime.js
+++ b/js/universal-ranged-ammo-runtime.js
@@ -1,0 +1,353 @@
+(function (global) {
+  'use strict';
+
+  const normalizeId = (value) => String(value ?? '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const intOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Math.trunc(Number(value)) : fallback;
+  const asArray = (value) => value == null ? [] : (Array.isArray(value) ? value : [value]);
+
+  function safeRequire(path) {
+    if (typeof require !== 'function') return null;
+    try { return require(path); } catch (_) { return null; }
+  }
+
+  const statusEngine = () => global.LuminousStatusEngine || safeRequire('./status-engine.js');
+  const statusLibrary = () => global.LuminousStatusLibrary || safeRequire('./status-library.js');
+  const itemRuntime = () => global.LuminousItemRuntime || safeRequire('./item-runtime-engine.js');
+  const inventoryRuntime = () => global.LuminousItemInventoryRuntime || safeRequire('./item-inventory-runtime.js');
+  const actionQueue = () => global.LuminousCombatActionQueue || safeRequire('./combat-action-queue.js');
+  const actionEconomy = () => global.LuminousActionEconomy || safeRequire('./universal-action-economy.js');
+
+  const AMMO = Object.freeze({
+    pebbles: Object.freeze({ id: 'pebbles', name: 'Pebbles', icon: 'https://imgur.com/hhYbwsi.png', type: 'neutral', mode: 'single', description: 'Ammunition for ranged Skills.' }),
+    rock: Object.freeze({ id: 'rock', name: 'Rock', icon: 'https://imgur.com/7rOv1S0.png', type: 'neutral', mode: 'single', maxCount: 1, description: 'Ammunition for ranged Skills.', metadata: Object.freeze({ projectileAsset: 'https://imgur.com/P4J48yc.png' }) }),
+    arrows: Object.freeze({ id: 'arrows', name: 'Arrows', icon: 'https://imgur.com/ivdNbBA.png', type: 'neutral', mode: 'single', description: 'Ammunition for ranged Skills.', metadata: Object.freeze({ onHitStatusId: 'pierced' }) }),
+    javelin: Object.freeze({ id: 'javelin', name: 'Javelin', icon: 'https://imgur.com/3wBN5qk.png', type: 'neutral', mode: 'single', description: 'Ammunition for ranged Skills.', metadata: Object.freeze({ onHitStatusId: 'pierced' }) }),
+  });
+
+  const PIERCED = Object.freeze({
+    id: 'pierced',
+    name: 'Pierced',
+    icon: 'https://imgur.com/xyOtGec.png',
+    type: 'negative',
+    mode: 'single',
+    description: 'Gain 1 Bind every 3 Count. Gain 1 Bleed Count every 4 Count. Use an Action to remove 3 Count.',
+    metadata: Object.freeze({ bindEveryCount: 3, bleedCountEveryCount: 4, actionRemovalCount: 3 }),
+  });
+
+  function registerStatuses() {
+    const library = statusLibrary();
+    if (!library?.registerExtension) return false;
+    Object.values(AMMO).forEach((definition) => library.registerExtension(definition.id, clone(definition)));
+    library.registerExtension(PIERCED.id, clone(PIERCED));
+    library.install?.();
+    return true;
+  }
+
+  function statusCount(unit, statusId) {
+    const entry = statusEngine()?.getStatus?.(unit, normalizeId(statusId));
+    return Math.max(0, intOr(entry?.count, 0));
+  }
+
+  function setStatusCount(unit, statusId, amount, data = {}) {
+    const id = normalizeId(statusId);
+    const engine = statusEngine();
+    const next = Math.max(0, intOr(amount, 0));
+    if (!engine || !id) return 0;
+    if (next <= 0) {
+      engine.removeStatus?.(unit, id, { from: 'self', ignoreProtection: true });
+      return 0;
+    }
+    engine.applyStatus?.(unit, id, { mode: 'set', count: next, potency: 0, data });
+    return statusCount(unit, id);
+  }
+
+  function ammoDefinition(ammoId) { return AMMO[normalizeId(ammoId)] || null; }
+  function ammoCount(unit, ammoId) { return statusCount(unit, ammoId); }
+
+  function setAmmo(unit, ammoId, amount) {
+    const id = normalizeId(ammoId);
+    const definition = ammoDefinition(id);
+    if (!definition) return 0;
+    const cap = Number.isFinite(Number(definition.maxCount)) ? Number(definition.maxCount) : Number.POSITIVE_INFINITY;
+    return setStatusCount(unit, id, Math.min(cap, Math.max(0, intOr(amount, 0))), { category: 'ammunition' });
+  }
+
+  function gainAmmo(unit, ammoId, amount = 1) {
+    return setAmmo(unit, ammoId, ammoCount(unit, ammoId) + Math.max(0, intOr(amount, 0)));
+  }
+
+  function consumeAmmo(unit, ammoId, amount = 1) {
+    const required = Math.max(1, intOr(amount, 1));
+    const current = ammoCount(unit, ammoId);
+    if (current < required) return { ok: false, current, required, remaining: current, reason: 'ammunition_unavailable' };
+    const remaining = setAmmo(unit, ammoId, current - required);
+    return { ok: true, current, required, remaining };
+  }
+
+  function skillRange(skill = {}) {
+    const range = Number(skill.skillRange ?? skill.range ?? skill.metadata?.skillRange);
+    return Number.isFinite(range) ? range : 1;
+  }
+
+  function sourceType(skill = {}) {
+    return normalizeId(skill.sourceType || skill.metadata?.sourceType || skill.type);
+  }
+
+  function ammoCosts(skill = {}) {
+    return asArray(skill.resourceCosts || skill.resources).filter((cost) => normalizeId(cost?.type || cost?.resourceType) === 'ammunition');
+  }
+
+  function isAmmoConsumingSkill(skill = {}, ammoId = null) {
+    if (skillRange(skill) <= 1) return false;
+    if (sourceType(skill) === 'spell' || normalizeId(skill.type) === 'spell') return false;
+    const wanted = normalizeId(ammoId);
+    const declared = normalizeId(skill.metadata?.ammoType || skill.ammoType || skill.ammunitionType);
+    const costs = ammoCosts(skill).map((cost) => normalizeId(cost.id));
+    if (!wanted) return Boolean(declared || costs.length);
+    return declared === wanted || costs.includes(wanted);
+  }
+
+  function isRangedWeaponSkill(skill = {}) {
+    if (skillRange(skill) <= 1) return false;
+    if (sourceType(skill) === 'spell' || normalizeId(skill.type) === 'spell') return false;
+    return skill.metadata?.weaponSkill === true || skill.weaponSkill === true || Boolean(skill.metadata?.weaponId || skill.weaponId);
+  }
+
+  function isMeleeSkill(skill = {}) { return skillRange(skill) <= 1; }
+
+  function ammunitionHandler() {
+    return {
+      validate({ action, actor, resource }) {
+        const skill = action?.metadata?.sourceDefinition || {};
+        if (!isAmmoConsumingSkill(skill, resource?.id)) return { available: false, current: ammoCount(actor, resource?.id), required: Number(resource?.amount || 1), reason: 'ammunition_requires_ranged_skill' };
+        const current = ammoCount(actor, resource?.id);
+        const required = Math.max(1, Number(resource?.amount || 1));
+        return { available: current >= required, current, required, reason: current >= required ? null : 'ammunition_unavailable' };
+      },
+      consume({ action, actor, resource }) {
+        const skill = action?.metadata?.sourceDefinition || {};
+        if (!isAmmoConsumingSkill(skill, resource?.id)) return { consumed: false, success: false, reason: 'ammunition_requires_ranged_skill' };
+        const result = consumeAmmo(actor, resource.id, resource.amount);
+        return { ...result, consumed: result.ok === true, success: result.ok === true };
+      },
+    };
+  }
+
+  function withAmmoResourceHandler(context = {}) {
+    return { ...context, resourceHandlers: { ...(context.resourceHandlers || {}), ammunition: context.resourceHandlers?.ammunition || ammunitionHandler() } };
+  }
+
+  function ammoLoadout(unit = {}) {
+    const raw = unit?.mechanics?.ammoLoadout || unit?.ammoLoadout || [];
+    return asArray(raw).map((row) => ({
+      id: normalizeId(row?.id || row?.ammoId || row?.type),
+      amount: Math.max(0, intOr(row?.amount ?? row?.encounterStart, 0)),
+      inventoryItemId: row?.inventoryItemId || row?.itemId || null,
+    })).filter((row) => row.id && row.amount > 0);
+  }
+
+  function isPlayer(unit = {}) {
+    return unit.isPlayer === true || normalizeId(unit.actorCategory) === 'player' || normalizeId(unit.unitType) === 'player';
+  }
+
+  function inventoryAmmoStacks(unit, ammoId) {
+    const runtime = itemRuntime();
+    const inventory = inventoryRuntime();
+    if (!runtime || !inventory?.inventorySnapshot) return [];
+    const wanted = normalizeId(ammoId);
+    const snapshot = inventory.inventorySnapshot(unit, { hydrate: false });
+    return [...(snapshot.active || []), ...(snapshot.stash || [])]
+      .map((entry) => entry.item)
+      .filter(Boolean)
+      .filter((item) => {
+        const resourceId = normalizeId(runtime.ammoResourceId?.(item));
+        const definitionId = normalizeId(runtime.definitionId?.(item));
+        return resourceId === wanted || definitionId === wanted || definitionId === `ammo_${wanted}`;
+      });
+  }
+
+  function withdrawPlayerAmmo(unit, row) {
+    const runtime = itemRuntime();
+    if (!runtime?.consumeQuantity) return { withdrawn: 0, requested: row.amount, reason: 'item_runtime_unavailable' };
+    let remaining = row.amount;
+    let withdrawn = 0;
+    const stacks = row.inventoryItemId ? [runtime.findItem?.(unit, row.inventoryItemId)].filter(Boolean) : inventoryAmmoStacks(unit, row.id);
+    for (const item of stacks) {
+      if (remaining <= 0) break;
+      const available = Math.max(0, intOr(runtime.quantityOf?.(item), 0));
+      const take = Math.min(remaining, available);
+      if (!take) continue;
+      const result = runtime.consumeQuantity(item, take);
+      if (result?.consumed !== true) continue;
+      withdrawn += take;
+      remaining -= take;
+    }
+    return { withdrawn, requested: row.amount, remaining };
+  }
+
+  function onEncounterStart(unit) {
+    registerStatuses();
+    const applied = [];
+    for (const row of ammoLoadout(unit)) {
+      const granted = isPlayer(unit) ? withdrawPlayerAmmo(unit, row).withdrawn : row.amount;
+      const total = gainAmmo(unit, row.id, granted);
+      applied.push({ id: row.id, requested: row.amount, granted, total, fromInventory: isPlayer(unit) });
+    }
+    return applied;
+  }
+
+  function grantLifecycleAmmo(unit, trigger) {
+    const grants = asArray(unit?.mechanics?.unitLifecycle?.[trigger]?.grantAmmunition);
+    return grants.map((grant) => ({ id: normalizeId(grant?.id), amount: Math.max(0, intOr(grant?.amount, 1)), total: gainAmmo(unit, grant?.id, grant?.amount) }));
+  }
+
+  function onComeback(unit) { return grantLifecycleAmmo(unit, 'onComeback'); }
+
+  function applyPierced(unit, amount = 1, options = {}) {
+    const add = Math.max(0, intOr(amount, 0));
+    const before = statusCount(unit, 'pierced');
+    const after = before + add;
+    setStatusCount(unit, 'pierced', after, { sourceUnitId: options.sourceUnitId || null });
+    const bindGain = Math.max(0, Math.floor(after / 3) - Math.floor(before / 3));
+    const bleedCountGain = Math.max(0, Math.floor(after / 4) - Math.floor(before / 4));
+    if (bindGain) statusEngine()?.applyStatus?.(unit, 'bind', { mode: 'gain', count: bindGain, potency: 0, sourceUnitId: options.sourceUnitId || null });
+    if (bleedCountGain) statusEngine()?.applyStatus?.(unit, 'bleed', { mode: 'gain', count: bleedCountGain, potency: 0, sourceUnitId: options.sourceUnitId || null });
+    return { before, after: statusCount(unit, 'pierced'), bindGain, bleedCountGain };
+  }
+
+  function removePiercedCount(unit, amount = 3) {
+    const before = statusCount(unit, 'pierced');
+    const removed = Math.min(before, Math.max(0, intOr(amount, 3)));
+    const after = setStatusCount(unit, 'pierced', before - removed);
+    return { before, after, removed };
+  }
+
+  function scheduleRemovePierced(unit, options = {}) {
+    if (statusCount(unit, 'pierced') <= 0) return { scheduled: false, reason: 'pierced_not_present' };
+    const economy = actionEconomy();
+    if (!economy?.scheduleAction) return { scheduled: false, reason: 'action_economy_unavailable' };
+    return economy.scheduleAction(unit, { kind: 'status_action', sourceId: 'remove_pierced', data: { statusId: 'pierced', removeCount: 3 } }, options);
+  }
+
+  function installPiercedActionBridge() {
+    const engine = global.CombatEngine;
+    if (!engine || engine.__universalPiercedActionBridge || typeof engine.resolveActionSlot !== 'function') return Boolean(engine?.__universalPiercedActionBridge);
+    const original = engine.resolveActionSlot;
+    engine.resolveActionSlot = function (unit, slotIndex, context = {}) {
+      const planned = context.plannedAction || null;
+      if (normalizeId(planned?.kind) === 'status_action' && normalizeId(planned?.sourceId) === 'remove_pierced') {
+        return { handled: true, planned, result: { resolved: true, action: 'remove_pierced', ...removePiercedCount(unit, 3) } };
+      }
+      return original.call(this, unit, slotIndex, context);
+    };
+    Object.defineProperty(engine, '__universalPiercedActionBridge', { value: true, configurable: true });
+    return true;
+  }
+
+  function unitById(context = {}, id) {
+    const wanted = String(id ?? '');
+    const units = asArray(context.units || Object.values(context.combatData || {}));
+    return units.find((unit) => String(unit?.id ?? unit?.unitId ?? unit?.characterId ?? '') === wanted) || null;
+  }
+
+  function actionSpeed(action = {}, context = {}) {
+    const roundOrder = context.roundOrder || context.combatRoundOrder || context.queueState;
+    const entry = roundOrder?.getEntry?.(action.id) || asArray(roundOrder?.entries).find((row) => String(row?.actionId || row?.action?.id || '') === String(action.id || ''));
+    if (Number.isFinite(Number(entry?.speed))) return Number(entry.speed);
+    const direct = [action.metadata?.resolvedSpeed, action.metadata?.actionSpeed, action.metadata?.speed].map(Number).find(Number.isFinite);
+    if (direct != null) return direct;
+    const unit = unitById(context, action.actorId);
+    return actionQueue()?.resolveRoundSpeed?.(unit || {}, action) ?? 0;
+  }
+
+  function sourceDefinition(action = {}) { return action?.metadata?.sourceDefinition || {}; }
+
+  function markRangedClashBonus(action, amount) {
+    if (!action.metadata) action.metadata = {};
+    if (!action.metadata.sourceDefinition) action.metadata.sourceDefinition = {};
+    const skill = action.metadata.sourceDefinition;
+    if (amount > 0) skill.__universalRangedWeaponClashPowerBonus = amount;
+    else delete skill.__universalRangedWeaponClashPowerBonus;
+    return action;
+  }
+
+  function prepareClashActions(actionA, actionB, context = {}) {
+    const a = clone(actionA);
+    const b = clone(actionB);
+    const skillA = sourceDefinition(a);
+    const skillB = sourceDefinition(b);
+    const speedA = actionSpeed(a, context);
+    const speedB = actionSpeed(b, context);
+    markRangedClashBonus(a, isRangedWeaponSkill(skillA) && isMeleeSkill(skillB) && speedA > speedB ? 2 : 0);
+    markRangedClashBonus(b, isRangedWeaponSkill(skillB) && isMeleeSkill(skillA) && speedB > speedA ? 2 : 0);
+    return { actionA: a, actionB: b, speedA, speedB };
+  }
+
+  function installEngineClashBridge() {
+    const engine = global.CombatEngine;
+    if (!engine || engine.__universalRangedWeaponClashBridge || typeof engine.applyPassiveModifiers !== 'function') return Boolean(engine?.__universalRangedWeaponClashBridge);
+    const original = engine.applyPassiveModifiers;
+    engine.applyPassiveModifiers = function (unit, contextOptions = null) {
+      const result = original.call(this, unit, contextOptions) || {};
+      const bonus = Number(contextOptions?.skill?.__universalRangedWeaponClashPowerBonus || 0);
+      if (Number.isFinite(bonus) && bonus) result.clash_power = Number(result.clash_power || 0) + bonus;
+      return result;
+    };
+    Object.defineProperty(engine, '__universalRangedWeaponClashBridge', { value: true, configurable: true });
+    return true;
+  }
+
+  function installResolverBridge() {
+    const base = global.LuminousCombatActionResolver;
+    if (!base || base.__universalRangedAmmoInstalled || typeof base.resolveCombatAction !== 'function') return Boolean(base?.__universalRangedAmmoInstalled);
+    const wrapped = function (input = {}, rawContext = {}) {
+      const context = withAmmoResourceHandler(rawContext);
+      let action = clone(input);
+      if (normalizeId(action?.resolution?.type) === 'clash' && context.opposingAction) {
+        const prepared = prepareClashActions(action, context.opposingAction, context);
+        action = prepared.actionA;
+        context.opposingAction = prepared.actionB;
+      }
+      return base.resolveCombatAction(action, context);
+    };
+    global.LuminousCombatActionResolver = Object.freeze({ ...base, __universalRangedAmmoInstalled: true, withAmmoResourceHandler, resolveCombatAction: wrapped });
+    return true;
+  }
+
+  function createAmmoTrait(ammoId, amount) {
+    const id = normalizeId(ammoId);
+    return {
+      id: `ammo_${id}`,
+      name: `Ammo — ${ammoDefinition(id)?.name || id}`,
+      type: 'passive',
+      source: { type: 'special', id: 'universal_ammo' },
+      description: `[On Encounter Start] Gain ${Math.max(0, intOr(amount, 0))} ${ammoDefinition(id)?.name || id}.`,
+      mechanics: { ammoId: id, encounterStart: Math.max(0, intOr(amount, 0)), statusMode: 'single', rangedSkillsOnly: true },
+    };
+  }
+
+  function install() {
+    registerStatuses();
+    installEngineClashBridge();
+    installResolverBridge();
+    installPiercedActionBridge();
+    return true;
+  }
+
+  const api = Object.freeze({
+    version: '1.0.0', AMMO, PIERCED, registerStatuses, statusCount, ammoCount, setAmmo, gainAmmo, consumeAmmo,
+    skillRange, isAmmoConsumingSkill, isRangedWeaponSkill, isMeleeSkill, ammunitionHandler, withAmmoResourceHandler,
+    ammoLoadout, withdrawPlayerAmmo, onEncounterStart, onComeback, applyPierced, removePiercedCount, scheduleRemovePierced,
+    actionSpeed, prepareClashActions, createAmmoTrait, installEngineClashBridge, installResolverBridge, installPiercedActionBridge, install,
+  });
+
+  global.LuminousUniversalRangedAmmoRuntime = api;
+  install();
+  if (global.document) {
+    global.setTimeout?.(install, 0);
+    global.setTimeout?.(install, 800);
+  }
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/scripts/smoke-goblin-unit-library.js
+++ b/scripts/smoke-goblin-unit-library.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const assert = require('assert');
+require('../js/status-library.js');
+require('../js/status-engine.js');
+const ammo = require('../js/universal-ranged-ammo-runtime.js');
+const goblinRuntime = require('../js/goblin-unit-runtime.js');
+const units = require('../js/unit-catalog-goblin.js');
+
+const ids = units.list().map((unit) => unit.id);
+assert.deepStrictEqual(ids.sort(), ['goblin', 'goblin_boss']);
+
+const goblin = units.resolve('goblin', { level: 60, rank: 'normal', initializeEncounter: true });
+assert.deepStrictEqual(goblin.scores, { str: 8, dex: 15, con: 10, int: 10, wis: 9, cha: 8 });
+assert.strictEqual(goblin.maxHp, Math.floor(7 + 60 * 0.21));
+assert(goblin.traitIds.includes('goblin_fury_of_small'));
+assert(goblin.traitIds.includes('goblin_nimble_escape'));
+assert(goblin.traitIds.includes('ammo_arrows'));
+assert.strictEqual(ammo.ammoCount(goblin, 'arrows'), 10);
+assert.strictEqual(goblin.mechanics.weaponLoadout[0].weaponId, 'scimitar');
+assert.strictEqual(goblin.mechanics.weaponLoadout[1].weaponId, 'shortbow');
+assert.strictEqual(goblin.mechanics.weaponLoadout[1].ammoType, 'arrows');
+assert.strictEqual(goblin.mechanics.weaponLoadout[1].onHitStatusId, 'pierced');
+assert.strictEqual(goblin.mechanics.weaponLoadout[1].onHitStatusCount, null);
+assert.strictEqual(goblin.metadata.weaponSkillsPendingCanonicalCatalog, true);
+assert.strictEqual(goblin.metadata.spritePending, true);
+
+const boss = units.resolve('goblin_boss', { level: 60, rank: 'captain', initializeEncounter: true });
+assert.deepStrictEqual(boss.scores, { str: 10, dex: 16, con: 12, int: 11, wis: 10, cha: 12 });
+assert.strictEqual(boss.effectiveLevel, 120);
+assert.strictEqual(boss.maxHp, Math.floor(21 + 120 * 0.24));
+assert.deepStrictEqual(boss.allowedRanks, ['captain']);
+assert.throws(() => units.resolve('goblin_boss', { level: 60, rank: 'normal' }), /UNIT_RANK_NOT_ALLOWED/);
+assert(boss.traitIds.includes('goblin_multi_attack'));
+assert(boss.traitIds.includes('goblin_redirect_attack'));
+assert(boss.traitIds.includes('ammo_javelin'));
+assert.strictEqual(ammo.ammoCount(boss, 'javelin'), 6);
+assert.strictEqual(boss.mechanics.weaponLoadout[1].weaponId, 'javelin');
+assert.strictEqual(boss.mechanics.weaponLoadout[1].ammoType, 'javelin');
+assert.strictEqual(boss.mechanics.weaponLoadout[1].onHitStatusId, 'pierced');
+assert.strictEqual(goblinRuntime.reuseTimes(boss), 5);
+
+const fiveCoinMelee = {
+  id: 'test-melee', name: 'Test Melee', skillRange: 1, coinAmount: 5, coinPower: 3, basePower: 4,
+  coins: Array.from({ length: 5 }, (_, index) => ({ index, status: 'active', effects: [] })),
+};
+const prepared = goblinRuntime.prepareMultiAttackSkill(boss, fiveCoinMelee);
+assert.strictEqual(prepared.coinAmount, 5);
+assert.strictEqual(prepared.coins.length, 5);
+prepared.coins.forEach((coin) => assert(coin.effects.some((effect) => effect.type === 'percentage_damage' && effect.potency === 5)));
+
+const fiveCoinRanged = { ...fiveCoinMelee, skillRange: 6, coins: fiveCoinMelee.coins.map((coin) => ({ ...coin, effects: [] })) };
+const rangedPrepared = goblinRuntime.prepareMultiAttackSkill(boss, fiveCoinRanged);
+rangedPrepared.coins.forEach((coin) => assert.strictEqual(coin.effects.length, 0));
+
+const ally = { id: 'ally-goblin', species: 'goblin', faction: 'enemy', hp: 10, deploymentState: 'field' };
+const backup = { id: 'backup-goblin', species: 'goblin', faction: 'enemy', hp: 10, deploymentState: 'backup' };
+assert.strictEqual(goblinRuntime.selectRedirectTarget(boss, [boss, backup, ally]), ally);
+boss.__goblinRedirectUsedThisTurn = true;
+assert.strictEqual(goblinRuntime.selectRedirectTarget(boss, [boss, ally]), null);
+goblinRuntime.onTurnStart(boss);
+assert.strictEqual(goblinRuntime.selectRedirectTarget(boss, [boss, ally]), ally);
+
+console.log('Goblin Unit Library smoke OK');

--- a/scripts/smoke-kobold-batch.js
+++ b/scripts/smoke-kobold-batch.js
@@ -1,12 +1,28 @@
 'use strict';
 
 const assert = require('assert');
+require('../js/status-library.js');
+require('../js/status-engine.js');
+const ammo = require('../js/universal-ranged-ammo-runtime.js');
 const mechanics = require('../js/unit-combat-mechanics-runtime.js');
 const skills = require('../js/skill-catalog-kobold-tier1.js');
 const units = require('../js/unit-catalog-kobold-tier1.js');
 
 const ids = units.list().map((unit) => unit.id);
 ['kobold_dagger', 'kobold_sling', 'winged_kobold', 'dragonheart_kobold', 'scale_sorcerer_kobold'].forEach((id) => assert(ids.includes(id), `missing ${id}`));
+
+const sling = units.resolve('kobold_sling', { level: 60, rank: 'normal', initializeEncounter: true });
+assert.strictEqual(ammo.ammoCount(sling, 'pebbles'), 6);
+assert(sling.traitIds.includes('ammo_pebbles'));
+const slingShot = skills.get('kobold_sling_shot');
+const rapidPebble = skills.get('kobold_rapid_pebble');
+assert.strictEqual(slingShot.resourceCosts[0].id, 'pebbles');
+assert.strictEqual(rapidPebble.resourceCosts[0].id, 'pebbles');
+assert.strictEqual(ammo.isAmmoConsumingSkill(slingShot, 'pebbles'), true);
+assert.strictEqual(ammo.isAmmoConsumingSkill(rapidPebble, 'pebbles'), true);
+const pebbleSpent = mechanics.consumeSkillAmmunition(sling, rapidPebble);
+assert.strictEqual(pebbleSpent.ok, true);
+assert.strictEqual(ammo.ammoCount(sling, 'pebbles'), 5);
 
 const winged = units.resolve('winged_kobold', { level: 60, rank: 'normal', initializeEncounter: true });
 assert.strictEqual(winged.mechanics.maxHp, Math.floor(7 + 60 * 0.22));
@@ -23,10 +39,13 @@ assert.strictEqual(fallingRock.basePower, 3);
 assert.strictEqual(fallingRock.coinPower, 3);
 assert.strictEqual(fallingRock.damageType, 'contundente');
 assert.strictEqual(fallingRock.resourceCosts[0].id, 'rock');
+assert.strictEqual(fallingRock.metadata.ammoType, 'rock');
 
 const spent = mechanics.consumeSkillAmmunition(winged, fallingRock);
 assert.strictEqual(spent.ok, true);
 assert.strictEqual(mechanics.ammunitionCount(winged, 'rock'), 0);
+mechanics.onComeback(winged);
+assert.strictEqual(mechanics.ammunitionCount(winged, 'rock'), 1);
 mechanics.onComeback(winged);
 assert.strictEqual(mechanics.ammunitionCount(winged, 'rock'), 1);
 

--- a/scripts/smoke-kobold-batch.js
+++ b/scripts/smoke-kobold-batch.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const assert = require('assert');
+const mechanics = require('../js/unit-combat-mechanics-runtime.js');
+const skills = require('../js/skill-catalog-kobold-tier1.js');
+const units = require('../js/unit-catalog-kobold-tier1.js');
+
+const ids = units.list().map((unit) => unit.id);
+['kobold_dagger', 'kobold_sling', 'winged_kobold', 'dragonheart_kobold', 'scale_sorcerer_kobold'].forEach((id) => assert(ids.includes(id), `missing ${id}`));
+
+const winged = units.resolve('winged_kobold', { level: 60, rank: 'normal', initializeEncounter: true });
+assert.strictEqual(winged.mechanics.maxHp, Math.floor(7 + 60 * 0.22));
+assert.strictEqual(winged.mechanics.maxSpeed, 7);
+assert.strictEqual(mechanics.isFlyingUnit(winged), true);
+assert.strictEqual(mechanics.ammunitionCount(winged, 'rock'), 1);
+
+const fallingRock = skills.get('winged_kobold_falling_rock');
+assert.strictEqual(fallingRock.save.ability, 'dexterity');
+assert.strictEqual(fallingRock.save.dc, 9);
+assert.strictEqual(fallingRock.save.onSuccess, 'negates');
+assert.strictEqual(fallingRock.save.onFailure, 'unopposed_attack');
+assert.strictEqual(fallingRock.basePower, 3);
+assert.strictEqual(fallingRock.coinPower, 3);
+assert.strictEqual(fallingRock.damageType, 'contundente');
+assert.strictEqual(fallingRock.resourceCosts[0].id, 'rock');
+
+const spent = mechanics.consumeSkillAmmunition(winged, fallingRock);
+assert.strictEqual(spent.ok, true);
+assert.strictEqual(mechanics.ammunitionCount(winged, 'rock'), 0);
+mechanics.onComeback(winged);
+assert.strictEqual(mechanics.ammunitionCount(winged, 'rock'), 1);
+
+const ground = { id: 'ground' };
+const flying = { id: 'flying', mechanics: { flying: true } };
+assert.strictEqual(mechanics.flyingTargetRule({ attacker: ground, target: flying, skill: { skillRange: 1 }, resolutionType: 'unopposed' }).allowed, false);
+assert.strictEqual(mechanics.flyingTargetRule({ attacker: ground, target: flying, skill: { skillRange: 6 }, resolutionType: 'unopposed' }).allowed, true);
+assert.strictEqual(mechanics.flyingClashDamageRule({ attacker: ground, defender: flying, attackerSkill: { skillRange: 1 }, defenderSkill: { skillRange: 6 } }).canDamage, false);
+assert.strictEqual(mechanics.flyingClashDamageRule({ attacker: ground, defender: flying, attackerSkill: { skillRange: 1 }, defenderSkill: { skillRange: 1 } }).canDamage, true);
+
+const dragonCaptain = units.resolve('dragonheart_kobold', { level: 60, rank: 'captain' });
+assert.strictEqual(dragonCaptain.mechanics.maxHp, Math.floor(44 + 120 * 0.30));
+assert.strictEqual(dragonCaptain.defensiveLevel, 123);
+assert.throws(() => units.resolve('dragonheart_kobold', { level: 60, rank: 'normal' }), /UNIT_RANK_NOT_ALLOWED/);
+
+const sorcererLeader = units.resolve('scale_sorcerer_kobold', { level: 60, rank: 'leader' });
+assert.strictEqual(sorcererLeader.mechanics.maxHp, Math.floor(27 + 180 * 0.25));
+assert.strictEqual(sorcererLeader.mechanics.spellcasting.spellSlots[1], 4);
+assert.strictEqual(sorcererLeader.mechanics.spellcasting.spellSlots[2], 2);
+assert.strictEqual(sorcererLeader.mechanics.sorceryPoints.encounterStart, 3);
+
+console.log('Kobold batch smoke OK');

--- a/scripts/smoke-universal-ranged-ammo.js
+++ b/scripts/smoke-universal-ranged-ammo.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const assert = require('assert');
+require('../js/status-library.js');
+require('../js/status-engine.js');
+const ammo = require('../js/universal-ranged-ammo-runtime.js');
+const status = global.LuminousStatusEngine;
+
+assert.strictEqual(ammo.AMMO.pebbles.mode, 'single');
+assert.strictEqual(ammo.AMMO.arrows.mode, 'single');
+assert.strictEqual(ammo.AMMO.javelin.mode, 'single');
+assert.strictEqual(ammo.AMMO.rock.maxCount, 1);
+assert.strictEqual(ammo.PIERCED.mode, 'single');
+
+const kobold = { id: 'kobold', actorCategory: 'enemy', mechanics: { ammoLoadout: [{ id: 'pebbles', amount: 6 }] } };
+ammo.onEncounterStart(kobold);
+assert.strictEqual(ammo.ammoCount(kobold, 'pebbles'), 6);
+assert.strictEqual(ammo.consumeAmmo(kobold, 'pebbles', 1).ok, true);
+assert.strictEqual(ammo.ammoCount(kobold, 'pebbles'), 5);
+
+const rockUnit = { id: 'winged', actorCategory: 'enemy' };
+ammo.gainAmmo(rockUnit, 'rock', 5);
+assert.strictEqual(ammo.ammoCount(rockUnit, 'rock'), 1);
+
+const rangedPebble = {
+  skillRange: 6,
+  sourceType: 'skill',
+  resourceCosts: [{ type: 'ammunition', id: 'pebbles', amount: 1 }],
+  metadata: { ammoType: 'pebbles', weaponSkill: true },
+};
+const meleeFakeAmmo = {
+  skillRange: 1,
+  sourceType: 'skill',
+  resourceCosts: [{ type: 'ammunition', id: 'pebbles', amount: 1 }],
+  metadata: { ammoType: 'pebbles', weaponSkill: true },
+};
+assert.strictEqual(ammo.isAmmoConsumingSkill(rangedPebble, 'pebbles'), true);
+assert.strictEqual(ammo.isAmmoConsumingSkill(meleeFakeAmmo, 'pebbles'), false);
+
+const piercedTarget = { id: 'target' };
+let pierced = ammo.applyPierced(piercedTarget, 3);
+assert.strictEqual(pierced.bindGain, 1);
+assert.strictEqual(status.getStatus(piercedTarget, 'bind').count, 1);
+pierced = ammo.applyPierced(piercedTarget, 1);
+assert.strictEqual(pierced.bleedCountGain, 1);
+assert.strictEqual(status.getStatus(piercedTarget, 'bleed').count, 1);
+assert.strictEqual(ammo.statusCount(piercedTarget, 'pierced'), 4);
+assert.strictEqual(ammo.removePiercedCount(piercedTarget, 3).after, 1);
+
+const rangedAction = {
+  id: 'ranged-action', actorId: 'archer', metadata: { resolvedSpeed: 5, sourceDefinition: { skillRange: 6, sourceType: 'skill', metadata: { weaponSkill: true } } },
+};
+const meleeAction = {
+  id: 'melee-action', actorId: 'melee', metadata: { resolvedSpeed: 3, sourceDefinition: { skillRange: 1, sourceType: 'skill', metadata: { weaponSkill: true } } },
+};
+let prepared = ammo.prepareClashActions(rangedAction, meleeAction, {});
+assert.strictEqual(prepared.actionA.metadata.sourceDefinition.__universalRangedWeaponClashPowerBonus, 2);
+assert.strictEqual(prepared.actionB.metadata.sourceDefinition.__universalRangedWeaponClashPowerBonus, undefined);
+
+prepared = ammo.prepareClashActions({ ...rangedAction, metadata: { ...rangedAction.metadata, resolvedSpeed: 3 } }, meleeAction, {});
+assert.strictEqual(prepared.actionA.metadata.sourceDefinition.__universalRangedWeaponClashPowerBonus, undefined);
+
+const rangedSpell = {
+  id: 'spell-action', actorId: 'caster', metadata: { resolvedSpeed: 6, sourceDefinition: { skillRange: 6, sourceType: 'spell', metadata: { weaponSkill: false } } },
+};
+prepared = ammo.prepareClashActions(rangedSpell, meleeAction, {});
+assert.strictEqual(prepared.actionA.metadata.sourceDefinition.__universalRangedWeaponClashPowerBonus, undefined);
+
+// Players withdraw Encounter ammo from inventory; only what exists is granted.
+const oldItemRuntime = global.LuminousItemRuntime;
+const oldInventoryRuntime = global.LuminousItemInventoryRuntime;
+const arrowStack = { id: 'arrow-stack', definitionId: 'ammo_arrows', quantity: 7 };
+global.LuminousItemRuntime = {
+  ammoResourceId: () => 'arrows',
+  definitionId: (item) => item.definitionId,
+  quantityOf: (item) => item.quantity,
+  consumeQuantity(item, amount) { if (item.quantity < amount) return { consumed: false }; item.quantity -= amount; return { consumed: true, remaining: item.quantity }; },
+  findItem: () => arrowStack,
+};
+global.LuminousItemInventoryRuntime = {
+  inventorySnapshot: () => ({ active: [{ item: arrowStack }], stash: [] }),
+};
+const player = { id: 'player', isPlayer: true, mechanics: { ammoLoadout: [{ id: 'arrows', amount: 10 }] } };
+const grant = ammo.onEncounterStart(player)[0];
+assert.strictEqual(grant.requested, 10);
+assert.strictEqual(grant.granted, 7);
+assert.strictEqual(grant.fromInventory, true);
+assert.strictEqual(ammo.ammoCount(player, 'arrows'), 7);
+assert.strictEqual(arrowStack.quantity, 0);
+global.LuminousItemRuntime = oldItemRuntime;
+global.LuminousItemInventoryRuntime = oldInventoryRuntime;
+
+console.log('Universal ranged ammo smoke OK');

--- a/tests/thrown-projectile-sequence-smoke.mjs
+++ b/tests/thrown-projectile-sequence-smoke.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+
+const require = createRequire(import.meta.url);
+const runtime = require('../js/thrown-projectile-sequence-runtime.js');
+const registry = require('../js/thrown-projectile-sequence-profiles.js');
+
+assert.equal(registry.install(), true);
+
+const fallingRock = runtime.getProfile('winged_kobold_falling_rock');
+assert.ok(fallingRock, 'Falling Rock visual profile must be registered');
+assert.equal(fallingRock.projectileAsset, 'https://imgur.com/P4J48yc.png');
+assert.equal(fallingRock.releaseSprite, 'https://imgur.com/zmA1FPz.png');
+assert.equal(fallingRock.postActionSprite, 'https://imgur.com/evsrs1B.png');
+assert.equal(fallingRock.returnToOrigin, true);
+assert.equal(fallingRock.resumeHover, true);
+
+const savePlan = runtime.buildSequencePlan('save_success', fallingRock);
+assert.deepEqual(savePlan.phases, [
+  'capture_origin',
+  'approach',
+  'release',
+  'projectile_from_actor',
+  'miss_to_ground',
+  'roll',
+  'vanish',
+  'equip_post_action',
+  'return_to_origin',
+  'resume_hover',
+]);
+
+const failPlan = runtime.buildSequencePlan('save_failure', fallingRock);
+assert.deepEqual(failPlan.phases, [
+  'capture_origin',
+  'approach',
+  'release',
+  'projectile_from_actor',
+  'hit_target',
+  'bounce_to_ground',
+  'roll',
+  'vanish',
+  'equip_post_action',
+  'return_to_origin',
+  'resume_hover',
+]);
+
+// Proves the approved sequence is not coupled to Rock/Kobold content.
+runtime.registerProfile('test_bottle_throw', {
+  projectileAsset: 'bottle.png',
+  releaseSprite: 'thrower-empty.png',
+  postActionSprite: 'thrower-idle.png',
+  returnToOrigin: true,
+  resumeHover: false,
+});
+const bottle = runtime.getProfile('test_bottle_throw');
+assert.equal(bottle.projectileAsset, 'bottle.png');
+const bottleFail = runtime.buildSequencePlan(false, bottle);
+assert.ok(bottleFail.phases.includes('hit_target'));
+assert.ok(bottleFail.phases.includes('bounce_to_ground'));
+assert.ok(bottleFail.phases.includes('roll'));
+assert.ok(bottleFail.phases.includes('vanish'));
+assert.ok(bottleFail.phases.includes('return_to_origin'));
+assert.ok(!bottleFail.phases.includes('resume_hover'));
+
+assert.equal(runtime.saveOutcomeFromResult({ resolution: { results: [{ targetId: 'a', result: { isSuccess: true } }] } }, 'a'), true);
+assert.equal(runtime.saveOutcomeFromResult({ resolution: { results: [{ targetId: 'a', result: { isSuccess: false } }] } }, 'a'), false);
+
+const statusBootstrap = readFileSync(new URL('../js/status-engine.js', import.meta.url), 'utf8');
+assert.match(statusBootstrap, /thrown-projectile-sequence-runtime\.js/);
+assert.match(statusBootstrap, /thrown-projectile-sequence-profiles\.js/);
+
+console.log('Thrown projectile sequence smoke OK');


### PR DESCRIPTION
Cierra el batch de referencia de Units early-game para pruebas del motor de combate.

Incluye:
- Kobold Unit catalog y Skills
- Goblin y Goblin Boss Unit catalog/runtime
- Ammo universal y Pierced
- Flying / Falling Rock / thrown projectile support
- smoke coverage escrita
- Unit Library seeder combinado para Kobolds + Goblins

Este batch se mergea como referencia estable antes de continuar con el siguiente grupo de Units.