### PR TITLE
Wolf + Dire Wolf Unit Library batch

### DIFF
--- a/.github/workflows/wolf-unit-library-smoke.yml
+++ b/.github/workflows/wolf-unit-library-smoke.yml
@@ -1,0 +1,28 @@
+name: Wolf Unit Library Smoke
+
+on:
+  push:
+    branches:
+      - feature/unit-library-wolves
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  wolf-unit-library-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Wolf Unit Library smoke
+        run: node tests/wolf-unit-library-smoke.mjs
+      - name: Wolf module syntax
+        run: |
+          node --check js/skill-catalog-wolf.js
+          node --check js/wolf-unit-runtime.js
+          node --check js/unit-catalog-wolf.js
+          node --check js/status-engine.js

--- a/dm-unit-library-seeder.html
+++ b/dm-unit-library-seeder.html
@@ -11,22 +11,26 @@
 <body>
 <div class="wrap"><div class="panel">
 <h1>Luminous · Unit Library</h1>
-<p>Seeder canónico conjunto para las Units Kobold y Goblin. La sincronización conserva IDs determinísticos y actualiza únicamente las entradas incluidas en estos catálogos.</p>
+<p>Seeder canónico conjunto para las familias Kobold, Goblin y Wolf. La sincronización conserva IDs determinísticos y actualiza únicamente las entradas incluidas en estos catálogos.</p>
 <div class="toolbar"><button class="btn primary" id="sync" disabled>SINCRONIZAR UNIT LIBRARY</button><button class="btn" id="refresh">REVISAR CATÁLOGOS</button><span>Units: <code>campaña/base_datos_unidades</code> · Skills canónicas disponibles: <code>campaña/base_datos_skills</code></span></div>
 <div id="status" class="status">Cargando catálogos y verificando sesión DM…</div>
 <div id="families" class="families"></div>
-<p>El sync usa <code>update()</code>: no elimina otras Units ni otras Skills. Las Skills Kobold se validan y sincronizan desde su catálogo canónico. Los Goblins se sincronizan como Units con sus Traits, Ammo y weapon loadouts declarados; este seeder no inventa un catálogo de Skills Goblin donde el catálogo de Unit todavía marca referencias pendientes.</p>
+<p>El sync usa <code>update()</code>: no elimina otras Units ni otras Skills. Las Skills Kobold y Wolf se validan y sincronizan desde sus catálogos canónicos. Los Goblins se sincronizan como Units con sus Traits, Ammo y weapon loadouts declarados sin fabricar Skills que su catálogo todavía marque como pendientes.</p>
 </div></div>
 <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
 <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
 <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-database.js"></script>
 <script src="js/combat-skill-schema.js"></script>
 <script src="js/skill-catalog-kobold-tier1.js"></script>
+<script src="js/skill-catalog-wolf.js"></script>
 <script src="js/unit-rank-runtime.js"></script>
+<script src="js/universal-action-economy.js"></script>
 <script src="js/universal-ranged-ammo-runtime.js"></script>
 <script src="js/goblin-unit-runtime.js"></script>
+<script src="js/wolf-unit-runtime.js"></script>
 <script src="js/unit-catalog-kobold-tier1.js"></script>
 <script src="js/unit-catalog-goblin.js"></script>
+<script src="js/unit-catalog-wolf.js"></script>
 <script src="js/battle-viewer-firebase-session-074.js"></script>
 <script>
 (function(){
@@ -38,7 +42,9 @@ const UNIT_PATH='campaña/base_datos_unidades';
 const SKILL_PATH='campaña/base_datos_skills';
 const kobolds=window.LuminousKoboldUnitCatalog;
 const goblins=window.LuminousGoblinUnitCatalog;
+const wolves=window.LuminousWolfUnitCatalog;
 const koboldSkills=window.LuminousKoboldTier1SkillCatalog;
+const wolfSkills=window.LuminousWolfSkillCatalog;
 const ranks=window.LuminousUnitRankRuntime;
 const schema=window.CombatSkillSchema;
 const session=window.LuminousBattleViewerFirebaseSession074;
@@ -50,12 +56,13 @@ function setStatus(text,kind){$('status').textContent=text;$('status').className
 function pending(value,fallback='Pendiente'){return value==null||value===''?`<span class="pending">${esc(fallback)}</span>`:esc(value)}
 function mergePayloads(...payloads){
  const merged={};
- for(const payload of payloads){for(const [id,value] of Object.entries(payload||{})){if(Object.prototype.hasOwnProperty.call(merged,id))throw new Error(`DUPLICATE_UNIT_ID:${id}`);merged[id]=value}}
+ for(const payload of payloads){for(const [id,value] of Object.entries(payload||{})){if(Object.prototype.hasOwnProperty.call(merged,id))throw new Error(`DUPLICATE_LIBRARY_ID:${id}`);merged[id]=value}}
  return merged;
 }
 function familyEntries(){return [
  {id:'kobold',label:'Kobolds',catalog:kobolds},
  {id:'goblin',label:'Goblins',catalog:goblins},
+ {id:'wolf',label:'Wolves',catalog:wolves},
 ]}
 function levelRange(unit){const range=unit.naturalWorldLevel||unit.baseLevel||{};const min=Number(range.min||1);const max=Number(range.max||min);return {min,max}}
 function rankRows(entry,unit){
@@ -68,7 +75,7 @@ function rankRows(entry,unit){
    const apply=low?.mechanics?.statusApplyBonus;
    const base=low?.mechanics?.basePowerBonus;
    const sp=low?.mechanics?.turnEndSpRecovery??low?.commandProfile?.turnEndSpRecovery;
-   return `<tr><td>${esc(String(rank).toUpperCase())}</td><td>${pending(speed)}</td><td>${esc(low?.mechanics?.hp??low?.hp??'—')}</td><td>${esc(high?.mechanics?.hp??high?.hp??'—')}</td><td>${apply==null?'—':`+${esc(apply)}`}</td><td>${base==null?'—':`+${esc(base)}`}</td><td>${sp==null?'—':`${esc(sp)} SP`}</td></tr>`;
+   return `<tr><td>${esc(String(rank).toUpperCase())}</td><td>${pending(speed)}</td><td>${esc(low?.mechanics?.hp??low?.hp??unit.hpBase??'—')}</td><td>${esc(high?.mechanics?.hp??high?.hp??unit.hpBase??'—')}</td><td>${apply==null?'—':`+${esc(apply)}`}</td><td>${base==null?'—':`+${esc(base)}`}</td><td>${sp==null?'—':`${esc(sp)} SP`}</td></tr>`;
   }catch(error){return `<tr><td>${esc(String(rank).toUpperCase())}</td><td colspan="6" class="pending">${esc(error.message||error)}</td></tr>`}
  }).join('');
 }
@@ -87,21 +94,21 @@ function unitCard(entry,unit){
  const ammo=(unit?.mechanics?.ammoLoadout||[]).map(a=>`${a.amount} ${a.id}`).join(' · ')||'—';
  return `<section class="unit">${portrait(unit)}<h3>${esc(unit.name)}</h3><div class="meta"><span class="label">ID:</span> ${esc(unit.id)} · <span class="label">Nivel natural:</span> ${levels.min}${levels.max!==levels.min?`–${levels.max}`:''} · <span class="label">Ranks:</span> ${(unit.allowedRanks||[]).map(esc).join(', ')}</div><div class="traits"><span class="label">Traits:</span> ${traitReferences(unit)}</div><div class="refs"><span class="label">Skills / Weapons:</span><br>${unitReferences(unit)}</div><div class="meta"><span class="label">Ammo:</span> ${esc(ammo)} · <span class="label">Defense:</span> ${defense(unit)}</div><table class="ranks"><thead><tr><th>Rank</th><th>Speed</th><th>HP Min</th><th>HP Max</th><th>Apply</th><th>Base</th><th>Turn End</th></tr></thead><tbody>${rankRows(entry,unit)}</tbody></table></section>`;
 }
-function validateKoboldSkills(){
- if(!koboldSkills||!schema)return {ok:false,error:'Falta CombatSkillSchema o LuminousKoboldTier1SkillCatalog.'};
- const list=koboldSkills.list();
+function validateSkillCatalog(label,catalog){
+ if(!catalog||!schema)return {ok:false,error:`Falta CombatSkillSchema o catálogo ${label}.`};
+ const list=catalog.list();
  const invalid=list.map(skill=>[skill,schema.validateCombatSkill(skill)]).filter(([,result])=>!result.valid);
- if(invalid.length)return {ok:false,error:`Skill inválida: ${invalid[0][0].id} · ${invalid[0][1].errors.join(' · ')}`};
+ if(invalid.length)return {ok:false,error:`${label}: Skill inválida ${invalid[0][0].id} · ${invalid[0][1].errors.join(' · ')}`};
  return {ok:true,count:list.length};
 }
 function render(){
- if(!kobolds||!goblins||!ranks){setStatus('Falta uno de los catálogos/runtimes requeridos por Unit Library.','bad');return false}
- const skillValidation=validateKoboldSkills();
- if(!skillValidation.ok){setStatus(skillValidation.error,'bad');return false}
+ if(!kobolds||!goblins||!wolves||!ranks){setStatus('Falta uno de los catálogos/runtimes requeridos por Unit Library.','bad');return false}
+ const kv=validateSkillCatalog('Kobold',koboldSkills);if(!kv.ok){setStatus(kv.error,'bad');return false}
+ const wv=validateSkillCatalog('Wolf',wolfSkills);if(!wv.ok){setStatus(wv.error,'bad');return false}
  const entries=familyEntries();
  const unitPayload=mergePayloads(...entries.map(entry=>entry.catalog.firebasePayload()));
  $('families').innerHTML=entries.map(entry=>{const definitions=entry.catalog.list();return `<section class="family"><h2>${esc(entry.label)} · ${definitions.length}</h2><div class="units">${definitions.map(unit=>unitCard(entry,unit)).join('')}</div></section>`}).join('');
- setStatus(`Unit Library válido: ${Object.keys(unitPayload).length} Units (${kobolds.list().length} Kobold + ${goblins.list().length} Goblin) · ${skillValidation.count} Skills Kobold validadas · Unit Rank ${ranks.version}.`,'ok');
+ setStatus(`Unit Library válido: ${Object.keys(unitPayload).length} Units (${kobolds.list().length} Kobold + ${goblins.list().length} Goblin + ${wolves.list().length} Wolf) · ${kv.count+wv.count} Skills canónicas validadas · Unit Rank ${ranks.version}.`,'ok');
  return true;
 }
 async function authorize(){
@@ -112,7 +119,7 @@ async function authorize(){
   if(!result?.ok){setStatus(`Firebase bloqueado: ${result?.reason||'FIREBASE_SESSION_FAILED'}.`,'bad');return false}
   if(result.role!=='dm'){setStatus(`Sesión válida pero sin autoridad DM (${result.role||'unknown'}).`,'bad');return false}
   dmReady=true;$('sync').disabled=false;
-  setStatus(`DM autorizado · Kobold ${kobolds.version} + Goblin ${goblins.version} listos para sincronizar.`,'ok');return true;
+  setStatus(`DM autorizado · Kobold ${kobolds.version} + Goblin ${goblins.version} + Wolf ${wolves.version} listos para sincronizar.`,'ok');return true;
  }catch(error){console.error(error);setStatus(`No se pudo validar la sesión DM: ${error.message||error}`,'bad');return false}
 }
 async function sync(){
@@ -120,8 +127,8 @@ async function sync(){
  if(!render())return;
  const button=$('sync');button.disabled=true;
  try{
-  const unitPayload=mergePayloads(kobolds.firebasePayload(),goblins.firebasePayload());
-  const skillPayload=kobolds.firebaseSkillPayload(schema);
+  const unitPayload=mergePayloads(kobolds.firebasePayload(),goblins.firebasePayload(),wolves.firebasePayload());
+  const skillPayload=mergePayloads(kobolds.firebaseSkillPayload(schema),wolves.firebaseSkillPayload(schema));
   await db.ref(UNIT_PATH).update(unitPayload);
   await db.ref(SKILL_PATH).update(skillPayload);
   setStatus(`Sincronización completa: ${Object.keys(unitPayload).length} Units y ${Object.keys(skillPayload).length} Skills canónicas actualizadas.`,'ok');

--- a/js/skill-catalog-wolf.js
+++ b/js/skill-catalog-wolf.js
@@ -1,0 +1,128 @@
+(function (global) {
+  'use strict';
+
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const safeRequire = (path) => {
+    if (typeof require !== 'function') return null;
+    try { return require(path); } catch (_) { return null; }
+  };
+  const schema = global.CombatSkillSchema || safeRequire('./combat-skill-schema.js');
+
+  function condition(status, component, value) {
+    return { target: 'target', stat: status, component, operator: '>=', value };
+  }
+  function statusEffect(status, potency, count, when = null) {
+    return {
+      trigger: '[On Hit]', target: 'target', type: 'status', status, potency, count,
+      maxCap: 0, scaleTarget: null, scaleCondition: null, is_reuse: false,
+      target_ally: false, timing: 'immediate', condition: when ? clone(when) : null,
+    };
+  }
+  function coin(index, effects = []) { return { index, type: 'normal', status: 'active', effects: clone(effects) }; }
+
+  function attack({ id, name, variant, tier = 1, basePower, coinPower, coinAmount, coinEffects = {}, metadata = {} }) {
+    const coins = Array.from({ length: coinAmount }, (_, index) => coin(index, coinEffects[index] || []));
+    return {
+      id, name, type: 'Attack', tier, maxCopies: tier === 1 ? 3 : 2,
+      basePower, coinPower, coinAmount, coinType: 'positive', attackWeight: 1, skillRange: 1,
+      damageType: 'perforante', sinAffinity: 'sinless', scalingStat: 'Fuerza', statUsed: '', skillUsed: '',
+      targetingType: 'Focused Attack', aoePattern: 'Self', skillAmount: 1, sourceType: 'skill', sourceId: id,
+      isItemSkill: false, isDefense: false, defenseSubtype: '', isClashable: true, isUnclashable: false,
+      isIndiscriminate: false, isTargetFixed: false, requiresUnlock: false, resourceCosts: [], effects: [], coins,
+      evolutionChain: null, schemaVersion: 2,
+      metadata: {
+        canonicalUnitSkill: true, species: variant === 'dire_wolf' ? 'dire_wolf' : 'wolf', unitVariant: variant,
+        tier, statusFamily: 'bleed_sinking', combatRange: 'melee', weaponSkill: true, naturalWeapon: 'fangs',
+        wolfRuntimeManagedStatusEffects: true, ...clone(metadata),
+      },
+    };
+  }
+
+  function evade({ id, name, variant, basePower, coinPower }) {
+    return {
+      id, name, type: 'Defense', tier: 1, maxCopies: 3,
+      basePower, coinPower, coinAmount: 1, coinType: 'positive', attackWeight: 1, skillRange: 1,
+      damageType: 'contundente', sinAffinity: 'sinless', scalingStat: 'Destreza', statUsed: '', skillUsed: '',
+      targetingType: 'Focused Attack', aoePattern: 'Self', skillAmount: 1, sourceType: 'skill', sourceId: id,
+      isItemSkill: false, isDefense: true, defenseSubtype: 'Evade', isClashable: true, isUnclashable: false,
+      isIndiscriminate: false, isTargetFixed: false, requiresUnlock: false, resourceCosts: [], effects: [],
+      coins: [coin(0)], evolutionChain: null, schemaVersion: 2,
+      metadata: { canonicalUnitSkill: true, species: variant === 'dire_wolf' ? 'dire_wolf' : 'wolf', unitVariant: variant, tier: 1, rulesPolicy: 'defense_only', combatRange: 'self', weaponSkill: false },
+    };
+  }
+
+  const bleed3 = condition('bleed', 'count', 3);
+  const bleed4 = condition('bleed', 'count', 4);
+  const sinking3 = condition('sinking', 'count', 3);
+  const sinking4 = condition('sinking', 'count', 4);
+
+  const DEFINITIONS = Object.freeze({
+    wolf_bite: Object.freeze(attack({
+      id: 'wolf_bite', name: 'Bite', variant: 'wolf', basePower: 6, coinPower: 5, coinAmount: 1,
+      coinEffects: { 0: [
+        statusEffect('bleed', 1, 2),
+        statusEffect('sinking', 0, 2, bleed3),
+      ] },
+    })),
+    wolf_gnaw: Object.freeze(attack({
+      id: 'wolf_gnaw', name: 'Gnaw', variant: 'wolf', basePower: 4, coinPower: 3, coinAmount: 2,
+      coinEffects: { 1: [
+        statusEffect('sinking', 1, 2),
+        statusEffect('bleed', 0, 2, sinking3),
+      ] },
+    })),
+    wolf_prowl_away: Object.freeze(evade({ id: 'wolf_prowl_away', name: 'Prowl Away', variant: 'wolf', basePower: 5, coinPower: 5 })),
+    wolf_hunting_bite: Object.freeze(attack({
+      id: 'wolf_hunting_bite', name: 'Hunting Bite', variant: 'wolf', tier: 2, basePower: 6, coinPower: 5, coinAmount: 2,
+      coinEffects: { 1: [
+        statusEffect('bleed', 1, 2),
+        statusEffect('sinking', 1, 2, bleed4),
+      ] },
+    })),
+
+    dire_wolf_bite: Object.freeze(attack({
+      id: 'dire_wolf_bite', name: 'Dire Bite', variant: 'dire_wolf', basePower: 6, coinPower: 6, coinAmount: 1,
+      coinEffects: { 0: [
+        statusEffect('bleed', 1, 2),
+        statusEffect('sinking', 1, 2, bleed3),
+      ] },
+    })),
+    dire_wolf_stalking_step: Object.freeze(evade({ id: 'dire_wolf_stalking_step', name: 'Stalking Step', variant: 'dire_wolf', basePower: 6, coinPower: 5 })),
+    dire_wolf_rending_fangs: Object.freeze(attack({
+      id: 'dire_wolf_rending_fangs', name: 'Rending Fangs', variant: 'dire_wolf', tier: 2, basePower: 7, coinPower: 5, coinAmount: 2,
+      coinEffects: {
+        0: [statusEffect('bleed', 0, 2)],
+        1: [statusEffect('bleed', 1, 3, sinking4)],
+      },
+    })),
+    dire_wolf_break_the_prey: Object.freeze(attack({
+      id: 'dire_wolf_break_the_prey', name: 'Break the Prey', variant: 'dire_wolf', tier: 2, basePower: 6, coinPower: 4, coinAmount: 3,
+      coinEffects: { 2: [statusEffect('bleed', 0, 2), statusEffect('sinking', 0, 2)] },
+      metadata: {
+        wolfFinalPowerIf: {
+          all: [condition('bleed', 'count', 4), condition('sinking', 'count', 4)],
+          bonus: 1,
+          timing: '[Before Attack]',
+        },
+      },
+    })),
+  });
+
+  const LOADOUTS = Object.freeze({
+    wolf: Object.freeze({ tier1: Object.freeze(['wolf_bite', 'wolf_gnaw', 'wolf_prowl_away']), tier2: Object.freeze(['wolf_hunting_bite']) }),
+    dire_wolf: Object.freeze({ tier1: Object.freeze(['dire_wolf_bite', 'dire_wolf_stalking_step']), tier2: Object.freeze(['dire_wolf_rending_fangs', 'dire_wolf_break_the_prey']) }),
+  });
+
+  function get(id) { return DEFINITIONS[String(id || '')] ? clone(DEFINITIONS[String(id || '')]) : null; }
+  function list() { return Object.values(DEFINITIONS).map(clone); }
+  function loadout(id) { return LOADOUTS[String(id || '')] ? clone(LOADOUTS[String(id || '')]) : null; }
+  function firebasePayload(schemaOverride = schema) {
+    const payload = {};
+    list().forEach((skill) => { payload[skill.id] = schemaOverride?.serializeCombatSkill ? schemaOverride.serializeCombatSkill(skill) : skill; });
+    return payload;
+  }
+
+  const api = Object.freeze({ version: '1.0.0', DEFINITIONS, LOADOUTS, condition, statusEffect, get, list, loadout, firebasePayload });
+  global.LuminousWolfSkillCatalog = api;
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/status-engine.js
+++ b/js/status-engine.js
@@ -176,6 +176,7 @@
     try { if (!global.LuminousConditionTheatreBridge) require("./core-condition-theatre-bridge.js"); } catch (_) {}
     try { if (!global.LuminousUniversalRangedAmmoRuntime) require("./universal-ranged-ammo-runtime.js"); } catch (_) {}
     try { if (!global.LuminousGoblinUnitRuntime) require("./goblin-unit-runtime.js"); } catch (_) {}
+    try { if (!global.LuminousWolfUnitRuntime) require("./wolf-unit-runtime.js"); } catch (_) {}
   }
 
   function loadScript(id, src) {
@@ -209,6 +210,7 @@
   if (global.document && !global.LuminousUniversalSpeedRuntime) loadScript("universal-speed-runtime-script", "js/universal-speed-runtime.js");
   if (global.document && !global.LuminousUniversalRangedAmmoRuntime) loadScript("universal-ranged-ammo-runtime-script", "js/universal-ranged-ammo-runtime.js");
   if (global.document && !global.LuminousGoblinUnitRuntime) loadScript("goblin-unit-runtime-script", "js/goblin-unit-runtime.js");
+  if (global.document && !global.LuminousWolfUnitRuntime) loadScript("wolf-unit-runtime-script", "js/wolf-unit-runtime.js");
   if (global.document && !global.LuminousFixedDamageRuntime) loadScript("fixed-damage-runtime-script", "js/fixed-damage-runtime.js");
   if (global.document && !global.LuminousElementalStatusRuntime) loadScript("elemental-status-runtime-script", "js/elemental-status-runtime.js");
   if (global.document && !global.LuminousElementalStatusCompatibility) loadScript("elemental-status-compat-script", "js/elemental-status-compat.js");

--- a/js/unit-catalog-wolf.js
+++ b/js/unit-catalog-wolf.js
@@ -1,0 +1,136 @@
+(function (global) {
+  'use strict';
+
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const safeRequire = (path) => {
+    if (typeof require !== 'function') return null;
+    try { return require(path); } catch (_) { return null; }
+  };
+
+  const rankRuntime = global.LuminousUnitRankRuntime || safeRequire('./unit-rank-runtime.js');
+  const skillCatalog = global.LuminousWolfSkillCatalog || safeRequire('./skill-catalog-wolf.js');
+  const wolfRuntime = global.LuminousWolfUnitRuntime || safeRequire('./wolf-unit-runtime.js');
+  const STAGGER_THRESHOLDS = Object.freeze([75, 50, 25]);
+  const PACK_TACTICS_ID = 'pack_tactics';
+
+  const FALLBACK_RANKS = Object.freeze({
+    normal: Object.freeze({ id: 'normal', levelMultiplier: 1, minSpeedBonus: 0, maxSpeedBonus: 0, applyBonus: 0, basePowerBonus: 0, commandLevel: 0, aiCoordination: 'independent', targetPriority: 'random', turnEndSpRecovery: 0 }),
+    captain: Object.freeze({ id: 'captain', levelMultiplier: 2, minSpeedBonus: 0, maxSpeedBonus: 1, applyBonus: 1, basePowerBonus: 0, commandLevel: 1, aiCoordination: 'focus_fire', targetPriority: 'lowest_hp_ratio', turnEndSpRecovery: 5 }),
+    leader: Object.freeze({ id: 'leader', levelMultiplier: 3, minSpeedBonus: 1, maxSpeedBonus: 2, applyBonus: 2, basePowerBonus: 1, commandLevel: 2, aiCoordination: 'directed_focus', targetPriority: 'lowest_hp_ratio_then_highest_threat', turnEndSpRecovery: 10 }),
+  });
+  const UNIVERSAL_RANKS = rankRuntime?.RANKS || FALLBACK_RANKS;
+  const MEANING = Object.freeze(clone(wolfRuntime?.MEANING || { id: 'wolf_meaning', name: 'Meaning', type: 'passive', description: "Can't be targeted by Units below 0 SP." }));
+  const HUNTING_HOWLING = Object.freeze(clone(wolfRuntime?.HUNTING_HOWLING || { id: 'hunting_howling', name: 'Hunting Howling', type: 'quick_action', description: 'Quick Action. All deployed allied Wolves recover 5 SP and gain 1 Attack Power Up. Once per Encounter, add 3 Wolf Backup Units.' }));
+
+  function packTacticsRef() { return { id: PACK_TACTICS_ID, source: 'racial_trait_catalog' }; }
+  function rankHowling(requiredRank) {
+    return { ...clone(HUNTING_HOWLING), requiredRank, rankOnly: true };
+  }
+  function skillRefs(unitId) {
+    const loadout = skillCatalog?.loadout?.(unitId);
+    return loadout ? [...(loadout.tier1 || []), ...(loadout.tier2 || [])] : [];
+  }
+
+  const DEFINITIONS = Object.freeze({
+    wolf: Object.freeze({
+      id: 'wolf', name: 'Wolf', species: 'wolf', variant: 'standard', unitType: 'enemy', actorCategory: 'enemy', faction: 'enemy', isPlayer: false,
+      naturalWorldLevel: Object.freeze({ min: 2, max: 4 }), baseLevel: Object.freeze({ min: 2, max: 4 }),
+      hpBase: 11, hpCoefficient: null,
+      traitIds: Object.freeze([PACK_TACTICS_ID, MEANING.id, HUNTING_HOWLING.id]),
+      traits: Object.freeze([packTacticsRef(), MEANING, Object.freeze(rankHowling('captain'))]),
+      allowedRanks: Object.freeze(['normal', 'captain']), rankProfiles: UNIVERSAL_RANKS,
+      staggerThresholds: STAGGER_THRESHOLDS,
+      visual: Object.freeze({ spriteUrl: 'https://imgur.com/W6efoaJ.png', spritePending: false }),
+      tier1: Object.freeze(['wolf_bite', 'wolf_gnaw', 'wolf_prowl_away']),
+      tier2: Object.freeze(['wolf_hunting_bite']),
+      action_slots: Object.freeze(skillRefs('wolf')),
+      mechanics: Object.freeze({
+        hpBase: 11, hpCoefficient: null, hpGrowthPendingCanonicalCoefficient: true,
+        naturalWeapon: 'fangs', build: Object.freeze(['bleed', 'sinking']),
+        packTacticsTraitId: PACK_TACTICS_ID, meaningTraitId: MEANING.id,
+        huntingHowling: Object.freeze({ requiredRank: 'captain', economy: 'quick_action', spRecovery: 5, attackPowerUp: 1, backupUnitId: 'wolf', backupAmount: 3, backupOncePerEncounter: true }),
+        encounterComposition: Object.freeze({ requiredRank: 'captain', minimum: 1 }),
+        skills: Object.freeze(skillRefs('wolf')), staggerThresholds: STAGGER_THRESHOLDS,
+      }),
+      metadata: Object.freeze({ canonicalUnit: true, catalog: 'wolf-batch', oneCaptainPerEncounter: true, physicalProfilePending: true, speedPending: true, scoresPending: true }),
+      schemaVersion: 2,
+    }),
+
+    dire_wolf: Object.freeze({
+      id: 'dire_wolf', name: 'Dire Wolf', species: 'dire_wolf', variant: 'dire', unitType: 'enemy', actorCategory: 'enemy', faction: 'enemy', isPlayer: false,
+      naturalWorldLevel: Object.freeze({ min: 5, max: 5 }), baseLevel: Object.freeze({ min: 5, max: 5 }),
+      hpBase: 37, hpCoefficient: null,
+      traitIds: Object.freeze([PACK_TACTICS_ID, MEANING.id, HUNTING_HOWLING.id]),
+      traits: Object.freeze([packTacticsRef(), MEANING, Object.freeze(rankHowling('leader'))]),
+      allowedRanks: Object.freeze(['normal', 'leader']), rankProfiles: UNIVERSAL_RANKS,
+      staggerThresholds: STAGGER_THRESHOLDS,
+      visual: Object.freeze({ spriteUrl: 'https://imgur.com/sqbDc2B.png', spritePending: false }),
+      tier1: Object.freeze(['dire_wolf_bite', 'dire_wolf_stalking_step']),
+      tier2: Object.freeze(['dire_wolf_rending_fangs', 'dire_wolf_break_the_prey']),
+      action_slots: Object.freeze(skillRefs('dire_wolf')),
+      mechanics: Object.freeze({
+        hpBase: 37, hpCoefficient: null, hpGrowthPendingCanonicalCoefficient: true,
+        naturalWeapon: 'fangs', build: Object.freeze(['bleed', 'sinking']),
+        packTacticsTraitId: PACK_TACTICS_ID, meaningTraitId: MEANING.id,
+        huntingHowling: Object.freeze({ requiredRank: 'leader', economy: 'quick_action', spRecovery: 5, attackPowerUp: 1, backupUnitId: 'wolf', backupAmount: 3, backupOncePerEncounter: true }),
+        encounterComposition: Object.freeze({ requiredRank: 'leader', minimum: 1 }),
+        skills: Object.freeze(skillRefs('dire_wolf')), staggerThresholds: STAGGER_THRESHOLDS,
+      }),
+      metadata: Object.freeze({ canonicalUnit: true, catalog: 'wolf-batch', oneLeaderPerEncounter: true, physicalProfilePending: true, speedPending: true, scoresPending: true }),
+      schemaVersion: 2,
+    }),
+  });
+
+  function get(id) { return DEFINITIONS[String(id || '')] ? clone(DEFINITIONS[String(id || '')]) : null; }
+  function list() { return Object.values(DEFINITIONS).map(clone); }
+  function normalizeRank(rank) {
+    const id = rankRuntime?.normalizeRank ? rankRuntime.normalizeRank(rank, '') : String(rank || 'normal').trim().toLowerCase();
+    if (!UNIVERSAL_RANKS[id]) throw new Error(`UNKNOWN_UNIT_RANK:${id}`);
+    return id;
+  }
+  function normalizeLevel(level) {
+    const value = Math.floor(Number(level));
+    if (!Number.isFinite(value) || value < 1) throw new Error(`UNIT_LEVEL_OUT_OF_RANGE:${level}`);
+    return value;
+  }
+  function resolveSkill(skillId, rank) {
+    if (!skillCatalog?.get) throw new Error('WOLF_SKILL_CATALOG_REQUIRED');
+    const skill = skillCatalog.get(skillId);
+    if (!skill) throw new Error(`UNKNOWN_WOLF_SKILL:${skillId}`);
+    const profile = UNIVERSAL_RANKS[normalizeRank(rank)];
+    skill.basePower += Number(profile.basePowerBonus || 0);
+    const boost = (effects) => (effects || []).forEach((effect) => {
+      if (effect?.type === 'status' && Number(effect.count) > 0) effect.count = Number(effect.count) + Number(profile.applyBonus || 0);
+    });
+    boost(skill.effects); (skill.coins || []).forEach((coin) => boost(coin.effects));
+    skill.metadata = { ...(skill.metadata || {}), unitRank: profile.id, rankBasePowerBonus: profile.basePowerBonus, rankApplyBonus: profile.applyBonus };
+    return skill;
+  }
+  function resolve(id, options = {}) {
+    const unit = get(id);
+    if (!unit) throw new Error(`UNKNOWN_WOLF_UNIT:${id}`);
+    const level = normalizeLevel(options.level ?? options.baseLevel ?? unit.naturalWorldLevel.min);
+    const rank = normalizeRank(options.rank ?? unit.allowedRanks[0]);
+    if (!unit.allowedRanks.includes(rank)) throw new Error(`UNIT_RANK_NOT_ALLOWED:${id}:${rank}`);
+    const profile = UNIVERSAL_RANKS[rank];
+    const effectiveLevel = rankRuntime?.effectiveLevel ? rankRuntime.effectiveLevel(level, rank) : level * Number(profile.levelMultiplier || 1);
+    const maxHp = unit.hpCoefficient == null ? Number(unit.hpBase) : Math.floor(Number(unit.hpBase) + effectiveLevel * Number(unit.hpCoefficient));
+    unit.rank = rank; unit.runtimeLevel = level; unit.baseLevelSelected = level; unit.effectiveLevel = effectiveLevel; unit.rankBonuses = clone(profile);
+    unit.commandProfile = { commandLevel: profile.commandLevel, aiCoordination: profile.aiCoordination, targetPriority: profile.targetPriority, turnEndSpRecovery: profile.turnEndSpRecovery };
+    unit.hp = maxHp; unit.maxHp = maxHp;
+    unit.resolvedSkills = unit.mechanics.skills.map((skillId) => resolveSkill(skillId, rank));
+    unit.mechanics = { ...unit.mechanics, hp: maxHp, maxHp, level: effectiveLevel, runtimeLevel: level, rank, statusApplyBonus: profile.applyBonus, basePowerBonus: profile.basePowerBonus, commandLevel: profile.commandLevel, turnEndSpRecovery: profile.turnEndSpRecovery };
+    if (options.initializeEncounter === true) wolfRuntime?.resetEncounter?.(unit, options);
+    return unit;
+  }
+  function firebasePayload() { const payload = {}; list().forEach((unit) => { payload[unit.id] = unit; }); return payload; }
+  function firebaseSkillPayload(schema) { if (!skillCatalog?.firebasePayload) throw new Error('WOLF_SKILL_CATALOG_REQUIRED'); return skillCatalog.firebasePayload(schema); }
+
+  const api = Object.freeze({
+    version: '1.0.0', STAGGER_THRESHOLDS, PACK_TACTICS_ID, UNIVERSAL_RANKS, MEANING, HUNTING_HOWLING,
+    DEFINITIONS, get, list, resolve, resolveSkill, firebasePayload, firebaseSkillPayload,
+  });
+  global.LuminousWolfUnitCatalog = api;
+  wolfRuntime?.install?.();
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/wolf-unit-runtime.js
+++ b/js/wolf-unit-runtime.js
@@ -1,0 +1,309 @@
+(function (global) {
+  'use strict';
+
+  const normalizeId = (value) => String(value ?? '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const asArray = (value) => value == null ? [] : (Array.isArray(value) ? value : [value]);
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+  const MEANING = Object.freeze({
+    id: 'wolf_meaning',
+    name: 'Meaning',
+    type: 'passive',
+    description: "Can't be targeted by Units below 0 SP.",
+    mechanics: Object.freeze({ targetRestriction: true, attackerSpBelow: 0 }),
+  });
+
+  const HUNTING_HOWLING = Object.freeze({
+    id: 'hunting_howling',
+    name: 'Hunting Howling',
+    type: 'quick_action',
+    description: 'Quick Action. All deployed allied Wolves recover 5 SP and gain 1 Attack Power Up. Once per Encounter, add 3 Wolf Backup Units.',
+    mechanics: Object.freeze({
+      economy: 'quick_action', spRecovery: 5, attackPowerUp: 1,
+      backupUnitId: 'wolf', backupAmount: 3, backupLimit: 'once_per_encounter',
+      wolfRequiredRank: 'captain', direWolfRequiredRank: 'leader',
+    }),
+  });
+
+  function unitTemplateId(unit = {}) {
+    return normalizeId(unit.catalogId ?? unit.templateId ?? unit.unitId ?? unit.id ?? unit.species);
+  }
+  function isWolf(unit = {}) {
+    const id = unitTemplateId(unit);
+    if (id === 'wolf' || id === 'dire_wolf') return true;
+    const species = normalizeId(unit.species ?? unit.raceId);
+    return species === 'wolf' || species === 'dire_wolf';
+  }
+  function isDireWolf(unit = {}) { return unitTemplateId(unit) === 'dire_wolf' || normalizeId(unit.species) === 'dire_wolf'; }
+  function sameSide(a = {}, b = {}) {
+    const af = normalizeId(a.faction ?? a.faccion ?? a.side ?? a.team);
+    const bf = normalizeId(b.faction ?? b.faccion ?? b.side ?? b.team);
+    return Boolean(af && bf && af === bf);
+  }
+  function isDeployed(unit = {}) {
+    if (!unit || unit.hp === 0 || unit.dead === true || unit.removed === true || unit.retreated === true || unit.escaped === true || unit.isBackup === true) return false;
+    const state = normalizeId(unit.deploymentState ?? unit.deployment ?? unit.positionState ?? unit.zone ?? 'field');
+    return !['backup', 'reserve', 'reserves', 'retreated', 'escaped', 'removed', 'dead'].includes(state);
+  }
+  function spOf(unit = {}) { return numberOr(unit.sp ?? unit.currentSp ?? unit.currentSP, 0); }
+  function rankOf(unit = {}) { return normalizeId(unit.rank ?? unit.mechanics?.rank ?? unit.unitRank ?? 'normal'); }
+
+  function canTarget(attacker, target) {
+    if (isWolf(target) && spOf(attacker) < 0) return { allowed: false, reason: 'wolf_meaning_negative_sp', traitId: MEANING.id };
+    return { allowed: true, reason: null, traitId: isWolf(target) ? MEANING.id : null };
+  }
+
+  function statusEngine() {
+    if (global.LuminousStatusEngine) return global.LuminousStatusEngine;
+    if (typeof require === 'function') {
+      try { return require('./status-engine.js'); } catch (_) {}
+    }
+    return null;
+  }
+  function actionEconomy() {
+    if (global.LuminousActionEconomy) return global.LuminousActionEconomy;
+    if (typeof require === 'function') {
+      try { return require('./universal-action-economy.js'); } catch (_) {}
+    }
+    return null;
+  }
+
+  function statusComponent(unit, statusId, component = null) {
+    const id = normalizeId(statusId);
+    const entry = unit?.statusEffects?.[id] ?? unit?.statuses?.[id] ?? null;
+    if (entry == null) return 0;
+    if (typeof entry === 'number') return numberOr(entry, 0);
+    const key = normalizeId(component);
+    if (key === 'count') return numberOr(entry.count, 0);
+    if (key === 'potency') return numberOr(entry.potency, 0);
+    return numberOr(entry.potency ?? entry.count ?? entry.value, 0);
+  }
+  function conditionPasses(condition, context = {}) {
+    if (!condition) return true;
+    const targetKey = normalizeId(condition.target || 'target');
+    const unit = targetKey === 'self'
+      ? (context.attacker || context.self || context.unit)
+      : (context.currentTarget || context.target || context.defender);
+    if (!unit) return false;
+    const actual = statusComponent(unit, condition.stat, condition.component);
+    const expected = numberOr(condition.value, 0);
+    const op = String(condition.operator || '=').trim();
+    if (op === '<') return actual < expected;
+    if (op === '<=') return actual <= expected;
+    if (op === '>=') return actual >= expected;
+    if (op === '>') return actual > expected;
+    return actual === expected;
+  }
+
+  function applyStatusDescriptor(effect, context = {}) {
+    if (!effect || effect.type !== 'status' || typeof effect.execute === 'function') return null;
+    if (!conditionPasses(effect.condition, context)) return null;
+    const target = normalizeId(effect.target || 'target') === 'self'
+      ? (context.attacker || context.self || context.unit)
+      : (context.currentTarget || context.target || context.defender);
+    if (!target) return null;
+    return statusEngine()?.applyStatus?.(target, effect.status, {
+      mode: 'gain', potency: numberOr(effect.potency, 0), count: numberOr(effect.count, 0),
+      sourceUnitId: context.attacker?.id || context.attacker?.unitId || null,
+      data: { sourceSkillId: context.skill?.id || null, wolfConditionalEffect: Boolean(effect.condition) },
+    }) || null;
+  }
+
+  function tagMatches(effect, tag) { return normalizeId(effect?.trigger) === normalizeId(tag); }
+  function isWolfManagedSkill(skill = {}) { return skill?.metadata?.wolfRuntimeManagedStatusEffects === true; }
+  function applyManagedSkillEffects(tag, context = {}, targetsHit = []) {
+    const skill = context.skill;
+    if (!isWolfManagedSkill(skill) || normalizeId(tag) !== 'on_hit') return [];
+    const effects = [
+      ...asArray(skill.effects).filter((effect) => tagMatches(effect, tag)),
+      ...asArray(context.currentCoin?.effects).filter((effect) => tagMatches(effect, tag)),
+    ];
+    if (!effects.length) return [];
+    const targets = asArray(targetsHit).length ? asArray(targetsHit) : [context.currentTarget || context.defender].filter(Boolean);
+    const applied = [];
+    targets.forEach((target) => {
+      const local = { ...context, currentTarget: target, target, defender: context.defender || target };
+      effects.forEach((effect) => {
+        const result = applyStatusDescriptor(effect, local);
+        if (result) applied.push({ target, effect, result });
+      });
+    });
+    return applied;
+  }
+
+  function finalPowerConditionPasses(skill = {}, target = {}) {
+    const rule = skill?.metadata?.wolfFinalPowerIf;
+    const all = asArray(rule?.all);
+    return Boolean(rule && all.length && all.every((entry) => conditionPasses(entry, { currentTarget: target, target, defender: target })));
+  }
+  function prepareConditionalSkill(skill = {}, target = {}) {
+    const prepared = clone(skill);
+    if (!finalPowerConditionPasses(prepared, target)) return prepared;
+    prepared.metadata = { ...(prepared.metadata || {}), wolfConditionalFinalPowerBonus: numberOr(prepared.metadata?.wolfFinalPowerIf?.bonus, 1), wolfConditionalFinalPowerActive: true };
+    return prepared;
+  }
+
+  function recoverSp(unit, amount = 5) {
+    const before = spOf(unit);
+    const raw = before + numberOr(amount, 0);
+    let next = raw;
+    if (global.CombatEngine?.limitSP) next = global.CombatEngine.limitSP(raw);
+    else {
+      const max = Number(unit?.maxSp ?? unit?.maxSP);
+      if (Number.isFinite(max)) next = Math.min(max, raw);
+    }
+    unit.sp = next;
+    if ('currentSp' in unit) unit.currentSp = next;
+    if ('currentSP' in unit) unit.currentSP = next;
+    return { before, after: next, recovered: next - before };
+  }
+  function applyHowlingBuff(unit, source) {
+    return statusEngine()?.applyStatus?.(unit, 'attack_power_up', {
+      mode: 'gain', count: 1, potency: 0, duration: 'this_turn',
+      sourceTraitId: HUNTING_HOWLING.id, sourceUnitId: source?.id || source?.unitId || null,
+    }) || null;
+  }
+  function requiredHowlingRank(source = {}) { return isDireWolf(source) ? 'leader' : 'captain'; }
+  function canUseHuntingHowling(source, options = {}) {
+    if (!isWolf(source)) return { allowed: false, reason: 'not_wolf' };
+    const requiredRank = requiredHowlingRank(source);
+    if (rankOf(source) !== requiredRank) return { allowed: false, reason: 'hunting_howling_rank_required', requiredRank };
+    const economy = actionEconomy();
+    if (economy?.availability) {
+      const gate = economy.availability(source, 'quick_action', { ...options, phase: options.phase || 'planning' });
+      if (!gate.available) return { allowed: false, reason: gate.reason || 'quick_action_unavailable', requiredRank };
+    }
+    return { allowed: true, reason: null, requiredRank };
+  }
+
+  function encounterStateFor(source, options = {}) {
+    if (options.encounterState && typeof options.encounterState === 'object') return options.encounterState;
+    if (!source.__wolfEncounterState || typeof source.__wolfEncounterState !== 'object') source.__wolfEncounterState = {};
+    return source.__wolfEncounterState;
+  }
+  function backupKey(source, index, reserves = {}) {
+    const root = normalizeId(source.instanceId || source.characterId || source.id || source.unitId || 'wolf_leader') || 'wolf_leader';
+    let key = `${root}_howling_wolf_${index + 1}`;
+    let n = 2;
+    while (Object.prototype.hasOwnProperty.call(reserves || {}, key)) key = `${root}_howling_wolf_${index + 1}_${n++}`;
+    return key;
+  }
+  function backupWolfTemplate(source = {}) {
+    const catalog = global.LuminousWolfUnitCatalog;
+    const base = catalog?.get?.('wolf') || {
+      id: 'wolf', unitId: 'wolf', catalogId: 'wolf', name: 'Wolf', species: 'wolf', unitType: 'enemy', actorCategory: 'enemy', isPlayer: false,
+      hpBase: 11, visual: { spriteUrl: 'https://imgur.com/W6efoaJ.png' },
+    };
+    const backup = clone(base);
+    backup.id = 'wolf';
+    backup.unitId = 'wolf';
+    backup.catalogId = 'wolf';
+    backup.rank = 'normal';
+    backup.deployment = 'backup';
+    backup.deploymentState = 'backup';
+    backup.isBackup = true;
+    backup.faction = source.faction ?? source.faccion ?? source.side ?? backup.faction ?? 'enemy';
+    backup.spawnSourceTraitId = HUNTING_HOWLING.id;
+    return backup;
+  }
+  function addHowlingBackups(source, options = {}) {
+    const state = encounterStateFor(source, options);
+    if (state.huntingHowlingBackupsUsed === true) return { added: [], alreadyUsed: true };
+    state.huntingHowlingBackupsUsed = true;
+    const reserves = options.reserves && typeof options.reserves === 'object' ? options.reserves : {};
+    const added = [];
+    for (let index = 0; index < 3; index += 1) {
+      const unit = backupWolfTemplate(source);
+      const key = backupKey(source, index, reserves);
+      unit.instanceId = key;
+      if (typeof options.addBackupUnit === 'function') options.addBackupUnit(unit, key);
+      else reserves[key] = unit;
+      added.push({ key, unit });
+    }
+    return { added, alreadyUsed: false, reserves };
+  }
+  function resetEncounter(source, options = {}) {
+    const state = encounterStateFor(source, options);
+    state.huntingHowlingBackupsUsed = false;
+    return state;
+  }
+
+  function useHuntingHowling(source, options = {}) {
+    const gate = canUseHuntingHowling(source, options);
+    if (!gate.allowed) return { used: false, ...gate };
+    const economy = actionEconomy();
+    if (economy?.consume && !economy.consume(source, 'quick_action', { ...options, phase: options.phase || 'planning' })) {
+      return { used: false, reason: 'quick_action_unavailable' };
+    }
+    const deployed = asArray(options.deployedUnits).length ? asArray(options.deployedUnits) : asArray(global.CombatEngine?.getAllAliveUnits?.());
+    const wolves = deployed.filter((unit) => isWolf(unit) && isDeployed(unit) && sameSide(source, unit));
+    if (isDeployed(source) && isWolf(source) && !wolves.includes(source)) wolves.push(source);
+    const affected = wolves.map((unit) => ({ unit, sp: recoverSp(unit, 5), attackPowerUp: applyHowlingBuff(unit, source) }));
+    const backup = addHowlingBackups(source, options);
+    return { used: true, traitId: HUNTING_HOWLING.id, affected, backup, quickActionSpent: true };
+  }
+
+  function installCombatBridge() {
+    const engine = global.CombatEngine;
+    if (!engine || engine.__wolfUnitRuntimeInstalled) return Boolean(engine?.__wolfUnitRuntimeInstalled);
+
+    if (typeof engine.triggerEvent === 'function') {
+      const originalTrigger = engine.triggerEvent;
+      engine.triggerEvent = function (tag, context = {}, targetsHit = []) {
+        const result = originalTrigger.call(this, tag, context, targetsHit);
+        const applied = applyManagedSkillEffects(tag, context, targetsHit);
+        if (applied.length) context.wolfStatusEffectsApplied = [...asArray(context.wolfStatusEffectsApplied), ...applied];
+        return result;
+      };
+    }
+
+    if (typeof engine.calculateFinalPower === 'function') {
+      const originalPower = engine.calculateFinalPower;
+      engine.calculateFinalPower = function (skill, headsFlipped, unit) {
+        const power = originalPower.call(this, skill, headsFlipped, unit);
+        return power + numberOr(skill?.metadata?.wolfConditionalFinalPowerBonus, 0);
+      };
+    }
+
+    if (typeof engine.resolveStandardClash === 'function') {
+      const originalClash = engine.resolveStandardClash;
+      engine.resolveStandardClash = function (unitA, skillA, unitB, skillB) {
+        return originalClash.call(this, unitA, prepareConditionalSkill(skillA, unitB), unitB, prepareConditionalSkill(skillB, unitA));
+      };
+    }
+
+    if (typeof engine.resolveUnilateralWithCounter === 'function') {
+      const originalResolve = engine.resolveUnilateralWithCounter;
+      engine.resolveUnilateralWithCounter = function (attacker, skill, defender, counterSkill, options = {}) {
+        const targetGate = canTarget(attacker, defender);
+        if (!targetGate.allowed) {
+          return { blocked: true, reason: targetGate.reason, traitId: MEANING.id, attackerId: attacker?.id || attacker?.unitId || null, defenderId: defender?.id || defender?.unitId || null, attackLogs: [], pendingActions: [] };
+        }
+        return originalResolve.call(this, attacker, prepareConditionalSkill(skill, defender), defender, counterSkill, options);
+      };
+    }
+
+    Object.defineProperty(engine, '__wolfUnitRuntimeInstalled', { value: true, configurable: true });
+    return true;
+  }
+
+  function install() { return installCombatBridge(); }
+
+  const api = Object.freeze({
+    version: '1.0.0', MEANING, HUNTING_HOWLING,
+    unitTemplateId, isWolf, isDireWolf, sameSide, isDeployed, spOf, rankOf, canTarget,
+    statusComponent, conditionPasses, applyStatusDescriptor, applyManagedSkillEffects,
+    finalPowerConditionPasses, prepareConditionalSkill, recoverSp, applyHowlingBuff,
+    requiredHowlingRank, canUseHuntingHowling, backupWolfTemplate, addHowlingBackups, resetEncounter, useHuntingHowling,
+    installCombatBridge, install,
+  });
+
+  global.LuminousWolfUnitRuntime = api;
+  install();
+  if (global.document) {
+    global.setTimeout?.(install, 0);
+    global.setTimeout?.(install, 800);
+  }
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/tests/wolf-unit-library-smoke.mjs
+++ b/tests/wolf-unit-library-smoke.mjs
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+
+await import('../js/status-engine.js');
+await import('../js/status-library.js');
+await import('../js/universal-action-economy.js');
+await import('../js/unit-rank-runtime.js');
+await import('../js/skill-catalog-wolf.js');
+await import('../js/wolf-unit-runtime.js');
+await import('../js/unit-catalog-wolf.js');
+
+const skills = globalThis.LuminousWolfSkillCatalog;
+const runtime = globalThis.LuminousWolfUnitRuntime;
+const units = globalThis.LuminousWolfUnitCatalog;
+const statuses = globalThis.LuminousStatusEngine;
+const economy = globalThis.LuminousActionEconomy;
+if (!skills || !runtime || !units || !statuses || !economy) throw new Error('Wolf batch runtimes did not initialize.');
+
+assert.deepEqual(Object.keys(units.firebasePayload()).sort(), ['dire_wolf', 'wolf']);
+assert.equal(skills.list().length, 8);
+
+const wolf = units.get('wolf');
+const dire = units.get('dire_wolf');
+assert.equal(wolf.hpBase, 11);
+assert.deepEqual(wolf.naturalWorldLevel, { min: 2, max: 4 });
+assert.equal(wolf.visual.spriteUrl, 'https://imgur.com/W6efoaJ.png');
+assert.deepEqual(wolf.allowedRanks, ['normal', 'captain']);
+assert.ok(wolf.traitIds.includes('pack_tactics'));
+assert.ok(wolf.traitIds.includes('wolf_meaning'));
+assert.ok(wolf.traitIds.includes('hunting_howling'));
+assert.equal(wolf.mechanics.huntingHowling.requiredRank, 'captain');
+assert.equal(wolf.mechanics.huntingHowling.backupAmount, 3);
+assert.equal(wolf.mechanics.huntingHowling.backupOncePerEncounter, true);
+
+assert.equal(dire.hpBase, 37);
+assert.deepEqual(dire.naturalWorldLevel, { min: 5, max: 5 });
+assert.equal(dire.visual.spriteUrl, 'https://imgur.com/sqbDc2B.png');
+assert.deepEqual(dire.allowedRanks, ['normal', 'leader']);
+assert.equal(dire.mechanics.huntingHowling.requiredRank, 'leader');
+
+const bite = skills.get('wolf_bite');
+assert.equal(bite.basePower, 6);
+assert.equal(bite.coinPower, 5);
+assert.equal(bite.coinAmount, 1);
+assert.equal(bite.damageType, 'perforante');
+assert.equal(bite.coins[0].effects[0].status, 'bleed');
+assert.equal(bite.coins[0].effects[1].status, 'sinking');
+assert.deepEqual(bite.coins[0].effects[1].condition, { target: 'target', stat: 'bleed', component: 'count', operator: '>=', value: 3 });
+
+const gnaw = skills.get('wolf_gnaw');
+assert.equal(gnaw.coins[1].effects[0].status, 'sinking');
+assert.equal(gnaw.coins[1].effects[1].condition.component, 'count');
+assert.equal(gnaw.coins[1].effects[1].condition.stat, 'sinking');
+
+const breakPrey = skills.get('dire_wolf_break_the_prey');
+assert.equal(breakPrey.tier, 2);
+assert.equal(breakPrey.basePower + breakPrey.coinPower * breakPrey.coinAmount, 18);
+assert.equal(breakPrey.metadata.wolfFinalPowerIf.bonus, 1);
+assert.equal(breakPrey.metadata.wolfFinalPowerIf.all.length, 2);
+
+const target = { id: 'target', hp: 50, maxHp: 50, sp: 0, statusEffects: {} };
+statuses.applyStatus(target, 'bleed', { mode: 'set', potency: 1, count: 1 });
+runtime.applyManagedSkillEffects('[On Hit]', { attacker: { id: 'wolf_a' }, defender: target, currentTarget: target, skill: bite, currentCoin: bite.coins[0] }, [target]);
+assert.equal(statuses.getStatus(target, 'bleed').count, 3);
+assert.equal(statuses.getStatus(target, 'bleed').potency, 2);
+assert.equal(statuses.getStatus(target, 'sinking').count, 2, 'Bite should cross the 3+ Bleed Count threshold on the same hit.');
+
+statuses.applyStatus(target, 'sinking', { mode: 'set', potency: 2, count: 4 });
+const prepared = runtime.prepareConditionalSkill(breakPrey, target);
+assert.equal(prepared.metadata.wolfConditionalFinalPowerActive, true);
+assert.equal(prepared.metadata.wolfConditionalFinalPowerBonus, 1);
+
+assert.equal(runtime.canTarget({ sp: -1 }, wolf).allowed, false);
+assert.equal(runtime.canTarget({ sp: 0 }, wolf).allowed, true);
+assert.equal(runtime.canTarget({ sp: -10 }, { id: 'goblin', species: 'goblin' }).allowed, true);
+
+const normalWolf = units.resolve('wolf', { level: 2, rank: 'normal' });
+const captain = units.resolve('wolf', { level: 2, rank: 'captain' });
+const allyWolf = units.resolve('wolf', { level: 2, rank: 'normal' });
+const leader = units.resolve('dire_wolf', { level: 5, rank: 'leader' });
+normalWolf.sp = 0;
+captain.sp = -5;
+allyWolf.sp = -10;
+leader.sp = 0;
+assert.equal(runtime.canUseHuntingHowling(normalWolf, { phase: 'planning' }).allowed, false);
+
+economy.beginPlanning(captain);
+const encounterState = {};
+const reserves = {};
+const howl1 = runtime.useHuntingHowling(captain, { phase: 'planning', deployedUnits: [captain, allyWolf], encounterState, reserves });
+assert.equal(howl1.used, true);
+assert.equal(captain.sp, 0);
+assert.equal(allyWolf.sp, -5);
+assert.equal(statuses.getStatus(captain, 'attack_power_up').count, 1);
+assert.equal(statuses.getStatus(allyWolf, 'attack_power_up').count, 1);
+assert.equal(Object.keys(reserves).length, 3);
+assert.ok(Object.values(reserves).every((entry) => entry.catalogId === 'wolf' && entry.isBackup === true && entry.rank === 'normal'));
+
+// New turn: Howling remains usable, but the encounter cannot create another +3 backups.
+economy.beginPlanning(captain);
+const howl2 = runtime.useHuntingHowling(captain, { phase: 'planning', deployedUnits: [captain, allyWolf], encounterState, reserves });
+assert.equal(howl2.used, true);
+assert.equal(howl2.backup.alreadyUsed, true);
+assert.equal(Object.keys(reserves).length, 3);
+
+// Dire Wolf gains the same Quick Action only at Leader rank.
+economy.beginPlanning(leader);
+assert.equal(runtime.canUseHuntingHowling(leader, { phase: 'planning' }).allowed, true);
+
+console.log('wolf unit library smoke: ok');

--- a/tests/wolf-unit-library-smoke.mjs
+++ b/tests/wolf-unit-library-smoke.mjs
@@ -64,6 +64,7 @@ assert.equal(statuses.getStatus(target, 'bleed').count, 3);
 assert.equal(statuses.getStatus(target, 'bleed').potency, 2);
 assert.equal(statuses.getStatus(target, 'sinking').count, 2, 'Bite should cross the 3+ Bleed Count threshold on the same hit.');
 
+statuses.applyStatus(target, 'bleed', { mode: 'set', potency: 2, count: 4 });
 statuses.applyStatus(target, 'sinking', { mode: 'set', potency: 2, count: 4 });
 const prepared = runtime.prepareConditionalSkill(breakPrey, target);
 assert.equal(prepared.metadata.wolfConditionalFinalPowerActive, true);


### PR DESCRIPTION
## Wolf Unit Library batch

Adds Wolf and Dire Wolf as reference Units for combat-engine testing.

### Units
- Wolf — Base HP 11, natural level 2–4, one Captain required by encounter composition
- Dire Wolf — Base HP 37, natural level 5, one Leader required by encounter composition
- canonical Pack Tactics reference
- Meaning: Units below 0 SP cannot target Wolves
- exact sprites supplied for Wolf and Dire Wolf

### Build
- Fangs use Bleed + Sinking as physical/mental attrition
- threshold `If` conditions explicitly distinguish Status Count
- Bleed can feed Sinking and Sinking can feed Bleed
- Break the Prey gains +1 Final Power at 4+ Bleed Count and 4+ Sinking Count
- all Unit Skills capped at Tier 2

### Hunting Howling
- Captain-only on Wolf / Leader-only on Dire Wolf
- Quick Action each turn
- all deployed allied Wolves recover 5 SP and gain 1 Attack Power Up
- first use per Encounter also creates exactly 3 normal Wolf Backup Units
- later uses in the same Encounter keep the SP/buff but do not create more backups

### Integration
- adds Wolf Skill catalog, Unit catalog and combat runtime
- status-engine bootstraps Wolf runtime
- Unit Library seeder now includes Wolves and Wolf Skills
- adds dedicated Wolf smoke workflow and tests
