### PR TITLE
Implement Fighter Second Wind status and runtime

### DIFF
--- a/js/class-status-semantics.js
+++ b/js/class-status-semantics.js
@@ -5,6 +5,7 @@
   const RAGE_ICON = "https://imgur.com/j3C7GzS.png";
   const BARDIC_INSPIRATION_ICON = "https://imgur.com/LaZgHYg.png";
   const PSYCHIC_BLADE_ICON = "https://imgur.com/vEDE8Q8.png";
+  const SECOND_WIND_ICON = "https://imgur.com/VSxnVEo.png";
   const INTERNAL_EFFECT_IDS = Object.freeze(new Set([
     "reckless_attack_armed",
     "countercharm",
@@ -59,9 +60,20 @@
       visible: true,
     });
 
+    library.registerExtension("second_wind", {
+      name: "Second Wind",
+      type: "positive",
+      mode: "single",
+      icon: SECOND_WIND_ICON,
+      description: "Fighter Second Wind. Count tracks the remaining Second Wind uses available during the Encounter.",
+      classId: "fighter",
+      visible: true,
+    });
+
     return library.get?.("rage")?.icon === RAGE_ICON
       && library.get?.("bardic_inspiration")?.icon === BARDIC_INSPIRATION_ICON
-      && library.get?.("psychic_blade")?.icon === PSYCHIC_BLADE_ICON;
+      && library.get?.("psychic_blade")?.icon === PSYCHIC_BLADE_ICON
+      && library.get?.("second_wind")?.icon === SECOND_WIND_ICON;
   }
 
   function patchRecklessAttack(definition) {
@@ -156,10 +168,33 @@
     return true;
   }
 
+  function ensureFighterRuntime() {
+    if (global.LuminousFighterClassRuntime) {
+      global.LuminousFighterClassRuntime.install?.();
+      return true;
+    }
+    if (typeof require === "function") {
+      try {
+        const runtime = require("./fighter-class-runtime.js");
+        runtime?.install?.();
+        if (runtime) return true;
+      } catch (_) {}
+    }
+    if (!global.document) return false;
+    if (global.document.getElementById("fighter-class-runtime-script")) return true;
+    const script = global.document.createElement("script");
+    script.id = "fighter-class-runtime-script";
+    script.src = "js/fighter-class-runtime.js";
+    script.async = false;
+    global.document.head?.appendChild(script);
+    return true;
+  }
+
   function install() {
     const status = registerClassStatuses();
     const catalog = patchTraitCatalog();
     const engine = patchStatusEngine();
+    ensureFighterRuntime();
     return { status, catalog, engine };
   }
 
@@ -168,6 +203,7 @@
     RAGE_ICON,
     BARDIC_INSPIRATION_ICON,
     PSYCHIC_BLADE_ICON,
+    SECOND_WIND_ICON,
     INTERNAL_EFFECT_IDS,
     RESOURCE_ONLY_IDS,
     isInternalEffectId,
@@ -176,6 +212,7 @@
     patchTraitCatalog,
     patchStatusEngine,
     patchRecklessAttack,
+    ensureFighterRuntime,
     install,
   });
 

--- a/js/fighter-class-runtime.js
+++ b/js/fighter-class-runtime.js
@@ -1,0 +1,388 @@
+(function (global) {
+  "use strict";
+
+  const CLASS_ID = "fighter";
+  const CLASS_NAME = "Fighter";
+  const CATALOG_VERSION = 1;
+  const SECOND_WIND_STATUS_ID = "second_wind";
+
+  const normalizeId = (value) => String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const intOr = (value, fallback = 0) => Number.isFinite(Number.parseInt(value, 10)) ? Number.parseInt(value, 10) : fallback;
+  const clone = (value) => value == null ? value : JSON.parse(JSON.stringify(value));
+
+  const FIGHTER_SOURCE = Object.freeze({ type: "class", id: CLASS_ID, classId: CLASS_ID, className: CLASS_NAME });
+
+  function deepFreeze(value, seen = new WeakSet()) {
+    if (!value || typeof value !== "object" || seen.has(value)) return value;
+    seen.add(value);
+    Reflect.ownKeys(value).forEach((key) => deepFreeze(value[key], seen));
+    return Object.freeze(value);
+  }
+
+  const FIGHTER_DEFINITIONS = deepFreeze({
+    second_wind: {
+      schemaVersion: 1,
+      id: "second_wind",
+      name: "Second Wind",
+      description: "[On Encounter Start] Gain 1 + floor(Fighter Class Level / 20) Second Wind Count. Quick Action: Spend 1 Second Wind Count to recover 25% Max HP. [On Turn Start] Recover 2% Max HP per Second Wind Count.",
+      source: FIGHTER_SOURCE,
+      contexts: ["combat"],
+      activation: {
+        type: "manual",
+        actionCost: "quick_action",
+        target: "self",
+        conditions: [{ path: "self.statusEffects.second_wind.count", operator: "gte", value: 1 }],
+      },
+      effects: [],
+      rules: [],
+      mechanics: {
+        statusId: SECOND_WIND_STATUS_ID,
+        encounterStartCountFormula: "1 + floor(ClassLevel / 20)",
+        quickActionSpend: 1,
+        quickActionHealPercent: 25,
+        turnStartHealPercentPerCount: 2,
+      },
+    },
+  });
+
+  const fighterGrant = (level, traitId) => ({
+    id: `core_class_fighter_l${level}_${traitId}`,
+    sourceType: "class",
+    sourceId: CLASS_ID,
+    source: { className: CLASS_NAME, atLevel: level, requiredClassLevel: level },
+    atLevel: level,
+    traitId,
+    grantType: "trait",
+    multiclassPolicy: "allowed",
+  });
+
+  const FIGHTER_GRANTS = deepFreeze([
+    fighterGrant(5, "second_wind"),
+  ]);
+
+  function classEntries(character = {}) {
+    const candidates = [character.classes, character.characterBuild?.classes, character.dnd?.classes, character.classLevels];
+    for (const value of candidates) {
+      if (Array.isArray(value)) return value;
+      if (value && typeof value === "object") {
+        return Object.entries(value).map(([id, entry]) => typeof entry === "object" ? { id, ...entry } : { id, level: entry });
+      }
+    }
+    return [];
+  }
+
+  function fighterClassLevel(character = {}, engine = global.LuminousTraitEngine) {
+    if (engine?.getClassLevel) {
+      const viaEngine = Number(engine.getClassLevel(character, CLASS_ID));
+      if (Number.isFinite(viaEngine) && viaEngine > 0) return Math.max(0, Math.trunc(viaEngine));
+    }
+    const found = classEntries(character).find((entry) => normalizeId(entry?.classId || entry?.id || entry?.name) === CLASS_ID);
+    return Math.max(0, intOr(found?.levels ?? found?.level ?? found?.classLevel, 0));
+  }
+
+  function secondWindMaximum(character = {}, engine = global.LuminousTraitEngine) {
+    const level = fighterClassLevel(character, engine);
+    return level >= 5 ? 1 + Math.floor(level / 20) : 0;
+  }
+
+  function traitBaseId(trait = {}) {
+    return normalizeId(trait.baseTraitId || String(trait.id || trait.name || "").split("__class__")[0]);
+  }
+
+  function hasSecondWindTrait(traits = []) {
+    return (traits || []).some((trait) => traitBaseId(trait) === "second_wind");
+  }
+
+  function statusEngine() {
+    return global.LuminousStatusEngine || null;
+  }
+
+  function getStatus(unit, statusId) {
+    if (!unit) return null;
+    const id = normalizeId(statusId);
+    const engine = statusEngine();
+    if (engine?.getStatus) return engine.getStatus(unit, id);
+    const value = unit.statusEffects?.[id];
+    return value && typeof value === "object" ? clone(value) : null;
+  }
+
+  function applyStatus(unit, statusId, input = {}) {
+    if (!unit) return null;
+    const id = normalizeId(statusId);
+    const engine = statusEngine();
+    if (engine?.applyStatus) return engine.applyStatus(unit, id, input);
+    if (!unit.statusEffects || typeof unit.statusEffects !== "object" || Array.isArray(unit.statusEffects)) unit.statusEffects = {};
+    unit.statusEffects[id] = {
+      id,
+      name: input.name || "Second Wind",
+      count: Math.max(0, numberOr(input.count, 0)),
+      potency: numberOr(input.potency, 0),
+      duration: normalizeId(input.duration || "encounter"),
+      sourceTraitId: input.sourceTraitId || "second_wind",
+      sourceUnitId: input.sourceUnitId || null,
+      data: clone(input.data || {}),
+    };
+    return clone(unit.statusEffects[id]);
+  }
+
+  function removeStatus(unit, statusId) {
+    if (!unit) return { removed: false, statusId: normalizeId(statusId) };
+    const id = normalizeId(statusId);
+    const engine = statusEngine();
+    if (engine?.removeStatus) return engine.removeStatus(unit, id, { from: "self", ignoreProtection: true });
+    const removed = Boolean(unit.statusEffects && Object.prototype.hasOwnProperty.call(unit.statusEffects, id));
+    if (removed) delete unit.statusEffects[id];
+    return { removed, statusId: id };
+  }
+
+  function secondWindCount(unit) {
+    return Math.max(0, intOr(getStatus(unit, SECOND_WIND_STATUS_ID)?.count, 0));
+  }
+
+  function setSecondWindCount(unit, count) {
+    const next = Math.max(0, intOr(count, 0));
+    if (next <= 0) {
+      removeStatus(unit, SECOND_WIND_STATUS_ID);
+      return null;
+    }
+    return applyStatus(unit, SECOND_WIND_STATUS_ID, {
+      name: "Second Wind",
+      count: next,
+      potency: 0,
+      duration: "encounter",
+      sourceTraitId: "second_wind",
+      sourceUnitId: unit?.id || unit?.unitId || unit?.characterId || null,
+      mode: "set",
+    });
+  }
+
+  function spendSecondWindCount(unit, amount = 1) {
+    const spend = Math.max(0, intOr(amount, 1));
+    const before = secondWindCount(unit);
+    if (!spend || before < spend) return { success: false, spent: 0, before, after: before };
+    const after = before - spend;
+    setSecondWindCount(unit, after);
+    return { success: true, spent: spend, before, after };
+  }
+
+  function readHp(unit = {}) {
+    const max = unit.maxHp ?? unit.hp_max ?? unit.combatStats?.hp_max;
+    const current = unit.hp ?? unit.currentHp ?? unit.hp_actual ?? unit.combatStats?.hp_actual;
+    return {
+      current: Number.isFinite(Number(current)) ? Number(current) : null,
+      max: Number.isFinite(Number(max)) ? Number(max) : null,
+    };
+  }
+
+  function writeHp(unit, value) {
+    if (!unit) return null;
+    const next = Math.max(0, Math.floor(numberOr(value, 0)));
+    if (Object.prototype.hasOwnProperty.call(unit, "hp")) unit.hp = next;
+    else if (Object.prototype.hasOwnProperty.call(unit, "currentHp")) unit.currentHp = next;
+    else if (Object.prototype.hasOwnProperty.call(unit, "hp_actual")) unit.hp_actual = next;
+    else if (unit.combatStats && Object.prototype.hasOwnProperty.call(unit.combatStats, "hp_actual")) unit.combatStats.hp_actual = next;
+    else unit.currentHp = next;
+    return next;
+  }
+
+  function healPercent(unit, percent) {
+    const hp = readHp(unit);
+    if (hp.current == null || hp.max == null) return { amount: 0, before: hp.current, after: hp.current, max: hp.max, percent };
+    const requested = Math.max(0, Math.floor(hp.max * Math.max(0, numberOr(percent, 0)) / 100));
+    const after = Math.min(hp.max, hp.current + requested);
+    writeHp(unit, after);
+    return { amount: Math.max(0, after - hp.current), before: hp.current, after, max: hp.max, requested, percent };
+  }
+
+  function initializeSecondWind(character, unit, engine = global.LuminousTraitEngine) {
+    const target = unit || character;
+    const maximum = secondWindMaximum(character || target || {}, engine);
+    const status = setSecondWindCount(target, maximum);
+    return { count: maximum, maximum, status };
+  }
+
+  function applyTurnStartSecondWind(unit) {
+    const count = secondWindCount(unit);
+    if (count <= 0) return { count: 0, percent: 0, heal: { amount: 0 } };
+    const percent = count * 2;
+    return { count, percent, heal: healPercent(unit, percent) };
+  }
+
+  function grantIdentity(grantValue = {}) {
+    return `${grantValue.sourceType}:${grantValue.sourceId}:${grantValue.traitId}:${grantValue.atLevel}`;
+  }
+
+  function wrapCatalog() {
+    const source = global.LuminousTraitCatalogCore || (typeof require === "function" ? (() => { try { return require("./trait-catalog-core.js"); } catch (_) { return null; } })() : null);
+    if (!source) return false;
+    if (source.__fighterClassExtended) return true;
+
+    const baseDefinitions = source.allDefinitions?.bind(source) || (() => clone(source.DEFINITIONS || {}));
+    const baseGrants = source.allGrants?.bind(source) || (() => clone(source.GRANTS || []));
+    const baseGet = source.getDefinition?.bind(source) || (() => null);
+    const baseValidate = source.validateAll?.bind(source) || (() => ({ valid: true, errors: [], warnings: [] }));
+
+    const allDefinitions = () => ({ ...baseDefinitions(), ...clone(FIGHTER_DEFINITIONS) });
+    const allGrants = () => {
+      const combined = [...baseGrants(), ...clone(FIGHTER_GRANTS)];
+      const seen = new Set();
+      return combined.filter((item) => {
+        const identity = grantIdentity(item);
+        if (seen.has(identity)) return false;
+        seen.add(identity);
+        return true;
+      });
+    };
+    const getDefinition = (id) => clone(FIGHTER_DEFINITIONS[normalizeId(id)] || baseGet(id));
+    const validateAll = (engine = global.LuminousTraitEngine) => {
+      const base = baseValidate(engine);
+      const errors = [...(base.errors || [])];
+      const warnings = [...(base.warnings || [])];
+      Object.entries(FIGHTER_DEFINITIONS).forEach(([key, definition]) => {
+        if (!engine?.validateTrait) return;
+        const validation = engine.validateTrait(definition);
+        validation.errors.forEach((message) => errors.push(`${key}: ${message}`));
+        validation.warnings.forEach((message) => warnings.push(`${key}: ${message}`));
+      });
+      return { valid: base.valid !== false && !errors.length, errors, warnings };
+    };
+
+    global.LuminousTraitCatalogCore = Object.freeze({
+      ...source,
+      __fighterClassExtended: true,
+      CATALOG_VERSION: Math.max(CATALOG_VERSION, Number(source.CATALOG_VERSION || 0)),
+      DEFINITIONS: Object.freeze(allDefinitions()),
+      GRANTS: Object.freeze(allGrants()),
+      allDefinitions,
+      allGrants,
+      getDefinition,
+      validateAll,
+    });
+    return true;
+  }
+
+  function applyCombatTrigger(engine, traits, trigger, runtime, outcomes) {
+    const normalized = normalizeId(trigger);
+    if (!hasSecondWindTrait(traits)) return;
+    const unit = runtime.self || runtime.character || null;
+    const character = runtime.character || unit || {};
+    if (!unit) return;
+
+    if (normalized === "encounter_start") {
+      const initialized = initializeSecondWind(character, unit, engine);
+      outcomes.push({ type: "fighter_second_wind_encounter_start", traitId: "second_wind", unit, ...initialized });
+    } else if (normalized === "turn_start") {
+      const result = applyTurnStartSecondWind(unit);
+      if (result.count > 0) outcomes.push({ type: "fighter_second_wind_turn_heal", traitId: "second_wind", unit, ...result });
+    } else if (normalized === "encounter_end") {
+      const removed = removeStatus(unit, SECOND_WIND_STATUS_ID);
+      outcomes.push({ type: "fighter_second_wind_encounter_end", traitId: "second_wind", unit, removed });
+    }
+  }
+
+  function applySecondWindActivation(result) {
+    const trait = result?.trait;
+    if (traitBaseId(trait) !== "second_wind" || !result?.available || result?.scheduled) return result;
+    const runtime = result.runtime || {};
+    const unit = runtime.self || runtime.character || null;
+    if (!unit) return result;
+    const spent = spendSecondWindCount(unit, 1);
+    if (!spent.success) {
+      return { ...result, available: false, reasons: ["No Second Wind Count remaining."], outcomes: result.outcomes || [] };
+    }
+    const heal = healPercent(unit, 25);
+    result.outcomes = [...(result.outcomes || []), {
+      type: "fighter_second_wind_used",
+      traitId: trait.id || "second_wind",
+      statusId: SECOND_WIND_STATUS_ID,
+      spent: spent.spent,
+      countBefore: spent.before,
+      countAfter: spent.after,
+      heal,
+    }];
+    return result;
+  }
+
+  function wrapEngine() {
+    const source = global.LuminousTraitEngine || (typeof require === "function" ? (() => { try { return require("./trait-engine.js"); } catch (_) { return null; } })() : null);
+    if (!source) return false;
+    if (source.__fighterClassRuntimeWrapped) return true;
+
+    const originalDispatchCombatEvent = source.dispatchCombatEvent?.bind(source);
+    const originalActivateTrait = source.activateTrait?.bind(source);
+
+    global.LuminousTraitEngine = Object.freeze({
+      ...source,
+      __fighterClassRuntimeWrapped: true,
+      dispatchCombatEvent(trigger, input = {}) {
+        const result = originalDispatchCombatEvent
+          ? originalDispatchCombatEvent(trigger, input)
+          : { state: input.state, runtime: input, outcomes: [] };
+        const extras = [];
+        applyCombatTrigger(source, input.traits || [], trigger, result.runtime || input, extras);
+        result.outcomes = [...(result.outcomes || []), ...extras];
+        return result;
+      },
+      activateTrait(traitInput, runtime = {}, state) {
+        const trait = source.normalizeTrait ? source.normalizeTrait(traitInput) : traitInput;
+        if (traitBaseId(trait) === "second_wind" && secondWindCount(runtime.self || runtime.character) <= 0) {
+          return {
+            available: false,
+            reasons: ["No Second Wind Count remaining."],
+            maximum: null,
+            remaining: 0,
+            actionCost: "quick_action",
+            trait,
+            state: state || source.createState?.(),
+            runtime,
+            outcomes: [],
+          };
+        }
+        const result = originalActivateTrait
+          ? originalActivateTrait(traitInput, runtime, state)
+          : { available: false, reasons: ["Trait Engine activation is unavailable."], trait, runtime, state, outcomes: [] };
+        return applySecondWindActivation(result);
+      },
+    });
+    return true;
+  }
+
+  function install() {
+    const catalog = wrapCatalog();
+    const engine = wrapEngine();
+    return catalog && engine;
+  }
+
+  const api = Object.freeze({
+    CLASS_ID,
+    CLASS_NAME,
+    CATALOG_VERSION,
+    SECOND_WIND_STATUS_ID,
+    FIGHTER_DEFINITIONS,
+    FIGHTER_GRANTS,
+    fighterClassLevel,
+    secondWindMaximum,
+    secondWindCount,
+    setSecondWindCount,
+    spendSecondWindCount,
+    healPercent,
+    initializeSecondWind,
+    applyTurnStartSecondWind,
+    grantIdentity,
+    wrapCatalog,
+    wrapEngine,
+    install,
+  });
+
+  global.LuminousFighterClassRuntime = api;
+  install();
+  if (!global.document && typeof queueMicrotask === "function") queueMicrotask(install);
+  if (global.document && global.setInterval) {
+    const timer = global.setInterval(() => {
+      if (install()) global.clearInterval?.(timer);
+    }, 800);
+    timer?.unref?.();
+  }
+  if (typeof module !== "undefined" && module.exports) module.exports = api;
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/player-archetype-runtime.js
+++ b/js/player-archetype-runtime.js
@@ -5,12 +5,13 @@
   if (!doc) return;
 
   function ensureScript(id, src, ready) {
-    if (ready?.()) return Promise.resolve();
+    if (ready?.()) return Promise.resolve(ready());
     const existing = doc.getElementById(id);
     if (existing) {
       return new Promise((resolve, reject) => {
-        if (ready?.()) return resolve();
-        existing.addEventListener("load", resolve, { once: true });
+        if (ready?.()) return resolve(ready());
+        const finish = () => resolve(ready?.() || true);
+        existing.addEventListener("load", finish, { once: true });
         existing.addEventListener("error", reject, { once: true });
       });
     }
@@ -19,57 +20,114 @@
       script.id = id;
       script.src = src;
       script.async = false;
-      script.addEventListener("load", resolve, { once: true });
+      script.addEventListener("load", () => resolve(ready?.() || true), { once: true });
       script.addEventListener("error", reject, { once: true });
       doc.head?.appendChild(script);
     });
   }
 
+  function ensureBattleOnlyRuntimes() {
+    if (!global.CombatEngine) return false;
+    ensureScript(
+      "rogue-combat-runtime-script",
+      "js/rogue-combat-runtime.js",
+      () => global.LuminousRogueCombatRuntime,
+    ).then((runtime) => runtime?.install?.())
+      .catch((error) => console.error("Player Runtime Bootstrap / Rogue Combat:", error));
+    return true;
+  }
+
+  function watchBattleOnlyRuntimes() {
+    if (ensureBattleOnlyRuntimes()) return;
+    let attempts = 0;
+    const timer = global.setInterval?.(() => {
+      attempts += 1;
+      if (ensureBattleOnlyRuntimes() || attempts >= 40) global.clearInterval?.(timer);
+    }, 250);
+    timer?.unref?.();
+  }
+
   Promise.resolve()
+    .then(() => ensureScript(
+      "status-library-script",
+      "js/status-library.js",
+      () => global.LuminousStatusLibrary,
+    ))
+    .then(() => ensureScript(
+      "class-status-semantics-script",
+      "js/class-status-semantics.js",
+      () => global.LuminousClassStatusSemantics,
+    ))
+    .then(() => ensureScript(
+      "fighter-class-runtime-script",
+      "js/fighter-class-runtime.js",
+      () => global.LuminousFighterClassRuntime,
+    ))
+    .then(() => ensureScript(
+      "player-trait-runtime-script",
+      "js/player-trait-runtime.js",
+      () => global.LuminousPlayerTraitRuntime,
+    ))
     .then(() => ensureScript(
       "player-archetype-runtime-core-script",
       "js/player-archetype-runtime-core.js",
-      () => Boolean(global.LuminousArchetypeRuntime),
+      () => global.LuminousArchetypeRuntime,
     ))
     .then(() => ensureScript(
       "orosh-lineage-runtime-script",
       "js/orosh-lineage-runtime.js",
-      () => Boolean(global.LuminousOroshLineageRuntime),
+      () => global.LuminousOroshLineageRuntime,
     ))
     .then(() => ensureScript(
       "orosh-lineage-complete-runtime-script",
       "js/orosh-lineage-complete-runtime.js",
-      () => Boolean(global.LuminousOroshLineageCompleteRuntime),
+      () => global.LuminousOroshLineageCompleteRuntime,
     ))
     .then(() => ensureScript(
       "rogue-class-runtime-script",
       "js/rogue-class-runtime.js",
-      () => Boolean(global.LuminousRogueClassRuntime),
+      () => global.LuminousRogueClassRuntime,
     ))
     .then(() => ensureScript(
       "rogue-theatre-runtime-script",
       "js/rogue-theatre-runtime.js",
-      () => Boolean(global.LuminousRogueTheatreRuntime),
+      () => global.LuminousRogueTheatreRuntime,
+    ))
+    .then(() => ensureScript(
+      "spellcasting-runtime-script",
+      "js/spellcasting-runtime.js",
+      () => global.LuminousSpellcastingRuntime,
+    ))
+    .then(() => ensureScript(
+      "sorcerer-class-runtime-script",
+      "js/sorcerer-class-runtime.js",
+      () => global.LuminousSorcererClassRuntime,
     ))
     .then(() => ensureScript(
       "fighter-maneuver-catalog-script",
       "js/fighter-maneuver-catalog.js",
-      () => Boolean(global.LuminousFighterManeuverCatalog),
+      () => global.LuminousFighterManeuverCatalog,
     ))
     .then(() => ensureScript(
       "battle-master-archetype-runtime-script",
       "js/battle-master-archetype-runtime.js",
-      () => Boolean(global.LuminousBattleMasterArchetypeRuntime),
+      () => global.LuminousBattleMasterArchetypeRuntime,
     ))
     .then(() => ensureScript(
       "mastermind-archetype-runtime-script",
       "js/mastermind-archetype-runtime.js",
-      () => Boolean(global.LuminousMastermindArchetypeRuntime),
+      () => global.LuminousMastermindArchetypeRuntime,
     ))
     .then(() => ensureScript(
       "mastermind-theatre-runtime-script",
       "js/mastermind-theatre-runtime.js",
-      () => Boolean(global.LuminousMastermindTheatreRuntime),
+      () => global.LuminousMastermindTheatreRuntime,
     ))
-    .catch((error) => console.error("Player Archetype Bootstrap:", error));
+    .then(() => {
+      global.LuminousClassStatusSemantics?.install?.();
+      global.LuminousFighterClassRuntime?.install?.();
+      global.LuminousSorcererClassRuntime?.install?.();
+      watchBattleOnlyRuntimes();
+    })
+    .catch((error) => console.error("Player Runtime Bootstrap:", error));
 })(window);

--- a/tests/class-status-semantics-smoke.mjs
+++ b/tests/class-status-semantics-smoke.mjs
@@ -47,6 +47,13 @@ assert.equal(library.get('psychic_blade')?.mode, 'single');
 assert.equal(library.get('psychic_blade')?.icon, 'https://imgur.com/vEDE8Q8.png');
 assert.equal(library.get('psychic_blade')?.archetypeId, 'college_of_whispers');
 
+// Second Wind is a visible Fighter Status whose Count tracks the remaining uses for the Encounter.
+assert.equal(library.has('second_wind'), true);
+assert.equal(library.get('second_wind')?.name, 'Second Wind');
+assert.equal(library.get('second_wind')?.mode, 'single');
+assert.equal(library.get('second_wind')?.icon, 'https://imgur.com/VSxnVEo.png');
+assert.equal(library.get('second_wind')?.classId, 'fighter');
+
 // Class resources and Action/Passive implementation markers are not Status Effects.
 assert.equal(library.has('sorcery_points'), false, 'Sorcery Points are a Sorcerer class resource, not a Status');
 assert.equal(library.has('reckless_attack_armed'), false, 'Reckless Attack arming is internal Trait state');
@@ -77,18 +84,21 @@ const unit = {
     haste: { id: 'haste', count: 2, potency: 0 },
     bardic_inspiration: { id: 'bardic_inspiration', count: 1, potency: 3 },
     psychic_blade: { id: 'psychic_blade', count: 2, potency: 0 },
+    second_wind: { id: 'second_wind', count: 3, potency: 0 },
     countercharm: { id: 'countercharm', count: 2, potency: 0 },
     reckless_attack_armed: { id: 'reckless_attack_armed', count: 1, potency: 0 },
   },
 };
 const visible = globalThis.LuminousStatusEngine.listStatuses(unit).map((entry) => entry.id).sort();
-assert.deepEqual(visible, ['bardic_inspiration', 'haste', 'psychic_blade', 'rage']);
+assert.deepEqual(visible, ['bardic_inspiration', 'haste', 'psychic_blade', 'rage', 'second_wind']);
 
 // Existing Trait runtimes must still reference the same canonical ids.
 const bardSource = fs.readFileSync(path.join(root, 'js/bard-class-runtime.js'), 'utf8');
 assert.match(bardSource, /bardic_inspiration/);
 const whispersSource = fs.readFileSync(path.join(root, 'js/college-of-whispers-runtime.js'), 'utf8');
 assert.match(whispersSource, /psychic_blade/);
+const fighterSource = fs.readFileSync(path.join(root, 'js/fighter-class-runtime.js'), 'utf8');
+assert.match(fighterSource, /second_wind/);
 
 // Sorcerer keeps Sorcery Points in classResources; it must not regress into the Status Library.
 const sorcererSource = fs.readFileSync(path.join(root, 'js/sorcerer-class-runtime.js'), 'utf8');
@@ -99,4 +109,4 @@ assert.doesNotMatch(sorcererSource, /statusId\s*:\s*["']sorcery_points["']/);
 const managerSource = fs.readFileSync(path.join(root, 'js/statusManager.js'), 'utf8');
 assert.match(managerSource, /class-status-semantics\.js/);
 
-console.log('Class Status semantics smoke passed: Rage, Bardic Inspiration, and Psychic Blade visible; internal Action markers hidden; Sorcery Points remain a resource.');
+console.log('Class Status semantics smoke passed: Rage, Bardic Inspiration, Psychic Blade, and Second Wind visible; internal Action markers hidden; Sorcery Points remain a resource.');

--- a/tests/fighter-class-runtime-smoke.mjs
+++ b/tests/fighter-class-runtime-smoke.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+
+for (const key of [
+  "LuminousStatusEngine",
+  "LuminousStatusLibrary",
+  "LuminousTraitEngine",
+  "LuminousTraitCatalogCore",
+  "LuminousClassStatusSemantics",
+  "LuminousFighterClassRuntime",
+  "STATUS_REGISTRY",
+]) delete globalThis[key];
+
+await import("../js/status-engine.js");
+await import("../js/status-library.js");
+await import("../js/trait-engine.js");
+await import("../js/trait-catalog-core.js");
+await import("../js/class-status-semantics.js");
+await import("../js/fighter-class-runtime.js");
+
+const runtime = globalThis.LuminousFighterClassRuntime;
+const engine = globalThis.LuminousTraitEngine;
+const catalog = globalThis.LuminousTraitCatalogCore;
+const statusLibrary = globalThis.LuminousStatusLibrary;
+
+assert.ok(runtime, "Fighter class runtime should install");
+assert.equal(runtime.CLASS_ID, "fighter");
+assert.equal(statusLibrary.get("second_wind")?.icon, "https://imgur.com/VSxnVEo.png");
+
+const secondWind = catalog.getDefinition("second_wind");
+assert.ok(secondWind, "Second Wind should exist in the canonical Trait catalog");
+assert.equal(secondWind.activation.type, "manual");
+assert.equal(secondWind.activation.actionCost, "quick_action");
+assert.ok(catalog.allGrants().some((grant) => grant.sourceId === "fighter" && grant.atLevel === 5 && grant.traitId === "second_wind"));
+
+const makeCharacter = (level, hp = 100, maxHp = 200) => ({
+  id: `fighter_${level}`,
+  hp,
+  maxHp,
+  classes: [{ id: "fighter", level }],
+});
+
+assert.equal(runtime.secondWindMaximum(makeCharacter(5)), 1);
+assert.equal(runtime.secondWindMaximum(makeCharacter(20)), 2);
+assert.equal(runtime.secondWindMaximum(makeCharacter(40)), 3);
+assert.equal(runtime.secondWindMaximum(makeCharacter(60)), 4);
+assert.equal(runtime.secondWindMaximum(makeCharacter(80)), 5);
+assert.equal(runtime.secondWindMaximum(makeCharacter(100)), 6);
+
+const character = makeCharacter(45);
+const combatUnit = { id: "fighter_unit", hp: 100, maxHp: 200, statusEffects: {} };
+const traits = engine.resolveTraitGrants(character, catalog.allGrants(), catalog.allDefinitions());
+assert.ok(traits.some((trait) => trait.id === "second_wind"));
+let state = engine.createState();
+
+let event = engine.dispatchCombatEvent("encounter_start", {
+  character,
+  self: combatUnit,
+  traits,
+  state,
+});
+state = event.state;
+assert.equal(runtime.secondWindCount(combatUnit), 3, "Level 45 Fighter should start an Encounter with 3 Second Wind Count");
+
+// 3 Count => 6% Max HP at Turn Start: 12 HP from a 200 Max HP unit.
+event = engine.dispatchCombatEvent("turn_start", {
+  character,
+  self: combatUnit,
+  traits,
+  state,
+});
+state = event.state;
+assert.equal(combatUnit.hp, 112);
+assert.ok(event.outcomes.some((outcome) => outcome.type === "fighter_second_wind_turn_heal" && outcome.heal.amount === 12));
+
+// Quick Action spends exactly 1 Count and heals 25% Max HP: 50 HP here.
+const economy = { quick_action: 1 };
+let activation = engine.activateTrait(secondWind, {
+  context: "combat",
+  character,
+  self: combatUnit,
+  actionEconomy: economy,
+}, state);
+state = activation.state;
+assert.equal(activation.available, true);
+assert.equal(economy.quick_action, 0);
+assert.equal(runtime.secondWindCount(combatUnit), 2);
+assert.equal(combatUnit.hp, 162);
+assert.ok(activation.outcomes.some((outcome) => outcome.type === "fighter_second_wind_used" && outcome.heal.amount === 50));
+
+// 2 Count => 4% Max HP at the next Turn Start: 8 HP.
+event = engine.dispatchCombatEvent("turn_start", {
+  character,
+  self: combatUnit,
+  traits,
+  state,
+});
+state = event.state;
+assert.equal(combatUnit.hp, 170);
+
+// Spend the final two Count. Healing clamps at Max HP and the Status disappears at zero Count.
+for (let i = 0; i < 2; i += 1) {
+  const actionEconomy = { quick_action: 1 };
+  activation = engine.activateTrait(secondWind, {
+    context: "combat",
+    character,
+    self: combatUnit,
+    actionEconomy,
+  }, state);
+  state = activation.state;
+  assert.equal(activation.available, true);
+  assert.equal(actionEconomy.quick_action, 0);
+}
+assert.equal(runtime.secondWindCount(combatUnit), 0);
+assert.equal(globalThis.LuminousStatusEngine.hasStatus(combatUnit, "second_wind"), false);
+assert.equal(combatUnit.hp, 200);
+
+// With 0 Count, activation is blocked before spending the Quick Action.
+const emptyEconomy = { quick_action: 1 };
+activation = engine.activateTrait(secondWind, {
+  context: "combat",
+  character,
+  self: combatUnit,
+  actionEconomy: emptyEconomy,
+}, state);
+assert.equal(activation.available, false);
+assert.equal(emptyEconomy.quick_action, 1);
+assert.match(activation.reasons.join(" "), /Second Wind Count/);
+
+// A new Encounter refreshes the Count to the current Fighter-level maximum.
+event = engine.dispatchCombatEvent("encounter_start", {
+  character,
+  self: combatUnit,
+  traits,
+  state,
+});
+state = event.state;
+assert.equal(runtime.secondWindCount(combatUnit), 3);
+
+engine.dispatchCombatEvent("encounter_end", {
+  character,
+  self: combatUnit,
+  traits,
+  state,
+});
+assert.equal(runtime.secondWindCount(combatUnit), 0);
+
+console.log("Fighter class runtime smoke passed: Second Wind Count, passive healing, Quick Action spend, refresh, cleanup, and icon contract verified.");

--- a/tests/player-runtime-wiring-smoke.mjs
+++ b/tests/player-runtime-wiring-smoke.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+const read = (file) => fs.readFileSync(path.join(root, file), "utf8");
+
+const battle = read("Battle-viewer.html");
+const theatre = read("hoja_personaje.html");
+const statusEngine = read("js/status-engine.js");
+const bootstrap = read("js/player-archetype-runtime.js");
+const playerTraits = read("js/player-trait-runtime.js");
+const rogueCombat = read("js/rogue-combat-runtime.js");
+const fighter = read("js/fighter-class-runtime.js");
+
+// Both player entrypoints enter through the same Status/runtime bootstrap chain.
+assert.match(battle, /<script src=["']js\/status-engine\.js["']><\/script>/);
+assert.match(theatre, /<script src=["']js\/status-engine\.js["']><\/script>/);
+assert.match(statusEngine, /js\/player-archetype-runtime\.js/);
+
+// Shared player bootstrap must guarantee visible class Statuses and the Trait lifecycle bridge.
+for (const runtimePath of [
+  "js/status-library.js",
+  "js/class-status-semantics.js",
+  "js/fighter-class-runtime.js",
+  "js/player-trait-runtime.js",
+  "js/rogue-class-runtime.js",
+  "js/rogue-theatre-runtime.js",
+  "js/spellcasting-runtime.js",
+  "js/sorcerer-class-runtime.js",
+  "js/rogue-combat-runtime.js",
+]) {
+  assert.ok(bootstrap.includes(runtimePath), `Shared player bootstrap must wire ${runtimePath}`);
+}
+
+// Sorcerer captures its Spellcasting dependency at module load, so Spellcasting must load first.
+assert.ok(
+  bootstrap.indexOf("js/spellcasting-runtime.js") < bootstrap.indexOf("js/sorcerer-class-runtime.js"),
+  "Spellcasting runtime must load before Sorcerer class runtime",
+);
+
+// Rogue Combat is Battle-only: do not inject its CombatEngine wrapper until CombatEngine exists.
+assert.match(bootstrap, /function ensureBattleOnlyRuntimes\(\)/);
+assert.match(bootstrap, /if \(!global\.CombatEngine\) return false;/);
+assert.match(bootstrap, /watchBattleOnlyRuntimes\(\)/);
+assert.match(rogueCombat, /function installEngine\(engine = global\.CombatEngine\)/);
+assert.match(rogueCombat, /__rogueClassCombatWrapped/);
+
+// The Player Trait runtime is the lifecycle bridge for both Theatre checks and Battle events.
+assert.match(playerTraits, /function installTheatreBridge\(\)/);
+assert.match(playerTraits, /function installCombatBridge\(\)/);
+assert.match(playerTraits, /dispatchCombatEvent\("encounter_start"/);
+assert.match(playerTraits, /dispatchCombatEvent\("turn_start"/);
+assert.match(playerTraits, /installLifecycleBridges\(\)/);
+
+// Fighter Second Wind consumes those real Battle lifecycle events.
+assert.match(fighter, /normalized === "encounter_start"/);
+assert.match(fighter, /normalized === "turn_start"/);
+assert.match(fighter, /fighter_second_wind_encounter_start/);
+assert.match(fighter, /fighter_second_wind_turn_heal/);
+
+console.log("Player runtime wiring smoke passed: Theatre/Battle share class Status + Trait bridges; Fighter, Rogue Combat, and Sorcerer are reachable in browser runtime.");


### PR DESCRIPTION
## Summary
- adds the Fighter `Second Wind` Trait at Fighter Class Level 5
- implements `[On Encounter Start]` Second Wind Count as `1 + floor(Fighter Class Level / 20)`
- implements `[On Turn Start]` healing for `2% Max HP` per remaining Second Wind Count
- implements the Quick Action spend: consume 1 Count to recover `25% Max HP`
- registers `second_wind` as a visible class Status using the supplied icon: `https://imgur.com/VSxnVEo.png`
- loads the Fighter runtime through the existing class-status bootstrap path
- adds smoke coverage for the icon/status contract and Fighter runtime behavior

## Notes
Second Wind Count is refreshed at Encounter Start and removed when it reaches 0 or the Encounter ends. A zero-Count activation is blocked before Quick Action consumption.