### PR TITLE
Combat AI foundation: Individual GOAP, slots, Battle Viewer E2E through Captain

### DIFF
--- a/.github/workflows/individual-goap-smoke.yml
+++ b/.github/workflows/individual-goap-smoke.yml
@@ -24,5 +24,6 @@ jobs:
           node --check js/unit-ai-kit-adapter.js
           node --check js/unit-action-economy-catalog.js
           node --check js/enemy-action-slot-allocator.js
+          node --check js/battle-viewer-enemy-planning-074.js
       - name: Individual GOAP suite
         run: npm run test:individual-goap

--- a/.github/workflows/individual-goap-smoke.yml
+++ b/.github/workflows/individual-goap-smoke.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - name: AI module syntax
         run: |
           node --check js/individual-goap-combat-ai.js

--- a/.github/workflows/individual-goap-smoke.yml
+++ b/.github/workflows/individual-goap-smoke.yml
@@ -1,0 +1,28 @@
+name: Individual GOAP Smoke
+
+on:
+  push:
+    branches:
+      - feature/individual-goap-combat-ai
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  individual-goap-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: AI module syntax
+        run: |
+          node --check js/individual-goap-combat-ai.js
+          node --check js/unit-ai-kit-adapter.js
+          node --check js/unit-action-economy-catalog.js
+          node --check js/enemy-action-slot-allocator.js
+      - name: Individual GOAP suite
+        run: npm run test:individual-goap

--- a/js/battle-viewer-enemy-planning-074.js
+++ b/js/battle-viewer-enemy-planning-074.js
@@ -274,7 +274,7 @@
 
     clearPreviousAiVectors(vectors);
     const staleSlotTargetsRemoved = pruneStaleEnemySlotTargets(slotTargets, result.allocation);
-    const applied = [];
+    const entriesApplied = [];
     const deferred = [];
 
     for (const row of result.allocation?.rows || []) {
@@ -315,7 +315,7 @@
           };
         }
         state.appliedVectorSlots.add(slotId);
-        applied.push({ unitId: entry.unitId, slotId, targetSlotId, defense: isDefenseAction(action), sourceId: action.source?.id || null });
+        entriesApplied.push({ unitId: entry.unitId, slotId, targetSlotId, defense: isDefenseAction(action), sourceId: action.source?.id || null });
       }
       if (actor) {
         try {
@@ -326,10 +326,10 @@
       }
     }
 
-    const appliedResult = { applied: true, result, applied, deferred, staleSlotTargetsRemoved };
+    const appliedResult = { applied: true, result, entriesApplied, deferred, staleSlotTargetsRemoved };
     state.lastResult = appliedResult;
     try {
-      global.dispatchEvent?.(new global.CustomEvent("luminous:enemy-planning-ready", { detail: { allocation: clone(result.allocation), applied: clone(applied), deferredCount: deferred.length } }));
+      global.dispatchEvent?.(new global.CustomEvent("luminous:enemy-planning-ready", { detail: { allocation: clone(result.allocation), applied: clone(entriesApplied), deferredCount: deferred.length } }));
     } catch (_) {}
     return appliedResult;
   }
@@ -344,10 +344,22 @@
     return applyPlanningToViewer(result, { ...options, units });
   }
 
+  function reaffirmCanonicalTimelineAuthority() {
+    const timeline = global.LuminousBattleViewerRuntime073?.executeCombatTimeline
+      || global.LuminousBattleViewerTimeline073?.executeCombatTimeline;
+    if (typeof timeline !== "function") return false;
+    global.executeCombatTimeline = timeline;
+    try { delete global.__luminousLegacyExecuteCombatTimeline; }
+    catch (_) { global.__luminousLegacyExecuteCombatTimeline = undefined; }
+    global.__luminousCombatTimelineAuthority = "v0.7.3-combat-action-runtime";
+    return true;
+  }
+
   function installPhaseHook() {
     const current = viewerFunction("syncCombatEnginePhase");
     if (!current) return false;
     if (current.__luminousEnemyPlanning074Wrapped === true) {
+      reaffirmCanonicalTimelineAuthority();
       state.installed = true;
       return true;
     }
@@ -355,6 +367,7 @@
     state.originalSyncCombatEnginePhase = current;
     const wrapped = function (rawState, ...rest) {
       const result = current.call(this, rawState, ...rest);
+      reaffirmCanonicalTimelineAuthority();
       const normalized = clean(rawState).toUpperCase();
       if (normalized === "PRE_COMBAT_PLANNING") {
         try { runViewerPlanning(); }
@@ -364,6 +377,7 @@
     };
     Object.defineProperty(wrapped, "__luminousEnemyPlanning074Wrapped", { value: true });
     global.syncCombatEnginePhase = wrapped;
+    reaffirmCanonicalTimelineAuthority();
     state.installed = true;
 
     const currentPhase = clean(global.LuminousCombatPhaseState).toUpperCase();
@@ -451,6 +465,7 @@
     applyPlanningToViewer,
     runViewerPlanning,
     renderEnemySlots,
+    reaffirmCanonicalTimelineAuthority,
     installPhaseHook,
     ensureDependencies,
     install,

--- a/js/battle-viewer-enemy-planning-074.js
+++ b/js/battle-viewer-enemy-planning-074.js
@@ -6,7 +6,7 @@
     return;
   }
 
-  const VERSION = "0.7.4";
+  const VERSION = "0.7.5";
   const STATE_KEY = "__luminousEnemyPlanning074State";
   const BOOTSTRAP_TIMEOUT_MS = 5000;
   const BOOTSTRAP_INTERVAL_MS = 25;
@@ -101,6 +101,125 @@
     return result;
   }
 
+  function canonicalUnitIdForCombatant(unit = {}) {
+    const actorRef = unit.actorRef && typeof unit.actorRef === "object" ? unit.actorRef : null;
+    if (normalizeId(actorRef?.scope) === "units" && clean(actorRef?.id)) return normalizeId(actorRef.id);
+    return normalizeId(
+      unit.canonicalUnitId
+      ?? unit.definitionId
+      ?? unit.catalogId
+      ?? unit.baseUnitId
+      ?? unit.actionSlotProfileId
+      ?? unit.actionEconomy?.profileId
+      ?? unit.metadata?.canonicalUnitId
+      ?? unit.metadata?.definitionId
+      ?? unit.metadata?.catalogId
+      ?? unit.metadata?.actionEconomyProfileId
+    );
+  }
+
+  function unitCatalogForId(canonicalId) {
+    const id = normalizeId(canonicalId);
+    const catalogs = [global.LuminousKoboldUnitCatalog, global.LuminousGoblinUnitCatalog].filter(Boolean);
+    return catalogs.find((catalog) => {
+      try { return Boolean(catalog?.get?.(id)); } catch (_) { return false; }
+    }) || null;
+  }
+
+  function runtimeLevelFor(unit = {}, definition = {}) {
+    const candidates = [
+      unit.runtimeLevel,
+      unit.baseLevelSelected,
+      unit.baseLevel,
+      unit.level,
+      unit.mechanics?.runtimeLevel,
+      unit.mechanics?.baseLevel,
+      unit.mechanics?.level,
+    ];
+    const found = candidates.map(finite).find((value) => value != null && value >= 1);
+    if (found != null) return Math.max(1, Math.trunc(found));
+    const natural = finite(definition.naturalWorldLevel?.min ?? definition.baseLevel?.min);
+    return Math.max(1, Math.trunc(natural ?? 1));
+  }
+
+  function runtimeRankFor(unit = {}, definition = {}) {
+    const explicit = clean(unit.rank ?? unit.unitRank ?? unit.mechanics?.rank ?? unit.metadata?.unitRank);
+    if (explicit) return explicit;
+    return clean(Array.isArray(definition.allowedRanks) ? definition.allowedRanks[0] : "normal", "normal");
+  }
+
+  function mergePlanningDefinition(unit, resolved, canonicalId) {
+    if (!unit || !resolved) return;
+    if (!unit.canonicalUnitId) unit.canonicalUnitId = canonicalId;
+    unit.metadata = {
+      ...(resolved.metadata && typeof resolved.metadata === "object" ? clone(resolved.metadata) : {}),
+      ...(unit.metadata && typeof unit.metadata === "object" ? unit.metadata : {}),
+      canonicalUnitId: canonicalId,
+    };
+    if (!unit.scores && resolved.scores) unit.scores = clone(resolved.scores);
+    if (!unit.abilityScores && resolved.abilityScores) unit.abilityScores = clone(resolved.abilityScores);
+    if (!Array.isArray(unit.resolvedSkills) && Array.isArray(resolved.resolvedSkills)) unit.resolvedSkills = clone(resolved.resolvedSkills);
+    if (!Array.isArray(unit.resolvedSpells) && Array.isArray(resolved.resolvedSpells)) unit.resolvedSpells = clone(resolved.resolvedSpells);
+    if (!Array.isArray(unit.traits) && Array.isArray(resolved.traits)) unit.traits = clone(resolved.traits);
+    if (!Array.isArray(unit.traitIds) && Array.isArray(resolved.traitIds)) unit.traitIds = clone(resolved.traitIds);
+    if (!Array.isArray(unit.action_slots) && Array.isArray(resolved.action_slots)) unit.action_slots = clone(resolved.action_slots);
+    unit.mechanics = {
+      ...(resolved.mechanics && typeof resolved.mechanics === "object" ? clone(resolved.mechanics) : {}),
+      ...(unit.mechanics && typeof unit.mechanics === "object" ? unit.mechanics : {}),
+    };
+  }
+
+  function hydrateEnemyCombatant(unit = {}) {
+    if (sideOf(unit) !== "enemy" || !isActiveTarget(unit)) return { hydrated: false, reason: "not_active_enemy", unitId: unitIdOf(unit) || null };
+    const unitId = unitIdOf(unit);
+    const canonicalId = canonicalUnitIdForCombatant(unit);
+    if (!canonicalId) return { hydrated: false, reason: "canonical_unit_reference_missing", unitId };
+
+    const catalog = unitCatalogForId(canonicalId);
+    if (!catalog?.resolve) {
+      const profileResult = profileCatalog()?.applyToUnit?.(unit, canonicalId) || null;
+      return {
+        hydrated: false,
+        reason: "canonical_unit_catalog_unavailable",
+        unitId,
+        canonicalUnitId: canonicalId,
+        profileApplied: profileResult?.applied === true,
+      };
+    }
+
+    let definition = null;
+    let resolved = null;
+    try {
+      definition = catalog.get(canonicalId);
+      resolved = catalog.resolve(canonicalId, {
+        level: runtimeLevelFor(unit, definition || {}),
+        rank: runtimeRankFor(unit, definition || {}),
+        initializeEncounter: false,
+      });
+    } catch (error) {
+      return { hydrated: false, reason: "canonical_unit_resolution_failed", unitId, canonicalUnitId: canonicalId, error: clean(error?.message || error) };
+    }
+
+    mergePlanningDefinition(unit, resolved, canonicalId);
+    const profileResult = profileCatalog()?.applyToUnit?.(unit, canonicalId) || null;
+    return {
+      hydrated: true,
+      unitId,
+      canonicalUnitId: canonicalId,
+      profileApplied: profileResult?.applied === true,
+      resolvedSkillCount: Array.isArray(unit.resolvedSkills) ? unit.resolvedSkills.length : 0,
+    };
+  }
+
+  function hydrateEnemiesForPlanning(units = []) {
+    const results = [];
+    for (const unit of Array.isArray(units) ? units : []) {
+      if (sideOf(unit) !== "enemy" || !isActiveTarget(unit)) continue;
+      results.push(hydrateEnemyCombatant(unit));
+    }
+    return results;
+  }
+
   function ensureCanonicalEnemyProfiles(units = []) {
     const catalog = profileCatalog();
     if (!catalog?.applyToUnit) return [];
@@ -108,7 +227,8 @@
     for (const unit of Array.isArray(units) ? units : []) {
       if (sideOf(unit) !== "enemy" || !isActiveTarget(unit)) continue;
       if (unit.actionEconomy?.minSlots != null && unit.actionEconomy?.maxSlots != null) continue;
-      const profile = catalog.get?.(unit);
+      const canonicalId = canonicalUnitIdForCombatant(unit);
+      const profile = catalog.get?.(canonicalId || unit);
       if (!profile) continue;
       const result = catalog.applyToUnit(unit, profile.id);
       if (result?.applied) applied.push({ unitId: unitIdOf(unit), profileId: profile.id });
@@ -161,6 +281,7 @@
     if (!slotAllocator?.allocateEnemySlots) return { planned: false, reason: "enemy_action_slot_allocator_unavailable", allocation: null, plans: [] };
     if (!adapter?.planUnitTurn) return { planned: false, reason: "unit_ai_kit_adapter_unavailable", allocation: null, plans: [] };
 
+    const hydration = hydrateEnemiesForPlanning(units);
     const profileApplications = ensureCanonicalEnemyProfiles(units);
     const speeds = options.speedByUnitId || roundSpeedByUnitId(units);
     const allocation = slotAllocator.allocateEnemySlots(units, {
@@ -169,7 +290,7 @@
       speedByUnitId: speeds,
       apply: true,
     });
-    if (!allocation.allocated) return { planned: false, reason: allocation.reason, allocation, plans: [], profileApplications };
+    if (!allocation.allocated) return { planned: false, reason: allocation.reason, allocation, plans: [], hydration, profileApplications };
 
     const unitById = new Map(units.map((unit) => [unitIdOf(unit), unit]).filter(([id]) => id));
     const targets = Array.isArray(options.targets) ? options.targets : activeAllyIdentities(units);
@@ -218,6 +339,7 @@
       plans,
       targets: targetIds,
       speedByUnitId: { ...speeds },
+      hydration,
       profileApplications,
     };
   }
@@ -417,6 +539,11 @@
       try { await global.LuminousBattleViewerRuntime073Ready; } catch (_) {}
     }
     if (!global.LuminousUniversalRangedAmmoRuntime) await loadScript("universal-ranged-ammo-runtime-script", "js/universal-ranged-ammo-runtime.js", "LuminousUniversalRangedAmmoRuntime");
+    if (!global.LuminousUnitRankRuntime) await loadScript("unit-rank-runtime-script", "js/unit-rank-runtime.js", "LuminousUnitRankRuntime");
+    if (!global.LuminousKoboldTier1SkillCatalog) await loadScript("kobold-tier1-skill-catalog-script", "js/skill-catalog-kobold-tier1.js", "LuminousKoboldTier1SkillCatalog");
+    if (!global.LuminousUnitCombatMechanics) await loadScript("unit-combat-mechanics-runtime-script", "js/unit-combat-mechanics-runtime.js", "LuminousUnitCombatMechanics");
+    if (!global.LuminousKoboldUnitCatalog) await loadScript("kobold-unit-catalog-script", "js/unit-catalog-kobold-tier1.js", "LuminousKoboldUnitCatalog");
+    if (!global.LuminousGoblinUnitCatalog) await loadScript("goblin-unit-catalog-script", "js/unit-catalog-goblin.js", "LuminousGoblinUnitCatalog");
     if (!global.LuminousUnitActionEconomyCatalog) await loadScript("unit-action-economy-catalog-script", "js/unit-action-economy-catalog.js", "LuminousUnitActionEconomyCatalog");
     if (!global.LuminousIndividualGoapCombatAI) await loadScript("individual-goap-combat-ai-script", "js/individual-goap-combat-ai.js", "LuminousIndividualGoapCombatAI");
     if (!global.LuminousUnitAiKitAdapter) await loadScript("unit-ai-kit-adapter-script", "js/unit-ai-kit-adapter.js", "LuminousUnitAiKitAdapter");
@@ -458,6 +585,9 @@
     isActiveTarget,
     activeAllyIdentities,
     roundSpeedByUnitId,
+    canonicalUnitIdForCombatant,
+    hydrateEnemyCombatant,
+    hydrateEnemiesForPlanning,
     ensureCanonicalEnemyProfiles,
     isDefenseAction,
     defenseViewerPlan,

--- a/js/battle-viewer-enemy-planning-074.js
+++ b/js/battle-viewer-enemy-planning-074.js
@@ -1,0 +1,466 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousBattleViewerEnemyPlanning074) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousBattleViewerEnemyPlanning074;
+    return;
+  }
+
+  const VERSION = "0.7.4";
+  const STATE_KEY = "__luminousEnemyPlanning074State";
+  const BOOTSTRAP_TIMEOUT_MS = 5000;
+  const BOOTSTRAP_INTERVAL_MS = 25;
+
+  const safeRequire = (path) => {
+    if (typeof require !== "function") return null;
+    try { return require(path); } catch (_) { return null; }
+  };
+  const clean = (value) => String(value ?? "").trim();
+  const normalizeId = (value) => clean(value).toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const finite = (value) => Number.isFinite(Number(value)) ? Number(value) : null;
+
+  const state = global[STATE_KEY] || {
+    installed: false,
+    originalSyncCombatEnginePhase: null,
+    lastResult: null,
+    appliedVectorSlots: new Set(),
+    intelByUnitId: {},
+  };
+  global[STATE_KEY] = state;
+
+  function allocator() { return global.LuminousEnemyActionSlotAllocator || safeRequire("./enemy-action-slot-allocator.js"); }
+  function kitAdapter() { return global.LuminousUnitAiKitAdapter || safeRequire("./unit-ai-kit-adapter.js"); }
+  function profileCatalog() { return global.LuminousUnitActionEconomyCatalog || safeRequire("./unit-action-economy-catalog.js"); }
+  function economy() { return global.LuminousActionEconomy || safeRequire("./universal-action-economy.js"); }
+
+  function lexical(name, fallback = null) {
+    try {
+      return typeof global.eval === "function"
+        ? (global.eval(`typeof ${name} !== 'undefined' ? ${name} : undefined`) ?? fallback)
+        : fallback;
+    } catch (_) {
+      return fallback;
+    }
+  }
+
+  function viewerFunction(name) {
+    const fn = global[name] || lexical(name, null);
+    return typeof fn === "function" ? fn : null;
+  }
+
+  function combatDataRef() {
+    return global.combatData || lexical("combatData", {}) || {};
+  }
+
+  function attackVectorsRef() {
+    return global.attackVectors || lexical("attackVectors", {}) || {};
+  }
+
+  function slotTargetsRef() {
+    return global.slotTargets || lexical("slotTargets", {}) || {};
+  }
+
+  function unitIdOf(unit = {}) {
+    return clean(unit.id ?? unit.unitId ?? unit.characterId ?? unit.actorId);
+  }
+
+  function sideOf(unit = {}) {
+    if (unit.isPlayer === true) return "ally";
+    const raw = normalizeId(unit.faction ?? unit.faccion ?? unit.side ?? unit.team ?? unit.actorCategory ?? unit.unitType ?? unit.type);
+    if (["ally", "allies", "friendly", "player", "players", "aliado", "aliados"].includes(raw)) return "ally";
+    if (["enemy", "enemies", "hostile", "boss", "enemigo", "enemigos"].includes(raw)) return "enemy";
+    return "neutral";
+  }
+
+  function isActiveTarget(unit = {}) {
+    if (!unit || typeof unit !== "object") return false;
+    if (unit.dead === true || unit.defeated === true || unit.isDead === true || unit.removed === true || unit.escaped === true || unit.annihilated === true) return false;
+    const hp = [unit.hp, unit.currentHp, unit.currentHP, unit.mechanics?.hp].map(finite).find((value) => value != null);
+    return hp == null || hp > 0;
+  }
+
+  function activeAllyIdentities(units = []) {
+    return (Array.isArray(units) ? units : [])
+      .filter((unit) => sideOf(unit) === "ally" && isActiveTarget(unit))
+      .map((unit) => ({ id: unitIdOf(unit) }))
+      .filter((unit) => unit.id);
+  }
+
+  function roundSpeedByUnitId(units = []) {
+    const result = {};
+    for (const unit of Array.isArray(units) ? units : []) {
+      if (sideOf(unit) !== "enemy") continue;
+      const id = unitIdOf(unit);
+      if (!id) continue;
+      const value = [unit.resolvedSpeed, unit.currentSpeed, unit.speedRoll, unit.speedValue, unit.speed]
+        .map(finite)
+        .find((candidate) => candidate != null);
+      if (value != null) result[id] = value;
+    }
+    return result;
+  }
+
+  function ensureCanonicalEnemyProfiles(units = []) {
+    const catalog = profileCatalog();
+    if (!catalog?.applyToUnit) return [];
+    const applied = [];
+    for (const unit of Array.isArray(units) ? units : []) {
+      if (sideOf(unit) !== "enemy" || !isActiveTarget(unit)) continue;
+      if (unit.actionEconomy?.minSlots != null && unit.actionEconomy?.maxSlots != null) continue;
+      const profile = catalog.get?.(unit);
+      if (!profile) continue;
+      const result = catalog.applyToUnit(unit, profile.id);
+      if (result?.applied) applied.push({ unitId: unitIdOf(unit), profileId: profile.id });
+    }
+    return applied;
+  }
+
+  function firstSlotIdForUnit(unit = {}) {
+    const id = unitIdOf(unit);
+    if (!id) return null;
+    if (Array.isArray(unit.slots) && unit.slots[0]?.id) return clean(unit.slots[0].id);
+    return `${id}_slot_0`;
+  }
+
+  function targetSlotForAction(action = {}, units = []) {
+    const targetId = clean(action.targeting?.mainTargetId || action.targetId);
+    if (!targetId) return null;
+    const target = (Array.isArray(units) ? units : []).find((unit) => unitIdOf(unit) === targetId);
+    return target ? firstSlotIdForUnit(target) : `${targetId}_slot_0`;
+  }
+
+  function isDefenseAction(action = {}) {
+    const definition = action.metadata?.sourceDefinition || {};
+    const subtype = normalizeId(action.metadata?.defenseSubtype || definition.defenseSubtype || definition.defense_subtype);
+    const type = normalizeId(definition.type || definition.actionType || definition.action_type);
+    return definition.isDefense === true || type === "defense" || ["guard", "evade", "counter", "clashable_guard", "clashable_counter"].includes(subtype);
+  }
+
+  function defenseViewerPlan(action = {}) {
+    const definition = clone(action.metadata?.sourceDefinition || {});
+    definition.id = definition.id || action.source?.id || "defense";
+    return {
+      type: "defense",
+      kind: "defense",
+      sourceId: definition.id,
+      data: definition,
+      metadata: {
+        individualGoap: true,
+        aiGoal: action.metadata?.aiGoal || null,
+        bridge: "battle-viewer-enemy-planning-074",
+      },
+    };
+  }
+
+  function planExistingPlanningPhase(options = {}) {
+    const units = Array.isArray(options.units) ? options.units : Object.values(options.combatData || combatDataRef()).filter(Boolean);
+    const slotAllocator = allocator();
+    const adapter = kitAdapter();
+    const actionEconomy = economy();
+    if (!slotAllocator?.allocateEnemySlots) return { planned: false, reason: "enemy_action_slot_allocator_unavailable", allocation: null, plans: [] };
+    if (!adapter?.planUnitTurn) return { planned: false, reason: "unit_ai_kit_adapter_unavailable", allocation: null, plans: [] };
+
+    const profileApplications = ensureCanonicalEnemyProfiles(units);
+    const speeds = options.speedByUnitId || roundSpeedByUnitId(units);
+    const allocation = slotAllocator.allocateEnemySlots(units, {
+      ...(options.allocationOptions || {}),
+      roundId: options.roundId ?? null,
+      speedByUnitId: speeds,
+      apply: true,
+    });
+    if (!allocation.allocated) return { planned: false, reason: allocation.reason, allocation, plans: [], profileApplications };
+
+    const unitById = new Map(units.map((unit) => [unitIdOf(unit), unit]).filter(([id]) => id));
+    const targets = Array.isArray(options.targets) ? options.targets : activeAllyIdentities(units);
+    const targetIds = Array.isArray(options.targetIds) ? options.targetIds.map(clean).filter(Boolean) : targets.map((target) => unitIdOf(target)).filter(Boolean);
+    const plans = [];
+
+    for (const row of allocation.rows) {
+      const actor = unitById.get(row.unitId);
+      if (!actor) continue;
+      const economyState = actionEconomy?.ensureState?.(actor) || null;
+      const planningPhaseReady = !economyState || economyState.phase === "planning";
+      if (!planningPhaseReady) {
+        plans.push({ unitId: row.unitId, slots: row.slots, slotIds: row.slotIds.slice(), plan: { planned: false, reason: "viewer_not_in_planning_phase", actions: [], sequence: [] } });
+        continue;
+      }
+
+      if (!targetIds.length) {
+        plans.push({ unitId: row.unitId, slots: row.slots, slotIds: row.slotIds.slice(), plan: { planned: false, reason: "no_active_player_targets", actorId: row.unitId, actions: [], sequence: [] } });
+        continue;
+      }
+
+      const intel = options.intelByUnitId?.[row.unitId] || state.intelByUnitId[row.unitId] || {};
+      const plan = adapter.planUnitTurn({
+        ...(options.planOptions || {}),
+        actor,
+        slotIds: row.slotIds.slice(),
+        availableSlots: row.slots,
+        targets: targets.length ? targets : undefined,
+        targetIds: targets.length ? undefined : targetIds,
+        intel,
+      });
+      plans.push({
+        unitId: row.unitId,
+        slots: row.slots,
+        slotIds: row.slotIds.slice(),
+        plannedActions: Array.isArray(plan?.actions) ? plan.actions.length : 0,
+        unusedSlots: Math.max(0, row.slots - (Array.isArray(plan?.actions) ? plan.actions.length : 0)),
+        plan,
+      });
+    }
+
+    return {
+      planned: true,
+      reason: null,
+      allocation,
+      plans,
+      targets: targetIds,
+      speedByUnitId: { ...speeds },
+      profileApplications,
+    };
+  }
+
+  function slotMarkup(slotId, faction = "enemy") {
+    return `<div class="action-slot-wrapper" id="${slotId}" data-faction="${faction}"><svg class="action-slot-svg" viewBox="0 0 100 100"><polygon class="slot-heptagon-bg" points="50,95 15,78 6,40 30,9 70,9 94,40 85,78" /><line class="slot-center-line" x1="25" y1="50" x2="75" y2="50" /></svg></div>`;
+  }
+
+  function escapeCss(value) {
+    return global.CSS?.escape ? global.CSS.escape(String(value)) : String(value).replace(/[^a-zA-Z0-9_-]/g, "\\$&");
+  }
+
+  function renderEnemySlots(unit = {}) {
+    if (!global.document) return false;
+    const id = unitIdOf(unit);
+    if (!id) return false;
+    const panel = global.document.querySelector?.(`#ui-panel-${escapeCss(id)} .action-slots`);
+    if (!panel) return false;
+    const ids = allocator()?.slotIdsFor?.(unit) || [];
+    panel.innerHTML = ids.map((slotId) => slotMarkup(slotId, "enemy")).join("");
+    return true;
+  }
+
+  function clearPreviousAiVectors(vectors) {
+    for (const slotId of state.appliedVectorSlots) {
+      if (vectors?.[slotId]?.__luminousEnemyGoap074 === true) delete vectors[slotId];
+    }
+    state.appliedVectorSlots = new Set();
+  }
+
+  function pruneStaleEnemySlotTargets(slotTargets, allocation) {
+    if (!slotTargets || typeof slotTargets !== "object" || !allocation?.rows) return [];
+    const validByUnit = new Map(allocation.rows.map((row) => [row.unitId, new Set(row.slotIds || [])]));
+    const removed = [];
+    for (const slotId of Object.keys(slotTargets)) {
+      const marker = "_slot_";
+      const splitAt = slotId.lastIndexOf(marker);
+      if (splitAt < 0) continue;
+      const unitId = slotId.slice(0, splitAt);
+      const valid = validByUnit.get(unitId);
+      if (!valid || valid.has(slotId)) continue;
+      delete slotTargets[slotId];
+      removed.push(slotId);
+    }
+    return removed;
+  }
+
+  function applyPlanningToViewer(result = {}, options = {}) {
+    const units = Array.isArray(options.units) ? options.units : Object.values(options.combatData || combatDataRef()).filter(Boolean);
+    const unitById = new Map(units.map((unit) => [unitIdOf(unit), unit]).filter(([id]) => id));
+    const vectors = options.attackVectors || attackVectorsRef();
+    const slotTargets = options.slotTargets || slotTargetsRef();
+    if (!vectors || typeof vectors !== "object") return { applied: false, reason: "viewer_attack_vectors_unavailable", result };
+
+    clearPreviousAiVectors(vectors);
+    const staleSlotTargetsRemoved = pruneStaleEnemySlotTargets(slotTargets, result.allocation);
+    const applied = [];
+    const deferred = [];
+
+    for (const row of result.allocation?.rows || []) {
+      const unit = unitById.get(row.unitId);
+      if (unit) {
+        if (typeof options.renderSlots === "function") options.renderSlots(unit, row);
+        else renderEnemySlots(unit);
+      }
+    }
+
+    for (const entry of result.plans || []) {
+      const actor = unitById.get(entry.unitId);
+      const actions = Array.isArray(entry.plan?.actions) ? entry.plan.actions : [];
+      const actorDeferred = [];
+      for (const action of actions) {
+        const slotId = clean(action.actionSlotId);
+        if (!slotId) continue;
+        if (action.phase?.executesAt && action.phase.executesAt !== "combat_phase") {
+          actorDeferred.push(action);
+          deferred.push({ unitId: entry.unitId, slotId, action });
+          continue;
+        }
+
+        const targetSlotId = targetSlotForAction(action, units);
+        if (isDefenseAction(action)) {
+          vectors[slotId] = {
+            target: null,
+            plan: defenseViewerPlan(action),
+            __luminousEnemyGoap074: true,
+            aiGoal: action.metadata?.aiGoal || null,
+          };
+        } else {
+          vectors[slotId] = {
+            target: targetSlotId,
+            combatAction: action,
+            __luminousEnemyGoap074: true,
+            aiGoal: action.metadata?.aiGoal || null,
+          };
+        }
+        state.appliedVectorSlots.add(slotId);
+        applied.push({ unitId: entry.unitId, slotId, targetSlotId, defense: isDefenseAction(action), sourceId: action.source?.id || null });
+      }
+      if (actor) {
+        try {
+          Object.defineProperty(actor, "__luminousEnemyDeferredActions074", { value: actorDeferred, writable: true, configurable: true, enumerable: false });
+        } catch (_) {
+          actor.__luminousEnemyDeferredActions074 = actorDeferred;
+        }
+      }
+    }
+
+    const appliedResult = { applied: true, result, applied, deferred, staleSlotTargetsRemoved };
+    state.lastResult = appliedResult;
+    try {
+      global.dispatchEvent?.(new global.CustomEvent("luminous:enemy-planning-ready", { detail: { allocation: clone(result.allocation), applied: clone(applied), deferredCount: deferred.length } }));
+    } catch (_) {}
+    return appliedResult;
+  }
+
+  function runViewerPlanning(options = {}) {
+    const units = Array.isArray(options.units) ? options.units : Object.values(combatDataRef()).filter(Boolean);
+    const result = planExistingPlanningPhase({ ...options, units });
+    if (!result.planned) {
+      state.lastResult = { applied: false, result };
+      return state.lastResult;
+    }
+    return applyPlanningToViewer(result, { ...options, units });
+  }
+
+  function installPhaseHook() {
+    const current = viewerFunction("syncCombatEnginePhase");
+    if (!current) return false;
+    if (current.__luminousEnemyPlanning074Wrapped === true) {
+      state.installed = true;
+      return true;
+    }
+
+    state.originalSyncCombatEnginePhase = current;
+    const wrapped = function (rawState, ...rest) {
+      const result = current.call(this, rawState, ...rest);
+      const normalized = clean(rawState).toUpperCase();
+      if (normalized === "PRE_COMBAT_PLANNING") {
+        try { runViewerPlanning(); }
+        catch (error) { global.console?.error?.("[EnemyPlanning074] Planning bridge failed", error); }
+      }
+      return result;
+    };
+    Object.defineProperty(wrapped, "__luminousEnemyPlanning074Wrapped", { value: true });
+    global.syncCombatEnginePhase = wrapped;
+    state.installed = true;
+
+    const currentPhase = clean(global.LuminousCombatPhaseState).toUpperCase();
+    if (currentPhase === "PRE_COMBAT_PLANNING") {
+      try { runViewerPlanning(); } catch (_) {}
+    }
+    return true;
+  }
+
+  function loadScript(id, src, globalName) {
+    if (global[globalName]) return Promise.resolve(global[globalName]);
+    if (!global.document) return Promise.resolve(null);
+    let script = global.document.getElementById(id);
+    if (!script) {
+      script = global.document.createElement("script");
+      script.id = id;
+      script.src = src;
+      script.async = false;
+      global.document.head?.appendChild(script);
+    }
+    return new Promise((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        resolve(global[globalName] || null);
+      };
+      script.addEventListener("load", finish, { once: true });
+      script.addEventListener("error", finish, { once: true });
+      if (global[globalName]) finish();
+    });
+  }
+
+  async function ensureDependencies() {
+    if (!global.LuminousBattleViewerRuntime073) {
+      await loadScript("battle-viewer-runtime-073-script", "js/battle-viewer-runtime-073.js", "LuminousBattleViewerRuntime073");
+      try { await global.LuminousBattleViewerRuntime073Ready; } catch (_) {}
+    }
+    if (!global.LuminousUniversalRangedAmmoRuntime) await loadScript("universal-ranged-ammo-runtime-script", "js/universal-ranged-ammo-runtime.js", "LuminousUniversalRangedAmmoRuntime");
+    if (!global.LuminousUnitActionEconomyCatalog) await loadScript("unit-action-economy-catalog-script", "js/unit-action-economy-catalog.js", "LuminousUnitActionEconomyCatalog");
+    if (!global.LuminousIndividualGoapCombatAI) await loadScript("individual-goap-combat-ai-script", "js/individual-goap-combat-ai.js", "LuminousIndividualGoapCombatAI");
+    if (!global.LuminousUnitAiKitAdapter) await loadScript("unit-ai-kit-adapter-script", "js/unit-ai-kit-adapter.js", "LuminousUnitAiKitAdapter");
+    if (!global.LuminousEnemyActionSlotAllocator) await loadScript("enemy-action-slot-allocator-script", "js/enemy-action-slot-allocator.js", "LuminousEnemyActionSlotAllocator");
+    return Boolean(allocator()?.allocateEnemySlots && kitAdapter()?.planUnitTurn && global.LuminousBattleViewerRuntime073);
+  }
+
+  function waitForPhaseHook() {
+    if (installPhaseHook()) return Promise.resolve(true);
+    if (typeof global.setInterval !== "function") return Promise.resolve(false);
+    return new Promise((resolve) => {
+      const started = Date.now();
+      const timer = global.setInterval(() => {
+        if (installPhaseHook()) {
+          global.clearInterval(timer);
+          resolve(true);
+          return;
+        }
+        if (Date.now() - started >= BOOTSTRAP_TIMEOUT_MS) {
+          global.clearInterval(timer);
+          resolve(false);
+        }
+      }, BOOTSTRAP_INTERVAL_MS);
+      timer?.unref?.();
+    });
+  }
+
+  async function install() {
+    const ready = await ensureDependencies();
+    if (!ready && global.document) return { installed: false, reason: "enemy_planning_dependencies_unavailable" };
+    const hooked = await waitForPhaseHook();
+    return { installed: hooked, reason: hooked ? null : "viewer_phase_hook_unavailable" };
+  }
+
+  const api = Object.freeze({
+    version: VERSION,
+    state,
+    sideOf,
+    isActiveTarget,
+    activeAllyIdentities,
+    roundSpeedByUnitId,
+    ensureCanonicalEnemyProfiles,
+    isDefenseAction,
+    defenseViewerPlan,
+    planExistingPlanningPhase,
+    applyPlanningToViewer,
+    runViewerPlanning,
+    renderEnemySlots,
+    installPhaseHook,
+    ensureDependencies,
+    install,
+  });
+
+  global.LuminousBattleViewerEnemyPlanning074 = api;
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = api;
+  } else if (global.document) {
+    global.LuminousBattleViewerEnemyPlanning074Ready = install();
+  }
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/enemy-action-slot-allocator.js
+++ b/js/enemy-action-slot-allocator.js
@@ -24,7 +24,7 @@
   const clampInt = (value, min, max) => Math.max(min, Math.min(max, finiteInt(value, min)));
 
   function unitIdOf(unit = {}) {
-    return clean(unit.id ?? unit.unitId ?? unit.characterId ?? unit.actorId ?? unit.name);
+    return clean(unit.id ?? unit.unitId ?? unit.characterId ?? unit.actorId);
   }
 
   function factionOf(unit = {}) {
@@ -51,11 +51,9 @@
   function embeddedProfile(unit = {}) {
     const raw = unit.actionEconomy || unit.mechanics?.actionEconomy || unit.ai?.actionEconomy || null;
     if (!raw || typeof raw !== "object") return null;
-    return {
-      source: "unit",
-      minSlots: Math.max(1, finiteInt(raw.minSlots ?? raw.minimumSlots ?? raw.baseSlots, 1)),
-      maxSlots: Math.max(1, finiteInt(raw.maxSlots ?? raw.maximumSlots ?? raw.slotCap, 1)),
-    };
+    const minSlots = Math.max(1, finiteInt(raw.minSlots ?? raw.minimumSlots ?? raw.baseSlots, 1));
+    const maxSlots = Math.max(minSlots, finiteInt(raw.maxSlots ?? raw.maximumSlots ?? raw.slotCap, minSlots));
+    return { source: "unit", minSlots, maxSlots };
   }
 
   function legacyProfile(unit = {}) {
@@ -73,35 +71,70 @@
     const teamCap = Math.max(1, finiteInt(options.teamSlotCap, DEFAULT_TEAM_SLOT_CAP));
     const minSlots = clampInt(raw.minSlots, 1, teamCap);
     const maxSlots = clampInt(raw.maxSlots, minSlots, teamCap);
-    return { source: raw.source || "catalog", minSlots, maxSlots };
+    return {
+      source: raw.source || "catalog",
+      profileId: raw.id || profileCatalog()?.canonicalUnitId?.(unit) || null,
+      minSlots,
+      maxSlots,
+    };
   }
 
-  function speedFor(unit = {}, options = {}) {
+  function speedInfoFor(unit = {}, options = {}) {
     const id = unitIdOf(unit);
     const source = options.speedByUnitId;
     let explicit;
     if (typeof source === "function") explicit = source(unit, id);
     else if (source && typeof source === "object") explicit = source[id];
-    if (Number.isFinite(Number(explicit))) return Number(explicit);
+    if (Number.isFinite(Number(explicit))) return { value: Number(explicit), source: "round_override" };
 
-    const candidates = [unit.resolvedSpeed, unit.currentSpeed, unit.speedRoll, unit.speedValue, unit.speed];
-    const found = candidates.map(Number).find(Number.isFinite);
-    return found == null ? null : found;
+    const candidates = [
+      ["resolvedSpeed", unit.resolvedSpeed],
+      ["currentSpeed", unit.currentSpeed],
+      ["speedRoll", unit.speedRoll],
+      ["speedValue", unit.speedValue],
+      ["speed", unit.speed],
+    ];
+    for (const [field, value] of candidates) {
+      if (Number.isFinite(Number(value))) return { value: Number(value), source: field };
+    }
+    return { value: null, source: null };
+  }
+
+  function speedFor(unit = {}, options = {}) {
+    return speedInfoFor(unit, options).value;
+  }
+
+  function validateEnemyIds(entries = []) {
+    const seen = new Set();
+    for (const entry of entries) {
+      const id = unitIdOf(entry.unit);
+      if (!id) return { valid: false, reason: "enemy_unit_id_required", deploymentIndex: entry.deploymentIndex };
+      if (seen.has(id)) return { valid: false, reason: "duplicate_enemy_unit_id", unitId: id };
+      seen.add(id);
+    }
+    return { valid: true, reason: null };
+  }
+
+  function slotIdsFor(unit, count = null) {
+    const id = unitIdOf(unit);
+    const max = count == null
+      ? Math.max(0, finiteInt(unit.activeSlots ?? unit.currentActionSlots ?? unit.actionSlots, 0))
+      : Math.max(0, finiteInt(count, 0));
+    return Array.from({ length: max }, (_, index) => `${id}_slot_${index}`);
   }
 
   function syncSlotObjects(unit, count) {
     const existing = Array.isArray(unit.slots) ? unit.slots : [];
     unit.slots = Array.from({ length: count }, (_, index) => ({
-      id: `${unitIdOf(unit) || "unit"}_slot_${index}`,
-      slotWeight: 1,
-      isTargetedThisRound: false,
       ...(existing[index] && typeof existing[index] === "object" ? existing[index] : {}),
-      id: `${unitIdOf(unit) || "unit"}_slot_${index}`,
+      id: `${unitIdOf(unit)}_slot_${index}`,
+      slotWeight: Number.isFinite(Number(existing[index]?.slotWeight)) ? Number(existing[index].slotWeight) : 1,
+      isTargetedThisRound: false,
     }));
     return unit.slots;
   }
 
-  function applySlotCount(unit, count, row = null) {
+  function applySlotCount(unit, count, row = null, options = {}) {
     const next = Math.max(0, finiteInt(count, 0));
     unit.activeSlots = next;
     unit.currentActionSlots = next;
@@ -109,12 +142,16 @@
     syncSlotObjects(unit, next);
     unit.actionSlotAllocation = {
       roundScoped: true,
+      roundId: options.roundId ?? row?.roundId ?? null,
       slots: next,
       speed: row?.speed ?? null,
+      speedSource: row?.speedSource ?? null,
       minSlots: row?.minSlots ?? next,
       maxSlots: row?.maxSlots ?? next,
       bonusSlots: row?.bonusSlots ?? Math.max(0, next - (row?.minSlots ?? next)),
+      profileId: row?.profileId ?? null,
       profileSource: row?.profileSource ?? null,
+      bonusEligible: row?.bonusEligible === true,
     };
     return next;
   }
@@ -122,23 +159,42 @@
   function allocateEnemySlots(units = [], options = {}) {
     const teamSlotCap = Math.max(1, finiteInt(options.teamSlotCap, DEFAULT_TEAM_SLOT_CAP));
     const bonusRecipientLimit = Math.max(0, finiteInt(options.bonusRecipientLimit, DEFAULT_BONUS_RECIPIENT_LIMIT));
-    const enemies = (Array.isArray(units) ? units : [])
+    const allEnemies = (Array.isArray(units) ? units : [])
       .map((unit, deploymentIndex) => ({ unit, deploymentIndex }))
-      .filter(({ unit }) => isEnemy(unit) && isActive(unit));
+      .filter(({ unit }) => isEnemy(unit));
+    const activeEnemies = allEnemies.filter(({ unit }) => isActive(unit));
 
-    const rows = enemies.map(({ unit, deploymentIndex }) => {
+    const idCheck = validateEnemyIds(activeEnemies);
+    if (!idCheck.valid) {
+      return {
+        allocated: false,
+        reason: idCheck.reason,
+        teamSlotCap,
+        bonusRecipientLimit,
+        totalSlots: 0,
+        minimumTotal: 0,
+        rows: [],
+        ...idCheck,
+      };
+    }
+
+    const rows = activeEnemies.map(({ unit, deploymentIndex }) => {
       const profile = profileFor(unit, { ...options, teamSlotCap });
+      const speedInfo = speedInfoFor(unit, options);
       return {
         unit,
         unitId: unitIdOf(unit),
         deploymentIndex,
-        speed: speedFor(unit, options),
+        speed: speedInfo.value,
+        speedSource: speedInfo.source,
         minSlots: profile.minSlots,
         maxSlots: profile.maxSlots,
         slots: profile.minSlots,
         bonusSlots: 0,
+        profileId: profile.profileId,
         profileSource: profile.source,
         bonusEligible: false,
+        roundId: options.roundId ?? null,
       };
     });
 
@@ -150,6 +206,8 @@
         teamSlotCap,
         minimumTotal,
         totalSlots: 0,
+        activeEnemyCount: rows.length,
+        inactiveEnemyCount: allEnemies.length - rows.length,
         bonusRecipientLimit,
         rows: rows.map((row) => ({ ...row, unit: undefined })),
       };
@@ -175,25 +233,34 @@
       }
     }
 
-    if (options.apply !== false) rows.forEach((row) => applySlotCount(row.unit, row.slots, row));
+    // Mutation happens only after every validation/allocation step has succeeded.
+    if (options.apply !== false) {
+      rows.forEach((row) => applySlotCount(row.unit, row.slots, row, options));
+    }
 
     const missingSpeed = rows.filter((row) => row.speed == null && row.maxSlots > row.minSlots).map((row) => row.unitId);
     const resultRows = rows.map((row) => ({
       unitId: row.unitId,
       deploymentIndex: row.deploymentIndex,
       speed: row.speed,
+      speedSource: row.speedSource,
       minSlots: row.minSlots,
       maxSlots: row.maxSlots,
       slots: row.slots,
       bonusSlots: row.bonusSlots,
+      profileId: row.profileId,
       profileSource: row.profileSource,
       bonusEligible: row.bonusEligible,
+      slotIds: slotIdsFor(row.unit, row.slots),
     }));
 
     return {
       allocated: true,
+      roundId: options.roundId ?? null,
       teamSlotCap,
       bonusRecipientLimit,
+      activeEnemyCount: rows.length,
+      inactiveEnemyCount: allEnemies.length - rows.length,
       minimumTotal,
       totalSlots,
       unusedSlots: Math.max(0, teamSlotCap - totalSlots),
@@ -206,42 +273,73 @@
 
   function beginEnemyPlanningRound(units = [], options = {}) {
     const allocation = allocateEnemySlots(units, options);
-    if (!allocation.allocated) return { allocation, planning: [] };
+    if (!allocation.allocated) return { allocation, planningReady: false, planning: [] };
+
     const economy = actionEconomy();
+    if (!economy?.beginPlanning || !economy?.actionSlotMaximum) {
+      return { allocation, planningReady: false, reason: "action_economy_unavailable", planning: [] };
+    }
+
+    const unitById = new Map((Array.isArray(units) ? units : []).map((unit) => [unitIdOf(unit), unit]));
     const planning = [];
     for (const row of allocation.rows) {
-      const unit = units.find((candidate) => unitIdOf(candidate) === row.unitId);
-      if (!unit) continue;
-      const snapshot = economy?.beginPlanning?.(unit) || null;
-      planning.push({ unitId: row.unitId, slots: row.slots, snapshot: snapshot ? clone(snapshot) : null });
+      const unit = unitById.get(row.unitId);
+      if (!unit) {
+        return { allocation, planningReady: false, reason: "allocated_unit_missing", unitId: row.unitId, planning };
+      }
+      const snapshot = economy.beginPlanning(unit);
+      const maximum = economy.actionSlotMaximum(unit);
+      if (!snapshot || maximum !== row.slots || snapshot.actionSlots !== row.slots || snapshot.action !== row.slots) {
+        return {
+          allocation,
+          planningReady: false,
+          reason: "action_economy_slot_mismatch",
+          unitId: row.unitId,
+          expectedSlots: row.slots,
+          actualSlots: maximum,
+          snapshot: snapshot ? clone(snapshot) : null,
+          planning,
+        };
+      }
+      planning.push({ unitId: row.unitId, slots: row.slots, slotIds: row.slotIds.slice(), snapshot: clone(snapshot) });
     }
-    return { allocation, planning };
+    return { allocation, planningReady: true, planning };
   }
 
   function allocateAndPlan(units = [], options = {}) {
     const round = beginEnemyPlanningRound(units, options);
-    if (!round.allocation.allocated) return { ...round, plans: [] };
+    if (!round.allocation.allocated || !round.planningReady) return { ...round, plans: [] };
+
     const adapter = kitAdapter();
     if (!adapter?.planUnitTurn) return { ...round, plans: [], reason: "unit_ai_kit_adapter_unavailable" };
 
     const targetIds = Array.isArray(options.targetIds) ? options.targetIds : undefined;
     const targets = Array.isArray(options.targets) ? options.targets : undefined;
+    const unitById = new Map((Array.isArray(units) ? units : []).map((unit) => [unitIdOf(unit), unit]));
     const plans = round.allocation.rows.map((row) => {
-      const actor = units.find((candidate) => unitIdOf(candidate) === row.unitId);
+      const actor = unitById.get(row.unitId);
       const plan = adapter.planUnitTurn({
         ...(options.planOptions || {}),
         actor,
+        slotIds: row.slotIds.slice(),
         availableSlots: row.slots,
         ...(targetIds ? { targetIds } : {}),
         ...(targets ? { targets } : {}),
       });
-      return { unitId: row.unitId, slots: row.slots, plan };
+      return {
+        unitId: row.unitId,
+        slots: row.slots,
+        slotIds: row.slotIds.slice(),
+        plannedActions: Array.isArray(plan?.actions) ? plan.actions.length : 0,
+        unusedSlots: Math.max(0, row.slots - (Array.isArray(plan?.actions) ? plan.actions.length : 0)),
+        plan,
+      };
     });
     return { ...round, plans };
   }
 
   const api = Object.freeze({
-    version: "1.0.0",
+    version: "1.1.0",
     DEFAULT_TEAM_SLOT_CAP,
     DEFAULT_BONUS_RECIPIENT_LIMIT,
     unitIdOf,
@@ -249,7 +347,10 @@
     isEnemy,
     isActive,
     profileFor,
+    speedInfoFor,
     speedFor,
+    validateEnemyIds,
+    slotIdsFor,
     applySlotCount,
     allocateEnemySlots,
     beginEnemyPlanningRound,

--- a/js/enemy-action-slot-allocator.js
+++ b/js/enemy-action-slot-allocator.js
@@ -1,0 +1,261 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousEnemyActionSlotAllocator) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousEnemyActionSlotAllocator;
+    return;
+  }
+
+  const safeRequire = (path) => {
+    if (typeof require !== "function") return null;
+    try { return require(path); } catch (_) { return null; }
+  };
+
+  const profileCatalog = () => global.LuminousUnitActionEconomyCatalog || safeRequire("./unit-action-economy-catalog.js");
+  const actionEconomy = () => global.LuminousActionEconomy || safeRequire("./universal-action-economy.js");
+  const kitAdapter = () => global.LuminousUnitAiKitAdapter || safeRequire("./unit-ai-kit-adapter.js");
+
+  const DEFAULT_TEAM_SLOT_CAP = 12;
+  const DEFAULT_BONUS_RECIPIENT_LIMIT = 2;
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const clean = (value) => String(value ?? "").trim();
+  const normalizeId = (value) => clean(value).toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  const finiteInt = (value, fallback = 0) => Number.isFinite(Number(value)) ? Math.trunc(Number(value)) : fallback;
+  const clampInt = (value, min, max) => Math.max(min, Math.min(max, finiteInt(value, min)));
+
+  function unitIdOf(unit = {}) {
+    return clean(unit.id ?? unit.unitId ?? unit.characterId ?? unit.actorId ?? unit.name);
+  }
+
+  function factionOf(unit = {}) {
+    return normalizeId(unit.faction ?? unit.faccion ?? unit.side ?? unit.team ?? unit.actorCategory ?? unit.unitType);
+  }
+
+  function isEnemy(unit = {}) {
+    return ["enemy", "enemies", "boss", "hostile"].includes(factionOf(unit));
+  }
+
+  function currentHp(unit = {}) {
+    const values = [unit.hp, unit.currentHp, unit.currentHP, unit.mechanics?.hp];
+    const found = values.map(Number).find(Number.isFinite);
+    return found == null ? null : found;
+  }
+
+  function isActive(unit = {}) {
+    if (!unit || typeof unit !== "object") return false;
+    if (unit.dead === true || unit.defeated === true || unit.isDead === true || unit.removed === true) return false;
+    const hp = currentHp(unit);
+    return hp == null || hp > 0;
+  }
+
+  function embeddedProfile(unit = {}) {
+    const raw = unit.actionEconomy || unit.mechanics?.actionEconomy || unit.ai?.actionEconomy || null;
+    if (!raw || typeof raw !== "object") return null;
+    return {
+      source: "unit",
+      minSlots: Math.max(1, finiteInt(raw.minSlots ?? raw.minimumSlots ?? raw.baseSlots, 1)),
+      maxSlots: Math.max(1, finiteInt(raw.maxSlots ?? raw.maximumSlots ?? raw.slotCap, 1)),
+    };
+  }
+
+  function legacyProfile(unit = {}) {
+    const minRaw = unit.mechanics?.actionSlots ?? unit.baseActionSlots ?? 1;
+    const maxRaw = unit.mechanics?.maxSlotsLimit ?? unit.maxActionSlots ?? minRaw;
+    const minSlots = Math.max(1, finiteInt(minRaw, 1));
+    const maxSlots = Math.max(minSlots, finiteInt(maxRaw, minSlots));
+    return { source: "legacy", minSlots, maxSlots };
+  }
+
+  function profileFor(unit = {}, options = {}) {
+    const embedded = embeddedProfile(unit);
+    const catalog = profileCatalog()?.get?.(unit);
+    const raw = embedded || (catalog ? { source: "catalog", ...catalog } : null) || legacyProfile(unit);
+    const teamCap = Math.max(1, finiteInt(options.teamSlotCap, DEFAULT_TEAM_SLOT_CAP));
+    const minSlots = clampInt(raw.minSlots, 1, teamCap);
+    const maxSlots = clampInt(raw.maxSlots, minSlots, teamCap);
+    return { source: raw.source || "catalog", minSlots, maxSlots };
+  }
+
+  function speedFor(unit = {}, options = {}) {
+    const id = unitIdOf(unit);
+    const source = options.speedByUnitId;
+    let explicit;
+    if (typeof source === "function") explicit = source(unit, id);
+    else if (source && typeof source === "object") explicit = source[id];
+    if (Number.isFinite(Number(explicit))) return Number(explicit);
+
+    const candidates = [unit.resolvedSpeed, unit.currentSpeed, unit.speedRoll, unit.speedValue, unit.speed];
+    const found = candidates.map(Number).find(Number.isFinite);
+    return found == null ? null : found;
+  }
+
+  function syncSlotObjects(unit, count) {
+    const existing = Array.isArray(unit.slots) ? unit.slots : [];
+    unit.slots = Array.from({ length: count }, (_, index) => ({
+      id: `${unitIdOf(unit) || "unit"}_slot_${index}`,
+      slotWeight: 1,
+      isTargetedThisRound: false,
+      ...(existing[index] && typeof existing[index] === "object" ? existing[index] : {}),
+      id: `${unitIdOf(unit) || "unit"}_slot_${index}`,
+    }));
+    return unit.slots;
+  }
+
+  function applySlotCount(unit, count, row = null) {
+    const next = Math.max(0, finiteInt(count, 0));
+    unit.activeSlots = next;
+    unit.currentActionSlots = next;
+    unit.actionSlots = next;
+    syncSlotObjects(unit, next);
+    unit.actionSlotAllocation = {
+      roundScoped: true,
+      slots: next,
+      speed: row?.speed ?? null,
+      minSlots: row?.minSlots ?? next,
+      maxSlots: row?.maxSlots ?? next,
+      bonusSlots: row?.bonusSlots ?? Math.max(0, next - (row?.minSlots ?? next)),
+      profileSource: row?.profileSource ?? null,
+    };
+    return next;
+  }
+
+  function allocateEnemySlots(units = [], options = {}) {
+    const teamSlotCap = Math.max(1, finiteInt(options.teamSlotCap, DEFAULT_TEAM_SLOT_CAP));
+    const bonusRecipientLimit = Math.max(0, finiteInt(options.bonusRecipientLimit, DEFAULT_BONUS_RECIPIENT_LIMIT));
+    const enemies = (Array.isArray(units) ? units : [])
+      .map((unit, deploymentIndex) => ({ unit, deploymentIndex }))
+      .filter(({ unit }) => isEnemy(unit) && isActive(unit));
+
+    const rows = enemies.map(({ unit, deploymentIndex }) => {
+      const profile = profileFor(unit, { ...options, teamSlotCap });
+      return {
+        unit,
+        unitId: unitIdOf(unit),
+        deploymentIndex,
+        speed: speedFor(unit, options),
+        minSlots: profile.minSlots,
+        maxSlots: profile.maxSlots,
+        slots: profile.minSlots,
+        bonusSlots: 0,
+        profileSource: profile.source,
+        bonusEligible: false,
+      };
+    });
+
+    const minimumTotal = rows.reduce((sum, row) => sum + row.minSlots, 0);
+    if (minimumTotal > teamSlotCap) {
+      return {
+        allocated: false,
+        reason: "minimum_slots_exceed_team_cap",
+        teamSlotCap,
+        minimumTotal,
+        totalSlots: 0,
+        bonusRecipientLimit,
+        rows: rows.map((row) => ({ ...row, unit: undefined })),
+      };
+    }
+
+    const eligible = rows
+      .filter((row) => row.speed != null && row.maxSlots > row.minSlots)
+      .sort((a, b) => (b.speed - a.speed) || (a.deploymentIndex - b.deploymentIndex) || a.unitId.localeCompare(b.unitId))
+      .slice(0, bonusRecipientLimit);
+    eligible.forEach((row) => { row.bonusEligible = true; });
+
+    let totalSlots = minimumTotal;
+    let progress = true;
+    while (totalSlots < teamSlotCap && progress && eligible.length) {
+      progress = false;
+      for (const row of eligible) {
+        if (totalSlots >= teamSlotCap) break;
+        if (row.slots >= row.maxSlots) continue;
+        row.slots += 1;
+        row.bonusSlots += 1;
+        totalSlots += 1;
+        progress = true;
+      }
+    }
+
+    if (options.apply !== false) rows.forEach((row) => applySlotCount(row.unit, row.slots, row));
+
+    const missingSpeed = rows.filter((row) => row.speed == null && row.maxSlots > row.minSlots).map((row) => row.unitId);
+    const resultRows = rows.map((row) => ({
+      unitId: row.unitId,
+      deploymentIndex: row.deploymentIndex,
+      speed: row.speed,
+      minSlots: row.minSlots,
+      maxSlots: row.maxSlots,
+      slots: row.slots,
+      bonusSlots: row.bonusSlots,
+      profileSource: row.profileSource,
+      bonusEligible: row.bonusEligible,
+    }));
+
+    return {
+      allocated: true,
+      teamSlotCap,
+      bonusRecipientLimit,
+      minimumTotal,
+      totalSlots,
+      unusedSlots: Math.max(0, teamSlotCap - totalSlots),
+      missingSpeed,
+      tieBreak: "deployment_order_then_unit_id",
+      bonusRecipients: eligible.map((row) => row.unitId),
+      rows: resultRows,
+    };
+  }
+
+  function beginEnemyPlanningRound(units = [], options = {}) {
+    const allocation = allocateEnemySlots(units, options);
+    if (!allocation.allocated) return { allocation, planning: [] };
+    const economy = actionEconomy();
+    const planning = [];
+    for (const row of allocation.rows) {
+      const unit = units.find((candidate) => unitIdOf(candidate) === row.unitId);
+      if (!unit) continue;
+      const snapshot = economy?.beginPlanning?.(unit) || null;
+      planning.push({ unitId: row.unitId, slots: row.slots, snapshot: snapshot ? clone(snapshot) : null });
+    }
+    return { allocation, planning };
+  }
+
+  function allocateAndPlan(units = [], options = {}) {
+    const round = beginEnemyPlanningRound(units, options);
+    if (!round.allocation.allocated) return { ...round, plans: [] };
+    const adapter = kitAdapter();
+    if (!adapter?.planUnitTurn) return { ...round, plans: [], reason: "unit_ai_kit_adapter_unavailable" };
+
+    const targetIds = Array.isArray(options.targetIds) ? options.targetIds : undefined;
+    const targets = Array.isArray(options.targets) ? options.targets : undefined;
+    const plans = round.allocation.rows.map((row) => {
+      const actor = units.find((candidate) => unitIdOf(candidate) === row.unitId);
+      const plan = adapter.planUnitTurn({
+        ...(options.planOptions || {}),
+        actor,
+        availableSlots: row.slots,
+        ...(targetIds ? { targetIds } : {}),
+        ...(targets ? { targets } : {}),
+      });
+      return { unitId: row.unitId, slots: row.slots, plan };
+    });
+    return { ...round, plans };
+  }
+
+  const api = Object.freeze({
+    version: "1.0.0",
+    DEFAULT_TEAM_SLOT_CAP,
+    DEFAULT_BONUS_RECIPIENT_LIMIT,
+    unitIdOf,
+    factionOf,
+    isEnemy,
+    isActive,
+    profileFor,
+    speedFor,
+    applySlotCount,
+    allocateEnemySlots,
+    beginEnemyPlanningRound,
+    allocateAndPlan,
+  });
+
+  global.LuminousEnemyActionSlotAllocator = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/enemy-action-slot-allocator.js
+++ b/js/enemy-action-slot-allocator.js
@@ -233,10 +233,7 @@
       }
     }
 
-    // Mutation happens only after every validation/allocation step has succeeded.
-    if (options.apply !== false) {
-      rows.forEach((row) => applySlotCount(row.unit, row.slots, row, options));
-    }
+    if (options.apply !== false) rows.forEach((row) => applySlotCount(row.unit, row.slots, row, options));
 
     const missingSpeed = rows.filter((row) => row.speed == null && row.maxSlots > row.minSlots).map((row) => row.unitId);
     const resultRows = rows.map((row) => ({
@@ -272,7 +269,9 @@
   }
 
   function beginEnemyPlanningRound(units = [], options = {}) {
-    const allocation = allocateEnemySlots(units, options);
+    // Preflight allocation without mutating live Units. Planning state is only touched
+    // after ids, caps, Speed input and the Universal Action Economy contract are valid.
+    const allocation = allocateEnemySlots(units, { ...options, apply: false });
     if (!allocation.allocated) return { allocation, planningReady: false, planning: [] };
 
     const economy = actionEconomy();
@@ -281,12 +280,19 @@
     }
 
     const unitById = new Map((Array.isArray(units) ? units : []).map((unit) => [unitIdOf(unit), unit]));
+    for (const row of allocation.rows) {
+      if (!unitById.has(row.unitId)) {
+        return { allocation, planningReady: false, reason: "allocated_unit_missing", unitId: row.unitId, planning: [] };
+      }
+    }
+
+    for (const row of allocation.rows) {
+      applySlotCount(unitById.get(row.unitId), row.slots, row, options);
+    }
+
     const planning = [];
     for (const row of allocation.rows) {
       const unit = unitById.get(row.unitId);
-      if (!unit) {
-        return { allocation, planningReady: false, reason: "allocated_unit_missing", unitId: row.unitId, planning };
-      }
       const snapshot = economy.beginPlanning(unit);
       const maximum = economy.actionSlotMaximum(unit);
       if (!snapshot || maximum !== row.slots || snapshot.actionSlots !== row.slots || snapshot.action !== row.slots) {
@@ -339,7 +345,7 @@
   }
 
   const api = Object.freeze({
-    version: "1.1.0",
+    version: "1.1.1",
     DEFAULT_TEAM_SLOT_CAP,
     DEFAULT_BONUS_RECIPIENT_LIMIT,
     unitIdOf,

--- a/js/individual-goap-combat-ai.js
+++ b/js/individual-goap-combat-ai.js
@@ -144,6 +144,13 @@
     if (explicit) return explicit;
     const id = normalizeId(definition.id || raw.id);
     if (sourceType === "universal" && ["escape", "retreat"].includes(id)) return "escape";
+
+    const definitionType = normalizeId(definition.type || definition.actionType || definition.action_type);
+    const defenseSubtype = normalizeId(definition.defenseSubtype || definition.defense_subtype);
+    if (definition.isDefense === true || definitionType === "defense" || ["guard", "evade", "counter", "clashable_guard", "clashable_counter"].includes(defenseSubtype)) {
+      return "defense";
+    }
+
     const tags = asArray(raw.tags || definition.tags).map(normalizeId);
     if (tags.some((tag) => ["defend", "defense", "guard", "dodge", "block", "protect"].includes(tag))) return "defense";
     if (tags.some((tag) => ["heal", "recover", "recovery", "restore"].includes(tag))) return "recover";
@@ -176,9 +183,9 @@
       available: raw.available !== false,
       availability: typeof raw.isAvailable === "function" ? raw.isAvailable : null,
       estimate: {
-        damage: Math.max(0, finite(estimateRaw.damage, roughDamage)),
+        damage: role === "defense" ? Math.max(0, finite(estimateRaw.damage, 0)) : Math.max(0, finite(estimateRaw.damage, roughDamage)),
         damageType,
-        safety: finite(estimateRaw.safety ?? raw.safety, role === "defense" ? 4 : 0),
+        safety: finite(estimateRaw.safety ?? raw.safety, role === "defense" ? Math.max(4, roughDamage) : 0),
         recovery: finite(estimateRaw.recovery ?? raw.recovery, role === "recover" ? 4 : 0),
         advantage: finite(estimateRaw.advantage ?? raw.advantage, role === "setup" ? 3 : 0),
         resourceCost: Math.max(0, finite(estimateRaw.resourceCost ?? raw.resourceCost, asArray(definition.resourceCosts || definition.resource_costs).length)),
@@ -392,7 +399,7 @@
   }
 
   const api = Object.freeze({
-    version: "0.1.0",
+    version: "0.1.1",
     GOALS,
     MAX_PLANNED_SLOTS,
     INTEL_SCHEMA_VERSION,

--- a/js/individual-goap-combat-ai.js
+++ b/js/individual-goap-combat-ai.js
@@ -113,8 +113,6 @@
   function targetIdOf(target) {
     if (typeof target === "string" || typeof target === "number") return clean(target);
     if (!target || typeof target !== "object") return "";
-    // Deliberately read identity only. Individual GOAP must not inspect private combat truth
-    // such as target HP, SP, resistances, skills, future slots, or planned actions.
     return clean(target.id ?? target.unitId ?? target.characterId);
   }
 
@@ -147,15 +145,39 @@
 
     const definitionType = normalizeId(definition.type || definition.actionType || definition.action_type);
     const defenseSubtype = normalizeId(definition.defenseSubtype || definition.defense_subtype);
-    if (definition.isDefense === true || definitionType === "defense" || ["guard", "evade", "counter", "clashable_guard", "clashable_counter"].includes(defenseSubtype)) {
-      return "defense";
-    }
+    if (definition.isDefense === true || definitionType === "defense" || ["guard", "evade", "counter", "clashable_guard", "clashable_counter"].includes(defenseSubtype)) return "defense";
 
     const tags = asArray(raw.tags || definition.tags).map(normalizeId);
     if (tags.some((tag) => ["defend", "defense", "guard", "dodge", "block", "protect"].includes(tag))) return "defense";
     if (tags.some((tag) => ["heal", "recover", "recovery", "restore"].includes(tag))) return "recover";
     if (tags.some((tag) => ["buff", "setup", "control", "debuff", "advantage"].includes(tag))) return "setup";
     return "offense";
+  }
+
+  function planningResourceKey(resource = {}) {
+    const type = normalizeId(resource.type || resource.resourceType);
+    const id = normalizeId(resource.id || resource.resourceId || "shared");
+    const slotLevel = resource.metadata?.slotLevel;
+    return `${type}:${id}${slotLevel == null ? "" : `:slot_${integer(slotLevel, 0)}`}`;
+  }
+
+  function normalizePlanningResources(raw = {}) {
+    const explicit = asArray(raw.planningResources);
+    const checks = explicit.length ? explicit : asArray(raw.metadata?.resourceChecks);
+    return checks.map((entry) => {
+      const resource = entry.resource || entry;
+      const detail = entry.detail || entry;
+      const amount = Math.max(0, finite(resource.amount ?? detail.required, 1));
+      const availableRaw = detail.current ?? entry.current ?? entry.availableAmount ?? resource.availableAmount;
+      const available = Number.isFinite(Number(availableRaw)) ? Math.max(0, Number(availableRaw)) : null;
+      return {
+        key: planningResourceKey(resource),
+        type: normalizeId(resource.type || resource.resourceType),
+        id: resource.id == null ? null : String(resource.id),
+        amount,
+        available,
+      };
+    }).filter((entry) => entry.type && entry.amount > 0);
   }
 
   function normalizeSourceDescriptor(raw = {}, index = 0) {
@@ -191,6 +213,7 @@
         resourceCost: Math.max(0, finite(estimateRaw.resourceCost ?? raw.resourceCost, asArray(definition.resourceCosts || definition.resource_costs).length)),
         risk: clamp(estimateRaw.risk ?? raw.risk ?? 0, 0, 10),
       },
+      planningResources: normalizePlanningResources(raw),
       producesTags: asArray(raw.producesTags ?? estimateRaw.producesTags).map(normalizeId).filter(Boolean),
       consumesTags: asArray(raw.consumesTags ?? estimateRaw.consumesTags).map(normalizeId).filter(Boolean),
       metadata: raw.metadata && typeof raw.metadata === "object" ? clone(raw.metadata) : {},
@@ -216,7 +239,6 @@
   function chooseGoal(input, context) {
     const explicit = normalizeId(input.goal || input.primaryGoal);
     if (Object.values(GOALS).includes(explicit)) return explicit;
-
     const { hpRatio, wisdomProfile: wis, hasEscape } = context;
     if (hasEscape && hpRatio <= wis.escapeHpRatio) return GOALS.ESCAPE;
     if (hpRatio <= Math.min(0.65, wis.escapeHpRatio + 0.15)) return GOALS.SURVIVE;
@@ -283,6 +305,24 @@
     return score;
   }
 
+  function canAffordPlanningResources(candidate, state) {
+    for (const resource of candidate.planningResources || []) {
+      if (!Number.isFinite(resource.available)) continue;
+      const spent = finite(state.resourceSpent?.[resource.key], 0);
+      if (spent + resource.amount > resource.available + 1e-9) return false;
+    }
+    return true;
+  }
+
+  function spendPlanningResources(candidate, state) {
+    const next = { ...(state.resourceSpent || {}) };
+    for (const resource of candidate.planningResources || []) {
+      if (!Number.isFinite(resource.available)) continue;
+      next[resource.key] = finite(next[resource.key], 0) + resource.amount;
+    }
+    return next;
+  }
+
   function expandState(state, candidate, score, context) {
     const producedTags = new Set(state.producedTags);
     if (context.intelligenceProfile.comboAwareness > 0) candidate.producesTags.forEach((tag) => producedTags.add(tag));
@@ -290,6 +330,7 @@
       sequence: state.sequence.concat(candidate),
       score: state.score + score,
       producedTags,
+      resourceSpent: spendPlanningResources(candidate, state),
       escaped: state.escaped || candidate.role === "escape",
     };
   }
@@ -321,7 +362,7 @@
     if (!actorId) return { planned: false, reason: "actor_id_required", actions: [] };
 
     const slots = resolveSlots(input);
-    if (!slots.length) return { planned: true, reason: "no_action_slots", actorId, actions: [], sequence: [] };
+    if (!slots.length) return { planned: true, reason: "no_action_slots", actorId, actions: [], sequence: [], slotsRequested: 0, slotsUsed: 0, unusedSlots: 0 };
 
     const intelligence = abilityScore(actor, "intelligence", "int", 10);
     const wisdom = abilityScore(actor, "wisdom", "wis", 10);
@@ -336,37 +377,43 @@
       .map(normalizeSourceDescriptor)
       .filter((candidate) => candidate.available && (!candidate.availability || candidate.availability(actor, input) !== false));
 
-    if (input.allowEscape !== false && !candidates.some((candidate) => candidate.sourceType === "universal" && normalizeId(candidate.sourceId) === "escape")) {
-      candidates.push(makeEscapeDescriptor());
-    }
+    if (input.allowEscape !== false && !candidates.some((candidate) => candidate.sourceType === "universal" && normalizeId(candidate.sourceId) === "escape")) candidates.push(makeEscapeDescriptor());
     if (!candidates.length) return { planned: false, reason: "no_available_actions", actorId, actions: [], sequence: [] };
 
     const hasEscape = candidates.some((candidate) => candidate.role === "escape");
     const goal = chooseGoal(input, { hpRatio, wisdomProfile: wisp, hasEscape });
     const context = { goal, hpRatio, intelligenceProfile: intp, wisdomProfile: wisp, intel, targetId };
 
-    // Low INT sees a smaller menu; higher INT gets more breadth. This is the main
-    // performance guard: the search never expands the full combat menu without a cap.
     candidates.sort((a, b) => quickCandidateScore(b) - quickCandidateScore(a) || a.key.localeCompare(b.key));
     candidates = candidates.slice(0, intp.candidateLimit);
     if (hasEscape && !candidates.some((candidate) => candidate.role === "escape")) candidates.push(makeEscapeDescriptor());
 
-    let beam = [{ sequence: [], score: 0, producedTags: new Set(), escaped: false }];
+    let beam = [{ sequence: [], score: 0, producedTags: new Set(), resourceSpent: {}, escaped: false }];
     for (let slotIndex = 0; slotIndex < slots.length; slotIndex += 1) {
       const next = [];
       for (const state of beam) {
+        // Escape leaves the encounter. It is terminal and can never be followed by another action.
+        if (state.escaped) {
+          next.push(state);
+          continue;
+        }
+
+        let expanded = false;
         for (const candidate of candidates) {
-          if (state.escaped && candidate.role === "escape") continue;
+          if (!canAffordPlanningResources(candidate, state)) continue;
           const score = candidateScore(candidate, state, context);
           next.push(expandState(state, candidate, score, context));
+          expanded = true;
         }
+        // A Unit is allowed to leave slots unused when all remaining actions are resource-blocked.
+        if (!expanded) next.push(state);
       }
       next.sort((a, b) => b.score - a.score || a.sequence.map((item) => item.key).join("|").localeCompare(b.sequence.map((item) => item.key).join("|")));
       beam = next.slice(0, intp.beamWidth);
       if (!beam.length) break;
     }
 
-    const best = beam[0] || { sequence: [], score: 0, producedTags: new Set() };
+    const best = beam[0] || { sequence: [], score: 0, producedTags: new Set(), resourceSpent: {} };
     const perActionScore = best.sequence.length ? best.score / best.sequence.length : 0;
     const actions = best.sequence.map((candidate, index) => compileCandidate(actor, candidate, {
       actionSlotId: slots[index],
@@ -381,6 +428,8 @@
       goal,
       targetId,
       slotsRequested: slots.length,
+      slotsUsed: actions.length,
+      unusedSlots: Math.max(0, slots.length - actions.length),
       actions,
       sequence: best.sequence.map((candidate, index) => ({
         slotId: slots[index],
@@ -389,6 +438,7 @@
         role: candidate.role,
       })),
       score: best.score,
+      resourceSpent: clone(best.resourceSpent || {}),
       intelligence,
       wisdom,
       profile: clone(intp),
@@ -399,7 +449,7 @@
   }
 
   const api = Object.freeze({
-    version: "0.1.1",
+    version: "0.2.0",
     GOALS,
     MAX_PLANNED_SLOTS,
     INTEL_SCHEMA_VERSION,
@@ -408,6 +458,8 @@
     createIntelState,
     observeDamageResult,
     normalizeSourceDescriptor,
+    normalizePlanningResources,
+    planningResourceKey,
     chooseGoal,
     planTurn,
   });

--- a/js/individual-goap-combat-ai.js
+++ b/js/individual-goap-combat-ai.js
@@ -35,8 +35,8 @@
     return fallback;
   }
   function ownHpRatio(actor = {}) {
-    const hp = Math.max(0, finite(actor.hp ?? actor.currentHp ?? actor.currentHP, 0));
-    const maxHp = Math.max(1, finite(actor.maxHp ?? actor.maxHP ?? actor.hpMax ?? actor.mechanics?.maxHp, hp || 1));
+    const hp = Math.max(0, finite(actor.hp ?? actor.currentHp ?? actor.currentHP ?? actor.mechanics?.hp, 0));
+    const maxHp = Math.max(1, finite(actor.maxHp ?? actor.maxHP ?? actor.hpMax ?? actor.mechanics?.maxHp ?? actor.mechanics?.hp, hp || 1));
     return clamp(hp / maxHp, 0, 1);
   }
   function planningProfile(intelligenceRaw) {
@@ -231,8 +231,6 @@
     const hasEscape = candidates.some((candidate) => candidate.role === "escape");
     const goal = chooseGoal(input, { hpRatio, wisdomProfile: wisp, hasEscape });
     const context = { goal, hpRatio, intelligenceProfile: intp, wisdomProfile: wisp, intel, targetId };
-
-    // Once critical survival logic commits to ESCAPE, do it immediately. Do not farm preceding attacks from extra slots.
     if (goal === GOALS.ESCAPE) {
       const escapeCandidate = candidates.find((candidate) => candidate.role === "escape");
       if (escapeCandidate) candidates = [escapeCandidate];
@@ -241,7 +239,6 @@
       candidates = candidates.slice(0, intp.candidateLimit);
       if (hasEscape && !candidates.some((candidate) => candidate.role === "escape")) candidates.push(makeEscapeDescriptor());
     }
-
     let beam = [{ sequence: [], score: 0, producedTags: new Set(), resourceSpent: {}, escaped: false }];
     for (let slotIndex = 0; slotIndex < slots.length; slotIndex += 1) {
       const next = [];
@@ -268,7 +265,7 @@
     };
   }
 
-  const api = Object.freeze({ version: "0.2.1", GOALS, MAX_PLANNED_SLOTS, INTEL_SCHEMA_VERSION, planningProfile, wisdomProfile, createIntelState, observeDamageResult, normalizeSourceDescriptor, normalizePlanningResources, planningResourceKey, chooseGoal, planTurn });
+  const api = Object.freeze({ version: "0.2.2", GOALS, MAX_PLANNED_SLOTS, INTEL_SCHEMA_VERSION, planningProfile, wisdomProfile, createIntelState, observeDamageResult, normalizeSourceDescriptor, normalizePlanningResources, planningResourceKey, chooseGoal, planTurn });
   global.LuminousIndividualGoapCombatAI = api;
   if (typeof module !== "undefined" && module.exports) module.exports = api;
 })(typeof window !== "undefined" ? window : globalThis);

--- a/js/individual-goap-combat-ai.js
+++ b/js/individual-goap-combat-ai.js
@@ -1,0 +1,410 @@
+(function (global) {
+  "use strict";
+
+  const adapters = global.LuminousCombatActionAdapters || null;
+  const schema = global.LuminousCombatAction || null;
+  if (!adapters || !schema) return;
+
+  const GOALS = Object.freeze({
+    KILL_TARGET: "kill_target",
+    SURVIVE: "survive",
+    ESCAPE: "escape",
+    PROTECT_SELF: "protect_self",
+    RECOVER_RESOURCE: "recover_resource",
+    GAIN_ADVANTAGE: "gain_advantage",
+  });
+
+  const SOURCE_TYPES = Object.freeze(["skill", "spell", "trait", "item", "universal"]);
+  const MAX_PLANNED_SLOTS = 12;
+  const INTEL_SCHEMA_VERSION = 1;
+
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const integer = (value, fallback = 0) => Math.trunc(finite(value, fallback));
+  const clamp = (value, min, max) => Math.max(min, Math.min(max, finite(value, min)));
+  const clean = (value, fallback = "") => String(value ?? fallback).trim() || fallback;
+  const normalizeId = (value) => clean(value).toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  const asArray = (value) => value == null ? [] : (Array.isArray(value) ? value : [value]);
+
+  function actorIdOf(actor = {}) {
+    return clean(actor.id ?? actor.unitId ?? actor.characterId);
+  }
+
+  function abilityScore(actor = {}, longName, shortName, fallback = 10) {
+    const sources = [actor.scores, actor.abilityScores, actor.stats, actor.attributes, actor];
+    for (const source of sources) {
+      if (!source || typeof source !== "object") continue;
+      const value = source[shortName] ?? source[longName] ?? source[longName.toUpperCase()];
+      if (Number.isFinite(Number(value))) return clamp(value, 1, 30);
+    }
+    return fallback;
+  }
+
+  function ownHpRatio(actor = {}) {
+    const hp = Math.max(0, finite(actor.hp ?? actor.currentHp ?? actor.currentHP, 0));
+    const maxHp = Math.max(1, finite(actor.maxHp ?? actor.maxHP ?? actor.hpMax ?? actor.mechanics?.maxHp, hp || 1));
+    return clamp(hp / maxHp, 0, 1);
+  }
+
+  function planningProfile(intelligenceRaw) {
+    const intelligence = clamp(intelligenceRaw, 1, 30);
+    if (intelligence <= 6) return Object.freeze({ intelligence, candidateLimit: 2, beamWidth: 2, comboAwareness: 0, intelAwareness: 0.05 });
+    if (intelligence <= 9) return Object.freeze({ intelligence, candidateLimit: 3, beamWidth: 2, comboAwareness: 0, intelAwareness: 0.20 });
+    if (intelligence <= 12) return Object.freeze({ intelligence, candidateLimit: 4, beamWidth: 3, comboAwareness: 0.20, intelAwareness: 0.40 });
+    if (intelligence <= 15) return Object.freeze({ intelligence, candidateLimit: 6, beamWidth: 4, comboAwareness: 0.50, intelAwareness: 0.65 });
+    if (intelligence <= 19) return Object.freeze({ intelligence, candidateLimit: 8, beamWidth: 6, comboAwareness: 0.80, intelAwareness: 0.90 });
+    return Object.freeze({ intelligence, candidateLimit: 10, beamWidth: 8, comboAwareness: 1, intelAwareness: 1 });
+  }
+
+  function wisdomProfile(wisdomRaw) {
+    const wisdom = clamp(wisdomRaw, 1, 30);
+    return Object.freeze({
+      wisdom,
+      escapeHpRatio: clamp(0.12 + wisdom * 0.012, 0.13, 0.42),
+      dangerWeight: 0.65 + wisdom / 20,
+      resourceConservation: clamp((wisdom - 5) / 20, 0, 1),
+    });
+  }
+
+  function createIntelState(seed = {}) {
+    const targets = {};
+    const rawTargets = seed.targets && typeof seed.targets === "object" ? seed.targets : {};
+    for (const [targetId, entry] of Object.entries(rawTargets)) {
+      const damageTypes = {};
+      for (const [damageType, belief] of Object.entries(entry?.damageTypes || {})) {
+        damageTypes[normalizeId(damageType)] = {
+          multiplierEstimate: clamp(belief?.multiplierEstimate ?? belief?.multiplier ?? 1, 0.1, 2.5),
+          confidence: clamp(belief?.confidence ?? 0, 0, 1),
+          samples: Math.max(0, integer(belief?.samples, 0)),
+        };
+      }
+      targets[clean(targetId)] = {
+        observations: Math.max(0, integer(entry?.observations, 0)),
+        threat: clamp(entry?.threat ?? 0.5, 0, 1),
+        damageTypes,
+      };
+    }
+    return { schemaVersion: INTEL_SCHEMA_VERSION, targets };
+  }
+
+  function observeDamageResult(intelRaw, observation = {}) {
+    const intel = createIntelState(intelRaw || {});
+    const targetId = clean(observation.targetId);
+    const damageType = normalizeId(observation.damageType || "unknown") || "unknown";
+    if (!targetId) return intel;
+
+    const expected = Math.max(0.01, finite(observation.expectedDamage, 0));
+    const actual = Math.max(0, finite(observation.actualDamage, 0));
+    if (!(expected > 0)) return intel;
+
+    const ratio = clamp(actual / expected, 0.1, 2.5);
+    const target = intel.targets[targetId] || { observations: 0, threat: 0.5, damageTypes: {} };
+    const previous = target.damageTypes[damageType] || { multiplierEstimate: 1, confidence: 0, samples: 0 };
+    const samples = previous.samples + 1;
+    const multiplierEstimate = ((previous.multiplierEstimate * previous.samples) + ratio) / samples;
+    const confidence = clamp(0.20 + samples * 0.15, 0, 0.95);
+
+    target.observations += 1;
+    target.damageTypes[damageType] = { multiplierEstimate, confidence, samples };
+    intel.targets[targetId] = target;
+    return intel;
+  }
+
+  function targetIdOf(target) {
+    if (typeof target === "string" || typeof target === "number") return clean(target);
+    if (!target || typeof target !== "object") return "";
+    // Deliberately read identity only. Individual GOAP must not inspect private combat truth
+    // such as target HP, SP, resistances, skills, future slots, or planned actions.
+    return clean(target.id ?? target.unitId ?? target.characterId);
+  }
+
+  function targetIdsFrom(input = {}) {
+    const ids = [];
+    const seen = new Set();
+    for (const target of asArray(input.targets ?? input.targetIds)) {
+      const id = targetIdOf(target);
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      ids.push(id);
+    }
+    return ids;
+  }
+
+  function bestKnownTarget(targetIds, intel) {
+    if (!targetIds.length) return null;
+    return [...targetIds].sort((a, b) => {
+      const threatA = finite(intel.targets?.[a]?.threat, 0.5);
+      const threatB = finite(intel.targets?.[b]?.threat, 0.5);
+      return threatB - threatA || a.localeCompare(b);
+    })[0];
+  }
+
+  function inferRole(raw = {}, definition = {}, sourceType = "skill") {
+    const explicit = normalizeId(raw.role || raw.aiRole || definition.aiRole || definition.ai_role);
+    if (explicit) return explicit;
+    const id = normalizeId(definition.id || raw.id);
+    if (sourceType === "universal" && ["escape", "retreat"].includes(id)) return "escape";
+    const tags = asArray(raw.tags || definition.tags).map(normalizeId);
+    if (tags.some((tag) => ["defend", "defense", "guard", "dodge", "block", "protect"].includes(tag))) return "defense";
+    if (tags.some((tag) => ["heal", "recover", "recovery", "restore"].includes(tag))) return "recover";
+    if (tags.some((tag) => ["buff", "setup", "control", "debuff", "advantage"].includes(tag))) return "setup";
+    return "offense";
+  }
+
+  function normalizeSourceDescriptor(raw = {}, index = 0) {
+    const definition = clone(raw.definition || raw.source || raw.skill || raw.spell || raw.action || raw);
+    let sourceType = normalizeId(raw.sourceType || raw.source_type || raw.kind || raw.combatSourceType);
+    if (!SOURCE_TYPES.includes(sourceType)) {
+      const hinted = normalizeId(definition.sourceType || definition.source_type);
+      sourceType = SOURCE_TYPES.includes(hinted) ? hinted : "skill";
+    }
+    const sourceId = clean(definition.id ?? definition.skillId ?? definition.spellId ?? raw.id, `ai_action_${index + 1}`);
+    definition.id = sourceId;
+    const estimateRaw = raw.estimate || raw.aiEstimate || definition.aiEstimate || {};
+    const coinAmount = Math.max(0, integer(definition.coinAmount ?? definition.coinCount ?? definition.coin_count, 0));
+    const roughDamage = Math.max(0, finite(definition.basePower ?? definition.base_power, 0))
+      + Math.max(0, finite(definition.coinPower ?? definition.coin_power, 0)) * Math.max(1, coinAmount) * 0.5;
+    const damageType = normalizeId(estimateRaw.damageType || raw.damageType || definition.damageType || definition.dmgType || definition.attackType || definition.tipo_dano);
+    const role = inferRole(raw, definition, sourceType);
+    return {
+      key: `${sourceType}:${normalizeId(sourceId) || index}`,
+      sourceType,
+      sourceId,
+      definition,
+      role,
+      fixedTargetId: clean(raw.targetId),
+      available: raw.available !== false,
+      availability: typeof raw.isAvailable === "function" ? raw.isAvailable : null,
+      estimate: {
+        damage: Math.max(0, finite(estimateRaw.damage, roughDamage)),
+        damageType,
+        safety: finite(estimateRaw.safety ?? raw.safety, role === "defense" ? 4 : 0),
+        recovery: finite(estimateRaw.recovery ?? raw.recovery, role === "recover" ? 4 : 0),
+        advantage: finite(estimateRaw.advantage ?? raw.advantage, role === "setup" ? 3 : 0),
+        resourceCost: Math.max(0, finite(estimateRaw.resourceCost ?? raw.resourceCost, asArray(definition.resourceCosts || definition.resource_costs).length)),
+        risk: clamp(estimateRaw.risk ?? raw.risk ?? 0, 0, 10),
+      },
+      producesTags: asArray(raw.producesTags ?? estimateRaw.producesTags).map(normalizeId).filter(Boolean),
+      consumesTags: asArray(raw.consumesTags ?? estimateRaw.consumesTags).map(normalizeId).filter(Boolean),
+      metadata: raw.metadata && typeof raw.metadata === "object" ? clone(raw.metadata) : {},
+    };
+  }
+
+  function makeEscapeDescriptor() {
+    return normalizeSourceDescriptor({
+      sourceType: "universal",
+      definition: { id: "escape" },
+      role: "escape",
+      estimate: { safety: 10, risk: 0, resourceCost: 0 },
+      metadata: { injectedByIndividualGoap: true },
+    }, 999);
+  }
+
+  function resolveSlots(input = {}) {
+    if (Array.isArray(input.slotIds)) return input.slotIds.slice(0, MAX_PLANNED_SLOTS).map(String);
+    const count = clamp(integer(input.availableSlots ?? input.slots, 1), 0, MAX_PLANNED_SLOTS);
+    return Array.from({ length: count }, (_, index) => `${actorIdOf(input.actor) || "ai"}_slot_${index}`);
+  }
+
+  function chooseGoal(input, context) {
+    const explicit = normalizeId(input.goal || input.primaryGoal);
+    if (Object.values(GOALS).includes(explicit)) return explicit;
+
+    const { hpRatio, wisdomProfile: wis, hasEscape } = context;
+    if (hasEscape && hpRatio <= wis.escapeHpRatio) return GOALS.ESCAPE;
+    if (hpRatio <= Math.min(0.65, wis.escapeHpRatio + 0.15)) return GOALS.SURVIVE;
+    return GOALS.KILL_TARGET;
+  }
+
+  function beliefMultiplier(intel, targetId, damageType, awareness) {
+    if (!targetId || !damageType) return 1;
+    const belief = intel.targets?.[targetId]?.damageTypes?.[damageType];
+    if (!belief) return 1;
+    const confidence = clamp(belief.confidence, 0, 1);
+    return 1 + (clamp(belief.multiplierEstimate, 0.1, 2.5) - 1) * confidence * awareness;
+  }
+
+  function quickCandidateScore(candidate) {
+    if (candidate.role === "offense") return 20 + candidate.estimate.damage - candidate.estimate.resourceCost;
+    if (candidate.role === "defense") return 14 + candidate.estimate.safety;
+    if (candidate.role === "recover") return 13 + candidate.estimate.recovery;
+    if (candidate.role === "setup") return 12 + candidate.estimate.advantage;
+    if (candidate.role === "escape") return 2;
+    return 5;
+  }
+
+  function candidateScore(candidate, state, context) {
+    const { goal, hpRatio, intelligenceProfile: intp, wisdomProfile: wisp, intel, targetId } = context;
+    const estimate = candidate.estimate;
+    const damageMultiplier = beliefMultiplier(intel, targetId, estimate.damageType, intp.intelAwareness);
+    const effectiveDamage = estimate.damage * damageMultiplier;
+    let score = 0;
+
+    if (goal === GOALS.KILL_TARGET) {
+      score += effectiveDamage * 2.4;
+      score += estimate.advantage * (1 + intp.comboAwareness);
+      score += estimate.safety * 0.25;
+      if (candidate.role === "escape") score -= 14;
+    } else if (goal === GOALS.ESCAPE) {
+      score += estimate.safety * 2.5 + estimate.recovery * 1.2;
+      score += effectiveDamage * 0.35;
+      if (candidate.role === "escape") score += 42 + wisp.wisdom;
+    } else if (goal === GOALS.SURVIVE || goal === GOALS.PROTECT_SELF) {
+      score += estimate.safety * (1.6 + wisp.dangerWeight);
+      score += estimate.recovery * 1.8;
+      score += effectiveDamage * 0.75;
+      if (candidate.role === "escape") score += hpRatio <= wisp.escapeHpRatio ? 30 : 5;
+    } else if (goal === GOALS.RECOVER_RESOURCE) {
+      score += estimate.recovery * 2.5 + estimate.safety;
+      score += effectiveDamage * 0.4;
+    } else if (goal === GOALS.GAIN_ADVANTAGE) {
+      score += estimate.advantage * 2.5 + effectiveDamage;
+      score += estimate.safety * 0.5;
+    }
+
+    score -= estimate.resourceCost * (0.75 + wisp.resourceConservation * 1.75);
+    score -= estimate.risk * wisp.dangerWeight * (1.15 - hpRatio * 0.35);
+
+    const repeats = state.sequence.filter((entry) => entry.key === candidate.key).length;
+    score -= repeats * (0.5 + wisp.resourceConservation);
+
+    if (intp.comboAwareness > 0 && candidate.consumesTags.length) {
+      const matches = candidate.consumesTags.filter((tag) => state.producedTags.has(tag)).length;
+      score += matches * 4 * intp.comboAwareness;
+    }
+
+    return score;
+  }
+
+  function expandState(state, candidate, score, context) {
+    const producedTags = new Set(state.producedTags);
+    if (context.intelligenceProfile.comboAwareness > 0) candidate.producesTags.forEach((tag) => producedTags.add(tag));
+    return {
+      sequence: state.sequence.concat(candidate),
+      score: state.score + score,
+      producedTags,
+      escaped: state.escaped || candidate.role === "escape",
+    };
+  }
+
+  function compileCandidate(actor, candidate, options = {}) {
+    const common = {
+      isAi: true,
+      actionSlotId: options.actionSlotId,
+      targetId: candidate.fixedTargetId || options.targetId || null,
+      mainTargetId: candidate.fixedTargetId || options.targetId || null,
+      metadata: {
+        ...(candidate.metadata || {}),
+        individualGoap: true,
+        aiGoal: options.goal,
+        aiScore: options.score,
+      },
+    };
+
+    if (candidate.sourceType === "universal") return adapters.compileUniversalAction(actor, candidate.sourceId, common);
+    if (candidate.sourceType === "skill") return adapters.compileSkillToCombatAction(actor, candidate.definition, common);
+    if (candidate.sourceType === "spell") return adapters.compileSpellToCombatAction(actor, candidate.definition, common);
+    if (candidate.sourceType === "trait") return adapters.compileTraitToCombatAction(actor, candidate.definition, common);
+    return adapters.compileSourceToCombatAction(actor, candidate.definition, { ...common, sourceType: candidate.sourceType });
+  }
+
+  function planTurn(input = {}) {
+    const actor = input.actor || {};
+    const actorId = actorIdOf(actor);
+    if (!actorId) return { planned: false, reason: "actor_id_required", actions: [] };
+
+    const slots = resolveSlots(input);
+    if (!slots.length) return { planned: true, reason: "no_action_slots", actorId, actions: [], sequence: [] };
+
+    const intelligence = abilityScore(actor, "intelligence", "int", 10);
+    const wisdom = abilityScore(actor, "wisdom", "wis", 10);
+    const intp = planningProfile(intelligence);
+    const wisp = wisdomProfile(wisdom);
+    const hpRatio = ownHpRatio(actor);
+    const intel = createIntelState(input.intel || {});
+    const targetIds = targetIdsFrom(input);
+    const targetId = clean(input.targetId) || bestKnownTarget(targetIds, intel);
+
+    let candidates = asArray(input.sources || input.actions)
+      .map(normalizeSourceDescriptor)
+      .filter((candidate) => candidate.available && (!candidate.availability || candidate.availability(actor, input) !== false));
+
+    if (input.allowEscape !== false && !candidates.some((candidate) => candidate.sourceType === "universal" && normalizeId(candidate.sourceId) === "escape")) {
+      candidates.push(makeEscapeDescriptor());
+    }
+    if (!candidates.length) return { planned: false, reason: "no_available_actions", actorId, actions: [], sequence: [] };
+
+    const hasEscape = candidates.some((candidate) => candidate.role === "escape");
+    const goal = chooseGoal(input, { hpRatio, wisdomProfile: wisp, hasEscape });
+    const context = { goal, hpRatio, intelligenceProfile: intp, wisdomProfile: wisp, intel, targetId };
+
+    // Low INT sees a smaller menu; higher INT gets more breadth. This is the main
+    // performance guard: the search never expands the full combat menu without a cap.
+    candidates.sort((a, b) => quickCandidateScore(b) - quickCandidateScore(a) || a.key.localeCompare(b.key));
+    candidates = candidates.slice(0, intp.candidateLimit);
+    if (hasEscape && !candidates.some((candidate) => candidate.role === "escape")) candidates.push(makeEscapeDescriptor());
+
+    let beam = [{ sequence: [], score: 0, producedTags: new Set(), escaped: false }];
+    for (let slotIndex = 0; slotIndex < slots.length; slotIndex += 1) {
+      const next = [];
+      for (const state of beam) {
+        for (const candidate of candidates) {
+          if (state.escaped && candidate.role === "escape") continue;
+          const score = candidateScore(candidate, state, context);
+          next.push(expandState(state, candidate, score, context));
+        }
+      }
+      next.sort((a, b) => b.score - a.score || a.sequence.map((item) => item.key).join("|").localeCompare(b.sequence.map((item) => item.key).join("|")));
+      beam = next.slice(0, intp.beamWidth);
+      if (!beam.length) break;
+    }
+
+    const best = beam[0] || { sequence: [], score: 0, producedTags: new Set() };
+    const perActionScore = best.sequence.length ? best.score / best.sequence.length : 0;
+    const actions = best.sequence.map((candidate, index) => compileCandidate(actor, candidate, {
+      actionSlotId: slots[index],
+      targetId,
+      goal,
+      score: perActionScore,
+    }));
+
+    return {
+      planned: true,
+      actorId,
+      goal,
+      targetId,
+      slotsRequested: slots.length,
+      actions,
+      sequence: best.sequence.map((candidate, index) => ({
+        slotId: slots[index],
+        sourceType: candidate.sourceType,
+        sourceId: candidate.sourceId,
+        role: candidate.role,
+      })),
+      score: best.score,
+      intelligence,
+      wisdom,
+      profile: clone(intp),
+      riskProfile: clone(wisp),
+      hpRatio,
+      intel: clone(intel),
+    };
+  }
+
+  const api = Object.freeze({
+    version: "0.1.0",
+    GOALS,
+    MAX_PLANNED_SLOTS,
+    INTEL_SCHEMA_VERSION,
+    planningProfile,
+    wisdomProfile,
+    createIntelState,
+    observeDamageResult,
+    normalizeSourceDescriptor,
+    chooseGoal,
+    planTurn,
+  });
+
+  global.LuminousIndividualGoapCombatAI = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/individual-goap-combat-ai.js
+++ b/js/individual-goap-combat-ai.js
@@ -13,11 +13,9 @@
     RECOVER_RESOURCE: "recover_resource",
     GAIN_ADVANTAGE: "gain_advantage",
   });
-
   const SOURCE_TYPES = Object.freeze(["skill", "spell", "trait", "item", "universal"]);
   const MAX_PLANNED_SLOTS = 12;
   const INTEL_SCHEMA_VERSION = 1;
-
   const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
   const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
   const integer = (value, fallback = 0) => Math.trunc(finite(value, fallback));
@@ -26,10 +24,7 @@
   const normalizeId = (value) => clean(value).toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
   const asArray = (value) => value == null ? [] : (Array.isArray(value) ? value : [value]);
 
-  function actorIdOf(actor = {}) {
-    return clean(actor.id ?? actor.unitId ?? actor.characterId);
-  }
-
+  function actorIdOf(actor = {}) { return clean(actor.id ?? actor.unitId ?? actor.characterId); }
   function abilityScore(actor = {}, longName, shortName, fallback = 10) {
     const sources = [actor.scores, actor.abilityScores, actor.stats, actor.attributes, actor];
     for (const source of sources) {
@@ -39,13 +34,11 @@
     }
     return fallback;
   }
-
   function ownHpRatio(actor = {}) {
     const hp = Math.max(0, finite(actor.hp ?? actor.currentHp ?? actor.currentHP, 0));
     const maxHp = Math.max(1, finite(actor.maxHp ?? actor.maxHP ?? actor.hpMax ?? actor.mechanics?.maxHp, hp || 1));
     return clamp(hp / maxHp, 0, 1);
   }
-
   function planningProfile(intelligenceRaw) {
     const intelligence = clamp(intelligenceRaw, 1, 30);
     if (intelligence <= 6) return Object.freeze({ intelligence, candidateLimit: 2, beamWidth: 2, comboAwareness: 0, intelAwareness: 0.05 });
@@ -55,112 +48,77 @@
     if (intelligence <= 19) return Object.freeze({ intelligence, candidateLimit: 8, beamWidth: 6, comboAwareness: 0.80, intelAwareness: 0.90 });
     return Object.freeze({ intelligence, candidateLimit: 10, beamWidth: 8, comboAwareness: 1, intelAwareness: 1 });
   }
-
   function wisdomProfile(wisdomRaw) {
     const wisdom = clamp(wisdomRaw, 1, 30);
-    return Object.freeze({
-      wisdom,
-      escapeHpRatio: clamp(0.12 + wisdom * 0.012, 0.13, 0.42),
-      dangerWeight: 0.65 + wisdom / 20,
-      resourceConservation: clamp((wisdom - 5) / 20, 0, 1),
-    });
+    return Object.freeze({ wisdom, escapeHpRatio: clamp(0.12 + wisdom * 0.012, 0.13, 0.42), dangerWeight: 0.65 + wisdom / 20, resourceConservation: clamp((wisdom - 5) / 20, 0, 1) });
   }
-
   function createIntelState(seed = {}) {
     const targets = {};
     const rawTargets = seed.targets && typeof seed.targets === "object" ? seed.targets : {};
     for (const [targetId, entry] of Object.entries(rawTargets)) {
       const damageTypes = {};
       for (const [damageType, belief] of Object.entries(entry?.damageTypes || {})) {
-        damageTypes[normalizeId(damageType)] = {
-          multiplierEstimate: clamp(belief?.multiplierEstimate ?? belief?.multiplier ?? 1, 0.1, 2.5),
-          confidence: clamp(belief?.confidence ?? 0, 0, 1),
-          samples: Math.max(0, integer(belief?.samples, 0)),
-        };
+        damageTypes[normalizeId(damageType)] = { multiplierEstimate: clamp(belief?.multiplierEstimate ?? belief?.multiplier ?? 1, 0.1, 2.5), confidence: clamp(belief?.confidence ?? 0, 0, 1), samples: Math.max(0, integer(belief?.samples, 0)) };
       }
-      targets[clean(targetId)] = {
-        observations: Math.max(0, integer(entry?.observations, 0)),
-        threat: clamp(entry?.threat ?? 0.5, 0, 1),
-        damageTypes,
-      };
+      targets[clean(targetId)] = { observations: Math.max(0, integer(entry?.observations, 0)), threat: clamp(entry?.threat ?? 0.5, 0, 1), damageTypes };
     }
     return { schemaVersion: INTEL_SCHEMA_VERSION, targets };
   }
-
   function observeDamageResult(intelRaw, observation = {}) {
     const intel = createIntelState(intelRaw || {});
     const targetId = clean(observation.targetId);
     const damageType = normalizeId(observation.damageType || "unknown") || "unknown";
     if (!targetId) return intel;
-
     const expected = Math.max(0.01, finite(observation.expectedDamage, 0));
     const actual = Math.max(0, finite(observation.actualDamage, 0));
     if (!(expected > 0)) return intel;
-
     const ratio = clamp(actual / expected, 0.1, 2.5);
     const target = intel.targets[targetId] || { observations: 0, threat: 0.5, damageTypes: {} };
     const previous = target.damageTypes[damageType] || { multiplierEstimate: 1, confidence: 0, samples: 0 };
     const samples = previous.samples + 1;
-    const multiplierEstimate = ((previous.multiplierEstimate * previous.samples) + ratio) / samples;
-    const confidence = clamp(0.20 + samples * 0.15, 0, 0.95);
-
     target.observations += 1;
-    target.damageTypes[damageType] = { multiplierEstimate, confidence, samples };
+    target.damageTypes[damageType] = { multiplierEstimate: ((previous.multiplierEstimate * previous.samples) + ratio) / samples, confidence: clamp(0.20 + samples * 0.15, 0, 0.95), samples };
     intel.targets[targetId] = target;
     return intel;
   }
-
   function targetIdOf(target) {
     if (typeof target === "string" || typeof target === "number") return clean(target);
     if (!target || typeof target !== "object") return "";
     return clean(target.id ?? target.unitId ?? target.characterId);
   }
-
   function targetIdsFrom(input = {}) {
-    const ids = [];
-    const seen = new Set();
+    const ids = [], seen = new Set();
     for (const target of asArray(input.targets ?? input.targetIds)) {
       const id = targetIdOf(target);
       if (!id || seen.has(id)) continue;
-      seen.add(id);
-      ids.push(id);
+      seen.add(id); ids.push(id);
     }
     return ids;
   }
-
   function bestKnownTarget(targetIds, intel) {
     if (!targetIds.length) return null;
-    return [...targetIds].sort((a, b) => {
-      const threatA = finite(intel.targets?.[a]?.threat, 0.5);
-      const threatB = finite(intel.targets?.[b]?.threat, 0.5);
-      return threatB - threatA || a.localeCompare(b);
-    })[0];
+    return [...targetIds].sort((a, b) => finite(intel.targets?.[b]?.threat, 0.5) - finite(intel.targets?.[a]?.threat, 0.5) || a.localeCompare(b))[0];
   }
-
   function inferRole(raw = {}, definition = {}, sourceType = "skill") {
     const explicit = normalizeId(raw.role || raw.aiRole || definition.aiRole || definition.ai_role);
     if (explicit) return explicit;
     const id = normalizeId(definition.id || raw.id);
     if (sourceType === "universal" && ["escape", "retreat"].includes(id)) return "escape";
-
     const definitionType = normalizeId(definition.type || definition.actionType || definition.action_type);
     const defenseSubtype = normalizeId(definition.defenseSubtype || definition.defense_subtype);
     if (definition.isDefense === true || definitionType === "defense" || ["guard", "evade", "counter", "clashable_guard", "clashable_counter"].includes(defenseSubtype)) return "defense";
-
     const tags = asArray(raw.tags || definition.tags).map(normalizeId);
     if (tags.some((tag) => ["defend", "defense", "guard", "dodge", "block", "protect"].includes(tag))) return "defense";
     if (tags.some((tag) => ["heal", "recover", "recovery", "restore"].includes(tag))) return "recover";
     if (tags.some((tag) => ["buff", "setup", "control", "debuff", "advantage"].includes(tag))) return "setup";
     return "offense";
   }
-
   function planningResourceKey(resource = {}) {
     const type = normalizeId(resource.type || resource.resourceType);
     const id = normalizeId(resource.id || resource.resourceId || "shared");
     const slotLevel = resource.metadata?.slotLevel;
     return `${type}:${id}${slotLevel == null ? "" : `:slot_${integer(slotLevel, 0)}`}`;
   }
-
   function normalizePlanningResources(raw = {}) {
     const explicit = asArray(raw.planningResources);
     const checks = explicit.length ? explicit : asArray(raw.metadata?.resourceChecks);
@@ -169,17 +127,9 @@
       const detail = entry.detail || entry;
       const amount = Math.max(0, finite(resource.amount ?? detail.required, 1));
       const availableRaw = detail.current ?? entry.current ?? entry.availableAmount ?? resource.availableAmount;
-      const available = Number.isFinite(Number(availableRaw)) ? Math.max(0, Number(availableRaw)) : null;
-      return {
-        key: planningResourceKey(resource),
-        type: normalizeId(resource.type || resource.resourceType),
-        id: resource.id == null ? null : String(resource.id),
-        amount,
-        available,
-      };
+      return { key: planningResourceKey(resource), type: normalizeId(resource.type || resource.resourceType), id: resource.id == null ? null : String(resource.id), amount, available: Number.isFinite(Number(availableRaw)) ? Math.max(0, Number(availableRaw)) : null };
     }).filter((entry) => entry.type && entry.amount > 0);
   }
-
   function normalizeSourceDescriptor(raw = {}, index = 0) {
     const definition = clone(raw.definition || raw.source || raw.skill || raw.spell || raw.action || raw);
     let sourceType = normalizeId(raw.sourceType || raw.source_type || raw.kind || raw.combatSourceType);
@@ -191,51 +141,22 @@
     definition.id = sourceId;
     const estimateRaw = raw.estimate || raw.aiEstimate || definition.aiEstimate || {};
     const coinAmount = Math.max(0, integer(definition.coinAmount ?? definition.coinCount ?? definition.coin_count, 0));
-    const roughDamage = Math.max(0, finite(definition.basePower ?? definition.base_power, 0))
-      + Math.max(0, finite(definition.coinPower ?? definition.coin_power, 0)) * Math.max(1, coinAmount) * 0.5;
+    const roughDamage = Math.max(0, finite(definition.basePower ?? definition.base_power, 0)) + Math.max(0, finite(definition.coinPower ?? definition.coin_power, 0)) * Math.max(1, coinAmount) * 0.5;
     const damageType = normalizeId(estimateRaw.damageType || raw.damageType || definition.damageType || definition.dmgType || definition.attackType || definition.tipo_dano);
     const role = inferRole(raw, definition, sourceType);
     return {
-      key: `${sourceType}:${normalizeId(sourceId) || index}`,
-      sourceType,
-      sourceId,
-      definition,
-      role,
-      fixedTargetId: clean(raw.targetId),
-      available: raw.available !== false,
+      key: `${sourceType}:${normalizeId(sourceId) || index}`, sourceType, sourceId, definition, role, fixedTargetId: clean(raw.targetId), available: raw.available !== false,
       availability: typeof raw.isAvailable === "function" ? raw.isAvailable : null,
-      estimate: {
-        damage: role === "defense" ? Math.max(0, finite(estimateRaw.damage, 0)) : Math.max(0, finite(estimateRaw.damage, roughDamage)),
-        damageType,
-        safety: finite(estimateRaw.safety ?? raw.safety, role === "defense" ? Math.max(4, roughDamage) : 0),
-        recovery: finite(estimateRaw.recovery ?? raw.recovery, role === "recover" ? 4 : 0),
-        advantage: finite(estimateRaw.advantage ?? raw.advantage, role === "setup" ? 3 : 0),
-        resourceCost: Math.max(0, finite(estimateRaw.resourceCost ?? raw.resourceCost, asArray(definition.resourceCosts || definition.resource_costs).length)),
-        risk: clamp(estimateRaw.risk ?? raw.risk ?? 0, 0, 10),
-      },
-      planningResources: normalizePlanningResources(raw),
-      producesTags: asArray(raw.producesTags ?? estimateRaw.producesTags).map(normalizeId).filter(Boolean),
-      consumesTags: asArray(raw.consumesTags ?? estimateRaw.consumesTags).map(normalizeId).filter(Boolean),
-      metadata: raw.metadata && typeof raw.metadata === "object" ? clone(raw.metadata) : {},
+      estimate: { damage: role === "defense" ? Math.max(0, finite(estimateRaw.damage, 0)) : Math.max(0, finite(estimateRaw.damage, roughDamage)), damageType, safety: finite(estimateRaw.safety ?? raw.safety, role === "defense" ? Math.max(4, roughDamage) : 0), recovery: finite(estimateRaw.recovery ?? raw.recovery, role === "recover" ? 4 : 0), advantage: finite(estimateRaw.advantage ?? raw.advantage, role === "setup" ? 3 : 0), resourceCost: Math.max(0, finite(estimateRaw.resourceCost ?? raw.resourceCost, asArray(definition.resourceCosts || definition.resource_costs).length)), risk: clamp(estimateRaw.risk ?? raw.risk ?? 0, 0, 10) },
+      planningResources: normalizePlanningResources(raw), producesTags: asArray(raw.producesTags ?? estimateRaw.producesTags).map(normalizeId).filter(Boolean), consumesTags: asArray(raw.consumesTags ?? estimateRaw.consumesTags).map(normalizeId).filter(Boolean), metadata: raw.metadata && typeof raw.metadata === "object" ? clone(raw.metadata) : {},
     };
   }
-
-  function makeEscapeDescriptor() {
-    return normalizeSourceDescriptor({
-      sourceType: "universal",
-      definition: { id: "escape" },
-      role: "escape",
-      estimate: { safety: 10, risk: 0, resourceCost: 0 },
-      metadata: { injectedByIndividualGoap: true },
-    }, 999);
-  }
-
+  function makeEscapeDescriptor() { return normalizeSourceDescriptor({ sourceType: "universal", definition: { id: "escape" }, role: "escape", estimate: { safety: 10, risk: 0, resourceCost: 0 }, metadata: { injectedByIndividualGoap: true } }, 999); }
   function resolveSlots(input = {}) {
     if (Array.isArray(input.slotIds)) return input.slotIds.slice(0, MAX_PLANNED_SLOTS).map(String);
     const count = clamp(integer(input.availableSlots ?? input.slots, 1), 0, MAX_PLANNED_SLOTS);
     return Array.from({ length: count }, (_, index) => `${actorIdOf(input.actor) || "ai"}_slot_${index}`);
   }
-
   function chooseGoal(input, context) {
     const explicit = normalizeId(input.goal || input.primaryGoal);
     if (Object.values(GOALS).includes(explicit)) return explicit;
@@ -244,15 +165,12 @@
     if (hpRatio <= Math.min(0.65, wis.escapeHpRatio + 0.15)) return GOALS.SURVIVE;
     return GOALS.KILL_TARGET;
   }
-
   function beliefMultiplier(intel, targetId, damageType, awareness) {
     if (!targetId || !damageType) return 1;
     const belief = intel.targets?.[targetId]?.damageTypes?.[damageType];
     if (!belief) return 1;
-    const confidence = clamp(belief.confidence, 0, 1);
-    return 1 + (clamp(belief.multiplierEstimate, 0.1, 2.5) - 1) * confidence * awareness;
+    return 1 + (clamp(belief.multiplierEstimate, 0.1, 2.5) - 1) * clamp(belief.confidence, 0, 1) * awareness;
   }
-
   function quickCandidateScore(candidate) {
     if (candidate.role === "offense") return 20 + candidate.estimate.damage - candidate.estimate.resourceCost;
     if (candidate.role === "defense") return 14 + candidate.estimate.safety;
@@ -261,209 +179,96 @@
     if (candidate.role === "escape") return 2;
     return 5;
   }
-
   function candidateScore(candidate, state, context) {
     const { goal, hpRatio, intelligenceProfile: intp, wisdomProfile: wisp, intel, targetId } = context;
     const estimate = candidate.estimate;
-    const damageMultiplier = beliefMultiplier(intel, targetId, estimate.damageType, intp.intelAwareness);
-    const effectiveDamage = estimate.damage * damageMultiplier;
+    const effectiveDamage = estimate.damage * beliefMultiplier(intel, targetId, estimate.damageType, intp.intelAwareness);
     let score = 0;
-
-    if (goal === GOALS.KILL_TARGET) {
-      score += effectiveDamage * 2.4;
-      score += estimate.advantage * (1 + intp.comboAwareness);
-      score += estimate.safety * 0.25;
-      if (candidate.role === "escape") score -= 14;
-    } else if (goal === GOALS.ESCAPE) {
-      score += estimate.safety * 2.5 + estimate.recovery * 1.2;
-      score += effectiveDamage * 0.35;
-      if (candidate.role === "escape") score += 42 + wisp.wisdom;
-    } else if (goal === GOALS.SURVIVE || goal === GOALS.PROTECT_SELF) {
-      score += estimate.safety * (1.6 + wisp.dangerWeight);
-      score += estimate.recovery * 1.8;
-      score += effectiveDamage * 0.75;
-      if (candidate.role === "escape") score += hpRatio <= wisp.escapeHpRatio ? 30 : 5;
-    } else if (goal === GOALS.RECOVER_RESOURCE) {
-      score += estimate.recovery * 2.5 + estimate.safety;
-      score += effectiveDamage * 0.4;
-    } else if (goal === GOALS.GAIN_ADVANTAGE) {
-      score += estimate.advantage * 2.5 + effectiveDamage;
-      score += estimate.safety * 0.5;
-    }
-
+    if (goal === GOALS.KILL_TARGET) { score += effectiveDamage * 2.4 + estimate.advantage * (1 + intp.comboAwareness) + estimate.safety * 0.25; if (candidate.role === "escape") score -= 14; }
+    else if (goal === GOALS.ESCAPE) { score += estimate.safety * 2.5 + estimate.recovery * 1.2 + effectiveDamage * 0.35; if (candidate.role === "escape") score += 42 + wisp.wisdom; }
+    else if (goal === GOALS.SURVIVE || goal === GOALS.PROTECT_SELF) { score += estimate.safety * (1.6 + wisp.dangerWeight) + estimate.recovery * 1.8 + effectiveDamage * 0.75; if (candidate.role === "escape") score += hpRatio <= wisp.escapeHpRatio ? 30 : 5; }
+    else if (goal === GOALS.RECOVER_RESOURCE) score += estimate.recovery * 2.5 + estimate.safety + effectiveDamage * 0.4;
+    else if (goal === GOALS.GAIN_ADVANTAGE) score += estimate.advantage * 2.5 + effectiveDamage + estimate.safety * 0.5;
     score -= estimate.resourceCost * (0.75 + wisp.resourceConservation * 1.75);
     score -= estimate.risk * wisp.dangerWeight * (1.15 - hpRatio * 0.35);
-
-    const repeats = state.sequence.filter((entry) => entry.key === candidate.key).length;
-    score -= repeats * (0.5 + wisp.resourceConservation);
-
-    if (intp.comboAwareness > 0 && candidate.consumesTags.length) {
-      const matches = candidate.consumesTags.filter((tag) => state.producedTags.has(tag)).length;
-      score += matches * 4 * intp.comboAwareness;
-    }
-
+    score -= state.sequence.filter((entry) => entry.key === candidate.key).length * (0.5 + wisp.resourceConservation);
+    if (intp.comboAwareness > 0 && candidate.consumesTags.length) score += candidate.consumesTags.filter((tag) => state.producedTags.has(tag)).length * 4 * intp.comboAwareness;
     return score;
   }
-
   function canAffordPlanningResources(candidate, state) {
-    for (const resource of candidate.planningResources || []) {
-      if (!Number.isFinite(resource.available)) continue;
-      const spent = finite(state.resourceSpent?.[resource.key], 0);
-      if (spent + resource.amount > resource.available + 1e-9) return false;
-    }
-    return true;
+    return (candidate.planningResources || []).every((resource) => !Number.isFinite(resource.available) || finite(state.resourceSpent?.[resource.key], 0) + resource.amount <= resource.available + 1e-9);
   }
-
   function spendPlanningResources(candidate, state) {
     const next = { ...(state.resourceSpent || {}) };
-    for (const resource of candidate.planningResources || []) {
-      if (!Number.isFinite(resource.available)) continue;
-      next[resource.key] = finite(next[resource.key], 0) + resource.amount;
-    }
+    for (const resource of candidate.planningResources || []) if (Number.isFinite(resource.available)) next[resource.key] = finite(next[resource.key], 0) + resource.amount;
     return next;
   }
-
   function expandState(state, candidate, score, context) {
     const producedTags = new Set(state.producedTags);
     if (context.intelligenceProfile.comboAwareness > 0) candidate.producesTags.forEach((tag) => producedTags.add(tag));
-    return {
-      sequence: state.sequence.concat(candidate),
-      score: state.score + score,
-      producedTags,
-      resourceSpent: spendPlanningResources(candidate, state),
-      escaped: state.escaped || candidate.role === "escape",
-    };
+    return { sequence: state.sequence.concat(candidate), score: state.score + score, producedTags, resourceSpent: spendPlanningResources(candidate, state), escaped: state.escaped || candidate.role === "escape" };
   }
-
   function compileCandidate(actor, candidate, options = {}) {
-    const common = {
-      isAi: true,
-      actionSlotId: options.actionSlotId,
-      targetId: candidate.fixedTargetId || options.targetId || null,
-      mainTargetId: candidate.fixedTargetId || options.targetId || null,
-      metadata: {
-        ...(candidate.metadata || {}),
-        individualGoap: true,
-        aiGoal: options.goal,
-        aiScore: options.score,
-      },
-    };
-
+    const common = { isAi: true, actionSlotId: options.actionSlotId, targetId: candidate.fixedTargetId || options.targetId || null, mainTargetId: candidate.fixedTargetId || options.targetId || null, metadata: { ...(candidate.metadata || {}), individualGoap: true, aiGoal: options.goal, aiScore: options.score } };
     if (candidate.sourceType === "universal") return adapters.compileUniversalAction(actor, candidate.sourceId, common);
     if (candidate.sourceType === "skill") return adapters.compileSkillToCombatAction(actor, candidate.definition, common);
     if (candidate.sourceType === "spell") return adapters.compileSpellToCombatAction(actor, candidate.definition, common);
     if (candidate.sourceType === "trait") return adapters.compileTraitToCombatAction(actor, candidate.definition, common);
     return adapters.compileSourceToCombatAction(actor, candidate.definition, { ...common, sourceType: candidate.sourceType });
   }
-
   function planTurn(input = {}) {
     const actor = input.actor || {};
     const actorId = actorIdOf(actor);
     if (!actorId) return { planned: false, reason: "actor_id_required", actions: [] };
-
     const slots = resolveSlots(input);
     if (!slots.length) return { planned: true, reason: "no_action_slots", actorId, actions: [], sequence: [], slotsRequested: 0, slotsUsed: 0, unusedSlots: 0 };
-
-    const intelligence = abilityScore(actor, "intelligence", "int", 10);
-    const wisdom = abilityScore(actor, "wisdom", "wis", 10);
-    const intp = planningProfile(intelligence);
-    const wisp = wisdomProfile(wisdom);
-    const hpRatio = ownHpRatio(actor);
-    const intel = createIntelState(input.intel || {});
-    const targetIds = targetIdsFrom(input);
-    const targetId = clean(input.targetId) || bestKnownTarget(targetIds, intel);
-
-    let candidates = asArray(input.sources || input.actions)
-      .map(normalizeSourceDescriptor)
-      .filter((candidate) => candidate.available && (!candidate.availability || candidate.availability(actor, input) !== false));
-
+    const intelligence = abilityScore(actor, "intelligence", "int", 10), wisdom = abilityScore(actor, "wisdom", "wis", 10);
+    const intp = planningProfile(intelligence), wisp = wisdomProfile(wisdom), hpRatio = ownHpRatio(actor), intel = createIntelState(input.intel || {});
+    const targetIds = targetIdsFrom(input), targetId = clean(input.targetId) || bestKnownTarget(targetIds, intel);
+    let candidates = asArray(input.sources || input.actions).map(normalizeSourceDescriptor).filter((candidate) => candidate.available && (!candidate.availability || candidate.availability(actor, input) !== false));
     if (input.allowEscape !== false && !candidates.some((candidate) => candidate.sourceType === "universal" && normalizeId(candidate.sourceId) === "escape")) candidates.push(makeEscapeDescriptor());
     if (!candidates.length) return { planned: false, reason: "no_available_actions", actorId, actions: [], sequence: [] };
-
     const hasEscape = candidates.some((candidate) => candidate.role === "escape");
     const goal = chooseGoal(input, { hpRatio, wisdomProfile: wisp, hasEscape });
     const context = { goal, hpRatio, intelligenceProfile: intp, wisdomProfile: wisp, intel, targetId };
 
-    candidates.sort((a, b) => quickCandidateScore(b) - quickCandidateScore(a) || a.key.localeCompare(b.key));
-    candidates = candidates.slice(0, intp.candidateLimit);
-    if (hasEscape && !candidates.some((candidate) => candidate.role === "escape")) candidates.push(makeEscapeDescriptor());
+    // Once critical survival logic commits to ESCAPE, do it immediately. Do not farm preceding attacks from extra slots.
+    if (goal === GOALS.ESCAPE) {
+      const escapeCandidate = candidates.find((candidate) => candidate.role === "escape");
+      if (escapeCandidate) candidates = [escapeCandidate];
+    } else {
+      candidates.sort((a, b) => quickCandidateScore(b) - quickCandidateScore(a) || a.key.localeCompare(b.key));
+      candidates = candidates.slice(0, intp.candidateLimit);
+      if (hasEscape && !candidates.some((candidate) => candidate.role === "escape")) candidates.push(makeEscapeDescriptor());
+    }
 
     let beam = [{ sequence: [], score: 0, producedTags: new Set(), resourceSpent: {}, escaped: false }];
     for (let slotIndex = 0; slotIndex < slots.length; slotIndex += 1) {
       const next = [];
       for (const state of beam) {
-        // Escape leaves the encounter. It is terminal and can never be followed by another action.
-        if (state.escaped) {
-          next.push(state);
-          continue;
-        }
-
+        if (state.escaped) { next.push(state); continue; }
         let expanded = false;
         for (const candidate of candidates) {
           if (!canAffordPlanningResources(candidate, state)) continue;
-          const score = candidateScore(candidate, state, context);
-          next.push(expandState(state, candidate, score, context));
-          expanded = true;
+          next.push(expandState(state, candidate, candidateScore(candidate, state, context), context)); expanded = true;
         }
-        // A Unit is allowed to leave slots unused when all remaining actions are resource-blocked.
         if (!expanded) next.push(state);
       }
       next.sort((a, b) => b.score - a.score || a.sequence.map((item) => item.key).join("|").localeCompare(b.sequence.map((item) => item.key).join("|")));
       beam = next.slice(0, intp.beamWidth);
       if (!beam.length) break;
     }
-
     const best = beam[0] || { sequence: [], score: 0, producedTags: new Set(), resourceSpent: {} };
     const perActionScore = best.sequence.length ? best.score / best.sequence.length : 0;
-    const actions = best.sequence.map((candidate, index) => compileCandidate(actor, candidate, {
-      actionSlotId: slots[index],
-      targetId,
-      goal,
-      score: perActionScore,
-    }));
-
+    const actions = best.sequence.map((candidate, index) => compileCandidate(actor, candidate, { actionSlotId: slots[index], targetId, goal, score: perActionScore }));
     return {
-      planned: true,
-      actorId,
-      goal,
-      targetId,
-      slotsRequested: slots.length,
-      slotsUsed: actions.length,
-      unusedSlots: Math.max(0, slots.length - actions.length),
-      actions,
-      sequence: best.sequence.map((candidate, index) => ({
-        slotId: slots[index],
-        sourceType: candidate.sourceType,
-        sourceId: candidate.sourceId,
-        role: candidate.role,
-      })),
-      score: best.score,
-      resourceSpent: clone(best.resourceSpent || {}),
-      intelligence,
-      wisdom,
-      profile: clone(intp),
-      riskProfile: clone(wisp),
-      hpRatio,
-      intel: clone(intel),
+      planned: true, actorId, goal, targetId, slotsRequested: slots.length, slotsUsed: actions.length, unusedSlots: Math.max(0, slots.length - actions.length), actions,
+      sequence: best.sequence.map((candidate, index) => ({ slotId: slots[index], sourceType: candidate.sourceType, sourceId: candidate.sourceId, role: candidate.role })),
+      score: best.score, resourceSpent: clone(best.resourceSpent || {}), intelligence, wisdom, profile: clone(intp), riskProfile: clone(wisp), hpRatio, intel: clone(intel),
     };
   }
 
-  const api = Object.freeze({
-    version: "0.2.0",
-    GOALS,
-    MAX_PLANNED_SLOTS,
-    INTEL_SCHEMA_VERSION,
-    planningProfile,
-    wisdomProfile,
-    createIntelState,
-    observeDamageResult,
-    normalizeSourceDescriptor,
-    normalizePlanningResources,
-    planningResourceKey,
-    chooseGoal,
-    planTurn,
-  });
-
+  const api = Object.freeze({ version: "0.2.1", GOALS, MAX_PLANNED_SLOTS, INTEL_SCHEMA_VERSION, planningProfile, wisdomProfile, createIntelState, observeDamageResult, normalizeSourceDescriptor, normalizePlanningResources, planningResourceKey, chooseGoal, planTurn });
   global.LuminousIndividualGoapCombatAI = api;
   if (typeof module !== "undefined" && module.exports) module.exports = api;
 })(typeof window !== "undefined" ? window : globalThis);

--- a/js/unit-action-economy-catalog.js
+++ b/js/unit-action-economy-catalog.js
@@ -9,8 +9,8 @@
   const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
   const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
 
-  // Canonical per-Unit data. Keep this separate from allocation policy: the allocator
-  // reads these limits, but never infers max slots from species/rank/type.
+  // Canonical per-Unit data. Allocation policy does not infer slot limits from species,
+  // rank, boss flags, or names. Live combatants should preserve one of these ids explicitly.
   const PROFILES = Object.freeze({
     kobold_dagger: Object.freeze({ minSlots: 1, maxSlots: 2 }),
     kobold_sling: Object.freeze({ minSlots: 1, maxSlots: 2 }),
@@ -25,10 +25,13 @@
     if (typeof unitOrId === "string" || typeof unitOrId === "number") return normalizeId(unitOrId);
     const unit = unitOrId || {};
     return normalizeId(
-      unit.canonicalUnitId
+      unit.actionEconomy?.profileId
+      ?? unit.actionSlotProfileId
+      ?? unit.canonicalUnitId
       ?? unit.definitionId
       ?? unit.catalogId
       ?? unit.baseUnitId
+      ?? unit.metadata?.actionEconomyProfileId
       ?? unit.metadata?.canonicalUnitId
       ?? unit.metadata?.definitionId
       ?? unit.metadata?.catalogId
@@ -45,7 +48,27 @@
     return Object.entries(PROFILES).map(([id, profile]) => ({ id, ...clone(profile) }));
   }
 
-  const api = Object.freeze({ version: "1.0.0", PROFILES, canonicalUnitId, get, list });
+  function applyToUnit(unit = {}, profileId = null) {
+    if (!unit || typeof unit !== "object") return { applied: false, reason: "unit_required", unit };
+    const id = canonicalUnitId(profileId || unit);
+    const profile = PROFILES[id];
+    if (!profile) return { applied: false, reason: "action_economy_profile_not_found", profileId: id || null, unit };
+
+    unit.actionEconomy = {
+      ...(unit.actionEconomy && typeof unit.actionEconomy === "object" ? unit.actionEconomy : {}),
+      profileId: id,
+      minSlots: profile.minSlots,
+      maxSlots: profile.maxSlots,
+    };
+    unit.actionSlotProfileId = id;
+    unit.metadata = {
+      ...(unit.metadata && typeof unit.metadata === "object" ? unit.metadata : {}),
+      actionEconomyProfileId: id,
+    };
+    return { applied: true, profileId: id, profile: { id, ...clone(profile) }, unit };
+  }
+
+  const api = Object.freeze({ version: "1.1.0", PROFILES, canonicalUnitId, get, list, applyToUnit });
   global.LuminousUnitActionEconomyCatalog = api;
   if (typeof module !== "undefined" && module.exports) module.exports = api;
 })(typeof window !== "undefined" ? window : globalThis);

--- a/js/unit-action-economy-catalog.js
+++ b/js/unit-action-economy-catalog.js
@@ -1,0 +1,51 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousUnitActionEconomyCatalog) {
+    if (typeof module !== "undefined" && module.exports) module.exports = global.LuminousUnitActionEconomyCatalog;
+    return;
+  }
+
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+
+  // Canonical per-Unit data. Keep this separate from allocation policy: the allocator
+  // reads these limits, but never infers max slots from species/rank/type.
+  const PROFILES = Object.freeze({
+    kobold_dagger: Object.freeze({ minSlots: 1, maxSlots: 2 }),
+    kobold_sling: Object.freeze({ minSlots: 1, maxSlots: 2 }),
+    winged_kobold: Object.freeze({ minSlots: 1, maxSlots: 2 }),
+    dragonheart_kobold: Object.freeze({ minSlots: 1, maxSlots: 3 }),
+    scale_sorcerer_kobold: Object.freeze({ minSlots: 1, maxSlots: 3 }),
+    goblin: Object.freeze({ minSlots: 1, maxSlots: 2 }),
+    goblin_boss: Object.freeze({ minSlots: 1, maxSlots: 3 }),
+  });
+
+  function canonicalUnitId(unitOrId) {
+    if (typeof unitOrId === "string" || typeof unitOrId === "number") return normalizeId(unitOrId);
+    const unit = unitOrId || {};
+    return normalizeId(
+      unit.canonicalUnitId
+      ?? unit.definitionId
+      ?? unit.catalogId
+      ?? unit.baseUnitId
+      ?? unit.metadata?.canonicalUnitId
+      ?? unit.metadata?.definitionId
+      ?? unit.metadata?.catalogId
+      ?? unit.id
+    );
+  }
+
+  function get(unitOrId) {
+    const id = canonicalUnitId(unitOrId);
+    return PROFILES[id] ? { id, ...clone(PROFILES[id]) } : null;
+  }
+
+  function list() {
+    return Object.entries(PROFILES).map(([id, profile]) => ({ id, ...clone(profile) }));
+  }
+
+  const api = Object.freeze({ version: "1.0.0", PROFILES, canonicalUnitId, get, list });
+  global.LuminousUnitActionEconomyCatalog = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/unit-ai-kit-adapter.js
+++ b/js/unit-ai-kit-adapter.js
@@ -1,0 +1,363 @@
+(function (global) {
+  "use strict";
+
+  const safeRequire = (path) => {
+    if (typeof require !== "function") return null;
+    try { return require(path); } catch (_) { return null; }
+  };
+
+  const goap = global.LuminousIndividualGoapCombatAI || safeRequire("./individual-goap-combat-ai.js");
+  const ammoRuntime = () => global.LuminousUniversalRangedAmmoRuntime || safeRequire("./universal-ranged-ammo-runtime.js");
+  const spellRuntime = () => global.LuminousSpellcastingRuntime || safeRequire("./spellcasting-runtime.js");
+
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+  const asArray = (value) => value == null ? [] : (Array.isArray(value) ? value : [value]);
+  const clean = (value, fallback = "") => String(value ?? fallback).trim() || fallback;
+  const normalizeId = (value) => clean(value).toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  const finite = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+
+  const ACTIONABLE_SOURCE_TYPES = Object.freeze(["skill", "spell", "trait", "item", "universal"]);
+
+  function actorIdOf(actor = {}) {
+    return clean(actor.id ?? actor.unitId ?? actor.characterId);
+  }
+
+  function sourceIdOf(definition = {}, fallback = "") {
+    return clean(definition.id ?? definition.skillId ?? definition.spellId ?? definition.traitId ?? definition.itemId, fallback);
+  }
+
+  function resourceCostsOf(definition = {}) {
+    return asArray(definition.resourceCosts || definition.resource_costs || definition.resources)
+      .filter(Boolean)
+      .map((resource) => ({
+        owner: normalizeId(resource.owner || "source") || "source",
+        type: normalizeId(resource.type || resource.resourceType),
+        id: resource.id == null ? null : String(resource.id),
+        amount: Math.max(0, finite(resource.amount ?? resource.value, 1)),
+        metadata: resource.metadata && typeof resource.metadata === "object" ? clone(resource.metadata) : null,
+      }))
+      .filter((resource) => resource.type);
+  }
+
+  function isPassiveTrait(definition = {}) {
+    const type = normalizeId(definition.type || definition.traitType || definition.trait_type);
+    const activation = normalizeId(definition.activation || definition.activationType || definition.activation_type);
+    if (definition.passive === true || type === "passive") return true;
+    if (["active", "action", "quick_action", "reaction"].includes(type)) return false;
+    if (["action", "quick_action", "reaction", "combat"].includes(activation)) return false;
+    if (definition.combatAction || definition.action || definition.skill || definition.spell) return false;
+    return type === "" && activation === "";
+  }
+
+  function isCombatItem(entry = {}) {
+    const definition = entry.definition || entry.item || entry;
+    if (!definition || typeof definition !== "object") return false;
+    if (entry.combatAction || definition.combatAction || entry.skill || definition.skill || entry.spell || definition.spell) return true;
+    if (definition.isCombatItem === true || definition.combatUsable === true || entry.combatUsable === true) return true;
+    const use = normalizeId(definition.useContext || definition.context || definition.activation);
+    return ["combat", "action", "quick_action"].includes(use);
+  }
+
+  function unwrapActionDefinition(entry = {}, sourceType) {
+    if (!entry || typeof entry !== "object") return null;
+    if (sourceType === "item") {
+      const nested = entry.combatAction || entry.skill || entry.spell || entry.item?.combatAction || entry.item?.skill || entry.item?.spell;
+      if (nested && typeof nested === "object") return clone({ ...nested, id: nested.id || entry.id || entry.item?.id });
+      return clone(entry.definition || entry.item || entry);
+    }
+    if (sourceType === "trait") {
+      const nested = entry.combatAction || entry.action || entry.trait?.combatAction || entry.trait?.action;
+      if (nested && typeof nested === "object") return clone({ ...nested, id: nested.id || entry.id || entry.trait?.id });
+      return clone(entry.definition || entry.trait || entry);
+    }
+    return clone(entry.definition || entry[sourceType] || entry);
+  }
+
+  function objectEntriesFrom(actor = {}, keys = []) {
+    const entries = [];
+    for (const key of keys) {
+      for (const entry of asArray(actor[key])) {
+        if (entry && typeof entry === "object") entries.push(entry);
+      }
+    }
+    return entries;
+  }
+
+  function resolveReference(id, resolver, actor, sourceType) {
+    if (!id || typeof resolver !== "function") return null;
+    try {
+      const value = resolver(id, actor, sourceType);
+      return value && typeof value === "object" ? value : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function collectSkills(actor = {}, options = {}, unresolved = []) {
+    const skills = objectEntriesFrom(actor, [
+      "resolvedSkills", "combatSkills", "skills",
+      "attack_tier_1_sequence", "attack_tier_2_sequence", "attack_tier_3_sequence",
+    ]);
+
+    for (const raw of asArray(actor.action_slots || actor.actionSlots)) {
+      if (raw && typeof raw === "object") {
+        skills.push(raw);
+        continue;
+      }
+      const id = clean(raw);
+      if (!id) continue;
+      const resolved = resolveReference(id, options.skillResolver, actor, "skill");
+      if (resolved) skills.push(resolved);
+      else if (!asArray(actor.resolvedSkills).some((skill) => sourceIdOf(skill) === id)) {
+        unresolved.push({ sourceType: "skill", sourceId: id, reason: "skill_definition_unresolved" });
+      }
+    }
+    return skills;
+  }
+
+  function collectSpells(actor = {}, options = {}, unresolved = []) {
+    const spells = objectEntriesFrom(actor, ["resolvedSpells", "combatSpells", "spells"]);
+    const prepared = [actor.preparedSpells, actor.spellcasting?.preparedSpells, actor.spellcasting?.prepared];
+    for (const collection of prepared) {
+      for (const raw of asArray(collection)) {
+        if (raw && typeof raw === "object") {
+          spells.push(raw);
+          continue;
+        }
+        const id = clean(raw);
+        if (!id) continue;
+        const resolved = resolveReference(id, options.spellResolver, actor, "spell");
+        if (resolved) spells.push(resolved);
+        else unresolved.push({ sourceType: "spell", sourceId: id, reason: "spell_definition_unresolved" });
+      }
+    }
+    return spells;
+  }
+
+  function collectTraits(actor = {}, options = {}, unresolved = []) {
+    const traits = [];
+    for (const raw of asArray(actor.traits || actor.combatTraits || actor.activeTraits)) {
+      if (raw && typeof raw === "object") {
+        const definition = raw.definition || raw.trait || raw;
+        if (!isPassiveTrait(definition)) traits.push(raw);
+        continue;
+      }
+      const id = clean(raw);
+      if (!id) continue;
+      const resolved = resolveReference(id, options.traitResolver, actor, "trait");
+      if (resolved && !isPassiveTrait(resolved)) traits.push(resolved);
+      else if (!resolved) unresolved.push({ sourceType: "trait", sourceId: id, reason: "trait_definition_unresolved" });
+    }
+    return traits;
+  }
+
+  function collectItems(actor = {}, options = {}, unresolved = []) {
+    const items = [];
+    const collections = [actor.combatItems, actor.items, actor.inventory?.active, actor.inventory?.items];
+    for (const collection of collections) {
+      for (const raw of asArray(collection)) {
+        if (raw && typeof raw === "object") {
+          if (isCombatItem(raw)) items.push(raw);
+          continue;
+        }
+        const id = clean(raw);
+        if (!id) continue;
+        const resolved = resolveReference(id, options.itemResolver, actor, "item");
+        if (resolved && isCombatItem(resolved)) items.push(resolved);
+        else if (!resolved) unresolved.push({ sourceType: "item", sourceId: id, reason: "item_definition_unresolved" });
+      }
+    }
+    return items;
+  }
+
+  function collectPendingWeaponRefs(actor = {}, unresolved = []) {
+    for (const weapon of asArray(actor.mechanics?.weaponLoadout || actor.weaponLoadout)) {
+      if (!weapon || typeof weapon !== "object") continue;
+      const id = clean(weapon.skillId || weapon.weaponSkillId || weapon.weaponId || weapon.id);
+      if (!id) continue;
+      if (weapon.canonicalWeaponSkillPending === true || actor.metadata?.weaponSkillsPendingCanonicalCatalog === true) {
+        unresolved.push({ sourceType: "skill", sourceId: id, reason: "canonical_weapon_skill_pending" });
+      }
+    }
+  }
+
+  function normalizeResourceHandlerResult(result, resource) {
+    if (result == null) return { known: false, available: true, reason: "resource_validation_unavailable", resource };
+    const available = !(result.available === false || result.valid === false || result.canUse === false || result.ok === false);
+    return {
+      known: true,
+      available,
+      reason: available ? null : (result.reason || "resource_unavailable"),
+      resource,
+      detail: clone(result),
+    };
+  }
+
+  function validateAmmo(actor, definition, resource) {
+    const runtime = ammoRuntime();
+    if (!runtime) return null;
+    if (typeof runtime.ammunitionHandler === "function") {
+      const handler = runtime.ammunitionHandler();
+      if (handler?.validate) {
+        return handler.validate({
+          actor,
+          resource,
+          action: { metadata: { sourceDefinition: definition } },
+        });
+      }
+    }
+    if (typeof runtime.ammoCount === "function") {
+      const current = runtime.ammoCount(actor, resource.id);
+      const required = Math.max(1, finite(resource.amount, 1));
+      return { available: current >= required, current, required, reason: current >= required ? null : "ammunition_unavailable" };
+    }
+    return null;
+  }
+
+  function validateSpellSlot(actor, definition, resource) {
+    const runtime = spellRuntime();
+    if (!runtime?.canSpendSpellSlot) return null;
+    const level = Math.max(0, Math.trunc(finite(resource.metadata?.slotLevel ?? definition.slotLevel ?? definition.level ?? definition.spellLevel, 0)));
+    try {
+      return runtime.canSpendSpellSlot(actor, resource.id, level);
+    } catch (_) {
+      return { available: false, reason: "spell_slot_validation_failed" };
+    }
+  }
+
+  function validateResources(actor, sourceType, definition, options = {}) {
+    const checks = [];
+    for (const resource of resourceCostsOf(definition)) {
+      let result = null;
+      const direct = options.resourceHandlers?.[resource.type];
+      if (direct?.validate) {
+        try {
+          result = direct.validate({ actor, resource, definition, sourceType });
+        } catch (_) {
+          result = { available: false, reason: "resource_validation_failed" };
+        }
+      } else if (resource.type === "ammunition") {
+        result = validateAmmo(actor, definition, resource);
+      } else if (resource.type === "spell_slot") {
+        result = validateSpellSlot(actor, definition, resource);
+      }
+      const check = normalizeResourceHandlerResult(result, resource);
+      checks.push(check);
+      if (!check.available) return { available: false, reason: check.reason, checks };
+      if (!check.known && options.strictResources === true) {
+        return { available: false, reason: "resource_validation_unavailable", checks };
+      }
+    }
+    return { available: true, reason: null, checks };
+  }
+
+  function descriptorFor(actor, sourceType, raw, options = {}) {
+    const definition = unwrapActionDefinition(raw, sourceType);
+    if (!definition) return null;
+    const sourceId = sourceIdOf(definition, sourceIdOf(raw));
+    if (!sourceId) return null;
+    definition.id = sourceId;
+    if (!definition.sourceType && sourceType !== "item") definition.sourceType = sourceType;
+
+    const resources = validateResources(actor, sourceType, definition, options);
+    return {
+      sourceType,
+      definition,
+      available: resources.available,
+      estimate: raw.aiEstimate || definition.aiEstimate || undefined,
+      metadata: {
+        ...(raw.metadata && typeof raw.metadata === "object" ? clone(raw.metadata) : {}),
+        unitAiKitAdapter: true,
+        resourceChecks: resources.checks,
+      },
+      __resourceValidation: resources,
+    };
+  }
+
+  function dedupeDescriptors(descriptors = []) {
+    const seen = new Set();
+    const result = [];
+    for (const descriptor of descriptors) {
+      if (!descriptor) continue;
+      const key = `${normalizeId(descriptor.sourceType)}:${normalizeId(sourceIdOf(descriptor.definition))}`;
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      result.push(descriptor);
+    }
+    return result;
+  }
+
+  function buildKit(actor = {}, options = {}) {
+    const actorId = actorIdOf(actor);
+    const unresolved = [];
+    collectPendingWeaponRefs(actor, unresolved);
+
+    const collected = [
+      ...collectSkills(actor, options, unresolved).map((entry) => ["skill", entry]),
+      ...collectSpells(actor, options, unresolved).map((entry) => ["spell", entry]),
+      ...collectTraits(actor, options, unresolved).map((entry) => ["trait", entry]),
+      ...collectItems(actor, options, unresolved).map((entry) => ["item", entry]),
+    ];
+
+    const allSources = dedupeDescriptors(collected.map(([sourceType, entry]) => descriptorFor(actor, sourceType, entry, options)));
+    const sources = allSources.filter((source) => source.available !== false);
+    const unavailable = allSources
+      .filter((source) => source.available === false)
+      .map((source) => ({
+        sourceType: source.sourceType,
+        sourceId: sourceIdOf(source.definition),
+        reason: source.__resourceValidation?.reason || "source_unavailable",
+        resourceChecks: clone(source.__resourceValidation?.checks || []),
+      }));
+
+    return {
+      version: "0.1.0",
+      actorId,
+      sources,
+      allSources,
+      unavailable,
+      unresolved,
+      counts: {
+        usable: sources.length,
+        total: allSources.length,
+        unavailable: unavailable.length,
+        unresolved: unresolved.length,
+      },
+    };
+  }
+
+  function planUnitTurn(input = {}) {
+    if (!goap?.planTurn) return { planned: false, reason: "individual_goap_unavailable", actions: [], sequence: [] };
+    const actor = input.actor || {};
+    const kit = buildKit(actor, input.kitOptions || input);
+
+    // A healthy Unit with no canonical combat sources must not flee merely because
+    // the GOAP injected Escape as its only candidate. Surface the catalog gap instead.
+    if (!kit.sources.length && input.allowEscapeOnly !== true) {
+      return {
+        planned: false,
+        reason: kit.unresolved.length ? "unit_combat_sources_unresolved" : "no_unit_combat_sources",
+        actorId: kit.actorId,
+        kit,
+        actions: [],
+        sequence: [],
+      };
+    }
+
+    const plan = goap.planTurn({ ...input, actor, sources: kit.sources });
+    return { ...plan, kit };
+  }
+
+  const api = Object.freeze({
+    version: "0.1.0",
+    ACTIONABLE_SOURCE_TYPES,
+    actorIdOf,
+    resourceCostsOf,
+    validateResources,
+    buildKit,
+    planUnitTurn,
+  });
+
+  global.LuminousUnitAiKitAdapter = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/unit-ai-kit-adapter.js
+++ b/js/unit-ai-kit-adapter.js
@@ -26,7 +26,7 @@
     return clean(definition.id ?? definition.skillId ?? definition.spellId ?? definition.traitId ?? definition.itemId, fallback);
   }
 
-  function resourceCostsOf(definition = {}) {
+  function declaredResourceCosts(definition = {}) {
     return asArray(definition.resourceCosts || definition.resource_costs || definition.resources)
       .filter(Boolean)
       .map((resource) => ({
@@ -37,6 +37,35 @@
         metadata: resource.metadata && typeof resource.metadata === "object" ? clone(resource.metadata) : null,
       }))
       .filter((resource) => resource.type);
+  }
+
+  function resourceCostsOf(definition = {}, sourceType = "") {
+    const resources = declaredResourceCosts(definition);
+    const type = normalizeId(sourceType || definition.sourceType || definition.source_type || definition.type);
+
+    // Mirror the canonical CombatAction adapters so planning validates the same implicit costs
+    // that resolution will later consume.
+    if (type === "spell") {
+      const slotLevel = Math.max(0, Math.trunc(finite(definition.slotLevel ?? definition.level ?? definition.spellLevel, 0)));
+      const cantrip = definition.cantrip === true || slotLevel === 0;
+      if (!cantrip && !resources.some((resource) => resource.type === "spell_slot")) {
+        resources.push({
+          owner: "source",
+          type: "spell_slot",
+          id: String(definition.sourceClassId || definition.classId || definition.class_id || ""),
+          amount: 1,
+          metadata: { slotLevel },
+        });
+      }
+    }
+
+    if (type === "trait") {
+      const maxUses = definition.uses ?? definition.maxUses ?? definition.max_uses;
+      if (maxUses != null && !resources.some((resource) => resource.type === "trait_use")) {
+        resources.push({ owner: "source", type: "trait_use", id: sourceIdOf(definition), amount: 1, metadata: null });
+      }
+    }
+    return resources;
   }
 
   function isPassiveTrait(definition = {}) {
@@ -181,8 +210,46 @@
     }
   }
 
+  function validateSourceState(actor, sourceType, raw, definition, options = {}) {
+    const sourceId = sourceIdOf(definition, sourceIdOf(raw));
+    if (raw.available === false || definition.available === false || raw.disabled === true || definition.disabled === true) {
+      return { available: false, reason: "source_disabled" };
+    }
+
+    const cooldown = raw.cooldownRemaining ?? raw.cooldown_remaining ?? definition.cooldownRemaining ?? definition.cooldown_remaining ?? actor.cooldowns?.[sourceId];
+    if (Number.isFinite(Number(cooldown)) && Number(cooldown) > 0) {
+      return { available: false, reason: "cooldown_active", cooldownRemaining: Number(cooldown) };
+    }
+
+    const remaining = raw.usesRemaining ?? raw.remainingUses ?? definition.usesRemaining ?? definition.remainingUses;
+    if (Number.isFinite(Number(remaining)) && Number(remaining) <= 0) {
+      return { available: false, reason: "uses_exhausted", remaining: Number(remaining) };
+    }
+
+    if (sourceType === "item") {
+      const quantity = raw.quantity ?? raw.item?.quantity ?? definition.quantity;
+      if (Number.isFinite(Number(quantity)) && Number(quantity) <= 0) return { available: false, reason: "item_quantity_empty" };
+      // CombatActionAdapters currently has no canonical item compiler. Do not pretend a nested
+      // item Skill is a complete Item action until that contract exists.
+      if (options.allowItemFallback !== true) return { available: false, reason: "item_combat_action_adapter_pending" };
+    }
+
+    if (typeof options.isSourceAvailable === "function") {
+      try {
+        const result = options.isSourceAvailable({ actor, sourceType, raw, definition });
+        if (result === false) return { available: false, reason: "source_unavailable" };
+        if (result && typeof result === "object" && (result.available === false || result.valid === false)) {
+          return { available: false, reason: result.reason || "source_unavailable", detail: clone(result) };
+        }
+      } catch (_) {
+        return { available: false, reason: "source_availability_check_failed" };
+      }
+    }
+    return { available: true, reason: null };
+  }
+
   function normalizeResourceHandlerResult(result, resource) {
-    if (result == null) return { known: false, available: true, reason: "resource_validation_unavailable", resource };
+    if (result == null) return { known: false, available: false, reason: "resource_validation_unavailable", resource };
     const available = !(result.available === false || result.valid === false || result.canUse === false || result.ok === false);
     return {
       known: true,
@@ -195,7 +262,7 @@
 
   function validateAmmo(actor, definition, resource) {
     const runtime = ammoRuntime();
-    if (!runtime) return null;
+    if (!runtime) return { available: false, reason: "ammunition_runtime_unavailable" };
     if (typeof runtime.ammunitionHandler === "function") {
       const handler = runtime.ammunitionHandler();
       if (handler?.validate) {
@@ -211,12 +278,13 @@
       const required = Math.max(1, finite(resource.amount, 1));
       return { available: current >= required, current, required, reason: current >= required ? null : "ammunition_unavailable" };
     }
-    return null;
+    return { available: false, reason: "ammunition_validator_unavailable" };
   }
 
   function validateSpellSlot(actor, definition, resource) {
     const runtime = spellRuntime();
-    if (!runtime?.canSpendSpellSlot) return null;
+    if (!runtime) return { available: false, reason: "spell_slot_runtime_unavailable" };
+    if (typeof runtime.canSpendSpellSlot !== "function") return { available: false, reason: "spell_slot_validator_unavailable" };
     const level = Math.max(0, Math.trunc(finite(resource.metadata?.slotLevel ?? definition.slotLevel ?? definition.level ?? definition.spellLevel, 0)));
     try {
       return runtime.canSpendSpellSlot(actor, resource.id, level);
@@ -227,7 +295,7 @@
 
   function validateResources(actor, sourceType, definition, options = {}) {
     const checks = [];
-    for (const resource of resourceCostsOf(definition)) {
+    for (const resource of resourceCostsOf(definition, sourceType)) {
       let result = null;
       const direct = options.resourceHandlers?.[resource.type];
       if (direct?.validate) {
@@ -241,12 +309,11 @@
       } else if (resource.type === "spell_slot") {
         result = validateSpellSlot(actor, definition, resource);
       }
-      const check = normalizeResourceHandlerResult(result, resource);
+
+      let check = normalizeResourceHandlerResult(result, resource);
+      if (!check.known && options.allowUnvalidatedResources === true) check = { ...check, available: true };
       checks.push(check);
       if (!check.available) return { available: false, reason: check.reason, checks };
-      if (!check.known && options.strictResources === true) {
-        return { available: false, reason: "resource_validation_unavailable", checks };
-      }
     }
     return { available: true, reason: null, checks };
   }
@@ -259,17 +326,25 @@
     definition.id = sourceId;
     if (!definition.sourceType && sourceType !== "item") definition.sourceType = sourceType;
 
-    const resources = validateResources(actor, sourceType, definition, options);
+    const sourceState = validateSourceState(actor, sourceType, raw, definition, options);
+    const resources = sourceState.available ? validateResources(actor, sourceType, definition, options) : { available: false, reason: sourceState.reason, checks: [] };
+    const availability = sourceState.available && resources.available
+      ? { available: true, reason: null }
+      : { available: false, reason: sourceState.reason || resources.reason || "source_unavailable" };
+
     return {
       sourceType,
       definition,
-      available: resources.available,
+      available: availability.available,
       estimate: raw.aiEstimate || definition.aiEstimate || undefined,
       metadata: {
         ...(raw.metadata && typeof raw.metadata === "object" ? clone(raw.metadata) : {}),
         unitAiKitAdapter: true,
+        sourceState: clone(sourceState),
         resourceChecks: resources.checks,
       },
+      __availability: availability,
+      __sourceState: sourceState,
       __resourceValidation: resources,
     };
   }
@@ -306,12 +381,13 @@
       .map((source) => ({
         sourceType: source.sourceType,
         sourceId: sourceIdOf(source.definition),
-        reason: source.__resourceValidation?.reason || "source_unavailable",
+        reason: source.__availability?.reason || "source_unavailable",
+        sourceState: clone(source.__sourceState),
         resourceChecks: clone(source.__resourceValidation?.checks || []),
       }));
 
     return {
-      version: "0.1.0",
+      version: "0.2.0",
       actorId,
       sources,
       allSources,
@@ -349,10 +425,11 @@
   }
 
   const api = Object.freeze({
-    version: "0.1.0",
+    version: "0.2.0",
     ACTIONABLE_SOURCE_TYPES,
     actorIdOf,
     resourceCostsOf,
+    validateSourceState,
     validateResources,
     buildKit,
     planUnitTurn,

--- a/js/universal-action-economy.js
+++ b/js/universal-action-economy.js
@@ -41,6 +41,22 @@
     global.document.head?.appendChild(script);
   }
 
+  function isBattleViewerPage() {
+    if (!global.document || !global.location) return false;
+    const filename = String(global.location.pathname || "").split("/").pop();
+    return /^battle-viewer\.html$/i.test(filename);
+  }
+
+  function ensureBattleViewerEnemyPlanningRuntime() {
+    if (!isBattleViewerPage() || global.LuminousBattleViewerEnemyPlanning074) return;
+    if (global.document.getElementById("battle-viewer-enemy-planning-074-bootstrap")) return;
+    const script = global.document.createElement("script");
+    script.id = "battle-viewer-enemy-planning-074-bootstrap";
+    script.src = "js/battle-viewer-enemy-planning-074.js";
+    script.async = false;
+    global.document.head?.appendChild(script);
+  }
+
   function normalizePhase(value) {
     const id = normalizeId(value);
     if (["pre_combat_planning", "planning", "planning_phase", "before_combat", "before_combat_phase"].includes(id)) return PHASES.PLANNING;
@@ -335,5 +351,6 @@
   global.LuminousActionEconomy = api;
   ensureEnvironmentRuntime();
   ensureUnitRankRuntime();
+  ensureBattleViewerEnemyPlanningRuntime();
   if (typeof module !== "undefined" && module.exports) module.exports = api;
 })(typeof window !== "undefined" ? window : globalThis);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "hoja_personaje.js",
   "scripts": {
     "firebase:deploy:rules": "npx firebase-tools deploy --only database --project luminous-system",
-    "test:individual-goap": "node tests/individual-goap-combat-ai-smoke.mjs && node tests/individual-goap-combat-ai-real-engine-smoke.mjs && node tests/unit-ai-kit-adapter-smoke.mjs && node tests/unit-ai-kit-adapter-real-engine-smoke.mjs"
+    "test:individual-goap": "node tests/individual-goap-combat-ai-smoke.mjs && node tests/individual-goap-combat-ai-real-engine-smoke.mjs && node tests/unit-ai-kit-adapter-smoke.mjs && node tests/unit-ai-kit-adapter-real-engine-smoke.mjs && node tests/enemy-action-slot-allocator-smoke.mjs"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "hoja_personaje.js",
   "scripts": {
     "firebase:deploy:rules": "npx firebase-tools deploy --only database --project luminous-system",
-    "test:individual-goap": "node tests/individual-goap-combat-ai-smoke.mjs && node tests/individual-goap-combat-ai-real-engine-smoke.mjs && node tests/unit-ai-kit-adapter-smoke.mjs && node tests/unit-ai-kit-adapter-real-engine-smoke.mjs && node tests/enemy-action-slot-allocator-smoke.mjs"
+    "test:individual-goap": "node tests/individual-goap-combat-ai-smoke.mjs && node tests/individual-goap-combat-ai-real-engine-smoke.mjs && node tests/unit-ai-kit-adapter-smoke.mjs && node tests/unit-ai-kit-adapter-real-engine-smoke.mjs && node tests/enemy-action-slot-allocator-smoke.mjs && node tests/enemy-action-slot-canonical-units-smoke.mjs"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "hoja_personaje.js",
   "scripts": {
     "firebase:deploy:rules": "npx firebase-tools deploy --only database --project luminous-system",
-    "test:individual-goap": "node tests/individual-goap-combat-ai-smoke.mjs && node tests/individual-goap-combat-ai-real-engine-smoke.mjs && node tests/unit-ai-kit-adapter-smoke.mjs && node tests/unit-ai-kit-adapter-real-engine-smoke.mjs && node tests/enemy-action-slot-allocator-smoke.mjs && node tests/enemy-action-slot-canonical-units-smoke.mjs"
+    "test:individual-goap": "node tests/individual-goap-combat-ai-smoke.mjs && node tests/individual-goap-combat-ai-real-engine-smoke.mjs && node tests/unit-ai-kit-adapter-smoke.mjs && node tests/unit-ai-kit-adapter-real-engine-smoke.mjs && node tests/enemy-action-slot-allocator-smoke.mjs && node tests/enemy-action-slot-canonical-units-smoke.mjs && node tests/individual-goap-resource-budget-smoke.mjs"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "hoja_personaje.js",
   "scripts": {
     "firebase:deploy:rules": "npx firebase-tools deploy --only database --project luminous-system",
-    "test:individual-goap": "node tests/individual-goap-combat-ai-smoke.mjs && node tests/individual-goap-combat-ai-real-engine-smoke.mjs && node tests/unit-ai-kit-adapter-smoke.mjs && node tests/unit-ai-kit-adapter-real-engine-smoke.mjs && node tests/enemy-action-slot-allocator-smoke.mjs && node tests/enemy-action-slot-canonical-units-smoke.mjs && node tests/individual-goap-resource-budget-smoke.mjs && node tests/battle-viewer-enemy-planning-074-smoke.mjs"
+    "test:individual-goap": "node tests/individual-goap-combat-ai-smoke.mjs && node tests/individual-goap-combat-ai-real-engine-smoke.mjs && node tests/unit-ai-kit-adapter-smoke.mjs && node tests/unit-ai-kit-adapter-real-engine-smoke.mjs && node tests/enemy-action-slot-allocator-smoke.mjs && node tests/enemy-action-slot-canonical-units-smoke.mjs && node tests/individual-goap-resource-budget-smoke.mjs && node tests/battle-viewer-enemy-planning-074-smoke.mjs && node tests/battle-viewer-enemy-planning-074-e2e-smoke.mjs"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "hoja_personaje.js",
   "scripts": {
     "firebase:deploy:rules": "npx firebase-tools deploy --only database --project luminous-system",
-    "test:individual-goap": "node tests/individual-goap-combat-ai-smoke.mjs && node tests/individual-goap-combat-ai-real-engine-smoke.mjs && node tests/unit-ai-kit-adapter-smoke.mjs && node tests/unit-ai-kit-adapter-real-engine-smoke.mjs && node tests/enemy-action-slot-allocator-smoke.mjs && node tests/enemy-action-slot-canonical-units-smoke.mjs && node tests/individual-goap-resource-budget-smoke.mjs"
+    "test:individual-goap": "node tests/individual-goap-combat-ai-smoke.mjs && node tests/individual-goap-combat-ai-real-engine-smoke.mjs && node tests/unit-ai-kit-adapter-smoke.mjs && node tests/unit-ai-kit-adapter-real-engine-smoke.mjs && node tests/enemy-action-slot-allocator-smoke.mjs && node tests/enemy-action-slot-canonical-units-smoke.mjs && node tests/individual-goap-resource-budget-smoke.mjs && node tests/battle-viewer-enemy-planning-074-smoke.mjs"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "hoja_personaje.js",
   "scripts": {
     "firebase:deploy:rules": "npx firebase-tools deploy --only database --project luminous-system",
-    "test:individual-goap": "node tests/individual-goap-combat-ai-smoke.mjs && node tests/individual-goap-combat-ai-real-engine-smoke.mjs"
+    "test:individual-goap": "node tests/individual-goap-combat-ai-smoke.mjs && node tests/individual-goap-combat-ai-real-engine-smoke.mjs && node tests/unit-ai-kit-adapter-smoke.mjs && node tests/unit-ai-kit-adapter-real-engine-smoke.mjs"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Luminous Character Maker.",
   "main": "hoja_personaje.js",
   "scripts": {
-    "firebase:deploy:rules": "npx firebase-tools deploy --only database --project luminous-system"
+    "firebase:deploy:rules": "npx firebase-tools deploy --only database --project luminous-system",
+    "test:individual-goap": "node tests/individual-goap-combat-ai-smoke.mjs && node tests/individual-goap-combat-ai-real-engine-smoke.mjs"
   },
   "repository": {
     "type": "git",

--- a/tests/battle-viewer-enemy-planning-074-e2e-smoke.mjs
+++ b/tests/battle-viewer-enemy-planning-074-e2e-smoke.mjs
@@ -108,8 +108,15 @@ function installViewerState(units) {
   installViewerState(units);
   beginViewerPlanning(units);
 
-  const planning = bridge.runViewerPlanning({ units, attackVectors: globalThis.attackVectors, slotTargets: globalThis.slotTargets, renderSlots: () => {} });
+  const planning = bridge.runViewerPlanning({
+    units,
+    attackVectors: globalThis.attackVectors,
+    slotTargets: globalThis.slotTargets,
+    renderSlots: () => {},
+    allocationOptions: { teamSlotCap: 1 },
+  });
   assert.equal(planning.applied, true);
+  assert.equal(planning.result.allocation.totalSlots, 1, 'single-slot fixture must isolate one timeline action');
   const vector = globalThis.attackVectors.timeline_kobold_slot_0;
   assert.ok(vector?.combatAction, 'GOAP should inject a canonical CombatAction into the enemy slot');
   assert.equal(vector.combatAction.source.id, 'kobold_dagger_jab');

--- a/tests/battle-viewer-enemy-planning-074-e2e-smoke.mjs
+++ b/tests/battle-viewer-enemy-planning-074-e2e-smoke.mjs
@@ -1,0 +1,201 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+// Exercise the browser/CommonJS CombatEngine directly. This test intentionally crosses
+// the real Battle Viewer Planning -> Timeline -> CombatActionResolver -> CombatEngine path.
+globalThis.window = globalThis;
+globalThis.STATUS_REGISTRY = globalThis.STATUS_REGISTRY || {};
+const engineSource = readFileSync(new URL('../js/combatEngine.js', import.meta.url), 'utf8');
+vm.runInThisContext(engineSource, { filename: 'js/combatEngine.js' });
+if (!globalThis.CombatEngine) throw new Error('CombatEngine did not initialize.');
+
+await import('../js/universal-action-economy.js');
+await import('../js/combat-action-schema.js');
+await import('../js/combat-action-adapters.js');
+await import('../js/combat-action-engine-bridge.js');
+await import('../js/combat-action-queue.js');
+await import('../js/combat-action-resolver.js');
+await import('../js/individual-goap-combat-ai.js');
+await import('../js/unit-ai-kit-adapter.js');
+await import('../js/unit-action-economy-catalog.js');
+await import('../js/enemy-action-slot-allocator.js');
+await import('../js/unit-rank-runtime.js');
+await import('../js/skill-catalog-kobold-tier1.js');
+await import('../js/battle-viewer-action-adapter-073.js');
+await import('../js/battle-viewer-runtime-073-timeline.js');
+await import('../js/battle-viewer-enemy-planning-074.js');
+
+const economy = globalThis.LuminousActionEconomy;
+const schema = globalThis.LuminousCombatAction;
+const skills = globalThis.LuminousKoboldTier1SkillCatalog;
+const rankRuntime = globalThis.LuminousUnitRankRuntime;
+const timeline = globalThis.LuminousBattleViewerTimeline073;
+const bridge = globalThis.LuminousBattleViewerEnemyPlanning074;
+
+if (!economy || !schema || !skills || !rankRuntime || !timeline || !bridge) {
+  throw new Error('Battle Viewer E2E dependencies were not initialized.');
+}
+
+function player(id, hp = 200) {
+  return {
+    id,
+    name: id,
+    faction: 'ally',
+    faccion: 'ally',
+    isPlayer: true,
+    hp,
+    maxHp: hp,
+    sp: 0,
+    level: 3,
+    speed: 5,
+    actionSlots: 4,
+    stats: {},
+    statusEffects: {},
+    shield: 0,
+    physRes: 1,
+    sinRes: 1,
+  };
+}
+
+function enemy({ id, canonicalUnitId, rank = 'normal', speed = 6, skill }) {
+  return {
+    id,
+    name: id,
+    canonicalUnitId,
+    rank,
+    faction: 'enemy',
+    faccion: 'enemy',
+    hp: 30,
+    maxHp: 30,
+    sp: 0,
+    maxSp: 45,
+    level: 3,
+    speed,
+    scores: { int: 10, wis: 9 },
+    stats: {},
+    statusEffects: {},
+    shield: 0,
+    resolvedSkills: [skill],
+  };
+}
+
+function beginViewerPlanning(units) {
+  units.forEach((unit) => economy.beginPlanning(unit));
+}
+
+function installViewerState(units) {
+  globalThis.combatData = Object.fromEntries(units.map((unit) => [unit.id, unit]));
+  globalThis.attackVectors = {};
+  globalThis.slotTargets = {};
+}
+
+// A clashable enemy Skill without a reciprocal player action is NOT a Clash event.
+// The Viewer must emit an ordinary action event and CombatActionResolver must fall back
+// to a unilateral attack in the real CombatEngine.
+{
+  const target = player('timeline_player', 200);
+  const dagger = skills.get('kobold_dagger_jab');
+  assert.equal(dagger.isClashable, true);
+  assert.equal(dagger.isUnclashable, false);
+  const kobold = enemy({
+    id: 'timeline_kobold',
+    canonicalUnitId: 'kobold_dagger',
+    speed: 8,
+    skill: dagger,
+  });
+  const units = [target, kobold];
+  installViewerState(units);
+  beginViewerPlanning(units);
+
+  const planning = bridge.runViewerPlanning({ units, attackVectors: globalThis.attackVectors, slotTargets: globalThis.slotTargets, renderSlots: () => {} });
+  assert.equal(planning.applied, true);
+  const vector = globalThis.attackVectors.timeline_kobold_slot_0;
+  assert.ok(vector?.combatAction, 'GOAP should inject a canonical CombatAction into the enemy slot');
+  assert.equal(vector.combatAction.source.id, 'kobold_dagger_jab');
+  assert.equal(vector.combatAction.resolution.type, 'clash', 'canonical Skill semantics must remain clashable');
+  assert.equal(vector.target, 'timeline_player_slot_0');
+  assert.equal(globalThis.slotTargets.timeline_player_slot_0, undefined, 'player has no reciprocal target/action');
+
+  const events = timeline.buildEvents();
+  assert.equal(events.length, 1);
+  assert.equal(events[0].type, 'action', 'non-reciprocal clashable Skill must become a normal timeline action');
+  assert.equal(events[0].opposingAction, undefined);
+  assert.equal(events[0].action.resolution.type, 'clash', 'timeline must not rewrite the canonical resolution contract');
+
+  const hpBefore = target.hp;
+  const resolved = await timeline.resolveEvent(events[0]);
+  assert.equal(resolved.resolved, true, resolved.reason || 'timeline action should resolve');
+  assert.ok(target.hp < hpBefore, `real CombatEngine should apply unilateral damage (${hpBefore} -> ${target.hp})`);
+}
+
+// Test boundary for this milestone: Normal + Captain only. Rank does not manufacture
+// Action Slots; the Captain uses its canonical Unit profile. A 3-slot Unit therefore gets
+// all three slots while still using the same Individual GOAP/CombatAction pipeline.
+{
+  const target = player('captain_player', 1000);
+  const captainSkill = skills.get('dragonheart_spear_thrust');
+  const normalSkill = skills.get('kobold_dagger_jab');
+  const captain = enemy({
+    id: 'captain_dragonheart',
+    canonicalUnitId: 'dragonheart_kobold',
+    rank: 'captain',
+    speed: 10,
+    skill: captainSkill,
+  });
+  const normal = enemy({
+    id: 'normal_kobold',
+    canonicalUnitId: 'kobold_dagger',
+    rank: 'normal',
+    speed: 7,
+    skill: normalSkill,
+  });
+  const units = [target, captain, normal];
+  installViewerState(units);
+  beginViewerPlanning(units);
+
+  assert.equal(rankRuntime.rankForUnit(captain), 'captain');
+  const captainRank = rankRuntime.profileForUnit(captain);
+  assert.equal(captainRank.commandLevel, 1);
+  assert.equal(rankRuntime.rankForUnit(normal), 'normal');
+  assert.equal(rankRuntime.profileForUnit(normal).commandLevel, 0);
+
+  const planning = bridge.runViewerPlanning({ units, attackVectors: globalThis.attackVectors, slotTargets: globalThis.slotTargets, renderSlots: () => {} });
+  assert.equal(planning.applied, true);
+  const rows = Object.fromEntries(planning.result.allocation.rows.map((row) => [row.unitId, row]));
+  assert.equal(rows.captain_dragonheart.maxSlots, 3);
+  assert.equal(rows.captain_dragonheart.slots, 3, '3-slot Captain profile should receive its full allocation when eligible');
+  assert.equal(rows.normal_kobold.maxSlots, 2);
+  assert.equal(rows.normal_kobold.slots, 2);
+  assert.deepEqual(planning.result.allocation.bonusRecipients, ['captain_dragonheart', 'normal_kobold']);
+  assert.equal(planning.result.allocation.totalSlots, 5);
+  assert.equal(planning.result.allocation.unusedSlots, 7, 'team cap is a ceiling, not a quota');
+
+  const captainVectors = Object.entries(globalThis.attackVectors).filter(([slotId]) => slotId.startsWith('captain_dragonheart_slot_'));
+  assert.equal(captainVectors.length, 3);
+  for (const [slotId, vector] of captainVectors) {
+    assert.equal(vector.__luminousEnemyGoap074, true);
+    assert.equal(vector.combatAction.actorId, captain.id);
+    assert.equal(vector.combatAction.actionSlotId, slotId);
+    assert.equal(vector.combatAction.source.id, 'dragonheart_spear_thrust');
+    assert.equal(vector.combatAction.phase.selectedAt, schema.PHASES.PLANNING_PHASE_AI);
+    assert.equal(schema.validateCombatAction(vector.combatAction).valid, true);
+  }
+
+  const events = timeline.buildEvents();
+  const captainEvents = events.filter((event) => event.actorSlotId.startsWith('captain_dragonheart_slot_'));
+  assert.equal(captainEvents.length, 3);
+  assert.ok(captainEvents.every((event) => event.type === 'action'), 'unanswered Captain attacks must remain unilateral timeline actions');
+
+  const hpBefore = target.hp;
+  for (const event of captainEvents) {
+    const resolved = await timeline.resolveEvent(event);
+    assert.equal(resolved.resolved, true, resolved.reason || 'Captain GOAP action should resolve');
+  }
+  assert.ok(target.hp < hpBefore, `Captain CombatActions should reach the real CombatEngine (${hpBefore} -> ${target.hp})`);
+
+  assert.equal(rankRuntime.RANKS.leader.commandLevel, 2, 'Leader definition remains available for a later milestone');
+  assert.equal(planning.result.plans.some((entry) => entry.plan?.metadata?.rank === 'leader'), false, 'this milestone must not inject Leader planning');
+}
+
+console.log('Battle Viewer enemy Planning 0.7.4 E2E (Normal + Captain): ok');

--- a/tests/battle-viewer-enemy-planning-074-smoke.mjs
+++ b/tests/battle-viewer-enemy-planning-074-smoke.mjs
@@ -1,5 +1,12 @@
 import assert from 'node:assert/strict';
 
+await import('../js/status-engine.js');
+await import('../js/universal-ranged-ammo-runtime.js');
+await import('../js/skill-catalog-kobold-tier1.js');
+await import('../js/unit-rank-runtime.js');
+await import('../js/unit-combat-mechanics-runtime.js');
+await import('../js/unit-catalog-kobold-tier1.js');
+await import('../js/unit-catalog-goblin.js');
 await import('../js/universal-action-economy.js');
 await import('../js/combat-action-schema.js');
 await import('../js/combat-action-adapters.js');
@@ -111,6 +118,43 @@ function enemy(id, speed, profileId = 'kobold_dagger', skill = strike) {
   assert.equal(slotTargets.player_live_slot_0, 'encounter_kobold_fast_slot_0', 'player targeting state must remain untouched');
 }
 
+// Real VTT/Battle Viewer combatants can arrive as lightweight token records. actorRef is
+// sufficient to recover canonical planning data without replacing live HP/Speed/state.
+{
+  const player = { id: 'actorref_player', faction: 'ally', isPlayer: true, hp: 40, maxHp: 40, actionSlots: 3 };
+  const tokenCombatant = {
+    id: 'enemy:kobold_dagger:runtime_001',
+    actorRef: { scope: 'units', id: 'kobold_dagger' },
+    actorCategory: 'enemy',
+    faction: 'enemy',
+    hp: 7,
+    maxHp: 13,
+    currentSpeed: 5,
+    actionSlots: 1,
+  };
+  const hpBefore = tokenCombatant.hp;
+  const maxHpBefore = tokenCombatant.maxHp;
+  economy.beginPlanning(player);
+  economy.beginPlanning(tokenCombatant);
+
+  const attackVectors = {};
+  const result = bridge.runViewerPlanning({ units: [player, tokenCombatant], attackVectors, slotTargets: {}, renderSlots: () => {} });
+  const hydration = result.result.hydration.find((entry) => entry.unitId === tokenCombatant.id);
+
+  assert.equal(result.applied, true);
+  assert.equal(hydration.hydrated, true);
+  assert.equal(hydration.canonicalUnitId, 'kobold_dagger');
+  assert.equal(tokenCombatant.canonicalUnitId, 'kobold_dagger');
+  assert.ok(Array.isArray(tokenCombatant.resolvedSkills) && tokenCombatant.resolvedSkills.length >= 3);
+  assert.deepEqual(tokenCombatant.scores, { str: 7, dex: 15, con: 9, int: 8, wis: 7, cha: 8 });
+  assert.equal(tokenCombatant.hp, hpBefore, 'rehydration must preserve live HP');
+  assert.equal(tokenCombatant.maxHp, maxHpBefore, 'rehydration must preserve live max HP');
+  assert.equal(tokenCombatant.currentSpeed, 5, 'rehydration must preserve round Speed');
+  assert.equal(tokenCombatant.actionSlots, 2, 'canonical 1-2 profile should apply to the live token id');
+  assert.equal(result.entriesApplied.length, 2);
+  assert.ok(Object.values(attackVectors).every((vector) => ['kobold_dagger_jab', 'kobold_desperate_stab'].includes(vector.combatAction?.source?.id)));
+}
+
 // Defense decisions are routed through the Viewer defense plan contract instead of being
 // sent to CombatActionResolver as unilateral attacks.
 {
@@ -198,4 +242,4 @@ function enemy(id, speed, profileId = 'kobold_dagger', skill = strike) {
   assert.equal(Object.keys(globalThis.attackVectors).length, 4, 'two 1-2 enemies should expose four GOAP vectors');
 }
 
-console.log('Battle Viewer enemy Planning 0.7.4 smoke: ok');
+console.log('Battle Viewer enemy Planning 0.7.5 smoke: ok');

--- a/tests/battle-viewer-enemy-planning-074-smoke.mjs
+++ b/tests/battle-viewer-enemy-planning-074-smoke.mjs
@@ -1,0 +1,194 @@
+import assert from 'node:assert/strict';
+
+await import('../js/universal-action-economy.js');
+await import('../js/combat-action-schema.js');
+await import('../js/combat-action-adapters.js');
+await import('../js/individual-goap-combat-ai.js');
+await import('../js/unit-ai-kit-adapter.js');
+await import('../js/unit-action-economy-catalog.js');
+await import('../js/enemy-action-slot-allocator.js');
+await import('../js/battle-viewer-enemy-planning-074.js');
+
+const economy = globalThis.LuminousActionEconomy;
+const schema = globalThis.LuminousCombatAction;
+const bridge = globalThis.LuminousBattleViewerEnemyPlanning074;
+
+if (!economy || !schema || !bridge) throw new Error('Battle Viewer enemy Planning dependencies were not initialized.');
+
+const strike = {
+  id: 'viewer_ai_strike',
+  sourceType: 'skill',
+  type: 'Attack',
+  basePower: 6,
+  coinPower: 4,
+  coinAmount: 1,
+  attackWeight: 1,
+  damageType: 'perforante',
+  sinAffinity: 'sinless',
+  targetingType: 'Focused Attack',
+  isDefense: false,
+  isClashable: false,
+  isUnclashable: true,
+  resourceCosts: [],
+  effects: [],
+  coins: [{ index: 0, type: 'normal', status: 'active', effects: [] }],
+};
+
+function enemy(id, speed, profileId = 'kobold_dagger', skill = strike) {
+  return {
+    id,
+    canonicalUnitId: profileId,
+    faction: 'enemy',
+    hp: 20,
+    maxHp: 20,
+    speed,
+    scores: { int: 10, wis: 9 },
+    resolvedSkills: [skill],
+  };
+}
+
+// The real Viewer phase handler begins ActionEconomy Planning first. The bridge must
+// allocate/plan enemies afterwards without touching player slot counts or starting a second turn.
+{
+  const player = { id: 'player_live', faction: 'ally', isPlayer: true, hp: 50, maxHp: 50, speed: 7, actionSlots: 4 };
+  const fast = enemy('encounter_kobold_fast', 8);
+  const second = enemy('encounter_kobold_second', 6);
+  const slow = enemy('encounter_kobold_slow', 4);
+  const dead = { ...enemy('encounter_kobold_dead', 20), hp: 0 };
+  const units = [player, fast, second, slow, dead];
+
+  units.forEach((unit) => economy.beginPlanning(unit));
+  const playerBefore = economy.snapshot(player, { phase: 'planning' });
+  const enemyTurnsBefore = Object.fromEntries([fast, second, slow].map((unit) => [unit.id, economy.snapshot(unit, { phase: 'planning' }).turn]));
+
+  const attackVectors = {};
+  const slotTargets = {
+    player_live_slot_0: 'encounter_kobold_fast_slot_0',
+    encounter_kobold_fast_slot_9: 'player_live_slot_0',
+  };
+  const rendered = [];
+  const result = bridge.runViewerPlanning({
+    units,
+    attackVectors,
+    slotTargets,
+    renderSlots: (unit, row) => rendered.push([unit.id, row.slots]),
+  });
+
+  assert.equal(result.applied, true);
+  assert.equal(result.result.allocation.totalSlots, 5);
+  const rows = Object.fromEntries(result.result.allocation.rows.map((row) => [row.unitId, row]));
+  assert.equal(rows.encounter_kobold_fast.slots, 2);
+  assert.equal(rows.encounter_kobold_second.slots, 2);
+  assert.equal(rows.encounter_kobold_slow.slots, 1);
+  assert.equal(rows.encounter_kobold_dead, undefined, 'dead enemies must not receive Viewer slots');
+  assert.deepEqual(rows.encounter_kobold_fast.slotIds, ['encounter_kobold_fast_slot_0', 'encounter_kobold_fast_slot_1']);
+  assert.deepEqual(result.result.allocation.bonusRecipients, ['encounter_kobold_fast', 'encounter_kobold_second']);
+
+  assert.equal(player.actionSlots, 4, 'enemy Planning must never rewrite player Action Slots');
+  assert.equal(economy.snapshot(player, { phase: 'planning' }).turn, playerBefore.turn, 'enemy Planning must never begin another player turn');
+  assert.equal(economy.snapshot(player, { phase: 'planning' }).actionSlots, 4);
+  for (const unit of [fast, second, slow]) {
+    assert.equal(economy.snapshot(unit, { phase: 'planning' }).turn, enemyTurnsBefore[unit.id], 'bridge must not call beginPlanning twice for enemies');
+  }
+
+  assert.deepEqual(rendered, [
+    ['encounter_kobold_fast', 2],
+    ['encounter_kobold_second', 2],
+    ['encounter_kobold_slow', 1],
+  ]);
+  assert.equal(Object.keys(attackVectors).length, 5);
+  for (const [slotId, vector] of Object.entries(attackVectors)) {
+    assert.equal(vector.__luminousEnemyGoap074, true);
+    assert.equal(vector.target, 'player_live_slot_0');
+    assert.equal(vector.combatAction.actionSlotId, slotId);
+    assert.equal(vector.combatAction.actorId, slotId.slice(0, slotId.lastIndexOf('_slot_')));
+    assert.equal(vector.combatAction.phase.selectedAt, schema.PHASES.PLANNING_PHASE_AI);
+    assert.equal(schema.validateCombatAction(vector.combatAction).valid, true);
+  }
+
+  assert.equal(slotTargets.encounter_kobold_fast_slot_9, undefined, 'stale enemy slot targets must be pruned locally');
+  assert.equal(slotTargets.player_live_slot_0, 'encounter_kobold_fast_slot_0', 'player targeting state must remain untouched');
+}
+
+// Defense decisions are routed through the Viewer defense plan contract instead of being
+// sent to CombatActionResolver as unilateral attacks.
+{
+  const defense = {
+    id: 'viewer_ai_evade',
+    sourceType: 'skill',
+    type: 'Defense',
+    isDefense: true,
+    defenseSubtype: 'Evade',
+    basePower: 5,
+    coinPower: 5,
+    coinAmount: 1,
+    targetingType: 'Focused Attack',
+    isClashable: true,
+    isUnclashable: false,
+    resourceCosts: [],
+    effects: [],
+    coins: [{ index: 0, type: 'normal', status: 'active', effects: [] }],
+  };
+  const player = { id: 'defense_target', faction: 'ally', isPlayer: true, hp: 40, maxHp: 40, actionSlots: 3 };
+  const defender = enemy('defense_enemy', 5, 'kobold_dagger', defense);
+  economy.beginPlanning(player);
+  economy.beginPlanning(defender);
+  const attackVectors = {};
+  const result = bridge.runViewerPlanning({ units: [player, defender], attackVectors, slotTargets: {}, renderSlots: () => {} });
+  assert.equal(result.applied, true);
+  const vector = attackVectors.defense_enemy_slot_0;
+  assert.ok(vector, 'defense slot should be represented in Viewer Planning');
+  assert.equal(vector.combatAction, undefined, 'defense must not be injected as a unilateral embedded attack');
+  assert.equal(vector.plan.type, 'defense');
+  assert.equal(vector.plan.data.isDefense, true);
+}
+
+// Escape remains a turn-end action. Planning stores it as deferred rather than injecting
+// a wrong-phase action into the combat timeline.
+{
+  const player = { id: 'escape_target', faction: 'ally', isPlayer: true, hp: 40, maxHp: 40, actionSlots: 2 };
+  const cautious = enemy('cautious_enemy', 7);
+  cautious.hp = 2;
+  cautious.maxHp = 20;
+  cautious.scores = { int: 10, wis: 18 };
+  economy.beginPlanning(player);
+  economy.beginPlanning(cautious);
+  const attackVectors = {};
+  const result = bridge.runViewerPlanning({ units: [player, cautious], attackVectors, slotTargets: {}, renderSlots: () => {} });
+  assert.equal(result.applied, true);
+  assert.equal(Object.keys(attackVectors).length, 0, 'turn-end Escape must not enter the combat-phase vector registry');
+  assert.equal(result.deferred.length, 1);
+  assert.equal(result.deferred[0].action.source.id, 'escape');
+  assert.equal(result.deferred[0].action.phase.executesAt, schema.PHASES.ON_TURN_END);
+  assert.equal(cautious.__luminousEnemyDeferredActions074.length, 1);
+}
+
+// Real hook contract: the existing Viewer sync owns beginPlanning for everyone; the bridge
+// runs after it. Player and enemy turn counters must each increment exactly once.
+{
+  const player = { id: 'hook_player', faction: 'ally', isPlayer: true, hp: 50, maxHp: 50, speed: 6, actionSlots: 5 };
+  const fast = enemy('hook_fast', 8);
+  const slow = enemy('hook_slow', 4);
+  globalThis.combatData = { hook_player: player, hook_fast: fast, hook_slow: slow };
+  globalThis.attackVectors = {};
+  globalThis.slotTargets = {};
+  let originalCalls = 0;
+  globalThis.syncCombatEnginePhase = function viewerPhaseSync(rawState) {
+    originalCalls += 1;
+    if (String(rawState).toUpperCase() === 'PRE_COMBAT_PLANNING') Object.values(globalThis.combatData).forEach((unit) => economy.beginPlanning(unit));
+    return String(rawState).toUpperCase();
+  };
+
+  bridge.state.installed = false;
+  assert.equal(bridge.installPhaseHook(), true);
+  globalThis.syncCombatEnginePhase('PRE_COMBAT_PLANNING');
+
+  assert.equal(originalCalls, 1);
+  assert.equal(economy.snapshot(player, { phase: 'planning' }).turn, 1);
+  assert.equal(economy.snapshot(fast, { phase: 'planning' }).turn, 1);
+  assert.equal(economy.snapshot(slow, { phase: 'planning' }).turn, 1);
+  assert.equal(player.actionSlots, 5);
+  assert.equal(Object.keys(globalThis.attackVectors).length, 4, 'two 1-2 enemies should expose four GOAP vectors');
+}
+
+console.log('Battle Viewer enemy Planning 0.7.4 smoke: ok');

--- a/tests/battle-viewer-enemy-planning-074-smoke.mjs
+++ b/tests/battle-viewer-enemy-planning-074-smoke.mjs
@@ -75,6 +75,7 @@ function enemy(id, speed, profileId = 'kobold_dagger', skill = strike) {
   });
 
   assert.equal(result.applied, true);
+  assert.equal(result.entriesApplied.length, 5);
   assert.equal(result.result.allocation.totalSlots, 5);
   const rows = Object.fromEntries(result.result.allocation.rows.map((row) => [row.unitId, row]));
   assert.equal(rows.encounter_kobold_fast.slots, 2);
@@ -164,7 +165,8 @@ function enemy(id, speed, profileId = 'kobold_dagger', skill = strike) {
 }
 
 // Real hook contract: the existing Viewer sync owns beginPlanning for everyone; the bridge
-// runs after it. Player and enemy turn counters must each increment exactly once.
+// runs after it. Player and enemy turn counters must each increment exactly once, and the
+// canonical v0.7.3 timeline must win even if a legacy inline function was declared later.
 {
   const player = { id: 'hook_player', faction: 'ally', isPlayer: true, hp: 50, maxHp: 50, speed: 6, actionSlots: 5 };
   const fast = enemy('hook_fast', 8);
@@ -178,9 +180,14 @@ function enemy(id, speed, profileId = 'kobold_dagger', skill = strike) {
     if (String(rawState).toUpperCase() === 'PRE_COMBAT_PLANNING') Object.values(globalThis.combatData).forEach((unit) => economy.beginPlanning(unit));
     return String(rawState).toUpperCase();
   };
+  const canonicalTimeline = function canonicalTimeline() {};
+  globalThis.LuminousBattleViewerRuntime073 = { executeCombatTimeline: canonicalTimeline };
+  globalThis.executeCombatTimeline = function legacyInlineTimeline() {};
 
   bridge.state.installed = false;
   assert.equal(bridge.installPhaseHook(), true);
+  assert.equal(globalThis.executeCombatTimeline, canonicalTimeline, 'canonical timeline authority must be restored when the phase hook installs');
+  assert.equal(globalThis.__luminousCombatTimelineAuthority, 'v0.7.3-combat-action-runtime');
   globalThis.syncCombatEnginePhase('PRE_COMBAT_PLANNING');
 
   assert.equal(originalCalls, 1);

--- a/tests/enemy-action-slot-allocator-smoke.mjs
+++ b/tests/enemy-action-slot-allocator-smoke.mjs
@@ -30,7 +30,6 @@ function rowMap(result) {
   return Object.fromEntries(result.rows.map((row) => [row.unitId, row]));
 }
 
-// 12 is a ceiling, not a quota. Only the two fastest Units may receive bonus slots.
 {
   const units = [enemy('fast', 8, 3), enemy('second', 6, 3), enemy('slow', 4, 3)];
   const result = allocator.allocateEnemySlots(units, { apply: false, roundId: 'round_1' });
@@ -48,7 +47,6 @@ function rowMap(result) {
   assert.equal(result.unusedSlots, 5);
 }
 
-// Minion-style maxSlots 2 still stops below 12 when individual caps are reached.
 {
   const units = [enemy('m1', 7, 2), enemy('m2', 5, 2), enemy('m3', 3, 2)];
   const result = allocator.allocateEnemySlots(units, { apply: false });
@@ -60,7 +58,6 @@ function rowMap(result) {
   assert.equal(result.unusedSlots, 7);
 }
 
-// Near the team ceiling, bonus slots are distributed round-robin to the two fastest.
 {
   const units = Array.from({ length: 10 }, (_, index) => enemy(`u${index + 1}`, 20 - index, 3));
   const result = allocator.allocateEnemySlots(units, { apply: false });
@@ -71,7 +68,6 @@ function rowMap(result) {
   for (let index = 3; index <= 10; index += 1) assert.equal(rows[`u${index}`].slots, 1);
 }
 
-// Encounter deployment itself is invalid if guaranteed minimum slots exceed the team cap.
 {
   const units = Array.from({ length: 13 }, (_, index) => enemy(`overflow_${index}`, index + 1, 2));
   const result = allocator.allocateEnemySlots(units, { apply: false });
@@ -80,7 +76,6 @@ function rowMap(result) {
   assert.equal(result.minimumTotal, 13);
 }
 
-// Runtime ids are mandatory and unique because they become slot ids.
 {
   const duplicateA = enemy('duplicate', 8, 2);
   const duplicateB = enemy('duplicate', 7, 2);
@@ -97,7 +92,6 @@ function rowMap(result) {
   assert.equal(missingResult.reason, 'enemy_unit_id_required');
 }
 
-// Equal Speed uses stable deployment order as the deterministic tie-break.
 {
   const units = [enemy('tie_a', 5, 2), enemy('tie_b', 5, 2), enemy('tie_c', 5, 2)];
   const result = allocator.allocateEnemySlots(units, { apply: false });
@@ -106,7 +100,6 @@ function rowMap(result) {
   assert.equal(result.tieBreak, 'deployment_order_then_unit_id');
 }
 
-// Missing round Speed never invents a value. The Unit keeps its guaranteed base slot only.
 {
   const noSpeedA = enemy('no_speed_a', undefined, 2);
   delete noSpeedA.speed;
@@ -121,7 +114,6 @@ function rowMap(result) {
   assert.deepEqual(result.missingSpeed.sort(), ['no_speed_a', 'no_speed_b']);
 }
 
-// Explicit round Speed has precedence over stale Unit fields.
 {
   const first = enemy('speed_override_a', 2, 2);
   const second = enemy('speed_override_b', 9, 2);
@@ -134,7 +126,6 @@ function rowMap(result) {
   assert.equal(rowMap(result).speed_override_a.speedSource, 'round_override');
 }
 
-// Allies and inactive enemies are outside active enemy allocation.
 {
   const hostile = enemy('hostile', 5, 2);
   const dead = { ...enemy('dead_enemy', 20, 3), hp: 0 };
@@ -145,7 +136,6 @@ function rowMap(result) {
   assert.equal(result.inactiveEnemyCount, 1);
 }
 
-// Canonical Unit profiles live in data and can be stamped onto a uniquely-id'd combatant instance.
 assert.deepEqual(catalog.get('kobold_dagger'), { id: 'kobold_dagger', minSlots: 1, maxSlots: 2 });
 assert.deepEqual(catalog.get('kobold_sling'), { id: 'kobold_sling', minSlots: 1, maxSlots: 2 });
 assert.deepEqual(catalog.get('dragonheart_kobold'), { id: 'dragonheart_kobold', minSlots: 1, maxSlots: 3 });
@@ -161,7 +151,6 @@ assert.deepEqual(catalog.get('goblin_boss'), { id: 'goblin_boss', minSlots: 1, m
   assert.equal(allocator.profileFor(instance).maxSlots, 2);
 }
 
-// Applying an allocation resets round-target flags and makes Universal Action Economy consume the exact count.
 {
   const first = enemy('apply_fast', 7, 3);
   const second = enemy('apply_slow', 4, 3);
@@ -182,7 +171,21 @@ assert.deepEqual(catalog.get('goblin_boss'), { id: 'goblin_boss', minSlots: 1, m
   assert.equal(first.slots.length, 3);
 }
 
-// End-to-end planner handoff: the exact allocated slot ids become GOAP CombatAction slot ids.
+// Planning round uses a non-mutating allocation preflight before touching live Unit state.
+{
+  const first = enemy('preflight_fast', 8, 2);
+  const second = enemy('preflight_slow', 4, 2);
+  first.actionSlots = 7;
+  const preview = allocator.allocateEnemySlots([first, second], { apply: false, roundId: 'preview' });
+  assert.equal(preview.allocated, true);
+  assert.equal(first.actionSlots, 7);
+  const round = allocator.beginEnemyPlanningRound([first, second], { roundId: 'commit' });
+  assert.equal(round.planningReady, true);
+  assert.equal(first.actionSlots, 2);
+  assert.equal(first.actionSlotAllocation.roundId, 'commit');
+  assert.equal(round.planning[0].snapshot.actionSlots, 2);
+}
+
 {
   const skill = {
     id: 'allocator_test_strike', sourceType: 'skill', type: 'Attack', basePower: 5, coinPower: 2, coinAmount: 1,

--- a/tests/enemy-action-slot-allocator-smoke.mjs
+++ b/tests/enemy-action-slot-allocator-smoke.mjs
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+
+await import('../js/unit-action-economy-catalog.js');
+await import('../js/universal-action-economy.js');
+await import('../js/combat-action-schema.js');
+await import('../js/combat-action-adapters.js');
+await import('../js/individual-goap-combat-ai.js');
+await import('../js/unit-ai-kit-adapter.js');
+await import('../js/enemy-action-slot-allocator.js');
+
+const catalog = globalThis.LuminousUnitActionEconomyCatalog;
+const economy = globalThis.LuminousActionEconomy;
+const allocator = globalThis.LuminousEnemyActionSlotAllocator;
+
+if (!catalog || !economy || !allocator) throw new Error('Action Slot allocator dependencies were not initialized.');
+
+function enemy(id, speed, maxSlots = 3) {
+  return {
+    id,
+    faction: 'enemy',
+    hp: 10,
+    maxHp: 10,
+    speed,
+    scores: { int: 10, wis: 9 },
+    actionEconomy: { minSlots: 1, maxSlots },
+  };
+}
+
+function rowMap(result) {
+  return Object.fromEntries(result.rows.map((row) => [row.unitId, row]));
+}
+
+// 12 is a ceiling, not a quota. Only the two fastest Units may receive bonus slots.
+{
+  const units = [enemy('fast', 8, 3), enemy('second', 6, 3), enemy('slow', 4, 3)];
+  const result = allocator.allocateEnemySlots(units, { apply: false });
+  const rows = rowMap(result);
+  assert.equal(result.allocated, true);
+  assert.equal(result.teamSlotCap, 12);
+  assert.deepEqual(result.bonusRecipients, ['fast', 'second']);
+  assert.equal(rows.fast.slots, 3);
+  assert.equal(rows.second.slots, 3);
+  assert.equal(rows.slow.slots, 1);
+  assert.equal(result.totalSlots, 7);
+  assert.equal(result.unusedSlots, 5);
+}
+
+// Minion-style maxSlots 2 still stops below 12 when individual caps are reached.
+{
+  const units = [enemy('m1', 7, 2), enemy('m2', 5, 2), enemy('m3', 3, 2)];
+  const result = allocator.allocateEnemySlots(units, { apply: false });
+  const rows = rowMap(result);
+  assert.equal(rows.m1.slots, 2);
+  assert.equal(rows.m2.slots, 2);
+  assert.equal(rows.m3.slots, 1);
+  assert.equal(result.totalSlots, 5);
+  assert.equal(result.unusedSlots, 7);
+}
+
+// Near the team ceiling, bonus slots are distributed round-robin to the two fastest.
+{
+  const units = Array.from({ length: 10 }, (_, index) => enemy(`u${index + 1}`, 20 - index, 3));
+  const result = allocator.allocateEnemySlots(units, { apply: false });
+  const rows = rowMap(result);
+  assert.equal(result.totalSlots, 12);
+  assert.equal(rows.u1.slots, 2);
+  assert.equal(rows.u2.slots, 2);
+  for (let index = 3; index <= 10; index += 1) assert.equal(rows[`u${index}`].slots, 1);
+}
+
+// Encounter deployment itself is invalid if guaranteed minimum slots exceed the team cap.
+{
+  const units = Array.from({ length: 13 }, (_, index) => enemy(`overflow_${index}`, index + 1, 2));
+  const result = allocator.allocateEnemySlots(units, { apply: false });
+  assert.equal(result.allocated, false);
+  assert.equal(result.reason, 'minimum_slots_exceed_team_cap');
+  assert.equal(result.minimumTotal, 13);
+}
+
+// Equal Speed uses stable deployment order as the deterministic tie-break.
+{
+  const units = [enemy('tie_a', 5, 2), enemy('tie_b', 5, 2), enemy('tie_c', 5, 2)];
+  const result = allocator.allocateEnemySlots(units, { apply: false });
+  assert.deepEqual(result.bonusRecipients, ['tie_a', 'tie_b']);
+  assert.equal(rowMap(result).tie_c.slots, 1);
+  assert.equal(result.tieBreak, 'deployment_order_then_unit_id');
+}
+
+// Missing round Speed never invents a value. The Unit keeps its guaranteed base slot only.
+{
+  const noSpeedA = enemy('no_speed_a', undefined, 2);
+  delete noSpeedA.speed;
+  const noSpeedB = enemy('no_speed_b', undefined, 2);
+  delete noSpeedB.speed;
+  const known = enemy('known_speed', 4, 2);
+  const result = allocator.allocateEnemySlots([noSpeedA, known, noSpeedB], { apply: false });
+  const rows = rowMap(result);
+  assert.equal(rows.known_speed.slots, 2);
+  assert.equal(rows.no_speed_a.slots, 1);
+  assert.equal(rows.no_speed_b.slots, 1);
+  assert.deepEqual(result.missingSpeed.sort(), ['no_speed_a', 'no_speed_b']);
+}
+
+// Allies are outside this allocator's authority.
+{
+  const hostile = enemy('hostile', 5, 2);
+  const ally = { ...enemy('ally', 20, 3), faction: 'ally' };
+  const result = allocator.allocateEnemySlots([hostile, ally], { apply: false });
+  assert.deepEqual(result.rows.map((row) => row.unitId), ['hostile']);
+}
+
+// Canonical Unit profiles live in data, not in species/rank inference inside the allocator.
+assert.deepEqual(catalog.get('kobold_dagger'), { id: 'kobold_dagger', minSlots: 1, maxSlots: 2 });
+assert.deepEqual(catalog.get('kobold_sling'), { id: 'kobold_sling', minSlots: 1, maxSlots: 2 });
+assert.deepEqual(catalog.get('dragonheart_kobold'), { id: 'dragonheart_kobold', minSlots: 1, maxSlots: 3 });
+assert.deepEqual(catalog.get('goblin'), { id: 'goblin', minSlots: 1, maxSlots: 2 });
+assert.deepEqual(catalog.get('goblin_boss'), { id: 'goblin_boss', minSlots: 1, maxSlots: 3 });
+
+// Applying an allocation makes the existing universal Action Economy consume the allocated count.
+{
+  const first = enemy('apply_fast', 7, 3);
+  const second = enemy('apply_slow', 4, 3);
+  const result = allocator.allocateEnemySlots([first, second]);
+  assert.equal(result.allocated, true);
+  assert.equal(first.actionSlots, 3);
+  assert.equal(first.activeSlots, 3);
+  assert.equal(second.actionSlots, 3);
+  assert.equal(economy.actionSlotMaximum(first), 3);
+  assert.equal(economy.actionSlotMaximum(second), 3);
+  const snap = economy.beginPlanning(first);
+  assert.equal(snap.actionSlots, 3);
+  assert.equal(snap.action, 3);
+  assert.equal(first.slots.length, 3);
+}
+
+// End-to-end planner handoff: allocator count becomes GOAP availableSlots automatically.
+{
+  const skill = {
+    id: 'allocator_test_strike',
+    sourceType: 'skill',
+    type: 'Attack',
+    basePower: 5,
+    coinPower: 2,
+    coinAmount: 1,
+    attackWeight: 1,
+    damageType: 'slash',
+    sinAffinity: 'sinless',
+    targetingType: 'Focused Attack',
+    isDefense: false,
+    isClashable: false,
+    isUnclashable: true,
+    resourceCosts: [],
+    effects: [],
+    coins: [{ index: 0, type: 'normal', status: 'active', effects: [] }],
+  };
+  const first = { ...enemy('planner_fast', 8, 2), combatSkills: [skill] };
+  const second = { ...enemy('planner_second', 6, 2), combatSkills: [skill] };
+  const third = { ...enemy('planner_slow', 4, 2), combatSkills: [skill] };
+  const result = allocator.allocateAndPlan([first, second, third], { targetIds: ['player_1'] });
+  assert.equal(result.allocation.totalSlots, 5);
+  const plans = Object.fromEntries(result.plans.map((entry) => [entry.unitId, entry]));
+  assert.equal(plans.planner_fast.slots, 2);
+  assert.equal(plans.planner_fast.plan.actions.length, 2);
+  assert.equal(plans.planner_second.plan.actions.length, 2);
+  assert.equal(plans.planner_slow.plan.actions.length, 1);
+}
+
+console.log('enemy Action Slot allocator smoke: ok');

--- a/tests/enemy-action-slot-allocator-smoke.mjs
+++ b/tests/enemy-action-slot-allocator-smoke.mjs
@@ -33,14 +33,17 @@ function rowMap(result) {
 // 12 is a ceiling, not a quota. Only the two fastest Units may receive bonus slots.
 {
   const units = [enemy('fast', 8, 3), enemy('second', 6, 3), enemy('slow', 4, 3)];
-  const result = allocator.allocateEnemySlots(units, { apply: false });
+  const result = allocator.allocateEnemySlots(units, { apply: false, roundId: 'round_1' });
   const rows = rowMap(result);
   assert.equal(result.allocated, true);
+  assert.equal(result.roundId, 'round_1');
   assert.equal(result.teamSlotCap, 12);
   assert.deepEqual(result.bonusRecipients, ['fast', 'second']);
   assert.equal(rows.fast.slots, 3);
   assert.equal(rows.second.slots, 3);
   assert.equal(rows.slow.slots, 1);
+  assert.equal(rows.fast.speedSource, 'speed');
+  assert.deepEqual(rows.fast.slotIds, ['fast_slot_0', 'fast_slot_1', 'fast_slot_2']);
   assert.equal(result.totalSlots, 7);
   assert.equal(result.unusedSlots, 5);
 }
@@ -77,6 +80,23 @@ function rowMap(result) {
   assert.equal(result.minimumTotal, 13);
 }
 
+// Runtime ids are mandatory and unique because they become slot ids.
+{
+  const duplicateA = enemy('duplicate', 8, 2);
+  const duplicateB = enemy('duplicate', 7, 2);
+  duplicateA.actionSlots = 99;
+  const duplicate = allocator.allocateEnemySlots([duplicateA, duplicateB]);
+  assert.equal(duplicate.allocated, false);
+  assert.equal(duplicate.reason, 'duplicate_enemy_unit_id');
+  assert.equal(duplicateA.actionSlots, 99, 'failed allocation must be atomic and leave Units untouched');
+
+  const missing = enemy('', 6, 2);
+  delete missing.id;
+  const missingResult = allocator.allocateEnemySlots([missing]);
+  assert.equal(missingResult.allocated, false);
+  assert.equal(missingResult.reason, 'enemy_unit_id_required');
+}
+
 // Equal Speed uses stable deployment order as the deterministic tie-break.
 {
   const units = [enemy('tie_a', 5, 2), enemy('tie_b', 5, 2), enemy('tie_c', 5, 2)];
@@ -101,66 +121,86 @@ function rowMap(result) {
   assert.deepEqual(result.missingSpeed.sort(), ['no_speed_a', 'no_speed_b']);
 }
 
-// Allies are outside this allocator's authority.
+// Explicit round Speed has precedence over stale Unit fields.
 {
-  const hostile = enemy('hostile', 5, 2);
-  const ally = { ...enemy('ally', 20, 3), faction: 'ally' };
-  const result = allocator.allocateEnemySlots([hostile, ally], { apply: false });
-  assert.deepEqual(result.rows.map((row) => row.unitId), ['hostile']);
+  const first = enemy('speed_override_a', 2, 2);
+  const second = enemy('speed_override_b', 9, 2);
+  const third = enemy('speed_override_c', 8, 2);
+  const result = allocator.allocateEnemySlots([first, second, third], {
+    apply: false,
+    speedByUnitId: { speed_override_a: 12, speed_override_b: 4, speed_override_c: 3 },
+  });
+  assert.deepEqual(result.bonusRecipients, ['speed_override_a', 'speed_override_b']);
+  assert.equal(rowMap(result).speed_override_a.speedSource, 'round_override');
 }
 
-// Canonical Unit profiles live in data, not in species/rank inference inside the allocator.
+// Allies and inactive enemies are outside active enemy allocation.
+{
+  const hostile = enemy('hostile', 5, 2);
+  const dead = { ...enemy('dead_enemy', 20, 3), hp: 0 };
+  const ally = { ...enemy('ally', 30, 3), faction: 'ally' };
+  const result = allocator.allocateEnemySlots([hostile, dead, ally], { apply: false });
+  assert.deepEqual(result.rows.map((row) => row.unitId), ['hostile']);
+  assert.equal(result.activeEnemyCount, 1);
+  assert.equal(result.inactiveEnemyCount, 1);
+}
+
+// Canonical Unit profiles live in data and can be stamped onto a uniquely-id'd combatant instance.
 assert.deepEqual(catalog.get('kobold_dagger'), { id: 'kobold_dagger', minSlots: 1, maxSlots: 2 });
 assert.deepEqual(catalog.get('kobold_sling'), { id: 'kobold_sling', minSlots: 1, maxSlots: 2 });
 assert.deepEqual(catalog.get('dragonheart_kobold'), { id: 'dragonheart_kobold', minSlots: 1, maxSlots: 3 });
 assert.deepEqual(catalog.get('goblin'), { id: 'goblin', minSlots: 1, maxSlots: 2 });
 assert.deepEqual(catalog.get('goblin_boss'), { id: 'goblin_boss', minSlots: 1, maxSlots: 3 });
+{
+  const instance = enemy('encounter_42_unit_7', 8, 1);
+  delete instance.actionEconomy;
+  const stamped = catalog.applyToUnit(instance, 'kobold_dagger');
+  assert.equal(stamped.applied, true);
+  assert.equal(instance.actionEconomy.profileId, 'kobold_dagger');
+  assert.equal(catalog.canonicalUnitId(instance), 'kobold_dagger');
+  assert.equal(allocator.profileFor(instance).maxSlots, 2);
+}
 
-// Applying an allocation makes the existing universal Action Economy consume the allocated count.
+// Applying an allocation resets round-target flags and makes Universal Action Economy consume the exact count.
 {
   const first = enemy('apply_fast', 7, 3);
   const second = enemy('apply_slow', 4, 3);
-  const result = allocator.allocateEnemySlots([first, second]);
+  first.slots = [{ id: 'old', slotWeight: 2, isTargetedThisRound: true }];
+  const result = allocator.allocateEnemySlots([first, second], { roundId: 'r77' });
   assert.equal(result.allocated, true);
   assert.equal(first.actionSlots, 3);
   assert.equal(first.activeSlots, 3);
   assert.equal(second.actionSlots, 3);
   assert.equal(economy.actionSlotMaximum(first), 3);
   assert.equal(economy.actionSlotMaximum(second), 3);
+  assert.equal(first.actionSlotAllocation.roundId, 'r77');
+  assert.equal(first.slots[0].slotWeight, 2);
+  assert.equal(first.slots[0].isTargetedThisRound, false);
   const snap = economy.beginPlanning(first);
   assert.equal(snap.actionSlots, 3);
   assert.equal(snap.action, 3);
   assert.equal(first.slots.length, 3);
 }
 
-// End-to-end planner handoff: allocator count becomes GOAP availableSlots automatically.
+// End-to-end planner handoff: the exact allocated slot ids become GOAP CombatAction slot ids.
 {
   const skill = {
-    id: 'allocator_test_strike',
-    sourceType: 'skill',
-    type: 'Attack',
-    basePower: 5,
-    coinPower: 2,
-    coinAmount: 1,
-    attackWeight: 1,
-    damageType: 'slash',
-    sinAffinity: 'sinless',
-    targetingType: 'Focused Attack',
-    isDefense: false,
-    isClashable: false,
-    isUnclashable: true,
-    resourceCosts: [],
-    effects: [],
+    id: 'allocator_test_strike', sourceType: 'skill', type: 'Attack', basePower: 5, coinPower: 2, coinAmount: 1,
+    attackWeight: 1, damageType: 'slash', sinAffinity: 'sinless', targetingType: 'Focused Attack',
+    isDefense: false, isClashable: false, isUnclashable: true, resourceCosts: [], effects: [],
     coins: [{ index: 0, type: 'normal', status: 'active', effects: [] }],
   };
   const first = { ...enemy('planner_fast', 8, 2), combatSkills: [skill] };
   const second = { ...enemy('planner_second', 6, 2), combatSkills: [skill] };
   const third = { ...enemy('planner_slow', 4, 2), combatSkills: [skill] };
-  const result = allocator.allocateAndPlan([first, second, third], { targetIds: ['player_1'] });
+  const result = allocator.allocateAndPlan([first, second, third], { targetIds: ['player_1'], roundId: 'planning_round' });
+  assert.equal(result.planningReady, true);
   assert.equal(result.allocation.totalSlots, 5);
   const plans = Object.fromEntries(result.plans.map((entry) => [entry.unitId, entry]));
   assert.equal(plans.planner_fast.slots, 2);
   assert.equal(plans.planner_fast.plan.actions.length, 2);
+  assert.deepEqual(plans.planner_fast.slotIds, ['planner_fast_slot_0', 'planner_fast_slot_1']);
+  assert.deepEqual(plans.planner_fast.plan.sequence.map((entry) => entry.slotId), plans.planner_fast.slotIds);
   assert.equal(plans.planner_second.plan.actions.length, 2);
   assert.equal(plans.planner_slow.plan.actions.length, 1);
 }

--- a/tests/enemy-action-slot-canonical-units-smoke.mjs
+++ b/tests/enemy-action-slot-canonical-units-smoke.mjs
@@ -17,18 +17,30 @@ await import('../js/enemy-action-slot-allocator.js');
 
 const kobolds = globalThis.LuminousKoboldUnitCatalog;
 const goblins = globalThis.LuminousGoblinUnitCatalog;
+const profiles = globalThis.LuminousUnitActionEconomyCatalog;
 const allocator = globalThis.LuminousEnemyActionSlotAllocator;
 const economy = globalThis.LuminousActionEconomy;
 
-if (!kobolds || !goblins || !allocator || !economy) throw new Error('Canonical slot test dependencies were not initialized.');
+if (!kobolds || !goblins || !profiles || !allocator || !economy) throw new Error('Canonical slot test dependencies were not initialized.');
 
-const dagger = kobolds.resolve('kobold_dagger', { level: 2, initializeEncounter: true });
-const sling = kobolds.resolve('kobold_sling', { level: 2, initializeEncounter: true });
-const winged = kobolds.resolve('winged_kobold', { level: 3, initializeEncounter: true });
+function prepare(unit, runtimeId, speed, profileId = null) {
+  unit.id = runtimeId;
+  unit.faction = 'enemy';
+  unit.faccion = 'enemy';
+  unit.hp = Number(unit.hp ?? unit.mechanics?.hp ?? 10);
+  unit.maxHp = Number(unit.maxHp ?? unit.mechanics?.maxHp ?? unit.hp);
+  unit.resolvedSpeed = speed;
+  if (profileId) {
+    const stamped = profiles.applyToUnit(unit, profileId);
+    assert.equal(stamped.applied, true);
+  }
+  return unit;
+}
 
-dagger.resolvedSpeed = 6;
-sling.resolvedSpeed = 5;
-winged.resolvedSpeed = 4;
+// Live encounter ids can be unique without losing the canonical Action Economy profile.
+const dagger = prepare(kobolds.resolve('kobold_dagger', { level: 2, initializeEncounter: true }), 'encounter_7_kobold_a', 6, 'kobold_dagger');
+const sling = prepare(kobolds.resolve('kobold_sling', { level: 2, initializeEncounter: true }), 'encounter_7_kobold_b', 5, 'kobold_sling');
+const winged = prepare(kobolds.resolve('winged_kobold', { level: 3, initializeEncounter: true }), 'encounter_7_kobold_c', 4, 'winged_kobold');
 
 const originalDaggerSkillSlots = dagger.action_slots.slice();
 const koboldAllocation = allocator.allocateEnemySlots([dagger, sling, winged]);
@@ -36,12 +48,15 @@ const koboldRows = Object.fromEntries(koboldAllocation.rows.map((row) => [row.un
 
 assert.equal(koboldAllocation.allocated, true);
 assert.equal(koboldAllocation.totalSlots, 5);
-assert.equal(koboldRows.kobold_dagger.maxSlots, 2);
-assert.equal(koboldRows.kobold_sling.maxSlots, 2);
-assert.equal(koboldRows.winged_kobold.maxSlots, 2);
-assert.equal(koboldRows.kobold_dagger.slots, 2);
-assert.equal(koboldRows.kobold_sling.slots, 2);
-assert.equal(koboldRows.winged_kobold.slots, 1);
+assert.equal(koboldRows.encounter_7_kobold_a.profileId, 'kobold_dagger');
+assert.equal(koboldRows.encounter_7_kobold_b.profileId, 'kobold_sling');
+assert.equal(koboldRows.encounter_7_kobold_c.profileId, 'winged_kobold');
+assert.equal(koboldRows.encounter_7_kobold_a.maxSlots, 2);
+assert.equal(koboldRows.encounter_7_kobold_b.maxSlots, 2);
+assert.equal(koboldRows.encounter_7_kobold_c.maxSlots, 2);
+assert.equal(koboldRows.encounter_7_kobold_a.slots, 2);
+assert.equal(koboldRows.encounter_7_kobold_b.slots, 2);
+assert.equal(koboldRows.encounter_7_kobold_c.slots, 1);
 assert.deepEqual(dagger.action_slots, originalDaggerSkillSlots, 'legacy Skill references must not be overwritten by runtime slot allocation');
 assert.equal(dagger.actionSlots, 2);
 assert.equal(economy.actionSlotMaximum(dagger), 2);
@@ -49,29 +64,28 @@ assert.equal(economy.actionSlotMaximum(dagger), 2);
 const target = { id: 'player_1' };
 const planned = allocator.allocateAndPlan([dagger, sling, winged], {
   targets: [target],
-  speedByUnitId: { kobold_dagger: 6, kobold_sling: 5, winged_kobold: 4 },
+  speedByUnitId: { encounter_7_kobold_a: 6, encounter_7_kobold_b: 5, encounter_7_kobold_c: 4 },
 });
 const plans = Object.fromEntries(planned.plans.map((entry) => [entry.unitId, entry]));
-assert.equal(plans.kobold_dagger.slots, 2);
-assert.equal(plans.kobold_dagger.plan.actions.length, 2);
-assert.equal(plans.kobold_sling.slots, 2);
-assert.equal(plans.kobold_sling.plan.actions.length, 2);
-assert.equal(plans.winged_kobold.slots, 1);
-assert.equal(plans.winged_kobold.plan.actions.length, 1);
+assert.equal(plans.encounter_7_kobold_a.slots, 2);
+assert.equal(plans.encounter_7_kobold_a.plan.actions.length, 2);
+assert.deepEqual(plans.encounter_7_kobold_a.plan.sequence.map((entry) => entry.slotId), ['encounter_7_kobold_a_slot_0', 'encounter_7_kobold_a_slot_1']);
+assert.equal(plans.encounter_7_kobold_b.slots, 2);
+assert.equal(plans.encounter_7_kobold_b.plan.actions.length, 2);
+assert.equal(plans.encounter_7_kobold_c.slots, 1);
+assert.equal(plans.encounter_7_kobold_c.plan.actions.length, 1);
 
-// Goblins still have pending canonical weapon Skills, but slot allocation is independent
-// from kit resolution and therefore can already honor their per-Unit slot caps.
-const goblin = goblins.resolve('goblin', { level: 3, initializeEncounter: true });
-const boss = goblins.resolve('goblin_boss', { level: 5, initializeEncounter: true });
-const goblinAllocation = allocator.allocateEnemySlots([goblin, boss], {
-  speedByUnitId: { goblin: 5, goblin_boss: 4 },
-  apply: false,
-});
+// Goblins still have pending canonical weapon Skills, but slot allocation is independent from kit resolution.
+const goblin = prepare(goblins.resolve('goblin', { level: 3, initializeEncounter: true }), 'encounter_9_goblin_a', 5, 'goblin');
+const boss = prepare(goblins.resolve('goblin_boss', { level: 5, initializeEncounter: true }), 'encounter_9_goblin_boss', 4, 'goblin_boss');
+const goblinAllocation = allocator.allocateEnemySlots([goblin, boss], { apply: false });
 const goblinRows = Object.fromEntries(goblinAllocation.rows.map((row) => [row.unitId, row]));
-assert.equal(goblinRows.goblin.maxSlots, 2);
-assert.equal(goblinRows.goblin.slots, 2);
-assert.equal(goblinRows.goblin_boss.maxSlots, 3);
-assert.equal(goblinRows.goblin_boss.slots, 3);
+assert.equal(goblinRows.encounter_9_goblin_a.profileId, 'goblin');
+assert.equal(goblinRows.encounter_9_goblin_a.maxSlots, 2);
+assert.equal(goblinRows.encounter_9_goblin_a.slots, 2);
+assert.equal(goblinRows.encounter_9_goblin_boss.profileId, 'goblin_boss');
+assert.equal(goblinRows.encounter_9_goblin_boss.maxSlots, 3);
+assert.equal(goblinRows.encounter_9_goblin_boss.slots, 3);
 assert.equal(goblinAllocation.totalSlots, 5);
 
 console.log('canonical Unit Action Slot allocation smoke: ok');

--- a/tests/enemy-action-slot-canonical-units-smoke.mjs
+++ b/tests/enemy-action-slot-canonical-units-smoke.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+
+await import('../js/status-engine.js');
+await import('../js/universal-ranged-ammo-runtime.js');
+await import('../js/skill-catalog-kobold-tier1.js');
+await import('../js/unit-rank-runtime.js');
+await import('../js/unit-combat-mechanics-runtime.js');
+await import('../js/unit-catalog-kobold-tier1.js');
+await import('../js/unit-catalog-goblin.js');
+await import('../js/unit-action-economy-catalog.js');
+await import('../js/universal-action-economy.js');
+await import('../js/combat-action-schema.js');
+await import('../js/combat-action-adapters.js');
+await import('../js/individual-goap-combat-ai.js');
+await import('../js/unit-ai-kit-adapter.js');
+await import('../js/enemy-action-slot-allocator.js');
+
+const kobolds = globalThis.LuminousKoboldUnitCatalog;
+const goblins = globalThis.LuminousGoblinUnitCatalog;
+const allocator = globalThis.LuminousEnemyActionSlotAllocator;
+const economy = globalThis.LuminousActionEconomy;
+
+if (!kobolds || !goblins || !allocator || !economy) throw new Error('Canonical slot test dependencies were not initialized.');
+
+const dagger = kobolds.resolve('kobold_dagger', { level: 2, initializeEncounter: true });
+const sling = kobolds.resolve('kobold_sling', { level: 2, initializeEncounter: true });
+const winged = kobolds.resolve('winged_kobold', { level: 3, initializeEncounter: true });
+
+dagger.resolvedSpeed = 6;
+sling.resolvedSpeed = 5;
+winged.resolvedSpeed = 4;
+
+const originalDaggerSkillSlots = dagger.action_slots.slice();
+const koboldAllocation = allocator.allocateEnemySlots([dagger, sling, winged]);
+const koboldRows = Object.fromEntries(koboldAllocation.rows.map((row) => [row.unitId, row]));
+
+assert.equal(koboldAllocation.allocated, true);
+assert.equal(koboldAllocation.totalSlots, 5);
+assert.equal(koboldRows.kobold_dagger.maxSlots, 2);
+assert.equal(koboldRows.kobold_sling.maxSlots, 2);
+assert.equal(koboldRows.winged_kobold.maxSlots, 2);
+assert.equal(koboldRows.kobold_dagger.slots, 2);
+assert.equal(koboldRows.kobold_sling.slots, 2);
+assert.equal(koboldRows.winged_kobold.slots, 1);
+assert.deepEqual(dagger.action_slots, originalDaggerSkillSlots, 'legacy Skill references must not be overwritten by runtime slot allocation');
+assert.equal(dagger.actionSlots, 2);
+assert.equal(economy.actionSlotMaximum(dagger), 2);
+
+const target = { id: 'player_1' };
+const planned = allocator.allocateAndPlan([dagger, sling, winged], {
+  targets: [target],
+  speedByUnitId: { kobold_dagger: 6, kobold_sling: 5, winged_kobold: 4 },
+});
+const plans = Object.fromEntries(planned.plans.map((entry) => [entry.unitId, entry]));
+assert.equal(plans.kobold_dagger.slots, 2);
+assert.equal(plans.kobold_dagger.plan.actions.length, 2);
+assert.equal(plans.kobold_sling.slots, 2);
+assert.equal(plans.kobold_sling.plan.actions.length, 2);
+assert.equal(plans.winged_kobold.slots, 1);
+assert.equal(plans.winged_kobold.plan.actions.length, 1);
+
+// Goblins still have pending canonical weapon Skills, but slot allocation is independent
+// from kit resolution and therefore can already honor their per-Unit slot caps.
+const goblin = goblins.resolve('goblin', { level: 3, initializeEncounter: true });
+const boss = goblins.resolve('goblin_boss', { level: 5, initializeEncounter: true });
+const goblinAllocation = allocator.allocateEnemySlots([goblin, boss], {
+  speedByUnitId: { goblin: 5, goblin_boss: 4 },
+  apply: false,
+});
+const goblinRows = Object.fromEntries(goblinAllocation.rows.map((row) => [row.unitId, row]));
+assert.equal(goblinRows.goblin.maxSlots, 2);
+assert.equal(goblinRows.goblin.slots, 2);
+assert.equal(goblinRows.goblin_boss.maxSlots, 3);
+assert.equal(goblinRows.goblin_boss.slots, 3);
+assert.equal(goblinAllocation.totalSlots, 5);
+
+console.log('canonical Unit Action Slot allocation smoke: ok');

--- a/tests/individual-goap-combat-ai-real-engine-smoke.mjs
+++ b/tests/individual-goap-combat-ai-real-engine-smoke.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+// combatEngine.js is a browser/CommonJS script rather than an ESM module.
+// Give it a browser-like global and evaluate the repository file directly so this
+// smoke test exercises the real engine implementation, not a mock.
+globalThis.window = globalThis;
+globalThis.STATUS_REGISTRY = globalThis.STATUS_REGISTRY || {};
+const engineSource = readFileSync(new URL('../js/combatEngine.js', import.meta.url), 'utf8');
+vm.runInThisContext(engineSource, { filename: 'js/combatEngine.js' });
+const engine = globalThis.CombatEngine;
+if (!engine) throw new Error('CombatEngine did not initialize.');
+
+await import('../js/combat-action-schema.js');
+const schema = globalThis.LuminousCombatAction;
+await import('../js/combat-action-adapters.js');
+await import('../js/combat-action-engine-bridge.js');
+await import('../js/combat-action-queue.js');
+await import('../js/combat-action-resolver.js');
+const resolver = globalThis.LuminousCombatActionResolver;
+await import('../js/individual-goap-combat-ai.js');
+const ai = globalThis.LuminousIndividualGoapCombatAI;
+
+if (!schema || !resolver || !ai) throw new Error('Canonical combat/GOAP modules were not initialized.');
+
+const goblin = {
+  id: 'real_engine_goblin',
+  name: 'GOAP Goblin',
+  faction: 'enemy',
+  faccion: 'enemy',
+  hp: 20,
+  maxHp: 20,
+  sp: 0,
+  level: 3,
+  scores: { int: 10, wis: 9 },
+  stats: {},
+  statusEffects: {},
+  shield: 0,
+};
+const player = {
+  id: 'real_engine_player',
+  name: 'Test Player',
+  faction: 'allies',
+  faccion: 'allies',
+  hp: 40,
+  maxHp: 40,
+  sp: 0,
+  level: 3,
+  stats: {},
+  statusEffects: {},
+  shield: 0,
+  physRes: 1,
+  sinRes: 1,
+};
+
+const strike = {
+  sourceType: 'skill',
+  definition: {
+    id: 'goap_real_strike',
+    name: 'GOAP Real Strike',
+    type: 'Attack',
+    basePower: 5,
+    coinPower: 2,
+    coinAmount: 1,
+    coinType: 'positive',
+    attackWeight: 1,
+    damageType: 'slash',
+    sinAffinity: 'sinless',
+    targetingType: 'Focused Attack',
+    isDefense: false,
+    isClashable: false,
+    isUnclashable: true,
+    resourceCosts: [],
+    effects: [],
+    coins: [{ index: 0, type: 'normal', status: 'active', effects: [] }],
+  },
+  estimate: { damage: 7, damageType: 'slash' },
+};
+
+const plan = ai.planTurn({
+  actor: goblin,
+  availableSlots: 1,
+  targetIds: [player.id],
+  sources: [strike],
+});
+assert.equal(plan.planned, true);
+assert.equal(plan.goal, ai.GOALS.KILL_TARGET);
+assert.equal(plan.actions.length, 1);
+assert.equal(schema.validateCombatAction(plan.actions[0]).valid, true);
+
+const hpBefore = player.hp;
+const result = resolver.resolveCombatAction(plan.actions[0], {
+  phase: schema.PHASES.COMBAT_PHASE,
+  units: [goblin, player],
+  engine,
+});
+
+assert.equal(result.resolved, true, result.reason || 'GOAP CombatAction should resolve');
+assert.ok(player.hp < hpBefore, `Real CombatEngine should apply damage (${hpBefore} -> ${player.hp})`);
+assert.equal(result.action.actorId, goblin.id);
+assert.equal(result.action.source.id, 'goap_real_strike');
+
+console.log(`individual GOAP real CombatEngine smoke: ok (${hpBefore} -> ${player.hp} HP)`);

--- a/tests/individual-goap-combat-ai-smoke.mjs
+++ b/tests/individual-goap-combat-ai-smoke.mjs
@@ -20,13 +20,8 @@ if (!schema || !adapters || !resolver || !goblins || !ai) {
 const slash = {
   sourceType: 'skill',
   definition: {
-    id: 'test_slash',
-    name: 'Test Slash',
-    basePower: 5,
-    coinPower: 2,
-    coinAmount: 1,
-    damageType: 'slash',
-    isClashable: false,
+    id: 'test_slash', name: 'Test Slash', basePower: 5, coinPower: 2, coinAmount: 1,
+    damageType: 'slash', isClashable: false,
   },
   estimate: { damage: 8, damageType: 'slash' },
 };
@@ -34,18 +29,12 @@ const slash = {
 const fire = {
   sourceType: 'skill',
   definition: {
-    id: 'test_fire',
-    name: 'Test Fire',
-    basePower: 4,
-    coinPower: 1,
-    coinAmount: 1,
-    damageType: 'fire',
-    isClashable: false,
+    id: 'test_fire', name: 'Test Fire', basePower: 4, coinPower: 1, coinAmount: 1,
+    damageType: 'fire', isClashable: false,
   },
   estimate: { damage: 6, damageType: 'fire' },
 };
 
-// Canonical Goblin scores are consumed directly by the planner.
 const goblin = goblins.resolve('goblin', { level: 3, rank: 'normal' });
 goblin.id = 'goblin_goap';
 goblin.hp = goblin.maxHp;
@@ -58,6 +47,8 @@ const healthyPlan = ai.planTurn({
 assert.equal(healthyPlan.planned, true);
 assert.equal(healthyPlan.goal, ai.GOALS.KILL_TARGET);
 assert.equal(healthyPlan.actions.length, 2);
+assert.equal(healthyPlan.slotsUsed, 2);
+assert.equal(healthyPlan.unusedSlots, 0);
 assert.equal(healthyPlan.actions[0].phase.selectedAt, schema.PHASES.PLANNING_PHASE_AI);
 assert.equal(healthyPlan.actions[0].actorId, goblin.id);
 assert.equal(healthyPlan.actions[0].targeting.mainTargetId, 'player_1');
@@ -65,15 +56,12 @@ for (const action of healthyPlan.actions) {
   assert.equal(schema.validateCombatAction(action).valid, true, 'GOAP output must remain a canonical CombatAction');
 }
 
-// The planner is slot-bounded; it can never create more actions than the economy gives it.
 const oneSlot = ai.planTurn({ actor: goblin, availableSlots: 1, targetIds: ['player_1'], sources: [slash, fire] });
 assert.equal(oneSlot.actions.length, 1);
 assert.equal(oneSlot.slotsRequested, 1);
 
-// Target objects are identity-only to the planner. Accessing hidden combat truth must explode the test.
 const privateTargetView = {
-  id: 'player_private',
-  faction: 'allies',
+  id: 'player_private', faction: 'allies',
   get hp() { throw new Error('GOAP read private target HP'); },
   get sp() { throw new Error('GOAP read private target SP'); },
   get resistances() { throw new Error('GOAP read private target resistances'); },
@@ -84,7 +72,6 @@ const fairPlan = ai.planTurn({ actor: goblin, availableSlots: 1, targets: [priva
 assert.equal(fairPlan.planned, true);
 assert.equal(fairPlan.targetId, 'player_private');
 
-// Personal observations, not target internals, create damage-type beliefs.
 let intel = ai.createIntelState();
 intel = ai.observeDamageResult(intel, { targetId: 'player_1', damageType: 'slash', expectedDamage: 10, actualDamage: 2 });
 intel = ai.observeDamageResult(intel, { targetId: 'player_1', damageType: 'slash', expectedDamage: 10, actualDamage: 3 });
@@ -92,7 +79,6 @@ intel = ai.observeDamageResult(intel, { targetId: 'player_1', damageType: 'slash
 assert.ok(intel.targets.player_1.damageTypes.slash.multiplierEstimate < 0.4);
 assert.ok(intel.targets.player_1.damageTypes.slash.confidence > 0.5);
 
-// High INT should exploit learned resistance information; very low INT mostly trusts its obvious stronger attack.
 const lowInt = { id: 'low_int', hp: 20, maxHp: 20, scores: { int: 5, wis: 10 } };
 const highInt = { id: 'high_int', hp: 20, maxHp: 20, scores: { int: 18, wis: 10 } };
 const lowPlan = ai.planTurn({ actor: lowInt, availableSlots: 1, targetIds: ['player_1'], sources: [slash, fire], intel });
@@ -100,15 +86,46 @@ const highPlan = ai.planTurn({ actor: highInt, availableSlots: 1, targetIds: ['p
 assert.equal(lowPlan.sequence[0].sourceId, 'test_slash');
 assert.equal(highPlan.sequence[0].sourceId, 'test_fire');
 
-// High WIS + critical personal HP selects escape without consulting target HP.
+// Escape is terminal: extra allocated slots remain unused after leaving the encounter.
 const cautious = { id: 'cautious', hp: 2, maxHp: 20, scores: { int: 10, wis: 18 } };
-const escapePlan = ai.planTurn({ actor: cautious, availableSlots: 1, targets: [privateTargetView], sources: [slash, fire] });
+const escapePlan = ai.planTurn({ actor: cautious, availableSlots: 3, targets: [privateTargetView], sources: [slash, fire] });
 assert.equal(escapePlan.goal, ai.GOALS.ESCAPE);
 assert.equal(escapePlan.sequence[0].sourceId, 'escape');
+assert.equal(escapePlan.actions.length, 1);
+assert.equal(escapePlan.slotsUsed, 1);
+assert.equal(escapePlan.unusedSlots, 2);
 assert.equal(escapePlan.actions[0].phase.executesAt, schema.PHASES.ON_TURN_END);
 assert.equal(escapePlan.actions[0].effects[0].deniesXp, true);
 
-// End-to-end: the action chosen by GOAP reaches the canonical resolver and then CombatEngine.
+// Resources are budgeted across the whole planned turn, not validated independently per slot.
+const onePebbleShot = {
+  sourceType: 'skill',
+  definition: {
+    id: 'one_pebble_shot', name: 'One Pebble Shot', type: 'Attack', basePower: 6, coinPower: 2, coinAmount: 1,
+    damageType: 'blunt', isClashable: false,
+    resourceCosts: [{ type: 'ammunition', id: 'pebbles', amount: 1 }],
+  },
+  estimate: { damage: 9, damageType: 'blunt' },
+  metadata: {
+    resourceChecks: [{
+      known: true,
+      resource: { type: 'ammunition', id: 'pebbles', amount: 1 },
+      detail: { available: true, current: 1, required: 1 },
+    }],
+  },
+};
+const resourcePlan = ai.planTurn({
+  actor: { id: 'ammo_ai', hp: 20, maxHp: 20, scores: { int: 12, wis: 10 } },
+  availableSlots: 2,
+  targetIds: ['player_1'],
+  sources: [onePebbleShot],
+  allowEscape: false,
+});
+assert.equal(resourcePlan.actions.length, 1);
+assert.equal(resourcePlan.sequence[0].sourceId, 'one_pebble_shot');
+assert.equal(resourcePlan.unusedSlots, 1);
+assert.equal(resourcePlan.resourceSpent['ammunition:pebbles'], 1);
+
 let attackCalls = 0;
 const engine = {
   calculateFinalPower(skill, heads) { return Number(skill.basePower || 0) + Number(heads || 0); },
@@ -130,7 +147,6 @@ assert.equal(engineResult.resolved, true);
 assert.equal(attackCalls, 1);
 assert.equal(realPlayer.hp, 17);
 
-// Escape also travels through the canonical resolver, using the existing structural effect hook.
 let escaped = false;
 const escapeResult = resolver.resolveCombatAction(escapePlan.actions[0], {
   phase: schema.PHASES.ON_TURN_END,

--- a/tests/individual-goap-combat-ai-smoke.mjs
+++ b/tests/individual-goap-combat-ai-smoke.mjs
@@ -1,0 +1,149 @@
+import assert from 'node:assert/strict';
+
+await import('../js/combat-action-schema.js');
+const schema = globalThis.LuminousCombatAction;
+await import('../js/combat-action-adapters.js');
+const adapters = globalThis.LuminousCombatActionAdapters;
+await import('../js/combat-action-engine-bridge.js');
+await import('../js/combat-action-queue.js');
+await import('../js/combat-action-resolver.js');
+const resolver = globalThis.LuminousCombatActionResolver;
+await import('../js/unit-catalog-goblin.js');
+const goblins = globalThis.LuminousGoblinUnitCatalog;
+await import('../js/individual-goap-combat-ai.js');
+const ai = globalThis.LuminousIndividualGoapCombatAI;
+
+if (!schema || !adapters || !resolver || !goblins || !ai) {
+  throw new Error('Individual GOAP combat test dependencies were not initialized.');
+}
+
+const slash = {
+  sourceType: 'skill',
+  definition: {
+    id: 'test_slash',
+    name: 'Test Slash',
+    basePower: 5,
+    coinPower: 2,
+    coinAmount: 1,
+    damageType: 'slash',
+    isClashable: false,
+  },
+  estimate: { damage: 8, damageType: 'slash' },
+};
+
+const fire = {
+  sourceType: 'skill',
+  definition: {
+    id: 'test_fire',
+    name: 'Test Fire',
+    basePower: 4,
+    coinPower: 1,
+    coinAmount: 1,
+    damageType: 'fire',
+    isClashable: false,
+  },
+  estimate: { damage: 6, damageType: 'fire' },
+};
+
+// Canonical Goblin scores are consumed directly by the planner.
+const goblin = goblins.resolve('goblin', { level: 3, rank: 'normal' });
+goblin.id = 'goblin_goap';
+goblin.hp = goblin.maxHp;
+const healthyPlan = ai.planTurn({
+  actor: goblin,
+  availableSlots: 2,
+  targets: [{ id: 'player_1', faction: 'allies' }],
+  sources: [slash, fire],
+});
+assert.equal(healthyPlan.planned, true);
+assert.equal(healthyPlan.goal, ai.GOALS.KILL_TARGET);
+assert.equal(healthyPlan.actions.length, 2);
+assert.equal(healthyPlan.actions[0].phase.selectedAt, schema.PHASES.PLANNING_PHASE_AI);
+assert.equal(healthyPlan.actions[0].actorId, goblin.id);
+assert.equal(healthyPlan.actions[0].targeting.mainTargetId, 'player_1');
+for (const action of healthyPlan.actions) {
+  assert.equal(schema.validateCombatAction(action).valid, true, 'GOAP output must remain a canonical CombatAction');
+}
+
+// The planner is slot-bounded; it can never create more actions than the economy gives it.
+const oneSlot = ai.planTurn({ actor: goblin, availableSlots: 1, targetIds: ['player_1'], sources: [slash, fire] });
+assert.equal(oneSlot.actions.length, 1);
+assert.equal(oneSlot.slotsRequested, 1);
+
+// Target objects are identity-only to the planner. Accessing hidden combat truth must explode the test.
+const privateTargetView = {
+  id: 'player_private',
+  faction: 'allies',
+  get hp() { throw new Error('GOAP read private target HP'); },
+  get sp() { throw new Error('GOAP read private target SP'); },
+  get resistances() { throw new Error('GOAP read private target resistances'); },
+  get skills() { throw new Error('GOAP read private target skills'); },
+  get plannedActions() { throw new Error('GOAP read future player actions'); },
+};
+const fairPlan = ai.planTurn({ actor: goblin, availableSlots: 1, targets: [privateTargetView], sources: [slash] });
+assert.equal(fairPlan.planned, true);
+assert.equal(fairPlan.targetId, 'player_private');
+
+// Personal observations, not target internals, create damage-type beliefs.
+let intel = ai.createIntelState();
+intel = ai.observeDamageResult(intel, { targetId: 'player_1', damageType: 'slash', expectedDamage: 10, actualDamage: 2 });
+intel = ai.observeDamageResult(intel, { targetId: 'player_1', damageType: 'slash', expectedDamage: 10, actualDamage: 3 });
+intel = ai.observeDamageResult(intel, { targetId: 'player_1', damageType: 'slash', expectedDamage: 10, actualDamage: 2 });
+assert.ok(intel.targets.player_1.damageTypes.slash.multiplierEstimate < 0.4);
+assert.ok(intel.targets.player_1.damageTypes.slash.confidence > 0.5);
+
+// High INT should exploit learned resistance information; very low INT mostly trusts its obvious stronger attack.
+const lowInt = { id: 'low_int', hp: 20, maxHp: 20, scores: { int: 5, wis: 10 } };
+const highInt = { id: 'high_int', hp: 20, maxHp: 20, scores: { int: 18, wis: 10 } };
+const lowPlan = ai.planTurn({ actor: lowInt, availableSlots: 1, targetIds: ['player_1'], sources: [slash, fire], intel });
+const highPlan = ai.planTurn({ actor: highInt, availableSlots: 1, targetIds: ['player_1'], sources: [slash, fire], intel });
+assert.equal(lowPlan.sequence[0].sourceId, 'test_slash');
+assert.equal(highPlan.sequence[0].sourceId, 'test_fire');
+
+// High WIS + critical personal HP selects escape without consulting target HP.
+const cautious = { id: 'cautious', hp: 2, maxHp: 20, scores: { int: 10, wis: 18 } };
+const escapePlan = ai.planTurn({ actor: cautious, availableSlots: 1, targets: [privateTargetView], sources: [slash, fire] });
+assert.equal(escapePlan.goal, ai.GOALS.ESCAPE);
+assert.equal(escapePlan.sequence[0].sourceId, 'escape');
+assert.equal(escapePlan.actions[0].phase.executesAt, schema.PHASES.ON_TURN_END);
+assert.equal(escapePlan.actions[0].effects[0].deniesXp, true);
+
+// End-to-end: the action chosen by GOAP reaches the canonical resolver and then CombatEngine.
+let attackCalls = 0;
+const engine = {
+  calculateFinalPower(skill, heads) { return Number(skill.basePower || 0) + Number(heads || 0); },
+  resolveUnilateralWithCounter(attacker, skill, defender) {
+    attackCalls += 1;
+    defender.hp -= 3;
+    return { damageTaken: 3, skillId: skill.id, attackerId: attacker.id, defenderId: defender.id };
+  },
+};
+const realPlayer = { id: 'player_1', faction: 'allies', hp: 20, maxHp: 20, sp: 0 };
+const engineGoblin = { ...goblin, faction: 'enemy', hp: goblin.maxHp };
+const enginePlan = ai.planTurn({ actor: engineGoblin, availableSlots: 1, targetIds: ['player_1'], sources: [slash] });
+const engineResult = resolver.resolveCombatAction(enginePlan.actions[0], {
+  phase: schema.PHASES.COMBAT_PHASE,
+  units: [engineGoblin, realPlayer],
+  engine,
+});
+assert.equal(engineResult.resolved, true);
+assert.equal(attackCalls, 1);
+assert.equal(realPlayer.hp, 17);
+
+// Escape also travels through the canonical resolver, using the existing structural effect hook.
+let escaped = false;
+const escapeResult = resolver.resolveCombatAction(escapePlan.actions[0], {
+  phase: schema.PHASES.ON_TURN_END,
+  units: [cautious, realPlayer],
+  engine,
+  effectHandlers: {
+    escape: ({ actor, effect }) => {
+      escaped = effect.leavesEncounter === true && actor.id === 'cautious';
+      return { escaped };
+    },
+  },
+});
+assert.equal(escapeResult.resolved, true);
+assert.equal(escaped, true);
+
+console.log('individual GOAP combat AI smoke: ok');

--- a/tests/individual-goap-combat-engine-harness.html
+++ b/tests/individual-goap-combat-engine-harness.html
@@ -1,0 +1,217 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Individual GOAP × CombatEngine Harness</title>
+  <style>
+    :root { color-scheme: dark; font-family: Inter, system-ui, sans-serif; }
+    body { margin: 0; background: #111318; color: #e8eaf0; }
+    main { max-width: 980px; margin: 0 auto; padding: 24px; }
+    h1 { margin: 0 0 8px; font-size: 24px; }
+    p { color: #aeb5c4; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit,minmax(180px,1fr)); gap: 12px; margin: 18px 0; }
+    label, .card { background: #1a1e26; border: 1px solid #303744; border-radius: 10px; padding: 12px; }
+    label { display: grid; gap: 7px; font-size: 13px; color: #bfc6d4; }
+    input { width: 100%; box-sizing: border-box; background: #0f1116; color: #fff; border: 1px solid #3b4352; border-radius: 7px; padding: 8px; }
+    .buttons { display: flex; flex-wrap: wrap; gap: 10px; margin: 14px 0 20px; }
+    button { border: 0; border-radius: 8px; padding: 10px 14px; font-weight: 700; cursor: pointer; }
+    pre { white-space: pre-wrap; overflow-wrap: anywhere; background: #0b0d11; border: 1px solid #2a303b; border-radius: 10px; padding: 14px; min-height: 220px; }
+    .status { display:flex; gap:20px; flex-wrap:wrap; margin: 12px 0; }
+    .status strong { display:block; font-size:22px; }
+    code { color:#d9e2ff; }
+  </style>
+</head>
+<body>
+<main>
+  <h1>Individual GOAP × CombatEngine</h1>
+  <p>This page exercises the new Individual GOAP planner, compiles its choice into canonical CombatAction, then resolves it through the repository CombatAction resolver and the real <code>CombatEngine</code>.</p>
+
+  <div class="grid">
+    <label>INT <input id="int" type="number" min="1" max="30" value="10"></label>
+    <label>WIS <input id="wis" type="number" min="1" max="30" value="9"></label>
+    <label>Goblin HP <input id="hp" type="number" min="0" max="20" value="20"></label>
+    <label>Action Slots <input id="slots" type="number" min="1" max="6" value="2"></label>
+    <label>Observed Slash Multiplier <input id="slashMult" type="number" min="0.1" max="2.5" step="0.1" value="1"></label>
+    <label>Intel Confidence <input id="confidence" type="number" min="0" max="1" step="0.05" value="0"></label>
+  </div>
+
+  <div class="status">
+    <div class="card">Player HP<strong id="playerHp">40</strong></div>
+    <div class="card">Goal<strong id="goal">—</strong></div>
+    <div class="card">Choice<strong id="choice">—</strong></div>
+  </div>
+
+  <div class="buttons">
+    <button id="plan">Plan AI Turn</button>
+    <button id="execute">Execute First CombatAction</button>
+    <button id="observe">Teach: Slash Was Resisted</button>
+    <button id="reset">Reset</button>
+  </div>
+
+  <pre id="log">Ready.</pre>
+</main>
+
+<script src="../js/combatEngine.js"></script>
+<script src="../js/combat-action-schema.js"></script>
+<script src="../js/combat-action-adapters.js"></script>
+<script src="../js/combat-action-engine-bridge.js"></script>
+<script src="../js/combat-action-queue.js"></script>
+<script src="../js/combat-action-resolver.js"></script>
+<script src="../js/individual-goap-combat-ai.js"></script>
+<script>
+(() => {
+  'use strict';
+
+  const schema = window.LuminousCombatAction;
+  const resolver = window.LuminousCombatActionResolver;
+  const ai = window.LuminousIndividualGoapCombatAI;
+  const engine = window.CombatEngine;
+  const $ = (id) => document.getElementById(id);
+
+  if (!schema || !resolver || !ai || !engine) {
+    $('log').textContent = 'Initialization failed: missing CombatEngine / CombatAction / GOAP module.';
+    return;
+  }
+
+  const strike = {
+    sourceType: 'skill',
+    definition: {
+      id: 'goap_slash', name: 'Slash', type: 'Attack',
+      basePower: 5, coinPower: 2, coinAmount: 1, coinType: 'positive',
+      attackWeight: 1, damageType: 'slash', sinAffinity: 'sinless',
+      targetingType: 'Focused Attack', isDefense: false,
+      isClashable: false, isUnclashable: true,
+      resourceCosts: [], effects: [],
+      coins: [{ index: 0, type: 'normal', status: 'active', effects: [] }]
+    },
+    estimate: { damage: 8, damageType: 'slash' }
+  };
+
+  const fire = {
+    sourceType: 'skill',
+    definition: {
+      id: 'goap_fire', name: 'Fire Attack', type: 'Attack',
+      basePower: 4, coinPower: 2, coinAmount: 1, coinType: 'positive',
+      attackWeight: 1, damageType: 'fire', sinAffinity: 'sinless',
+      targetingType: 'Focused Attack', isDefense: false,
+      isClashable: false, isUnclashable: true,
+      resourceCosts: [], effects: [],
+      coins: [{ index: 0, type: 'normal', status: 'active', effects: [] }]
+    },
+    estimate: { damage: 6, damageType: 'fire' }
+  };
+
+  let player;
+  let goblin;
+  let intel;
+  let plan;
+
+  function resetUnits() {
+    goblin = {
+      id: 'goap_goblin', name: 'GOAP Goblin', faction: 'enemy', faccion: 'enemy',
+      hp: Number($('hp').value || 20), maxHp: 20, sp: 0, level: 3,
+      scores: { int: Number($('int').value || 10), wis: Number($('wis').value || 9) },
+      stats: {}, statusEffects: {}, shield: 0
+    };
+    player = {
+      id: 'player_1', name: 'Player', faction: 'allies', faccion: 'allies',
+      hp: 40, maxHp: 40, sp: 0, level: 3,
+      stats: {}, statusEffects: {}, shield: 0, physRes: 1, sinRes: 1
+    };
+    intel = ai.createIntelState();
+    plan = null;
+    syncStatus();
+  }
+
+  function syncActorInputs() {
+    goblin.hp = Math.max(0, Math.min(20, Number($('hp').value || 0)));
+    goblin.scores.int = Number($('int').value || 10);
+    goblin.scores.wis = Number($('wis').value || 10);
+  }
+
+  function intelFromControls() {
+    const multiplier = Number($('slashMult').value || 1);
+    const confidence = Number($('confidence').value || 0);
+    if (confidence <= 0) return intel;
+    return ai.createIntelState({
+      targets: {
+        player_1: {
+          observations: 3,
+          damageTypes: {
+            slash: { multiplierEstimate: multiplier, confidence, samples: 3 }
+          }
+        }
+      }
+    });
+  }
+
+  function syncStatus() {
+    $('playerHp').textContent = player ? player.hp : '—';
+    $('goal').textContent = plan?.goal || '—';
+    $('choice').textContent = plan?.sequence?.[0]?.sourceId || '—';
+  }
+
+  function show(value) {
+    $('log').textContent = JSON.stringify(value, null, 2);
+    syncStatus();
+  }
+
+  $('plan').addEventListener('click', () => {
+    syncActorInputs();
+    const controlledIntel = intelFromControls();
+    plan = ai.planTurn({
+      actor: goblin,
+      availableSlots: Number($('slots').value || 1),
+      targetIds: [player.id],
+      sources: [strike, fire],
+      intel: controlledIntel
+    });
+    show(plan);
+  });
+
+  $('execute').addEventListener('click', () => {
+    if (!plan?.actions?.length) $('plan').click();
+    if (!plan?.actions?.length) return;
+    const action = plan.actions[0];
+    const phase = action.phase.executesAt;
+    const result = resolver.resolveCombatAction(action, {
+      phase,
+      units: [goblin, player],
+      engine,
+      effectHandlers: {
+        escape: ({ actor, effect }) => ({ escaped: actor.id === goblin.id && effect.leavesEncounter === true })
+      }
+    });
+    show({ plan: { goal: plan.goal, sequence: plan.sequence }, result, playerHp: player.hp });
+  });
+
+  $('observe').addEventListener('click', () => {
+    intel = ai.observeDamageResult(intel, {
+      targetId: player.id,
+      damageType: 'slash',
+      expectedDamage: 10,
+      actualDamage: 2
+    });
+    const belief = intel.targets[player.id].damageTypes.slash;
+    $('slashMult').value = belief.multiplierEstimate.toFixed(2);
+    $('confidence').value = belief.confidence.toFixed(2);
+    show(intel);
+  });
+
+  $('reset').addEventListener('click', () => {
+    $('int').value = 10;
+    $('wis').value = 9;
+    $('hp').value = 20;
+    $('slots').value = 2;
+    $('slashMult').value = 1;
+    $('confidence').value = 0;
+    resetUnits();
+    $('log').textContent = 'Reset complete.';
+  });
+
+  resetUnits();
+})();
+</script>
+</body>
+</html>

--- a/tests/individual-goap-combat-engine-harness.html
+++ b/tests/individual-goap-combat-engine-harness.html
@@ -25,7 +25,7 @@
 <body>
 <main>
   <h1>Individual GOAP × Canonical Units × CombatEngine</h1>
-  <p>The planner now reads the selected Unit's real canonical kit. No manual <code>sources[]</code> is created in this harness. Kobold ammunition is preflighted before GOAP planning; Goblin exposes its currently pending canonical weapon definitions instead of fabricating attacks.</p>
+  <p>The planner reads the selected Unit's real canonical kit. No manual <code>sources[]</code> is created here. Kobold ammunition is preflighted before planning; Goblin exposes pending canonical weapon definitions instead of fabricated attacks. Defensive actions are planned but are not resolved standalone by this harness because they require queue/opposing-action context.</p>
 
   <div class="grid">
     <label>Canonical Unit
@@ -223,6 +223,19 @@
     }
 
     const action = plan.actions[0];
+    const definition = action.metadata?.sourceDefinition || {};
+    if (definition.isDefense === true || String(definition.type || '').toLowerCase() === 'defense') {
+      show({
+        planned: true,
+        selectedSource: plan.sequence[0]?.sourceId,
+        executionSkipped: true,
+        reason: 'defense_requires_queue_or_opposing_action_context',
+        note: 'This harness intentionally does not feed a defense into unilateral resolution.',
+        kit: kitSummary(kit),
+      });
+      return;
+    }
+
     const before = player.hp;
     const result = resolver.resolveCombatAction(action, {
       phase: action.phase.executesAt,

--- a/tests/individual-goap-combat-engine-harness.html
+++ b/tests/individual-goap-combat-engine-harness.html
@@ -3,55 +3,72 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Individual GOAP × CombatEngine Harness</title>
+  <title>Individual GOAP × Canonical Units × CombatEngine</title>
   <style>
     :root { color-scheme: dark; font-family: Inter, system-ui, sans-serif; }
     body { margin: 0; background: #111318; color: #e8eaf0; }
-    main { max-width: 980px; margin: 0 auto; padding: 24px; }
+    main { max-width: 1080px; margin: 0 auto; padding: 24px; }
     h1 { margin: 0 0 8px; font-size: 24px; }
     p { color: #aeb5c4; }
     .grid { display: grid; grid-template-columns: repeat(auto-fit,minmax(180px,1fr)); gap: 12px; margin: 18px 0; }
     label, .card { background: #1a1e26; border: 1px solid #303744; border-radius: 10px; padding: 12px; }
     label { display: grid; gap: 7px; font-size: 13px; color: #bfc6d4; }
-    input { width: 100%; box-sizing: border-box; background: #0f1116; color: #fff; border: 1px solid #3b4352; border-radius: 7px; padding: 8px; }
+    input, select { width: 100%; box-sizing: border-box; background: #0f1116; color: #fff; border: 1px solid #3b4352; border-radius: 7px; padding: 8px; }
     .buttons { display: flex; flex-wrap: wrap; gap: 10px; margin: 14px 0 20px; }
     button { border: 0; border-radius: 8px; padding: 10px 14px; font-weight: 700; cursor: pointer; }
-    pre { white-space: pre-wrap; overflow-wrap: anywhere; background: #0b0d11; border: 1px solid #2a303b; border-radius: 10px; padding: 14px; min-height: 220px; }
-    .status { display:flex; gap:20px; flex-wrap:wrap; margin: 12px 0; }
-    .status strong { display:block; font-size:22px; }
+    pre { white-space: pre-wrap; overflow-wrap: anywhere; background: #0b0d11; border: 1px solid #2a303b; border-radius: 10px; padding: 14px; min-height: 260px; }
+    .status { display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr)); gap:12px; margin: 12px 0; }
+    .status strong { display:block; font-size:20px; margin-top:4px; }
     code { color:#d9e2ff; }
   </style>
 </head>
 <body>
 <main>
-  <h1>Individual GOAP × CombatEngine</h1>
-  <p>This page exercises the new Individual GOAP planner, compiles its choice into canonical CombatAction, then resolves it through the repository CombatAction resolver and the real <code>CombatEngine</code>.</p>
+  <h1>Individual GOAP × Canonical Units × CombatEngine</h1>
+  <p>The planner now reads the selected Unit's real canonical kit. No manual <code>sources[]</code> is created in this harness. Kobold ammunition is preflighted before GOAP planning; Goblin exposes its currently pending canonical weapon definitions instead of fabricating attacks.</p>
 
   <div class="grid">
-    <label>INT <input id="int" type="number" min="1" max="30" value="10"></label>
-    <label>WIS <input id="wis" type="number" min="1" max="30" value="9"></label>
-    <label>Goblin HP <input id="hp" type="number" min="0" max="20" value="20"></label>
+    <label>Canonical Unit
+      <select id="unit">
+        <option value="kobold_dagger">Kobold Dagger</option>
+        <option value="kobold_sling">Kobold Sling</option>
+        <option value="goblin">Goblin (weapon Skills pending)</option>
+      </select>
+    </label>
+    <label>INT override <input id="int" type="number" min="1" max="30" value="8"></label>
+    <label>WIS override <input id="wis" type="number" min="1" max="30" value="7"></label>
+    <label>Unit HP % <input id="hpPct" type="number" min="1" max="100" value="100"></label>
     <label>Action Slots <input id="slots" type="number" min="1" max="6" value="2"></label>
-    <label>Observed Slash Multiplier <input id="slashMult" type="number" min="0.1" max="2.5" step="0.1" value="1"></label>
-    <label>Intel Confidence <input id="confidence" type="number" min="0" max="1" step="0.05" value="0"></label>
+    <label>Pebbles <input id="ammo" type="number" min="0" max="20" value="20"></label>
   </div>
 
   <div class="status">
-    <div class="card">Player HP<strong id="playerHp">40</strong></div>
+    <div class="card">Player HP<strong id="playerHp">80</strong></div>
     <div class="card">Goal<strong id="goal">—</strong></div>
     <div class="card">Choice<strong id="choice">—</strong></div>
+    <div class="card">Usable Kit<strong id="kitCount">—</strong></div>
+    <div class="card">Unavailable<strong id="unavailable">—</strong></div>
+    <div class="card">Unresolved<strong id="unresolved">—</strong></div>
   </div>
 
   <div class="buttons">
+    <button id="rebuild">Rebuild Canonical Unit</button>
+    <button id="inspect">Inspect AI Kit</button>
     <button id="plan">Plan AI Turn</button>
     <button id="execute">Execute First CombatAction</button>
-    <button id="observe">Teach: Slash Was Resisted</button>
-    <button id="reset">Reset</button>
+    <button id="resetPlayer">Reset Player HP</button>
   </div>
 
   <pre id="log">Ready.</pre>
 </main>
 
+<script src="../js/status-engine.js"></script>
+<script src="../js/universal-ranged-ammo-runtime.js"></script>
+<script src="../js/unit-rank-runtime.js"></script>
+<script src="../js/skill-catalog-kobold-tier1.js"></script>
+<script src="../js/unit-combat-mechanics-runtime.js"></script>
+<script src="../js/unit-catalog-kobold-tier1.js"></script>
+<script src="../js/unit-catalog-goblin.js"></script>
 <script src="../js/combatEngine.js"></script>
 <script src="../js/combat-action-schema.js"></script>
 <script src="../js/combat-action-adapters.js"></script>
@@ -59,97 +76,96 @@
 <script src="../js/combat-action-queue.js"></script>
 <script src="../js/combat-action-resolver.js"></script>
 <script src="../js/individual-goap-combat-ai.js"></script>
+<script src="../js/unit-ai-kit-adapter.js"></script>
 <script>
 (() => {
   'use strict';
 
-  const schema = window.LuminousCombatAction;
   const resolver = window.LuminousCombatActionResolver;
   const ai = window.LuminousIndividualGoapCombatAI;
+  const kitAdapter = window.LuminousUnitAiKitAdapter;
+  const kobolds = window.LuminousKoboldUnitCatalog;
+  const goblins = window.LuminousGoblinUnitCatalog;
+  const ammoRuntime = window.LuminousUniversalRangedAmmoRuntime;
   const engine = window.CombatEngine;
   const $ = (id) => document.getElementById(id);
 
-  if (!schema || !resolver || !ai || !engine) {
-    $('log').textContent = 'Initialization failed: missing CombatEngine / CombatAction / GOAP module.';
+  if (!resolver || !ai || !kitAdapter || !kobolds || !goblins || !ammoRuntime || !engine) {
+    $('log').textContent = 'Initialization failed: missing canonical Unit / CombatEngine / CombatAction / GOAP module.';
     return;
   }
 
-  const strike = {
-    sourceType: 'skill',
-    definition: {
-      id: 'goap_slash', name: 'Slash', type: 'Attack',
-      basePower: 5, coinPower: 2, coinAmount: 1, coinType: 'positive',
-      attackWeight: 1, damageType: 'slash', sinAffinity: 'sinless',
-      targetingType: 'Focused Attack', isDefense: false,
-      isClashable: false, isUnclashable: true,
-      resourceCosts: [], effects: [],
-      coins: [{ index: 0, type: 'normal', status: 'active', effects: [] }]
-    },
-    estimate: { damage: 8, damageType: 'slash' }
-  };
+  let actor = null;
+  let player = null;
+  let kit = null;
+  let plan = null;
 
-  const fire = {
-    sourceType: 'skill',
-    definition: {
-      id: 'goap_fire', name: 'Fire Attack', type: 'Attack',
-      basePower: 4, coinPower: 2, coinAmount: 1, coinType: 'positive',
-      attackWeight: 1, damageType: 'fire', sinAffinity: 'sinless',
-      targetingType: 'Focused Attack', isDefense: false,
-      isClashable: false, isUnclashable: true,
-      resourceCosts: [], effects: [],
-      coins: [{ index: 0, type: 'normal', status: 'active', effects: [] }]
-    },
-    estimate: { damage: 6, damageType: 'fire' }
-  };
-
-  let player;
-  let goblin;
-  let intel;
-  let plan;
-
-  function resetUnits() {
-    goblin = {
-      id: 'goap_goblin', name: 'GOAP Goblin', faction: 'enemy', faccion: 'enemy',
-      hp: Number($('hp').value || 20), maxHp: 20, sp: 0, level: 3,
-      scores: { int: Number($('int').value || 10), wis: Number($('wis').value || 9) },
-      stats: {}, statusEffects: {}, shield: 0
-    };
-    player = {
+  function makePlayer() {
+    return {
       id: 'player_1', name: 'Player', faction: 'allies', faccion: 'allies',
-      hp: 40, maxHp: 40, sp: 0, level: 3,
-      stats: {}, statusEffects: {}, shield: 0, physRes: 1, sinRes: 1
+      hp: 80, maxHp: 80, sp: 0, level: 2, stats: {}, statusEffects: {},
+      shield: 0, physRes: 1, sinRes: 1,
     };
-    intel = ai.createIntelState();
+  }
+
+  function selectedCatalog() {
+    return $('unit').value === 'goblin' ? goblins : kobolds;
+  }
+
+  function defaultScoresFor(unitId) {
+    return unitId === 'goblin' ? { int: 10, wis: 9 } : { int: 8, wis: 7 };
+  }
+
+  function rebuildActor(resetInputs = false) {
+    const unitId = $('unit').value;
+    const catalog = selectedCatalog();
+    actor = catalog.resolve(unitId, { level: unitId === 'goblin' ? 3 : 2, initializeEncounter: true });
+    actor.id = `goap_${unitId}`;
+    actor.faction = 'enemy';
+    actor.faccion = 'enemy';
+    actor.sp = Number(actor.sp || 0);
+    actor.level = actor.effectiveLevel || actor.runtimeLevel || actor.level || 2;
+    actor.statusEffects = actor.statusEffects || {};
+    actor.stats = actor.stats || {};
+    actor.physRes = actor.physRes || 1;
+    actor.sinRes = actor.sinRes || 1;
+
+    const defaults = defaultScoresFor(unitId);
+    if (resetInputs) {
+      $('int').value = defaults.int;
+      $('wis').value = defaults.wis;
+      $('hpPct').value = 100;
+      $('slots').value = 2;
+      $('ammo').value = unitId === 'kobold_sling' ? 20 : 0;
+    }
+
+    actor.scores = { ...(actor.scores || {}), int: Number($('int').value || defaults.int), wis: Number($('wis').value || defaults.wis) };
+    const ratio = Math.max(0.01, Math.min(1, Number($('hpPct').value || 100) / 100));
+    actor.hp = Math.max(1, Math.round(Number(actor.maxHp || actor.hp || 1) * ratio));
+    if (unitId === 'kobold_sling') ammoRuntime.setAmmo(actor, 'pebbles', Number($('ammo').value || 0));
+
+    kit = kitAdapter.buildKit(actor);
     plan = null;
     syncStatus();
+    return actor;
   }
 
-  function syncActorInputs() {
-    goblin.hp = Math.max(0, Math.min(20, Number($('hp').value || 0)));
-    goblin.scores.int = Number($('int').value || 10);
-    goblin.scores.wis = Number($('wis').value || 10);
-  }
-
-  function intelFromControls() {
-    const multiplier = Number($('slashMult').value || 1);
-    const confidence = Number($('confidence').value || 0);
-    if (confidence <= 0) return intel;
-    return ai.createIntelState({
-      targets: {
-        player_1: {
-          observations: 3,
-          damageTypes: {
-            slash: { multiplierEstimate: multiplier, confidence, samples: 3 }
-          }
-        }
-      }
-    });
+  function syncActorControls() {
+    if (!actor || !actor.id.includes($('unit').value)) rebuildActor();
+    const defaults = defaultScoresFor($('unit').value);
+    actor.scores = { ...(actor.scores || {}), int: Number($('int').value || defaults.int), wis: Number($('wis').value || defaults.wis) };
+    const ratio = Math.max(0.01, Math.min(1, Number($('hpPct').value || 100) / 100));
+    actor.hp = Math.max(1, Math.round(Number(actor.maxHp || actor.hp || 1) * ratio));
+    if ($('unit').value === 'kobold_sling') ammoRuntime.setAmmo(actor, 'pebbles', Number($('ammo').value || 0));
   }
 
   function syncStatus() {
-    $('playerHp').textContent = player ? player.hp : '—';
+    $('playerHp').textContent = player?.hp ?? '—';
     $('goal').textContent = plan?.goal || '—';
     $('choice').textContent = plan?.sequence?.[0]?.sourceId || '—';
+    $('kitCount').textContent = kit?.counts?.usable ?? '—';
+    $('unavailable').textContent = kit?.counts?.unavailable ?? '—';
+    $('unresolved').textContent = kit?.counts?.unresolved ?? '—';
   }
 
   function show(value) {
@@ -157,60 +173,85 @@
     syncStatus();
   }
 
+  function kitSummary(currentKit) {
+    return {
+      actorId: currentKit.actorId,
+      usable: currentKit.sources.map((source) => source.definition.id),
+      unavailable: currentKit.unavailable,
+      unresolved: currentKit.unresolved,
+      counts: currentKit.counts,
+      ammo: $('unit').value === 'kobold_sling' ? ammoRuntime.ammoCount(actor, 'pebbles') : null,
+    };
+  }
+
+  $('unit').addEventListener('change', () => rebuildActor(true));
+  $('rebuild').addEventListener('click', () => {
+    rebuildActor(false);
+    show({ actor: { id: actor.id, name: actor.name, hp: actor.hp, maxHp: actor.maxHp, scores: actor.scores }, kit: kitSummary(kit) });
+  });
+
+  $('inspect').addEventListener('click', () => {
+    syncActorControls();
+    kit = kitAdapter.buildKit(actor);
+    show(kitSummary(kit));
+  });
+
   $('plan').addEventListener('click', () => {
-    syncActorInputs();
-    const controlledIntel = intelFromControls();
-    plan = ai.planTurn({
-      actor: goblin,
+    syncActorControls();
+    plan = kitAdapter.planUnitTurn({
+      actor,
+      targets: [player],
       availableSlots: Number($('slots').value || 1),
-      targetIds: [player.id],
-      sources: [strike, fire],
-      intel: controlledIntel
+      intel: ai.createIntelState(),
     });
-    show(plan);
+    kit = plan.kit || kitAdapter.buildKit(actor);
+    show({
+      planned: plan.planned,
+      reason: plan.reason || null,
+      goal: plan.goal || null,
+      sequence: plan.sequence || [],
+      combatActions: plan.actions || [],
+      kit: kitSummary(kit),
+    });
   });
 
   $('execute').addEventListener('click', () => {
     if (!plan?.actions?.length) $('plan').click();
-    if (!plan?.actions?.length) return;
+    if (!plan?.actions?.length) {
+      show({ planned: plan?.planned || false, reason: plan?.reason || 'no_action_to_execute', kit: kitSummary(kit) });
+      return;
+    }
+
     const action = plan.actions[0];
-    const phase = action.phase.executesAt;
+    const before = player.hp;
     const result = resolver.resolveCombatAction(action, {
-      phase,
-      units: [goblin, player],
+      phase: action.phase.executesAt,
+      units: [actor, player],
       engine,
+      resourceHandlers: { ammunition: ammoRuntime.ammunitionHandler() },
       effectHandlers: {
-        escape: ({ actor, effect }) => ({ escaped: actor.id === goblin.id && effect.leavesEncounter === true })
-      }
+        escape: ({ actor: escapingActor, effect }) => ({ escaped: escapingActor.id === actor.id && effect.leavesEncounter === true }),
+      },
     });
-    show({ plan: { goal: plan.goal, sequence: plan.sequence }, result, playerHp: player.hp });
-  });
-
-  $('observe').addEventListener('click', () => {
-    intel = ai.observeDamageResult(intel, {
-      targetId: player.id,
-      damageType: 'slash',
-      expectedDamage: 10,
-      actualDamage: 2
+    show({
+      selectedUnit: actor.name,
+      selectedSource: plan.sequence[0]?.sourceId,
+      playerHpBefore: before,
+      playerHpAfter: player.hp,
+      result,
+      kit: kitSummary(kitAdapter.buildKit(actor)),
     });
-    const belief = intel.targets[player.id].damageTypes.slash;
-    $('slashMult').value = belief.multiplierEstimate.toFixed(2);
-    $('confidence').value = belief.confidence.toFixed(2);
-    show(intel);
   });
 
-  $('reset').addEventListener('click', () => {
-    $('int').value = 10;
-    $('wis').value = 9;
-    $('hp').value = 20;
-    $('slots').value = 2;
-    $('slashMult').value = 1;
-    $('confidence').value = 0;
-    resetUnits();
-    $('log').textContent = 'Reset complete.';
+  $('resetPlayer').addEventListener('click', () => {
+    player = makePlayer();
+    syncStatus();
+    $('log').textContent = 'Player HP reset.';
   });
 
-  resetUnits();
+  player = makePlayer();
+  rebuildActor(true);
+  $('log').textContent = 'Ready. The harness is using canonical Unit definitions.';
 })();
 </script>
 </body>

--- a/tests/individual-goap-resource-budget-smoke.mjs
+++ b/tests/individual-goap-resource-budget-smoke.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+
+await import('../js/status-engine.js');
+await import('../js/universal-ranged-ammo-runtime.js');
+await import('../js/skill-catalog-kobold-tier1.js');
+await import('../js/unit-rank-runtime.js');
+await import('../js/unit-combat-mechanics-runtime.js');
+await import('../js/unit-catalog-kobold-tier1.js');
+await import('../js/combat-action-schema.js');
+await import('../js/combat-action-adapters.js');
+await import('../js/individual-goap-combat-ai.js');
+await import('../js/unit-ai-kit-adapter.js');
+
+const ammo = globalThis.LuminousUniversalRangedAmmoRuntime;
+const kobolds = globalThis.LuminousKoboldUnitCatalog;
+const kitAdapter = globalThis.LuminousUnitAiKitAdapter;
+
+if (!ammo || !kobolds || !kitAdapter) throw new Error('GOAP resource budget dependencies were not initialized.');
+
+const sling = kobolds.resolve('kobold_sling', { level: 2, initializeEncounter: true });
+sling.id = 'budget_sling';
+sling.hp = sling.maxHp;
+ammo.setAmmo(sling, 'pebbles', 1);
+assert.equal(ammo.ammoCount(sling, 'pebbles'), 1);
+
+const plan = kitAdapter.planUnitTurn({
+  actor: sling,
+  availableSlots: 2,
+  targetIds: ['player_1'],
+  allowEscape: false,
+});
+
+assert.equal(plan.planned, true);
+assert.equal(plan.slotsRequested, 2);
+assert.equal(plan.actions.length, 2, 'the remaining slot should be usable by the canonical defense');
+
+const ammoActions = plan.actions.filter((action) =>
+  (action.resources || []).some((resource) => resource.type === 'ammunition' && resource.id === 'pebbles')
+);
+assert.equal(ammoActions.length, 1, 'one Pebble can fund only one ranged action across the whole turn');
+assert.equal(plan.resourceSpent['ammunition:pebbles'], 1);
+assert.ok(plan.sequence.some((entry) => entry.sourceId === 'kobold_duck_away'));
+
+console.log('individual GOAP multi-slot resource budget smoke: ok');

--- a/tests/unit-ai-kit-adapter-real-engine-smoke.mjs
+++ b/tests/unit-ai-kit-adapter-real-engine-smoke.mjs
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+
+await import('../js/status-engine.js');
+await import('../js/universal-ranged-ammo-runtime.js');
+await import('../js/skill-catalog-kobold-tier1.js');
+await import('../js/unit-rank-runtime.js');
+await import('../js/unit-combat-mechanics-runtime.js');
+await import('../js/unit-catalog-kobold-tier1.js');
+await import('../js/combat-action-schema.js');
+await import('../js/combat-action-adapters.js');
+await import('../js/combat-action-engine-bridge.js');
+await import('../js/combat-action-queue.js');
+await import('../js/combat-action-resolver.js');
+await import('../js/individual-goap-combat-ai.js');
+await import('../js/unit-ai-kit-adapter.js');
+
+const { default: importedEngine } = await import('../js/combatEngine.js');
+const engine = importedEngine || globalThis.CombatEngine;
+const resolver = globalThis.LuminousCombatActionResolver;
+const kitAdapter = globalThis.LuminousUnitAiKitAdapter;
+const kobolds = globalThis.LuminousKoboldUnitCatalog;
+const ammo = globalThis.LuminousUniversalRangedAmmoRuntime;
+
+if (!engine || !resolver || !kitAdapter || !kobolds || !ammo) {
+  throw new Error('Real-engine Unit AI dependencies were not initialized.');
+}
+
+engine.currentState = 'COMBAT_ACTIVE';
+
+const kobold = kobolds.resolve('kobold_dagger', { level: 2, initializeEncounter: true });
+kobold.id = 'real_kobold';
+kobold.name = 'Real GOAP Kobold';
+kobold.hp = Math.max(kobold.hp, 10);
+kobold.maxHp = Math.max(kobold.maxHp, 10);
+kobold.sp = 0;
+kobold.level = kobold.effectiveLevel || 2;
+kobold.faction = 'enemy';
+kobold.faccion = 'enemy';
+kobold.statusEffects = kobold.statusEffects || {};
+kobold.stats = kobold.stats || {};
+kobold.physRes = kobold.physRes || 1;
+kobold.sinRes = kobold.sinRes || 1;
+
+const player = {
+  id: 'real_player', name: 'Target Player', faction: 'allies', faccion: 'allies',
+  hp: 80, maxHp: 80, sp: 0, level: 2, statusEffects: {}, stats: {},
+  shield: 0, physRes: 1, sinRes: 1,
+};
+
+const plan = kitAdapter.planUnitTurn({
+  actor: kobold,
+  targets: [player],
+  availableSlots: 1,
+  allowEscape: false,
+});
+assert.equal(plan.planned, true);
+assert.equal(plan.actions.length, 1);
+assert.ok(['kobold_dagger_jab', 'kobold_desperate_stab'].includes(plan.sequence[0].sourceId), 'healthy melee Kobold should choose an offensive canonical Skill');
+
+const hpBefore = player.hp;
+const result = resolver.resolveCombatAction(plan.actions[0], {
+  phase: plan.actions[0].phase.executesAt,
+  units: [kobold, player],
+  engine,
+  resourceHandlers: { ammunition: ammo.ammunitionHandler() },
+});
+assert.equal(result.resolved, true);
+assert.ok(player.hp < hpBefore, `real CombatEngine should apply damage (${hpBefore} -> ${player.hp})`);
+
+// A Sling Kobold with no ammunition must plan its remaining canonical defense rather than
+// send an action that the resolver will reject for missing ammunition.
+const sling = kobolds.resolve('kobold_sling', { level: 2, initializeEncounter: true });
+sling.id = 'real_sling';
+sling.hp = Math.max(sling.hp, 10);
+sling.maxHp = Math.max(sling.maxHp, 10);
+sling.faction = 'enemy';
+sling.faccion = 'enemy';
+ammo.setAmmo(sling, 'pebbles', 0);
+const dryPlan = kitAdapter.planUnitTurn({ actor: sling, targetIds: [player.id], availableSlots: 1, allowEscape: false });
+assert.equal(dryPlan.planned, true);
+assert.equal(dryPlan.sequence[0].sourceId, 'kobold_duck_away');
+assert.equal(dryPlan.kit.unavailable.filter((entry) => entry.reason === 'ammunition_unavailable').length, 2);
+
+console.log('unit-ai-kit-adapter real-engine smoke: ok');

--- a/tests/unit-ai-kit-adapter-real-engine-smoke.mjs
+++ b/tests/unit-ai-kit-adapter-real-engine-smoke.mjs
@@ -35,19 +35,30 @@ if (!engine || !resolver || !kitAdapter || !kobolds || !ammo) {
 
 engine.currentState = 'COMBAT_ACTIVE';
 
-const kobold = kobolds.resolve('kobold_dagger', { level: 2, initializeEncounter: true });
-kobold.id = 'real_kobold';
-kobold.name = 'Real GOAP Kobold';
-kobold.hp = Math.max(kobold.hp, 10);
-kobold.maxHp = Math.max(kobold.maxHp, 10);
-kobold.sp = 0;
-kobold.level = kobold.effectiveLevel || 2;
-kobold.faction = 'enemy';
-kobold.faccion = 'enemy';
-kobold.statusEffects = kobold.statusEffects || {};
-kobold.stats = kobold.stats || {};
-kobold.physRes = kobold.physRes || 1;
-kobold.sinRes = kobold.sinRes || 1;
+function hydrateCombatant(unit, id, name) {
+  const canonicalHp = Number(unit.hp ?? unit.mechanics?.hp ?? 1);
+  const canonicalMaxHp = Number(unit.maxHp ?? unit.mechanics?.maxHp ?? canonicalHp);
+  unit.id = id;
+  unit.name = name;
+  unit.hp = Math.max(Number.isFinite(canonicalHp) ? canonicalHp : 1, 10);
+  unit.maxHp = Math.max(Number.isFinite(canonicalMaxHp) ? canonicalMaxHp : unit.hp, unit.hp);
+  unit.mechanics = { ...(unit.mechanics || {}), hp: unit.hp, maxHp: unit.maxHp };
+  unit.sp = Number.isFinite(Number(unit.sp ?? unit.mechanics?.sp)) ? Number(unit.sp ?? unit.mechanics?.sp) : 0;
+  unit.level = unit.effectiveLevel || unit.mechanics?.level || 2;
+  unit.faction = 'enemy';
+  unit.faccion = 'enemy';
+  unit.statusEffects = unit.statusEffects || {};
+  unit.stats = unit.stats || {};
+  unit.physRes = unit.physRes || 1;
+  unit.sinRes = unit.sinRes || 1;
+  return unit;
+}
+
+const kobold = hydrateCombatant(
+  kobolds.resolve('kobold_dagger', { level: 2, initializeEncounter: true }),
+  'real_kobold',
+  'Real GOAP Kobold',
+);
 
 const player = {
   id: 'real_player', name: 'Target Player', faction: 'allies', faccion: 'allies',
@@ -75,14 +86,11 @@ const result = resolver.resolveCombatAction(plan.actions[0], {
 assert.equal(result.resolved, true, result.reason || 'canonical Unit CombatAction should resolve');
 assert.ok(player.hp < hpBefore, `real CombatEngine should apply damage (${hpBefore} -> ${player.hp})`);
 
-// A Sling Kobold with no ammunition must plan its remaining canonical defense rather than
-// send an action that the resolver will reject for missing ammunition.
-const sling = kobolds.resolve('kobold_sling', { level: 2, initializeEncounter: true });
-sling.id = 'real_sling';
-sling.hp = Math.max(sling.hp, 10);
-sling.maxHp = Math.max(sling.maxHp, 10);
-sling.faction = 'enemy';
-sling.faccion = 'enemy';
+const sling = hydrateCombatant(
+  kobolds.resolve('kobold_sling', { level: 2, initializeEncounter: true }),
+  'real_sling',
+  'Real Sling Kobold',
+);
 ammo.setAmmo(sling, 'pebbles', 0);
 const dryPlan = kitAdapter.planUnitTurn({ actor: sling, targetIds: [player.id], availableSlots: 1, allowEscape: false });
 assert.equal(dryPlan.planned, true);

--- a/tests/unit-ai-kit-adapter-real-engine-smoke.mjs
+++ b/tests/unit-ai-kit-adapter-real-engine-smoke.mjs
@@ -1,4 +1,14 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+// combatEngine.js is a browser/CommonJS script, not an ESM export. Evaluate the
+// repository file in a browser-like global so this test exercises the real engine.
+globalThis.window = globalThis;
+globalThis.STATUS_REGISTRY = globalThis.STATUS_REGISTRY || {};
+const engineSource = readFileSync(new URL('../js/combatEngine.js', import.meta.url), 'utf8');
+vm.runInThisContext(engineSource, { filename: 'js/combatEngine.js' });
+const engine = globalThis.CombatEngine;
 
 await import('../js/status-engine.js');
 await import('../js/universal-ranged-ammo-runtime.js');
@@ -14,8 +24,6 @@ await import('../js/combat-action-resolver.js');
 await import('../js/individual-goap-combat-ai.js');
 await import('../js/unit-ai-kit-adapter.js');
 
-const { default: importedEngine } = await import('../js/combatEngine.js');
-const engine = importedEngine || globalThis.CombatEngine;
 const resolver = globalThis.LuminousCombatActionResolver;
 const kitAdapter = globalThis.LuminousUnitAiKitAdapter;
 const kobolds = globalThis.LuminousKoboldUnitCatalog;
@@ -64,7 +72,7 @@ const result = resolver.resolveCombatAction(plan.actions[0], {
   engine,
   resourceHandlers: { ammunition: ammo.ammunitionHandler() },
 });
-assert.equal(result.resolved, true);
+assert.equal(result.resolved, true, result.reason || 'canonical Unit CombatAction should resolve');
 assert.ok(player.hp < hpBefore, `real CombatEngine should apply damage (${hpBefore} -> ${player.hp})`);
 
 // A Sling Kobold with no ammunition must plan its remaining canonical defense rather than
@@ -81,4 +89,4 @@ assert.equal(dryPlan.planned, true);
 assert.equal(dryPlan.sequence[0].sourceId, 'kobold_duck_away');
 assert.equal(dryPlan.kit.unavailable.filter((entry) => entry.reason === 'ammunition_unavailable').length, 2);
 
-console.log('unit-ai-kit-adapter real-engine smoke: ok');
+console.log(`unit-ai-kit-adapter real-engine smoke: ok (${hpBefore} -> ${player.hp} HP)`);

--- a/tests/unit-ai-kit-adapter-smoke.mjs
+++ b/tests/unit-ai-kit-adapter-smoke.mjs
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+
+await import('../js/status-engine.js');
+await import('../js/universal-ranged-ammo-runtime.js');
+await import('../js/skill-catalog-kobold-tier1.js');
+await import('../js/unit-rank-runtime.js');
+await import('../js/unit-combat-mechanics-runtime.js');
+await import('../js/unit-catalog-kobold-tier1.js');
+await import('../js/unit-catalog-goblin.js');
+await import('../js/combat-action-schema.js');
+await import('../js/combat-action-adapters.js');
+await import('../js/individual-goap-combat-ai.js');
+await import('../js/unit-ai-kit-adapter.js');
+
+const ammo = globalThis.LuminousUniversalRangedAmmoRuntime;
+const kobolds = globalThis.LuminousKoboldUnitCatalog;
+const goblins = globalThis.LuminousGoblinUnitCatalog;
+const ai = globalThis.LuminousIndividualGoapCombatAI;
+const kitAdapter = globalThis.LuminousUnitAiKitAdapter;
+
+if (!ammo || !kobolds || !goblins || !ai || !kitAdapter) {
+  throw new Error('Unit AI kit test dependencies were not initialized.');
+}
+
+const playerIdentityOnly = new Proxy({ id: 'player_1' }, {
+  get(target, prop, receiver) {
+    if (['hp', 'maxHp', 'sp', 'physRes', 'sinRes', 'skills', 'plannedActions'].includes(String(prop))) {
+      throw new Error(`AI attempted to read private target field: ${String(prop)}`);
+    }
+    return Reflect.get(target, prop, receiver);
+  },
+});
+
+// Canonical Kobold dagger: resolvedSkills should become usable AI sources without a manual sources[] array.
+const dagger = kobolds.resolve('kobold_dagger', { level: 2, initializeEncounter: true });
+dagger.id = 'kobold_dagger_test';
+const daggerKit = kitAdapter.buildKit(dagger);
+const daggerIds = daggerKit.sources.map((source) => source.definition.id).sort();
+assert.ok(daggerIds.includes('kobold_dagger_jab'));
+assert.ok(daggerIds.includes('kobold_desperate_stab'));
+assert.ok(daggerIds.includes('kobold_scurry'));
+assert.equal(daggerKit.unavailable.length, 0);
+
+const daggerPlan = kitAdapter.planUnitTurn({
+  actor: dagger,
+  targets: [playerIdentityOnly],
+  availableSlots: 2,
+  intel: ai.createIntelState(),
+});
+assert.equal(daggerPlan.planned, true);
+assert.equal(daggerPlan.actions.length, 2);
+assert.ok(daggerPlan.actions.every((action) => action.actorId === dagger.id));
+assert.ok(daggerPlan.actions.every((action) => action.phase.selectedAt === 'planning_phase_ai'));
+assert.ok(daggerPlan.actions.every((action) => action.targeting.mainTargetId === 'player_1'));
+
+// Canonical Sling Kobold: ammunition is real encounter state and must gate its ranged attacks.
+const sling = kobolds.resolve('kobold_sling', { level: 2, initializeEncounter: true });
+sling.id = 'kobold_sling_test';
+assert.ok(ammo.ammoCount(sling, 'pebbles') > 0, 'encounter initialization should grant pebbles');
+
+const loadedKit = kitAdapter.buildKit(sling);
+const loadedIds = loadedKit.sources.map((source) => source.definition.id);
+assert.ok(loadedIds.includes('kobold_sling_shot'));
+assert.ok(loadedIds.includes('kobold_rapid_pebble'));
+assert.ok(loadedIds.includes('kobold_duck_away'));
+
+ammo.setAmmo(sling, 'pebbles', 0);
+assert.equal(ammo.ammoCount(sling, 'pebbles'), 0);
+const dryKit = kitAdapter.buildKit(sling);
+const dryIds = dryKit.sources.map((source) => source.definition.id);
+assert.equal(dryIds.includes('kobold_sling_shot'), false, 'Sling Shot must be removed when ammunition is unavailable');
+assert.equal(dryIds.includes('kobold_rapid_pebble'), false, 'Rapid Pebble must be removed when ammunition is unavailable');
+assert.ok(dryIds.includes('kobold_duck_away'), 'defense must remain available with no ammunition');
+assert.ok(dryKit.unavailable.some((entry) => entry.sourceId === 'kobold_sling_shot' && entry.reason === 'ammunition_unavailable'));
+assert.ok(dryKit.unavailable.some((entry) => entry.sourceId === 'kobold_rapid_pebble' && entry.reason === 'ammunition_unavailable'));
+
+const dryPlan = kitAdapter.planUnitTurn({
+  actor: sling,
+  targetIds: ['player_1'],
+  availableSlots: 1,
+});
+assert.equal(dryPlan.planned, true);
+assert.equal(dryPlan.sequence[0].sourceId, 'kobold_duck_away');
+
+ammo.setAmmo(sling, 'pebbles', 3);
+const reloadedKit = kitAdapter.buildKit(sling);
+assert.ok(reloadedKit.sources.some((source) => source.definition.id === 'kobold_sling_shot'));
+assert.ok(reloadedKit.sources.some((source) => source.definition.id === 'kobold_rapid_pebble'));
+
+// Goblin catalog currently declares weapon references, but its canonical weapon Skills are explicitly pending.
+// The AI adapter must report that catalog gap rather than inventing fake Scimitar/Shortbow attacks.
+const goblin = goblins.resolve('goblin', { level: 3, initializeEncounter: true });
+goblin.id = 'goblin_test';
+const goblinKit = kitAdapter.buildKit(goblin);
+assert.equal(goblinKit.sources.some((source) => ['scimitar', 'shortbow'].includes(source.definition.id)), false);
+assert.ok(goblinKit.unresolved.some((entry) => entry.sourceId === 'scimitar' && entry.reason === 'canonical_weapon_skill_pending'));
+assert.ok(goblinKit.unresolved.some((entry) => entry.sourceId === 'shortbow' && entry.reason === 'canonical_weapon_skill_pending'));
+
+const goblinPlan = kitAdapter.planUnitTurn({ actor: goblin, targetIds: ['player_1'], availableSlots: 2 });
+assert.equal(goblinPlan.planned, false);
+assert.equal(goblinPlan.reason, 'unit_combat_sources_unresolved');
+
+// Generic resource handlers can preflight future Items/Traits without coupling GOAP to their runtimes.
+const customActor = {
+  id: 'custom_unit', hp: 10, maxHp: 10, scores: { int: 12, wis: 10 },
+  combatSkills: [{
+    id: 'charged_hit', sourceType: 'skill', type: 'Attack', basePower: 5, coinPower: 2, coinAmount: 1,
+    resourceCosts: [{ type: 'charge', id: 'battery', amount: 1 }],
+  }],
+};
+const blockedCustom = kitAdapter.buildKit(customActor, {
+  resourceHandlers: { charge: { validate: () => ({ available: false, reason: 'battery_empty' }) } },
+});
+assert.equal(blockedCustom.sources.length, 0);
+assert.equal(blockedCustom.unavailable[0].reason, 'battery_empty');
+
+console.log('unit-ai-kit-adapter smoke: ok');

--- a/tests/unit-ai-kit-adapter-smoke.mjs
+++ b/tests/unit-ai-kit-adapter-smoke.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 
 await import('../js/status-engine.js');
 await import('../js/universal-ranged-ammo-runtime.js');
+await import('../js/spellcasting-runtime.js');
 await import('../js/skill-catalog-kobold-tier1.js');
 await import('../js/unit-rank-runtime.js');
 await import('../js/unit-combat-mechanics-runtime.js');
@@ -100,7 +101,7 @@ const goblinPlan = kitAdapter.planUnitTurn({ actor: goblin, targetIds: ['player_
 assert.equal(goblinPlan.planned, false);
 assert.equal(goblinPlan.reason, 'unit_combat_sources_unresolved');
 
-// Generic resource handlers can preflight future Items/Traits without coupling GOAP to their runtimes.
+// Generic resource handlers can preflight future resource-bearing Skills/Traits without coupling GOAP to their runtimes.
 const customActor = {
   id: 'custom_unit', hp: 10, maxHp: 10, scores: { int: 12, wis: 10 },
   combatSkills: [{
@@ -113,5 +114,43 @@ const blockedCustom = kitAdapter.buildKit(customActor, {
 });
 assert.equal(blockedCustom.sources.length, 0);
 assert.equal(blockedCustom.unavailable[0].reason, 'battery_empty');
+
+const allowedCustom = kitAdapter.buildKit(customActor, {
+  resourceHandlers: { charge: { validate: () => ({ available: true }) } },
+});
+assert.equal(allowedCustom.sources[0].definition.id, 'charged_hit');
+
+// Unknown resource contracts fail closed; GOAP should never plan an action the resolver cannot validate.
+const unknownResourceKit = kitAdapter.buildKit(customActor);
+assert.equal(unknownResourceKit.sources.length, 0);
+assert.equal(unknownResourceKit.unavailable[0].reason, 'resource_validation_unavailable');
+
+// Cooldown state is filtered before GOAP candidate scoring.
+const cooldownActor = {
+  id: 'cooldown_unit', hp: 10, maxHp: 10, scores: { int: 12, wis: 10 }, cooldowns: { burst: 2 },
+  combatSkills: [{ id: 'burst', sourceType: 'skill', type: 'Attack', basePower: 8, coinPower: 2, coinAmount: 1 }],
+};
+const cooldownKit = kitAdapter.buildKit(cooldownActor);
+assert.equal(cooldownKit.sources.length, 0);
+assert.equal(cooldownKit.unavailable[0].reason, 'cooldown_active');
+
+// Leveled Spells implicitly consume a spell slot in CombatActionAdapters. The current spellcasting runtime
+// does not expose canSpendSpellSlot yet, so the AI must block that Spell rather than choose a doomed action.
+const caster = {
+  id: 'caster', hp: 10, maxHp: 10, scores: { int: 14, wis: 10 },
+  resolvedSpells: [{ id: 'leveled_spell', sourceType: 'spell', level: 1, slotLevel: 1, classId: 'wizard', targetType: 'single' }],
+};
+const casterKit = kitAdapter.buildKit(caster);
+assert.equal(casterKit.sources.length, 0);
+assert.equal(casterKit.unavailable[0].reason, 'spell_slot_validator_unavailable');
+
+// Cantrips do not require a spell slot and remain eligible.
+const cantripCaster = {
+  id: 'cantrip_caster', hp: 10, maxHp: 10, scores: { int: 14, wis: 10 },
+  resolvedSpells: [{ id: 'test_cantrip', sourceType: 'spell', level: 0, slotLevel: 0, cantrip: true, targetType: 'single' }],
+};
+const cantripKit = kitAdapter.buildKit(cantripCaster);
+assert.equal(cantripKit.sources.length, 1);
+assert.equal(cantripKit.sources[0].definition.id, 'test_cantrip');
 
 console.log('unit-ai-kit-adapter smoke: ok');


### PR DESCRIPTION
## Objetivo
Cerrar la primera base estable de IA de combate enemiga hasta rango Captain para que nuevas Units, Encounter Events y Encounter Packs puedan construirse encima de un contrato único.

## Flujo cerrado
`Unit -> Unit AI Kit -> Action Slot Allocator -> Individual GOAP -> CombatAction -> Battle Viewer Timeline -> CombatActionResolver -> CombatEngine`

## Incluye
- Individual GOAP acotado por INT/WIS, Personal Intel y Goals de combate.
- Unit AI Kit Adapter con Skills/Spells/Traits/Items canónicos y preflight de recursos.
- Action Slot Allocator enemigo con ceiling de equipo 12, base por Unit, bonus solo para las 2 más rápidas y caps individuales 2/3.
- Presupuesto multi-slot de recursos para evitar gastar dos veces munición/recursos en el mismo turno.
- Bridge de Planning del Battle Viewer hacia GOAP y `attackVectors` canónicos.
- E2E real Planning -> Timeline -> CombatActionResolver -> CombatEngine.
- Ataques `isClashable:true` sin respuesta recíproca permanecen canónicos y se ejecutan como acción unilateral en timeline/resolver.
- Cobertura explícita hasta `normal` + `captain`. Leader queda para un milestone posterior.

## Captain en este milestone
Captain conserva `commandLevel: 1` y su perfil de rango, pero el rango no fabrica Action Slots. Los slots siguen viniendo del perfil canónico de la Unit. El E2E cubre un Captain con perfil de 3 slots atravesando el mismo Individual GOAP y CombatEngine real.

## Tests
`npm run test:individual-goap` cubre GOAP, kit automático, recursos, allocator, Units canónicas, resource budget, Battle Viewer Planning y E2E Normal + Captain.

El workflow `Individual GOAP Smoke` está verde en el head final.

## Check general conocido
`Combat Runtime Smoke` continúa fallando en `tests/kobold-unit-library-smoke.mjs` porque ese test legacy espera `units.list().length === 2` y el catálogo actual contiene 5 definiciones. El fallo es anterior e independiente de este bloque; los pasos anteriores al test pasan y la suite específica de GOAP está verde.

## Fuera de alcance a propósito
- Leader strategic AI.
- Captain Orders/coordinación táctica avanzada.
- Encounter Events.
- Encounter Packs.
- Expansión masiva de Unit catalogs.

Esos frentes pasan a ramas/PRs siguientes construidas sobre esta base.