### PR TITLE
feat(items): canonical icon groups + first 20 HP healing items

### DIFF
--- a/.github/workflows/item-catalog-smoke.yml
+++ b/.github/workflows/item-catalog-smoke.yml
@@ -1,0 +1,29 @@
+name: Item Catalog Smoke
+
+on:
+  pull_request:
+    paths:
+      - js/item-icon-registry.js
+      - js/item-healing-catalog.js
+      - tests/item-icon-healing-catalog-smoke.mjs
+      - docs/items/icon-groups-and-hp-healing-batch.md
+      - .github/workflows/item-catalog-smoke.yml
+  push:
+    branches:
+      - feature/item-icon-groups-hp-healing-batch
+
+jobs:
+  item-catalog-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Syntax validation
+        run: |
+          node --check js/item-icon-registry.js
+          node --check js/item-healing-catalog.js
+          node --check tests/item-icon-healing-catalog-smoke.mjs
+      - name: Item catalog smoke
+        run: node tests/item-icon-healing-catalog-smoke.mjs

--- a/docs/items/icon-groups-and-hp-healing-batch.md
+++ b/docs/items/icon-groups-and-hp-healing-batch.md
@@ -1,0 +1,205 @@
+# Item icon groups + HP Healing Batch V1
+
+This document defines the first canonical visual grouping contract for Luminous items and the first authored batch of HP healing consumables.
+
+## Why grouped icons
+
+Most consumables, materials and generic loot do not need one unique illustration per ItemDefinition. Item identity stays in the ItemDefinition; the visual family is selected through `iconGroup`.
+
+Resolution order is:
+
+1. `iconOverride` / legacy explicit icon when an item genuinely needs unique art.
+2. `iconGroup` shared art.
+3. Category/subtype inference.
+4. `generic_item` fallback.
+
+Changing one URL in `LuminousItemIconRegistry` therefore updates the whole family without editing every ItemDefinition.
+
+## Canonical icon groups
+
+### Recovery and consumables
+
+| Group | Asset |
+| --- | --- |
+| `healing_hp` | https://imgur.com/GcnX53v.png |
+| `healing_sp` | https://imgur.com/LCpKGIH.png |
+| `healing_hybrid` | https://imgur.com/DrIZie0.png |
+| `status_cure` | https://imgur.com/17tJuSM.png |
+| `buff_consumable` | https://imgur.com/9wGle81.png |
+| `poison_consumable` | https://imgur.com/VsWisJQ.png |
+| `consumable_other` | https://imgur.com/1RZqDFI.png |
+| `medical_supply` | https://imgur.com/CrWqqZh.png |
+| `throwable` | https://imgur.com/3w2YnUX.png |
+
+### Food and survival
+
+| Group | Asset |
+| --- | --- |
+| `food_meat` | https://imgur.com/uFmUpuD.png |
+| `ration` | https://imgur.com/6yDrI9e.png |
+| `drink` | https://imgur.com/Tf3bZPM.png |
+
+### Scrap, crafting and materials
+
+| Group | Asset |
+| --- | --- |
+| `scrap_mechanical` | https://imgur.com/IrtN5aS.png |
+| `electronic_parts` | https://imgur.com/wTNk2Te.png |
+| `precision_component` | https://imgur.com/8684d59.png |
+| `circuitry` | https://imgur.com/FfDiki6.png |
+| `chemical` | https://imgur.com/MvbtE4u.png |
+| `textile` | https://imgur.com/4gr0EeJ.png |
+| `hide_leather` | https://imgur.com/nK6vQIR.png |
+| `ore_mineral` | https://imgur.com/Pwm1Idx.png |
+| `organic_material` | https://imgur.com/lqQbJds.png |
+| `plant_herb` | https://imgur.com/DucSfXD.png |
+| `bone_horn` | https://imgur.com/fUEV5vu.png |
+| `organ_gland` | https://imgur.com/rXlXbOG.png |
+| `toxin_material` | https://imgur.com/4kqV4TO.png |
+| `abnormality_part` | https://imgur.com/JpK4vSq.png |
+| `craft_component` | https://imgur.com/exU9uZ1.png |
+
+### Resources and utility
+
+| Group | Asset |
+| --- | --- |
+| `ammo` | https://imgur.com/gFEZebC.png |
+| `energy_cell` | https://imgur.com/32d4YwR.png |
+| `fuel` | https://imgur.com/mOsNK1L.png |
+| `repair_kit` | https://imgur.com/OZdAHys.png |
+| `tool` | https://imgur.com/rGCFKQD.png |
+| `key_access` | https://imgur.com/trjsYlm.png |
+| `document` | https://imgur.com/Mx8Vwn9.png |
+| `data_storage` | https://imgur.com/9vCVQL4.png |
+| `valuable` | https://imgur.com/XhS73M2.png |
+| `relic` | https://imgur.com/WfXrRoE.png |
+| `quest_item` | https://imgur.com/eLUFiXE.png |
+| `generic_item` | https://imgur.com/clIQfGj.png |
+
+### Equipment fallback families
+
+Unique or signature equipment may still use `iconOverride`, but ordinary equipment now has a safe family fallback.
+
+| Group | Asset |
+| --- | --- |
+| `weapon_melee` | https://imgur.com/3AEGrWu.png |
+| `weapon_ranged` | https://imgur.com/PWnWMq1.png |
+| `shield` | https://imgur.com/UnS3IAr.png |
+| `accessory` | https://imgur.com/G6YFWYw.png |
+| `armor_light` | https://imgur.com/yO2oNKD.png |
+| `armor_medium` | https://imgur.com/Yq7KrcC.png |
+| `armor_heavy` | https://imgur.com/Jqri9Tk.png |
+
+Total in V1: **46 visual families**.
+
+## HP healing design target
+
+Player HP can range roughly from **10 to 200**. A useful healing catalog therefore cannot be one flat progression where every higher Tier simply invalidates the lower one.
+
+Each Tier contains four purchase roles:
+
+- **Budget** — best Ahn per restored HP; strongest reason to buy for routine/out-of-combat recovery.
+- **Standard** — balanced carry item for self, combat and ally recovery.
+- **Combat** — lower Ahn efficiency, but `quick_action` makes it valuable when action tempo matters.
+- **Rescue** — highest burst in the Tier; intentionally expensive because saving a critical ally can be worth more than efficiency.
+
+All definitions use `targetMode: "self_or_target"`. Current Item Runtime defaults to the user when no target is supplied and can heal an ally when the caller supplies `options.target`.
+
+Outside combat, Item Runtime applies the consumable immediately without Action Economy cost. In combat planning, normal healing uses an Action Slot while Combat-role injectors consume the existing `quick_action` resource.
+
+## Ahn economy
+
+The character code already uses **Ahn** as the campaign currency, with starting backgrounds ranging from very poor characters with tens of thousands of Ahn to wealthy backgrounds with millions. The first healing batch is priced to make Tier choice a real inventory/economic decision instead of a negligible fee.
+
+The price curve deliberately makes:
+
+- Tier I something even poor characters can reasonably stock.
+- Tier II/III meaningful expedition spending.
+- Tier IV a serious purchase.
+- Tier V emergency/corporate-grade medicine whose use should be a decision.
+
+## HP Healing Batch V1
+
+| Tier | Item | Role | HP | Price | Ahn / HP | Intended band |
+| --- | --- | --- | ---: | ---: | ---: | --- |
+| I | Coagulant Gauze Patch I | Budget | 5 | 1,000 Ahn | 200 | 10-30 HP |
+| I | Basic Recovery Ampoule I | Standard | 8 | 2,400 Ahn | 300 | 10-30 HP |
+| I | SnapDose Injector I | Combat / Quick Action | 6 | 3,500 Ahn | 583 | 10-30 HP |
+| I | Field Trauma Pack I | Rescue | 10 | 5,000 Ahn | 500 | 10-30 HP |
+| II | ClotFoam Cartridge II | Budget | 12 | 6,000 Ahn | 500 | 20-60 HP |
+| II | Recovery Ampoule II | Standard | 16 | 9,000 Ahn | 563 | 20-60 HP |
+| II | Redline Injector II | Combat / Quick Action | 14 | 12,000 Ahn | 857 | 20-60 HP |
+| II | Rescue Medpack II | Rescue | 20 | 16,000 Ahn | 800 | 20-60 HP |
+| III | Hemostatic Nanogel III | Budget | 24 | 22,000 Ahn | 917 | 50-100 HP |
+| III | Regeneration Ampoule III | Standard | 32 | 30,000 Ahn | 938 | 50-100 HP |
+| III | Rapid Recovery Injector III | Combat / Quick Action | 28 | 42,000 Ahn | 1,500 | 50-100 HP |
+| III | Trauma Stabilizer III | Rescue | 40 | 55,000 Ahn | 1,375 | 50-100 HP |
+| IV | Synth-Tissue Sealant IV | Budget | 45 | 75,000 Ahn | 1,667 | 80-150 HP |
+| IV | Regeneration Ampoule IV | Standard | 60 | 100,000 Ahn | 1,667 | 80-150 HP |
+| IV | Priority Combat Injector IV | Combat / Quick Action | 50 | 135,000 Ahn | 2,700 | 80-150 HP |
+| IV | Critical Care Pack IV | Rescue | 75 | 180,000 Ahn | 2,400 | 80-150 HP |
+| V | Corp-Grade Regenerator V | Budget | 80 | 250,000 Ahn | 3,125 | 120-200+ HP |
+| V | Hyper-Regeneration Ampoule V | Standard | 100 | 325,000 Ahn | 3,250 | 120-200+ HP |
+| V | Emergency Reconstruction Injector V | Combat / Quick Action | 90 | 450,000 Ahn | 5,000 | 120-200+ HP |
+| V | Full Trauma Reconstructor V | Rescue | 125 | 650,000 Ahn | 5,200 | 120-200+ HP |
+
+### Why this still gives lower-Tier items a reason to exist
+
+A character should not automatically buy the highest heal they can find.
+
+- A 20 HP character can solve most ordinary damage cheaply with Tier I/II medicine.
+- A 70 HP character gets good routine value from Tier II/III and may carry one Rescue item.
+- A 140-200 HP veteran can justify Tier IV/V because smaller consumables no longer change the fight enough.
+- Quick Action injectors are deliberately less efficient: the player is purchasing **tempo**, not raw HP.
+- Rescue items are deliberately burst-heavy: their value is highest when an ally would otherwise be lost.
+
+## Runtime schema used by the batch
+
+Example:
+
+```js
+{
+  canonicalId: "item:regeneration_ampoule_iii",
+  category: "consumable",
+  subtype: "medical",
+  tier: "III",
+  iconGroup: "healing_hp",
+  priceAhn: 30000,
+  valorBase: 30000,
+  function: ["use"],
+  runtime: {
+    actionCost: "action",
+    targetMode: "self_or_target",
+    consumeQty: 1,
+    effects: { hpRestore: 32 }
+  },
+  consumable_details: {
+    curacion_hp: 32,
+    action_cost: "action"
+  }
+}
+```
+
+`consumable_details` remains as a compatibility mirror while the canonical runtime reads `runtime.effects.hpRestore` and `runtime.actionCost`.
+
+## Scope of this PR
+
+This PR intentionally establishes **definitions and contracts**, not production seeding.
+
+Included:
+
+- canonical icon registry;
+- 46 shared visual families;
+- first 20 HP Healing ItemDefinitions;
+- Tier I-V purchase/use roles;
+- compatibility fields for the current Item Runtime;
+- smoke validation.
+
+Not included yet:
+
+- writing these definitions into production Firebase;
+- assigning `iconGroup` to all 560 spreadsheet ItemDefinitions;
+- changing the Player HUD/DM Forge to render the new registry directly;
+- SP Healing, Hybrid, Cure, food or crafting batches.
+
+Those can follow on top of this stable registry without redefining the visual contract.

--- a/js/item-healing-catalog.js
+++ b/js/item-healing-catalog.js
@@ -1,0 +1,295 @@
+(function (global) {
+  "use strict";
+
+  const HP_ICON_GROUP = "healing_hp";
+  const HP_ICON_URL = "https://imgur.com/GcnX53v.png";
+
+  const HP_BANDS = Object.freeze({
+    I: "10-30 HP",
+    II: "20-60 HP",
+    III: "50-100 HP",
+    IV: "80-150 HP",
+    V: "120-200+ HP",
+  });
+
+  const ROLE_CONFIG = Object.freeze({
+    budget: {
+      actionCost: "action",
+      useCases: ["outside_combat", "self", "ally"],
+      summary: "Best Ahn-per-HP option; intended for routine recovery when action economy is not the priority.",
+    },
+    standard: {
+      actionCost: "action",
+      useCases: ["combat", "outside_combat", "self", "ally"],
+      summary: "Balanced recovery, price and burst for general inventory use.",
+    },
+    combat: {
+      actionCost: "quick_action",
+      useCases: ["combat", "self", "ally"],
+      summary: "Pays a premium for Quick Action access during combat planning.",
+    },
+    rescue: {
+      actionCost: "action",
+      useCases: ["combat", "outside_combat", "ally", "critical_recovery"],
+      summary: "Highest burst in its Tier; expensive but attractive when an ally is close to defeat.",
+    },
+  });
+
+  function makeItem({ id, name, tier, hp, priceAhn, role, description }) {
+    const roleConfig = ROLE_CONFIG[role];
+    if (!roleConfig) throw new Error(`Unknown healing role: ${role}`);
+    const tierNumber = ["I", "II", "III", "IV", "V"].indexOf(tier) + 1;
+    return Object.freeze({
+      canonicalId: `item:${id}`,
+      definitionId: `item:${id}`,
+      displayName: name,
+      nombre: name,
+      category: "consumable",
+      tipo_categoria: "consumable",
+      subtype: "medical",
+      tier,
+      tierNumber,
+      function: ["use"],
+      iconGroup: HP_ICON_GROUP,
+      priceAhn,
+      valorBase: priceAhn,
+      tags: ["healing_hp", "medical", `tier_${tierNumber}`, role, "ally_targetable"],
+      description,
+      descripcion: description,
+      runtime: {
+        actionCost: roleConfig.actionCost,
+        targetMode: "self_or_target",
+        consumeQty: 1,
+        effects: {
+          hpRestore: hp,
+        },
+      },
+      consumable_details: {
+        curacion_hp: hp,
+        curacion_sp: 0,
+        action_cost: roleConfig.actionCost,
+      },
+      design: {
+        batch: "hp_healing_v1",
+        role,
+        hpRestore: hp,
+        hpBand: HP_BANDS[tier],
+        useCases: [...roleConfig.useCases],
+        purchaseRationale: roleConfig.summary,
+        ahnPerHp: Math.round(priceAhn / hp),
+        currency: "Ahn",
+      },
+    });
+  }
+
+  const ITEMS = Object.freeze([
+    makeItem({
+      id: "coagulant_gauze_patch_i",
+      name: "Coagulant Gauze Patch I",
+      tier: "I",
+      hp: 5,
+      priceAhn: 1000,
+      role: "budget",
+      description: "Cheap pressure dressing with coagulant mesh. Low burst, excellent value for routine wounds and post-combat recovery.",
+    }),
+    makeItem({
+      id: "basic_recovery_ampoule_i",
+      name: "Basic Recovery Ampoule I",
+      tier: "I",
+      hp: 8,
+      priceAhn: 2400,
+      role: "standard",
+      description: "Entry-grade medical ampoule for ordinary trauma. A practical carry item for low-HP personnel.",
+    }),
+    makeItem({
+      id: "snapdose_injector_i",
+      name: "SnapDose Injector I",
+      tier: "I",
+      hp: 6,
+      priceAhn: 3500,
+      role: "combat",
+      description: "Fast injector designed for immediate field use. Less efficient per Ahn, but preserves the user's main Action Slot.",
+    }),
+    makeItem({
+      id: "field_trauma_pack_i",
+      name: "Field Trauma Pack I",
+      tier: "I",
+      hp: 10,
+      priceAhn: 5000,
+      role: "rescue",
+      description: "Compact trauma bundle meant to stabilize a badly injured low-HP ally in one use.",
+    }),
+
+    makeItem({
+      id: "clotfoam_cartridge_ii",
+      name: "ClotFoam Cartridge II",
+      tier: "II",
+      hp: 12,
+      priceAhn: 6000,
+      role: "budget",
+      description: "Expanding clotting foam for affordable field treatment. Efficient between encounters and useful on allies.",
+    }),
+    makeItem({
+      id: "recovery_ampoule_ii",
+      name: "Recovery Ampoule II",
+      tier: "II",
+      hp: 16,
+      priceAhn: 9000,
+      role: "standard",
+      description: "Reliable mid-grade recovery ampoule with enough output to matter for trained combatants.",
+    }),
+    makeItem({
+      id: "redline_injector_ii",
+      name: "Redline Injector II",
+      tier: "II",
+      hp: 14,
+      priceAhn: 12000,
+      role: "combat",
+      description: "Quick-deploy injector for combat planning. Premium pricing trades efficiency for tempo.",
+    }),
+    makeItem({
+      id: "rescue_medpack_ii",
+      name: "Rescue Medpack II",
+      tier: "II",
+      hp: 20,
+      priceAhn: 16000,
+      role: "rescue",
+      description: "High-output Tier II medpack for pulling an ally away from a dangerous HP threshold.",
+    }),
+
+    makeItem({
+      id: "hemostatic_nanogel_iii",
+      name: "Hemostatic Nanogel III",
+      tier: "III",
+      hp: 24,
+      priceAhn: 22000,
+      role: "budget",
+      description: "Dense regenerative gel sold as a cost-effective solution for sustained expedition recovery.",
+    }),
+    makeItem({
+      id: "regeneration_ampoule_iii",
+      name: "Regeneration Ampoule III",
+      tier: "III",
+      hp: 32,
+      priceAhn: 30000,
+      role: "standard",
+      description: "Professional recovery ampoule balancing cost, inventory value and meaningful mid-combat healing.",
+    }),
+    makeItem({
+      id: "rapid_recovery_injector_iii",
+      name: "Rapid Recovery Injector III",
+      tier: "III",
+      hp: 28,
+      priceAhn: 42000,
+      role: "combat",
+      description: "Fast-action medical injector for agents who cannot afford to spend their primary action on treatment.",
+    }),
+    makeItem({
+      id: "trauma_stabilizer_iii",
+      name: "Trauma Stabilizer III",
+      tier: "III",
+      hp: 40,
+      priceAhn: 55000,
+      role: "rescue",
+      description: "Heavy single-use stabilizer with enough recovery to change the outcome of an ally rescue.",
+    }),
+
+    makeItem({
+      id: "synth_tissue_sealant_iv",
+      name: "Synth-Tissue Sealant IV",
+      tier: "IV",
+      hp: 45,
+      priceAhn: 75000,
+      role: "budget",
+      description: "Industrial synthetic tissue sealant. Expensive in absolute terms, but efficient for high-HP personnel outside combat.",
+    }),
+    makeItem({
+      id: "regeneration_ampoule_iv",
+      name: "Regeneration Ampoule IV",
+      tier: "IV",
+      hp: 60,
+      priceAhn: 100000,
+      role: "standard",
+      description: "High-grade recovery ampoule intended for veteran agents with large HP pools.",
+    }),
+    makeItem({
+      id: "priority_combat_injector_iv",
+      name: "Priority Combat Injector IV",
+      tier: "IV",
+      hp: 50,
+      priceAhn: 135000,
+      role: "combat",
+      description: "Premium rapid injector. Sacrifices Ahn efficiency for a substantial Quick Action recovery window.",
+    }),
+    makeItem({
+      id: "critical_care_pack_iv",
+      name: "Critical Care Pack IV",
+      tier: "IV",
+      hp: 75,
+      priceAhn: 180000,
+      role: "rescue",
+      description: "Critical-care bundle built for major trauma and high-value ally recovery.",
+    }),
+
+    makeItem({
+      id: "corp_grade_regenerator_v",
+      name: "Corp-Grade Regenerator V",
+      tier: "V",
+      hp: 80,
+      priceAhn: 250000,
+      role: "budget",
+      description: "Bulk corporate regenerative compound. The most economical Tier V option for repeated recovery between fights.",
+    }),
+    makeItem({
+      id: "hyper_regeneration_ampoule_v",
+      name: "Hyper-Regeneration Ampoule V",
+      tier: "V",
+      hp: 100,
+      priceAhn: 325000,
+      role: "standard",
+      description: "Top-grade medical ampoule capable of restoring a meaningful fraction of a 200 HP veteran's health.",
+    }),
+    makeItem({
+      id: "emergency_reconstruction_injector_v",
+      name: "Emergency Reconstruction Injector V",
+      tier: "V",
+      hp: 90,
+      priceAhn: 450000,
+      role: "combat",
+      description: "Extremely expensive Quick Action reconstruction dose for emergencies where action tempo is worth more than money.",
+    }),
+    makeItem({
+      id: "full_trauma_reconstructor_v",
+      name: "Full Trauma Reconstructor V",
+      tier: "V",
+      hp: 125,
+      priceAhn: 650000,
+      role: "rescue",
+      description: "Maximum-burst medical system in the first catalog. Intended to save a severely wounded high-HP ally, not for routine topping off.",
+    }),
+  ]);
+
+  const byId = new Map(ITEMS.map((item) => [item.canonicalId, item]));
+
+  const api = Object.freeze({
+    version: 1,
+    batchId: "hp_healing_v1",
+    iconGroup: HP_ICON_GROUP,
+    iconUrl: HP_ICON_URL,
+    hpBands: HP_BANDS,
+    items: ITEMS,
+    get(id) {
+      const key = String(id || "").startsWith("item:") ? String(id) : `item:${id}`;
+      return byId.get(key) || null;
+    },
+    listByTier(tier) {
+      return ITEMS.filter((item) => item.tier === String(tier || "").toUpperCase());
+    },
+    listByRole(role) {
+      return ITEMS.filter((item) => item.design.role === String(role || "").toLowerCase());
+    },
+  });
+
+  global.LuminousItemHealingCatalog = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof globalThis !== "undefined" ? globalThis : this);

--- a/js/item-icon-registry.js
+++ b/js/item-icon-registry.js
@@ -65,7 +65,8 @@
 
     const category = normalize(item.category || item.tipo_categoria || item.itemType || item.type);
     const subtype = normalize(item.subtype || item.subType || item.armorType || item.weaponType);
-    const haystack = `${category} ${subtype} ${(item.tags || []).join ? item.tags.join(" ") : item.tags || ""}`.toLowerCase();
+    const rawTags = Array.isArray(item.tags) ? item.tags.join(" ") : String(item.tags || item.tag || "");
+    const haystack = `${category} ${subtype} ${rawTags}`.toLowerCase();
 
     if (category === "weapon") {
       if (/ranged|firearm|pistol|revolver|rifle|shotgun|smg|machinegun|bow|crossbow|launcher/.test(haystack)) return "weapon_ranged";

--- a/js/item-icon-registry.js
+++ b/js/item-icon-registry.js
@@ -1,0 +1,115 @@
+(function (global) {
+  "use strict";
+
+  const GROUPS = Object.freeze({
+    healing_hp: "https://imgur.com/GcnX53v.png",
+    healing_sp: "https://imgur.com/LCpKGIH.png",
+    healing_hybrid: "https://imgur.com/DrIZie0.png",
+    status_cure: "https://imgur.com/17tJuSM.png",
+    buff_consumable: "https://imgur.com/9wGle81.png",
+    poison_consumable: "https://imgur.com/VsWisJQ.png",
+    consumable_other: "https://imgur.com/1RZqDFI.png",
+
+    food_meat: "https://imgur.com/uFmUpuD.png",
+    ration: "https://imgur.com/6yDrI9e.png",
+    drink: "https://imgur.com/Tf3bZPM.png",
+
+    scrap_mechanical: "https://imgur.com/IrtN5aS.png",
+    electronic_parts: "https://imgur.com/wTNk2Te.png",
+    precision_component: "https://imgur.com/8684d59.png",
+    circuitry: "https://imgur.com/FfDiki6.png",
+    chemical: "https://imgur.com/MvbtE4u.png",
+    textile: "https://imgur.com/4gr0EeJ.png",
+    hide_leather: "https://imgur.com/nK6vQIR.png",
+    ore_mineral: "https://imgur.com/Pwm1Idx.png",
+    organic_material: "https://imgur.com/lqQbJds.png",
+    plant_herb: "https://imgur.com/DucSfXD.png",
+
+    bone_horn: "https://imgur.com/fUEV5vu.png",
+    organ_gland: "https://imgur.com/rXlXbOG.png",
+    toxin_material: "https://imgur.com/4kqV4TO.png",
+    abnormality_part: "https://imgur.com/JpK4vSq.png",
+
+    ammo: "https://imgur.com/gFEZebC.png",
+    energy_cell: "https://imgur.com/32d4YwR.png",
+    fuel: "https://imgur.com/mOsNK1L.png",
+
+    repair_kit: "https://imgur.com/OZdAHys.png",
+    medical_supply: "https://imgur.com/CrWqqZh.png",
+    throwable: "https://imgur.com/3w2YnUX.png",
+    tool: "https://imgur.com/rGCFKQD.png",
+    craft_component: "https://imgur.com/exU9uZ1.png",
+
+    key_access: "https://imgur.com/trjsYlm.png",
+    document: "https://imgur.com/Mx8Vwn9.png",
+    data_storage: "https://imgur.com/9vCVQL4.png",
+    valuable: "https://imgur.com/XhS73M2.png",
+    relic: "https://imgur.com/WfXrRoE.png",
+    quest_item: "https://imgur.com/eLUFiXE.png",
+    generic_item: "https://imgur.com/clIQfGj.png",
+
+    weapon_melee: "https://imgur.com/3AEGrWu.png",
+    weapon_ranged: "https://imgur.com/PWnWMq1.png",
+    shield: "https://imgur.com/UnS3IAr.png",
+    accessory: "https://imgur.com/G6YFWYw.png",
+    armor_light: "https://imgur.com/yO2oNKD.png",
+    armor_medium: "https://imgur.com/Yq7KrcC.png",
+    armor_heavy: "https://imgur.com/Jqri9Tk.png",
+  });
+
+  const normalize = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+
+  function inferGroup(item = {}) {
+    const explicit = normalize(item.iconGroup || item.icon_group);
+    if (explicit && GROUPS[explicit]) return explicit;
+
+    const category = normalize(item.category || item.tipo_categoria || item.itemType || item.type);
+    const subtype = normalize(item.subtype || item.subType || item.armorType || item.weaponType);
+    const haystack = `${category} ${subtype} ${(item.tags || []).join ? item.tags.join(" ") : item.tags || ""}`.toLowerCase();
+
+    if (category === "weapon") {
+      if (/ranged|firearm|pistol|revolver|rifle|shotgun|smg|machinegun|bow|crossbow|launcher/.test(haystack)) return "weapon_ranged";
+      return "weapon_melee";
+    }
+    if (category === "armor") {
+      if (/heavy/.test(haystack)) return "armor_heavy";
+      if (/light/.test(haystack)) return "armor_light";
+      return "armor_medium";
+    }
+    if (category === "shield") return "shield";
+    if (category === "accessory") return "accessory";
+    if (category === "ammo" || category === "ammunition") return "ammo";
+    if (category === "tool") return "tool";
+    if (category === "consumable") return "consumable_other";
+    return "generic_item";
+  }
+
+  function resolveGroup(item = {}) {
+    return inferGroup(item);
+  }
+
+  function resolveIcon(item = {}) {
+    const override = String(item.iconOverride || item.icon_override || item.icono || item.icon || "").trim();
+    if (override) return override;
+    return GROUPS[resolveGroup(item)] || GROUPS.generic_item;
+  }
+
+  const api = Object.freeze({
+    version: 1,
+    groups: GROUPS,
+    has(groupId) {
+      return Boolean(GROUPS[normalize(groupId)]);
+    },
+    get(groupId) {
+      return GROUPS[normalize(groupId)] || null;
+    },
+    resolveGroup,
+    resolveIcon,
+    list() {
+      return Object.entries(GROUPS).map(([id, url]) => ({ id, url }));
+    },
+  });
+
+  global.LuminousItemIconRegistry = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof globalThis !== "undefined" ? globalThis : this);

--- a/tests/item-icon-healing-catalog-smoke.mjs
+++ b/tests/item-icon-healing-catalog-smoke.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const icons = require("../js/item-icon-registry.js");
+const healing = require("../js/item-healing-catalog.js");
+const runtime = require("../js/item-runtime-engine.js");
+
+assert.equal(icons.version, 1);
+assert.equal(icons.list().length, 46, "V1 should expose exactly 46 shared icon families");
+assert.equal(icons.get("healing_hp"), "https://imgur.com/GcnX53v.png");
+assert.equal(icons.resolveGroup({ category: "weapon", subtype: "rifle" }), "weapon_ranged");
+assert.equal(icons.resolveGroup({ category: "weapon", subtype: "sword" }), "weapon_melee");
+assert.equal(icons.resolveGroup({ category: "armor", subtype: "light" }), "armor_light");
+assert.equal(icons.resolveGroup({ category: "armor", subtype: "heavy" }), "armor_heavy");
+assert.equal(icons.resolveIcon({ category: "unknown" }), icons.get("generic_item"));
+
+assert.equal(healing.version, 1);
+assert.equal(healing.items.length, 20, "HP Healing V1 should contain twenty items");
+assert.equal(new Set(healing.items.map((item) => item.canonicalId)).size, 20, "canonical IDs must be unique");
+
+for (const tier of ["I", "II", "III", "IV", "V"]) {
+  const tierItems = healing.listByTier(tier);
+  assert.equal(tierItems.length, 4, `Tier ${tier} should contain four purchase roles`);
+  assert.deepEqual(new Set(tierItems.map((item) => item.design.role)), new Set(["budget", "standard", "combat", "rescue"]));
+  assert.equal(tierItems.filter((item) => item.runtime.actionCost === "quick_action").length, 1, `Tier ${tier} should have one Quick Action option`);
+}
+
+for (const item of healing.items) {
+  assert.equal(item.category, "consumable");
+  assert.equal(item.subtype, "medical");
+  assert.equal(item.iconGroup, "healing_hp");
+  assert.equal(item.runtime.targetMode, "self_or_target");
+  assert.ok(item.runtime.effects.hpRestore > 0);
+  assert.ok(item.priceAhn > 0);
+  assert.equal(item.valorBase, item.priceAhn);
+  assert.equal(item.consumable_details.curacion_hp, item.runtime.effects.hpRestore);
+}
+
+assert.deepEqual(
+  ["I", "II", "III", "IV", "V"].map((tier) => Math.max(...healing.listByTier(tier).map((item) => item.runtime.effects.hpRestore))),
+  [10, 20, 40, 75, 125],
+  "Rescue burst should scale across the 10-200 HP character range",
+);
+
+const basic = runtime.makeInstance(healing.get("basic_recovery_ampoule_i"), { quantity: 1, instanceId: "test_basic" });
+const user = { hp: 2, maxHp: 20 };
+const basicUse = runtime.useItem(user, basic, { phase: "other" });
+assert.equal(basicUse.used, true);
+assert.equal(user.hp, 10);
+assert.equal(runtime.quantityOf(basic), 0);
+
+const allyDose = runtime.makeInstance(healing.get("basic_recovery_ampoule_i"), { quantity: 1, instanceId: "test_ally" });
+const medic = { hp: 20, maxHp: 20 };
+const ally = { hp: 3, maxHp: 20 };
+const allyUse = runtime.useItem(medic, allyDose, { phase: "other", target: ally });
+assert.equal(allyUse.used, true);
+assert.equal(medic.hp, 20, "healing an ally must not heal the user");
+assert.equal(ally.hp, 11, "ally targeting should use the same canonical hpRestore effect");
+
+assert.equal(runtime.actionCostFor(healing.get("snapdose_injector_i")), "quick_action");
+assert.equal(runtime.actionCostFor(healing.get("field_trauma_pack_i")), "action");
+
+console.log("Item icon + HP healing catalog smoke: OK");

--- a/tests/item-icon-healing-catalog-smoke.mjs
+++ b/tests/item-icon-healing-catalog-smoke.mjs
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
-import { createRequire } from "node:module";
 
-const require = createRequire(import.meta.url);
-const icons = require("../js/item-icon-registry.js");
-const healing = require("../js/item-healing-catalog.js");
-const runtime = require("../js/item-runtime-engine.js");
+await import("../js/item-icon-registry.js");
+await import("../js/item-healing-catalog.js");
+await import("../js/item-runtime-engine.js");
+
+const icons = globalThis.LuminousItemIconRegistry;
+const healing = globalThis.LuminousItemHealingCatalog;
+const runtime = globalThis.LuminousItemRuntime;
 
 assert.equal(icons.version, 1);
 assert.equal(icons.list().length, 46, "V1 should expose exactly 46 shared icon families");


### PR DESCRIPTION
## Objetivo

Establecer una base canónica para dejar de producir arte redundante por ItemDefinition y empezar a poblar el catálogo real de Items por familias visuales.

Este PR añade el contrato de iconos compartidos y el primer batch jugable: **20 consumibles de curación de HP**, distribuidos entre Tier I–V y diseñados para personajes de aproximadamente 10–200 HP.

## Icon Group Registry

Añade `js/item-icon-registry.js` con **46 familias visuales** proporcionadas para Luminous.

Incluye:
- HP / SP / Hybrid Healing
- Cure, Buff, Poison, Other Consumable
- Food, Ration, Drink
- Scrap / mechanical / electronics / precision / circuitry
- chemical / textile / hide / mineral / organic / plant
- bone / organ / toxin / abnormality
- ammo / energy cell / fuel
- repair / medical supply / throwable / tool / crafting
- key / document / data / valuable / relic / quest / generic
- melee weapon / ranged weapon / shield / accessory
- light / medium / heavy armor

Resolución propuesta:

`iconOverride -> iconGroup -> category/subtype inference -> generic_item`

Así un ItemDefinition sólo necesita `iconGroup: "healing_hp"` y no repetir la URL del asset en cada objeto.

## HP Healing Batch V1

Añade `js/item-healing-catalog.js` con **20 ItemDefinitions**: 4 por Tier.

Cada Tier tiene cuatro decisiones de compra distintas:

1. **Budget** — mejor Ahn por HP; pensado para recuperación rutinaria y fuera de combate.
2. **Standard** — balance general de precio, burst y utilidad.
3. **Combat** — menor eficiencia económica a cambio de `quick_action` durante combat planning.
4. **Rescue** — máximo burst del Tier para salvar a un aliado en situación crítica.

Todos usan:
- `category: "consumable"`
- `subtype: "medical"`
- `iconGroup: "healing_hp"`
- `runtime.effects.hpRestore`
- `runtime.targetMode: "self_or_target"`
- mirror compatible `consumable_details.curacion_hp`
- precio canónico `priceAhn` + mirror `valorBase`

## Curación / precios

| Tier | HP del batch | Rango de precio |
| --- | --- | --- |
| I | 5 / 8 / 6 / 10 | 1,000–5,000 Ahn |
| II | 12 / 16 / 14 / 20 | 6,000–16,000 Ahn |
| III | 24 / 32 / 28 / 40 | 22,000–55,000 Ahn |
| IV | 45 / 60 / 50 / 75 | 75,000–180,000 Ahn |
| V | 80 / 100 / 90 / 125 | 250,000–650,000 Ahn |

El objetivo es que la medicina siga siendo una decisión real de inventario/economía. Los injectors de combate compran **tempo**, no eficiencia; los Rescue compran **burst** para aliados.

## Compatibilidad con Item Runtime

El batch usa directamente contratos que ya existen en `item-runtime-engine.js`:
- `action`
- `quick_action`
- `runtime.effects.hpRestore`
- targeting mediante `options.target`
- consumo de cantidad
- uso inmediato fuera de Action Economy

El smoke prueba tanto autocuración como curación de un aliado usando el runtime real.

## Documentación

`docs/items/icon-groups-and-hp-healing-batch.md` explica:
- por qué se generaliza el arte;
- las 46 familias y sus assets;
- la filosofía económica de Ahn;
- los 20 Items completos;
- Ahn por HP;
- bandas de HP sugeridas por Tier;
- qué queda fuera de este PR.

## Validación

`Item Catalog Smoke`: **PASS**
- sintaxis de los módulos nuevos;
- exactamente 46 icon groups;
- 20 IDs únicos;
- 4 roles por Tier;
- 1 Quick Action item por Tier;
- mirrors de compatibilidad;
- autocuración real con `LuminousItemRuntime`;
- curación real de un aliado con `options.target`.

También pasan en el head actual:
- `Individual GOAP Smoke`: **PASS**
- `Wolf Unit Library Smoke`: **PASS**

`Combat Runtime Smoke` continúa fallando en el paso legacy `Kobold Unit Library smoke`; el fallo ocurre antes de cualquier código de Items y no toca ninguno de los cinco archivos de este PR.

## Fuera de alcance intencional

Este PR **no escribe ni migra producción Firebase** todavía.

Tampoco hace aún:
- clasificación de los 560 ItemDefinitions del XLSX;
- seed a `campaña/base_datos_items`;
- integración visual directa del registry en HUD/DM Forge;
- batches de SP Healing, Hybrid, Cure, Food, Materials, etc.

La intención es congelar primero este contrato y construir los siguientes batches encima sin volver a discutir IDs/arte/esquema.