### PR TITLE
feat(fighter): add Battle Master martial archetype

### DIFF
--- a/.github/workflows/combat-runtime-smoke.yml
+++ b/.github/workflows/combat-runtime-smoke.yml
@@ -41,6 +41,12 @@ jobs:
         run: node tests/pierre-spell-batch-smoke.mjs
       - name: Angelo universal spell batch smoke
         run: node tests/angelo-spell-batch-smoke.mjs
+      - name: Fighter Battle Master module syntax
+        run: |
+          node --check js/fighter-maneuver-catalog.js
+          node --check js/battle-master-archetype-runtime.js
+      - name: Battle Master archetype smoke
+        run: node tests/battle-master-archetype-runtime-smoke.mjs
       - name: Kobold Unit Library smoke
         run: node tests/kobold-unit-library-smoke.mjs
       - name: Universal Unit rank command smoke

--- a/js/battle-master-archetype-runtime.js
+++ b/js/battle-master-archetype-runtime.js
@@ -1,0 +1,253 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousBattleMasterArchetypeRuntime) return;
+
+  const ARCHETYPE_ID = "battle_master";
+  const ARCHETYPE_NAME = "Battle Master";
+  const CLASS_ID = "fighter";
+  const CLASS_NAME = "Fighter";
+  const PATCH_INTERVAL_MS = 500;
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  const intOr = (value, fallback = 0) => Number.isFinite(Number.parseInt(value, 10)) ? Number.parseInt(value, 10) : fallback;
+
+  const ARCHETYPE = Object.freeze({ id: ARCHETYPE_ID, name: ARCHETYPE_NAME, classId: CLASS_ID, className: CLASS_NAME, unlockLevel: 15, traitLevels: [15, 35, 50, 75, 90] });
+  const SOURCE = Object.freeze({ type: "archetype", id: ARCHETYPE_ID, archetypeId: ARCHETYPE_ID, archetypeName: ARCHETYPE_NAME, classId: CLASS_ID, className: CLASS_NAME });
+
+  const DEFINITIONS = Object.freeze({
+    combat_superiority: Object.freeze({
+      schemaVersion: 1, id: "combat_superiority", name: "Combat Superiority",
+      description: "Learn 3 Maneuvers from the Fighter Maneuver list. You can gain Superiority. [On Clash Win] Gain +3 Superiority. [On Hit] Gain +1 Superiority. Maneuver Damage Cap is 10%.",
+      source: SOURCE, contexts: ["combat", "any"], activation: { type: "passive", actionCost: "none" }, effects: [], rules: [],
+      mechanics: { maneuverCatalog: "fighter", learnManeuvers: 3, superiority: { clashWinGain: 3, onHitGain: 1 }, maneuverDamageCap: 0.10, superiorTechniqueManeuverCountsAgainstLimit: false },
+    }),
+    student_of_war: Object.freeze({
+      schemaVersion: 1, id: "student_of_war", name: "Student of War", description: "Gain proficiency with 1 Artisan Tool of your choice.",
+      source: SOURCE, contexts: ["theatre", "any"], activation: { type: "passive", actionCost: "none" }, effects: [], rules: [], mechanics: { narrative: true, artisanToolChoices: 1 },
+    }),
+    know_your_enemy: Object.freeze({
+      schemaVersion: 1, id: "know_your_enemy", name: "Know Your Enemy",
+      description: "Every 10 Turns, unlock 1 feature from the currently observed Enemy Type without requiring an Analyse Check. This advances that Enemy Type's Observation Level in the Player Compendium.",
+      source: SOURCE, contexts: ["combat"], activation: { type: "passive", actionCost: "none" }, effects: [], rules: [],
+      mechanics: { system: "analyse", observationScope: "encounter_global_enemy_type", everyTurns: 10, unlockFeatures: 1, bypassAnalyseCheck: true, advancesObservationLevel: true, compendium: "player", usesExistingObservationTarget: true },
+    }),
+    combat_superiority_plus: Object.freeze({
+      schemaVersion: 1, id: "combat_superiority_plus", name: "Combat Superiority+",
+      description: "Learn +1 additional Maneuver. [On Clash Win] Gain +4 Superiority. [On Hit] Gain +2 Superiority. Maneuver Damage Cap becomes 15%.",
+      source: SOURCE, contexts: ["combat", "any"], activation: { type: "passive", actionCost: "none" }, effects: [], rules: [],
+      mechanics: { additionalManeuvers: 1, superiority: { clashWinGain: 4, onHitGain: 2 }, maneuverDamageCap: 0.15 },
+    }),
+    relentless: Object.freeze({
+      schemaVersion: 1, id: "relentless", name: "Relentless",
+      description: "While at 25% Max HP or lower, double all Maneuver effects and their caps. Superiority costs are not doubled.",
+      source: SOURCE, contexts: ["combat"], activation: { type: "passive", actionCost: "none" }, effects: [], rules: [],
+      mechanics: { hpThresholdRatio: 0.25, maneuverEffectMultiplier: 2, maneuverCapMultiplier: 2, superiorityCostMultiplier: 1 },
+    }),
+    combat_superiority_plus_plus: Object.freeze({
+      schemaVersion: 1, id: "combat_superiority_plus_plus", name: "Combat Superiority++",
+      description: "Learn +1 additional Maneuver. [On Clash Win] Gain +5 Superiority. [On Hit] Gain +3 Superiority. Maneuver Damage Cap becomes 20%.",
+      source: SOURCE, contexts: ["combat", "any"], activation: { type: "passive", actionCost: "none" }, effects: [], rules: [],
+      mechanics: { additionalManeuvers: 1, superiority: { clashWinGain: 5, onHitGain: 3 }, maneuverDamageCap: 0.20 },
+    }),
+  });
+
+  const grant = (level, traitId) => Object.freeze({ sourceType: "archetype", sourceId: ARCHETYPE_ID, archetypeId: ARCHETYPE_ID, classId: CLASS_ID, atLevel: level, traitId, source: { ...SOURCE, atLevel: level, requiredClassLevel: level } });
+  const GRANTS = Object.freeze([
+    grant(15, "combat_superiority"), grant(15, "student_of_war"), grant(35, "know_your_enemy"),
+    grant(50, "combat_superiority_plus"), grant(75, "relentless"), grant(90, "combat_superiority_plus_plus"),
+  ]);
+
+  function normalizedCharacter(character = {}) {
+    if (Array.isArray(character.classes)) return character;
+    if (Array.isArray(character.characterBuild?.classes)) return { ...character, classes: character.characterBuild.classes };
+    return character;
+  }
+
+  function fighterLevel(character = {}) {
+    const engine = global.LuminousArchetypeEngine;
+    if (engine?.getClassLevel) return Math.max(0, intOr(engine.getClassLevel(normalizedCharacter(character), CLASS_ID), 0));
+    const classes = Array.isArray(character.classes) ? character.classes : Array.isArray(character.characterBuild?.classes) ? character.characterBuild.classes : [];
+    const found = classes.find((entry) => normalizeId(entry?.classId || entry?.id || entry?.name) === CLASS_ID);
+    return Math.max(0, intOr(found?.levels ?? found?.level, 0));
+  }
+
+  function selectedBattleMaster(character = {}) {
+    const engine = global.LuminousArchetypeEngine;
+    if (engine?.isSelected) return Boolean(engine.isSelected(character, ARCHETYPE_ID, CLASS_ID));
+    const raw = character.characterBuild?.archetypes ?? character.archetypes ?? [];
+    const list = Array.isArray(raw) ? raw : Object.entries(raw || {}).map(([classId, value]) => typeof value === "string" ? { classId, archetypeId: value } : { classId, ...(value || {}) });
+    return list.some((entry) => normalizeId(entry?.classId || entry?.parentClassId) === CLASS_ID && normalizeId(entry?.archetypeId || entry?.subclassId || entry?.id) === ARCHETYPE_ID);
+  }
+
+  function hasBattleMasterLevel(character, level) { return selectedBattleMaster(character) && fighterLevel(character) >= Number(level || 0); }
+
+  function traitObjects(character = {}) {
+    const candidates = [character.traitDefinitions, character.traits, character.characterBuild?.traits, character.characterBuild?.traitDefinitions];
+    return candidates.flatMap((value) => Array.isArray(value) ? value : []).filter(Boolean);
+  }
+
+  function hasSuperiorTechnique(character = {}) {
+    if (character.superiorTechnique === true || character.characterBuild?.superiorTechnique === true) return true;
+    return traitObjects(character).some((trait) => normalizeId(typeof trait === "string" ? trait : trait.id || trait.name) === "superior_technique");
+  }
+
+  function combatSuperiorityProfile(character = {}) {
+    if (!hasBattleMasterLevel(character, 15)) return null;
+    const level = fighterLevel(character);
+    if (level >= 90) return Object.freeze({ tier: 2, name: "Combat Superiority++", clashWinGain: 5, onHitGain: 3, damageCap: 0.20, battleMasterManeuvers: 5 });
+    if (level >= 50) return Object.freeze({ tier: 1, name: "Combat Superiority+", clashWinGain: 4, onHitGain: 2, damageCap: 0.15, battleMasterManeuvers: 4 });
+    return Object.freeze({ tier: 0, name: "Combat Superiority", clashWinGain: 3, onHitGain: 1, damageCap: 0.10, battleMasterManeuvers: 3 });
+  }
+
+  function maneuverCapacity(character = {}) {
+    const profile = combatSuperiorityProfile(character);
+    if (!profile) return 0;
+    return profile.battleMasterManeuvers + (hasSuperiorTechnique(character) ? 1 : 0);
+  }
+
+  function superiorityGain(character = {}, trigger) {
+    const profile = combatSuperiorityProfile(character);
+    if (!profile) return 0;
+    const id = normalizeId(trigger);
+    if (["clash_win", "on_clash_win"].includes(id)) return profile.clashWinGain;
+    if (["hit", "on_hit"].includes(id)) return profile.onHitGain;
+    return 0;
+  }
+
+  function hpRatio(unit = {}) {
+    const current = Number(unit.hp ?? unit.currentHp ?? unit.hp_actual ?? unit.combatStats?.hp_actual);
+    const max = Number(unit.maxHp ?? unit.max_hp ?? unit.hp_max ?? unit.combatStats?.hp_max ?? unit.combatStats?.maxHp);
+    if (!Number.isFinite(current) || !Number.isFinite(max) || max <= 0) return 1;
+    return current / max;
+  }
+
+  function relentlessActive(character = {}, unit = character) { return hasBattleMasterLevel(character, 75) && hpRatio(unit) <= 0.25; }
+  function maneuverEffectMultiplier(character = {}, unit = character) { return relentlessActive(character, unit) ? 2 : 1; }
+  function maneuverDamageCap(character = {}, unit = character) {
+    const profile = combatSuperiorityProfile(character);
+    if (!profile) return 0;
+    return profile.damageCap * maneuverEffectMultiplier(character, unit);
+  }
+
+  function maneuverCatalog() {
+    const catalog = global.LuminousFighterManeuverCatalog;
+    return catalog?.all ? catalog.all() : { ...(catalog?.MANEUVERS || {}) };
+  }
+  function maneuverDefinition(id) {
+    const catalog = global.LuminousFighterManeuverCatalog;
+    return catalog?.get ? catalog.get(id) : maneuverCatalog()[normalizeId(id)] || null;
+  }
+
+  function knowYourEnemyUnlockDue(character = {}, turnNumber) {
+    if (!hasBattleMasterLevel(character, 35)) return false;
+    const turn = Math.max(0, intOr(turnNumber, 0));
+    return turn > 0 && turn % 10 === 0;
+  }
+  function knowYourEnemyRequest(character = {}, turnNumber, observedEnemyType = null) {
+    if (!knowYourEnemyUnlockDue(character, turnNumber)) return null;
+    return Object.freeze({ type: "analyse_feature_unlock", sourceTraitId: "know_your_enemy", enemyType: observedEnemyType, unlockFeatures: 1, bypassAnalyseCheck: true, advanceObservationLevel: true, useExistingObservationTarget: true });
+  }
+
+  function patchArchetypeCatalog() {
+    const source = global.LuminousArchetypeTraitCatalog;
+    if (!source?.allDefinitions || !source?.allGrants || !source?.allArchetypes) return false;
+    if (source.__battleMasterArchetypeIntegrated) return true;
+    const originalDefinitions = source.allDefinitions.bind(source);
+    const originalGrants = source.allGrants.bind(source);
+    const originalArchetypes = source.allArchetypes.bind(source);
+    const originalGet = typeof source.getDefinition === "function" ? source.getDefinition.bind(source) : null;
+    const originalResolve = typeof source.resolveTraitGrants === "function" ? source.resolveTraitGrants.bind(source) : null;
+    global.LuminousArchetypeTraitCatalog = Object.freeze({
+      ...source, __battleMasterArchetypeIntegrated: true, BATTLE_MASTER_ID: ARCHETYPE_ID, BATTLE_MASTER_CLASS_ID: CLASS_ID,
+      ARCHETYPES: Object.freeze({ ...(source.ARCHETYPES || {}), [ARCHETYPE_ID]: ARCHETYPE }),
+      DEFINITIONS: Object.freeze({ ...(source.DEFINITIONS || {}), ...DEFINITIONS }),
+      GRANTS: Object.freeze([...(source.GRANTS || []), ...GRANTS]),
+      allDefinitions() { return { ...originalDefinitions(), ...DEFINITIONS }; },
+      allGrants() { return [...originalGrants(), ...GRANTS.map((entry) => ({ ...entry, source: { ...(entry.source || {}) } }))]; },
+      allArchetypes() { return { ...originalArchetypes(), [ARCHETYPE_ID]: { ...ARCHETYPE } }; },
+      getDefinition(id) { return DEFINITIONS[normalizeId(id)] || originalGet?.(id) || null; },
+      resolveTraitGrants(character = {}, definitions) {
+        const base = originalResolve ? originalResolve(character, definitions) || [] : [];
+        const engine = global.LuminousArchetypeEngine;
+        const extra = engine?.resolveTraitGrants ? engine.resolveTraitGrants(character, GRANTS, definitions ? { ...definitions, ...DEFINITIONS } : DEFINITIONS, { [ARCHETYPE_ID]: ARCHETYPE }, global.LuminousTraitEngine) || [] : [];
+        const byId = new Map();
+        [...base, ...extra].forEach((trait) => { const id = normalizeId(trait?.id || trait?.name); if (id && !byId.has(id)) byId.set(id, trait); });
+        return [...byId.values()];
+      },
+    });
+    return true;
+  }
+
+  function patchCoreCatalog() {
+    const source = global.LuminousTraitCatalogCore;
+    if (!source?.allDefinitions || !source?.allGrants || source.__battleMasterArchetypeIntegrated) return Boolean(source?.__battleMasterArchetypeIntegrated);
+    const originalDefinitions = source.allDefinitions.bind(source);
+    const originalGrants = source.allGrants.bind(source);
+    const originalGet = typeof source.getDefinition === "function" ? source.getDefinition.bind(source) : null;
+    global.LuminousTraitCatalogCore = Object.freeze({
+      ...source, __battleMasterArchetypeIntegrated: true,
+      allDefinitions() { return { ...originalDefinitions(), ...DEFINITIONS }; },
+      allGrants() { return [...originalGrants(), ...GRANTS]; },
+      getDefinition(id) { return DEFINITIONS[normalizeId(id)] || originalGet?.(id) || null; },
+    });
+    return true;
+  }
+
+  function patchTraitEngine() {
+    const source = global.LuminousTraitEngine;
+    if (!source?.resolveTraitGrants || source.__battleMasterArchetypeIntegrated) return Boolean(source?.__battleMasterArchetypeIntegrated);
+    const originalResolve = source.resolveTraitGrants.bind(source);
+    global.LuminousTraitEngine = Object.freeze({
+      ...source, __battleMasterArchetypeIntegrated: true,
+      resolveTraitGrants(character = {}, grants = [], definitions = {}) {
+        const base = originalResolve(character, grants, definitions) || [];
+        const engine = global.LuminousArchetypeEngine;
+        const extra = engine?.resolveTraitGrants ? engine.resolveTraitGrants(character, GRANTS, { ...definitions, ...DEFINITIONS }, { [ARCHETYPE_ID]: ARCHETYPE }, source) || [] : [];
+        const byId = new Map();
+        [...base, ...extra].forEach((trait) => { const id = normalizeId(trait?.id || trait?.name); if (id && !byId.has(id)) byId.set(id, trait); });
+        return [...byId.values()];
+      },
+    });
+    return true;
+  }
+
+  function isBattleMasterTrait(trait = {}) {
+    const source = trait.source || {};
+    return ["archetype", "subclass", "class_archetype"].includes(normalizeId(source.type || trait.sourceType)) && normalizeId(source.archetypeId || source.id) === ARCHETYPE_ID;
+  }
+
+  function patchArchetypeRuntime() {
+    const source = global.LuminousArchetypeRuntime;
+    if (!source?.syncArchetypeTraitsForUnit || source.__battleMasterArchetypeIntegrated) return Boolean(source?.__battleMasterArchetypeIntegrated);
+    const originalSync = source.syncArchetypeTraitsForUnit.bind(source);
+    global.LuminousArchetypeRuntime = Object.freeze({
+      ...source, __battleMasterArchetypeIntegrated: true,
+      syncArchetypeTraitsForUnit(unit = {}) {
+        const base = originalSync(unit) || [];
+        const engine = global.LuminousArchetypeEngine;
+        const granted = engine?.resolveTraitGrants ? engine.resolveTraitGrants(unit, GRANTS, DEFINITIONS, { [ARCHETYPE_ID]: ARCHETYPE }, global.LuminousTraitEngine) || [] : [];
+        const existing = Array.isArray(unit.traitDefinitions) ? unit.traitDefinitions : [];
+        const byId = new Map();
+        [...existing.filter((trait) => !isBattleMasterTrait(trait)), ...granted].forEach((trait) => { const id = normalizeId(trait?.id || trait?.name); if (id && !byId.has(id)) byId.set(id, trait); });
+        unit.traitDefinitions = [...byId.values()];
+        return [...base, ...granted];
+      },
+    });
+    return true;
+  }
+
+  function install() { patchArchetypeCatalog(); patchCoreCatalog(); patchTraitEngine(); patchArchetypeRuntime(); return true; }
+
+  const api = Object.freeze({
+    ARCHETYPE_ID, ARCHETYPE_NAME, CLASS_ID, CLASS_NAME, ARCHETYPE, SOURCE, DEFINITIONS, GRANTS,
+    fighterLevel, selectedBattleMaster, hasBattleMasterLevel, hasSuperiorTechnique, combatSuperiorityProfile,
+    maneuverCapacity, superiorityGain, hpRatio, relentlessActive, maneuverEffectMultiplier, maneuverDamageCap,
+    maneuverCatalog, maneuverDefinition, knowYourEnemyUnlockDue, knowYourEnemyRequest,
+    patchArchetypeCatalog, patchCoreCatalog, patchTraitEngine, patchArchetypeRuntime, install,
+  });
+
+  global.LuminousBattleMasterArchetypeRuntime = api;
+  install();
+  if (global.document && global.setInterval) global.setInterval(install, PATCH_INTERVAL_MS);
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/fighter-maneuver-catalog.js
+++ b/js/fighter-maneuver-catalog.js
@@ -1,0 +1,51 @@
+(function (global) {
+  "use strict";
+
+  if (global.LuminousFighterManeuverCatalog) return;
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  const freeze = (value) => Object.freeze(value);
+
+  const maneuver = (id, name, description, mechanics = {}) => freeze({
+    schemaVersion: 1,
+    id,
+    name,
+    description,
+    source: freeze({ type: "class_maneuver", classId: "fighter", className: "Fighter" }),
+    mechanics: freeze({ ...mechanics }),
+  });
+
+  const MANEUVERS = freeze({
+    commanders_strike: maneuver("commanders_strike", "Commander's Strike", "Quick Action; Spend 20 Superiority; select an Ally. [On Combat Start] you and the selected Ally perform free Unopposed Attacks against the same selected target.", { actionCost: "quick_action", superiorityCost: 20, target: "selected_ally", trigger: "combat_start", freeUnopposedAttacks: 2, sameTarget: true }),
+    disarming_attack: maneuver("disarming_attack", "Disarming Attack", "+1% Damage per Superiority Count. [On Hit] inflict 1 Clash Power Down every 10 Superiority Count.", { damagePerSuperiority: 0.01, baseDamageCap: 0.10, onHit: { clashPowerDownEverySuperiority: 10, amount: 1 } }),
+    distracting_attack: maneuver("distracting_attack", "Distracting Attack", "+1% Damage per Superiority Count. Apply +1 Clash Power Up to 1 random Ally every 5 Superiority Count, up to 5 Allies.", { damagePerSuperiority: 0.01, baseDamageCap: 0.10, allyBuff: { status: "clash_power_up", amount: 1, randomAlliesEverySuperiority: 5, maxAllies: 5 } }),
+    evasive_footwork: maneuver("evasive_footwork", "Evasive Footwork", "+1 Defensive Level every 5 Superiority Count (Max 5); +1 Defense Power every 5 Superiority Count (Max 3); [On Turn Start] +1 Haste every 3 Superiority Count (Max 3).", { defensiveLevelEverySuperiority: 5, defensiveLevelCap: 5, defensePowerEverySuperiority: 5, defensePowerCap: 3, turnStartHasteEverySuperiority: 3, hasteCap: 3 }),
+    feinting_attack: maneuver("feinting_attack", "Feinting Attack", "+1% Damage per Superiority Count; +1 Clash Power Up every 5 Superiority Count (Max 3).", { damagePerSuperiority: 0.01, baseDamageCap: 0.10, clashPowerUpEverySuperiority: 5, clashPowerUpCap: 3 }),
+    goading_attack: maneuver("goading_attack", "Goading Attack", "Spend 5 Superiority; +10% Damage. [On Hit] inflict Duel Mark - [Unit Name]. Duel Mark gives -3 Clash Power against Units other than the inflictor.", { superiorityCost: 5, flatDamageBonus: 0.10, onHitStatus: "duel_mark_[unit_name]", duelMarkOtherTargetClashPower: -3, dynamicInflictorIdentity: true }),
+    lunging_attack: maneuver("lunging_attack", "Lunging Attack", "+1% Damage per Superiority Count; gain +1 Clash Power every 5 Superiority Count against slower targets (Max 4).", { damagePerSuperiority: 0.01, baseDamageCap: 0.10, slowerTargetClashPowerEverySuperiority: 5, slowerTargetClashPowerCap: 4 }),
+    maneuvering_attack: maneuver("maneuvering_attack", "Maneuvering Attack", "+1% Damage per Superiority Count; apply +1 Haste to 1 random Ally every 5 Superiority Count, up to 5 Allies.", { damagePerSuperiority: 0.01, baseDamageCap: 0.10, allyBuff: { status: "haste", amount: 1, randomAlliesEverySuperiority: 5, maxAllies: 5 } }),
+    menacing_attack: maneuver("menacing_attack", "Menacing Attack", "Spend 10 Superiority; +10% Damage. [On Hit] inflict 2 Frightened.", { superiorityCost: 10, flatDamageBonus: 0.10, onHit: { status: "frightened", amount: 2 } }),
+    parry: maneuver("parry", "Parry", "[On Clash Win] raise the target's Stagger Threshold by 1 per Superiority Count.", { trigger: "clash_win", staggerThresholdPerSuperiority: 1 }),
+    precision_attack: maneuver("precision_attack", "Precision Attack", "+2% Damage per Superiority Count.", { damagePerSuperiority: 0.02, baseDamageCap: 0.10 }),
+    pushing_attack: maneuver("pushing_attack", "Pushing Attack", "+1% Damage per Superiority Count. [On Hit] raise Stagger Threshold by 1 every 2 Superiority Count.", { damagePerSuperiority: 0.01, baseDamageCap: 0.10, onHit: { staggerThresholdEverySuperiority: 2, amount: 1 } }),
+    rally: maneuver("rally", "Rally", "+1% Damage per Superiority Count; apply 8 × Superiority Count Shield to a chosen Ally.", { damagePerSuperiority: 0.01, baseDamageCap: 0.10, shieldPerSuperiority: 8, target: "chosen_ally" }),
+    riposte: maneuver("riposte", "Riposte", "[On Evade] Consume 5 Superiority; when the attacker's Skill ends, use a Counter against that attacker.", { trigger: "on_evade", superiorityCost: 5, counterOnAttackerSkillEnd: true }),
+    sweeping_attack: maneuver("sweeping_attack", "Sweeping Attack", "+1% Damage per Superiority Count; +1 ATK Weight every 10 Superiority Count (Max 2).", { damagePerSuperiority: 0.01, baseDamageCap: 0.10, atkWeightEverySuperiority: 10, atkWeightCap: 2 }),
+    trip_attack: maneuver("trip_attack", "Trip Attack", "Spend 15 Superiority; +10% Damage. [On Hit] inflict Prone.", { superiorityCost: 15, flatDamageBonus: 0.10, onHit: { status: "prone", amount: 1 } }),
+    ambush: maneuver("ambush", "Ambush", "[On Encounter Start] gain 10 Superiority and 5 Haste.", { trigger: "encounter_start", gainSuperiority: 10, gainHaste: 5 }),
+    bait_and_switch: maneuver("bait_and_switch", "Bait and Switch", "Gain 1 Aggro every 2 Superiority Count; for every Unit that targets you, apply 2 Haste to an Ally.", { aggroEverySuperiority: 2, hastePerTargetingUnit: 2, allySelection: "runtime_choice_pending" }),
+    brace: maneuver("brace", "Brace", "Quick Action; Spend 15 Superiority; use a Tier 1 Skill on an Enemy.", { actionCost: "quick_action", superiorityCost: 15, useSkillTier: 1, target: "enemy", unopposed: false }),
+    commanding_presence: maneuver("commanding_presence", "Commanding Presence", "[On Turn Start] Allies heal 3 SP every 5 Superiority Count; Enemies lose 1 SP every 5 Superiority Count.", { trigger: "turn_start", allySpEverySuperiority: 5, allySpAmount: 3, enemySpEverySuperiority: 5, enemySpAmount: -1 }),
+    grappling_strike: maneuver("grappling_strike", "Grappling Strike", "Spend 10 Superiority. [On Hit] inflict Grappled.", { superiorityCost: 10, onHit: { status: "grappled", amount: 1 } }),
+    quick_toss: maneuver("quick_toss", "Quick Toss", "Quick Action; Spend 10 Superiority; use a Tier 1 Ranged/Thrown Skill as an Unopposed Attack.", { actionCost: "quick_action", superiorityCost: 10, useSkillTier: 1, skillMode: ["ranged", "thrown"], unopposed: true }),
+    tactical_assessment: maneuver("tactical_assessment", "Tactical Assessment", "[On Encounter Start] gain +1 Clash Power Up every 5 Superiority Count (Max 3) and apply +1 Clash Power Up to 1 random Ally every 10 Superiority Count, up to 2 Allies.", { trigger: "encounter_start", selfClashPowerUpEverySuperiority: 5, selfClashPowerUpCap: 3, allyClashPowerUpEverySuperiority: 10, allyClashPowerUpAmount: 1, maxAllies: 2, allySelection: "random" }),
+  });
+
+  function all() { return { ...MANEUVERS }; }
+  function list() { return Object.values(MANEUVERS); }
+  function get(id) { return MANEUVERS[normalizeId(id)] || null; }
+
+  const api = freeze({ MANEUVERS, all, list, get, normalizeId });
+  global.LuminousFighterManeuverCatalog = api;
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/player-archetype-runtime.js
+++ b/js/player-archetype-runtime.js
@@ -52,6 +52,16 @@
       () => Boolean(global.LuminousRogueTheatreRuntime),
     ))
     .then(() => ensureScript(
+      "fighter-maneuver-catalog-script",
+      "js/fighter-maneuver-catalog.js",
+      () => Boolean(global.LuminousFighterManeuverCatalog),
+    ))
+    .then(() => ensureScript(
+      "battle-master-archetype-runtime-script",
+      "js/battle-master-archetype-runtime.js",
+      () => Boolean(global.LuminousBattleMasterArchetypeRuntime),
+    ))
+    .then(() => ensureScript(
       "mastermind-archetype-runtime-script",
       "js/mastermind-archetype-runtime.js",
       () => Boolean(global.LuminousMastermindArchetypeRuntime),

--- a/tests/battle-master-archetype-runtime-smoke.mjs
+++ b/tests/battle-master-archetype-runtime-smoke.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+
+const g = globalThis;
+const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+function fighterLevel(character = {}) {
+  const classes = Array.isArray(character.classes) ? character.classes : character.characterBuild?.classes || [];
+  const found = classes.find((entry) => normalizeId(entry.id || entry.classId || entry.name) === "fighter");
+  return Number(found?.level ?? found?.levels ?? 0);
+}
+function isBattleMaster(character = {}) {
+  const raw = character.characterBuild?.archetypes || character.archetypes || [];
+  return raw.some((entry) => normalizeId(entry.classId) === "fighter" && normalizeId(entry.archetypeId || entry.id) === "battle_master");
+}
+
+g.LuminousArchetypeEngine = {
+  getClassLevel(character, classId) { return normalizeId(classId) === "fighter" ? fighterLevel(character) : 0; },
+  isSelected(character, archetypeId, classId) { return normalizeId(archetypeId) === "battle_master" && normalizeId(classId) === "fighter" && isBattleMaster(character); },
+  resolveTraitGrants(character, grants = [], definitions = {}) {
+    if (!isBattleMaster(character)) return [];
+    const level = fighterLevel(character);
+    return grants.filter((grant) => level >= Number(grant.atLevel || 0)).map((grant) => ({ ...clone(definitions[grant.traitId]), source: { ...(definitions[grant.traitId]?.source || {}), ...(grant.source || {}) } })).filter((trait) => trait.id);
+  },
+};
+g.LuminousArchetypeTraitCatalog = { ARCHETYPES: {}, DEFINITIONS: {}, GRANTS: [], allArchetypes() { return {}; }, allDefinitions() { return {}; }, allGrants() { return []; }, getDefinition() { return null; }, resolveTraitGrants() { return []; } };
+g.LuminousTraitCatalogCore = { allDefinitions() { return {}; }, allGrants() { return []; }, getDefinition() { return null; } };
+g.LuminousTraitEngine = { resolveTraitGrants() { return []; }, normalizeTrait(trait) { return clone(trait); } };
+g.LuminousArchetypeRuntime = { syncArchetypeTraitsForUnit() { return []; } };
+
+await import("../js/fighter-maneuver-catalog.js");
+await import("../js/battle-master-archetype-runtime.js");
+const runtime = g.LuminousBattleMasterArchetypeRuntime;
+assert.ok(runtime, "Battle Master archetype runtime should install");
+assert.equal(runtime.ARCHETYPE_ID, "battle_master");
+assert.equal(runtime.CLASS_ID, "fighter");
+assert.equal(g.LuminousArchetypeTraitCatalog.allArchetypes().battle_master.name, "Battle Master");
+assert.equal(g.LuminousFighterManeuverCatalog.list().length, 23, "Fighter Maneuver list contains all 23 Maneuvers");
+assert.equal(g.LuminousFighterManeuverCatalog.get("Brace").mechanics.unopposed, false, "Brace is not Unopposed");
+assert.equal(g.LuminousFighterManeuverCatalog.get("Quick Toss").mechanics.unopposed, true, "Quick Toss is Unopposed");
+
+const makeCharacter = (level, extra = {}) => ({ id: `fighter_${level}`, hp: 100, maxHp: 100, classes: [{ id: "fighter", level }], characterBuild: { archetypes: [{ classId: "fighter", archetypeId: "battle_master" }] }, ...extra });
+const traits15 = g.LuminousArchetypeTraitCatalog.resolveTraitGrants(makeCharacter(15));
+assert.deepEqual(traits15.map((trait) => trait.id).sort(), ["combat_superiority", "student_of_war"].sort());
+assert.ok(g.LuminousArchetypeTraitCatalog.resolveTraitGrants(makeCharacter(35)).some((trait) => trait.id === "know_your_enemy"));
+const traits90 = g.LuminousArchetypeTraitCatalog.resolveTraitGrants(makeCharacter(90));
+assert.deepEqual(traits90.map((trait) => trait.id).sort(), ["combat_superiority", "student_of_war", "know_your_enemy", "combat_superiority_plus", "relentless", "combat_superiority_plus_plus"].sort());
+
+assert.deepEqual(runtime.combatSuperiorityProfile(makeCharacter(15)), { tier: 0, name: "Combat Superiority", clashWinGain: 3, onHitGain: 1, damageCap: 0.10, battleMasterManeuvers: 3 });
+assert.deepEqual(runtime.combatSuperiorityProfile(makeCharacter(50)), { tier: 1, name: "Combat Superiority+", clashWinGain: 4, onHitGain: 2, damageCap: 0.15, battleMasterManeuvers: 4 });
+assert.deepEqual(runtime.combatSuperiorityProfile(makeCharacter(90)), { tier: 2, name: "Combat Superiority++", clashWinGain: 5, onHitGain: 3, damageCap: 0.20, battleMasterManeuvers: 5 });
+assert.equal(runtime.superiorityGain(makeCharacter(90), "clash_win"), 5);
+assert.equal(runtime.superiorityGain(makeCharacter(90), "on_hit"), 3);
+assert.equal(runtime.maneuverCapacity(makeCharacter(50)), 4);
+assert.equal(runtime.maneuverCapacity(makeCharacter(50, { traits: [{ id: "superior_technique" }] })), 5, "Superior Technique remains an extra Maneuver");
+
+const relentless = makeCharacter(90, { hp: 25, maxHp: 100 });
+assert.equal(runtime.relentlessActive(relentless), true);
+assert.equal(runtime.maneuverEffectMultiplier(relentless), 2);
+assert.equal(runtime.maneuverDamageCap(relentless), 0.40, "Relentless doubles the 20% cap to 40%");
+assert.equal(runtime.maneuverDamageCap(makeCharacter(90, { hp: 26, maxHp: 100 })), 0.20);
+
+assert.equal(runtime.knowYourEnemyUnlockDue(makeCharacter(35), 9), false);
+assert.equal(runtime.knowYourEnemyUnlockDue(makeCharacter(35), 10), true);
+assert.deepEqual(runtime.knowYourEnemyRequest(makeCharacter(35), 10, "kobold"), { type: "analyse_feature_unlock", sourceTraitId: "know_your_enemy", enemyType: "kobold", unlockFeatures: 1, bypassAnalyseCheck: true, advanceObservationLevel: true, useExistingObservationTarget: true });
+assert.match(g.LuminousArchetypeTraitCatalog.getDefinition("know_your_enemy").description, /Analyse Check/);
+
+console.log("Battle Master archetype smoke passed.");


### PR DESCRIPTION
## Summary
- registers **Battle Master** as a Fighter Martial Archetype at Class Level 15
- grants Battle Master features at Levels **15 / 35 / 50 / 75 / 90**
- adds the shared **23-entry Fighter Maneuver catalog** for reuse by Battle Master and Superior Technique
- implements Combat Superiority progression helpers, Superior Technique extra-Maneuver capacity, Relentless low-HP doubling, and Know Your Enemy Analyse-bypass request metadata
- bootstraps the new catalog/runtime through `player-archetype-runtime.js`
- adds a Battle Master smoke test covering progression and core mechanical contracts

## Battle Master progression
- **Lv15:** Combat Superiority + Student of War
- **Lv35:** Know Your Enemy
- **Lv50:** Combat Superiority+
- **Lv75:** Relentless
- **Lv90:** Combat Superiority++

## Notes
- Know Your Enemy is modeled as a request into the existing **Analyse / Observation** system; it does not create a parallel Observation Check.
- The shared Maneuver catalog preserves unresolved runtime-selection semantics as metadata instead of inventing behavior.
- No merge requested in this PR.